### PR TITLE
Iteration 1: Frontmatter parser & property commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ Organize in subfolders. Use `[[wikilinks]]` for cross-references. Keep Obsidian-
 Use the rust-analyzer LSP plugin for code intelligence: analyzing code, finding references, go-to-definition, checking clippy warnings.
 
 ## Code Quality Gates
+Make the code unit testable. Add tests if feasible. Add e2e tests for all commands/subcommands.
+
+Performance is key. Optimize the code to not read whole files into memory if not needed, but process them as streams if possible.
+
 Before committing or creating a PR, run **in this order** and fix all issues:
 1. `cargo fmt`
 2. `cargo clippy --workspace --all-targets -- -D warnings`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "tempfile",
 ]
 
@@ -562,10 +562,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +158,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,9 +276,50 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hyalo"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "assert_cmd",
  "clap",
+ "globset",
+ "ignore",
+ "predicates",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -126,16 +335,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -154,6 +448,75 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -199,6 +562,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,16 +592,127 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-link"
@@ -240,6 +727,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.6.0", features = ["derive", "env"] }
+globset = "0.4"
+ignore = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+serde_yaml = "0.9"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ globset = "0.4"
 ignore = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/hyalo-knowledgebase/SEED.md
+++ b/hyalo-knowledgebase/SEED.md
@@ -1,0 +1,71 @@
+❯ We want to build a CLI tool to manage md files. The md files should be compatible with obsidian. We need to epxlore what this compatibility means. I don't want to
+implement any functionality that manages obsidian or features of obsidian (like the vaults, file history, bookmarks, daily notes etc.), but keep compatibility of the md
+files and also esp. of their frontmatter. Worth exploring:
+- https://obsidian.md/help/obsidian-flavored-markdown
+- https://obsidian.md/help/syntax
+- https://obsidian.md/help/advanced-syntax
+- https://obsidian.md/help/tags
+- https://obsidian.md/help/callouts
+
+Very important and useful are the properties that allow you to organize notes with structured data in the frontmatter. Allowed values are of type text, numbers,
+checkboxes, dates, dates and times, or lists:
+- https://obsidian.md/help/properties
+
+The obsidian CLI has many commands to deal with the files like "create", "read", "append", which doesn't need to be implemented, because AI agents can do this obviously
+out of the box. Interesting are the move and rename file commands that update the internal links of all the other md files (probably using the functionality to find all
+outgoing and incoming links of a document (backlinks)).
+
+Interesting commands are IMHO e.g: tags, tasks, properties, outline, links and search
+Have a look here:
+- https://obsidian.md/help/cli
+- https://obsidian.md/help/plugins/search
+- https://obsidian.md/help/plugins/outline
+- https://obsidian.md/help/plugins/search
+
+Esp. the search and the navigation by finding outgoing and incoming links could be very powerful tools for an AI agent to work with a bunch of md files.
+To give an idea, what you can do with obsidian search:
+```
+# Find all ready stories (frontmatter query — much more reliable than grep)
+obsidian vault=stova-knowledgebase search query='type = "story" status = "ready"' path="backlog" format=json
+
+# Filter by priority
+obsidian vault=stova-knowledgebase search query='type = "story" status = "ready" priority = "high"' path="backlog" format=json
+
+# Filter by sprint (searches all domain subfolders)
+obsidian vault=stova-knowledgebase search query='type = "story" sprint = "sprint-3" status = "ready"' path="backlog" format=json
+```
+How obsidian deals with frontmatter properties:
+```
+# Read a single property
+obsidian vault=stova-knowledgebase property:read name=status path="backlog/backend/STORY-003-idx-parser-validator.md"
+
+# Update story status — use this instead of editing the file manually
+obsidian vault=stova-knowledgebase property:set name=status value=in-progress path="backlog/backend/STORY-003-idx-parser-validator.md"
+obsidian vault=stova-knowledgebase property:set name=status value=done        path="backlog/backend/STORY-003-idx-parser-validator.md"
+
+# Read all frontmatter properties
+obsidian vault=stova-knowledgebase properties path="backlog/backend/STORY-003-idx-parser-validator.md" format=json
+```
+And this is how obsidian deals with tasks:
+```
+# Show task info
+task file=Recipe line=8
+task ref="Recipe.md:8"
+
+# Toggle task completion
+task ref="Recipe.md:8" toggle
+
+# Toggle task in daily note
+task daily line=3 toggle
+
+# Set task status
+task file=Recipe line=8 done      # → [x]
+task file=Recipe line=8 todo      # → [ ]
+task file=Recipe line=8 status=-  # → [-]
+```
+
+Keep this initial pitch already in the hyalo-knowledgebase so that we can iterate on it later.
+
+Go through the documentation of obsidian to get a better picture and document the importan things. Then let's discuss how we plan the iterations, what features make
+sense, what is needed for which feature etc.
+At a later stage, let's discuss how he can speed up searching documents based on properties etc. by introducing kind of an index.

--- a/hyalo-knowledgebase/SEED.md
+++ b/hyalo-knowledgebase/SEED.md
@@ -1,4 +1,4 @@
-❯ We want to build a CLI tool to manage md files. The md files should be compatible with obsidian. We need to epxlore what this compatibility means. I don't want to
+❯ We want to build a CLI tool to manage md files. The md files should be compatible with obsidian. We need to explore what this compatibility means. I don't want to
 implement any functionality that manages obsidian or features of obsidian (like the vaults, file history, bookmarks, daily notes etc.), but keep compatibility of the md
 files and also esp. of their frontmatter. Worth exploring:
 - https://obsidian.md/help/obsidian-flavored-markdown
@@ -66,6 +66,6 @@ task file=Recipe line=8 status=-  # → [-]
 
 Keep this initial pitch already in the hyalo-knowledgebase so that we can iterate on it later.
 
-Go through the documentation of obsidian to get a better picture and document the importan things. Then let's discuss how we plan the iterations, what features make
+Go through the documentation of obsidian to get a better picture and document the important things. Then let's discuss how we plan the iterations, what features make
 sense, what is needed for which feature etc.
 At a later stage, let's discuss how he can speed up searching documents based on properties etc. by introducing kind of an index.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -45,6 +45,30 @@ Fields (`path`, `hint`, `cause`) are omitted when not applicable. The `cause` fi
 
 ## DEC-006: Frontmatter Rewrite on Mutation (2026-03-20)
 
-**Decision:** Use serde_yaml for both reading and writing frontmatter. Full rewrite of the YAML block on `set`/`remove` — no formatting preservation.
+**Decision:** Use serde_yaml_ng for both reading and writing frontmatter. Full rewrite of the YAML block on `set`/`remove` — no formatting preservation.
 
-**Why:** serde_yaml cannot preserve formatting (comments, quoting style, blank lines). Obsidian itself rewrites frontmatter on save. The files are machine-managed. Keeps the implementation simple. Can revisit if hand-edited YAML preservation becomes important.
+**Why:** serde_yaml_ng cannot preserve formatting (comments, quoting style, blank lines). Obsidian itself rewrites frontmatter on save. The files are machine-managed. Keeps the implementation simple. Can revisit if hand-edited YAML preservation becomes important.
+
+## DEC-007: serde_yaml_ng over serde_yaml (2026-03-20)
+
+**Decision:** Use `serde_yaml_ng` 0.10 instead of the deprecated `serde_yaml` 0.9.
+
+**Why:** dtolnay archived `serde_yaml` — no further fixes. `serde_yaml_ng` is the community-endorsed fork with active maintenance and a drop-in API. Avoid `serde_yml` (RUSTSEC-2025-0068: unsound, causes segfaults). `serde_norway` was considered but has less community endorsement.
+
+## DEC-008: Sandbox --dir with Path Traversal Rejection (2026-03-20)
+
+**Decision:** `resolve_file` rejects absolute paths, backslash-prefixed paths, and any path containing `..` segments. Operations are sandboxed to `--dir`.
+
+**Why:** Without this, `property set --path ../../../etc/important.md` could write outside the intended directory. Since `property set`/`remove` are mutation commands, this is a security boundary.
+
+## DEC-009: Unclosed Frontmatter is an Error (2026-03-20)
+
+**Decision:** `Document::parse` returns an error when a file starts with `---` but has no closing `---` delimiter. The streaming `read_frontmatter` reader also enforces a 100-line / 8KB budget.
+
+**Why:** Silently treating unclosed frontmatter as "no frontmatter" would cause `property set` to write a new `---` block on top, leaving the original opening `---` in the body — corrupting the file. Failing early is safer than silent corruption.
+
+## DEC-010: Forward-Slash Path Normalization (2026-03-20)
+
+**Decision:** All relative paths in output and glob matching use forward slashes (`/`), even on Windows.
+
+**Why:** `std::path::Path::to_string_lossy()` uses `\` on Windows, which breaks glob patterns and produces inconsistent JSON output across platforms. Forward slashes work on all OSes.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -1,0 +1,50 @@
+---
+title: "Decision Log"
+type: decisions
+date: 2026-03-20
+tags:
+  - decisions
+  - architecture
+---
+
+# Decision Log
+
+## DEC-001: CLI Flag Style (2026-03-20)
+
+**Decision:** Use idiomatic `--flag` style with clap subcommands, not Obsidian's `key=value` style.
+
+**Why:** AI agents generate CLI calls — standard flag syntax is universally supported across all agent frameworks and shell environments.
+
+## DEC-002: `--dir` Instead of Vault Concept (2026-03-20)
+
+**Decision:** Accept `--dir <path>` global option (defaults to `.`) to specify the working directory. No vault registry, no vault names.
+
+**Why:** Self-contained tool. No application state, no config files to manage. Just point at a directory.
+
+## DEC-003: `--path` for File Targeting (2026-03-20)
+
+**Decision:** Single `--path` flag for all file targeting. Always relative to `--dir`. Always requires `.md` extension. Accepts globs for multi-file commands (`--path "research/*.md"`). No fuzzy wikilink-style name resolution.
+
+**Why:** AI agents work with exact file paths. Fuzzy resolution adds complexity and ambiguity. Leading `./` is tolerated and normalized. Missing `.md` triggers a helpful error with a hint.
+
+## DEC-004: Output Formats — JSON Default, Text for Humans (2026-03-20)
+
+**Decision:** Global `--format` option on all commands. Two formats: `json` (default) and `text`. No YAML output format.
+
+**Why:** JSON is what AI agents parse. Text is for human debugging. YAML adds complexity with little value — frontmatter is already readable via `text`. Can be added later if needed.
+
+## DEC-005: Structured Error Output (2026-03-20)
+
+**Decision:** Errors go to stderr, with non-zero exit code. Error format matches `--format`:
+- JSON (default): `{"error": "...", "path": "...", "hint": "...", "cause": "..."}`
+- Text: plain human-readable message
+
+Fields (`path`, `hint`, `cause`) are omitted when not applicable. The `cause` field carries the underlying OS/library error (e.g. "permission denied", "disk full").
+
+**Why:** AI agents need parseable errors to react programmatically. The `hint` field enables self-correction (e.g. suggesting `.md` extension). The `cause` field surfaces the actual system error without the agent needing to guess.
+
+## DEC-006: Frontmatter Rewrite on Mutation (2026-03-20)
+
+**Decision:** Use serde_yaml for both reading and writing frontmatter. Full rewrite of the YAML block on `set`/`remove` — no formatting preservation.
+
+**Why:** serde_yaml cannot preserve formatting (comments, quoting style, blank lines). Obsidian itself rewrites frontmatter on save. The files are machine-managed. Keeps the implementation simple. Can revisit if hand-edited YAML preservation becomes important.

--- a/hyalo-knowledgebase/iteration-plan.md
+++ b/hyalo-knowledgebase/iteration-plan.md
@@ -1,0 +1,63 @@
+---
+title: "Hyalo — High-Level Iteration Plan"
+type: plan
+date: 2026-03-20
+status: active
+tags:
+  - plan
+  - iterations
+---
+
+# High-Level Iteration Plan
+
+## Iteration 1 — Frontmatter Parser & Property Commands
+
+The foundation. Parse YAML frontmatter, infer types, implement property commands. After this iteration, hyalo will be used to manage its own knowledgebase (dogfooding).
+
+**Commands:** `properties`, `property:read`, `property:set`, `property:remove`
+
+## Iteration 2 — Wikilink Parser & Link Graph
+
+Parse `[[wikilinks]]` and `![[embeds]]`. Navigate the knowledge graph.
+
+**Commands:** `links`, `backlinks`, `unresolved`, `orphans`, `deadends`
+
+## Iteration 3 — Tags & Tasks
+
+Parse inline `#tags` (including nested) and task checkboxes with any status character.
+
+**Commands:** `tags`, `tag`, `tasks`, `task` (with toggle/status)
+
+## Iteration 4 — Search
+
+Property query syntax, boolean logic, operators. Ties iterations 1–3 together into one query interface.
+
+**Commands:** `search` with `[prop:value]`, `path:`, `file:`, `tag:`, `content:`, `task-todo:`, `task-done:`
+
+## Iteration 5 — Move/Rename with Link Updates
+
+Move or rename a file and update all wikilinks across the knowledge base.
+
+**Commands:** `move`, `rename`
+
+## Iteration 6 — Outline & Polish
+
+Heading extraction, output formats (JSON, text, tree), CLI ergonomics.
+
+**Commands:** `outline`
+
+## Later — Indexing
+
+SQLite or similar index for properties, tags, and links. Incremental updates based on file mtime. Triggered when file scanning becomes a bottleneck on large vaults.
+
+## Dependencies
+
+```
+Iteration 1 (frontmatter) ──→ Iteration 4 (search needs parser)
+Iteration 2 (link graph)  ──→ Iteration 5 (rename needs links)
+Iterations 1–3             ──→ Iteration 4 (search unifies all)
+```
+
+## Dogfooding
+
+Starting after iteration 1, hyalo manages its own `hyalo-knowledgebase/`.

--- a/hyalo-knowledgebase/iterations/iteration-01-frontmatter-properties.md
+++ b/hyalo-knowledgebase/iterations/iteration-01-frontmatter-properties.md
@@ -18,14 +18,14 @@ Parse YAML frontmatter from markdown files, infer property types, and provide CL
 
 ## CLI Interface
 
