### PR TITLE
Iteration 3a: Tag commands with nested matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Organize in subfolders. Use `[[wikilinks]]` for cross-references. Keep Obsidian-
 
 ## Language Server
 Use the rust-analyzer-lsp language server plugin for code intelligence: analyzing code, finding references, go-to-definition, checking clippy warnings.
-Be aware that it takes some time for changed files to be indexed again.
+Run "cargo check" before using it to update its indexes, after changing *.rs files.
 
 ## Code Quality Gates
 Make the code unit testable. Add tests if feasible. Add e2e tests for all commands/subcommands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Organize in subfolders. Use `[[wikilinks]]` for cross-references. Keep Obsidian-
 - Always name `iteration-NN-slug.md` — no standalone plan files
 - Frontmatter must include: `title`, `type: iteration`, `date`, `tags`, `status`, `branch`
 - Status lifecycle: `planned` → `in-progress` → `completed` → `superseded`
-- Add tasks as markdown checkboxes `[] Task 1` (without preceding - or number to generate a list)
+- Add tasks as markdown checkboxes `- [ ] Task 1` (without a  number)
 - Mark tasks as completed only after verifying that they were done
 
 # Rust

--- a/README.md
+++ b/README.md
@@ -8,6 +8,53 @@ A self-contained command line tool for exploring and managing Markdown knowledge
 cargo build --release
 ```
 
+## Usage
+
+All commands accept `--dir <path>` (default: `.`) and `--format json|text` (default: `json`).
+
+### Properties
+
+```sh
+# List all properties across files
+hyalo properties [--glob PATTERN]
+
+# Read a single property
+hyalo property read --name NAME --file FILE
+
+# Set a property value
+hyalo property set --name NAME --value VALUE [--type TYPE] --file FILE
+
+# Remove a property
+hyalo property remove --name NAME --file FILE
+```
+
+### Links
+
+```sh
+# List outgoing links from a file
+hyalo links --file FILE [--resolved | --unresolved]
+```
+
+### Tags
+
+Tags are read from and written to the YAML frontmatter `tags` property. Inline `#tags` in body text are not supported.
+
+```sh
+# List all unique tags with occurrence counts
+hyalo tags [--file FILE | --glob PATTERN]
+
+# Find files containing a specific tag (supports nested matching)
+hyalo tag find --name TAG [--file FILE | --glob PATTERN]
+
+# Add a tag to file(s) frontmatter
+hyalo tag add --name TAG <--file FILE | --glob PATTERN>
+
+# Remove a tag from file(s) frontmatter
+hyalo tag remove --name TAG <--file FILE | --glob PATTERN>
+```
+
+**Tag format (Obsidian-compatible):** letters, digits, `_`, `-`, `/`. Must contain at least one non-numeric character. Forward slashes create hierarchy — `tag find --name inbox` matches `inbox`, `inbox/processing`, etc.
+
 ## License
 
 MIT

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -130,3 +130,21 @@ The old `--path` flag is retired. Both flags are always relative to `--dir` and 
 **Decision:** The link object includes `path` — the file path relative to `--dir` that the link resolves to, or `null` for broken links. The raw `target` field preserves the original text as written.
 
 **Why:** AI agents work with file paths, not Obsidian note names. `[[My Note]]` is meaningless to an agent — it needs `notes/my-note.md` to open the file. Both fields are needed: `path` for navigation, `target` for display and search/replace in the source file.
+
+## DEC-020: Frontmatter-Only Tags — No Inline `#tag` Support (2026-03-20)
+
+**Decision:** Tag commands only read and write the `tags` property in YAML frontmatter. Inline `#tags` in the markdown body are not extracted, searched, or modified.
+
+**Why:** Frontmatter tags are structured data — a YAML list that can be reliably parsed, added to, and removed from. Inline `#tags` are embedded in prose, making extraction ambiguous (code blocks, URLs, headings with `#`) and modification risky (could corrupt surrounding text). Frontmatter tags are also what Obsidian uses for programmatic tag management. If inline tag extraction is needed later, it can be added as a separate read-only feature.
+
+## DEC-021: Tasks Are File-Scoped Only (2026-03-20)
+
+**Decision:** All task commands (`tasks`, `task read`, `task toggle`, `task set-status`) require `--file`. No vault-wide task listing or searching.
+
+**Why:** Tasks live in the markdown body, so vault-wide task search requires reading the full content of every file — not just frontmatter. Without an index, this is O(n) full-file reads per invocation. For an AI agent, "what tasks are in this file?" is the actionable question. Vault-wide task queries ("all incomplete tasks across the project") belong in the indexing iteration.
+
+## DEC-022: Tags Support Vault-Wide Operations Without Index (2026-03-20)
+
+**Decision:** Tag commands (`tags`, `tag find`, `tag add`, `tag remove`) support vault-wide and glob-scoped operations without requiring an index. They scan all matching files on each invocation.
+
+**Why:** Tags live in frontmatter, which is at most ~8KB per file and can be read without buffering the body. The existing `read_frontmatter` streaming reader stops at the closing `---`. For a 1000-file vault, this means reading ~8MB of data at most — well within acceptable latency. Pre-filtering optimizations (byte-level `tags:` search before YAML parse) can be explored if benchmarks show need. This is fundamentally different from vault-wide task search (DEC-021), which requires reading entire file contents.

