### PR TITLE
Add property find & generic list operations, refactor tags

### DIFF
--- a/hyalo-knowledgebase/iterations/iteration-04-property-find.md
+++ b/hyalo-knowledgebase/iterations/iteration-04-property-find.md
@@ -1,0 +1,46 @@
+---
+title: "Iteration 4 — Property Find Command"
+type: iteration
+date: 2026-03-21
+tags:
+  - iteration
+  - properties
+  - search
+status: in-progress
+branch: iter-4/property-find
+---
+
+# Iteration 4 — Property Find Command
+
+## Goal
+
+Add `hyalo property find --name <key> [--value <val>] [--file | --glob]` to find files that have a specific frontmatter property, optionally filtering by value. This mirrors `hyalo tag find` but operates on arbitrary frontmatter properties.
+
+## Motivation
+
+`tag find` lets you search by tag, but there's no equivalent for arbitrary properties like `status: draft` or `priority: 3`. Users need a way to query files by property existence or by property value. This partly overlaps with `hyalo properties` (which lists all properties) but serves a different use case: filtering files rather than listing metadata.
+
+## Relationship to `search`
+
+A general `search` command could subsume both `tag find` and `property find`. For now, `property find` fills the gap without over-engineering. If a `search` command is added later, it may cannibalize both `tag find` and `property find`.
+
+## Tasks
+
+- [x] Add `Find` variant to `PropertyAction` enum in `main.rs` with `--name`, `--value` (optional), `--file`, `--glob` flags
+- [x] Implement `property_find()` in `src/commands/properties.rs`, reusing `collect_files()` and `read_frontmatter()`
+- [x] Match logic: if `--value` given, compare property value (case-insensitive for strings); if omitted, match on property existence
+- [x] Output JSON: `{"property": name, "value": value_or_null, "files": [...], "total": N}`
+- [x] Wire up routing in `main.rs`
+- [x] Add comprehensive help text following existing LLM-friendly pattern
+- [x] Add unit tests in `properties.rs` (happy + unhappy paths) — 12 unit tests
+- [x] Add e2e tests in `tests/e2e_property_find.rs` (happy + unhappy paths) — 19 e2e tests
+- [x] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
+
+## Design Notes
+
+- Reuse `collect_files()` from `commands/mod.rs` (same as `tag find`)
+- `property find` is read-only — no `--file`/`--glob` requirement (scan all by default)
+- Value matching: use `yaml_to_json()` to normalize, then compare JSON string representations for non-string types; case-insensitive for strings
+- Number matching: compare as numbers (e.g. `--value 3` matches `priority: 3`)
+- Boolean matching: `--value true` matches `draft: true`
+- List matching: `--value rust` matches if the list contains "rust"

--- a/hyalo-knowledgebase/iterations/iteration-04-property-find.md
+++ b/hyalo-knowledgebase/iterations/iteration-04-property-find.md
@@ -1,46 +1,63 @@
 ---
-title: "Iteration 4 — Property Find Command"
+title: "Iteration 4 — Property Find & List Operations"
 type: iteration
 date: 2026-03-21
 tags:
   - iteration
   - properties
   - search
+  - refactor
 status: in-progress
 branch: iter-4/property-find
 ---
 
-# Iteration 4 — Property Find Command
+# Iteration 4 — Property Find & List Operations
 
 ## Goal
 
-Add `hyalo property find --name <key> [--value <val>] [--file | --glob]` to find files that have a specific frontmatter property, optionally filtering by value. This mirrors `hyalo tag find` but operates on arbitrary frontmatter properties.
+1. Add `hyalo property find` to search files by frontmatter property (done).
+2. Add generic list-property mutations: `property add-to-list` and `property remove-from-list`.
+3. Refactor `tag add/remove` to delegate to the generic list operations, keeping tag-specific validation as a pre-step.
 
 ## Motivation
 
-`tag find` lets you search by tag, but there's no equivalent for arbitrary properties like `status: draft` or `priority: 3`. Users need a way to query files by property existence or by property value. This partly overlaps with `hyalo properties` (which lists all properties) but serves a different use case: filtering files rather than listing metadata.
+Tags are just a list property named "tags". By implementing generic list operations on properties, we eliminate duplication and enable the same operations on any list property (e.g. `aliases`, `authors`). The `tag` commands become thin wrappers that add tag-specific validation before delegating.
 
 ## Relationship to `search`
 
-A general `search` command could subsume both `tag find` and `property find`. For now, `property find` fills the gap without over-engineering. If a `search` command is added later, it may cannibalize both `tag find` and `property find`.
+A general `search` command could subsume both `tag find` and `property find`. For now, `property find` fills the gap without over-engineering.
 
-## Tasks
+## Phase 1 — Property Find (done)
 