-Target root directory is passed as a positional arg or defaults to `.`:
+Target root directory is controlled by a global `--dir` option (default `.`):
 
 ```sh
 # List all properties across files
-hyalo properties [--path <glob>] [--format json|yaml|text]
+hyalo properties [--path <glob>] [--format json|text]
 
 # Read all properties of a file
-hyalo properties --path path/to/file.md [--format json|yaml|text]
+hyalo properties --path path/to/file.md [--format json|text]
 
 # Read a single property
 hyalo property read --name status --path path/to/file.md

--- a/hyalo-knowledgebase/iterations/iteration-01-frontmatter-properties.md
+++ b/hyalo-knowledgebase/iterations/iteration-01-frontmatter-properties.md
@@ -1,0 +1,132 @@
+---
+title: "Iteration 1 — Frontmatter Parser & Property Commands"
+type: iteration
+date: 2026-03-20
+status: planned
+branch: iter-1/frontmatter-properties
+tags:
+  - iteration
+  - frontmatter
+  - properties
+---
+
+# Iteration 1 — Frontmatter Parser & Property Commands
+
+## Goal
+
+Parse YAML frontmatter from markdown files, infer property types, and provide CLI commands to read/list/set/remove properties. After this iteration, hyalo is a useful tool for AI agents working with structured markdown.
+
+## CLI Interface
+
+Target root directory is passed as a positional arg or defaults to `.`:
+
+```sh
+# List all properties across files
+hyalo properties [--path <glob>] [--format json|yaml|text]
+
+# Read all properties of a file
+hyalo properties --path path/to/file.md [--format json|yaml|text]
+
+# Read a single property
+hyalo property read --name status --path path/to/file.md
+
+# Set a property (type inferred or explicit)
+hyalo property set --name status --value "in-progress" --path path/to/file.md
+hyalo property set --name priority --value 3 --type number --path path/to/file.md
+
+# Remove a property
+hyalo property remove --name status --path path/to/file.md
+```
+
+See [[decision-log]] for cross-cutting design decisions (CLI style, `--dir`, `--path`, `--format`, error output, frontmatter rewrite strategy).
+
+## Tasks
+
+### Crate & CLI Setup
+- [ ] Set up clap with subcommands: `properties`, `property read`, `property set`, `property remove`
+- [ ] Add `--dir` global option (default `.`)
+- [ ] Add `--path` option for file/glob targeting
+- [ ] Add `--format` option (json, yaml, text) with json as default
+- [ ] Add `--name`, `--value`, `--type` options for property subcommands
+
+### Frontmatter Parser
+- [ ] Add `serde_yaml` dependency
+- [ ] Extract YAML frontmatter from between `---` delimiters
+- [ ] Parse into a `BTreeMap<String, serde_yaml::Value>` (preserves key order)
+- [ ] Infer property type from YAML value: text, number, checkbox, date, datetime, list
+- [ ] Handle edge cases: no frontmatter, empty frontmatter, JSON frontmatter
+- [ ] Preserve non-frontmatter content when writing back
+
+### File Discovery
+- [ ] Walk directory tree recursively, collecting `*.md` files
+- [ ] Support `--path` as exact file path or glob pattern
+- [ ] Respect `.gitignore` patterns (use `ignore` crate)
+- [ ] Skip hidden directories (`.obsidian/`, `.git/`, etc.)
+
+### Property Commands
+- [ ] `properties` — list all properties of a file (or aggregate across files)
+- [ ] `property read` — read a single named property, output its value
+- [ ] `property set` — set a property value with type inference or explicit `--type`
+- [ ] `property remove` — remove a property from frontmatter
+- [ ] Preserve existing YAML formatting: don't rewrite untouched properties
+- [ ] Create frontmatter block if file has none (for `property set`)
+
+### Output Formatting
+- [ ] JSON output (default): structured, machine-readable
+- [ ] YAML output: frontmatter-style
+- [ ] Text output: human-readable key: value pairs
+
+### Unit Tests (in-module `#[cfg(test)]`)
+- [ ] Frontmatter extraction: valid, missing, empty, malformed, JSON-in-YAML
+- [ ] Type inference: text, number, bool, date, datetime, list
+- [ ] Property set: add new, overwrite existing, create frontmatter if absent
+- [ ] Property remove: existing key, missing key (no-op), last key (empty frontmatter)
+- [ ] Roundtrip: set then read returns same value; body content preserved
+
+### E2E Tests (`tests/` directory, `assert_cmd` + `tempfile`)
+- [ ] `hyalo properties --path file.md` — reads all properties as JSON
+- [ ] `hyalo property read --name <key> --path file.md` — outputs value
+- [ ] `hyalo property read` — missing property returns exit code 1
+- [ ] `hyalo property set --name <key> --value <val> --path file.md` — mutates file correctly
+- [ ] `hyalo property set` on file without frontmatter — creates frontmatter
+- [ ] `hyalo property remove --name <key> --path file.md` — removes property, body intact
+- [ ] `hyalo properties` (no --path) — aggregates across all .md files in --dir
+- [ ] `--format json` / `--format yaml` / `--format text` output validation
+- [ ] Error cases: nonexistent file, nonexistent dir, invalid YAML
+- [ ] Smoke test: run against `hyalo-knowledgebase/` files
+
+### Quality Gates
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+
+## Acceptance Criteria
+
+1. `hyalo properties --path file.md --format json` outputs all frontmatter properties with inferred types
+2. `hyalo property read --name status --path file.md` outputs the value of a single property
+3. `hyalo property set --name status --value done --path file.md` updates the property in-place without disturbing other content
+4. `hyalo property remove --name status --path file.md` removes the property
+5. `hyalo properties --format json` aggregates properties across all `.md` files in the root
+6. All commands exit with appropriate codes (0 success, 1 not found, 2 error)
+7. Dogfooding: hyalo can read its own knowledgebase files' frontmatter correctly
+
+## Dependencies (Crates)
+
+- `clap` (already present) — CLI parsing
+- `serde` + `serde_yaml` — YAML frontmatter
+- `serde_json` (already present) — JSON output
+- `ignore` — gitignore-aware file walking
+- `anyhow` — error handling
+- `glob` or `globset` — path matching
+
+### Dev Dependencies
+- `assert_cmd` — run binary in tests, assert on stdout/stderr/exit code
+- `predicates` — fluent assertions for assert_cmd
+- `tempfile` — per-test temp directories (no shared fixtures)
+
+## Notes
+
+- **Formatting preservation: not needed.** serde_yaml rewrites the full frontmatter on set/remove. Obsidian itself does the same. Keeps iteration 1 simple.
+- YAML frontmatter in Obsidian is always flat (no nested objects) — we can rely on this
+- Internal links in property values (`"[[Note]]"`) are just strings for now — link parsing comes in iteration 2
+- The `tags` property is a list type but has special semantics — tag aggregation comes in iteration 3

--- a/hyalo-knowledgebase/iterations/iteration-01-frontmatter-properties.md
+++ b/hyalo-knowledgebase/iterations/iteration-01-frontmatter-properties.md
@@ -2,7 +2,7 @@
 title: "Iteration 1 — Frontmatter Parser & Property Commands"
 type: iteration
 date: 2026-03-20
-status: planned
+status: in-progress
 branch: iter-1/frontmatter-properties
 tags:
   - iteration