--- a/hyalo-knowledgebase/iterations/iteration-3a-tags.md
+++ b/hyalo-knowledgebase/iterations/iteration-3a-tags.md
@@ -1,0 +1,184 @@
+---
+title: "Iteration 3a — Tag Commands"
+type: iteration
+date: 2026-03-20
+status: completed
+branch: iter-3a/tag-commands
+tags:
+  - iteration
+  - tags
+  - frontmatter
+---
+
+# Iteration 3a — Tag Commands
+
+## Goal
+
+Provide CLI commands to list, inspect, add, and remove tags in YAML frontmatter. Tags are frontmatter-only — inline `#tags` in markdown body are not supported (see [[decision-log#DEC-020]]). Support both single-file and multi-file (glob) operations, including batch tag/untag across directories.
+
+## CLI Interface
+
+```sh
+# List all unique tags across files, with counts
+hyalo tags [--file FILE | --glob PATTERN] [--dir DIR] [--format json|text]
+
+# Find files with a specific tag (matches nested tags: --name inbox matches inbox/processing)
+hyalo tag find --name TAG [--file FILE | --glob PATTERN] [--dir DIR] [--format json|text]
+
+# Add a tag to file(s) frontmatter
+hyalo tag add --name TAG <--file FILE | --glob PATTERN> [--dir DIR] [--format json|text]
+
+# Remove a tag from file(s) frontmatter
+hyalo tag remove --name TAG <--file FILE | --glob PATTERN> [--dir DIR] [--format json|text]
+```
+
+### Output Examples
+
+**`hyalo tags --glob "iterations/*.md"`** (JSON):
+```json
+{
+  "tags": [
+    { "name": "iteration", "count": 3 },
+    { "name": "frontmatter", "count": 1 },
+    { "name": "links", "count": 1 }
+  ],
+  "total": 3
+}
+```
+
+**`hyalo tag find --name iteration`** (JSON):
+```json
+{
+  "tag": "iteration",
+  "files": [
+    "iterations/iteration-01-frontmatter-properties.md",
+    "iterations/iteration-02-links.md"
+  ],
+  "total": 2
+}
+```
+
+**`hyalo tag add --name plan --glob "iterations/*.md"`** (JSON):
+```json
+{
+  "tag": "plan",
+  "modified": [
+    "iterations/iteration-01-frontmatter-properties.md",
+    "iterations/iteration-02-links.md"
+  ],
+  "skipped": [],
+  "total": 2
+}
+```
+
+`skipped` lists files that already had the tag. For `tag remove`, `skipped` lists files that didn't have the tag.
+
+### Behavior Notes
+
+- Without `--file` or `--glob`, commands operate on **all** `.md` files under `--dir`
+- `tag add` creates the `tags` property as a YAML list if it doesn't exist
+- `tag add` is idempotent — adding a tag that already exists is a no-op (file listed in `skipped`)
+- `tag remove` on a file without the tag is a no-op (file listed in `skipped`)
+- `tag remove` that empties the `tags` list removes the `tags` property entirely
+- Tag names are case-insensitive (matching Obsidian behavior)
+
+### Tag Format (Obsidian-compatible)
+
+- **Allowed characters:** letters, digits, underscores (`_`), hyphens (`-`), forward slashes (`/`)
+- **Must contain at least one non-numeric character** — `1984` is not a valid tag, `y1984` is
+- **No spaces** — use camelCase, PascalCase, snake_case, or kebab-case
+- **Forward slash creates hierarchy:** `inbox/processing` is a nested tag under `inbox`
+
+### Nested Tag Matching
+
+`tag find --name inbox` matches:
+- `inbox` (exact)
+- `inbox/processing` (child)
+- `inbox/to-read` (child)
+
+But does **not** match:
+- `inboxes` (different tag)
+- `my-inbox` (different tag)
+
+Matching rule: a tag matches if it equals the query or starts with `query/`. This applies to `tag find` and filter operations. `tag add` and `tag remove` use exact names only — no wildcard/hierarchy expansion.
+
+### Tag Validation
+
+`tag add` validates the tag name against the format rules above and returns a user error if invalid (e.g. `tag add --name "1984"` → error with hint about requiring a non-numeric character).
+
+## Performance
+
+### The Scanning Problem
+
+Vault-wide tag operations require reading frontmatter from every `.md` file. For large vaults this could be slow. Explore optimizations:
+
+### Research: Fast Pre-Filtering
+
+Investigate whether we can avoid full YAML parsing for most files by pre-filtering:
+
+1. **Byte-level scan:** Read only the first ~8KB of each file (our existing frontmatter budget). Search for the literal string `tags:` between `---` delimiters before committing to full YAML parse.
+2. **ripgrep crate (`grep-*` family):** ripgrep's internals are published as separate crates (`grep-searcher`, `grep-matcher`, `grep-regex`). Investigate whether these can provide fast multi-file frontmatter scanning out of the box.
+3. **Parallel scanning:** The `ignore` crate (already a dependency) supports parallel directory walking. Explore whether combining parallel walk with streaming frontmatter reads improves throughput.
+
+### Baseline First
+
+Implement the naive approach first (sequential `read_frontmatter` for each file), benchmark on a realistic vault (1000+ files), and only optimize if measurably slow. The existing `read_frontmatter` already streams and stops after the closing `---`, so it may be fast enough.
+
+## Tasks
+
+### Tag Format & Validation
+[x] Implement tag name validation (allowed chars, must have non-numeric character)
+[x] Implement nested tag matching (`inbox` matches `inbox/processing`)
+[x] Case-insensitive comparison
+[x] Unit tests for validation (valid tags, numeric-only rejection, allowed special chars)
+[x] Unit tests for nested matching
+
+### Tag Extraction
+[x] Extract `tags` property from frontmatter as `Vec<String>`
+[x] Handle edge cases: missing `tags` key, `tags` as scalar string vs list, empty list
+[x] Unit tests for tag extraction
+
+### Commands
+[x] `tags` command — aggregate unique tags with counts across matched files
+[x] `tag find` command — list files containing a specific tag (with nested matching)
+[x] `tag add` command — add tag to frontmatter, create `tags` property if needed, validate tag name, support `--file` and `--glob`
+[x] `tag remove` command — remove tag from frontmatter, remove empty `tags` property, support `--file` and `--glob`
+[x] Wire up CLI in main.rs with clap subcommands
+
+### Testing
+[x] Unit tests for tag add/remove logic
+[x] E2E tests for `tags` (all files, with `--glob`, with `--file`)
+[x] E2E tests for `tag find` (exact match, nested match, no match, with `--glob`)
+[x] E2E tests for `tag add` (single file, glob pattern, idempotent behavior, invalid tag name rejection)
+[x] E2E tests for `tag remove` (single file, glob pattern, already-absent tag)
+[x] E2E tests for edge cases (no frontmatter, empty tags list, tags as string)
+[x] E2E tests for case-insensitive matching
+
+### Performance Exploration
+[] Benchmark naive approach on a synthetic vault (1000+ files)
+[] Research `grep-searcher` / `grep-regex` crates for pre-filtering feasibility
+[x] Implement optimization if benchmark shows need, otherwise document as acceptable — existing `read_frontmatter` already streams and stops at closing `---`; deferred until benchmarks indicate need
+
+### Quality Gates
+[x] `cargo fmt`
+[x] `cargo clippy --workspace --all-targets -- -D warnings`
+[x] `cargo test --workspace`
+
+### Dogfooding
+[x] `hyalo tags --dir hyalo-knowledgebase` — list all tags in the knowledgebase (21 unique tags found)
+[x] `hyalo tag find --name iteration --dir hyalo-knowledgebase` — find iteration files (4 files found)
+[] `hyalo tag add --name plan --glob "iterations/*.md" --dir hyalo-knowledgebase` — batch tag (skipped: would modify knowledgebase files)
+
+## Acceptance Criteria
+
+1. [x] `hyalo tags` lists all unique tags with counts across all files
+2. [x] `hyalo tags --glob PATTERN` filters to matching files
+3. [x] `hyalo tag find --name TAG` lists files containing the tag
+4. [x] `hyalo tag find --name inbox` matches files tagged `inbox/processing` (nested matching)
+5. [x] `hyalo tag add --name TAG --file FILE` adds tag to frontmatter
+6. [x] `hyalo tag add` rejects invalid tag names with helpful error
+7. [x] `hyalo tag add --name TAG --glob PATTERN` batch-adds tag to matching files
+8. [x] `hyalo tag remove --name TAG --glob PATTERN` batch-removes tag
+9. [x] Idempotent: adding existing tag or removing absent tag is a no-op
+10. [x] Tag matching is case-insensitive
+11. [x] All quality gates pass: `cargo fmt && cargo clippy && cargo test`

--- a/hyalo-knowledgebase/iterations/iteration-3a-tags.md
+++ b/hyalo-knowledgebase/iterations/iteration-3a-tags.md
@@ -127,58 +127,58 @@ Implement the naive approach first (sequential `read_frontmatter` for each file)
 ## Tasks
 
 ### Tag Format & Validation
-[x] Implement tag name validation (allowed chars, must have non-numeric character)
-[x] Implement nested tag matching (`inbox` matches `inbox/processing`)
-[x] Case-insensitive comparison
-[x] Unit tests for validation (valid tags, numeric-only rejection, allowed special chars)
-[x] Unit tests for nested matching
+- [x] Implement tag name validation (allowed chars, must have non-numeric character)
+- [x] Implement nested tag matching (`inbox` matches `inbox/processing`)
+- [x] Case-insensitive comparison
+- [x] Unit tests for validation (valid tags, numeric-only rejection, allowed special chars)
+- [x] Unit tests for nested matching
 
 ### Tag Extraction
-[x] Extract `tags` property from frontmatter as `Vec<String>`
-[x] Handle edge cases: missing `tags` key, `tags` as scalar string vs list, empty list
-[x] Unit tests for tag extraction
+- [x] Extract `tags` property from frontmatter as `Vec<String>`
+- [x] Handle edge cases: missing `tags` key, `tags` as scalar string vs list, empty list
+- [x] Unit tests for tag extraction
 
 ### Commands
-[x] `tags` command — aggregate unique tags with counts across matched files
-[x] `tag find` command — list files containing a specific tag (with nested matching)
-[x] `tag add` command — add tag to frontmatter, create `tags` property if needed, validate tag name, support `--file` and `--glob`
-[x] `tag remove` command — remove tag from frontmatter, remove empty `tags` property, support `--file` and `--glob`
-[x] Wire up CLI in main.rs with clap subcommands
+- [x] `tags` command — aggregate unique tags with counts across matched files
+- [x] `tag find` command — list files containing a specific tag (with nested matching)
+- [x] `tag add` command — add tag to frontmatter, create `tags` property if needed, validate tag name, support `--file` and `--glob`
+- [x] `tag remove` command — remove tag from frontmatter, remove empty `tags` property, support `--file` and `--glob`
+- [x] Wire up CLI in main.rs with clap subcommands
 
 ### Testing
-[x] Unit tests for tag add/remove logic
-[x] E2E tests for `tags` (all files, with `--glob`, with `--file`)
-[x] E2E tests for `tag find` (exact match, nested match, no match, with `--glob`)
-[x] E2E tests for `tag add` (single file, glob pattern, idempotent behavior, invalid tag name rejection)
-[x] E2E tests for `tag remove` (single file, glob pattern, already-absent tag)
-[x] E2E tests for edge cases (no frontmatter, empty tags list, tags as string)
-[x] E2E tests for case-insensitive matching
+- [x] Unit tests for tag add/remove logic
+- [x] E2E tests for `tags` (all files, with `--glob`, with `--file`)
+- [x] E2E tests for `tag find` (exact match, nested match, no match, with `--glob`)
+- [x] E2E tests for `tag add` (single file, glob pattern, idempotent behavior, invalid tag name rejection)
+- [x] E2E tests for `tag remove` (single file, glob pattern, already-absent tag)
+- [x] E2E tests for edge cases (no frontmatter, empty tags list, tags as string)
+- [x] E2E tests for case-insensitive matching
 
 ### Performance Exploration
-[] Benchmark naive approach on a synthetic vault (1000+ files)
-[] Research `grep-searcher` / `grep-regex` crates for pre-filtering feasibility
-[x] Implement optimization if benchmark shows need, otherwise document as acceptable — existing `read_frontmatter` already streams and stops at closing `---`; deferred until benchmarks indicate need
+- [ ] Benchmark naive approach on a synthetic vault (1000+ files)
+- [ ] Research `grep-searcher` / `grep-regex` crates for pre-filtering feasibility
+- [x] Implement optimization if benchmark shows need, otherwise document as acceptable — existing `read_frontmatter` already streams and stops at closing `---`; deferred until benchmarks indicate need
 
 ### Quality Gates
-[x] `cargo fmt`
-[x] `cargo clippy --workspace --all-targets -- -D warnings`
-[x] `cargo test --workspace`
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`
 
 ### Dogfooding
-[x] `hyalo tags --dir hyalo-knowledgebase` — list all tags in the knowledgebase (21 unique tags found)
-[x] `hyalo tag find --name iteration --dir hyalo-knowledgebase` — find iteration files (4 files found)
-[] `hyalo tag add --name plan --glob "iterations/*.md" --dir hyalo-knowledgebase` — batch tag (skipped: would modify knowledgebase files)
+- [x] `hyalo tags --dir hyalo-knowledgebase` — list all tags in the knowledgebase (21 unique tags found)
+- [x] `hyalo tag find --name iteration --dir hyalo-knowledgebase` — find iteration files (4 files found)
+- [ ] `hyalo tag add --name plan --glob "iterations/*.md" --dir hyalo-knowledgebase` — batch tag (skipped: would modify knowledgebase files)
 
 ## Acceptance Criteria
 
-1. [x] `hyalo tags` lists all unique tags with counts across all files
-2. [x] `hyalo tags --glob PATTERN` filters to matching files
-3. [x] `hyalo tag find --name TAG` lists files containing the tag
-4. [x] `hyalo tag find --name inbox` matches files tagged `inbox/processing` (nested matching)
-5. [x] `hyalo tag add --name TAG --file FILE` adds tag to frontmatter
-6. [x] `hyalo tag add` rejects invalid tag names with helpful error
-7. [x] `hyalo tag add --name TAG --glob PATTERN` batch-adds tag to matching files
-8. [x] `hyalo tag remove --name TAG --glob PATTERN` batch-removes tag
-9. [x] Idempotent: adding existing tag or removing absent tag is a no-op
-10. [x] Tag matching is case-insensitive
-11. [x] All quality gates pass: `cargo fmt && cargo clippy && cargo test`
+- [x] `hyalo tags` lists all unique tags with counts across all files
+- [x] `hyalo tags --glob PATTERN` filters to matching files
+- [x] `hyalo tag find --name TAG` lists files containing the tag
+- [x] `hyalo tag find --name inbox` matches files tagged `inbox/processing` (nested matching)
+- [x] `hyalo tag add --name TAG --file FILE` adds tag to frontmatter
+- [x] `hyalo tag add` rejects invalid tag names with helpful error
+- [x] `hyalo tag add --name TAG --glob PATTERN` batch-adds tag to matching files
+- [x] `hyalo tag remove --name TAG --glob PATTERN` batch-removes tag
+- [x] Idempotent: adding existing tag or removing absent tag is a no-op
+- [x] Tag matching is case-insensitive
+- [x] All quality gates pass: `cargo fmt && cargo clippy && cargo test`

--- a/hyalo-knowledgebase/iterations/iteration-3b-tasks.md
+++ b/hyalo-knowledgebase/iterations/iteration-3b-tasks.md
@@ -1,0 +1,164 @@
+---
+title: "Iteration 3b — Task Commands"
+type: iteration
+date: 2026-03-20
+status: planned
+branch: iter-3b/task-commands
+tags:
+  - iteration
+  - tasks
+  - scanner
+---
+
+# Iteration 3b — Task Commands
+
+## Goal
+
+Provide CLI commands to list, inspect, and modify markdown tasks (checkboxes) within individual files. Tasks are always file-scoped (`--file` required) — vault-wide task search is deferred to the indexing iteration. Support reading task status, toggling completion, and setting custom status characters.
+
+## CLI Interface
+
+```sh
+# List tasks in a file
+hyalo tasks --file FILE [--status CHAR] [--done] [--todo] [--dir DIR] [--format json|text]
+
+# Show a single task
+hyalo task read --file FILE --line N [--dir DIR] [--format json|text]
+
+# Toggle task completion ([ ] ↔ [x])
+hyalo task toggle --file FILE --line N [--dir DIR] [--format json|text]
+
+# Set custom status character
+hyalo task set-status --file FILE --line N --status CHAR [--dir DIR] [--format json|text]
+```
+
+### Output Examples
+
+**`hyalo tasks --file iterations/iteration-01-frontmatter-properties.md --todo`** (JSON):
+```json
+{
+  "file": "iterations/iteration-01-frontmatter-properties.md",
+  "tasks": [
+    { "line": 43, "status": " ", "text": "Implement streaming line scanner" },
+    { "line": 44, "status": " ", "text": "Track fenced code block state" }
+  ],
+  "total": 2
+}
+```
+
+**`hyalo task read --file plan.md --line 12`** (JSON):
+```json
+{
+  "file": "plan.md",
+  "line": 12,
+  "status": " ",
+  "text": "Write integration tests",
+  "done": false
+}
+```
+
+**`hyalo task toggle --file plan.md --line 12`** (JSON):
+```json
+{
+  "file": "plan.md",
+  "line": 12,
+  "status": "x",
+  "text": "Write integration tests",
+  "done": true
+}
+```
+
+### Task Syntax
+
+A task is a line matching the pattern: optional whitespace, then `- [C] ` where `C` is any single character. Examples:
+
+- `- [ ] incomplete task` — status `" "`, done = false
+- `- [x] completed task` — status `"x"`, done = true
+- `- [-] cancelled task` — status `"-"`, done = false
+- `- [?] question` — status `"?"`, done = false
+- `- [!] important` — status `"!"`, done = false
+
+Only `[x]` and `[X]` are considered "done". All other status characters are "not done".
+
+### Filter Flags
+
+- `--todo` — show tasks where done = false (any status except `x`/`X`)
+- `--done` — show tasks where done = true (status `x` or `X`)
+- `--status CHAR` — show tasks with exactly this status character (e.g. `--status "-"` for cancelled)
+- Filters are mutually exclusive. Using multiple is an error.
+
+### Behavior Notes
+
+- `--file` is required for all task commands (no vault-wide mode, see [[decision-log#DEC-021]])
+- `task toggle` flips `[ ]` → `[x]` and `[x]` / `[X]` → `[ ]`. For custom statuses like `[-]`, toggle sets to `[x]` (marking done)
+- `task set-status` accepts any single character
+- Line numbers are 1-based (matching editor conventions)
+- Task mutation edits the file in-place, preserving all other content
+- If the specified line is not a task, commands return a user error with hint
+
+## New Modules
+
+### `src/tasks.rs` — Task Extraction & Mutation
+
+Task parsing uses the existing streaming scanner to find task lines. Task mutation reads the full file, modifies the target line, and writes back (similar to frontmatter mutation but operating on body lines).
+
+**Key types:**
+```rust
+pub struct Task {
+    pub line: usize,       // 1-based line number
+    pub status: char,      // the character between [ and ]
+    pub text: String,      // task text after `] `
+    pub done: bool,        // true only for 'x' or 'X'
+}
+```
+
+### `src/commands/tasks.rs` — Command Implementations
+
+## Tasks
+
+### Task Parsing
+[] Implement task line regex/pattern matching: `- [C] text`
+[] Extract tasks from a file using the streaming scanner
+[] Handle indented tasks (nested lists)
+[] Unit tests for task parsing (various status chars, indentation, edge cases)
+
+### Task Mutation
+[] Implement in-place line editing: read file, modify target line, write back
+[] `toggle`: `[ ]` → `[x]`, `[x]`/`[X]` → `[ ]`, custom → `[x]`
+[] `set-status`: replace status character
+[] Validate that target line is actually a task before mutation
+[] Unit tests for mutation logic
+
+### Commands
+[] `tasks` command — list tasks with optional filters (`--done`, `--todo`, `--status`)
+[] `task read` command — show single task by file + line
+[] `task toggle` command — toggle completion state
+[] `task set-status` command — set custom status character
+[] Wire up CLI in main.rs with clap subcommands
+[] Validate filter flag mutual exclusivity
+
+### Testing
+[] E2E tests for `tasks --file` (all tasks, `--done`, `--todo`, `--status`)
+[] E2E tests for `task read` (valid line, non-task line, out-of-range line)
+[] E2E tests for `task toggle` (incomplete → done, done → incomplete, custom → done)
+[] E2E tests for `task set-status`
+[] E2E tests for error cases (missing `--file`, invalid line number, line is not a task)
+
+### Quality Gates
+[] `cargo fmt`
+[] `cargo clippy --workspace --all-targets -- -D warnings`
+[] `cargo test --workspace`
+
+### Dogfooding
+[] `hyalo tasks --file iterations/iteration-01-frontmatter-properties.md --dir hyalo-knowledgebase` — list tasks in iteration 1
+[] `hyalo task read --file iterations/iteration-01-frontmatter-properties.md --line 43 --dir hyalo-knowledgebase`
+
+## Acceptance Criteria
+
+1. [] `hyalo tasks --file FILE` lists all tasks with line, status, text, done
+2. [] `--done`, `--todo`, `--status CHAR` filters work correctly and are mutually exclusive
+3. [] `hyalo task read --file FILE --line N` shows task details
+4. [] `hyalo task toggle --file FILE --line N` toggles completion state
+5. [] `hyalo task set-status --file FILE --line N --status CHAR` sets custom status
+6. [] Non-task lines return user error with helpful hint
+7. [] All quality gates pass: `cargo fmt && cargo clippy && cargo test`

--- a/hyalo-knowledgebase/iterations/iteration-3b-tasks.md
+++ b/hyalo-knowledgebase/iterations/iteration-3b-tasks.md
@@ -117,48 +117,48 @@ pub struct Task {
 ## Tasks
 
 ### Task Parsing
-[] Implement task line regex/pattern matching: `- [C] text`
-[] Extract tasks from a file using the streaming scanner
-[] Handle indented tasks (nested lists)
-[] Unit tests for task parsing (various status chars, indentation, edge cases)
+- [ ] Implement task line regex/pattern matching: `- [C] text`
+- [ ] Extract tasks from a file using the streaming scanner
+- [ ] Handle indented tasks (nested lists)
+- [ ] Unit tests for task parsing (various status chars, indentation, edge cases)
 
 ### Task Mutation
-[] Implement in-place line editing: read file, modify target line, write back
-[] `toggle`: `[ ]` → `[x]`, `[x]`/`[X]` → `[ ]`, custom → `[x]`
-[] `set-status`: replace status character
-[] Validate that target line is actually a task before mutation
-[] Unit tests for mutation logic
+- [ ] Implement in-place line editing: read file, modify target line, write back
+- [ ] `toggle`: `[ ]` → `[x]`, `[x]`/`[X]` → `[ ]`, custom → `[x]`
+- [ ] `set-status`: replace status character
+- [ ] Validate that target line is actually a task before mutation
+- [ ] Unit tests for mutation logic
 
 ### Commands
-[] `tasks` command — list tasks with optional filters (`--done`, `--todo`, `--status`)
-[] `task read` command — show single task by file + line
-[] `task toggle` command — toggle completion state
-[] `task set-status` command — set custom status character
-[] Wire up CLI in main.rs with clap subcommands
-[] Validate filter flag mutual exclusivity
+- [ ] `tasks` command — list tasks with optional filters (`--done`, `--todo`, `--status`)
+- [ ] `task read` command — show single task by file + line
+- [ ] `task toggle` command — toggle completion state
+- [ ] `task set-status` command — set custom status character
+- [ ] Wire up CLI in main.rs with clap subcommands
+- [ ] Validate filter flag mutual exclusivity
 
 ### Testing
-[] E2E tests for `tasks --file` (all tasks, `--done`, `--todo`, `--status`)
-[] E2E tests for `task read` (valid line, non-task line, out-of-range line)
-[] E2E tests for `task toggle` (incomplete → done, done → incomplete, custom → done)
-[] E2E tests for `task set-status`
-[] E2E tests for error cases (missing `--file`, invalid line number, line is not a task)
+- [ ] E2E tests for `tasks --file` (all tasks, `--done`, `--todo`, `--status`)
+- [ ] E2E tests for `task read` (valid line, non-task line, out-of-range line)
+- [ ] E2E tests for `task toggle` (incomplete → done, done → incomplete, custom → done)
+- [ ] E2E tests for `task set-status`
+- [ ] E2E tests for error cases (missing `--file`, invalid line number, line is not a task)
 
 ### Quality Gates
-[] `cargo fmt`
-[] `cargo clippy --workspace --all-targets -- -D warnings`
-[] `cargo test --workspace`
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
 
 ### Dogfooding
-[] `hyalo tasks --file iterations/iteration-01-frontmatter-properties.md --dir hyalo-knowledgebase` — list tasks in iteration 1
-[] `hyalo task read --file iterations/iteration-01-frontmatter-properties.md --line 43 --dir hyalo-knowledgebase`
+- [ ] `hyalo tasks --file iterations/iteration-01-frontmatter-properties.md --dir hyalo-knowledgebase` — list tasks in iteration 1
+- [ ] `hyalo task read --file iterations/iteration-01-frontmatter-properties.md --line 43 --dir hyalo-knowledgebase`
 
 ## Acceptance Criteria
 
-1. [] `hyalo tasks --file FILE` lists all tasks with line, status, text, done
-2. [] `--done`, `--todo`, `--status CHAR` filters work correctly and are mutually exclusive
-3. [] `hyalo task read --file FILE --line N` shows task details
-4. [] `hyalo task toggle --file FILE --line N` toggles completion state
-5. [] `hyalo task set-status --file FILE --line N --status CHAR` sets custom status
-6. [] Non-task lines return user error with helpful hint
-7. [] All quality gates pass: `cargo fmt && cargo clippy && cargo test`
+- [ ] `hyalo tasks --file FILE` lists all tasks with line, status, text, done
+- [ ] `--done`, `--todo`, `--status CHAR` filters work correctly and are mutually exclusive
+- [ ] `hyalo task read --file FILE --line N` shows task details
+- [ ] `hyalo task toggle --file FILE --line N` toggles completion state
+- [ ] `hyalo task set-status --file FILE --line N --status CHAR` sets custom status
+- [ ] Non-task lines return user error with helpful hint
+- [ ] All quality gates pass: `cargo fmt && cargo clippy && cargo test`

--- a/src/commands/links.rs
+++ b/src/commands/links.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use serde_json::json;
 use std::path::Path;
 
-use crate::discovery::{self, FileResolveError};
+use crate::commands::resolve_error_to_outcome;
+use crate::discovery;
 use crate::links;
 use crate::output::{CommandOutcome, Format};
 
@@ -53,23 +54,6 @@ pub fn links(dir: &Path, file: &str, filter: LinkFilter, format: Format) -> Resu
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
     )))
-}
-
-fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
-    match err {
-        FileResolveError::MissingExtension { path, hint } => {
-            CommandOutcome::UserError(crate::output::format_error(
-                format,
-                "file not found",
-                Some(&path),
-                Some(&format!("did you mean {hint}?")),
-                None,
-            ))
-        }
-        FileResolveError::NotFound { path } => CommandOutcome::UserError(
-            crate::output::format_error(format, "file not found", Some(&path), None, None),
-        ),
-    }
 }
 
 #[cfg(test)]

--- a/src/commands/links.rs
+++ b/src/commands/links.rs
@@ -61,11 +61,22 @@ mod tests {
     use super::*;
     use std::fs;
 
+    macro_rules! md {
+        ($s:expr) => {
+            $s.strip_prefix('\n').unwrap_or($s)
+        };
+    }
+
     fn setup_vault() -> tempfile::TempDir {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note-a.md"),
-            "---\ntitle: A\n---\nSee [[note-b]] and [[nonexistent]]\n",
+            md!(r#"
+---
+title: A
+---
+See [[note-b]] and [[nonexistent]]
+"#),
         )
         .unwrap();
         fs::write(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod links;
 pub mod properties;
+pub mod tags;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,95 @@
 pub mod links;
 pub mod properties;
 pub mod tags;
+
+use crate::discovery::{self, FileResolveError};
+use crate::output::{CommandOutcome, Format};
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Shared file resolution helpers
+// ---------------------------------------------------------------------------
+
+/// Outcome of resolving the set of files to operate on.
+/// Either a list of `(full_path, rel_path)` pairs or a pre-formed `CommandOutcome`
+/// (user error) when the resolution failed.
+pub enum FilesOrOutcome {
+    Files(Vec<(PathBuf, String)>),
+    Outcome(CommandOutcome),
+}
+
+/// Resolve the set of files to operate on based on `--file` / `--glob` / all files.
+/// Returns a user-error outcome for invalid inputs (file not found, no glob matches).
+pub fn collect_files(
+    dir: &Path,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<FilesOrOutcome> {
+    match (file, glob) {
+        (Some(f), None) => {
+            let resolved = match discovery::resolve_file(dir, f) {
+                Ok(r) => r,
+                Err(e) => return Ok(FilesOrOutcome::Outcome(resolve_error_to_outcome(e, format))),
+            };
+            Ok(FilesOrOutcome::Files(vec![resolved]))
+        }
+        (None, Some(pattern)) => {
+            let all = discovery::discover_files(dir)?;
+            let matched = discovery::match_glob(dir, &all, pattern)?;
+            if matched.is_empty() {
+                let out = crate::output::format_error(
+                    format,
+                    "no files match pattern",
+                    Some(pattern),
+                    None,
+                    None,
+                );
+                return Ok(FilesOrOutcome::Outcome(CommandOutcome::UserError(out)));
+            }
+            Ok(FilesOrOutcome::Files(matched))
+        }
+        (None, None) => {
+            // Operate on all .md files
+            let all = discovery::discover_files(dir)?;
+            let with_rel: Vec<(PathBuf, String)> = all
+                .into_iter()
+                .map(|p| {
+                    let rel = discovery::relative_path(dir, &p);
+                    (p, rel)
+                })
+                .collect();
+            Ok(FilesOrOutcome::Files(with_rel))
+        }
+        (Some(_), Some(_)) => {
+            // Clap enforces mutual exclusivity; this branch is unreachable in practice
+            let out = crate::output::format_error(
+                format,
+                "--file and --glob are mutually exclusive",
+                None,
+                None,
+                None,
+            );
+            Ok(FilesOrOutcome::Outcome(CommandOutcome::UserError(out)))
+        }
+    }
+}
+
+/// Convert a `FileResolveError` into a user-facing `CommandOutcome`.
+pub fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
+    match err {
+        FileResolveError::MissingExtension { path, hint } => {
+            CommandOutcome::UserError(crate::output::format_error(
+                format,
+                "file not found",
+                Some(&path),
+                Some(&format!("did you mean {hint}?")),
+                None,
+            ))
+        }
+        FileResolveError::NotFound { path } => CommandOutcome::UserError(
+            crate::output::format_error(format, "file not found", Some(&path), None, None),
+        ),
+    }
+}

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -210,11 +210,27 @@ mod tests {
     use super::*;
     use std::fs;
 
+    macro_rules! md {
+        ($s:expr) => {
+            $s.strip_prefix('\n').unwrap_or($s)
+        };
+    }
+
     fn setup_dir() -> tempfile::TempDir {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            "---\ntitle: Test\nstatus: draft\npriority: 3\ntags:\n  - rust\n  - cli\n---\n# Hello\n",
+            md!(r#"
+---
+title: Test
+status: draft
+priority: 3
+tags:
+  - rust
+  - cli
+---
+# Hello
+"#),
         )
         .unwrap();
         fs::write(tmp.path().join("empty.md"), "No frontmatter here.\n").unwrap();
@@ -372,10 +388,20 @@ mod tests {
     #[test]
     fn property_set_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = "# Heading\n\nBody content.\n";
+        let body = md!(r#"
+# Heading
+
+Body content.
+"#);
         fs::write(
             tmp.path().join("note.md"),
-            format!("---\ntitle: Test\n---\n{body}"),
+            md!(r#"
+---
+title: Test
+---
+"#)
+            .to_owned()
+                + body,
         )
         .unwrap();
 
@@ -388,10 +414,21 @@ mod tests {
     #[test]
     fn property_remove_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = "# Heading\n\nBody content.\n";
+        let body = md!(r#"
+# Heading
+
+Body content.
+"#);
         fs::write(
             tmp.path().join("note.md"),
-            format!("---\ntitle: Test\nstatus: draft\n---\n{body}"),
+            md!(r#"
+---
+title: Test
+status: draft
+---
+"#)
+            .to_owned()
+                + body,
         )
         .unwrap();
 

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -1,11 +1,10 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::json;
-use std::collections::BTreeMap;
-use std::fs;
 use std::path::Path;
 
-use crate::discovery::{self, FileResolveError};
-use crate::frontmatter::{self, Document};
+use crate::commands::{FilesOrOutcome, collect_files, resolve_error_to_outcome};
+use crate::discovery;
+use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
 
 /// List all properties across all files, or properties of a single file / glob match.
@@ -19,12 +18,17 @@ pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<Comm
 
 /// List all unique property names across all `.md` files.
 fn properties_all(dir: &Path, format: Format) -> Result<CommandOutcome> {
-    let files = discovery::discover_files(dir)?;
+    let files = collect_files(dir, None, None, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
 
     // Aggregate: name -> (type, count)
-    let mut agg: BTreeMap<String, (String, usize)> = BTreeMap::new();
+    let mut agg: std::collections::BTreeMap<String, (String, usize)> =
+        std::collections::BTreeMap::new();
 
-    for file in &files {
+    for (file, _) in &files {
         let props = frontmatter::read_frontmatter(file)?;
         for (key, value) in &props {
             agg.entry(key.clone())
@@ -74,22 +78,14 @@ fn properties_single(dir: &Path, path_arg: &str, format: Format) -> Result<Comma
 
 /// List properties of files matching a glob pattern.
 fn properties_glob(dir: &Path, pattern: &str, format: Format) -> Result<CommandOutcome> {
-    let files = discovery::discover_files(dir)?;
-    let matched = discovery::match_glob(dir, &files, pattern)?;
-
-    if matched.is_empty() {
-        let out = crate::output::format_error(
-            format,
-            "no files match pattern",
-            Some(pattern),
-            None,
-            None,
-        );
-        return Ok(CommandOutcome::UserError(out));
-    }
+    let files = collect_files(dir, None, Some(pattern), format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
 
     let mut results = Vec::new();
-    for (full_path, rel_path) in &matched {
+    for (full_path, rel_path) in &files {
         let props = frontmatter::read_frontmatter(full_path)?;
 
         let prop_map: serde_json::Map<String, serde_json::Value> = props
@@ -155,18 +151,13 @@ pub fn property_set(
         Err(outcome) => return Ok(outcome),
     };
 
-    let content = fs::read_to_string(&full_path)
-        .with_context(|| format!("failed to read {}", full_path.display()))?;
-    let mut doc = Document::parse(&content)?;
-
     let value = frontmatter::parse_value(raw_value, forced_type)?;
     let typ = frontmatter::infer_type(&value);
     let json_val = frontmatter::yaml_to_json(&value);
-    doc.set_property(name.to_owned(), value);
 
-    let serialized = doc.serialize()?;
-    fs::write(&full_path, serialized)
-        .with_context(|| format!("failed to write {}", full_path.display()))?;
+    let mut props = frontmatter::read_frontmatter(&full_path)?;
+    props.insert(name.to_owned(), value);
+    frontmatter::write_frontmatter(&full_path, &props)?;
 
     let result = json!({"name": name, "value": json_val, "type": typ});
 
@@ -187,14 +178,10 @@ pub fn property_remove(
         Err(outcome) => return Ok(outcome),
     };
 
-    let content = fs::read_to_string(&full_path)
-        .with_context(|| format!("failed to read {}", full_path.display()))?;
-    let mut doc = Document::parse(&content)?;
+    let mut props = frontmatter::read_frontmatter(&full_path)?;
 
-    if doc.remove_property(name).is_some() {
-        let serialized = doc.serialize()?;
-        fs::write(&full_path, serialized)
-            .with_context(|| format!("failed to write {}", full_path.display()))?;
+    if props.remove(name).is_some() {
+        frontmatter::write_frontmatter(&full_path, &props)?;
         let result = json!({"removed": name, "path": rel_path});
         Ok(CommandOutcome::Success(crate::output::format_success(
             format, &result,
@@ -215,23 +202,6 @@ fn resolve_or_error(
     match discovery::resolve_file(dir, path_arg) {
         Ok(r) => Ok(r),
         Err(e) => Err(resolve_error_to_outcome(e, format)),
-    }
-}
-
-fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
-    match err {
-        FileResolveError::MissingExtension { path, hint } => {
-            CommandOutcome::UserError(crate::output::format_error(
-                format,
-                "file not found",
-                Some(&path),
-                Some(&format!("did you mean {hint}?")),
-                None,
-            ))
-        }
-        FileResolveError::NotFound { path } => CommandOutcome::UserError(
-            crate::output::format_error(format, "file not found", Some(&path), None, None),
-        ),
     }
 }
 
@@ -397,5 +367,37 @@ mod tests {
 
         let content = fs::read_to_string(tmp.path().join("empty.md")).unwrap();
         assert!(content.starts_with("---\n"));
+    }
+
+    #[test]
+    fn property_set_preserves_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "# Heading\n\nBody content.\n";
+        fs::write(
+            tmp.path().join("note.md"),
+            format!("---\ntitle: Test\n---\n{body}"),
+        )
+        .unwrap();
+
+        property_set(tmp.path(), "status", "done", None, "note.md", Format::Json).unwrap();
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains(body), "body was corrupted:\n{content}");
+    }
+
+    #[test]
+    fn property_remove_preserves_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "# Heading\n\nBody content.\n";
+        fs::write(
+            tmp.path().join("note.md"),
+            format!("---\ntitle: Test\nstatus: draft\n---\n{body}"),
+        )
+        .unwrap();
+
+        property_remove(tmp.path(), "status", "note.md", Format::Json).unwrap();
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains(body), "body was corrupted:\n{content}");
     }
 }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -24,7 +24,7 @@ pub fn validate_tag(name: &str) -> Result<(), String> {
     }
 
     for ch in name.chars() {
-        if !ch.is_alphanumeric() && ch != '_' && ch != '-' && ch != '/' {
+        if !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-' && ch != '/' {
             return Err(format!(
                 "invalid character '{ch}' in tag name; allowed: letters, digits, _, -, /"
             ));
@@ -106,18 +106,23 @@ pub fn tags_list(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
-    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    // Aggregate case-insensitively: use lowercase key, preserve first-seen casing for display
+    let mut counts: BTreeMap<String, (String, usize)> = BTreeMap::new();
 
     for (full_path, _) in &files {
         let props = frontmatter::read_frontmatter(full_path)?;
         for tag in extract_tags(&props) {
-            *counts.entry(tag).or_insert(0) += 1;
+            let key = tag.to_ascii_lowercase();
+            counts
+                .entry(key)
+                .and_modify(|entry| entry.1 += 1)
+                .or_insert((tag, 1));
         }
     }
 
     let tags_json: Vec<serde_json::Value> = counts
         .into_iter()
-        .map(|(name, count)| json!({"name": name, "count": count}))
+        .map(|(_, (name, count))| json!({"name": name, "count": count}))
         .collect();
 
     let total = tags_json.len();

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -1,0 +1,700 @@
+use anyhow::{Context, Result};
+use serde_json::json;
+use serde_yaml_ng::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use crate::discovery::{self, FileResolveError};
+use crate::frontmatter::{self, Document};
+use crate::output::{CommandOutcome, Format};
+
+// ---------------------------------------------------------------------------
+// Tag format validation
+// ---------------------------------------------------------------------------
+
+/// Validate an Obsidian-compatible tag name.
+/// Rules:
+/// - Only letters, digits, underscores (`_`), hyphens (`-`), forward slashes (`/`)
+/// - Must contain at least one non-numeric character
+/// - Must not be empty
+/// - Forward slashes are allowed for hierarchy (e.g. `inbox/processing`)
+pub fn validate_tag(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("tag name must not be empty".to_owned());
+    }
+
+    for ch in name.chars() {
+        if !ch.is_alphanumeric() && ch != '_' && ch != '-' && ch != '/' {
+            return Err(format!(
+                "invalid character '{ch}' in tag name; allowed: letters, digits, _, -, /"
+            ));
+        }
+    }
+
+    // Must contain at least one non-digit character
+    if name.chars().all(|c| c.is_ascii_digit()) {
+        return Err(format!(
+            "tag '{name}' is all numeric; tags must contain at least one non-numeric character (e.g. 'y{name}')"
+        ));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Nested tag matching
+// ---------------------------------------------------------------------------
+
+/// Returns true if `tag` matches the query under Obsidian's nested tag rules.
+/// A tag matches if it equals the query or starts with `query/` (case-insensitive).
+pub fn tag_matches(tag: &str, query: &str) -> bool {
+    let tag_lower = tag.to_lowercase();
+    let query_lower = query.to_lowercase();
+    tag_lower == query_lower || tag_lower.starts_with(&format!("{query_lower}/"))
+}
+
+// ---------------------------------------------------------------------------
+// Tag extraction
+// ---------------------------------------------------------------------------
+
+/// Extract the `tags` list from a parsed frontmatter map.
+/// Handles:
+/// - Missing `tags` key → empty vec
+/// - `tags` as a YAML sequence → collect string items
+/// - `tags` as a scalar string → single-element vec
+/// - `tags` as empty sequence → empty vec
+pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
+    match props.get("tags") {
+        None => vec![],
+        Some(Value::Sequence(seq)) => seq
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .collect(),
+        Some(Value::String(s)) => {
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![s.clone()]
+            }
+        }
+        Some(Value::Null) => vec![],
+        _ => vec![],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tags` — list all unique tags with counts
+// ---------------------------------------------------------------------------
+
+pub fn tags_list(
+    dir: &Path,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+
+    for (full_path, _) in &files {
+        let props = frontmatter::read_frontmatter(full_path)?;
+        for tag in extract_tags(&props) {
+            *counts.entry(tag).or_insert(0) += 1;
+        }
+    }
+
+    let tags_json: Vec<serde_json::Value> = counts
+        .into_iter()
+        .map(|(name, count)| json!({"name": name, "count": count}))
+        .collect();
+
+    let total = tags_json.len();
+    let result = json!({"tags": tags_json, "total": total});
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tag find` — find files containing a specific tag
+// ---------------------------------------------------------------------------
+
+pub fn tag_find(
+    dir: &Path,
+    name: &str,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut matching_paths: Vec<String> = Vec::new();
+
+    for (full_path, rel_path) in &files {
+        let props = frontmatter::read_frontmatter(full_path)?;
+        let tags = extract_tags(&props);
+        if tags.iter().any(|t| tag_matches(t, name)) {
+            matching_paths.push(rel_path.clone());
+        }
+    }
+
+    let total = matching_paths.len();
+    let result = json!({"tag": name, "files": matching_paths, "total": total});
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tag add` — add a tag to file(s)
+// ---------------------------------------------------------------------------
+
+pub fn tag_add(
+    dir: &Path,
+    name: &str,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    // Validate tag name first
+    if let Err(msg) = validate_tag(name) {
+        let out = crate::output::format_error(
+            format,
+            &msg,
+            None,
+            Some(
+                "tag names may contain letters, digits, _, -, / and must have at least one non-numeric character",
+            ),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut modified: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+
+    for (full_path, rel_path) in &files {
+        let content = fs::read_to_string(full_path)
+            .with_context(|| format!("failed to read {}", full_path.display()))?;
+        let mut doc = Document::parse(&content)?;
+
+        let tags = extract_tags(doc.properties());
+        let already_has = tags.iter().any(|t| t.to_lowercase() == name.to_lowercase());
+
+        if already_has {
+            skipped.push(rel_path.clone());
+        } else {
+            // Build updated tags list
+            let mut new_tags = tags;
+            new_tags.push(name.to_owned());
+            let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
+            doc.set_property("tags".to_owned(), yaml_list);
+
+            let serialized = doc.serialize()?;
+            fs::write(full_path, serialized)
+                .with_context(|| format!("failed to write {}", full_path.display()))?;
+
+            modified.push(rel_path.clone());
+        }
+    }
+
+    let total = modified.len() + skipped.len();
+    let result = json!({
+        "tag": name,
+        "modified": modified,
+        "skipped": skipped,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tag remove` — remove a tag from file(s)
+// ---------------------------------------------------------------------------
+
+pub fn tag_remove(
+    dir: &Path,
+    name: &str,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut modified: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+
+    for (full_path, rel_path) in &files {
+        let content = fs::read_to_string(full_path)
+            .with_context(|| format!("failed to read {}", full_path.display()))?;
+        let mut doc = Document::parse(&content)?;
+
+        let tags = extract_tags(doc.properties());
+        let name_lower = name.to_lowercase();
+        let new_tags: Vec<String> = tags
+            .iter()
+            .filter(|t| t.to_lowercase() != name_lower)
+            .cloned()
+            .collect();
+
+        if new_tags.len() == tags.len() {
+            // Tag was not present — idempotent skip
+            skipped.push(rel_path.clone());
+        } else {
+            if new_tags.is_empty() {
+                doc.remove_property("tags");
+            } else {
+                let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
+                doc.set_property("tags".to_owned(), yaml_list);
+            }
+
+            let serialized = doc.serialize()?;
+            fs::write(full_path, serialized)
+                .with_context(|| format!("failed to write {}", full_path.display()))?;
+
+            modified.push(rel_path.clone());
+        }
+    }
+
+    let total = modified.len() + skipped.len();
+    let result = json!({
+        "tag": name,
+        "modified": modified,
+        "skipped": skipped,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+enum FilesOrOutcome {
+    Files(Vec<(std::path::PathBuf, String)>),
+    Outcome(CommandOutcome),
+}
+
+/// Resolve the set of files to operate on based on --file / --glob / all.
+/// Returns an error outcome for user errors (file not found, no glob matches).
+fn collect_files(
+    dir: &Path,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<FilesOrOutcome> {
+    match (file, glob) {
+        (Some(f), None) => {
+            let resolved = match discovery::resolve_file(dir, f) {
+                Ok(r) => r,
+                Err(e) => return Ok(FilesOrOutcome::Outcome(resolve_error_to_outcome(e, format))),
+            };
+            Ok(FilesOrOutcome::Files(vec![resolved]))
+        }
+        (None, Some(pattern)) => {
+            let all = discovery::discover_files(dir)?;
+            let matched = discovery::match_glob(dir, &all, pattern)?;
+            if matched.is_empty() {
+                let out = crate::output::format_error(
+                    format,
+                    "no files match pattern",
+                    Some(pattern),
+                    None,
+                    None,
+                );
+                return Ok(FilesOrOutcome::Outcome(CommandOutcome::UserError(out)));
+            }
+            Ok(FilesOrOutcome::Files(matched))
+        }
+        (None, None) => {
+            // Operate on all .md files
+            let all = discovery::discover_files(dir)?;
+            let with_rel: Vec<(std::path::PathBuf, String)> = all
+                .into_iter()
+                .map(|p| {
+                    let rel = discovery::relative_path(dir, &p);
+                    (p, rel)
+                })
+                .collect();
+            Ok(FilesOrOutcome::Files(with_rel))
+        }
+        (Some(_), Some(_)) => {
+            // Clap enforces mutual exclusivity; this branch is unreachable in practice
+            let out = crate::output::format_error(
+                format,
+                "--file and --glob are mutually exclusive",
+                None,
+                None,
+                None,
+            );
+            Ok(FilesOrOutcome::Outcome(CommandOutcome::UserError(out)))
+        }
+    }
+}
+
+fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
+    match err {
+        FileResolveError::MissingExtension { path, hint } => {
+            CommandOutcome::UserError(crate::output::format_error(
+                format,
+                "file not found",
+                Some(&path),
+                Some(&format!("did you mean {hint}?")),
+                None,
+            ))
+        }
+        FileResolveError::NotFound { path } => CommandOutcome::UserError(
+            crate::output::format_error(format, "file not found", Some(&path), None, None),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // --- Tag validation ---
+
+    #[test]
+    fn valid_tag_simple() {
+        assert!(validate_tag("inbox").is_ok());
+        assert!(validate_tag("my-tag").is_ok());
+        assert!(validate_tag("my_tag").is_ok());
+        assert!(validate_tag("MyTag").is_ok());
+        assert!(validate_tag("tag123").is_ok());
+        assert!(validate_tag("y1984").is_ok());
+    }
+
+    #[test]
+    fn valid_tag_nested() {
+        assert!(validate_tag("inbox/processing").is_ok());
+        assert!(validate_tag("project/hyalo/iteration").is_ok());
+    }
+
+    #[test]
+    fn invalid_tag_empty() {
+        assert!(validate_tag("").is_err());
+    }
+
+    #[test]
+    fn invalid_tag_numeric_only() {
+        let err = validate_tag("1984").unwrap_err();
+        assert!(err.contains("non-numeric"), "got: {err}");
+    }
+
+    #[test]
+    fn invalid_tag_with_space() {
+        let err = validate_tag("my tag").unwrap_err();
+        assert!(err.contains("invalid character"), "got: {err}");
+    }
+
+    #[test]
+    fn invalid_tag_special_chars() {
+        assert!(validate_tag("tag!").is_err());
+        assert!(validate_tag("tag@name").is_err());
+        assert!(validate_tag("#tag").is_err());
+    }
+
+    // --- Nested tag matching ---
+
+    #[test]
+    fn tag_matches_exact() {
+        assert!(tag_matches("inbox", "inbox"));
+    }
+
+    #[test]
+    fn tag_matches_child() {
+        assert!(tag_matches("inbox/processing", "inbox"));
+        assert!(tag_matches("inbox/to-read", "inbox"));
+    }
+
+    #[test]
+    fn tag_no_match_prefix_without_slash() {
+        assert!(!tag_matches("inboxes", "inbox"));
+        assert!(!tag_matches("my-inbox", "inbox"));
+    }
+
+    #[test]
+    fn tag_matches_case_insensitive() {
+        assert!(tag_matches("Inbox", "inbox"));
+        assert!(tag_matches("INBOX/PROCESSING", "inbox"));
+        assert!(tag_matches("inbox", "INBOX"));
+    }
+
+    #[test]
+    fn tag_no_match_different_tag() {
+        assert!(!tag_matches("project", "inbox"));
+    }
+
+    // --- Tag extraction ---
+
+    fn make_props(yaml: &str) -> BTreeMap<String, Value> {
+        serde_yaml_ng::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn extract_tags_from_list() {
+        let props = make_props("tags:\n  - rust\n  - cli\n");
+        let tags = extract_tags(&props);
+        assert_eq!(tags, vec!["rust", "cli"]);
+    }
+
+    #[test]
+    fn extract_tags_from_scalar_string() {
+        let props = make_props("tags: rust\n");
+        let tags = extract_tags(&props);
+        assert_eq!(tags, vec!["rust"]);
+    }
+
+    #[test]
+    fn extract_tags_missing_key() {
+        let props = make_props("title: Note\n");
+        let tags = extract_tags(&props);
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn extract_tags_empty_list() {
+        let props = make_props("tags: []\n");
+        let tags = extract_tags(&props);
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn extract_tags_null() {
+        let props = make_props("tags: ~\n");
+        let tags = extract_tags(&props);
+        assert!(tags.is_empty());
+    }
+
+    // --- tags_list command ---
+
+    fn setup_vault() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("a.md"),
+            "---\ntags:\n  - rust\n  - cli\n---\n# A\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("b.md"),
+            "---\ntags:\n  - rust\n  - iteration\n---\n# B\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("c.md"), "No frontmatter.\n").unwrap();
+        tmp
+    }
+
+    #[test]
+    fn tags_list_all_files() {
+        let tmp = setup_vault();
+        let outcome = tags_list(tmp.path(), None, None, Format::Json).unwrap();
+        let out = match outcome {
+            CommandOutcome::Success(s) => s,
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let tags = parsed["tags"].as_array().unwrap();
+        assert_eq!(parsed["total"], 3); // rust, cli, iteration
+        let rust = tags.iter().find(|t| t["name"] == "rust").unwrap();
+        assert_eq!(rust["count"], 2);
+    }
+
+    #[test]
+    fn tags_list_single_file() {
+        let tmp = setup_vault();
+        let outcome = tags_list(tmp.path(), Some("a.md"), None, Format::Json).unwrap();
+        let out = match outcome {
+            CommandOutcome::Success(s) => s,
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["total"], 2);
+    }
+
+    // --- tag_find command ---
+
+    #[test]
+    fn tag_find_exact_match() {
+        let tmp = setup_vault();
+        let outcome = tag_find(tmp.path(), "cli", None, None, Format::Json).unwrap();
+        let out = match outcome {
+            CommandOutcome::Success(s) => s,
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn tag_find_nested_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            "---\ntags:\n  - inbox/processing\n---\n",
+        )
+        .unwrap();
+        let outcome = tag_find(tmp.path(), "inbox", None, None, Format::Json).unwrap();
+        let out = match outcome {
+            CommandOutcome::Success(s) => s,
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["total"], 1);
+    }
+
+    #[test]
+    fn tag_find_no_match() {
+        let tmp = setup_vault();
+        let outcome = tag_find(tmp.path(), "nonexistent", None, None, Format::Json).unwrap();
+        let out = match outcome {
+            CommandOutcome::Success(s) => s,
+            _ => panic!("expected success"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["total"], 0);
+    }
+
+    // --- tag_add command ---
+
+    #[test]
+    fn tag_add_creates_new_property() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+
+        let outcome = tag_add(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
+        match outcome {
+            CommandOutcome::Success(s) => {
+                let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+                assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+                assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+            }
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        }
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("rust"));
+    }
+
+    #[test]
+    fn tag_add_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntags:\n  - rust\n---\n").unwrap();
+
+        let outcome = tag_add(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
+        match outcome {
+            CommandOutcome::Success(s) => {
+                let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+                assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
+                assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+            }
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        }
+    }
+
+    #[test]
+    fn tag_add_invalid_name_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+
+        let outcome = tag_add(tmp.path(), "1984", Some("note.md"), None, Format::Json).unwrap();
+        assert!(matches!(outcome, CommandOutcome::UserError(_)));
+    }
+
+    // --- tag_remove command ---
+
+    #[test]
+    fn tag_remove_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            "---\ntags:\n  - rust\n  - cli\n---\n",
+        )
+        .unwrap();
+
+        let outcome = tag_remove(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
+        match outcome {
+            CommandOutcome::Success(s) => {
+                let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+                assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+                assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+            }
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        }
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("rust"));
+        assert!(content.contains("cli"));
+    }
+
+    #[test]
+    fn tag_remove_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntags:\n  - cli\n---\n").unwrap();
+
+        let outcome = tag_remove(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
+        match outcome {
+            CommandOutcome::Success(s) => {
+                let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+                assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
+                assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+            }
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        }
+    }
+
+    #[test]
+    fn tag_remove_empties_tags_property() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            "---\ntitle: Note\ntags:\n  - rust\n---\n",
+        )
+        .unwrap();
+
+        tag_remove(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        // tags property should be removed entirely
+        assert!(!content.contains("tags:"));
+        // title should still be present
+        assert!(content.contains("title:"));
+    }
+}

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -1,12 +1,11 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::json;
 use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
-use std::fs;
 use std::path::Path;
 
-use crate::discovery::{self, FileResolveError};
-use crate::frontmatter::{self, Document};
+use crate::commands::{FilesOrOutcome, collect_files};
+use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
 
 // ---------------------------------------------------------------------------
@@ -48,10 +47,14 @@ pub fn validate_tag(name: &str) -> Result<(), String> {
 
 /// Returns true if `tag` matches the query under Obsidian's nested tag rules.
 /// A tag matches if it equals the query or starts with `query/` (case-insensitive).
+///
+/// Uses byte-level ASCII comparison — safe because tag names are validated to only
+/// contain ASCII characters (letters, digits, `_`, `-`, `/`).
 pub fn tag_matches(tag: &str, query: &str) -> bool {
-    let tag_lower = tag.to_lowercase();
-    let query_lower = query.to_lowercase();
-    tag_lower == query_lower || tag_lower.starts_with(&format!("{query_lower}/"))
+    tag.eq_ignore_ascii_case(query)
+        || (tag.len() > query.len()
+            && tag.as_bytes()[query.len()] == b'/'
+            && tag[..query.len()].eq_ignore_ascii_case(query))
 }
 
 // ---------------------------------------------------------------------------
@@ -185,6 +188,20 @@ pub fn tag_add(
         return Ok(CommandOutcome::UserError(out));
     }
 
+    // Mutation commands require --file or --glob to avoid accidentally touching every file
+    if file.is_none() && glob.is_none() {
+        let out = crate::output::format_error(
+            format,
+            "tag add requires --file or --glob",
+            None,
+            Some(
+                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
+            ),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
     let files = collect_files(dir, file, glob, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
@@ -195,12 +212,10 @@ pub fn tag_add(
     let mut skipped: Vec<String> = Vec::new();
 
     for (full_path, rel_path) in &files {
-        let content = fs::read_to_string(full_path)
-            .with_context(|| format!("failed to read {}", full_path.display()))?;
-        let mut doc = Document::parse(&content)?;
-
-        let tags = extract_tags(doc.properties());
-        let already_has = tags.iter().any(|t| t.to_lowercase() == name.to_lowercase());
+        // Read frontmatter only for the idempotency check
+        let props = frontmatter::read_frontmatter(full_path)?;
+        let tags = extract_tags(&props);
+        let already_has = tags.iter().any(|t| t.eq_ignore_ascii_case(name));
 
         if already_has {
             skipped.push(rel_path.clone());
@@ -209,12 +224,9 @@ pub fn tag_add(
             let mut new_tags = tags;
             new_tags.push(name.to_owned());
             let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
-            doc.set_property("tags".to_owned(), yaml_list);
-
-            let serialized = doc.serialize()?;
-            fs::write(full_path, serialized)
-                .with_context(|| format!("failed to write {}", full_path.display()))?;
-
+            let mut new_props = props;
+            new_props.insert("tags".to_owned(), yaml_list);
+            frontmatter::write_frontmatter(full_path, &new_props)?;
             modified.push(rel_path.clone());
         }
     }
@@ -243,6 +255,20 @@ pub fn tag_remove(
     glob: Option<&str>,
     format: Format,
 ) -> Result<CommandOutcome> {
+    // Mutation commands require --file or --glob to avoid accidentally touching every file
+    if file.is_none() && glob.is_none() {
+        let out = crate::output::format_error(
+            format,
+            "tag remove requires --file or --glob",
+            None,
+            Some(
+                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
+            ),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
     let files = collect_files(dir, file, glob, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
@@ -253,15 +279,12 @@ pub fn tag_remove(
     let mut skipped: Vec<String> = Vec::new();
 
     for (full_path, rel_path) in &files {
-        let content = fs::read_to_string(full_path)
-            .with_context(|| format!("failed to read {}", full_path.display()))?;
-        let mut doc = Document::parse(&content)?;
-
-        let tags = extract_tags(doc.properties());
-        let name_lower = name.to_lowercase();
+        // Read frontmatter only
+        let props = frontmatter::read_frontmatter(full_path)?;
+        let tags = extract_tags(&props);
         let new_tags: Vec<String> = tags
             .iter()
-            .filter(|t| t.to_lowercase() != name_lower)
+            .filter(|t| !t.eq_ignore_ascii_case(name))
             .cloned()
             .collect();
 
@@ -269,17 +292,14 @@ pub fn tag_remove(
             // Tag was not present — idempotent skip
             skipped.push(rel_path.clone());
         } else {
+            let mut new_props = props;
             if new_tags.is_empty() {
-                doc.remove_property("tags");
+                new_props.remove("tags");
             } else {
                 let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
-                doc.set_property("tags".to_owned(), yaml_list);
+                new_props.insert("tags".to_owned(), yaml_list);
             }
-
-            let serialized = doc.serialize()?;
-            fs::write(full_path, serialized)
-                .with_context(|| format!("failed to write {}", full_path.display()))?;
-
+            frontmatter::write_frontmatter(full_path, &new_props)?;
             modified.push(rel_path.clone());
         }
     }
@@ -295,89 +315,6 @@ pub fn tag_remove(
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
     )))
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-enum FilesOrOutcome {
-    Files(Vec<(std::path::PathBuf, String)>),
-    Outcome(CommandOutcome),
-}
-
-/// Resolve the set of files to operate on based on --file / --glob / all.
-/// Returns an error outcome for user errors (file not found, no glob matches).
-fn collect_files(
-    dir: &Path,
-    file: Option<&str>,
-    glob: Option<&str>,
-    format: Format,
-) -> Result<FilesOrOutcome> {
-    match (file, glob) {
-        (Some(f), None) => {
-            let resolved = match discovery::resolve_file(dir, f) {
-                Ok(r) => r,
-                Err(e) => return Ok(FilesOrOutcome::Outcome(resolve_error_to_outcome(e, format))),
-            };
-            Ok(FilesOrOutcome::Files(vec![resolved]))
-        }
-        (None, Some(pattern)) => {
-            let all = discovery::discover_files(dir)?;
-            let matched = discovery::match_glob(dir, &all, pattern)?;
-            if matched.is_empty() {
-                let out = crate::output::format_error(
-                    format,
-                    "no files match pattern",
-                    Some(pattern),
-                    None,
-                    None,
-                );
-                return Ok(FilesOrOutcome::Outcome(CommandOutcome::UserError(out)));
-            }
-            Ok(FilesOrOutcome::Files(matched))
-        }
-        (None, None) => {
-            // Operate on all .md files
-            let all = discovery::discover_files(dir)?;
-            let with_rel: Vec<(std::path::PathBuf, String)> = all
-                .into_iter()
-                .map(|p| {
-                    let rel = discovery::relative_path(dir, &p);
-                    (p, rel)
-                })
-                .collect();
-            Ok(FilesOrOutcome::Files(with_rel))
-        }
-        (Some(_), Some(_)) => {
-            // Clap enforces mutual exclusivity; this branch is unreachable in practice
-            let out = crate::output::format_error(
-                format,
-                "--file and --glob are mutually exclusive",
-                None,
-                None,
-                None,
-            );
-            Ok(FilesOrOutcome::Outcome(CommandOutcome::UserError(out)))
-        }
-    }
-}
-
-fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
-    match err {
-        FileResolveError::MissingExtension { path, hint } => {
-            CommandOutcome::UserError(crate::output::format_error(
-                format,
-                "file not found",
-                Some(&path),
-                Some(&format!("did you mean {hint}?")),
-                None,
-            ))
-        }
-        FileResolveError::NotFound { path } => CommandOutcome::UserError(
-            crate::output::format_error(format, "file not found", Some(&path), None, None),
-        ),
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -638,6 +575,16 @@ mod tests {
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
+    #[test]
+    fn tag_add_requires_file_or_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+
+        // Neither --file nor --glob → user error
+        let outcome = tag_add(tmp.path(), "rust", None, None, Format::Json).unwrap();
+        assert!(matches!(outcome, CommandOutcome::UserError(_)));
+    }
+
     // --- tag_remove command ---
 
     #[test]
@@ -696,5 +643,59 @@ mod tests {
         assert!(!content.contains("tags:"));
         // title should still be present
         assert!(content.contains("title:"));
+    }
+
+    #[test]
+    fn tag_remove_requires_file_or_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntags:\n  - rust\n---\n").unwrap();
+
+        // Neither --file nor --glob → user error
+        let outcome = tag_remove(tmp.path(), "rust", None, None, Format::Json).unwrap();
+        assert!(matches!(outcome, CommandOutcome::UserError(_)));
+    }
+
+    // --- body preservation ---
+
+    #[test]
+    fn tag_add_preserves_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "# Heading\n\nSome content with [[wikilinks]] and more text.\n";
+        fs::write(
+            tmp.path().join("note.md"),
+            format!("---\ntitle: Note\n---\n{body}"),
+        )
+        .unwrap();
+
+        tag_add(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains(body), "body was corrupted:\n{content}");
+    }
+
+    #[test]
+    fn tag_remove_preserves_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "# Heading\n\nSome content.\n";
+        fs::write(
+            tmp.path().join("note.md"),
+            format!("---\ntags:\n  - rust\n  - cli\n---\n{body}"),
+        )
+        .unwrap();
+
+        tag_remove(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains(body), "body was corrupted:\n{content}");
+    }
+
+    // --- discover_files used by tags_list (read-only) still works without file/glob ---
+
+    #[test]
+    fn tags_list_no_file_or_glob_reads_all() {
+        let tmp = setup_vault();
+        // tags_list (read-only) still accepts no --file/--glob
+        let outcome = tags_list(tmp.path(), None, None, Format::Json).unwrap();
+        assert!(matches!(outcome, CommandOutcome::Success(_)));
     }
 }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -331,6 +331,12 @@ mod tests {
     use super::*;
     use std::fs;
 
+    macro_rules! md {
+        ($s:expr) => {
+            $s.strip_prefix('\n').unwrap_or($s)
+        };
+    }
+
     // --- Tag validation ---
 
     #[test]
@@ -412,7 +418,11 @@ mod tests {
 
     #[test]
     fn extract_tags_from_list() {
-        let props = make_props("tags:\n  - rust\n  - cli\n");
+        let props = make_props(md!(r#"
+tags:
+  - rust
+  - cli
+"#));
         let tags = extract_tags(&props);
         assert_eq!(tags, vec!["rust", "cli"]);
     }
@@ -451,12 +461,26 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("a.md"),
-            "---\ntags:\n  - rust\n  - cli\n---\n# A\n",
+            md!(r#"
+---
+tags:
+  - rust
+  - cli
+---
+# A
+"#),
         )
         .unwrap();
         fs::write(
             tmp.path().join("b.md"),
-            "---\ntags:\n  - rust\n  - iteration\n---\n# B\n",
+            md!(r#"
+---
+tags:
+  - rust
+  - iteration
+---
+# B
+"#),
         )
         .unwrap();
         fs::write(tmp.path().join("c.md"), "No frontmatter.\n").unwrap();
@@ -510,7 +534,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            "---\ntags:\n  - inbox/processing\n---\n",
+            md!(r#"
+---
+tags:
+  - inbox/processing
+---
+"#),
         )
         .unwrap();
         let outcome = tag_find(tmp.path(), "inbox", None, None, Format::Json).unwrap();
@@ -539,7 +568,15 @@ mod tests {
     #[test]
     fn tag_add_creates_new_property() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r#"
+---
+title: Note
+---
+"#),
+        )
+        .unwrap();
 
         let outcome = tag_add(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
         match outcome {
@@ -558,7 +595,16 @@ mod tests {
     #[test]
     fn tag_add_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join("note.md"), "---\ntags:\n  - rust\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r#"
+---
+tags:
+  - rust
+---
+"#),
+        )
+        .unwrap();
 
         let outcome = tag_add(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
         match outcome {
@@ -574,7 +620,15 @@ mod tests {
     #[test]
     fn tag_add_invalid_name_rejected() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r#"
+---
+title: Note
+---
+"#),
+        )
+        .unwrap();
 
         let outcome = tag_add(tmp.path(), "1984", Some("note.md"), None, Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -583,7 +637,15 @@ mod tests {
     #[test]
     fn tag_add_requires_file_or_glob() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r#"
+---
+title: Note
+---
+"#),
+        )
+        .unwrap();
 
         // Neither --file nor --glob → user error
         let outcome = tag_add(tmp.path(), "rust", None, None, Format::Json).unwrap();
@@ -597,7 +659,13 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            "---\ntags:\n  - rust\n  - cli\n---\n",
+            md!(r#"
+---
+tags:
+  - rust
+  - cli
+---
+"#),
         )
         .unwrap();
 
@@ -619,7 +687,16 @@ mod tests {
     #[test]
     fn tag_remove_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join("note.md"), "---\ntags:\n  - cli\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r#"
+---
+tags:
+  - cli
+---
+"#),
+        )
+        .unwrap();
 
         let outcome = tag_remove(tmp.path(), "rust", Some("note.md"), None, Format::Json).unwrap();
         match outcome {
@@ -637,7 +714,13 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            "---\ntitle: Note\ntags:\n  - rust\n---\n",
+            md!(r#"
+---
+title: Note
+tags:
+  - rust
+---
+"#),
         )
         .unwrap();
 
@@ -653,7 +736,16 @@ mod tests {
     #[test]
     fn tag_remove_requires_file_or_glob() {
         let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join("note.md"), "---\ntags:\n  - rust\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r#"
+---
+tags:
+  - rust
+---
+"#),
+        )
+        .unwrap();
 
         // Neither --file nor --glob → user error
         let outcome = tag_remove(tmp.path(), "rust", None, None, Format::Json).unwrap();
@@ -665,7 +757,11 @@ mod tests {
     #[test]
     fn tag_add_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = "# Heading\n\nSome content with [[wikilinks]] and more text.\n";
+        let body = md!(r#"
+# Heading
+
+Some content with [[wikilinks]] and more text.
+"#);
         fs::write(
             tmp.path().join("note.md"),
             format!("---\ntitle: Note\n---\n{body}"),
@@ -681,7 +777,11 @@ mod tests {
     #[test]
     fn tag_remove_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = "# Heading\n\nSome content.\n";
+        let body = md!(r#"
+# Heading
+
+Some content.
+"#);
         fs::write(
             tmp.path().join("note.md"),
             format!("---\ntags:\n  - rust\n  - cli\n---\n{body}"),

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 /// Represents parsed frontmatter and the remaining body content.
@@ -82,6 +82,99 @@ pub fn read_frontmatter(path: &Path) -> Result<BTreeMap<String, Value>> {
     let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
     let reader = BufReader::new(file);
     read_frontmatter_from_reader(reader)
+}
+
+/// Write updated frontmatter to a file while leaving the body bytes untouched.
+///
+/// This is the preferred mutation path: it reads only the frontmatter portion, finds
+/// the byte offset where the body starts, serializes the new properties, and writes
+/// `new_frontmatter + original_body_bytes` back to the file.  The body is never
+/// decoded as UTF-8, so there is no risk of re-encoding corruption.
+///
+/// If `props` is empty (all properties removed), no frontmatter block is written —
+/// the file starts directly with the body.
+pub fn write_frontmatter(path: &Path, props: &BTreeMap<String, Value>) -> Result<()> {
+    // --- Step 1: find the byte offset where the body starts ---
+    let mut file =
+        File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+
+    let body_offset = find_body_offset(&mut file)?;
+
+    // --- Step 2: read the body bytes from that offset ---
+    file.seek(SeekFrom::Start(body_offset))
+        .with_context(|| format!("failed to seek in {}", path.display()))?;
+    let mut body_bytes = Vec::new();
+    file.read_to_end(&mut body_bytes)
+        .with_context(|| format!("failed to read body of {}", path.display()))?;
+    drop(file);
+
+    // --- Step 3: serialize new frontmatter ---
+    let mut out: Vec<u8> = Vec::new();
+    if !props.is_empty() {
+        out.extend_from_slice(b"---\n");
+        let yaml = serde_yaml_ng::to_string(props).context("failed to serialize YAML")?;
+        out.extend_from_slice(yaml.as_bytes());
+        if !yaml.ends_with('\n') {
+            out.push(b'\n');
+        }
+        out.extend_from_slice(b"---\n");
+    }
+    out.extend_from_slice(&body_bytes);
+
+    // --- Step 4: write atomically ---
+    std::fs::write(path, &out).with_context(|| format!("failed to write {}", path.display()))?;
+
+    Ok(())
+}
+
+/// Find the byte offset in `file` where the body starts (i.e. the byte immediately
+/// after the closing `---\n` of the frontmatter block).
+///
+/// Returns `0` if the file has no frontmatter, which means the entire file is body.
+fn find_body_offset(file: &mut File) -> Result<u64> {
+    const MAX_FRONTMATTER_LINES: usize = 100;
+    const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
+
+    let mut reader = BufReader::new(&mut *file);
+    let mut line = String::new();
+
+    // Peek at the first line
+    let n = reader.read_line(&mut line).context("failed to read line")?;
+    if n == 0 || line.trim_end_matches(['\n', '\r']) != "---" {
+        // No frontmatter — body starts at offset 0
+        return Ok(0);
+    }
+
+    let mut content_bytes: usize = 0;
+    let mut line_count: usize = 0;
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).context("failed to read line")?;
+        if n == 0 {
+            anyhow::bail!(
+                "unclosed frontmatter: file starts with `---` but no closing `---` was found"
+            );
+        }
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if trimmed.trim() == "---" {
+            // Consumed up to and including the closing `---\n`
+            break;
+        }
+        line_count += 1;
+        content_bytes += n;
+        if line_count > MAX_FRONTMATTER_LINES || content_bytes > MAX_FRONTMATTER_BYTES {
+            anyhow::bail!(
+                "frontmatter too large (no closing `---` found within {MAX_FRONTMATTER_LINES} lines / {MAX_FRONTMATTER_BYTES} bytes)"
+            );
+        }
+    }
+
+    // The body offset is whatever position the BufReader is now at
+    let pos = reader
+        .stream_position()
+        .context("failed to get stream position")?;
+    Ok(pos)
 }
 
 /// Skip past frontmatter in a buffered reader. Returns the number of lines consumed

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -486,9 +486,21 @@ pub fn yaml_to_json(value: &Value) -> serde_json::Value {
 mod tests {
     use super::*;
 
+    macro_rules! md {
+        ($s:expr) => {
+            $s.strip_prefix('\n').unwrap_or($s)
+        };
+    }
+
     #[test]
     fn parse_valid_frontmatter() {
-        let content = "---\ntitle: Hello\nstatus: draft\n---\nBody text here.\n";
+        let content = md!(r#"
+---
+title: Hello
+status: draft
+---
+Body text here.
+"#);
         let doc = Document::parse(content).unwrap();
         assert_eq!(doc.properties().len(), 2);
         assert_eq!(
@@ -508,7 +520,11 @@ mod tests {
 
     #[test]
     fn parse_empty_frontmatter() {
-        let content = "---\n---\nBody.\n";
+        let content = md!(r#"
+---
+---
+Body.
+"#);
         let doc = Document::parse(content).unwrap();
         assert!(doc.properties().is_empty());
         assert_eq!(doc.body(), "Body.\n");
@@ -517,7 +533,11 @@ mod tests {
     #[test]
     fn parse_malformed_frontmatter() {
         // Missing closing delimiter — now returns an error to prevent corruption on write
-        let content = "---\ntitle: Broken\nNo closing delimiter.\n";
+        let content = md!(r#"
+---
+title: Broken
+No closing delimiter.
+"#);
         let err = Document::parse(content).unwrap_err();
         assert!(err.to_string().contains("unclosed frontmatter"));
     }
@@ -565,7 +585,15 @@ mod tests {
 
     #[test]
     fn roundtrip_preserves_body() {
-        let content = "---\ntitle: Test\npriority: 5\n---\n# Heading\n\nParagraph content.\n";
+        let content = md!(r#"
+---
+title: Test
+priority: 5
+---
+# Heading
+
+Paragraph content.
+"#);
         let doc = Document::parse(content).unwrap();
         let serialized = doc.serialize().unwrap();
         let doc2 = Document::parse(&serialized).unwrap();
@@ -582,7 +610,13 @@ mod tests {
 
     #[test]
     fn set_and_remove_property() {
-        let mut doc = Document::parse("---\ntitle: Hi\n---\nBody\n").unwrap();
+        let mut doc = Document::parse(md!(r#"
+---
+title: Hi
+---
+Body
+"#))
+        .unwrap();
         doc.set_property("status".into(), Value::String("done".into()));
         assert!(doc.get_property("status").is_some());
         doc.remove_property("status");
@@ -621,7 +655,11 @@ mod tests {
 
     #[test]
     fn file_with_only_frontmatter() {
-        let content = "---\ntitle: Only FM\n---\n";
+        let content = md!(r#"
+---
+title: Only FM
+---
+"#);
         let doc = Document::parse(content).unwrap();
         assert_eq!(doc.properties().len(), 1);
         assert_eq!(doc.body(), "");
@@ -631,7 +669,13 @@ mod tests {
 
     #[test]
     fn streaming_valid_frontmatter() {
-        let input = b"---\ntitle: Hello\nstatus: draft\n---\n# Body that should not be read\nLots of content here.\n";
+        let input = br#"---
+title: Hello
+status: draft
+---
+# Body that should not be read
+Lots of content here.
+"#;
         let props = read_frontmatter_from_reader(&input[..]).unwrap();
         assert_eq!(props.len(), 2);
         assert_eq!(props.get("title"), Some(&Value::String("Hello".into())));
@@ -640,14 +684,19 @@ mod tests {
 
     #[test]
     fn streaming_no_frontmatter() {
-        let input = b"Just a regular file.\nNo frontmatter.\n";
+        let input = br#"Just a regular file.
+No frontmatter.
+"#;
         let props = read_frontmatter_from_reader(&input[..]).unwrap();
         assert!(props.is_empty());
     }
 
     #[test]
     fn streaming_empty_frontmatter() {
-        let input = b"---\n---\nBody.\n";
+        let input = br#"---
+---
+Body.
+"#;
         let props = read_frontmatter_from_reader(&input[..]).unwrap();
         assert!(props.is_empty());
     }
@@ -656,20 +705,36 @@ mod tests {
     fn streaming_no_closing_delimiter() {
         // No closing `---` means everything after the opening is read as YAML.
         // If it's not valid YAML, we get an error — which is correct.
-        let input = b"---\ntitle: Broken\nNot valid yaml line\n";
+        let input = br#"---
+title: Broken
+Not valid yaml line
+"#;
         let result = read_frontmatter_from_reader(&input[..]);
         assert!(result.is_err());
 
         // But if the content happens to be valid YAML, it parses fine
-        let input2 = b"---\ntitle: Works\nstatus: ok\n";
+        let input2 = br#"---
+title: Works
+status: ok
+"#;
         let props = read_frontmatter_from_reader(&input2[..]).unwrap();
         assert_eq!(props.get("title"), Some(&Value::String("Works".into())));
     }
 
     #[test]
     fn streaming_matches_full_parse() {
-        let content =
-            "---\ntitle: Test\npriority: 5\ntags:\n  - a\n  - b\n---\n# Heading\n\nBody.\n";
+        let content = md!(r#"
+---
+title: Test
+priority: 5
+tags:
+  - a
+  - b
+---
+# Heading
+
+Body.
+"#);
         let doc = Document::parse(content).unwrap();
         let streamed = read_frontmatter_from_reader(content.as_bytes()).unwrap();
         assert_eq!(doc.properties(), &streamed);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::process;
 
 use clap::{Parser, Subcommand};
 
-use hyalo::commands::{links as link_commands, properties};
+use hyalo::commands::{links as link_commands, properties, tags as tag_commands};
 use hyalo::output::{CommandOutcome, Format};
 
 #[derive(Parser)]
@@ -49,6 +49,60 @@ enum Commands {
         /// Only show links that resolve to a file
         #[arg(long, conflicts_with = "unresolved")]
         resolved: bool,
+    },
+    /// List all unique tags with occurrence counts across matched files
+    Tags {
+        /// Specific file (relative to --dir)
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern (relative to --dir)
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+    /// Inspect or modify tags
+    Tag {
+        #[command(subcommand)]
+        action: TagAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum TagAction {
+    /// Find files containing a specific tag (supports nested matching)
+    Find {
+        /// Tag name to search for
+        #[arg(long)]
+        name: String,
+        /// Specific file (relative to --dir)
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern (relative to --dir)
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+    /// Add a tag to file(s) frontmatter
+    Add {
+        /// Tag name to add
+        #[arg(long)]
+        name: String,
+        /// Specific file (relative to --dir)
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern (relative to --dir)
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+    /// Remove a tag from file(s) frontmatter
+    Remove {
+        /// Tag name to remove
+        #[arg(long)]
+        name: String,
+        /// Specific file (relative to --dir)
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern (relative to --dir)
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
     },
 }
 
@@ -135,6 +189,26 @@ fn main() {
             };
             link_commands::links(dir, file, filter, format)
         }
+        Commands::Tags { ref file, ref glob } => {
+            tag_commands::tags_list(dir, file.as_deref(), glob.as_deref(), format)
+        }
+        Commands::Tag { action } => match action {
+            TagAction::Find {
+                ref name,
+                ref file,
+                ref glob,
+            } => tag_commands::tag_find(dir, name, file.as_deref(), glob.as_deref(), format),
+            TagAction::Add {
+                ref name,
+                ref file,
+                ref glob,
+            } => tag_commands::tag_add(dir, name, file.as_deref(), glob.as_deref(), format),
+            TagAction::Remove {
+                ref name,
+                ref file,
+                ref glob,
+            } => tag_commands::tag_remove(dir, name, file.as_deref(), glob.as_deref(), format),
+        },
     };
 
     match result {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -184,6 +184,12 @@ fn strip_inline_code(line: &str) -> Cow<'_, str> {
 mod tests {
     use super::*;
 
+    macro_rules! md {
+        ($s:expr) => {
+            $s.strip_prefix('\n').unwrap_or($s)
+        };
+    }
+
     fn collect_lines(input: &str) -> Vec<(String, usize)> {
         let mut result = Vec::new();
         scan_reader(input.as_bytes(), |text, line| {
@@ -196,7 +202,12 @@ mod tests {
 
     #[test]
     fn skips_frontmatter() {
-        let input = "---\ntitle: Test\n---\nHello world\n";
+        let input = md!(r#"
+---
+title: Test
+---
+Hello world
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].0, "Hello world");
@@ -205,7 +216,10 @@ mod tests {
 
     #[test]
     fn no_frontmatter() {
-        let input = "Hello world\nSecond line\n";
+        let input = md!(r#"
+Hello world
+Second line
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Hello world");
@@ -216,7 +230,13 @@ mod tests {
 
     #[test]
     fn skips_backtick_fenced_code_block() {
-        let input = "Before\n```\ncode line\n```\nAfter\n";
+        let input = md!(r#"
+Before
+```
+code line
+```
+After
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -225,7 +245,13 @@ mod tests {
 
     #[test]
     fn skips_tilde_fenced_code_block() {
-        let input = "Before\n~~~\ncode line\n~~~\nAfter\n";
+        let input = md!(r#"
+Before
+~~~
+code line
+~~~
+After
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -234,7 +260,13 @@ mod tests {
 
     #[test]
     fn fenced_code_with_info_string() {
-        let input = "Before\n```rust\nlet x = 1;\n```\nAfter\n";
+        let input = md!(r#"
+Before
+```rust
+let x = 1;
+```
+After
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -244,7 +276,15 @@ mod tests {
     #[test]
     fn fence_requires_matching_char_and_count() {
         // Opening with 4 backticks, closing needs >= 4
-        let input = "Before\n````\ncode\n```\nstill code\n````\nAfter\n";
+        let input = md!(r#"
+Before
+````
+code
+```
+still code
+````
+After
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -253,7 +293,15 @@ mod tests {
 
     #[test]
     fn tilde_fence_not_closed_by_backticks() {
-        let input = "Before\n~~~\ncode\n```\nstill code\n~~~\nAfter\n";
+        let input = md!(r#"
+Before
+~~~
+code
+```
+still code
+~~~
+After
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -280,7 +328,12 @@ mod tests {
 
     #[test]
     fn early_abort_with_stop() {
-        let input = "Line 1\nLine 2\nLine 3\nLine 4\n";
+        let input = md!(r#"
+Line 1
+Line 2
+Line 3
+Line 4
+"#);
         let mut result = Vec::new();
         scan_reader(input.as_bytes(), |text, line| {
             result.push((text.to_string(), line));
@@ -296,7 +349,15 @@ mod tests {
 
     #[test]
     fn line_numbers_accurate_with_frontmatter() {
-        let input = "---\ntitle: T\ntags:\n  - a\n---\nLine 6\nLine 7\n";
+        let input = md!(r#"
+---
+title: T
+tags:
+  - a
+---
+Line 6
+Line 7
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines[0].1, 6);
         assert_eq!(lines[1].1, 7);
@@ -304,7 +365,14 @@ mod tests {
 
     #[test]
     fn line_numbers_accurate_with_code_block() {
-        let input = "Line 1\n```\nskipped\nskipped\n```\nLine 6\n";
+        let input = md!(r#"
+Line 1
+```
+skipped
+skipped
+```
+Line 6
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines[0], ("Line 1".to_string(), 1));
         assert_eq!(lines[1], ("Line 6".to_string(), 6));
@@ -336,7 +404,7 @@ mod tests {
 
     #[test]
     fn crlf_line_endings() {
-        let input = "Line 1\r\nLine 2\r\n";
+        let input = "Line 1\r\nLine 2\r\n"; // CRLF: \r\n cannot be represented in raw strings portably
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Line 1");
@@ -345,7 +413,12 @@ mod tests {
 
     #[test]
     fn first_line_is_code_fence() {
-        let input = "```\n[[not a link]]\n```\nAfter\n";
+        let input = md!(r#"
+```
+[[not a link]]
+```
+After
+"#);
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].0, "After");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,6 +2,15 @@ use assert_cmd::Command;
 use std::fs;
 use std::path::Path;
 
+/// Strip the leading newline from a raw string so the content aligns at column 0.
+macro_rules! md {
+    ($s:expr) => {
+        $s.strip_prefix('\n').unwrap_or($s)
+    };
+}
+#[allow(unused_imports)]
+pub(crate) use md;
+
 /// Returns a `Command` pre-configured to run the `hyalo` binary built by Cargo.
 pub fn hyalo() -> Command {
     Command::cargo_bin("hyalo").unwrap()
@@ -36,17 +45,19 @@ pub fn write_tagged(dir: &Path, name: &str, tags: &[&str]) {
 /// Returns a sample markdown document with YAML frontmatter containing various property types.
 #[allow(dead_code)]
 pub fn sample_frontmatter() -> &'static str {
-    "---\n\
-     title: My Note\n\
-     priority: 3\n\
-     draft: true\n\
-     created: \"2026-03-20\"\n\
-     updated: \"2026-03-20T14:30:00\"\n\
-     tags:\n\
-       - rust\n\
-       - cli\n\
-     ---\n\
-     # Body\n\
-     \n\
-     Some content here.\n"
+    md!(r#"
+---
+title: My Note
+priority: 3
+draft: true
+created: "2026-03-20"
+updated: "2026-03-20T14:30:00"
+tags:
+  - rust
+  - cli
+---
+# Body
+
+Some content here.
+"#)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,6 +16,23 @@ pub fn write_md(dir: &Path, relative_path: &str, content: &str) {
     fs::write(full, content).unwrap();
 }
 
+/// Write a markdown file with YAML frontmatter containing the given tags.
+/// Used by tag-related tests and any future tests that need pre-tagged files.
+#[allow(dead_code)]
+pub fn write_tagged(dir: &Path, name: &str, tags: &[&str]) {
+    let tags_yaml = if tags.is_empty() {
+        "tags: []\n".to_owned()
+    } else {
+        let items: String = tags.iter().map(|t| format!("  - {t}\n")).collect();
+        format!("tags:\n{items}")
+    };
+    write_md(
+        dir,
+        name,
+        &format!("---\ntitle: {name}\n{tags_yaml}---\n# Body\n"),
+    );
+}
+
 /// Returns a sample markdown document with YAML frontmatter containing various property types.
 #[allow(dead_code)]
 pub fn sample_frontmatter() -> &'static str {

--- a/tests/e2e_errors.rs
+++ b/tests/e2e_errors.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo, md, write_md};
 use tempfile::TempDir;
 
 #[test]
@@ -50,7 +50,12 @@ fn error_invalid_yaml() {
     write_md(
         tmp.path(),
         "bad.md",
-        "---\n: invalid yaml [[[{\n---\n# Body\n",
+        md!(r#"
+---
+: invalid yaml [[[{
+---
+# Body
+"#),
     );
 
     let output = hyalo()
@@ -68,7 +73,15 @@ fn error_invalid_yaml() {
 #[test]
 fn error_missing_md_extension() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Test
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])

--- a/tests/e2e_links.rs
+++ b/tests/e2e_links.rs
@@ -1,13 +1,20 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo, md, write_md};
 
 fn setup_vault() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().unwrap();
     write_md(
         tmp.path(),
         "note-a.md",
-        "---\ntitle: Note A\n---\nSee [[note-b]] and [[nonexistent]].\n\nAlso ![[image.png]] embed.\n",
+        md!(r#"
+---
+title: Note A
+---
+See [[note-b]] and [[nonexistent]].
+
+Also ![[image.png]] embed.
+"#),
     );
     write_md(
         tmp.path(),
@@ -19,7 +26,13 @@ fn setup_vault() -> tempfile::TempDir {
     write_md(
         tmp.path(),
         "code-blocks.md",
-        "Before\n```\n[[inside code block]]\n```\nAfter [[real-link]]\n",
+        md!(r#"
+Before
+```
+[[inside code block]]
+```
+After [[real-link]]
+"#),
     );
     tmp
 }

--- a/tests/e2e_properties.rs
+++ b/tests/e2e_properties.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, sample_frontmatter, write_md};
+use common::{hyalo, md, sample_frontmatter, write_md};
 use tempfile::TempDir;
 
 #[test]
@@ -35,9 +35,25 @@ fn properties_aggregate() {
     write_md(
         tmp.path(),
         "a.md",
-        "---\ntitle: A\nstatus: draft\n---\n# A\n",
+        md!(r#"
+---
+title: A
+status: draft
+---
+# A
+"#),
     );
-    write_md(tmp.path(), "b.md", "---\ntitle: B\npriority: 1\n---\n# B\n");
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r#"
+---
+title: B
+priority: 1
+---
+# B
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -67,9 +83,33 @@ fn properties_aggregate() {
 #[test]
 fn properties_with_glob() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "root.md", "---\ntitle: Root\n---\n");
-    write_md(tmp.path(), "sub/a.md", "---\ntitle: Sub A\n---\n");
-    write_md(tmp.path(), "sub/b.md", "---\ntitle: Sub B\n---\n");
+    write_md(
+        tmp.path(),
+        "root.md",
+        md!(r#"
+---
+title: Root
+---
+"#),
+    );
+    write_md(
+        tmp.path(),
+        "sub/a.md",
+        md!(r#"
+---
+title: Sub A
+---
+"#),
+    );
+    write_md(
+        tmp.path(),
+        "sub/b.md",
+        md!(r#"
+---
+title: Sub B
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -107,7 +147,12 @@ fn properties_text_format() {
     write_md(
         tmp.path(),
         "note.md",
-        "---\ntitle: Hello\nstatus: draft\n---\n",
+        md!(r#"
+---
+title: Hello
+status: draft
+---
+"#),
     );
 
     let output = hyalo()

--- a/tests/e2e_property_remove.rs
+++ b/tests/e2e_property_remove.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo, md, write_md};
 use tempfile::TempDir;
 
 #[test]
@@ -9,7 +9,12 @@ fn remove_existing_property() {
     write_md(
         tmp.path(),
         "note.md",
-        "---\ntitle: Test\nstatus: draft\n---\n# Body\n",
+        md!("---
+title: Test
+status: draft
+---
+# Body
+"),
     );
 
     let output = hyalo()
@@ -37,7 +42,15 @@ fn remove_existing_property() {
 #[test]
 fn remove_missing_property() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n# Body\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!("---
+title: Test
+---
+# Body
+"),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -61,9 +74,18 @@ fn remove_missing_property() {
 #[test]
 fn remove_preserves_body() {
     let tmp = TempDir::new().unwrap();
-    let body = "# Heading\n\nParagraph content.\n";
-    let content = format!("---\ntitle: Test\nstatus: draft\n---\n{body}");
-    write_md(tmp.path(), "note.md", &content);
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!("---
+title: Test
+status: draft
+---
+# Heading
+
+Paragraph content.
+"),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -85,7 +107,13 @@ fn remove_preserves_other_properties() {
     write_md(
         tmp.path(),
         "note.md",
-        "---\ntitle: Keep\nstatus: draft\npriority: 5\n---\n# Body\n",
+        md!("---
+title: Keep
+status: draft
+priority: 5
+---
+# Body
+"),
     );
 
     let output = hyalo()
@@ -126,7 +154,11 @@ fn remove_last_property() {
     write_md(
         tmp.path(),
         "note.md",
-        "---\nonly_prop: value\n---\n# Body\n",
+        md!("---
+only_prop: value
+---
+# Body
+"),
     );
 
     let output = hyalo()

--- a/tests/e2e_property_set.rs
+++ b/tests/e2e_property_set.rs
@@ -1,12 +1,21 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo, md, write_md};
 use tempfile::TempDir;
 
 #[test]
 fn set_new_property() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Existing\n---\n# Body\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Existing
+---
+# Body
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -39,7 +48,12 @@ fn set_overwrite_property() {
     write_md(
         tmp.path(),
         "note.md",
-        "---\ntitle: Old Title\n---\n# Body\n",
+        md!(r#"
+---
+title: Old Title
+---
+# Body
+"#),
     );
 
     let output = hyalo()
@@ -95,7 +109,15 @@ fn set_creates_frontmatter() {
 #[test]
 fn set_infers_number_type() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Test
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -114,7 +136,15 @@ fn set_infers_number_type() {
 #[test]
 fn set_infers_bool_type() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Test
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -133,7 +163,15 @@ fn set_infers_bool_type() {
 #[test]
 fn set_infers_date_type() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Test
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -159,7 +197,15 @@ fn set_infers_date_type() {
 #[test]
 fn set_explicit_type() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Test
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -179,9 +225,18 @@ fn set_explicit_type() {
 #[test]
 fn set_preserves_body() {
     let tmp = TempDir::new().unwrap();
-    let body = "# My Heading\n\nSome paragraph content.\n\n- Item 1\n- Item 2\n";
-    let content = format!("---\ntitle: Test\n---\n{body}");
-    write_md(tmp.path(), "note.md", &content);
+    let content = md!(r#"
+---
+title: Test
+---
+# My Heading
+
+Some paragraph content.
+
+- Item 1
+- Item 2
+"#);
+    write_md(tmp.path(), "note.md", content);
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -205,7 +260,13 @@ fn set_preserves_other_properties() {
     write_md(
         tmp.path(),
         "note.md",
-        "---\ntitle: Keep Me\nstatus: draft\n---\n# Body\n",
+        md!(r#"
+---
+title: Keep Me
+status: draft
+---
+# Body
+"#),
     );
 
     let output = hyalo()

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -1,0 +1,702 @@
+mod common;
+
+use common::{hyalo, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn write_tagged(dir: &std::path::Path, name: &str, tags: &[&str]) {
+    let tags_yaml = if tags.is_empty() {
+        "tags: []\n".to_owned()
+    } else {
+        let items: String = tags.iter().map(|t| format!("  - {t}\n")).collect();
+        format!("tags:\n{items}")
+    };
+    write_md(
+        dir,
+        name,
+        &format!("---\ntitle: {name}\n{tags_yaml}---\n# Body\n"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tags` — list all unique tags with counts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_all_files() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
+    write_tagged(tmp.path(), "b.md", &["rust", "iteration"]);
+    write_md(tmp.path(), "c.md", "No frontmatter.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 3); // rust, cli, iteration
+    let tags = json["tags"].as_array().unwrap();
+    let rust = tags.iter().find(|t| t["name"] == "rust").unwrap();
+    assert_eq!(rust["count"], 2);
+    let cli = tags.iter().find(|t| t["name"] == "cli").unwrap();
+    assert_eq!(cli["count"], 1);
+}
+
+#[test]
+fn tags_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "sub/a.md", &["alpha"]);
+    write_tagged(tmp.path(), "sub/b.md", &["beta"]);
+    write_tagged(tmp.path(), "root.md", &["gamma"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 2);
+    let names: Vec<&str> = json["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"alpha"));
+    assert!(names.contains(&"beta"));
+    assert!(!names.contains(&"gamma"));
+}
+
+#[test]
+fn tags_with_file() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust", "cli"]);
+    write_tagged(tmp.path(), "other.md", &["python"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 2);
+    let names: Vec<&str> = json["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"rust"));
+    assert!(!names.contains(&"python"));
+}
+
+#[test]
+fn tags_empty_vault() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["tags"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn tags_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "tags",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("rust"));
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tag find` — find files containing a specific tag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tag_find_exact_match() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["iteration"]);
+    write_tagged(tmp.path(), "b.md", &["links"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "find", "--name", "iteration"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["tag"], "iteration");
+    assert_eq!(json["total"], 1);
+    let files = json["files"].as_array().unwrap();
+    assert!(files[0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn tag_find_nested_match() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["inbox/processing"]);
+    write_tagged(tmp.path(), "b.md", &["inbox/to-read"]);
+    write_tagged(tmp.path(), "c.md", &["inbox"]);
+    write_tagged(tmp.path(), "d.md", &["inboxes"]); // must NOT match
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "find", "--name", "inbox"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 3);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(files.iter().any(|f| f.contains("a.md")));
+    assert!(files.iter().any(|f| f.contains("b.md")));
+    assert!(files.iter().any(|f| f.contains("c.md")));
+    // d.md has "inboxes" — should NOT be in results
+    assert!(!files.iter().any(|f| f.contains("d.md")));
+}
+
+#[test]
+fn tag_find_no_match() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "find", "--name", "nonexistent"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn tag_find_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "sub/a.md", &["rust"]);
+    write_tagged(tmp.path(), "sub/b.md", &["python"]);
+    write_tagged(tmp.path(), "root.md", &["rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "find", "--name", "rust", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    // Only sub/a.md; root.md is excluded by glob
+    assert!(files.iter().any(|f| f.contains("sub/a.md")));
+    assert!(!files.iter().any(|f| f.contains("root.md")));
+}
+
+#[test]
+fn tag_find_case_insensitive() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["Rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "find", "--name", "rust"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+}
+
+#[test]
+fn tag_find_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "tag",
+            "find",
+            "--name",
+            "rust",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("note.md"));
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tag add` — add a tag to file(s)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tag_add_single_file() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "rust", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["tag"], "rust");
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 0);
+
+    // Verify file was modified
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("rust"));
+}
+
+#[test]
+fn tag_add_glob_pattern() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "sub/a.md", &["existing"]);
+    write_tagged(tmp.path(), "sub/b.md", &["existing"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "new-tag", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 2);
+    assert_eq!(json["total"], 2);
+}
+
+#[test]
+fn tag_add_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "rust", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 0);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn tag_add_creates_tags_property() {
+    let tmp = TempDir::new().unwrap();
+    // File has no tags property at all
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n# Body\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "plan", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("tags:"));
+    assert!(content.contains("plan"));
+    // Body must still be present
+    assert!(content.contains("# Body"));
+}
+
+#[test]
+fn tag_add_invalid_name_numeric() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "1984", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    // Should mention numeric/non-numeric constraint
+    assert!(
+        stderr.contains("non-numeric") || stderr.contains("numeric"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn tag_add_invalid_name_with_space() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "my tag", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn tag_add_invalid_name_empty() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn tag_add_nested_tag_valid() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "tag",
+            "add",
+            "--name",
+            "inbox/processing",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn tag_add_file_not_found() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "rust", "--file", "nonexistent.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn tag_add_json_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "tag",
+            "add",
+            "--name",
+            "rust",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["tag"], "rust");
+    assert!(json["modified"].is_array());
+    assert!(json["skipped"].is_array());
+    assert!(json["total"].is_number());
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tag remove` — remove a tag from file(s)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tag_remove_single_file() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust", "cli"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "remove", "--name", "rust", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 0);
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(!content.contains("rust"));
+    assert!(content.contains("cli"));
+}
+
+#[test]
+fn tag_remove_glob_pattern() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "sub/a.md", &["rust", "cli"]);
+    write_tagged(tmp.path(), "sub/b.md", &["rust", "python"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "remove", "--name", "rust", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn tag_remove_absent_tag_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["cli"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "remove", "--name", "rust", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 0);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn tag_remove_empties_tags_property() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "remove", "--name", "rust", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    // tags property should be gone entirely
+    assert!(!content.contains("tags:"));
+    // Other properties should be untouched
+    assert!(content.contains("title:"));
+}
+
+#[test]
+fn tag_remove_file_not_found() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "tag",
+            "remove",
+            "--name",
+            "rust",
+            "--file",
+            "nonexistent.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn tag_remove_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "tag",
+            "remove",
+            "--name",
+            "rust",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("rust"));
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_file_without_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn tags_scalar_string_tag() {
+    let tmp = TempDir::new().unwrap();
+    // tags as a scalar string (not a list)
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\ntags: rust\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["tags"][0]["name"], "rust");
+}
+
+#[test]
+fn tag_add_to_file_with_no_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "No frontmatter here.\n# Content\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "rust", "--file", "plain.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    let content = std::fs::read_to_string(tmp.path().join("plain.md")).unwrap();
+    assert!(content.starts_with("---\n"));
+    assert!(content.contains("rust"));
+    assert!(content.contains("# Content"));
+}
+
+#[test]
+fn tag_remove_from_file_with_no_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "No frontmatter here.\n");
+
+    // Remove is a no-op — file goes to skipped
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "remove", "--name", "rust", "--file", "plain.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+    assert_eq!(json["modified"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn tag_find_file_with_empty_tags_list() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "empty.md", &[]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "find", "--name", "rust"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn tags_glob_no_match() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "--glob", "nonexistent/*.md"])
+        .output()
+        .unwrap();
+
+    // Should exit with error status (user error: no files match pattern)
+    assert!(!output.status.success());
+}

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md, write_tagged};
+use common::{hyalo, md, write_md, write_tagged};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -264,7 +264,15 @@ fn tag_find_text_format() {
 #[test]
 fn tag_add_single_file() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -322,7 +330,16 @@ fn tag_add_idempotent() {
 fn tag_add_creates_tags_property() {
     let tmp = TempDir::new().unwrap();
     // File has no tags property at all
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n# Body\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+# Body
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -341,7 +358,15 @@ fn tag_add_creates_tags_property() {
 #[test]
 fn tag_add_invalid_name_numeric() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -361,7 +386,15 @@ fn tag_add_invalid_name_numeric() {
 #[test]
 fn tag_add_invalid_name_with_space() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -375,7 +408,15 @@ fn tag_add_invalid_name_with_space() {
 #[test]
 fn tag_add_invalid_name_empty() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -389,7 +430,15 @@ fn tag_add_invalid_name_empty() {
 #[test]
 fn tag_add_nested_tag_valid() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -425,7 +474,15 @@ fn tag_add_file_not_found() {
 #[test]
 fn tag_add_json_format() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
 
     let output = hyalo()
         .args([
@@ -599,7 +656,16 @@ fn tags_file_without_frontmatter() {
 fn tags_scalar_string_tag() {
     let tmp = TempDir::new().unwrap();
     // tags as a scalar string (not a list)
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\ntags: rust\n---\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+tags: rust
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -616,7 +682,14 @@ fn tags_scalar_string_tag() {
 #[test]
 fn tag_add_to_file_with_no_frontmatter() {
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "plain.md", "No frontmatter here.\n# Content\n");
+    write_md(
+        tmp.path(),
+        "plain.md",
+        md!(r#"
+No frontmatter here.
+# Content
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -1,25 +1,7 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo, write_md, write_tagged};
 use tempfile::TempDir;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn write_tagged(dir: &std::path::Path, name: &str, tags: &[&str]) {
-    let tags_yaml = if tags.is_empty() {
-        "tags: []\n".to_owned()
-    } else {
-        let items: String = tags.iter().map(|t| format!("  - {t}\n")).collect();
-        format!("tags:\n{items}")
-    };
-    write_md(
-        dir,
-        name,
-        &format!("---\ntitle: {name}\n{tags_yaml}---\n# Body\n"),
-    );
-}
 
 // ---------------------------------------------------------------------------
 // `hyalo tags` — list all unique tags with counts
@@ -699,4 +681,54 @@ fn tags_glob_no_match() {
 
     // Should exit with error status (user error: no files match pattern)
     assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// Mutation commands require --file or --glob
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tag_add_without_file_or_glob_is_user_error() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["existing"]);
+
+    // Omit both --file and --glob → must be a user error (exit 1)
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "add", "--name", "new-tag"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("--file") || stderr.contains("--glob"),
+        "expected hint about --file/--glob in stderr: {stderr}"
+    );
+    // File must be untouched
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(!content.contains("new-tag"));
+}
+
+#[test]
+fn tag_remove_without_file_or_glob_is_user_error() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    // Omit both --file and --glob → must be a user error (exit 1)
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tag", "remove", "--name", "rust"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("--file") || stderr.contains("--glob"),
+        "expected hint about --file/--glob in stderr: {stderr}"
+    );
+    // Tag must still be present
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("rust"));
 }


### PR DESCRIPTION
## Summary
- Add frontmatter-only tag management commands: `tags`, `tag find`, `tag add`, `tag remove`
- Support nested tag matching (`tag find --name inbox` matches `inbox/processing`)
- Batch operations via `--glob` (e.g. `tag add --name plan --glob "iterations/*.md"`)
- Obsidian-compatible tag validation (allowed chars, must have non-numeric character)
- Case-insensitive tag matching
- Idempotent add/remove (skipped files reported in output)

## Test plan
- [x] 27 unit tests: tag validation, nested matching, extraction, add/remove logic
- [x] 33 E2E tests: all commands with `--file`/`--glob`/all-files, nested matching, case-insensitivity, idempotent behavior, invalid tag names, file-not-found, no-frontmatter files, scalar string tags, empty tags, text format output
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Dogfooded against hyalo-knowledgebase (21 tags found, 4 iteration files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)