-- [x] Add `Find` variant to `PropertyAction` enum in `main.rs` with `--name`, `--value` (optional), `--file`, `--glob` flags
-- [x] Implement `property_find()` in `src/commands/properties.rs`, reusing `collect_files()` and `read_frontmatter()`
-- [x] Match logic: if `--value` given, compare property value (case-insensitive for strings); if omitted, match on property existence
-- [x] Output JSON: `{"property": name, "value": value_or_null, "files": [...], "total": N}`
-- [x] Wire up routing in `main.rs`
-- [x] Add comprehensive help text following existing LLM-friendly pattern
-- [x] Add unit tests in `properties.rs` (happy + unhappy paths) — 12 unit tests
-- [x] Add e2e tests in `tests/e2e_property_find.rs` (happy + unhappy paths) — 19 e2e tests
-- [x] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
+- [x] Add `Find` variant to `PropertyAction` enum in `main.rs`
+- [x] Implement `property_find()` with type-aware value matching
+- [x] Wire up routing, help text, unit tests (12), e2e tests (19)
+- [x] Quality gates passed
+
+## Phase 2 — Generic List Operations & Tag Refactor
+
+### New commands
+- [ ] `hyalo property add-to-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — append values to a list property, create the list if absent, skip duplicates (case-insensitive)
+- [ ] `hyalo property remove-from-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — remove values from a list property, remove the key if list becomes empty
+
+### Refactor tag commands
+- [ ] Extract core list logic into shared helpers in `properties.rs`: `property_add_to_list()` and `property_remove_from_list()`
+- [ ] Refactor `tag_add()` to: validate tag → delegate to `property_add_to_list(name="tags", ...)`
+- [ ] Refactor `tag_remove()` to: delegate to `property_remove_from_list(name="tags", ...)`
+- [ ] Keep `tag find` separate (nested tag matching is tag-domain logic, not generic list behavior)
+
+### Tests
+- [ ] Unit tests for `property_add_to_list` and `property_remove_from_list` (happy + unhappy paths)
+- [ ] E2e tests for the new CLI commands (happy + unhappy paths)
+- [ ] Verify all existing tag e2e tests still pass (no behavioral changes)
+- [ ] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
 
 ## Design Notes
 
-- Reuse `collect_files()` from `commands/mod.rs` (same as `tag find`)
-- `property find` is read-only — no `--file`/`--glob` requirement (scan all by default)
-- Value matching: use `yaml_to_json()` to normalize, then compare JSON string representations for non-string types; case-insensitive for strings
-- Number matching: compare as numbers (e.g. `--value 3` matches `priority: 3`)
-- Boolean matching: `--value true` matches `draft: true`
-- List matching: `--value rust` matches if the list contains "rust"
+- `--value` accepts multiple values: `--value foo --value bar` (clap `Vec<String>`)
+- Mutation commands require `--file` or `--glob` (same safety rule as `tag add/remove`)
+- Duplicate detection is case-insensitive for strings (consistent with tag behavior)
+- When a list becomes empty after removal, the property key is removed entirely
+- `tag add/remove` keep their existing CLI interface unchanged — this is a pure internal refactor
+- `tag add` still validates tag names before delegating (no spaces, non-numeric, etc.)
+- Output format for list ops: `{"property": name, "values": [...], "modified": [...], "skipped": [...], "total": N}`

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -193,6 +193,75 @@ pub fn property_remove(
     }
 }
 