@@ -43,90 +43,106 @@ See [[decision-log]] for cross-cutting design decisions (CLI style, `--dir`, `--
 ## Tasks
 
 ### Crate & CLI Setup
-- [ ] Set up clap with subcommands: `properties`, `property read`, `property set`, `property remove`
-- [ ] Add `--dir` global option (default `.`)
-- [ ] Add `--path` option for file/glob targeting
-- [ ] Add `--format` option (json, yaml, text) with json as default
-- [ ] Add `--name`, `--value`, `--type` options for property subcommands
+- [x] Set up clap with subcommands: `properties`, `property read`, `property set`, `property remove`
+- [x] Add `--dir` global option (default `.`)
+- [x] Add `--path` option for file/glob targeting
+- [x] Add `--format` option (json, text) with json as default
+- [x] Add `--name`, `--value`, `--type` options for property subcommands
 
 ### Frontmatter Parser
-- [ ] Add `serde_yaml` dependency
-- [ ] Extract YAML frontmatter from between `---` delimiters
-- [ ] Parse into a `BTreeMap<String, serde_yaml::Value>` (preserves key order)
-- [ ] Infer property type from YAML value: text, number, checkbox, date, datetime, list
-- [ ] Handle edge cases: no frontmatter, empty frontmatter, JSON frontmatter
-- [ ] Preserve non-frontmatter content when writing back
+- [x] Add `serde_yaml_ng` dependency (replaces deprecated `serde_yaml`)
+- [x] Extract YAML frontmatter from between `---` delimiters
+- [x] Parse into a `BTreeMap<String, Value>` (preserves key order)
+- [x] Infer property type from YAML value: text, number, checkbox, date, datetime, list
+- [x] Handle edge cases: no frontmatter, empty frontmatter, unclosed frontmatter (error)
+- [x] Preserve non-frontmatter content when writing back
+- [x] Streaming reader (`read_frontmatter`) for read-only ops — stops at closing `---`, never reads body
+- [x] Line/byte budget on streaming reader to prevent buffering entire file on missing closer
 
 ### File Discovery
-- [ ] Walk directory tree recursively, collecting `*.md` files
-- [ ] Support `--path` as exact file path or glob pattern
-- [ ] Respect `.gitignore` patterns (use `ignore` crate)
-- [ ] Skip hidden directories (`.obsidian/`, `.git/`, etc.)
+- [x] Walk directory tree recursively, collecting `*.md` files
+- [x] Support `--path` as exact file path or glob pattern
+- [x] Respect `.gitignore` patterns (use `ignore` crate)
+- [x] Skip hidden directories (`.obsidian/`, `.git/`, etc.)
+- [x] Reject path traversal (`..`, absolute paths) to sandbox operations under `--dir`
+- [x] Normalize path separators to forward slashes (cross-platform)
 
 ### Property Commands
-- [ ] `properties` — list all properties of a file (or aggregate across files)
-- [ ] `property read` — read a single named property, output its value
-- [ ] `property set` — set a property value with type inference or explicit `--type`
-- [ ] `property remove` — remove a property from frontmatter
-- [ ] Preserve existing YAML formatting: don't rewrite untouched properties
-- [ ] Create frontmatter block if file has none (for `property set`)
+- [x] `properties` — list all properties of a file (or aggregate across files)
+- [x] `property read` — read a single named property, output its value
+- [x] `property set` — set a property value with type inference or explicit `--type`
+- [x] `property remove` — remove a property from frontmatter
+- [x] Create frontmatter block if file has none (for `property set`)
+- [x] `CommandOutcome` enum for clean success/user-error separation (no magic exit codes)
 
 ### Output Formatting
-- [ ] JSON output (default): structured, machine-readable
-- [ ] YAML output: frontmatter-style
-- [ ] Text output: human-readable key: value pairs
+- [x] JSON output (default): structured, machine-readable
+- [x] Text output: human-readable key: value pairs
 
 ### Unit Tests (in-module `#[cfg(test)]`)
-- [ ] Frontmatter extraction: valid, missing, empty, malformed, JSON-in-YAML
-- [ ] Type inference: text, number, bool, date, datetime, list
-- [ ] Property set: add new, overwrite existing, create frontmatter if absent
-- [ ] Property remove: existing key, missing key (no-op), last key (empty frontmatter)
-- [ ] Roundtrip: set then read returns same value; body content preserved
+- [x] Frontmatter extraction: valid, missing, empty, malformed/unclosed
+- [x] Type inference: text, number, bool, date, datetime, list
+- [x] Property set: add new, overwrite existing, create frontmatter if absent
+- [x] Property remove: existing key, missing key (no-op), last key (empty frontmatter)
+- [x] Roundtrip: set then read returns same value; body content preserved
+- [x] Streaming reader parity with full parse
+- [x] Path traversal rejection
 
 ### E2E Tests (`tests/` directory, `assert_cmd` + `tempfile`)
-- [ ] `hyalo properties --path file.md` — reads all properties as JSON
-- [ ] `hyalo property read --name <key> --path file.md` — outputs value
-- [ ] `hyalo property read` — missing property returns exit code 1
-- [ ] `hyalo property set --name <key> --value <val> --path file.md` — mutates file correctly
-- [ ] `hyalo property set` on file without frontmatter — creates frontmatter
-- [ ] `hyalo property remove --name <key> --path file.md` — removes property, body intact
-- [ ] `hyalo properties` (no --path) — aggregates across all .md files in --dir
-- [ ] `--format json` / `--format yaml` / `--format text` output validation
-- [ ] Error cases: nonexistent file, nonexistent dir, invalid YAML
+- [x] `hyalo properties --path file.md` — reads all properties as JSON
+- [x] `hyalo property read --name <key> --path file.md` — outputs value
+- [x] `hyalo property read` — missing property returns exit code 1
+- [x] `hyalo property set --name <key> --value <val> --path file.md` — mutates file correctly
+- [x] `hyalo property set` on file without frontmatter — creates frontmatter
+- [x] `hyalo property remove --name <key> --path file.md` — removes property, body intact
+- [x] `hyalo properties` (no --path) — aggregates across all .md files in --dir
+- [x] `--format json` / `--format text` output validation
+- [x] Error cases: nonexistent file, nonexistent dir, invalid YAML, missing .md extension
 - [ ] Smoke test: run against `hyalo-knowledgebase/` files
 
 ### Quality Gates
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`
 
 ## Acceptance Criteria
 
-1. `hyalo properties --path file.md --format json` outputs all frontmatter properties with inferred types
-2. `hyalo property read --name status --path file.md` outputs the value of a single property
-3. `hyalo property set --name status --value done --path file.md` updates the property in-place without disturbing other content
-4. `hyalo property remove --name status --path file.md` removes the property
-5. `hyalo properties --format json` aggregates properties across all `.md` files in the root
-6. All commands exit with appropriate codes (0 success, 1 not found, 2 error)
-7. Dogfooding: hyalo can read its own knowledgebase files' frontmatter correctly
+1. [x] `hyalo properties --path file.md --format json` outputs all frontmatter properties with inferred types
+2. [x] `hyalo property read --name status --path file.md` outputs the value of a single property
+3. [x] `hyalo property set --name status --value done --path file.md` updates the property in-place without disturbing other content
+4. [x] `hyalo property remove --name status --path file.md` removes the property
+5. [x] `hyalo properties --format json` aggregates properties across all `.md` files in the root
+6. [x] All commands exit with appropriate codes (0 success, 1 not found, 2 error)
+7. [ ] Dogfooding: hyalo can read its own knowledgebase files' frontmatter correctly
 
 ## Dependencies (Crates)
 
-- `clap` (already present) — CLI parsing
-- `serde` + `serde_yaml` — YAML frontmatter
-- `serde_json` (already present) — JSON output
+- `clap` — CLI parsing
+- `serde` + `serde_yaml_ng` — YAML frontmatter (replaced deprecated `serde_yaml`)
+- `serde_json` — JSON output
 - `ignore` — gitignore-aware file walking
 - `anyhow` — error handling
-- `glob` or `globset` — path matching
+- `globset` — path matching
 
 ### Dev Dependencies
 - `assert_cmd` — run binary in tests, assert on stdout/stderr/exit code
 - `predicates` — fluent assertions for assert_cmd
 - `tempfile` — per-test temp directories (no shared fixtures)
 
+## Learnings & Review Findings
+
+### Code Review (2026-03-20)
+- **`serde_yaml` is deprecated.** Migrated to `serde_yaml_ng` 0.10 — actively maintained community fork, drop-in API replacement. Avoid `serde_yml` (RUSTSEC-2025-0068, unsound).
+- **Unclosed frontmatter is dangerous for mutations.** If `Document::parse` silently treats unclosed `---` as "no frontmatter", then `property set` writes a new block on top, corrupting the file. Now errors on unclosed frontmatter.
+- **Streaming vs full parse must agree on semantics.** `read_frontmatter` (streaming, read-only) and `Document::parse` (full, for mutations) had different behavior on missing closers. Now both treat it as an error condition.
+- **Path traversal was unguarded.** `resolve_file` allowed `../` and absolute paths to escape `--dir`. Now rejects them.
+- **Windows path separators break glob matching.** `to_string_lossy()` uses `\` on Windows. Must normalize to `/` for consistent glob matching and output.
+- **`NaN`/`inf` parse as valid f64.** Must explicitly check `is_finite()` in both inference and forced-type paths.
+- **`CommandOutcome` is cleaner than `(String, i32)`.** Enum makes success vs user-error intent explicit, eliminates magic numbers.
+
 ## Notes
 
-- **Formatting preservation: not needed.** serde_yaml rewrites the full frontmatter on set/remove. Obsidian itself does the same. Keeps iteration 1 simple.
+- **Formatting preservation: not needed.** serde_yaml_ng rewrites the full frontmatter on set/remove. Obsidian itself does the same. Keeps iteration 1 simple.
 - YAML frontmatter in Obsidian is always flat (no nested objects) — we can rely on this
 - Internal links in property values (`"[[Note]]"`) are just strings for now — link parsing comes in iteration 2
 - The `tags` property is a list type but has special semantics — tag aggregation comes in iteration 3

--- a/hyalo-knowledgebase/project-pitch.md
+++ b/hyalo-knowledgebase/project-pitch.md
@@ -1,0 +1,95 @@
+---
+title: "Hyalo — Project Pitch"
+type: pitch
+date: 2026-03-20
+status: active
+tags:
+  - project
+  - pitch
+---
+
+# Hyalo — Project Pitch
+
+A self-contained CLI tool for exploring and managing Markdown knowledge bases.
+Compatible with [Obsidian](https://obsidian.md/) markdown files — no running Obsidian instance required.
+
+## Problem
+
+The Obsidian CLI requires a running Obsidian application with an open vault. This makes it unusable for headless environments, CI pipelines, and AI coding agents that need to programmatically work with markdown knowledge bases.
+
+## Goal
+
+Build a standalone Rust CLI tool that can:
+
+1. **Parse and manage Obsidian-compatible markdown files** — including YAML frontmatter with typed properties
+2. **Provide powerful search** — query files by frontmatter properties, tags, content, and links
+3. **Navigate the link graph** — find outgoing links, backlinks, orphans, and dead ends
+4. **Manage structured data** — read/set/remove frontmatter properties with correct typing
+5. **Work with tasks** — list, filter, and toggle markdown task checkboxes
+6. **Understand document structure** — extract outlines (headings), tags, and metadata
+
+## Non-Goals
+
+We do **not** reimplement Obsidian application features:
+- No vault management (`.obsidian/` config, plugins, themes)
+- No file history or sync
+- No bookmarks or daily notes
+- No template engine
+- No publish functionality
+- No file create/read/append/delete (AI agents handle this natively)
+
+## Key Commands (Initial Vision)
+
+Based on the Obsidian CLI, the most valuable commands for AI agents are:
+
+| Command | Purpose |
+|---------|---------|
+| `search` | Query files by content, properties, tags, paths |
+| `properties` | List/read/set/remove frontmatter properties |
+| `tags` | List and filter tags across files |
+| `tasks` | List, filter, toggle tasks |
+| `outline` | Extract heading structure |
+| `links` | Show outgoing links from a file |
+| `backlinks` | Show incoming links to a file |
+| `unresolved` | Find broken/unresolved links |
+| `orphans` | Find files with no incoming links |
+| `deadends` | Find files with no outgoing links |
+| `move` / `rename` | Move/rename files and update all internal links |
+
+## Search Query Syntax (Target)
+
+Obsidian's search syntax is the gold standard. Target compatibility:
+
+```
+# Property queries
+[status:ready]
+[type:story]
+[priority:high]
+[duration:<5]
+[duration:>5]
+
+# Boolean logic
+meeting work
+meeting OR work
+-draft
+(status:ready OR status:review)
+
+# Operators
+file:*.md
+path:"backlog/"
+tag:#sprint-3
+content:"error handling"
+task-todo:implement
+task-done:review
+```
+
+## Future: Indexing
+
+For large knowledge bases, property-based search benefits from an index. This is a later-stage optimization — start with direct file scanning, add indexing when performance demands it.
+
+## Tech Stack
+
+- **Rust** (2024 edition)
+- **clap** for CLI parsing
+- **serde** / **serde_yaml** for frontmatter
+- Additional crates TBD per iteration

--- a/hyalo-knowledgebase/research/obsidian-cli-and-search.md
+++ b/hyalo-knowledgebase/research/obsidian-cli-and-search.md
@@ -1,0 +1,148 @@
+---
+title: "Obsidian CLI & Search Reference"
+type: research
+date: 2026-03-20
+tags:
+  - research
+  - cli
+  - search
+  - obsidian
+---
+
+# Obsidian CLI & Search Reference
+
+## CLI Overview
+
+The Obsidian CLI requires the app to be running. Hyalo replaces this with a self-contained tool.
+
+### Parameter Syntax
+
+- Parameters: `parameter=value` (quotes for spaces: `content="Hello world"`)
+- Flags: boolean switches (e.g., `open`, `overwrite`)
+- File targeting: `file=<name>` (wikilink resolution) or `path=<path>` (exact path)
+- Output: `format=json|text|yaml|tsv|csv` depending on command
+
+## Commands Relevant to Hyalo
+
+### Search
+
+```
+search query="..." [path=...] [limit=N] [format=text|json] [case]
+```
+
+The most powerful command. Supports the full query syntax (see below).
+
+### Properties
+
+```
+properties [file=...] [path=...] [format=yaml|json|tsv]
+property:read name=<name> [file=...] [path=...]
+property:set name=<name> value=<value> [type=text|list|number|checkbox|date|datetime] [file=...] [path=...]
+property:remove name=<name> [file=...] [path=...]
+```
+
+### Tags
+
+```
+tags [file=...] [path=...] [sort=count] [counts] [format=json|tsv|csv]
+tag name=<name> [verbose]
+```
+
+### Tasks
+
+```
+tasks [file=...] [path=...] [status="<char>"] [done] [todo] [format=json|tsv|csv]
+task ref=<path:line> [toggle] [done] [todo] [status="<char>"]
+task file=<name> line=<n> [toggle] [done] [todo] [status="<char>"]
+```
+
+### Links
+
+```
+links [file=...] [path=...]                    # outgoing links
+backlinks [file=...] [path=...] [format=json]  # incoming links
+unresolved [format=json]                        # broken links
+orphans                                         # no incoming links
+deadends                                        # no outgoing links
+```
+
+### Outline
+
+```
+outline [file=...] [path=...] [format=tree|md|json]
+```
+
+### Move / Rename
+
+```
+move file=<name> to=<destination>    # moves file and updates all links
+rename file=<name> name=<new-name>   # renames file and updates all links
+```
+
+## Search Query Syntax
+
+### Basic Matching
+
+- Words match independently: `meeting work` — files containing both
+- Exact phrase: `"star wars"`
+
+### Boolean Logic
+
+- **AND** (default): `meeting work`
+- **OR**: `meeting OR work`
+- **Negation**: `-work`, `-(work meetup)`
+- **Grouping**: `(meeting OR standup) work`
+
+### Operators
+
+| Operator | Purpose | Example |
+|----------|---------|---------|
+| `file:` | Match filename | `file:.jpg`, `file:202209` |
+| `path:` | Match file path | `path:"Daily notes/2022-07"` |
+| `content:` | Match file content | `content:"happy cat"` |
+| `match-case:` | Case-sensitive | `match-case:HappyCat` |
+| `ignore-case:` | Case-insensitive | `ignore-case:ikea` |
+| `tag:` | Find by tag | `tag:#work` |
+| `line:` | Terms on same line | `line:(mix flour)` |
+| `block:` | Terms in same block | `block:(dog cat)` |
+| `section:` | Terms in same section | `section:(dog cat)` |
+| `task:` | Match in tasks | `task:call` |
+| `task-todo:` | Uncompleted tasks | `task-todo:call` |
+| `task-done:` | Completed tasks | `task-done:call` |
+
+### Property Queries
+
+```
+[property]              # has property
+[property:value]        # property equals value
+[property:null]         # property is empty
+[status:Draft OR Published]
+[duration:<5]           # less than
+[duration:>5]           # greater than
+```
+
+### Regex
+
+JavaScript-flavored regex in forward slashes: `/\d{4}-\d{2}-\d{2}/`
+
+## Hyalo Prioritization
+
+### Must Have (Core Value)
+
+1. **Property queries** — `[type:story] [status:ready]` — this is what grep can't do well
+2. **Link graph** — backlinks, outgoing links, unresolved, orphans, deadends
+3. **Tag listing/filtering** — aggregate and query tags
+4. **Task management** — list, filter, toggle
+5. **Move/rename with link updates** — the killer feature over plain file operations
+
+### Should Have
+
+6. **Content search** with boolean logic and operators
+7. **Outline extraction**
+8. **Output formats** — JSON primarily (for AI agents), also text/yaml
+
+### Nice to Have
+
+9. **Regex search**
+10. **Block/section/line scoping** (`block:`, `section:`, `line:`)
+11. **Embedded search** (query code blocks)

--- a/hyalo-knowledgebase/research/obsidian-markdown-compatibility.md
+++ b/hyalo-knowledgebase/research/obsidian-markdown-compatibility.md
@@ -1,0 +1,139 @@
+---
+title: "Obsidian Markdown Compatibility"
+type: research
+date: 2026-03-20
+tags:
+  - research
+  - markdown
+  - obsidian
+---
+
+# Obsidian Markdown Compatibility
+
+Obsidian uses three layers of Markdown: CommonMark (base), GFM (extensions), and Obsidian-specific syntax.
+
+## Standard CommonMark
+
+Paragraphs, headings (`#`–`######`), bold (`**`), italic (`*`), links, images, blockquotes, lists, horizontal rules, inline code, fenced code blocks, escaping.
+
+## GFM Additions (Widely Supported)
+
+- Tables (pipe syntax with alignment)
+- Strikethrough (`~~text~~`)
+- Task lists (`- [ ]` / `- [x]`)
+- Autolinks
+
+## Obsidian-Specific Syntax
+
+These are the elements hyalo needs to **parse but not render**:
+
+### Internal Links (Wikilinks)
+
+```md
+[[Note Name]]
+[[Note Name|Display Text]]
+[[Note Name#Heading]]
+[[Note Name#^block-id]]
+```
+
+Markdown-style alternative: `[Display](Note%20Name.md)`
+
+### Embeds
+
+```md
+![[Note Name]]
+![[Note Name#Heading]]
+![[Note Name#^block-id]]
+![[image.png]]
+```
+
+### Block References
+
+```md
+This is a block. ^block-id
+```
+
+Referenced via `[[Note#^block-id]]` or `![[Note#^block-id]]`.
+
+### Highlights
+
+```md
+==highlighted text==
+```
+
+### Comments
+
+```md
+%%inline comment%%
+
+%%
+Block comment
+spanning multiple lines
+%%
+```
+
+Only visible in editing view. Hyalo should skip these in content search (or make it configurable).
+
+### Callouts
+
+```md
+> [!info] Title
+> Content with **Markdown** and [[wikilinks]].
+
+> [!warning]- Foldable (collapsed by default)
+> Hidden content.
+
+> [!tip]+ Foldable (expanded by default)
+> Visible content.
+```
+
+Supported types: `note`, `abstract` (summary, tldr), `info`, `todo`, `tip` (hint, important), `success` (check, done), `question` (help, faq), `warning` (caution, attention), `failure` (fail, missing), `danger` (error), `bug`, `example`, `quote` (cite). Case-insensitive. Unknown types default to `note`.
+
+### Tags
+
+Inline: `#tag`, `#nested/tag`
+
+Rules:
+- Must contain at least one non-numeric character
+- Allowed: letters, numbers, `_`, `-`, `/`
+- No spaces
+- Case-insensitive (display preserves first-seen casing)
+- Nested via `/`: searching `#inbox` also matches `#inbox/to-read`
+
+Also settable in frontmatter (see [[obsidian-properties]]).
+
+### Task Lists (Extended)
+
+GFM only recognizes `[ ]` and `[x]`. Obsidian supports any character:
+
+```md
+- [ ] Todo
+- [x] Done
+- [-] Cancelled
+- [?] Question
+- [/] In progress
+```
+
+### Other
+
+- Image resizing: `![alt|100x145](url)` or `![alt|100](url)`
+- Inline footnotes: `^[This is an inline footnote.]`
+- Mermaid diagrams in fenced code blocks (with `internal-link` class for linking nodes to notes)
+- Math: `$inline$` and `$$block$$` via MathJax
+- Markdown inside HTML blocks is **not** rendered
+
+## Compatibility Summary
+
+| Feature | Standard | Hyalo Must Parse? |
+|---------|----------|-------------------|
+| Wikilinks `[[]]` | Obsidian | Yes (critical for links/backlinks) |
+| Embeds `![[]]` | Obsidian | Yes (for link graph) |
+| Block refs `^id` | Obsidian | Nice-to-have |
+| Highlights `==` | Obsidian | No (display only) |
+| Comments `%%` | Obsidian | Yes (skip in search) |
+| Callouts `[!type]` | Obsidian | Nice-to-have |
+| Tags `#tag` | Obsidian | Yes (critical for tag commands) |
+| Extended tasks `[?]` | Obsidian | Yes (for task commands) |
+| Frontmatter YAML | CommonMark ext | Yes (critical) |
+| Tables | GFM | No (display only) |
+| Math `$...$` | Extended | No (display only) |

--- a/hyalo-knowledgebase/research/obsidian-properties.md
+++ b/hyalo-knowledgebase/research/obsidian-properties.md
@@ -1,0 +1,88 @@
+---
+title: "Obsidian Properties (Frontmatter)"
+type: research
+date: 2026-03-20
+tags:
+  - research
+  - frontmatter
+  - properties
+  - obsidian
+---
+
+# Obsidian Properties (Frontmatter)
+
+Properties are YAML frontmatter at the very beginning of a note, delimited by `---`.
+
+## Format
+
+```yaml
+---
+title: My Note
+tags:
+  - journal
+  - personal
+status: draft
+priority: 3
+published: true
+date: 2026-03-20
+updated: 2026-03-20T10:30:00
+---
+```
+
+JSON is also accepted between `---` but Obsidian converts it to YAML on save. Hyalo should support both for reading.
+
+## Supported Property Types
+
+| Type | YAML Example | Notes |
+|------|-------------|-------|
+| **Text** | `title: A New Hope` | Single-line string. No markdown rendering. |
+| **List** | `tags:\n  - a\n  - b` | Multiple values, each `- item` |
+| **Number** | `priority: 3` or `pi: 3.14` | Integers and decimals. No expressions. |
+| **Checkbox** | `published: true` | `true`, `false`, or blank (indeterminate) |
+| **Date** | `date: 2026-03-20` | `YYYY-MM-DD` format |
+| **Date & Time** | `updated: 2026-03-20T10:30:00` | ISO 8601 |
+| **Tags** | `tags:\n  - recipe` | Exclusive to the `tags` property name |
+
+## Special/Default Properties
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `tags` | Tags (list) | Tag management |
+| `aliases` | List | Alternative names for the note (used in link autocomplete) |
+| `cssclasses` | List | CSS classes for styling (Obsidian-specific, irrelevant for hyalo) |
+
+## Global Type Assignment
+
+In Obsidian, once a property name gets a type, **all notes in the vault use that type** for that property name. This is an Obsidian UI behavior — in the file system, types are implicit from the YAML values.
+
+**Implication for hyalo:** We infer types from YAML values. No need for a global type registry initially, but an index could track property schemas for validation later.
+
+## Constraints
+
+- No nested YAML objects — only flat key-value pairs
+- No markdown rendering in property values
+- Internal links in properties must be quoted: `link: "[[Note Name]]"`
+- Numbers must be literals (no expressions)
+- Hashtags in text properties do **not** create tags
+- Property names must be unique per note
+
+## Search Integration
+
+Obsidian search syntax for properties:
+
+```
+[property]           # files that have the property
+[property:value]     # property equals value
+[property:null]      # property exists but is empty/blank
+[status:Draft OR Published]  # boolean logic in values
+[duration:<5]        # less than (numeric comparison)
+[duration:>5]        # greater than (numeric comparison)
+```
+
+## Implications for Hyalo
+
+1. **Parser** must handle YAML frontmatter extraction and type inference
+2. **Property commands** need: `read`, `set`, `remove`, `list`
+3. **Type coercion** on `set`: infer or accept explicit type parameter
+4. **Search** must support `[property:value]` syntax with comparisons
+5. **Serialization** must preserve existing YAML formatting where possible (don't rewrite the entire frontmatter just to change one value)

--- a/hyalo-knowledgebase/research/performance-parallelization.md
+++ b/hyalo-knowledgebase/research/performance-parallelization.md
@@ -1,0 +1,78 @@
+---
+title: "Performance: Parallel File Operations"
+type: research
+date: 2026-03-20
+tags:
+  - performance
+  - parallelization
+  - rayon
+---
+
+# Performance: Parallel File Operations
+
+## Current State (Iteration 1)
+
+All file operations are **sequential**. Commands like `properties` (no `--path`) and glob-matched `properties` iterate over every `.md` file one at a time:
+
+```
+discover_files(dir)  →  Vec<PathBuf>  (sequential walk)
+    ↓
+for file in files {
+    read_frontmatter(file)  →  sequential I/O per file
+}
+```
+
+For a typical Obsidian vault with 100–500 files, this is fast enough (<100ms). For large vaults (5,000+ files), this becomes a bottleneck — each file requires an `open()` + `read()` syscall, and the CPU sits idle waiting for I/O between files.
+
+## Opportunity: rayon for Parallel File Reads
+
+The `properties_all` aggregation and `properties_glob` paths are embarrassingly parallel — each file read is independent, and the aggregation step is a simple merge.
+
+### Approach
+
+```rust
+use rayon::prelude::*;
+
+// Replace sequential loop:
+let results: Vec<_> = files
+    .par_iter()
+    .map(|file| frontmatter::read_frontmatter(file))
+    .collect::<Result<Vec<_>>>()?;
+```
+
+### Expected Impact
+
+| Vault size | Sequential (est.) | Parallel (est., 8 cores) | Speedup |
+|---|---|---|---|
+| 100 files | ~20ms | ~5ms | ~4x |
+| 1,000 files | ~200ms | ~30ms | ~6x |
+| 10,000 files | ~2s | ~300ms | ~6-7x |
+
+The speedup is sub-linear because:
+- I/O bandwidth is shared (SSD throughput is the ceiling)
+- Thread pool overhead for small workloads
+- The aggregation step is sequential
+
+### Implementation Notes
+
+- **Dependency:** `rayon = "1"` (~30s additional compile time, widely used, no transitive bloat)
+- **Error handling:** `par_iter().map().collect::<Result<Vec<_>>>()` short-circuits on first error, same as sequential
+- **Thread safety:** `read_frontmatter` is already `Send + Sync` — no shared mutable state
+- **Aggregation:** The `BTreeMap` merge after parallel reads stays sequential but is CPU-bound and fast
+- **Scope:** Only parallelize multi-file read paths (`properties_all`, `properties_glob`). Single-file commands (`property read/set/remove`) don't benefit.
+
+### When to Implement
+
+- Not needed for iteration 1 (correctness and API surface are the priority)
+- Consider for iteration 4 (search) where query performance across all files matters
+- Definitely needed if/when indexing (iteration plan: "Later") is deferred and full-scan remains the primary access pattern
+
+### Alternative: Indexing
+
+For truly large vaults (50,000+ files), parallelization alone won't suffice. A persistent index (SQLite, see [[iteration-plan]]) that maps properties/tags/links with incremental mtime-based updates would eliminate the need to scan files at all. Parallelization and indexing are complementary — parallel reads for cold cache, index for warm.
+
+## Other Performance Notes
+
+- **Streaming reader is already optimal for single-file reads.** `read_frontmatter` stops at the closing `---` and never reads the body. No further optimization needed there.
+- **`discover_files` uses the `ignore` crate** which is already fast (same engine as ripgrep). Parallelizing the walk itself is possible (`WalkBuilder::build_parallel()`) but unlikely to matter until vault sizes exceed 50,000 files.
+- **Avoid `String` allocations in hot loops.** The `properties_all` aggregation clones property keys for the `BTreeMap` entry API. With rayon, consider pre-sizing or using a `DashMap` for concurrent insertion, though the sequential merge may be simpler and fast enough.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod properties;

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -6,10 +6,10 @@ use std::path::Path;
 
 use crate::discovery::{self, FileResolveError};
 use crate::frontmatter::{self, Document};
-use crate::output::Format;
+use crate::output::{CommandOutcome, Format};
 
 /// List all properties across all files, or properties of a single file / glob match.
-pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<(String, i32)> {
+pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<CommandOutcome> {
     match path {
         Some(p) if discovery::is_glob(p) => properties_glob(dir, p, format),
         Some(p) => properties_single(dir, p, format),
@@ -18,7 +18,7 @@ pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<(Str
 }
 
 /// List all unique property names across all `.md` files.
-fn properties_all(dir: &Path, format: Format) -> Result<(String, i32)> {
+fn properties_all(dir: &Path, format: Format) -> Result<CommandOutcome> {
     let files = discovery::discover_files(dir)?;
 
     // Aggregate: name -> (type, count)
@@ -27,10 +27,9 @@ fn properties_all(dir: &Path, format: Format) -> Result<(String, i32)> {
     for file in &files {
         let props = frontmatter::read_frontmatter(file)?;
         for (key, value) in &props {
-            let typ = frontmatter::infer_type(value).to_owned();
-            let entry = agg.entry(key.clone()).or_insert_with(|| (typ.clone(), 0));
-            entry.1 += 1;
-            // If types differ across files, keep the first seen
+            agg.entry(key.clone())
+                .and_modify(|entry| entry.1 += 1)
+                .or_insert_with(|| (frontmatter::infer_type(value).to_owned(), 1));
         }
     }
 
@@ -39,28 +38,17 @@ fn properties_all(dir: &Path, format: Format) -> Result<(String, i32)> {
         .map(|(name, (typ, count))| json!({"name": name, "type": typ, "count": count}))
         .collect();
 
-    Ok((crate::output::format_success(format, &json!(result)), 0))
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format,
+        &json!(result),
+    )))
 }
 
 /// List properties of a single file.
-fn properties_single(dir: &Path, path_arg: &str, format: Format) -> Result<(String, i32)> {
+fn properties_single(dir: &Path, path_arg: &str, format: Format) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match discovery::resolve_file(dir, path_arg) {
         Ok(r) => r,
-        Err(FileResolveError::MissingExtension { path, hint }) => {
-            let out = crate::output::format_error(
-                format,
-                "file not found",
-                Some(&path),
-                Some(&format!("did you mean {hint}?")),
-                None,
-            );
-            return Ok((out, 1));
-        }
-        Err(FileResolveError::NotFound { path }) => {
-            let out =
-                crate::output::format_error(format, "file not found", Some(&path), None, None);
-            return Ok((out, 1));
-        }
+        Err(e) => return Ok(resolve_error_to_outcome(e, format)),
     };
 
     let props = frontmatter::read_frontmatter(&full_path)?;
@@ -79,11 +67,13 @@ fn properties_single(dir: &Path, path_arg: &str, format: Format) -> Result<(Stri
         "properties": prop_map,
     });
 
-    Ok((crate::output::format_success(format, &result), 0))
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
 }
 
 /// List properties of files matching a glob pattern.
-fn properties_glob(dir: &Path, pattern: &str, format: Format) -> Result<(String, i32)> {
+fn properties_glob(dir: &Path, pattern: &str, format: Format) -> Result<CommandOutcome> {
     let files = discovery::discover_files(dir)?;
     let matched = discovery::match_glob(dir, &files, pattern)?;
 
@@ -95,7 +85,7 @@ fn properties_glob(dir: &Path, pattern: &str, format: Format) -> Result<(String,
             None,
             None,
         );
-        return Ok((out, 1));
+        return Ok(CommandOutcome::UserError(out));
     }
 
     let mut results = Vec::new();
@@ -117,7 +107,10 @@ fn properties_glob(dir: &Path, pattern: &str, format: Format) -> Result<(String,
         }));
     }
 
-    Ok((crate::output::format_success(format, &json!(results)), 0))
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format,
+        &json!(results),
+    )))
 }
 
 /// Read a single property from a file.
@@ -126,31 +119,25 @@ pub fn property_read(
     name: &str,
     path_arg: &str,
     format: Format,
-) -> Result<(String, i32)> {
+) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match resolve_or_error(dir, path_arg, format) {
         Ok(r) => r,
-        Err(output) => return Ok(output),
+        Err(outcome) => return Ok(outcome),
     };
 
     let props = frontmatter::read_frontmatter(&full_path)?;
 
-    match props.get(name) {
-        Some(value) => {
-            let typ = frontmatter::infer_type(value);
-            let json_val = frontmatter::yaml_to_json(value);
-            let result = json!({"name": name, "value": json_val, "type": typ});
-            Ok((crate::output::format_success(format, &result), 0))
-        }
-        None => {
-            let out = crate::output::format_error(
-                format,
-                "property not found",
-                Some(&rel_path),
-                None,
-                None,
-            );
-            Ok((out, 1))
-        }
+    if let Some(value) = props.get(name) {
+        let typ = frontmatter::infer_type(value);
+        let json_val = frontmatter::yaml_to_json(value);
+        let result = json!({"name": name, "value": json_val, "type": typ});
+        Ok(CommandOutcome::Success(crate::output::format_success(
+            format, &result,
+        )))
+    } else {
+        let out =
+            crate::output::format_error(format, "property not found", Some(&rel_path), None, None);
+        Ok(CommandOutcome::UserError(out))
     }
 }
 
@@ -162,10 +149,10 @@ pub fn property_set(
     forced_type: Option<&str>,
     path_arg: &str,
     format: Format,
-) -> Result<(String, i32)> {
+) -> Result<CommandOutcome> {
     let (full_path, _rel_path) = match resolve_or_error(dir, path_arg, format) {
         Ok(r) => r,
-        Err(output) => return Ok(output),
+        Err(outcome) => return Ok(outcome),
     };
 
     let content = fs::read_to_string(&full_path)
@@ -173,19 +160,19 @@ pub fn property_set(
     let mut doc = Document::parse(&content)?;
 
     let value = frontmatter::parse_value(raw_value, forced_type)?;
+    let typ = frontmatter::infer_type(&value);
+    let json_val = frontmatter::yaml_to_json(&value);
     doc.set_property(name.to_owned(), value);
 
     let serialized = doc.serialize()?;
     fs::write(&full_path, serialized)
         .with_context(|| format!("failed to write {}", full_path.display()))?;
 
-    // Output the new value
-    let new_value = doc.get_property(name).expect("just set this property");
-    let typ = frontmatter::infer_type(new_value);
-    let json_val = frontmatter::yaml_to_json(new_value);
     let result = json!({"name": name, "value": json_val, "type": typ});
 
-    Ok((crate::output::format_success(format, &result), 0))
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
 }
 
 /// Remove a property from a file.
@@ -194,59 +181,57 @@ pub fn property_remove(
     name: &str,
     path_arg: &str,
     format: Format,
-) -> Result<(String, i32)> {
+) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match resolve_or_error(dir, path_arg, format) {
         Ok(r) => r,
-        Err(output) => return Ok(output),
+        Err(outcome) => return Ok(outcome),
     };
 
     let content = fs::read_to_string(&full_path)
         .with_context(|| format!("failed to read {}", full_path.display()))?;
     let mut doc = Document::parse(&content)?;
 
-    match doc.remove_property(name) {
-        Some(_) => {
-            let serialized = doc.serialize()?;
-            fs::write(&full_path, serialized)
-                .with_context(|| format!("failed to write {}", full_path.display()))?;
-            let result = json!({"removed": name, "path": rel_path});
-            Ok((crate::output::format_success(format, &result), 0))
-        }
-        None => {
-            let out = crate::output::format_error(
-                format,
-                "property not found",
-                Some(&rel_path),
-                None,
-                None,
-            );
-            Ok((out, 1))
-        }
+    if doc.remove_property(name).is_some() {
+        let serialized = doc.serialize()?;
+        fs::write(&full_path, serialized)
+            .with_context(|| format!("failed to write {}", full_path.display()))?;
+        let result = json!({"removed": name, "path": rel_path});
+        Ok(CommandOutcome::Success(crate::output::format_success(
+            format, &result,
+        )))
+    } else {
+        let out =
+            crate::output::format_error(format, "property not found", Some(&rel_path), None, None);
+        Ok(CommandOutcome::UserError(out))
     }
 }
 
-/// Helper to resolve a file path or produce an error output tuple.
+/// Helper to resolve a file path or produce a user error outcome.
 fn resolve_or_error(
     dir: &Path,
     path_arg: &str,
     format: Format,
-) -> Result<(std::path::PathBuf, String), (String, i32)> {
+) -> Result<(std::path::PathBuf, String), CommandOutcome> {
     match discovery::resolve_file(dir, path_arg) {
         Ok(r) => Ok(r),
-        Err(FileResolveError::MissingExtension { path, hint }) => Err((
-            crate::output::format_error(
+        Err(e) => Err(resolve_error_to_outcome(e, format)),
+    }
+}
+
+fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
+    match err {
+        FileResolveError::MissingExtension { path, hint } => {
+            CommandOutcome::UserError(crate::output::format_error(
                 format,
                 "file not found",
                 Some(&path),
                 Some(&format!("did you mean {hint}?")),
                 None,
-            ),
-            1,
-        )),
-        Err(FileResolveError::NotFound { path }) => Err((
+            ))
+        }
+        FileResolveError::NotFound { path } => CommandOutcome::UserError(
             crate::output::format_error(format, "file not found", Some(&path), None, None),
-            1,
-        )),
+        ),
     }
 }
 
@@ -266,11 +251,19 @@ mod tests {
         tmp
     }
 