+/// Find files that contain a specific frontmatter property, optionally filtering by value.
+pub fn property_find(
+    dir: &Path,
+    name: &str,
+    value: Option<&str>,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut matching_paths: Vec<String> = Vec::new();
+
+    for (full_path, rel_path) in &files {
+        let props = frontmatter::read_frontmatter(full_path)?;
+        if let Some(yaml_val) = props.get(name) {
+            let matches = match value {
+                None => true,
+                Some(query) => value_matches(yaml_val, query),
+            };
+            if matches {
+                matching_paths.push(rel_path.clone());
+            }
+        }
+    }
+
+    let total = matching_paths.len();
+    let result = serde_json::json!({
+        "property": name,
+        "value": value,
+        "files": matching_paths,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+/// Check if a YAML value matches a query string, using type-aware comparison.
+fn value_matches(yaml_val: &serde_yaml_ng::Value, query: &str) -> bool {
+    use serde_yaml_ng::Value;
+    match yaml_val {
+        Value::String(s) => s.eq_ignore_ascii_case(query),
+        Value::Number(n) => {
+            // Try integer match first, then float
+            if let Some(i) = n.as_i64() {
+                query.parse::<i64>() == Ok(i)
+            } else if let Some(f) = n.as_f64() {
+                query.parse::<f64>() == Ok(f)
+            } else {
+                false
+            }
+        }
+        Value::Bool(b) => match query {
+            "true" => *b,
+            "false" => !b,
+            _ => false,
+        },
+        Value::Sequence(seq) => seq.iter().any(|item| value_matches(item, query)),
+        Value::Null => false,
+        Value::Mapping(_) | Value::Tagged(_) => false,
+    }
+}
+
 /// Helper to resolve a file path or produce a user error outcome.
 fn resolve_or_error(
     dir: &Path,
@@ -436,5 +505,264 @@ status: draft
 
         let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
         assert!(content.contains(body), "body was corrupted:\n{content}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // property_find tests
+    // ---------------------------------------------------------------------------
+
+    fn setup_find_vault() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        // a.md: status=draft (string), priority=3 (number), draft=true (bool), tags=[rust,cli]
+        fs::write(
+            tmp.path().join("a.md"),
+            md!(r#"
+---
+status: draft
+priority: 3
+draft: true
+tags:
+  - rust
+  - cli
+---
+"#),
+        )
+        .unwrap();
+        // b.md: status=done (string), priority=5 (number), draft=false (bool)
+        fs::write(
+            tmp.path().join("b.md"),
+            md!(r#"
+---
+status: done
+priority: 5
+draft: false
+---
+"#),
+        )
+        .unwrap();
+        // c.md: no frontmatter
+        fs::write(tmp.path().join("c.md"), "No frontmatter.\n").unwrap();
+        tmp
+    }
+
+    fn unwrap_success(outcome: CommandOutcome) -> serde_json::Value {
+        match outcome {
+            CommandOutcome::Success(s) => serde_json::from_str(&s).unwrap(),
+            CommandOutcome::UserError(s) => panic!("unexpected user error: {s}"),
+        }
+    }
+
+    fn unwrap_user_error(outcome: CommandOutcome) -> serde_json::Value {
+        match outcome {
+            CommandOutcome::UserError(s) => serde_json::from_str(&s).unwrap(),
+            CommandOutcome::Success(s) => panic!("expected user error, got success: {s}"),
+        }
+    }
+
+    #[test]
+    fn property_find_by_existence() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 2);
+        let files: Vec<&str> = parsed["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(files.iter().any(|f| f.contains("a.md")));
+        assert!(files.iter().any(|f| f.contains("b.md")));
+        assert!(!files.iter().any(|f| f.contains("c.md")));
+    }
+
+    #[test]
+    fn property_find_by_string_value() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                Some("draft"),
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_by_number_value() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "priority", Some("3"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_by_bool_value() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "draft", Some("true"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_in_list() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "tags", Some("rust"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_case_insensitive() {
+        let tmp = setup_find_vault();
+        // "Draft" should match "draft" case-insensitively
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                Some("Draft"),
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_with_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("sub")).unwrap();
+        fs::write(
+            tmp.path().join("sub/x.md"),
+            md!(r#"
+---
+status: draft
+---
+"#),
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("root.md"),
+            md!(r#"
+---
+status: draft
+---
+"#),
+        )
+        .unwrap();
+
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                None,
+                None,
+                Some("sub/*.md"),
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("sub/x.md"));
+    }
+
+    #[test]
+    fn property_find_with_file() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, Some("a.md"), None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+    }
+
+    #[test]
+    fn property_find_no_match() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                Some("nonexistent-value"),
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+        assert!(parsed["files"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn property_find_value_no_match() {
+        let tmp = setup_find_vault();
+        // Property exists but value doesn't match any file
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "priority", Some("99"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+    }
+
+    #[test]
+    fn property_find_nonexistent_property() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "does_not_exist", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+    }
+
+    #[test]
+    fn property_find_file_not_found() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_user_error(
+            property_find(
+                tmp.path(),
+                "status",
+                None,
+                Some("nope.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["error"], "file not found");
+    }
+
+    #[test]
+    fn property_find_no_frontmatter_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Only a file with no frontmatter
+        fs::write(tmp.path().join("plain.md"), "Just text.\n").unwrap();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+    }
+
+    #[test]
+    fn property_find_empty_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+        assert!(parsed["files"].as_array().unwrap().is_empty());
     }
 }

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -1,11 +1,232 @@
 use anyhow::Result;
 use serde_json::json;
+use serde_yaml_ng::Value;
 use std::path::Path;
 
 use crate::commands::{FilesOrOutcome, collect_files, resolve_error_to_outcome};
 use crate::discovery;
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
+
+// ---------------------------------------------------------------------------
+// Generic list-property helpers
+// ---------------------------------------------------------------------------
+
+/// Extract a list from any YAML value under `property_name`.
+///
+/// - Sequence → collect string and number items as strings
+/// - String → single-element vec (empty string → empty vec)
+/// - Null / missing → empty vec
+/// - Any other type → empty vec
+fn extract_list_property(
+    props: &std::collections::BTreeMap<String, Value>,
+    name: &str,
+) -> Vec<String> {
+    match props.get(name) {
+        None | Some(Value::Null) => vec![],
+        Some(Value::Sequence(seq)) => seq
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .collect(),
+        Some(Value::String(s)) => {
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![s.clone()]
+            }
+        }
+        _ => vec![],
+    }
+}
+
+/// Result type for list-mutation operations.
+pub(crate) struct ListOpResult {
+    pub(crate) modified: Vec<String>,
+    pub(crate) skipped: Vec<String>,
+}
+
+/// Core logic: add `values` to the list property `property_name` across `files`.
+///
+/// For each file:
+/// - Reads current list (empty if absent or non-list).
+/// - Appends any value not already present (case-insensitive for strings).
+/// - Writes back if at least one value was added; otherwise marks file as skipped.
+pub(crate) fn add_values_to_list_property(
+    files: &[(std::path::PathBuf, String)],
+    property_name: &str,
+    values: &[String],
+) -> Result<ListOpResult> {
+    let mut modified = Vec::new();
+    let mut skipped = Vec::new();
+
+    for (full_path, rel_path) in files {
+        let mut props = frontmatter::read_frontmatter(full_path)?;
+        let mut current = extract_list_property(&props, property_name);
+        let before_len = current.len();
+
+        for value in values {
+            let already_present = current.iter().any(|v| v.eq_ignore_ascii_case(value));
+            if !already_present {
+                current.push(value.clone());
+            }
+        }
+
+        if current.len() > before_len {
+            let yaml_list = Value::Sequence(current.into_iter().map(Value::String).collect());
+            props.insert(property_name.to_owned(), yaml_list);
+            frontmatter::write_frontmatter(full_path, &props)?;
+            modified.push(rel_path.clone());
+        } else {
+            skipped.push(rel_path.clone());
+        }
+    }
+
+    Ok(ListOpResult { modified, skipped })
+}
+
+/// Core logic: remove `values` from the list property `property_name` across `files`.
+///
+/// For each file:
+/// - Reads current list.
+/// - Removes matching values (case-insensitive).
+/// - If list becomes empty, removes the entire key.
+/// - Writes back if at least one value was removed; otherwise marks file as skipped.
+pub(crate) fn remove_values_from_list_property(
+    files: &[(std::path::PathBuf, String)],
+    property_name: &str,
+    values: &[String],
+) -> Result<ListOpResult> {
+    let mut modified = Vec::new();
+    let mut skipped = Vec::new();
+
+    for (full_path, rel_path) in files {
+        let mut props = frontmatter::read_frontmatter(full_path)?;
+        let current = extract_list_property(&props, property_name);
+        let new_list: Vec<String> = current
+            .iter()
+            .filter(|v| !values.iter().any(|rm| rm.eq_ignore_ascii_case(v)))
+            .cloned()
+            .collect();
+
+        if new_list.len() == current.len() {
+            // Nothing was removed
+            skipped.push(rel_path.clone());
+        } else {
+            if new_list.is_empty() {
+                props.remove(property_name);
+            } else {
+                let yaml_list = Value::Sequence(new_list.into_iter().map(Value::String).collect());
+                props.insert(property_name.to_owned(), yaml_list);
+            }
+            frontmatter::write_frontmatter(full_path, &props)?;
+            modified.push(rel_path.clone());
+        }
+    }
+
+    Ok(ListOpResult { modified, skipped })
+}
+
+// ---------------------------------------------------------------------------
+// Public CLI-facing list-property commands
+// ---------------------------------------------------------------------------
+
+/// Add values to a list property in file(s). Creates the list if absent.
+/// Skips duplicates (case-insensitive). Returns a `CommandOutcome` with JSON.
+///
+/// JSON output: `{"property": name, "values": [...], "modified": [...], "skipped": [...], "total": N}`
+pub fn property_add_to_list(
+    dir: &Path,
+    name: &str,
+    values: &[String],
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    if file.is_none() && glob.is_none() {
+        let out = crate::output::format_error(
+            format,
+            "property add-to-list requires --file or --glob",
+            None,
+            Some(
+                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
+            ),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let ListOpResult { modified, skipped } = add_values_to_list_property(&files, name, values)?;
+
+    let total = modified.len() + skipped.len();
+    let result = json!({
+        "property": name,
+        "values": values,
+        "modified": modified,
+        "skipped": skipped,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+/// Remove values from a list property in file(s). Removes the key if list becomes empty.
+///
+/// JSON output: `{"property": name, "values": [...], "modified": [...], "skipped": [...], "total": N}`
+pub fn property_remove_from_list(
+    dir: &Path,
+    name: &str,
+    values: &[String],
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    if file.is_none() && glob.is_none() {
+        let out = crate::output::format_error(
+            format,
+            "property remove-from-list requires --file or --glob",
+            None,
+            Some(
+                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
+            ),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let ListOpResult { modified, skipped } =
+        remove_values_from_list_property(&files, name, values)?;
+
+    let total = modified.len() + skipped.len();
+    let result = json!({
+        "property": name,
+        "values": values,
+        "modified": modified,
+        "skipped": skipped,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
 
 /// List all properties across all files, or properties of a single file / glob match.
 pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<CommandOutcome> {
@@ -764,5 +985,312 @@ status: draft
         );
         assert_eq!(parsed["total"], 0);
         assert!(parsed["files"].as_array().unwrap().is_empty());
+    }
+
+    // ---------------------------------------------------------------------------
+    // property_add_to_list / property_remove_from_list unit tests
+    // ---------------------------------------------------------------------------
+
+    fn write_note(dir: &std::path::Path, name: &str, content: &str) {
+        fs::write(dir.join(name), content).unwrap();
+    }
+
+    // --- Happy paths: add ---
+
+    #[test]
+    fn property_add_to_list_creates_new_list() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\ntitle: T\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["property"], "aliases");
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("foo"));
+    }
+
+    #[test]
+    fn property_add_to_list_appends_to_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - bar\n---\n");
+
+        unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["baz".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("bar"));
+        assert!(content.contains("baz"));
+    }
+
+    #[test]
+    fn property_add_to_list_skips_duplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - Foo\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()], // different case
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn property_add_to_list_multiple_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\ntitle: T\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "authors",
+                &["alice".to_owned(), "bob".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("alice"));
+        assert!(content.contains("bob"));
+    }
+
+    #[test]
+    fn property_add_to_list_to_scalar_string() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Property exists as a scalar string
+        write_note(tmp.path(), "note.md", "---\naliases: old\n---\n");
+
+        unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["new".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("old"));
+        assert!(content.contains("new"));
+    }
+
+    // --- Happy paths: remove ---
+
+    #[test]
+    fn property_remove_from_list_removes_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(
+            tmp.path(),
+            "note.md",
+            "---\naliases:\n  - foo\n  - bar\n---\n",
+        );
+
+        let parsed = unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("foo"));
+        assert!(content.contains("bar"));
+    }
+
+    #[test]
+    fn property_remove_from_list_empties_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(
+            tmp.path(),
+            "note.md",
+            "---\ntitle: T\naliases:\n  - solo\n---\n",
+        );
+
+        unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["solo".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("aliases:"));
+        assert!(content.contains("title:"));
+    }
+
+    #[test]
+    fn property_remove_from_list_case_insensitive() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - Rust\n---\n");
+
+        let parsed = unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["rust".to_owned()], // lowercase
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn property_remove_from_list_multiple_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(
+            tmp.path(),
+            "note.md",
+            "---\naliases:\n  - a\n  - b\n  - c\n---\n",
+        );
+
+        unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["a".to_owned(), "b".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("- a\n") && !content.contains("- b\n"));
+        assert!(content.contains("c"));
+    }
+
+    // --- Unhappy paths ---
+
+    #[test]
+    fn property_add_to_list_requires_file_or_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\ntitle: T\n---\n");
+
+        let parsed = unwrap_user_error(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert!(
+            parsed["error"].as_str().unwrap().contains("--file")
+                || parsed["error"].as_str().unwrap().contains("--glob")
+        );
+    }
+
+    #[test]
+    fn property_remove_from_list_requires_file_or_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - foo\n---\n");
+
+        let parsed = unwrap_user_error(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert!(
+            parsed["error"].as_str().unwrap().contains("--file")
+                || parsed["error"].as_str().unwrap().contains("--glob")
+        );
+    }
+
+    #[test]
+    fn property_add_to_list_file_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let parsed = unwrap_user_error(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                Some("nonexistent.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["error"], "file not found");
+    }
+
+    #[test]
+    fn property_remove_from_list_absent_values_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - bar\n---\n");
+
+        let parsed = unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["nothere".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
     }
 }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -4,6 +4,9 @@ use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use crate::commands::properties::{
+    ListOpResult, add_values_to_list_property, remove_values_from_list_property,
+};
 use crate::commands::{FilesOrOutcome, collect_files};
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
@@ -213,28 +216,8 @@ pub fn tag_add(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
-    let mut modified: Vec<String> = Vec::new();
-    let mut skipped: Vec<String> = Vec::new();
-
-    for (full_path, rel_path) in &files {
-        // Read frontmatter only for the idempotency check
-        let props = frontmatter::read_frontmatter(full_path)?;
-        let tags = extract_tags(&props);
-        let already_has = tags.iter().any(|t| t.eq_ignore_ascii_case(name));
-
-        if already_has {
-            skipped.push(rel_path.clone());
-        } else {
-            // Build updated tags list
-            let mut new_tags = tags;
-            new_tags.push(name.to_owned());
-            let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
-            let mut new_props = props;
-            new_props.insert("tags".to_owned(), yaml_list);
-            frontmatter::write_frontmatter(full_path, &new_props)?;
-            modified.push(rel_path.clone());
-        }
-    }
+    let ListOpResult { modified, skipped } =
+        add_values_to_list_property(&files, "tags", &[name.to_owned()])?;
 
     let total = modified.len() + skipped.len();
     let result = json!({
@@ -280,34 +263,8 @@ pub fn tag_remove(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
-    let mut modified: Vec<String> = Vec::new();
-    let mut skipped: Vec<String> = Vec::new();
-
-    for (full_path, rel_path) in &files {
-        // Read frontmatter only
-        let props = frontmatter::read_frontmatter(full_path)?;
-        let tags = extract_tags(&props);
-        let new_tags: Vec<String> = tags
-            .iter()
-            .filter(|t| !t.eq_ignore_ascii_case(name))
-            .cloned()
-            .collect();
-
-        if new_tags.len() == tags.len() {
-            // Tag was not present — idempotent skip
-            skipped.push(rel_path.clone());
-        } else {
-            let mut new_props = props;
-            if new_tags.is_empty() {
-                new_props.remove("tags");
-            } else {
-                let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
-                new_props.insert("tags".to_owned(), yaml_list);
-            }
-            frontmatter::write_frontmatter(full_path, &new_props)?;
-            modified.push(rel_path.clone());
-        }
-    }
+    let ListOpResult { modified, skipped } =
+        remove_values_from_list_property(&files, "tags", &[name.to_owned()])?;
 
     let total = modified.len() + skipped.len();
     let result = json!({

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,15 @@ use hyalo::output::{CommandOutcome, Format};
         Globs use standard syntax: '**/*.md' matches recursively, 'notes/*.md' matches one level.\n\n\
         OUTPUT: Returns JSON by default (--format json). Use --format text for human-readable output. \
         Successful output goes to stdout; errors go to stderr with exit code 1 (user error) or 2 (internal error).\n\n\
-        COMMANDS: Use 'properties'/'tags' to list across files. Use 'property'/'tag' for single-item mutations. \
+        COMMANDS: Use 'properties'/'tags' to list across files. Use 'property' for read/set/remove/find \
+        and list operations (add-to-list, remove-from-list). Use 'tag' for tag-specific find/add/remove. \
         Use 'links' to inspect wikilink targets.",
     after_help = "EXAMPLES:\n  \
         List all properties:        hyalo properties --glob '**/*.md'\n  \
         Set a property:             hyalo property set --name status --value done --file notes/todo.md\n  \
+        Find files by property:     hyalo property find --name status --value draft\n  \
+        Add to a list property:     hyalo property add-to-list --name aliases --value \"My Note\" --file note.md\n  \
+        Remove from a list:         hyalo property remove-from-list --name authors --value Alice --file note.md\n  \
         List tags with counts:      hyalo tags\n  \
         Find files by tag:          hyalo tag find --name project/backend\n  \
         Find broken wikilinks:      hyalo links --file index.md --unresolved"
@@ -56,12 +60,18 @@ enum Commands {
         #[arg(long)]
         glob: Option<String>,
     },
-    /// Read, set, or remove a single frontmatter property on one file
+    /// Read, set, find, or remove frontmatter properties; add/remove items from list properties
     #[command(
-        long_about = "Read, set, or remove a single frontmatter property on one file.\n\n\
-        Subcommands: read, set, remove. Each operates on exactly one property in one file.\n\
-        USE 'read' to get a value, 'set' to create/overwrite, 'remove' to delete.\n\
-        SIDE EFFECTS: 'set' and 'remove' modify the file on disk. 'read' is read-only."
+        long_about = "Read, set, find, or remove frontmatter properties; add/remove items from list properties.\n\n\
+        Subcommands:\n\
+        - read: Get a single property value from one file (read-only).\n\
+        - set: Create or overwrite a property on one file.\n\
+        - remove: Delete a property from one file.\n\
+        - find: Search files by property existence or value (read-only).\n\
+        - add-to-list: Append values to a list property across file(s).\n\
+        - remove-from-list: Remove values from a list property across file(s).\n\
+        SIDE EFFECTS: 'set', 'remove', 'add-to-list', and 'remove-from-list' modify files on disk. \
+        'read' and 'find' are read-only."
     )]
     Property {
         #[command(subcommand)]
@@ -259,6 +269,58 @@ enum PropertyAction {
         #[arg(long, conflicts_with = "file")]
         glob: Option<String>,
     },
+    /// Add values to a list property in file(s) frontmatter (mutates files on disk)
+    #[command(
+        long_about = "Add values to a list property in file(s) frontmatter.\n\n\
+            INPUT: A property name (--name), one or more values (--value, repeatable), and target file(s) via --file or --glob.\n\
+            BEHAVIOR: Reads the current list for the named property (or treats it as empty if absent). \
+            Appends each value that is not already present (comparison is case-insensitive for strings). \
+            If the property does not exist it is created. If it exists as a scalar string it is promoted to a list.\n\
+            IDEMPOTENT: Files where all requested values already exist are reported as 'skipped', not modified.\n\
+            OUTPUT: {\"property\": name, \"values\": [...], \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
+            SIDE EFFECTS: Modifies matched files on disk.\n\
+            USE WHEN: You need to append items to any list-type frontmatter property such as 'tags', 'aliases', or 'authors'."
+    )]
+    AddToList {
+        /// Property name (e.g. 'tags', 'aliases', 'authors')
+        #[arg(long)]
+        name: String,
+        /// Values to add (can be specified multiple times, e.g. --value rust --value cli)
+        #[arg(long, required = true)]
+        value: Vec<String>,
+        /// Target a single file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern for multiple files (e.g. 'notes/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+    /// Remove values from a list property in file(s) frontmatter (mutates files on disk)
+    #[command(
+        long_about = "Remove values from a list property in file(s) frontmatter.\n\n\
+            INPUT: A property name (--name), one or more values (--value, repeatable), and target file(s) via --file or --glob.\n\
+            BEHAVIOR: Reads the current list for the named property and removes any matching values \
+            (comparison is case-insensitive for strings). If the list becomes empty after removal, \
+            the entire property key is deleted from frontmatter.\n\
+            IDEMPOTENT: Files where none of the requested values are present are reported as 'skipped', not an error.\n\
+            OUTPUT: {\"property\": name, \"values\": [...], \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
+            SIDE EFFECTS: Modifies matched files on disk.\n\
+            USE WHEN: You need to remove items from any list-type frontmatter property such as 'tags', 'aliases', or 'authors'."
+    )]
+    RemoveFromList {
+        /// Property name (e.g. 'tags', 'aliases', 'authors')
+        #[arg(long)]
+        name: String,
+        /// Values to remove (can be specified multiple times, e.g. --value rust --value cli)
+        #[arg(long, required = true)]
+        value: Vec<String>,
+        /// Target a single file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern for multiple files (e.g. 'notes/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
 }
 
 fn main() {
@@ -301,6 +363,32 @@ fn main() {
                 dir,
                 name,
                 value.as_deref(),
+                file.as_deref(),
+                glob.as_deref(),
+                format,
+            ),
+            PropertyAction::AddToList {
+                ref name,
+                ref value,
+                ref file,
+                ref glob,
+            } => properties::property_add_to_list(
+                dir,
+                name,
+                value,
+                file.as_deref(),
+                glob.as_deref(),
+                format,
+            ),
+            PropertyAction::RemoveFromList {
+                ref name,
+                ref value,
+                ref file,
+                ref glob,
+            } => properties::property_remove_from_list(
+                dir,
+                name,
+                value,
                 file.as_deref(),
                 glob.as_deref(),
                 format,

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,33 @@ enum PropertyAction {
         #[arg(long)]
         file: String,
     },
+    /// Find files containing a specific frontmatter property (read-only)
+    #[command(
+        long_about = "Find files that contain a specific frontmatter property, optionally matching a value.\n\n\
+            INPUT: A property name (--name), an optional value filter (--value), and an optional file scope (--file or --glob).\n\
+            OUTPUT: List of files whose frontmatter contains the given property (and matching value if --value is provided).\n\
+            VALUE MATCHING: If --value is given, the comparison is type-aware:\n\
+              - String properties: case-insensitive string comparison.\n\
+              - Number properties: numeric comparison (parse --value as a number).\n\
+              - Boolean properties: parse --value as 'true' or 'false'.\n\
+              - List properties: match if any element equals --value (case-insensitive for strings).\n\
+            SIDE EFFECTS: None (read-only).\n\
+            USE WHEN: You need to find files with a particular metadata property or a specific value for that property."
+    )]
+    Find {
+        /// Property name to search for (e.g. 'status', 'priority', 'draft')
+        #[arg(long)]
+        name: String,
+        /// Optional value to match (e.g. 'draft', '3', 'true'). If omitted, matches any file that has the property
+        #[arg(long)]
+        value: Option<String>,
+        /// Search only in this file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern to limit which files to search (e.g. 'docs/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
 }
 
 fn main() {
@@ -265,6 +292,19 @@ fn main() {
             PropertyAction::Remove { ref name, ref file } => {
                 properties::property_remove(dir, name, file, format)
             }
+            PropertyAction::Find {
+                ref name,
+                ref value,
+                ref file,
+                ref glob,
+            } => properties::property_find(
+                dir,
+                name,
+                value.as_deref(),
+                file.as_deref(),
+                glob.as_deref(),
+                format,
+            ),
         },
         Commands::Links {
             ref file,

--- a/tests/e2e_property_find.rs
+++ b/tests/e2e_property_find.rs
@@ -1,0 +1,421 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write a markdown file with the given YAML frontmatter string (without delimiters).
+fn write_with_frontmatter(dir: &std::path::Path, name: &str, yaml: &str) {
+    write_md(dir, name, &format!("---\n{yaml}---\n# Body\n"));
+}
+
+// ---------------------------------------------------------------------------
+// Happy path tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_find_by_existence() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\ntitle: A\n");
+    write_with_frontmatter(tmp.path(), "b.md", "title: B\n"); // no status
+    write_md(tmp.path(), "c.md", "No frontmatter.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    let files = json["files"].as_array().unwrap();
+    assert!(files[0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_by_value_string() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: done\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_by_value_number() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "priority: 3\n");
+    write_with_frontmatter(tmp.path(), "b.md", "priority: 5\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "priority", "--value", "3"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_by_value_boolean() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "draft: true\n");
+    write_with_frontmatter(tmp.path(), "b.md", "draft: false\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "draft", "--value", "true"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_in_list_value() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "tags:\n  - rust\n  - cli\n");
+    write_with_frontmatter(tmp.path(), "b.md", "tags:\n  - python\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "tags", "--value", "rust"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_case_insensitive_value() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: Draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: done\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_with_glob_filter() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "sub/a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "root.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(files.iter().any(|f| f.contains("sub/a.md")));
+    assert!(!files.iter().any(|f| f.contains("root.md")));
+}
+
+#[test]
+fn property_find_with_file_filter() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--file", "a.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "find",
+            "--name",
+            "status",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("note.md"));
+}
+
+#[test]
+fn property_find_json_format_structure() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Verify all required fields are present
+    assert!(json["property"].is_string());
+    assert_eq!(json["property"], "status");
+    assert!(json["value"].is_string());
+    assert_eq!(json["value"], "draft");
+    assert!(json["files"].is_array());
+    assert!(json["total"].is_number());
+}
+
+// ---------------------------------------------------------------------------
+// Unhappy path tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_find_no_match_returns_success() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: done\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "find",
+            "--name",
+            "status",
+            "--value",
+            "nonexistent",
+        ])
+        .output()
+        .unwrap();
+
+    // No match is still exit 0 with total: 0
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn property_find_nonexistent_file() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--file", "nope.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("file not found") || stderr.contains("not found"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn property_find_glob_no_match() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "find",
+            "--name",
+            "status",
+            "--glob",
+            "nonexistent/*.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn property_find_empty_vault() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn property_find_no_frontmatter_files() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "No frontmatter here.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn property_find_value_type_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    // priority is a number, searching with a non-numeric string → no match (not an error)
+    write_with_frontmatter(tmp.path(), "note.md", "priority: 3\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "priority", "--value", "high"])
+        .output()
+        .unwrap();
+
+    // Not an error — just no match
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn property_find_json_value_is_null_when_no_value_filter() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // value field should be null when no --value was given
+    assert!(
+        json["value"].is_null(),
+        "expected null, got: {}",
+        json["value"]
+    );
+}
+
+#[test]
+fn property_find_multiple_files_matching() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "c.md", "status: done\n");
+    write_md(tmp.path(), "d.md", "No frontmatter.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 2);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(files.iter().any(|f| f.contains("a.md")));
+    assert!(files.iter().any(|f| f.contains("b.md")));
+    assert!(!files.iter().any(|f| f.contains("c.md")));
+    assert!(!files.iter().any(|f| f.contains("d.md")));
+}
+
+// ---------------------------------------------------------------------------
+// Verify the md! macro is available (it's used in some e2e tests)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_find_with_complex_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: My Note
+status: draft
+priority: 2
+draft: true
+tags:
+  - rust
+  - cli
+---
+# Body
+
+Some content.
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "tags", "--value", "cli"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+}

--- a/tests/e2e_property_list.rs
+++ b/tests/e2e_property_list.rs
@@ -1,0 +1,498 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn write_with_list(dir: &std::path::Path, name: &str, prop: &str, items: &[&str]) {
+    let list_yaml = if items.is_empty() {
+        format!("{prop}: []\n")
+    } else {
+        let rows: String = items.iter().map(|v| format!("  - {v}\n")).collect();
+        format!("{prop}:\n{rows}")
+    };
+    write_md(dir, name, &format!("---\ntitle: {name}\n{list_yaml}---\n"));
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo property add-to-list` — happy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_to_list_creates_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "my-alias",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["property"], "aliases");
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 0);
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("my-alias"));
+}
+
+#[test]
+fn add_to_list_appends_values() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["existing"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "new-one",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("existing"));
+    assert!(content.contains("new-one"));
+}
+
+#[test]
+fn add_to_list_skips_duplicates() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["AlreadyHere"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "alreadyhere", // different case
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 0);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn add_to_list_multiple_values() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "authors",
+            "--value",
+            "alice",
+            "--value",
+            "bob",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("alice"));
+    assert!(content.contains("bob"));
+}
+
+#[test]
+fn add_to_list_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "sub/a.md",
+        md!(r#"
+---
+title: A
+---
+"#),
+    );
+    write_md(
+        tmp.path(),
+        "sub/b.md",
+        md!(r#"
+---
+title: B
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "tags",
+            "--value",
+            "batch",
+            "--glob",
+            "sub/*.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 2);
+    assert_eq!(json["total"], 2);
+}
+
+#[test]
+fn add_to_list_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "alias1",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    // text output should at least mention the property name or value
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo property remove-from-list` — happy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_from_list_removes_values() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["keep", "remove-me"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "remove-me",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("keep"));
+    assert!(!content.contains("remove-me"));
+}
+
+#[test]
+fn remove_from_list_removes_key_when_empty() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["only-one"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "only-one",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(!content.contains("aliases:"));
+    assert!(content.contains("title:"));
+}
+
+#[test]
+fn remove_from_list_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "sub/a.md", "aliases", &["shared", "extra"]);
+    write_with_list(tmp.path(), "sub/b.md", "aliases", &["shared"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "shared",
+            "--glob",
+            "sub/*.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn remove_from_list_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["foo"]);
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "foo",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Unhappy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_to_list_without_file_or_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "x",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn remove_from_list_without_file_or_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["foo"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "foo",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn add_to_list_file_not_found() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "x",
+            "--file",
+            "nonexistent.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn remove_from_list_file_not_found() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "x",
+            "--file",
+            "nonexistent.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn remove_from_list_absent_value() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["bar"]);
+
+    // Value "foo" is not in the list — file should be skipped, exit 0
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "foo",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 0);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn add_to_list_no_values_provided() {
+    // Clap enforces --value is required; omitting it should produce a clap error (exit 2)
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--file",
+            "note.md",
+            // No --value provided
+        ])
+        .output()
+        .unwrap();
+
+    // Clap should reject this with non-zero exit
+    assert!(!output.status.success());
+}


### PR DESCRIPTION
## Summary
- Add `property find --name <key> [--value <val>]` command for searching files by frontmatter property existence or value, with type-aware matching (strings, numbers, booleans, list membership)
- Add `property add-to-list` and `property remove-from-list` commands for generic list-property mutations (works with any list property: tags, aliases, authors, etc.)
- Refactor `tag add` / `tag remove` to delegate to shared list helpers, eliminating duplication while preserving tag-specific validation and backward-compatible JSON output
- 26 new unit tests and 35 new e2e tests (happy + unhappy paths), all existing tests unchanged

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 283 tests pass
- [x] All existing tag e2e tests still pass with identical behavior after refactor
- [x] `property find` tested: existence search, string/number/bool/list value matching, case-insensitive, glob/file scoping, empty vault, no-match, file-not-found
- [x] `property add-to-list` tested: create new list, append, skip duplicates, multiple values, glob, no-file-or-glob error, file-not-found
- [x] `property remove-from-list` tested: remove values, empty-list removes key, case-insensitive, glob, absent values skipped, no-file-or-glob error

🤖 Generated with [Claude Code](https://claude.com/claude-code)