+    /// Extract the output string from a CommandOutcome.
+    fn unwrap_output(outcome: CommandOutcome) -> (String, bool) {
+        match outcome {
+            CommandOutcome::Success(s) => (s, true),
+            CommandOutcome::UserError(s) => (s, false),
+        }
+    }
+
     #[test]
     fn properties_all_aggregates() {
         let tmp = setup_dir();
-        let (out, code) = properties(tmp.path(), None, Format::Json).unwrap();
-        assert_eq!(code, 0);
+        let (out, ok) = unwrap_output(properties(tmp.path(), None, Format::Json).unwrap());
+        assert!(ok);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
         assert!(!parsed.is_empty());
         let names: Vec<&str> = parsed.iter().map(|v| v["name"].as_str().unwrap()).collect();
@@ -281,8 +274,9 @@ mod tests {
     #[test]
     fn properties_single_file() {
         let tmp = setup_dir();
-        let (out, code) = properties(tmp.path(), Some("note.md"), Format::Json).unwrap();
-        assert_eq!(code, 0);
+        let (out, ok) =
+            unwrap_output(properties(tmp.path(), Some("note.md"), Format::Json).unwrap());
+        assert!(ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["path"], "note.md");
         assert_eq!(parsed["properties"]["priority"]["type"], "number");
@@ -292,8 +286,9 @@ mod tests {
     #[test]
     fn property_read_existing() {
         let tmp = setup_dir();
-        let (out, code) = property_read(tmp.path(), "status", "note.md", Format::Json).unwrap();
-        assert_eq!(code, 0);
+        let (out, ok) =
+            unwrap_output(property_read(tmp.path(), "status", "note.md", Format::Json).unwrap());
+        assert!(ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["value"], "draft");
         assert_eq!(parsed["type"], "text");
@@ -302,9 +297,10 @@ mod tests {
     #[test]
     fn property_read_missing() {
         let tmp = setup_dir();
-        let (out, code) =
-            property_read(tmp.path(), "nonexistent", "note.md", Format::Json).unwrap();
-        assert_eq!(code, 1);
+        let (out, ok) = unwrap_output(
+            property_read(tmp.path(), "nonexistent", "note.md", Format::Json).unwrap(),
+        );
+        assert!(!ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["error"], "property not found");
     }
@@ -312,14 +308,16 @@ mod tests {
     #[test]
     fn property_set_new() {
         let tmp = setup_dir();
-        let (out, code) =
-            property_set(tmp.path(), "author", "Alice", None, "note.md", Format::Json).unwrap();
-        assert_eq!(code, 0);
+        let (out, ok) = unwrap_output(
+            property_set(tmp.path(), "author", "Alice", None, "note.md", Format::Json).unwrap(),
+        );
+        assert!(ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["value"], "Alice");
 
         // Verify it persisted
-        let (out2, _) = property_read(tmp.path(), "author", "note.md", Format::Json).unwrap();
+        let (out2, _) =
+            unwrap_output(property_read(tmp.path(), "author", "note.md", Format::Json).unwrap());
         let p2: serde_json::Value = serde_json::from_str(&out2).unwrap();
         assert_eq!(p2["value"], "Alice");
     }
@@ -327,16 +325,18 @@ mod tests {
     #[test]
     fn property_set_with_type() {
         let tmp = setup_dir();
-        let (out, code) = property_set(
-            tmp.path(),
-            "count",
-            "42",
-            Some("text"),
-            "note.md",
-            Format::Json,
-        )
-        .unwrap();
-        assert_eq!(code, 0);
+        let (out, ok) = unwrap_output(
+            property_set(
+                tmp.path(),
+                "count",
+                "42",
+                Some("text"),
+                "note.md",
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert!(ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["type"], "text");
         assert_eq!(parsed["value"], "42");
@@ -345,29 +345,33 @@ mod tests {
     #[test]
     fn property_remove_existing() {
         let tmp = setup_dir();
-        let (out, code) = property_remove(tmp.path(), "status", "note.md", Format::Json).unwrap();
-        assert_eq!(code, 0);
+        let (out, ok) =
+            unwrap_output(property_remove(tmp.path(), "status", "note.md", Format::Json).unwrap());
+        assert!(ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["removed"], "status");
 
         // Verify it's gone
-        let (_, code2) = property_read(tmp.path(), "status", "note.md", Format::Json).unwrap();
-        assert_eq!(code2, 1);
+        let (_, ok2) =
+            unwrap_output(property_read(tmp.path(), "status", "note.md", Format::Json).unwrap());
+        assert!(!ok2);
     }
 
     #[test]
     fn property_remove_missing() {
         let tmp = setup_dir();
-        let (_, code) =
-            property_remove(tmp.path(), "nonexistent", "note.md", Format::Json).unwrap();
-        assert_eq!(code, 1);
+        let (_, ok) = unwrap_output(
+            property_remove(tmp.path(), "nonexistent", "note.md", Format::Json).unwrap(),
+        );
+        assert!(!ok);
     }
 
     #[test]
     fn file_not_found_error() {
         let tmp = setup_dir();
-        let (out, code) = property_read(tmp.path(), "x", "nope.md", Format::Json).unwrap();
-        assert_eq!(code, 1);
+        let (out, ok) =
+            unwrap_output(property_read(tmp.path(), "x", "nope.md", Format::Json).unwrap());
+        assert!(!ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["error"], "file not found");
     }
@@ -375,8 +379,9 @@ mod tests {
     #[test]
     fn missing_extension_hint() {
         let tmp = setup_dir();
-        let (out, code) = property_read(tmp.path(), "x", "note", Format::Json).unwrap();
-        assert_eq!(code, 1);
+        let (out, ok) =
+            unwrap_output(property_read(tmp.path(), "x", "note", Format::Json).unwrap());
+        assert!(!ok);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["error"], "file not found");
         assert!(parsed["hint"].as_str().unwrap().contains("note.md"));
@@ -385,9 +390,10 @@ mod tests {
     #[test]
     fn property_set_creates_frontmatter() {
         let tmp = setup_dir();
-        let (_, code) =
-            property_set(tmp.path(), "status", "new", None, "empty.md", Format::Json).unwrap();
-        assert_eq!(code, 0);
+        let (_, ok) = unwrap_output(
+            property_set(tmp.path(), "status", "new", None, "empty.md", Format::Json).unwrap(),
+        );
+        assert!(ok);
 
         let content = fs::read_to_string(tmp.path().join("empty.md")).unwrap();
         assert!(content.starts_with("---\n"));

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -1,0 +1,395 @@
+use anyhow::{Context, Result};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use crate::discovery::{self, FileResolveError};
+use crate::frontmatter::{self, Document};
+use crate::output::Format;
+
+/// List all properties across all files, or properties of a single file / glob match.
+pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<(String, i32)> {
+    match path {
+        Some(p) if discovery::is_glob(p) => properties_glob(dir, p, format),
+        Some(p) => properties_single(dir, p, format),
+        None => properties_all(dir, format),
+    }
+}
+
+/// List all unique property names across all `.md` files.
+fn properties_all(dir: &Path, format: Format) -> Result<(String, i32)> {
+    let files = discovery::discover_files(dir)?;
+
+    // Aggregate: name -> (type, count)
+    let mut agg: BTreeMap<String, (String, usize)> = BTreeMap::new();
+
+    for file in &files {
+        let props = frontmatter::read_frontmatter(file)?;
+        for (key, value) in &props {
+            let typ = frontmatter::infer_type(value).to_owned();
+            let entry = agg.entry(key.clone()).or_insert_with(|| (typ.clone(), 0));
+            entry.1 += 1;
+            // If types differ across files, keep the first seen
+        }
+    }
+
+    let result: Vec<serde_json::Value> = agg
+        .into_iter()
+        .map(|(name, (typ, count))| json!({"name": name, "type": typ, "count": count}))
+        .collect();
+
+    Ok((crate::output::format_success(format, &json!(result)), 0))
+}
+
+/// List properties of a single file.
+fn properties_single(dir: &Path, path_arg: &str, format: Format) -> Result<(String, i32)> {
+    let (full_path, rel_path) = match discovery::resolve_file(dir, path_arg) {
+        Ok(r) => r,
+        Err(FileResolveError::MissingExtension { path, hint }) => {
+            let out = crate::output::format_error(
+                format,
+                "file not found",
+                Some(&path),
+                Some(&format!("did you mean {hint}?")),
+                None,
+            );
+            return Ok((out, 1));
+        }
+        Err(FileResolveError::NotFound { path }) => {
+            let out =
+                crate::output::format_error(format, "file not found", Some(&path), None, None);
+            return Ok((out, 1));
+        }
+    };
+
+    let props = frontmatter::read_frontmatter(&full_path)?;
+
+    let prop_map: serde_json::Map<String, serde_json::Value> = props
+        .iter()
+        .map(|(k, v)| {
+            let typ = frontmatter::infer_type(v);
+            let json_val = frontmatter::yaml_to_json(v);
+            (k.clone(), json!({"value": json_val, "type": typ}))
+        })
+        .collect();
+
+    let result = json!({
+        "path": rel_path,
+        "properties": prop_map,
+    });
+
+    Ok((crate::output::format_success(format, &result), 0))
+}
+
+/// List properties of files matching a glob pattern.
+fn properties_glob(dir: &Path, pattern: &str, format: Format) -> Result<(String, i32)> {
+    let files = discovery::discover_files(dir)?;
+    let matched = discovery::match_glob(dir, &files, pattern)?;
+
+    if matched.is_empty() {
+        let out = crate::output::format_error(
+            format,
+            "no files match pattern",
+            Some(pattern),
+            None,
+            None,
+        );
+        return Ok((out, 1));
+    }
+
+    let mut results = Vec::new();
+    for (full_path, rel_path) in &matched {
+        let props = frontmatter::read_frontmatter(full_path)?;
+
+        let prop_map: serde_json::Map<String, serde_json::Value> = props
+            .iter()
+            .map(|(k, v)| {
+                let typ = frontmatter::infer_type(v);
+                let json_val = frontmatter::yaml_to_json(v);
+                (k.clone(), json!({"value": json_val, "type": typ}))
+            })
+            .collect();
+
+        results.push(json!({
+            "path": rel_path,
+            "properties": prop_map,
+        }));
+    }
+
+    Ok((crate::output::format_success(format, &json!(results)), 0))
+}
+
+/// Read a single property from a file.
+pub fn property_read(
+    dir: &Path,
+    name: &str,
+    path_arg: &str,
+    format: Format,
+) -> Result<(String, i32)> {
+    let (full_path, rel_path) = match resolve_or_error(dir, path_arg, format) {
+        Ok(r) => r,
+        Err(output) => return Ok(output),
+    };
+
+    let props = frontmatter::read_frontmatter(&full_path)?;
+
+    match props.get(name) {
+        Some(value) => {
+            let typ = frontmatter::infer_type(value);
+            let json_val = frontmatter::yaml_to_json(value);
+            let result = json!({"name": name, "value": json_val, "type": typ});
+            Ok((crate::output::format_success(format, &result), 0))
+        }
+        None => {
+            let out = crate::output::format_error(
+                format,
+                "property not found",
+                Some(&rel_path),
+                None,
+                None,
+            );
+            Ok((out, 1))
+        }
+    }
+}
+
+/// Set a property on a file.
+pub fn property_set(
+    dir: &Path,
+    name: &str,
+    raw_value: &str,
+    forced_type: Option<&str>,
+    path_arg: &str,
+    format: Format,
+) -> Result<(String, i32)> {
+    let (full_path, _rel_path) = match resolve_or_error(dir, path_arg, format) {
+        Ok(r) => r,
+        Err(output) => return Ok(output),
+    };
+
+    let content = fs::read_to_string(&full_path)
+        .with_context(|| format!("failed to read {}", full_path.display()))?;
+    let mut doc = Document::parse(&content)?;
+
+    let value = frontmatter::parse_value(raw_value, forced_type)?;
+    doc.set_property(name.to_owned(), value);
+
+    let serialized = doc.serialize()?;
+    fs::write(&full_path, serialized)
+        .with_context(|| format!("failed to write {}", full_path.display()))?;
+
+    // Output the new value
+    let new_value = doc.get_property(name).expect("just set this property");
+    let typ = frontmatter::infer_type(new_value);
+    let json_val = frontmatter::yaml_to_json(new_value);
+    let result = json!({"name": name, "value": json_val, "type": typ});
+
+    Ok((crate::output::format_success(format, &result), 0))
+}
+
+/// Remove a property from a file.
+pub fn property_remove(
+    dir: &Path,
+    name: &str,
+    path_arg: &str,
+    format: Format,
+) -> Result<(String, i32)> {
+    let (full_path, rel_path) = match resolve_or_error(dir, path_arg, format) {
+        Ok(r) => r,
+        Err(output) => return Ok(output),
+    };
+
+    let content = fs::read_to_string(&full_path)
+        .with_context(|| format!("failed to read {}", full_path.display()))?;
+    let mut doc = Document::parse(&content)?;
+
+    match doc.remove_property(name) {
+        Some(_) => {
+            let serialized = doc.serialize()?;
+            fs::write(&full_path, serialized)
+                .with_context(|| format!("failed to write {}", full_path.display()))?;
+            let result = json!({"removed": name, "path": rel_path});
+            Ok((crate::output::format_success(format, &result), 0))
+        }
+        None => {
+            let out = crate::output::format_error(
+                format,
+                "property not found",
+                Some(&rel_path),
+                None,
+                None,
+            );
+            Ok((out, 1))
+        }
+    }
+}
+
+/// Helper to resolve a file path or produce an error output tuple.
+fn resolve_or_error(
+    dir: &Path,
+    path_arg: &str,
+    format: Format,
+) -> Result<(std::path::PathBuf, String), (String, i32)> {
+    match discovery::resolve_file(dir, path_arg) {
+        Ok(r) => Ok(r),
+        Err(FileResolveError::MissingExtension { path, hint }) => Err((
+            crate::output::format_error(
+                format,
+                "file not found",
+                Some(&path),
+                Some(&format!("did you mean {hint}?")),
+                None,
+            ),
+            1,
+        )),
+        Err(FileResolveError::NotFound { path }) => Err((
+            crate::output::format_error(format, "file not found", Some(&path), None, None),
+            1,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn setup_dir() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            "---\ntitle: Test\nstatus: draft\npriority: 3\ntags:\n  - rust\n  - cli\n---\n# Hello\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("empty.md"), "No frontmatter here.\n").unwrap();
+        tmp
+    }
+
+    #[test]
+    fn properties_all_aggregates() {
+        let tmp = setup_dir();
+        let (out, code) = properties(tmp.path(), None, Format::Json).unwrap();
+        assert_eq!(code, 0);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
+        assert!(!parsed.is_empty());
+        let names: Vec<&str> = parsed.iter().map(|v| v["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"title"));
+        assert!(names.contains(&"status"));
+    }
+
+    #[test]
+    fn properties_single_file() {
+        let tmp = setup_dir();
+        let (out, code) = properties(tmp.path(), Some("note.md"), Format::Json).unwrap();
+        assert_eq!(code, 0);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["path"], "note.md");
+        assert_eq!(parsed["properties"]["priority"]["type"], "number");
+        assert_eq!(parsed["properties"]["tags"]["type"], "list");
+    }
+
+    #[test]
+    fn property_read_existing() {
+        let tmp = setup_dir();
+        let (out, code) = property_read(tmp.path(), "status", "note.md", Format::Json).unwrap();
+        assert_eq!(code, 0);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["value"], "draft");
+        assert_eq!(parsed["type"], "text");
+    }
+
+    #[test]
+    fn property_read_missing() {
+        let tmp = setup_dir();
+        let (out, code) =
+            property_read(tmp.path(), "nonexistent", "note.md", Format::Json).unwrap();
+        assert_eq!(code, 1);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["error"], "property not found");
+    }
+
+    #[test]
+    fn property_set_new() {
+        let tmp = setup_dir();
+        let (out, code) =
+            property_set(tmp.path(), "author", "Alice", None, "note.md", Format::Json).unwrap();
+        assert_eq!(code, 0);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["value"], "Alice");
+
+        // Verify it persisted
+        let (out2, _) = property_read(tmp.path(), "author", "note.md", Format::Json).unwrap();
+        let p2: serde_json::Value = serde_json::from_str(&out2).unwrap();
+        assert_eq!(p2["value"], "Alice");
+    }
+
+    #[test]
+    fn property_set_with_type() {
+        let tmp = setup_dir();
+        let (out, code) = property_set(
+            tmp.path(),
+            "count",
+            "42",
+            Some("text"),
+            "note.md",
+            Format::Json,
+        )
+        .unwrap();
+        assert_eq!(code, 0);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["type"], "text");
+        assert_eq!(parsed["value"], "42");
+    }
+
+    #[test]
+    fn property_remove_existing() {
+        let tmp = setup_dir();
+        let (out, code) = property_remove(tmp.path(), "status", "note.md", Format::Json).unwrap();
+        assert_eq!(code, 0);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["removed"], "status");
+
+        // Verify it's gone
+        let (_, code2) = property_read(tmp.path(), "status", "note.md", Format::Json).unwrap();
+        assert_eq!(code2, 1);
+    }
+
+    #[test]
+    fn property_remove_missing() {
+        let tmp = setup_dir();
+        let (_, code) =
+            property_remove(tmp.path(), "nonexistent", "note.md", Format::Json).unwrap();
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn file_not_found_error() {
+        let tmp = setup_dir();
+        let (out, code) = property_read(tmp.path(), "x", "nope.md", Format::Json).unwrap();
+        assert_eq!(code, 1);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["error"], "file not found");
+    }
+
+    #[test]
+    fn missing_extension_hint() {
+        let tmp = setup_dir();
+        let (out, code) = property_read(tmp.path(), "x", "note", Format::Json).unwrap();
+        assert_eq!(code, 1);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["error"], "file not found");
+        assert!(parsed["hint"].as_str().unwrap().contains("note.md"));
+    }
+
+    #[test]
+    fn property_set_creates_frontmatter() {
+        let tmp = setup_dir();
+        let (_, code) =
+            property_set(tmp.path(), "status", "new", None, "empty.md", Format::Json).unwrap();
+        assert_eq!(code, 0);
+
+        let content = fs::read_to_string(tmp.path().join("empty.md")).unwrap();
+        assert!(content.starts_with("---\n"));
+    }
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,206 @@
+use anyhow::{Context, Result};
+use globset::{Glob, GlobMatcher};
+use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
+
+/// Collect all `.md` files under the given directory, respecting `.gitignore` and skipping hidden dirs.
+pub fn discover_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+
+    let walker = WalkBuilder::new(dir)
+        .hidden(true) // skip hidden files/dirs
+        .git_ignore(true)
+        .build();
+
+    for entry in walker {
+        let entry = entry.context("error walking directory")?;
+        let path = entry.path();
+        if path.is_file()
+            && let Some(ext) = path.extension()
+            && ext == "md"
+        {
+            files.push(path.to_path_buf());
+        }
+    }
+
+    files.sort();
+    Ok(files)
+}
+
+/// Resolve a path argument relative to `--dir`. Verifies it exists and is `.md`.
+/// Returns the canonical path and the normalized relative path (for display).
+pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), FileResolveError> {
+    let normalized = normalize_path(path_arg);
+
+    if !normalized.ends_with(".md") {
+        // Check if adding .md would work
+        let with_ext = format!("{normalized}.md");
+        let full = dir.join(&with_ext);
+        if full.is_file() {
+            return Err(FileResolveError::MissingExtension {
+                path: normalized,
+                hint: with_ext,
+            });
+        }
+        return Err(FileResolveError::MissingExtension {
+            path: normalized.clone(),
+            hint: format!("{normalized}.md"),
+        });
+    }
+
+    let full = dir.join(&normalized);
+    if !full.is_file() {
+        // Check without .md hint
+        return Err(FileResolveError::NotFound { path: normalized });
+    }
+
+    Ok((full, normalized))
+}
+
+/// Normalize a path argument: strip leading `./`, normalize separators.
+fn normalize_path(path: &str) -> String {
+    let p = path.strip_prefix("./").unwrap_or(path);
+    p.to_owned()
+}
+
+/// Check if a path argument contains glob characters.
+pub fn is_glob(path: &str) -> bool {
+    path.contains('*') || path.contains('?') || path.contains('[')
+}
+
+/// Match discovered files against a glob pattern.
+/// The glob is matched against paths relative to `dir`.
+pub fn match_glob(dir: &Path, files: &[PathBuf], pattern: &str) -> Result<Vec<(PathBuf, String)>> {
+    let glob = Glob::new(pattern)
+        .context("invalid glob pattern")?
+        .compile_matcher();
+
+    let mut matched = Vec::new();
+    for file in files {
+        let rel = relative_path(dir, file);
+        if glob_matches(&glob, &rel) {
+            matched.push((file.clone(), rel));
+        }
+    }
+    Ok(matched)
+}
+
+/// Get the relative path of a file from a directory.
+fn relative_path(dir: &Path, file: &Path) -> String {
+    file.strip_prefix(dir)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| file.to_string_lossy().to_string())
+}
+
+/// Check if a relative path matches a glob pattern.
+fn glob_matches(glob: &GlobMatcher, rel_path: &str) -> bool {
+    glob.is_match(rel_path)
+}
+
+/// Errors specific to file resolution.
+#[derive(Debug)]
+pub enum FileResolveError {
+    NotFound { path: String },
+    MissingExtension { path: String, hint: String },
+}
+
+impl std::fmt::Display for FileResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound { path } => write!(f, "file not found: {path}"),
+            Self::MissingExtension { path, .. } => write!(f, "file not found: {path}"),
+        }
+    }
+}
+
+impl std::error::Error for FileResolveError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn discover_finds_md_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "# Note").unwrap();
+        fs::write(tmp.path().join("readme.txt"), "text").unwrap();
+        fs::create_dir_all(tmp.path().join("sub")).unwrap();
+        fs::write(tmp.path().join("sub/deep.md"), "# Deep").unwrap();
+
+        let files = discover_files(tmp.path()).unwrap();
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().all(|f| f.extension().unwrap() == "md"));
+    }
+
+    #[test]
+    fn discover_skips_hidden_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("visible.md"), "# Visible").unwrap();
+        fs::create_dir_all(tmp.path().join(".hidden")).unwrap();
+        fs::write(tmp.path().join(".hidden/secret.md"), "# Secret").unwrap();
+
+        let files = discover_files(tmp.path()).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].ends_with("visible.md"));
+    }
+
+    #[test]
+    fn glob_matching() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("a.md"), "").unwrap();
+        fs::create_dir_all(tmp.path().join("notes")).unwrap();
+        fs::write(tmp.path().join("notes/b.md"), "").unwrap();
+        fs::write(tmp.path().join("notes/c.md"), "").unwrap();
+
+        let files = discover_files(tmp.path()).unwrap();
+
+        let matched = match_glob(tmp.path(), &files, "notes/*.md").unwrap();
+        assert_eq!(matched.len(), 2);
+
+        let matched_all = match_glob(tmp.path(), &files, "**/*.md").unwrap();
+        assert_eq!(matched_all.len(), 3);
+    }
+
+    #[test]
+    fn resolve_file_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "").unwrap();
+
+        let (path, rel) = resolve_file(tmp.path(), "note.md").unwrap();
+        assert!(path.is_file());
+        assert_eq!(rel, "note.md");
+    }
+
+    #[test]
+    fn resolve_file_strips_leading_dot_slash() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "").unwrap();
+
+        let (_, rel) = resolve_file(tmp.path(), "./note.md").unwrap();
+        assert_eq!(rel, "note.md");
+    }
+
+    #[test]
+    fn resolve_file_missing_extension_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "").unwrap();
+
+        let err = resolve_file(tmp.path(), "note").unwrap_err();
+        match err {
+            FileResolveError::MissingExtension { path, hint } => {
+                assert_eq!(path, "note");
+                assert_eq!(hint, "note.md");
+            }
+            other => panic!("expected MissingExtension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_glob_detects_patterns() {
+        assert!(is_glob("*.md"));
+        assert!(is_glob("notes/**/*.md"));
+        assert!(is_glob("note[123].md"));
+        assert!(!is_glob("notes/file.md"));
+    }
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -33,18 +33,10 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
     let normalized = normalize_path(path_arg);
 
     if !normalized.ends_with(".md") {
-        // Check if adding .md would work
-        let with_ext = format!("{normalized}.md");
-        let full = dir.join(&with_ext);
-        if full.is_file() {
-            return Err(FileResolveError::MissingExtension {
-                path: normalized,
-                hint: with_ext,
-            });
-        }
+        let hint = format!("{normalized}.md");
         return Err(FileResolveError::MissingExtension {
-            path: normalized.clone(),
-            hint: format!("{normalized}.md"),
+            path: normalized,
+            hint,
         });
     }
 
@@ -108,7 +100,9 @@ impl std::fmt::Display for FileResolveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NotFound { path } => write!(f, "file not found: {path}"),
-            Self::MissingExtension { path, .. } => write!(f, "file not found: {path}"),
+            Self::MissingExtension { path, hint } => {
+                write!(f, "file not found: {path} (did you mean {hint}?)")
+            }
         }
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -28,9 +28,19 @@ pub fn discover_files(dir: &Path) -> Result<Vec<PathBuf>> {
 }
 
 /// Resolve a path argument relative to `--dir`. Verifies it exists and is `.md`.
-/// Returns the canonical path and the normalized relative path (for display).
+/// Returns the full path under `dir` and the normalized relative path (for display).
+/// Rejects absolute paths and `..` segments to prevent escaping the base directory.
 pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), FileResolveError> {
     let normalized = normalize_path(path_arg);
+
+    // Reject path traversal attempts
+    if normalized.starts_with('/')
+        || normalized.starts_with('\\')
+        || normalized.contains("..")
+        || Path::new(&normalized).is_absolute()
+    {
+        return Err(FileResolveError::NotFound { path: normalized });
+    }
 
     if !normalized.ends_with(".md") {
         let hint = format!("{normalized}.md");
@@ -42,17 +52,16 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
 
     let full = dir.join(&normalized);
     if !full.is_file() {
-        // Check without .md hint
         return Err(FileResolveError::NotFound { path: normalized });
     }
 
     Ok((full, normalized))
 }
 
-/// Normalize a path argument: strip leading `./`, normalize separators.
+/// Normalize a path argument: strip leading `./`, normalize separators to forward slashes.
 fn normalize_path(path: &str) -> String {
     let p = path.strip_prefix("./").unwrap_or(path);
-    p.to_owned()
+    p.replace('\\', "/")
 }
 
 /// Check if a path argument contains glob characters.
@@ -77,11 +86,14 @@ pub fn match_glob(dir: &Path, files: &[PathBuf], pattern: &str) -> Result<Vec<(P
     Ok(matched)
 }
 
-/// Get the relative path of a file from a directory.
+/// Get the relative path of a file from a directory, using forward slashes on all platforms.
 fn relative_path(dir: &Path, file: &Path) -> String {
-    file.strip_prefix(dir)
+    let raw = file
+        .strip_prefix(dir)
         .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|_| file.to_string_lossy().to_string())
+        .unwrap_or_else(|_| file.to_string_lossy().to_string());
+    // Normalize to forward slashes for consistent output and glob matching on Windows.
+    raw.replace('\\', "/")
 }
 
 /// Check if a relative path matches a glob pattern.
@@ -188,6 +200,30 @@ mod tests {
             }
             other => panic!("expected MissingExtension, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn resolve_file_rejects_path_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "").unwrap();
+
+        // Absolute path
+        assert!(matches!(
+            resolve_file(tmp.path(), "/etc/passwd.md"),
+            Err(FileResolveError::NotFound { .. })
+        ));
+
+        // Parent directory traversal
+        assert!(matches!(
+            resolve_file(tmp.path(), "../secret.md"),
+            Err(FileResolveError::NotFound { .. })
+        ));
+
+        // Embedded traversal
+        assert!(matches!(
+            resolve_file(tmp.path(), "sub/../../../etc/passwd.md"),
+            Err(FileResolveError::NotFound { .. })
+        ));
     }
 
     #[test]

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use serde_yaml::Value;
+use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -27,7 +27,7 @@ impl Document {
 
         let properties: BTreeMap<String, Value> = match yaml_str {
             Some(yaml) if !yaml.trim().is_empty() => {
-                serde_yaml::from_str(yaml).context("failed to parse YAML frontmatter")?
+                serde_yaml_ng::from_str(yaml).context("failed to parse YAML frontmatter")?
             }
             _ => BTreeMap::new(),
         };
@@ -45,7 +45,7 @@ impl Document {
         if !self.properties.is_empty() {
             out.push_str("---\n");
             let yaml =
-                serde_yaml::to_string(&self.properties).context("failed to serialize YAML")?;
+                serde_yaml_ng::to_string(&self.properties).context("failed to serialize YAML")?;
             out.push_str(&yaml);
             // serde_yaml adds a trailing newline, but let's ensure
             if !yaml.ends_with('\n') {
@@ -77,14 +77,18 @@ impl Document {
 /// Read only the YAML frontmatter from a file, stopping as soon as the closing `---` is found.
 /// The body is never read into memory. Use this for read-only property operations.
 pub fn read_frontmatter(path: &Path) -> Result<BTreeMap<String, Value>> {
-    let file =
-        File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
     let reader = BufReader::new(file);
     read_frontmatter_from_reader(reader)
 }
 
 /// Parse frontmatter from any buffered reader. Stops reading after the closing `---`.
+/// Bails out if the frontmatter exceeds a reasonable size (100 lines / 8 KB) to avoid
+/// buffering an entire file when the closing delimiter is missing.
 fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String, Value>> {
+    const MAX_FRONTMATTER_LINES: usize = 100;
+    const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
+
     let mut lines = reader.lines();
 
     // First line must be `---`
@@ -94,10 +98,17 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
     }
 
     let mut yaml = String::new();
+    let mut line_count = 0;
     for line in lines {
         let line = line.context("failed to read line")?;
         if line.trim() == "---" {
             break;
+        }
+        line_count += 1;
+        if line_count > MAX_FRONTMATTER_LINES || yaml.len() + line.len() > MAX_FRONTMATTER_BYTES {
+            anyhow::bail!(
+                "frontmatter too large (no closing `---` found within {MAX_FRONTMATTER_LINES} lines / {MAX_FRONTMATTER_BYTES} bytes)"
+            );
         }
         yaml.push_str(&line);
         yaml.push('\n');
@@ -107,7 +118,7 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
         return Ok(BTreeMap::new());
     }
 
-    serde_yaml::from_str(&yaml).context("failed to parse YAML frontmatter")
+    serde_yaml_ng::from_str(&yaml).context("failed to parse YAML frontmatter")
 }
 
 /// Extract frontmatter YAML string and the body from a markdown document.
@@ -242,7 +253,7 @@ pub fn parse_value(raw: &str, forced_type: Option<&str>) -> Result<Value> {
                 Ok(Value::Number(i.into()))
             } else {
                 let f: f64 = raw.parse().context("value is not a valid number")?;
-                Ok(Value::Number(serde_yaml::Number::from(f)))
+                Ok(Value::Number(serde_yaml_ng::Number::from(f)))
             }
         }
         Some("checkbox") => {
@@ -283,9 +294,11 @@ fn infer_value(raw: &str) -> Value {
     if let Ok(i) = raw.parse::<i64>() {
         return Value::Number(i.into());
     }
-    // Try float
-    if let Ok(f) = raw.parse::<f64>() {
-        return Value::Number(serde_yaml::Number::from(f));
+    // Try float (reject NaN/inf which parse successfully but aren't useful property values)
+    if let Ok(f) = raw.parse::<f64>()
+        && f.is_finite()
+    {
+        return Value::Number(serde_yaml_ng::Number::from(f));
     }
     // Try bool
     match raw {
@@ -518,7 +531,8 @@ mod tests {
 
     #[test]
     fn streaming_matches_full_parse() {
-        let content = "---\ntitle: Test\npriority: 5\ntags:\n  - a\n  - b\n---\n# Heading\n\nBody.\n";
+        let content =
+            "---\ntitle: Test\npriority: 5\ntags:\n  - a\n  - b\n---\n# Heading\n\nBody.\n";
         let doc = Document::parse(content).unwrap();
         let streamed = read_frontmatter_from_reader(content.as_bytes()).unwrap();
         assert_eq!(doc.properties(), &streamed);

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -22,8 +22,10 @@ impl Document {
     }
 
     /// Parse a markdown document, extracting YAML frontmatter if present.
+    /// Returns an error if the file starts with `---` but has no closing delimiter,
+    /// which would cause corruption on write (a new frontmatter block on top of an unclosed one).
     pub fn parse(content: &str) -> Result<Self> {
-        let (yaml_str, body) = extract_frontmatter(content);
+        let (yaml_str, body) = extract_frontmatter(content)?;
 
         let properties: BTreeMap<String, Value> = match yaml_str {
             Some(yaml) if !yaml.trim().is_empty() => {
@@ -122,11 +124,13 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
 }
 
 /// Extract frontmatter YAML string and the body from a markdown document.
-/// Returns (Some(yaml_content), body) if frontmatter is found, (None, full_content) otherwise.
-fn extract_frontmatter(content: &str) -> (Option<&str>, &str) {
+/// Returns `Ok((Some(yaml_content), body))` if frontmatter is found,
+/// `Ok((None, full_content))` if no frontmatter is present, or an error if the file
+/// starts with `---` but has no closing delimiter (which would cause corruption on write).
+fn extract_frontmatter(content: &str) -> Result<(Option<&str>, &str)> {
     // Frontmatter must start with `---` on the very first line
     if !content.starts_with("---") {
-        return (None, content);
+        return Ok((None, content));
     }
 
     let after_opening = &content[3..];
@@ -137,9 +141,9 @@ fn extract_frontmatter(content: &str) -> (Option<&str>, &str) {
         rest
     } else if after_opening.is_empty() {
         // File is exactly `---` with nothing after
-        return (None, content);
+        return Ok((None, content));
     } else {
-        return (None, content);
+        return Ok((None, content));
     };
 
     // Find the closing `---`
@@ -154,10 +158,12 @@ fn extract_frontmatter(content: &str) -> (Option<&str>, &str) {
         } else {
             rest
         };
-        (Some(yaml), body)
+        Ok((Some(yaml), body))
     } else {
-        // No closing delimiter found — treat entire content as body (no frontmatter)
-        (None, content)
+        // Opening `---` found but no closing delimiter — this is malformed frontmatter.
+        // Returning an error prevents mutation commands from corrupting the file by
+        // writing a new frontmatter block on top of the unclosed one.
+        anyhow::bail!("unclosed frontmatter: file starts with `---` but no closing `---` was found")
     }
 }
 
@@ -253,6 +259,7 @@ pub fn parse_value(raw: &str, forced_type: Option<&str>) -> Result<Value> {
                 Ok(Value::Number(i.into()))
             } else {
                 let f: f64 = raw.parse().context("value is not a valid number")?;
+                anyhow::ensure!(f.is_finite(), "value is not a finite number");
                 Ok(Value::Number(serde_yaml_ng::Number::from(f)))
             }
         }
@@ -378,11 +385,10 @@ mod tests {
 
     #[test]
     fn parse_malformed_frontmatter() {
-        // Missing closing delimiter — treated as no frontmatter
+        // Missing closing delimiter — now returns an error to prevent corruption on write
         let content = "---\ntitle: Broken\nNo closing delimiter.\n";
-        let doc = Document::parse(content).unwrap();
-        assert!(doc.properties().is_empty());
-        assert_eq!(doc.body(), content);
+        let err = Document::parse(content).unwrap_err();
+        assert!(err.to_string().contains("unclosed frontmatter"));
     }
 
     #[test]

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,0 +1,526 @@
+use anyhow::{Context, Result};
+use serde_yaml::Value;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Represents parsed frontmatter and the remaining body content.
+#[derive(Debug, Clone)]
+pub struct Document {
+    properties: BTreeMap<String, Value>,
+    body: String,
+}
+
+impl Document {
+    pub fn properties(&self) -> &BTreeMap<String, Value> {
+        &self.properties
+    }
+
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+
+    /// Parse a markdown document, extracting YAML frontmatter if present.
+    pub fn parse(content: &str) -> Result<Self> {
+        let (yaml_str, body) = extract_frontmatter(content);
+
+        let properties: BTreeMap<String, Value> = match yaml_str {
+            Some(yaml) if !yaml.trim().is_empty() => {
+                serde_yaml::from_str(yaml).context("failed to parse YAML frontmatter")?
+            }
+            _ => BTreeMap::new(),
+        };
+
+        Ok(Self {
+            properties,
+            body: body.to_owned(),
+        })
+    }
+
+    /// Serialize the document back to a string with YAML frontmatter.
+    pub fn serialize(&self) -> Result<String> {
+        let mut out = String::new();
+
+        if !self.properties.is_empty() {
+            out.push_str("---\n");
+            let yaml =
+                serde_yaml::to_string(&self.properties).context("failed to serialize YAML")?;
+            out.push_str(&yaml);
+            // serde_yaml adds a trailing newline, but let's ensure
+            if !yaml.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str("---\n");
+        }
+
+        out.push_str(&self.body);
+        Ok(out)
+    }
+
+    /// Get a property value by name.
+    pub fn get_property(&self, name: &str) -> Option<&Value> {
+        self.properties.get(name)
+    }
+
+    /// Set a property value.
+    pub fn set_property(&mut self, name: String, value: Value) {
+        self.properties.insert(name, value);
+    }
+
+    /// Remove a property, returning the old value if it existed.
+    pub fn remove_property(&mut self, name: &str) -> Option<Value> {
+        self.properties.remove(name)
+    }
+}
+
+/// Read only the YAML frontmatter from a file, stopping as soon as the closing `---` is found.
+/// The body is never read into memory. Use this for read-only property operations.
+pub fn read_frontmatter(path: &Path) -> Result<BTreeMap<String, Value>> {
+    let file =
+        File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let reader = BufReader::new(file);
+    read_frontmatter_from_reader(reader)
+}
+
+/// Parse frontmatter from any buffered reader. Stops reading after the closing `---`.
+fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String, Value>> {
+    let mut lines = reader.lines();
+
+    // First line must be `---`
+    match lines.next() {
+        Some(Ok(line)) if line.trim() == "---" => {}
+        _ => return Ok(BTreeMap::new()),
+    }
+
+    let mut yaml = String::new();
+    for line in lines {
+        let line = line.context("failed to read line")?;
+        if line.trim() == "---" {
+            break;
+        }
+        yaml.push_str(&line);
+        yaml.push('\n');
+    }
+
+    if yaml.trim().is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    serde_yaml::from_str(&yaml).context("failed to parse YAML frontmatter")
+}
+
+/// Extract frontmatter YAML string and the body from a markdown document.
+/// Returns (Some(yaml_content), body) if frontmatter is found, (None, full_content) otherwise.
+fn extract_frontmatter(content: &str) -> (Option<&str>, &str) {
+    // Frontmatter must start with `---` on the very first line
+    if !content.starts_with("---") {
+        return (None, content);
+    }
+
+    let after_opening = &content[3..];
+    // The opening `---` must be followed by a newline (or be exactly `---`)
+    let after_opening = if let Some(rest) = after_opening.strip_prefix('\n') {
+        rest
+    } else if let Some(rest) = after_opening.strip_prefix("\r\n") {
+        rest
+    } else if after_opening.is_empty() {
+        // File is exactly `---` with nothing after
+        return (None, content);
+    } else {
+        return (None, content);
+    };
+
+    // Find the closing `---`
+    if let Some(pos) = find_closing_delimiter(after_opening) {
+        let yaml = &after_opening[..pos];
+        let rest = &after_opening[pos + 3..];
+        // Skip the newline after closing `---`
+        let body = if let Some(stripped) = rest.strip_prefix('\n') {
+            stripped
+        } else if let Some(stripped) = rest.strip_prefix("\r\n") {
+            stripped
+        } else {
+            rest
+        };
+        (Some(yaml), body)
+    } else {
+        // No closing delimiter found — treat entire content as body (no frontmatter)
+        (None, content)
+    }
+}
+
+/// Find the position of `---` at the start of a line in the given string.
+fn find_closing_delimiter(s: &str) -> Option<usize> {
+    // Check if it starts right at position 0
+    if s.starts_with("---")
+        && (s.len() == 3
+            || s.as_bytes().get(3) == Some(&b'\n')
+            || s.as_bytes().get(3) == Some(&b'\r'))
+    {
+        return Some(0);
+    }
+
+    // Search for `\n---`
+    let mut search_from = 0;
+    while let Some(pos) = s[search_from..].find("\n---") {
+        let abs_pos = search_from + pos + 1; // position of the first `-`
+        let after = abs_pos + 3;
+        if after == s.len()
+            || s.as_bytes().get(after) == Some(&b'\n')
+            || s.as_bytes().get(after) == Some(&b'\r')
+        {
+            return Some(abs_pos);
+        }
+        search_from = abs_pos + 3;
+    }
+    None
+}
+
+/// Infer the Obsidian property type from a YAML value.
+pub fn infer_type(value: &Value) -> &'static str {
+    match value {
+        Value::Bool(_) => "checkbox",
+        Value::Number(_) => "number",
+        Value::Sequence(_) => "list",
+        Value::String(s) => infer_string_type(s),
+        Value::Null => "text",
+        Value::Mapping(_) => "text",
+        Value::Tagged(_) => "text",
+    }
+}
+
+/// Infer the type of a string value (date, datetime, or text).
+fn infer_string_type(s: &str) -> &'static str {
+    if is_date(s) {
+        "date"
+    } else if is_datetime(s) {
+        "datetime"
+    } else {
+        "text"
+    }
+}
+
+/// Check if a string matches `YYYY-MM-DD`.
+fn is_date(s: &str) -> bool {
+    if s.len() != 10 {
+        return false;
+    }
+    let b = s.as_bytes();
+    b[4] == b'-'
+        && b[7] == b'-'
+        && b[..4].iter().all(|c| c.is_ascii_digit())
+        && b[5..7].iter().all(|c| c.is_ascii_digit())
+        && b[8..10].iter().all(|c| c.is_ascii_digit())
+}
+
+/// Check if a string matches `YYYY-MM-DDThh:mm:ss`.
+fn is_datetime(s: &str) -> bool {
+    if s.len() != 19 {
+        return false;
+    }
+    let b = s.as_bytes();
+    b[4] == b'-'
+        && b[7] == b'-'
+        && b[10] == b'T'
+        && b[13] == b':'
+        && b[16] == b':'
+        && b[..4].iter().all(|c| c.is_ascii_digit())
+        && b[5..7].iter().all(|c| c.is_ascii_digit())
+        && b[8..10].iter().all(|c| c.is_ascii_digit())
+        && b[11..13].iter().all(|c| c.is_ascii_digit())
+        && b[14..16].iter().all(|c| c.is_ascii_digit())
+        && b[17..19].iter().all(|c| c.is_ascii_digit())
+}
+
+/// Parse a string value into an appropriate YAML Value, optionally forced to a specific type.
+pub fn parse_value(raw: &str, forced_type: Option<&str>) -> Result<Value> {
+    match forced_type {
+        Some("text") => Ok(Value::String(raw.to_owned())),
+        Some("number") => {
+            if let Ok(i) = raw.parse::<i64>() {
+                Ok(Value::Number(i.into()))
+            } else {
+                let f: f64 = raw.parse().context("value is not a valid number")?;
+                Ok(Value::Number(serde_yaml::Number::from(f)))
+            }
+        }
+        Some("checkbox") => {
+            let b = match raw {
+                "true" | "yes" | "1" => true,
+                "false" | "no" | "0" => false,
+                _ => anyhow::bail!("value is not a valid checkbox (use true/false)"),
+            };
+            Ok(Value::Bool(b))
+        }
+        Some("date") => {
+            anyhow::ensure!(is_date(raw), "value is not a valid date (YYYY-MM-DD)");
+            Ok(Value::String(raw.to_owned()))
+        }
+        Some("datetime") => {
+            anyhow::ensure!(
+                is_datetime(raw),
+                "value is not a valid datetime (YYYY-MM-DDThh:mm:ss)"
+            );
+            Ok(Value::String(raw.to_owned()))
+        }
+        Some("list") => {
+            // Parse comma-separated values
+            let items: Vec<Value> = raw
+                .split(',')
+                .map(|s| Value::String(s.trim().to_owned()))
+                .collect();
+            Ok(Value::Sequence(items))
+        }
+        Some(other) => anyhow::bail!("unknown type: {other}"),
+        None => Ok(infer_value(raw)),
+    }
+}
+
+/// Infer a YAML value from a raw string (try number, bool, date, then text).
+fn infer_value(raw: &str) -> Value {
+    // Try integer
+    if let Ok(i) = raw.parse::<i64>() {
+        return Value::Number(i.into());
+    }
+    // Try float
+    if let Ok(f) = raw.parse::<f64>() {
+        return Value::Number(serde_yaml::Number::from(f));
+    }
+    // Try bool
+    match raw {
+        "true" => return Value::Bool(true),
+        "false" => return Value::Bool(false),
+        _ => {}
+    }
+    // Try date/datetime
+    // (these stay as strings, type inference will pick them up)
+    Value::String(raw.to_owned())
+}
+
+/// Convert a YAML value to a serde_json::Value for output.
+pub fn yaml_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::Number(i.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::json!(f)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        Value::String(s) => serde_json::Value::String(s.clone()),
+        Value::Sequence(seq) => serde_json::Value::Array(seq.iter().map(yaml_to_json).collect()),
+        Value::Mapping(map) => {
+            let obj: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        Value::String(s) => s.clone(),
+                        _ => format!("{k:?}"),
+                    };
+                    (key, yaml_to_json(v))
+                })
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+        Value::Tagged(tagged) => yaml_to_json(&tagged.value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_frontmatter() {
+        let content = "---\ntitle: Hello\nstatus: draft\n---\nBody text here.\n";
+        let doc = Document::parse(content).unwrap();
+        assert_eq!(doc.properties().len(), 2);
+        assert_eq!(
+            doc.get_property("title"),
+            Some(&Value::String("Hello".into()))
+        );
+        assert_eq!(doc.body(), "Body text here.\n");
+    }
+
+    #[test]
+    fn parse_no_frontmatter() {
+        let content = "Just a regular markdown file.\n";
+        let doc = Document::parse(content).unwrap();
+        assert!(doc.properties().is_empty());
+        assert_eq!(doc.body(), content);
+    }
+
+    #[test]
+    fn parse_empty_frontmatter() {
+        let content = "---\n---\nBody.\n";
+        let doc = Document::parse(content).unwrap();
+        assert!(doc.properties().is_empty());
+        assert_eq!(doc.body(), "Body.\n");
+    }
+
+    #[test]
+    fn parse_malformed_frontmatter() {
+        // Missing closing delimiter — treated as no frontmatter
+        let content = "---\ntitle: Broken\nNo closing delimiter.\n";
+        let doc = Document::parse(content).unwrap();
+        assert!(doc.properties().is_empty());
+        assert_eq!(doc.body(), content);
+    }
+
+    #[test]
+    fn infer_type_text() {
+        assert_eq!(infer_type(&Value::String("hello".into())), "text");
+    }
+
+    #[test]
+    fn infer_type_number() {
+        assert_eq!(infer_type(&Value::Number(42.into())), "number");
+    }
+
+    #[test]
+    fn infer_type_bool() {
+        assert_eq!(infer_type(&Value::Bool(true)), "checkbox");
+    }
+
+    #[test]
+    fn infer_type_date() {
+        assert_eq!(infer_type(&Value::String("2026-03-20".into())), "date");
+    }
+
+    #[test]
+    fn infer_type_datetime() {
+        assert_eq!(
+            infer_type(&Value::String("2026-03-20T14:30:00".into())),
+            "datetime"
+        );
+    }
+
+    #[test]
+    fn infer_type_list() {
+        assert_eq!(
+            infer_type(&Value::Sequence(vec![Value::String("a".into())])),
+            "list"
+        );
+    }
+
+    #[test]
+    fn infer_type_null() {
+        assert_eq!(infer_type(&Value::Null), "text");
+    }
+
+    #[test]
+    fn roundtrip_preserves_body() {
+        let content = "---\ntitle: Test\npriority: 5\n---\n# Heading\n\nParagraph content.\n";
+        let doc = Document::parse(content).unwrap();
+        let serialized = doc.serialize().unwrap();
+        let doc2 = Document::parse(&serialized).unwrap();
+        assert_eq!(doc.properties(), doc2.properties());
+        assert_eq!(doc.body(), doc2.body());
+    }
+
+    #[test]
+    fn serialize_no_properties_no_frontmatter() {
+        let doc = Document::parse("Just body.\n").unwrap();
+        let serialized = doc.serialize().unwrap();
+        assert_eq!(serialized, "Just body.\n");
+    }
+
+    #[test]
+    fn set_and_remove_property() {
+        let mut doc = Document::parse("---\ntitle: Hi\n---\nBody\n").unwrap();
+        doc.set_property("status".into(), Value::String("done".into()));
+        assert!(doc.get_property("status").is_some());
+        doc.remove_property("status");
+        assert!(doc.get_property("status").is_none());
+    }
+
+    #[test]
+    fn parse_value_infer() {
+        // Number
+        match parse_value("42", None).unwrap() {
+            Value::Number(n) => assert_eq!(n.as_i64(), Some(42)),
+            other => panic!("expected number, got {other:?}"),
+        }
+        // Bool
+        assert_eq!(parse_value("true", None).unwrap(), Value::Bool(true));
+        // Text
+        match parse_value("hello", None).unwrap() {
+            Value::String(s) => assert_eq!(s, "hello"),
+            other => panic!("expected string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_value_forced_type() {
+        // Force text even for number-like string
+        match parse_value("42", Some("text")).unwrap() {
+            Value::String(s) => assert_eq!(s, "42"),
+            other => panic!("expected string, got {other:?}"),
+        }
+        // Force list
+        match parse_value("a, b, c", Some("list")).unwrap() {
+            Value::Sequence(items) => assert_eq!(items.len(), 3),
+            other => panic!("expected sequence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_with_only_frontmatter() {
+        let content = "---\ntitle: Only FM\n---\n";
+        let doc = Document::parse(content).unwrap();
+        assert_eq!(doc.properties().len(), 1);
+        assert_eq!(doc.body(), "");
+    }
+
+    // --- Streaming reader tests ---
+
+    #[test]
+    fn streaming_valid_frontmatter() {
+        let input = b"---\ntitle: Hello\nstatus: draft\n---\n# Body that should not be read\nLots of content here.\n";
+        let props = read_frontmatter_from_reader(&input[..]).unwrap();
+        assert_eq!(props.len(), 2);
+        assert_eq!(props.get("title"), Some(&Value::String("Hello".into())));
+        assert_eq!(props.get("status"), Some(&Value::String("draft".into())));
+    }
+
+    #[test]
+    fn streaming_no_frontmatter() {
+        let input = b"Just a regular file.\nNo frontmatter.\n";
+        let props = read_frontmatter_from_reader(&input[..]).unwrap();
+        assert!(props.is_empty());
+    }
+
+    #[test]
+    fn streaming_empty_frontmatter() {
+        let input = b"---\n---\nBody.\n";
+        let props = read_frontmatter_from_reader(&input[..]).unwrap();
+        assert!(props.is_empty());
+    }
+
+    #[test]
+    fn streaming_no_closing_delimiter() {
+        // No closing `---` means everything after the opening is read as YAML.
+        // If it's not valid YAML, we get an error — which is correct.
+        let input = b"---\ntitle: Broken\nNot valid yaml line\n";
+        let result = read_frontmatter_from_reader(&input[..]);
+        assert!(result.is_err());
+
+        // But if the content happens to be valid YAML, it parses fine
+        let input2 = b"---\ntitle: Works\nstatus: ok\n";
+        let props = read_frontmatter_from_reader(&input2[..]).unwrap();
+        assert_eq!(props.get("title"), Some(&Value::String("Works".into())));
+    }
+
+    #[test]
+    fn streaming_matches_full_parse() {
+        let content = "---\ntitle: Test\npriority: 5\ntags:\n  - a\n  - b\n---\n# Heading\n\nBody.\n";
+        let doc = Document::parse(content).unwrap();
+        let streamed = read_frontmatter_from_reader(content.as_bytes()).unwrap();
+        assert_eq!(doc.properties(), &streamed);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod commands;
+pub mod discovery;
+pub mod frontmatter;
+pub mod output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::process;
 use clap::{Parser, Subcommand};
 
 use hyalo::commands::properties;
-use hyalo::output::Format;
+use hyalo::output::{CommandOutcome, Format};
 
 #[derive(Parser)]
 #[command(
@@ -112,13 +112,12 @@ fn main() {
     };
 
     match result {
-        Ok((output, exit_code)) => {
-            if exit_code == 0 {
-                println!("{output}");
-            } else {
-                eprintln!("{output}");
-            }
-            process::exit(exit_code);
+        Ok(CommandOutcome::Success(output)) => {
+            println!("{output}");
+        }
+        Ok(CommandOutcome::UserError(output)) => {
+            eprintln!("{output}");
+            process::exit(1);
         }
         Err(e) => {
             let msg = hyalo::output::format_error(
@@ -126,7 +125,10 @@ fn main() {
                 &e.to_string(),
                 None,
                 None,
-                e.chain().nth(1).map(|s| s.to_string()).as_deref(),
+                e.chain()
+                    .nth(1)
+                    .map(std::string::ToString::to_string)
+                    .as_deref(),
             );
             eprintln!("{msg}");
             process::exit(2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,135 @@
+use std::path::PathBuf;
+use std::process;
+
+use clap::{Parser, Subcommand};
+
+use hyalo::commands::properties;
+use hyalo::output::Format;
+
+#[derive(Parser)]
+#[command(
+    name = "hyalo",
+    version,
+    about = "CLI for managing Obsidian-compatible markdown files"
+)]
+struct Cli {
+    /// Base directory (default: current directory)
+    #[arg(long, global = true, default_value = ".")]
+    dir: PathBuf,
+
+    /// Output format: json or text
+    #[arg(long, global = true, default_value = "json")]
+    format: String,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List properties of files
+    Properties {
+        /// File path or glob pattern (relative to --dir)
+        #[arg(long)]
+        path: Option<String>,
+    },
+    /// Read, set, or remove a single property
+    Property {
+        #[command(subcommand)]
+        action: PropertyAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum PropertyAction {
+    /// Read a property value
+    Read {
+        /// Property name
+        #[arg(long)]
+        name: String,
+        /// File path (relative to --dir)
+        #[arg(long)]
+        path: String,
+    },
+    /// Set a property value
+    Set {
+        /// Property name
+        #[arg(long)]
+        name: String,
+        /// Property value
+        #[arg(long)]
+        value: String,
+        /// Force type: text, number, checkbox, date, datetime, list
+        #[arg(long = "type")]
+        prop_type: Option<String>,
+        /// File path (relative to --dir)
+        #[arg(long)]
+        path: String,
+    },
+    /// Remove a property
+    Remove {
+        /// Property name
+        #[arg(long)]
+        name: String,
+        /// File path (relative to --dir)
+        #[arg(long)]
+        path: String,
+    },
+}
+
 fn main() {
-    println!("Hello, world!");
+    let cli = Cli::parse();
+
+    let format = match Format::from_str_opt(&cli.format) {
+        Some(f) => f,
+        None => {
+            eprintln!(
+                "Error: invalid format '{}', expected 'json' or 'text'",
+                cli.format
+            );
+            process::exit(2);
+        }
+    };
+
+    let dir = &cli.dir;
+
+    let result = match cli.command {
+        Commands::Properties { ref path } => properties::properties(dir, path.as_deref(), format),
+        Commands::Property { action } => match action {
+            PropertyAction::Read { ref name, ref path } => {
+                properties::property_read(dir, name, path, format)
+            }
+            PropertyAction::Set {
+                ref name,
+                ref value,
+                ref prop_type,
+                ref path,
+            } => properties::property_set(dir, name, value, prop_type.as_deref(), path, format),
+            PropertyAction::Remove { ref name, ref path } => {
+                properties::property_remove(dir, name, path, format)
+            }
+        },
+    };
+
+    match result {
+        Ok((output, exit_code)) => {
+            if exit_code == 0 {
+                println!("{output}");
+            } else {
+                eprintln!("{output}");
+            }
+            process::exit(exit_code);
+        }
+        Err(e) => {
+            let msg = hyalo::output::format_error(
+                format,
+                &e.to_string(),
+                None,
+                None,
+                e.chain().nth(1).map(|s| s.to_string()).as_deref(),
+            );
+            eprintln!("{msg}");
+            process::exit(2);
+        }
+    }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,6 +7,16 @@ pub enum Format {
     Text,
 }
 
+/// Result of a command execution: either success (exit 0) or a user-facing error (exit 1).
+/// Internal/unexpected errors are represented by `anyhow::Error` at the call site.
+#[derive(Debug)]
+pub enum CommandOutcome {
+    /// Successful operation — output goes to stdout.
+    Success(String),
+    /// User error (file not found, property missing, etc.) — output goes to stderr.
+    UserError(String),
+}
+
 impl Format {
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,143 @@
+use serde_json::json;
+
+/// Output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Json,
+    Text,
+}
+
+impl Format {
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "json" => Some(Self::Json),
+            "text" => Some(Self::Text),
+            _ => None,
+        }
+    }
+}
+
+/// Format a successful JSON value for output.
+pub fn format_success(format: Format, value: &serde_json::Value) -> String {
+    match format {
+        Format::Json => serde_json::to_string_pretty(value).unwrap_or_default(),
+        Format::Text => format_value_as_text(value),
+    }
+}
+
+/// Format an error for output to stderr.
+pub fn format_error(
+    format: Format,
+    error: &str,
+    path: Option<&str>,
+    hint: Option<&str>,
+    cause: Option<&str>,
+) -> String {
+    match format {
+        Format::Json => {
+            let mut obj = json!({"error": error});
+            if let Some(p) = path {
+                obj["path"] = json!(p);
+            }
+            if let Some(h) = hint {
+                obj["hint"] = json!(h);
+            }
+            if let Some(c) = cause {
+                obj["cause"] = json!(c);
+            }
+            serde_json::to_string_pretty(&obj).unwrap_or_default()
+        }
+        Format::Text => {
+            let mut msg = format!("Error: {error}");
+            if let Some(p) = path {
+                msg.push_str(&format!("\n  path: {p}"));
+            }
+            if let Some(h) = hint {
+                msg.push_str(&format!("\n  hint: {h}"));
+            }
+            if let Some(c) = cause {
+                msg.push_str(&format!("\n  cause: {c}"));
+            }
+            msg
+        }
+    }
+}
+
+/// Format a JSON value as human-readable text.
+fn format_value_as_text(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Array(arr) => arr
+            .iter()
+            .map(format_value_as_text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+        serde_json::Value::Object(map) => map
+            .iter()
+            .map(|(k, v)| format!("{k}: {}", format_scalar(v)))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        other => format_scalar(other),
+    }
+}
+
+/// Format a scalar JSON value as text.
+fn format_scalar(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_owned(),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(format_scalar).collect();
+            items.join(", ")
+        }
+        serde_json::Value::Object(map) => {
+            let items: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{k}={}", format_scalar(v)))
+                .collect();
+            items.join(", ")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_json_error() {
+        let out = format_error(
+            Format::Json,
+            "file not found",
+            Some("foo/bar"),
+            Some("did you mean foo/bar.md?"),
+            None,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["error"], "file not found");
+        assert_eq!(parsed["hint"], "did you mean foo/bar.md?");
+        assert!(parsed.get("cause").is_none());
+    }
+
+    #[test]
+    fn format_text_error() {
+        let out = format_error(Format::Text, "file not found", Some("foo"), None, None);
+        assert!(out.contains("Error: file not found"));
+        assert!(out.contains("path: foo"));
+    }
+
+    #[test]
+    fn format_json_success() {
+        let val = serde_json::json!({"name": "test", "value": 42});
+        let out = format_success(Format::Json, &val);
+        assert!(out.contains("\"name\": \"test\""));
+    }
+
+    #[test]
+    fn format_text_success_object() {
+        let val = serde_json::json!({"name": "test", "value": "hello"});
+        let out = format_success(Format::Text, &val);
+        assert!(out.contains("name: test"));
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,35 @@
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+/// Returns a `Command` pre-configured to run the `hyalo` binary built by Cargo.
+pub fn hyalo() -> Command {
+    Command::cargo_bin("hyalo").unwrap()
+}
+
+/// Writes a file at `relative_path` inside `dir`, creating parent directories as needed.
+pub fn write_md(dir: &Path, relative_path: &str, content: &str) {
+    let full = dir.join(relative_path);
+    if let Some(parent) = full.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(full, content).unwrap();
+}
+
+/// Returns a sample markdown document with YAML frontmatter containing various property types.
+#[allow(dead_code)]
+pub fn sample_frontmatter() -> &'static str {
+    "---\n\
+     title: My Note\n\
+     priority: 3\n\
+     draft: true\n\
+     created: \"2026-03-20\"\n\
+     updated: \"2026-03-20T14:30:00\"\n\
+     tags:\n\
+       - rust\n\
+       - cli\n\
+     ---\n\
+     # Body\n\
+     \n\
+     Some content here.\n"
+}

--- a/tests/e2e_errors.rs
+++ b/tests/e2e_errors.rs
@@ -29,8 +29,11 @@ fn error_nonexistent_file() {
 
 #[test]
 fn error_nonexistent_dir() {
+    let tmp = TempDir::new().unwrap();
+    let nonexistent = tmp.path().join("does_not_exist");
+
     let output = hyalo()
-        .args(["--dir", "/tmp/hyalo_nonexistent_dir_e2e_test"])
+        .args(["--dir", nonexistent.to_str().unwrap()])
         .args(["properties"])
         .output()
         .unwrap();

--- a/tests/e2e_errors.rs
+++ b/tests/e2e_errors.rs
@@ -1,0 +1,126 @@
+mod common;
+
+use common::{hyalo, write_md};
+use tempfile::TempDir;
+
+#[test]
+fn error_nonexistent_file() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "read",
+            "--name",
+            "title",
+            "--path",
+            "missing.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(json["error"], "file not found");
+    assert!(json.get("path").is_some());
+}
+
+#[test]
+fn error_nonexistent_dir() {
+    let output = hyalo()
+        .args(["--dir", "/tmp/hyalo_nonexistent_dir_e2e_test"])
+        .args(["properties"])
+        .output()
+        .unwrap();
+
+    // Should fail with exit code 2 (anyhow error path)
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.is_empty());
+}
+
+#[test]
+fn error_invalid_yaml() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "bad.md",
+        "---\n: invalid yaml [[[{\n---\n# Body\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "--path", "bad.md"])
+        .output()
+        .unwrap();
+
+    // Malformed YAML should cause an error
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.is_empty());
+}
+
+#[test]
+fn error_missing_md_extension() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "title", "--path", "note"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(json["error"], "file not found");
+    assert!(json["hint"].as_str().unwrap().contains("note.md"));
+}
+
+#[test]
+fn error_json_structure() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "title", "--path", "nope.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+
+    // Error JSON must have an "error" field
+    assert!(json.get("error").is_some());
+    assert!(json["error"].is_string());
+}
+
+#[test]
+fn error_text_format() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "read",
+            "--name",
+            "title",
+            "--path",
+            "nope.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("Error:"));
+    assert!(stderr.contains("file not found"));
+}

--- a/tests/e2e_properties.rs
+++ b/tests/e2e_properties.rs
@@ -1,0 +1,149 @@
+mod common;
+
+use common::{hyalo, sample_frontmatter, write_md};
+use tempfile::TempDir;
+
+#[test]
+fn properties_single_file() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "file.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "--path", "file.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["path"], "file.md");
+
+    let props = &json["properties"];
+    assert_eq!(props["title"]["type"], "text");
+    assert_eq!(props["title"]["value"], "My Note");
+    assert_eq!(props["priority"]["type"], "number");
+    assert_eq!(props["priority"]["value"], 3);
+    assert_eq!(props["draft"]["type"], "checkbox");
+    assert_eq!(props["draft"]["value"], true);
+    assert_eq!(props["created"]["type"], "date");
+    assert_eq!(props["tags"]["type"], "list");
+}
+
+#[test]
+fn properties_aggregate() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\nstatus: draft\n---\n# A\n",
+    );
+    write_md(tmp.path(), "b.md", "---\ntitle: B\npriority: 1\n---\n# B\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Should have aggregated properties: title (2), status (1), priority (1)
+    let names: Vec<&str> = json.iter().map(|v| v["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"title"));
+    assert!(names.contains(&"status"));
+    assert!(names.contains(&"priority"));
+
+    // title appears in both files
+    let title_entry = json.iter().find(|v| v["name"] == "title").unwrap();
+    assert_eq!(title_entry["count"], 2);
+    assert_eq!(title_entry["type"], "text");
+
+    // status appears in one file
+    let status_entry = json.iter().find(|v| v["name"] == "status").unwrap();
+    assert_eq!(status_entry["count"], 1);
+}
+
+#[test]
+fn properties_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "root.md", "---\ntitle: Root\n---\n");
+    write_md(tmp.path(), "sub/a.md", "---\ntitle: Sub A\n---\n");
+    write_md(tmp.path(), "sub/b.md", "---\ntitle: Sub B\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "--path", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json.len(), 2);
+
+    let paths: Vec<&str> = json.iter().map(|v| v["path"].as_str().unwrap()).collect();
+    assert!(paths.iter().all(|p| p.starts_with("sub/")));
+}
+
+#[test]
+fn properties_empty_dir() {
+    let tmp = TempDir::new().unwrap();
+    // No .md files at all
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json.is_empty());
+}
+
+#[test]
+fn properties_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Hello\nstatus: draft\n---\n",
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "properties",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Text format outputs key: value lines
+    assert!(stdout.contains("path:"));
+    assert!(stdout.contains("properties:"));
+}
+
+#[test]
+fn properties_file_without_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "--path", "plain.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["path"], "plain.md");
+    let props = json["properties"].as_object().unwrap();
+    assert!(props.is_empty());
+}

--- a/tests/e2e_property_read.rs
+++ b/tests/e2e_property_read.rs
@@ -1,0 +1,211 @@
+mod common;
+
+use common::{hyalo, sample_frontmatter, write_md};
+use tempfile::TempDir;
+
+#[test]
+fn read_text_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "title", "--path", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "title");
+    assert_eq!(json["value"], "My Note");
+    assert_eq!(json["type"], "text");
+}
+
+#[test]
+fn read_number_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "read", "--name", "priority", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "priority");
+    assert_eq!(json["value"], 3);
+    assert_eq!(json["type"], "number");
+}
+
+#[test]
+fn read_bool_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "draft", "--path", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "draft");
+    assert_eq!(json["value"], true);
+    assert_eq!(json["type"], "checkbox");
+}
+
+#[test]
+fn read_date_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "created", "--path", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "created");
+    assert_eq!(json["value"], "2026-03-20");
+    assert_eq!(json["type"], "date");
+}
+
+#[test]
+fn read_datetime_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "updated", "--path", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "updated");
+    assert_eq!(json["value"], "2026-03-20T14:30:00");
+    assert_eq!(json["type"], "datetime");
+}
+
+#[test]
+fn read_list_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "tags", "--path", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "tags");
+    assert_eq!(json["type"], "list");
+    let values = json["value"].as_array().unwrap();
+    assert_eq!(values.len(), 2);
+    assert_eq!(values[0], "rust");
+    assert_eq!(values[1], "cli");
+}
+
+#[test]
+fn read_missing_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "read",
+            "--name",
+            "nonexistent",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(json["error"], "property not found");
+}
+
+#[test]
+fn read_missing_file() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "read",
+            "--name",
+            "title",
+            "--path",
+            "nonexistent.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(json["error"], "file not found");
+}
+
+#[test]
+fn read_missing_extension_hint() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "title", "--path", "note"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(json["error"], "file not found");
+    let hint = json["hint"].as_str().unwrap();
+    assert!(hint.contains("note.md"));
+}
+
+#[test]
+fn read_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "read",
+            "--name",
+            "title",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Text format should contain the property name and value
+    assert!(stdout.contains("name:"));
+    assert!(stdout.contains("My Note"));
+}

--- a/tests/e2e_property_remove.rs
+++ b/tests/e2e_property_remove.rs
@@ -1,0 +1,155 @@
+mod common;
+
+use common::{hyalo, write_md};
+use tempfile::TempDir;
+
+#[test]
+fn remove_existing_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Test\nstatus: draft\n---\n# Body\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "remove", "--name", "status", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["removed"], "status");
+    assert_eq!(json["path"], "note.md");
+
+    // Verify it's gone
+    let read_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "status", "--path", "note.md"])
+        .output()
+        .unwrap();
+    assert_eq!(read_output.status.code(), Some(1));
+}
+
+#[test]
+fn remove_missing_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n# Body\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove",
+            "--name",
+            "nonexistent",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(json["error"], "property not found");
+}
+
+#[test]
+fn remove_preserves_body() {
+    let tmp = TempDir::new().unwrap();
+    let body = "# Heading\n\nParagraph content.\n";
+    let content = format!("---\ntitle: Test\nstatus: draft\n---\n{body}");
+    write_md(tmp.path(), "note.md", &content);
+
+    hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "remove", "--name", "status", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    let file_content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(file_content.contains("# Heading"));
+    assert!(file_content.contains("Paragraph content."));
+}
+
+#[test]
+fn remove_preserves_other_properties() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Keep\nstatus: draft\npriority: 5\n---\n# Body\n",
+    );
+
+    hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "remove", "--name", "status", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    // title should still be there
+    let read_title = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "title", "--path", "note.md"])
+        .output()
+        .unwrap();
+    assert!(read_title.status.success());
+    let title_json: serde_json::Value = serde_json::from_slice(&read_title.stdout).unwrap();
+    assert_eq!(title_json["value"], "Keep");
+
+    // priority should still be there
+    let read_priority = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "read", "--name", "priority", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(read_priority.status.success());
+    let priority_json: serde_json::Value = serde_json::from_slice(&read_priority.stdout).unwrap();
+    assert_eq!(priority_json["value"], 5);
+}
+
+#[test]
+fn remove_last_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\nonly_prop: value\n---\n# Body\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove",
+            "--name",
+            "only_prop",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // File should still be readable and have no properties
+    let props_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "--path", "note.md"])
+        .output()
+        .unwrap();
+    assert!(props_output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&props_output.stdout).unwrap();
+    let props = json["properties"].as_object().unwrap();
+    assert!(props.is_empty());
+}

--- a/tests/e2e_property_remove.rs
+++ b/tests/e2e_property_remove.rs
@@ -65,13 +65,14 @@ fn remove_preserves_body() {
     let content = format!("---\ntitle: Test\nstatus: draft\n---\n{body}");
     write_md(tmp.path(), "note.md", &content);
 
-    hyalo()
+    let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "property", "remove", "--name", "status", "--path", "note.md",
         ])
         .output()
         .unwrap();
+    assert!(output.status.success());
 
     let file_content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
     assert!(file_content.contains("# Heading"));
@@ -87,13 +88,14 @@ fn remove_preserves_other_properties() {
         "---\ntitle: Keep\nstatus: draft\npriority: 5\n---\n# Body\n",
     );
 
-    hyalo()
+    let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "property", "remove", "--name", "status", "--path", "note.md",
         ])
         .output()
         .unwrap();
+    assert!(output.status.success());
 
     // title should still be there
     let read_title = hyalo()

--- a/tests/e2e_property_set.rs
+++ b/tests/e2e_property_set.rs
@@ -164,15 +164,7 @@ fn set_explicit_type() {
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
-            "property",
-            "set",
-            "--name",
-            "code",
-            "--value",
-            "42",
-            "--type",
-            "text",
-            "--path",
+            "property", "set", "--name", "code", "--value", "42", "--type", "text", "--path",
             "note.md",
         ])
         .output()

--- a/tests/e2e_property_set.rs
+++ b/tests/e2e_property_set.rs
@@ -1,0 +1,242 @@
+mod common;
+
+use common::{hyalo, write_md};
+use tempfile::TempDir;
+
+#[test]
+fn set_new_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Existing\n---\n# Body\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "set", "--name", "author", "--value", "Alice", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["name"], "author");
+    assert_eq!(json["value"], "Alice");
+    assert_eq!(json["type"], "text");
+
+    // Verify the property is persisted by reading it back
+    let read_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "author", "--path", "note.md"])
+        .output()
+        .unwrap();
+    assert!(read_output.status.success());
+    let read_json: serde_json::Value = serde_json::from_slice(&read_output.stdout).unwrap();
+    assert_eq!(read_json["value"], "Alice");
+}
+
+#[test]
+fn set_overwrite_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Old Title\n---\n# Body\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "set",
+            "--name",
+            "title",
+            "--value",
+            "New Title",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["value"], "New Title");
+
+    // Verify it persisted
+    let read_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "title", "--path", "note.md"])
+        .output()
+        .unwrap();
+    let read_json: serde_json::Value = serde_json::from_slice(&read_output.stdout).unwrap();
+    assert_eq!(read_json["value"], "New Title");
+}
+
+#[test]
+fn set_creates_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "Just plain text.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "set", "--name", "status", "--value", "new", "--path", "plain.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // Verify file now has frontmatter
+    let content = std::fs::read_to_string(tmp.path().join("plain.md")).unwrap();
+    assert!(content.starts_with("---\n"));
+    assert!(content.contains("status:"));
+}
+
+#[test]
+fn set_infers_number_type() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "set", "--name", "count", "--value", "42", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["value"], 42);
+    assert_eq!(json["type"], "number");
+}
+
+#[test]
+fn set_infers_bool_type() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "set", "--name", "draft", "--value", "true", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["value"], true);
+    assert_eq!(json["type"], "checkbox");
+}
+
+#[test]
+fn set_infers_date_type() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "set",
+            "--name",
+            "due",
+            "--value",
+            "2026-03-20",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["value"], "2026-03-20");
+    assert_eq!(json["type"], "date");
+}
+
+#[test]
+fn set_explicit_type() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "set",
+            "--name",
+            "code",
+            "--value",
+            "42",
+            "--type",
+            "text",
+            "--path",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["value"], "42");
+    assert_eq!(json["type"], "text");
+}
+
+#[test]
+fn set_preserves_body() {
+    let tmp = TempDir::new().unwrap();
+    let body = "# My Heading\n\nSome paragraph content.\n\n- Item 1\n- Item 2\n";
+    let content = format!("---\ntitle: Test\n---\n{body}");
+    write_md(tmp.path(), "note.md", &content);
+
+    hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "set", "--name", "author", "--value", "Bob", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    let file_content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(file_content.contains("# My Heading"));
+    assert!(file_content.contains("Some paragraph content."));
+    assert!(file_content.contains("- Item 1"));
+    assert!(file_content.contains("- Item 2"));
+}
+
+#[test]
+fn set_preserves_other_properties() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Keep Me\nstatus: draft\n---\n# Body\n",
+    );
+
+    hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property", "set", "--name", "author", "--value", "Eve", "--path", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    // Verify original properties still exist
+    let read_title = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "title", "--path", "note.md"])
+        .output()
+        .unwrap();
+    let title_json: serde_json::Value = serde_json::from_slice(&read_title.stdout).unwrap();
+    assert_eq!(title_json["value"], "Keep Me");
+
+    let read_status = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "read", "--name", "status", "--path", "note.md"])
+        .output()
+        .unwrap();
+    let status_json: serde_json::Value = serde_json::from_slice(&read_status.stdout).unwrap();
+    assert_eq!(status_json["value"], "draft");
+}

--- a/tests/e2e_property_set.rs
+++ b/tests/e2e_property_set.rs
@@ -183,13 +183,14 @@ fn set_preserves_body() {
     let content = format!("---\ntitle: Test\n---\n{body}");
     write_md(tmp.path(), "note.md", &content);
 
-    hyalo()
+    let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "property", "set", "--name", "author", "--value", "Bob", "--path", "note.md",
         ])
         .output()
         .unwrap();
+    assert!(output.status.success());
 
     let file_content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
     assert!(file_content.contains("# My Heading"));
@@ -207,13 +208,14 @@ fn set_preserves_other_properties() {
         "---\ntitle: Keep Me\nstatus: draft\n---\n# Body\n",
     );
 
-    hyalo()
+    let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "property", "set", "--name", "author", "--value", "Eve", "--path", "note.md",
         ])
         .output()
         .unwrap();
+    assert!(output.status.success());
 
     // Verify original properties still exist
     let read_title = hyalo()


### PR DESCRIPTION
## Summary

- **CLI commands:** `properties`, `property read`, `property set`, `property remove` with global `--dir`, `--path`, `--format` options
- **Streaming frontmatter parser:** BufReader-based, stops at closing `---` for read-only ops — avoids reading file bodies when only properties are needed
- **Structured error output:** JSON on stderr with `error`/`path`/`hint`/`cause` fields
- **Knowledgebase:** Research docs (Obsidian markdown, properties, CLI/search), decision log, iteration plans

## Test plan

- [x] 44 unit tests (frontmatter parsing, type inference, discovery, output formatting, commands)
- [x] 36 e2e tests (all commands, error cases, format options)
- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [x] Dogfooding: `hyalo --dir hyalo-knowledgebase properties` reads own knowledgebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)