### PR TITLE
Refactor properties/tags into summary + list subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hyalo
 
-A self-contained command line tool for exploring and managing Markdown knowledge bases. Compatible with the [Obsidian CLI](https://obsidian.md/help/cli) — no running Obsidian instance required.
+A self-contained command line tool for exploring and managing Markdown knowledge bases. Compatible with [Obsidian](https://obsidian.md/) vaults — no running Obsidian instance required.
 
 ## Build
 
@@ -15,8 +15,11 @@ All commands accept `--dir <path>` (default: `.`) and `--format json|text` (defa
 ### Properties
 
 ```sh
-# List all properties across files
-hyalo properties [--glob PATTERN]
+# Aggregate property summary (unique names, types, file counts)
+hyalo properties summary [--file FILE | --glob PATTERN]
+
+# Per-file property detail (each file with its key/value pairs)
+hyalo properties list [--file FILE | --glob PATTERN]
 
 # Read a single property
 hyalo property read --name NAME --file FILE
@@ -26,7 +29,18 @@ hyalo property set --name NAME --value VALUE [--type TYPE] --file FILE
 
 # Remove a property
 hyalo property remove --name NAME --file FILE
+
+# Find files by property existence or value
+hyalo property find --name NAME [--value VALUE] [--file FILE | --glob PATTERN]
+
+# Add values to a list property (e.g. aliases, authors)
+hyalo property add-to-list --name NAME --value VAL... <--file FILE | --glob PATTERN>
+
+# Remove values from a list property
+hyalo property remove-from-list --name NAME --value VAL... <--file FILE | --glob PATTERN>
 ```
+
+`properties summary` is the default when no subcommand is given (`hyalo properties` runs `summary`).
 
 ### Links
 
@@ -40,8 +54,11 @@ hyalo links --file FILE [--resolved | --unresolved]
 Tags are read from and written to the YAML frontmatter `tags` property. Inline `#tags` in body text are not supported.
 
 ```sh
-# List all unique tags with occurrence counts
-hyalo tags [--file FILE | --glob PATTERN]
+# Aggregate tag summary (unique tags with file counts)
+hyalo tags summary [--file FILE | --glob PATTERN]
+
+# Per-file tag detail (each file with its tags array)
+hyalo tags list [--file FILE | --glob PATTERN]
 
 # Find files containing a specific tag (supports nested matching)
 hyalo tag find --name TAG [--file FILE | --glob PATTERN]
@@ -52,6 +69,8 @@ hyalo tag add --name TAG <--file FILE | --glob PATTERN>
 # Remove a tag from file(s) frontmatter
 hyalo tag remove --name TAG <--file FILE | --glob PATTERN>
 ```
+
+`tags summary` is the default when no subcommand is given (`hyalo tags` runs `summary`).
 
 **Tag format (Obsidian-compatible):** letters, digits, `_`, `-`, `/`. Must contain at least one non-numeric character. Forward slashes create hierarchy — `tag find --name inbox` matches `inbox`, `inbox/processing`, etc.
 

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -148,3 +148,19 @@ The old `--path` flag is retired. Both flags are always relative to `--dir` and 
 **Decision:** Tag commands (`tags`, `tag find`, `tag add`, `tag remove`) support vault-wide and glob-scoped operations without requiring an index. They scan all matching files on each invocation.
 
 **Why:** Tags live in frontmatter, which is at most ~8KB per file and can be read without buffering the body. The existing `read_frontmatter` streaming reader stops at the closing `---`. For a 1000-file vault, this means reading ~8MB of data at most — well within acceptable latency. Pre-filtering optimizations (byte-level `tags:` search before YAML parse) can be explored if benchmarks show need. This is fundamentally different from vault-wide task search (DEC-021), which requires reading entire file contents.
+
+## DEC-023: Split `properties`/`tags` into `summary` + `list` Subcommands (2026-03-21)
+
+**Context:** The `properties` and `tags` commands each produced a single aggregate output (unique names with counts). There was no way to get per-file detail — which file has which properties or tags. Adding `--file`/`--glob` to the top-level commands overloaded a single output shape, making it unclear whether the output was aggregate or per-file.
+
+**Decision:** Split both commands into two subcommands:
+- `summary` (default) — aggregate unique names with types/counts, same as the original output
+- `list` — per-file detail, each file with its property key/value pairs or tags array
+
+The `summary` subcommand is the default, so `hyalo properties` and `hyalo tags` without a subcommand still produce the same aggregate output as before. The `--file`/`--glob` flags move to the subcommand level.
+
+**Consequences:**
+- No breaking change for callers that used `hyalo properties` or `hyalo tags` without flags — they get `summary` by default
+- Callers that used `--file`/`--glob` at the top level must now place them after the subcommand name (e.g. `hyalo properties list --glob '*.md'`)
+- Consistent CLI model: both `properties` and `tags` follow the same `summary`/`list` pattern
+- Shared helpers extracted to avoid duplicating file-discovery logic between the two command groups

--- a/hyalo-knowledgebase/iterations/iteration-04-property-find.md
+++ b/hyalo-knowledgebase/iterations/iteration-04-property-find.md
@@ -1,0 +1,46 @@
+---
+title: "Iteration 4 — Property Find Command"
+type: iteration
+date: 2026-03-21
+tags:
+  - iteration
+  - properties
+  - search
+status: in-progress
+branch: iter-4/property-find
+---
+
+# Iteration 4 — Property Find Command
+
+## Goal
+
+Add `hyalo property find --name <key> [--value <val>] [--file | --glob]` to find files that have a specific frontmatter property, optionally filtering by value. This mirrors `hyalo tag find` but operates on arbitrary frontmatter properties.
+
+## Motivation
+
+`tag find` lets you search by tag, but there's no equivalent for arbitrary properties like `status: draft` or `priority: 3`. Users need a way to query files by property existence or by property value. This partly overlaps with `hyalo properties` (which lists all properties) but serves a different use case: filtering files rather than listing metadata.
+
+## Relationship to `search`
+
+A general `search` command could subsume both `tag find` and `property find`. For now, `property find` fills the gap without over-engineering. If a `search` command is added later, it may cannibalize both `tag find` and `property find`.
+
+## Tasks
+
+- [x] Add `Find` variant to `PropertyAction` enum in `main.rs` with `--name`, `--value` (optional), `--file`, `--glob` flags
+- [x] Implement `property_find()` in `src/commands/properties.rs`, reusing `collect_files()` and `read_frontmatter()`
+- [x] Match logic: if `--value` given, compare property value (case-insensitive for strings); if omitted, match on property existence
+- [x] Output JSON: `{"property": name, "value": value_or_null, "files": [...], "total": N}`
+- [x] Wire up routing in `main.rs`
+- [x] Add comprehensive help text following existing LLM-friendly pattern
+- [x] Add unit tests in `properties.rs` (happy + unhappy paths) — 12 unit tests
+- [x] Add e2e tests in `tests/e2e_property_find.rs` (happy + unhappy paths) — 19 e2e tests
+- [x] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
+
+## Design Notes
+
+- Reuse `collect_files()` from `commands/mod.rs` (same as `tag find`)
+- `property find` is read-only — no `--file`/`--glob` requirement (scan all by default)
+- Value matching: use `yaml_to_json()` to normalize, then compare JSON string representations for non-string types; case-insensitive for strings
+- Number matching: compare as numbers (e.g. `--value 3` matches `priority: 3`)
+- Boolean matching: `--value true` matches `draft: true`
+- List matching: `--value rust` matches if the list contains "rust"

--- a/hyalo-knowledgebase/iterations/iteration-04-property-find.md
+++ b/hyalo-knowledgebase/iterations/iteration-04-property-find.md
@@ -1,46 +1,63 @@
 ---
-title: "Iteration 4 — Property Find Command"
+title: "Iteration 4 — Property Find & List Operations"
 type: iteration
 date: 2026-03-21
 tags:
   - iteration
   - properties
   - search
+  - refactor
 status: in-progress
 branch: iter-4/property-find
 ---
 
-# Iteration 4 — Property Find Command
+# Iteration 4 — Property Find & List Operations
 
 ## Goal
 
-Add `hyalo property find --name <key> [--value <val>] [--file | --glob]` to find files that have a specific frontmatter property, optionally filtering by value. This mirrors `hyalo tag find` but operates on arbitrary frontmatter properties.
+1. Add `hyalo property find` to search files by frontmatter property (done).
+2. Add generic list-property mutations: `property add-to-list` and `property remove-from-list`.
+3. Refactor `tag add/remove` to delegate to the generic list operations, keeping tag-specific validation as a pre-step.
 
 ## Motivation
 
-`tag find` lets you search by tag, but there's no equivalent for arbitrary properties like `status: draft` or `priority: 3`. Users need a way to query files by property existence or by property value. This partly overlaps with `hyalo properties` (which lists all properties) but serves a different use case: filtering files rather than listing metadata.
+Tags are just a list property named "tags". By implementing generic list operations on properties, we eliminate duplication and enable the same operations on any list property (e.g. `aliases`, `authors`). The `tag` commands become thin wrappers that add tag-specific validation before delegating.
 
 ## Relationship to `search`
 
-A general `search` command could subsume both `tag find` and `property find`. For now, `property find` fills the gap without over-engineering. If a `search` command is added later, it may cannibalize both `tag find` and `property find`.
+A general `search` command could subsume both `tag find` and `property find`. For now, `property find` fills the gap without over-engineering.
 
-## Tasks
+## Phase 1 — Property Find (done)
 
-- [x] Add `Find` variant to `PropertyAction` enum in `main.rs` with `--name`, `--value` (optional), `--file`, `--glob` flags
-- [x] Implement `property_find()` in `src/commands/properties.rs`, reusing `collect_files()` and `read_frontmatter()`
-- [x] Match logic: if `--value` given, compare property value (case-insensitive for strings); if omitted, match on property existence
-- [x] Output JSON: `{"property": name, "value": value_or_null, "files": [...], "total": N}`
-- [x] Wire up routing in `main.rs`
-- [x] Add comprehensive help text following existing LLM-friendly pattern
-- [x] Add unit tests in `properties.rs` (happy + unhappy paths) — 12 unit tests
-- [x] Add e2e tests in `tests/e2e_property_find.rs` (happy + unhappy paths) — 19 e2e tests
-- [x] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
+- [x] Add `Find` variant to `PropertyAction` enum in `main.rs`
+- [x] Implement `property_find()` with type-aware value matching
+- [x] Wire up routing, help text, unit tests (12), e2e tests (19)
+- [x] Quality gates passed
+
+## Phase 2 — Generic List Operations & Tag Refactor
+
+### New commands
+- [ ] `hyalo property add-to-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — append values to a list property, create the list if absent, skip duplicates (case-insensitive)
+- [ ] `hyalo property remove-from-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — remove values from a list property, remove the key if list becomes empty
+
+### Refactor tag commands
+- [ ] Extract core list logic into shared helpers in `properties.rs`: `property_add_to_list()` and `property_remove_from_list()`
+- [ ] Refactor `tag_add()` to: validate tag → delegate to `property_add_to_list(name="tags", ...)`
+- [ ] Refactor `tag_remove()` to: delegate to `property_remove_from_list(name="tags", ...)`
+- [ ] Keep `tag find` separate (nested tag matching is tag-domain logic, not generic list behavior)
+
+### Tests
+- [ ] Unit tests for `property_add_to_list` and `property_remove_from_list` (happy + unhappy paths)
+- [ ] E2e tests for the new CLI commands (happy + unhappy paths)
+- [ ] Verify all existing tag e2e tests still pass (no behavioral changes)
+- [ ] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
 
 ## Design Notes
 
-- Reuse `collect_files()` from `commands/mod.rs` (same as `tag find`)
-- `property find` is read-only — no `--file`/`--glob` requirement (scan all by default)
-- Value matching: use `yaml_to_json()` to normalize, then compare JSON string representations for non-string types; case-insensitive for strings
-- Number matching: compare as numbers (e.g. `--value 3` matches `priority: 3`)
-- Boolean matching: `--value true` matches `draft: true`
-- List matching: `--value rust` matches if the list contains "rust"
+- `--value` accepts multiple values: `--value foo --value bar` (clap `Vec<String>`)
+- Mutation commands require `--file` or `--glob` (same safety rule as `tag add/remove`)
+- Duplicate detection is case-insensitive for strings (consistent with tag behavior)
+- When a list becomes empty after removal, the property key is removed entirely
+- `tag add/remove` keep their existing CLI interface unchanged — this is a pure internal refactor
+- `tag add` still validates tag names before delegating (no spaces, non-numeric, etc.)
+- Output format for list ops: `{"property": name, "values": [...], "modified": [...], "skipped": [...], "total": N}`

--- a/hyalo-knowledgebase/iterations/iteration-04-property-find.md
+++ b/hyalo-knowledgebase/iterations/iteration-04-property-find.md
@@ -7,7 +7,7 @@ tags:
   - properties
   - search
   - refactor
-status: in-progress
+status: completed
 branch: iter-4/property-find
 ---
 
@@ -37,20 +37,20 @@ A general `search` command could subsume both `tag find` and `property find`. Fo
 ## Phase 2 — Generic List Operations & Tag Refactor
 
 ### New commands
-- [ ] `hyalo property add-to-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — append values to a list property, create the list if absent, skip duplicates (case-insensitive)
-- [ ] `hyalo property remove-from-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — remove values from a list property, remove the key if list becomes empty
+- [x] `hyalo property add-to-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — append values to a list property, create the list if absent, skip duplicates (case-insensitive)
+- [x] `hyalo property remove-from-list --name <key> --value <val>... --file <path> [--glob <pattern>]` — remove values from a list property, remove the key if list becomes empty
 
 ### Refactor tag commands
-- [ ] Extract core list logic into shared helpers in `properties.rs`: `property_add_to_list()` and `property_remove_from_list()`
-- [ ] Refactor `tag_add()` to: validate tag → delegate to `property_add_to_list(name="tags", ...)`
-- [ ] Refactor `tag_remove()` to: delegate to `property_remove_from_list(name="tags", ...)`
-- [ ] Keep `tag find` separate (nested tag matching is tag-domain logic, not generic list behavior)
+- [x] Extract core list logic into shared helpers in `properties.rs`: `property_add_to_list()` and `property_remove_from_list()`
+- [x] Refactor `tag_add()` to: validate tag → delegate to `property_add_to_list(name="tags", ...)`
+- [x] Refactor `tag_remove()` to: delegate to `property_remove_from_list(name="tags", ...)`
+- [x] Keep `tag find` separate (nested tag matching is tag-domain logic, not generic list behavior)
 
 ### Tests
-- [ ] Unit tests for `property_add_to_list` and `property_remove_from_list` (happy + unhappy paths)
-- [ ] E2e tests for the new CLI commands (happy + unhappy paths)
-- [ ] Verify all existing tag e2e tests still pass (no behavioral changes)
-- [ ] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
+- [x] Unit tests for `property_add_to_list` and `property_remove_from_list` (happy + unhappy paths)
+- [x] E2e tests for the new CLI commands (happy + unhappy paths)
+- [x] Verify all existing tag e2e tests still pass (no behavioral changes)
+- [x] Run quality gates: `cargo fmt`, `cargo clippy`, `cargo test`
 
 ## Design Notes
 

--- a/hyalo-knowledgebase/iterations/iteration-05-summary-list-refactor.md
+++ b/hyalo-knowledgebase/iterations/iteration-05-summary-list-refactor.md
@@ -1,0 +1,63 @@
+---
+title: "Iteration 5 — Summary + List Subcommand Refactor"
+type: iteration
+date: 2026-03-21
+tags:
+  - iteration
+  - refactor
+  - cli
+  - properties
+  - tags
+status: in-progress
+branch: iter-5/summary-list-refactor
+---
+
+# Iteration 5 — Summary + List Subcommand Refactor
+
+## Goal
+
+Refactor `properties` and `tags` commands into consistent `summary` + `list` subcommands, extract shared helpers, and clean up clippy pedantic warnings.
+
+## Motivation
+
+Before this iteration, `properties` dumped an aggregate summary and `tags` did the same, but there was no way to get per-file detail (which file has which properties/tags). Adding `--file`/`--glob` to the top-level commands was overloading a single output format. Splitting into `summary` (aggregate) and `list` (per-file detail) gives each subcommand a clear purpose while keeping `summary` as the default for backward compatibility.
+
+The same pattern applies to both `properties` and `tags`, so a consistent CLI model reduces cognitive load.
+
+## Relationship to [[iteration-04-property-find]]
+
+Iteration 4 added `property find` and generic list operations (`add-to-list`, `remove-from-list`). This iteration restructures the read-only listing commands (`properties`, `tags`) without changing the mutation commands from iteration 4.
+
+## Tasks
+
+### Subcommand refactor
+- [x] Split `properties` into `properties summary` (default) and `properties list`
+- [x] Split `tags` into `tags summary` (default) and `tags list`
+- [x] Move `--file`/`--glob` flags to the subcommand level
+- [x] Ensure `summary` is the default subcommand (running `hyalo properties` still works)
+
+### Code quality
+- [x] Extract shared helpers to reduce duplication between properties and tags
+- [x] Fix clippy pedantic warnings across the workspace
+- [x] Run quality gates: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
+
+### Documentation
+- [x] Update README.md to reflect new CLI structure
+- [x] Add iteration file for iteration 5
+- [x] Add decision log entry for the summary/list split
+- [x] Verify all e2e tests cover the new subcommands
+
+## Commits
+
+- `84b7a00` Add `property find` command for searching files by frontmatter properties
+- `42a866c` Add generic list-property operations and refactor tag commands to delegate
+- `1372993` Address PR review: fix clippy warnings, harden list ops, update iteration doc
+- `7f91cda` Refactor properties/tags into summary + list subcommands for consistent CLI
+- `0ad43d2` Fix clippy pedantic warnings and extract shared helpers for code reuse
+
+## Design Notes
+
+- `summary` is the default subcommand for both `properties` and `tags` — no breaking change for existing callers that omit the subcommand name
+- `list` provides per-file detail: each file with its property key/value pairs (for `properties list`) or tags array (for `tags list`)
+- Both subcommands accept `--file` and `--glob` for scoping; omitting both scans all `.md` files under `--dir`
+- Shared helpers extracted to avoid duplicating file-discovery and frontmatter-reading logic between the two command groups

--- a/src/commands/links.rs
+++ b/src/commands/links.rs
@@ -71,12 +71,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note-a.md"),
-            md!(r#"
+            md!(r"
 ---
 title: A
 ---
 See [[note-b]] and [[nonexistent]]
-"#),
+"),
         )
         .unwrap();
         fs::write(

--- a/src/commands/links.rs
+++ b/src/commands/links.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
 use serde_json::json;
 use std::path::Path;
@@ -176,7 +177,7 @@ See [[note-b]] and [[nonexistent]]
                 let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
                 assert_eq!(parsed["error"], "file not found");
             }
-            _ => panic!("expected user error"),
+            CommandOutcome::Success(_) => panic!("expected user error"),
         }
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 pub mod links;
 pub mod properties;
 pub mod tags;
@@ -76,7 +77,91 @@ pub fn collect_files(
     }
 }
 
+/// Guard that mutation commands require `--file` or `--glob`.
+///
+/// Returns `Some(CommandOutcome::UserError(...))` when neither flag is provided, or `None`
+/// when the caller may proceed.  The `command_name` is used in the error message.
+#[must_use]
+pub fn require_file_or_glob(
+    file: Option<&str>,
+    glob: Option<&str>,
+    command_name: &str,
+    format: Format,
+) -> Option<CommandOutcome> {
+    if file.is_none() && glob.is_none() {
+        let out = crate::output::format_error(
+            format,
+            &format!("{command_name} requires --file or --glob"),
+            None,
+            Some(
+                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
+            ),
+            None,
+        );
+        Some(CommandOutcome::UserError(out))
+    } else {
+        None
+    }
+}
+
+/// Build the standard JSON output for list-mutation commands
+/// (`property add-to-list`, `property remove-from-list`, `tag add`, `tag remove`).
+///
+/// - `key_name`: top-level key (e.g. `"property"` or `"tag"`)
+/// - `key_value`: the name that was mutated
+/// - `values_label`: label for the list-of-values key (e.g. `"values"`)
+/// - `values`: the values that were requested (may be empty — tags only have one)
+/// - `modified`, `skipped`: file lists from the operation
+#[must_use]
+pub fn build_list_mutation_json(
+    key_name: &str,
+    key_value: &str,
+    values_label: Option<&str>,
+    values: Option<&[String]>,
+    modified: &[String],
+    skipped: &[String],
+) -> serde_json::Value {
+    use serde_json::json;
+    let total = modified.len() + skipped.len();
+    let mut obj = serde_json::Map::new();
+    obj.insert(key_name.to_owned(), json!(key_value));
+    if let (Some(label), Some(vals)) = (values_label, values) {
+        obj.insert(label.to_owned(), json!(vals));
+    }
+    obj.insert("modified".to_owned(), json!(modified));
+    obj.insert("skipped".to_owned(), json!(skipped));
+    obj.insert("total".to_owned(), json!(total));
+    serde_json::Value::Object(obj)
+}
+
+/// Build the standard JSON output for find commands
+/// (`tag find`, `property find`).
+///
+/// - `key_name`: top-level key (e.g. `"tag"` or `"property"`)
+/// - `key_value`: the name that was searched
+/// - `value_filter`: the optional value filter (may be `None`)
+/// - `files`: the matched file paths
+#[must_use]
+pub fn build_find_json(
+    key_name: &str,
+    key_value: &str,
+    value_filter: Option<&str>,
+    files: &[String],
+) -> serde_json::Value {
+    use serde_json::json;
+    let total = files.len();
+    let mut obj = serde_json::Map::new();
+    obj.insert(key_name.to_owned(), json!(key_value));
+    if let Some(v) = value_filter {
+        obj.insert("value".to_owned(), json!(v));
+    }
+    obj.insert("files".to_owned(), json!(files));
+    obj.insert("total".to_owned(), json!(total));
+    serde_json::Value::Object(obj)
+}
+
 /// Convert a `FileResolveError` into a user-facing `CommandOutcome`.
+#[must_use]
 pub fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
     match err {
         FileResolveError::MissingExtension { path, hint } => {

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -4,7 +4,10 @@ use serde_json::json;
 use serde_yaml_ng::Value;
 use std::path::Path;
 
-use crate::commands::{FilesOrOutcome, collect_files, resolve_error_to_outcome};
+use crate::commands::{
+    FilesOrOutcome, build_find_json, build_list_mutation_json, collect_files, require_file_or_glob,
+    resolve_error_to_outcome,
+};
 use crate::discovery;
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
@@ -70,7 +73,7 @@ pub(crate) fn add_values_to_list_property(
 
         // Guard against silently overwriting non-list scalar types.
         match props.get(property_name) {
-            None | Some(Value::Null) | Some(Value::String(_)) | Some(Value::Sequence(_)) => {}
+            None | Some(Value::Null | Value::String(_) | Value::Sequence(_)) => {}
             Some(existing) => {
                 let kind = match existing {
                     Value::Bool(_) => "boolean",
@@ -79,48 +82,42 @@ pub(crate) fn add_values_to_list_property(
                     _ => "unknown",
                 };
                 anyhow::bail!(
-                    "property '{}' in '{}' is a {kind} value, not a list — \
-                     use `property set` to overwrite it explicitly",
-                    property_name,
-                    rel_path
+                    "property '{property_name}' in '{rel_path}' is a {kind} value, not a list — \
+                     use `property set` to overwrite it explicitly"
                 );
             }
         }
 
         // If the property is already a sequence, append directly to preserve element types.
         // Otherwise fall back to the string-based approach for null / absent / scalar-string.
-        let added_any = match props.get_mut(property_name) {
-            Some(Value::Sequence(seq)) => {
-                let before_len = seq.len();
-                for value in values {
-                    let already_present = seq.iter().any(|v| match v {
-                        Value::String(s) => s.eq_ignore_ascii_case(value),
-                        _ => v.as_str().is_some_and(|s| s.eq_ignore_ascii_case(value)),
-                    });
-                    if !already_present {
-                        seq.push(Value::String(value.clone()));
-                    }
+        let added_any = if let Some(Value::Sequence(seq)) = props.get_mut(property_name) {
+            let before_len = seq.len();
+            for value in values {
+                let already_present = seq.iter().any(|v| match v {
+                    Value::String(s) => s.eq_ignore_ascii_case(value),
+                    _ => v.as_str().is_some_and(|s| s.eq_ignore_ascii_case(value)),
+                });
+                if !already_present {
+                    seq.push(Value::String(value.clone()));
                 }
-                seq.len() > before_len
             }
-            _ => {
-                // Build a fresh list from the existing string value (if any) plus new values.
-                let mut current = extract_list_property(&props, property_name);
-                let before_len = current.len();
-                for value in values {
-                    let already_present = current.iter().any(|v| v.eq_ignore_ascii_case(value));
-                    if !already_present {
-                        current.push(value.clone());
-                    }
+            seq.len() > before_len
+        } else {
+            // Build a fresh list from the existing string value (if any) plus new values.
+            let mut current = extract_list_property(&props, property_name);
+            let before_len = current.len();
+            for value in values {
+                let already_present = current.iter().any(|v| v.eq_ignore_ascii_case(value));
+                if !already_present {
+                    current.push(value.clone());
                 }
-                if current.len() > before_len {
-                    let yaml_list =
-                        Value::Sequence(current.into_iter().map(Value::String).collect());
-                    props.insert(property_name.to_owned(), yaml_list);
-                    true
-                } else {
-                    false
-                }
+            }
+            if current.len() > before_len {
+                let yaml_list = Value::Sequence(current.into_iter().map(Value::String).collect());
+                props.insert(property_name.to_owned(), yaml_list);
+                true
+            } else {
+                false
             }
         };
 
@@ -193,17 +190,8 @@ pub fn property_add_to_list(
     glob: Option<&str>,
     format: Format,
 ) -> Result<CommandOutcome> {
-    if file.is_none() && glob.is_none() {
-        let out = crate::output::format_error(
-            format,
-            "property add-to-list requires --file or --glob",
-            None,
-            Some(
-                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
-            ),
-            None,
-        );
-        return Ok(CommandOutcome::UserError(out));
+    if let Some(outcome) = require_file_or_glob(file, glob, "property add-to-list", format) {
+        return Ok(outcome);
     }
 
     let files = collect_files(dir, file, glob, format)?;
@@ -214,14 +202,14 @@ pub fn property_add_to_list(
 
     let ListOpResult { modified, skipped } = add_values_to_list_property(&files, name, values)?;
 
-    let total = modified.len() + skipped.len();
-    let result = json!({
-        "property": name,
-        "values": values,
-        "modified": modified,
-        "skipped": skipped,
-        "total": total,
-    });
+    let result = build_list_mutation_json(
+        "property",
+        name,
+        Some("values"),
+        Some(values),
+        &modified,
+        &skipped,
+    );
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
@@ -239,17 +227,8 @@ pub fn property_remove_from_list(
     glob: Option<&str>,
     format: Format,
 ) -> Result<CommandOutcome> {
-    if file.is_none() && glob.is_none() {
-        let out = crate::output::format_error(
-            format,
-            "property remove-from-list requires --file or --glob",
-            None,
-            Some(
-                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
-            ),
-            None,
-        );
-        return Ok(CommandOutcome::UserError(out));
+    if let Some(outcome) = require_file_or_glob(file, glob, "property remove-from-list", format) {
+        return Ok(outcome);
     }
 
     let files = collect_files(dir, file, glob, format)?;
@@ -261,14 +240,14 @@ pub fn property_remove_from_list(
     let ListOpResult { modified, skipped } =
         remove_values_from_list_property(&files, name, values)?;
 
-    let total = modified.len() + skipped.len();
-    let result = json!({
-        "property": name,
-        "values": values,
-        "modified": modified,
-        "skipped": skipped,
-        "total": total,
-    });
+    let result = build_list_mutation_json(
+        "property",
+        name,
+        Some("values"),
+        Some(values),
+        &modified,
+        &skipped,
+    );
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
@@ -466,13 +445,7 @@ pub fn property_find(
         }
     }
 
-    let total = matching_paths.len();
-    let result = serde_json::json!({
-        "property": name,
-        "value": value,
-        "files": matching_paths,
-        "total": total,
-    });
+    let result = build_find_json("property", name, value, &matching_paths);
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
@@ -557,7 +530,7 @@ tags:
         tmp
     }
 
-    /// Extract the output string from a CommandOutcome.
+    /// Extract the output string from a `CommandOutcome`.
     fn unwrap_output(outcome: CommandOutcome) -> (String, bool) {
         match outcome {
             CommandOutcome::Success(s) => (s, true),
@@ -1263,7 +1236,7 @@ status: draft
 
         let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
         assert!(!content.contains("- a\n") && !content.contains("- b\n"));
-        assert!(content.contains("c"));
+        assert!(content.contains('c'));
     }
 
     // --- Unhappy paths ---

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -93,9 +93,14 @@ pub(crate) fn add_values_to_list_property(
         let added_any = if let Some(Value::Sequence(seq)) = props.get_mut(property_name) {
             let before_len = seq.len();
             for value in values {
+                // Duplicate detection: compare strings case-insensitively; for non-string scalars
+                // (e.g. YAML number 42) stringify them so that adding "42" is detected as a
+                // duplicate of the existing numeric element.
                 let already_present = seq.iter().any(|v| match v {
                     Value::String(s) => s.eq_ignore_ascii_case(value),
-                    _ => v.as_str().is_some_and(|s| s.eq_ignore_ascii_case(value)),
+                    Value::Number(n) => n.to_string().eq_ignore_ascii_case(value),
+                    Value::Bool(b) => b.to_string().eq_ignore_ascii_case(value),
+                    _ => false,
                 });
                 if !already_present {
                     seq.push(Value::String(value.clone()));
@@ -149,22 +154,56 @@ pub(crate) fn remove_values_from_list_property(
 
     for (full_path, rel_path) in files {
         let mut props = frontmatter::read_frontmatter(full_path)?;
-        let current = extract_list_property(&props, property_name);
-        let new_list: Vec<String> = current
-            .iter()
-            .filter(|v| !values.iter().any(|rm| rm.eq_ignore_ascii_case(v)))
-            .cloned()
-            .collect();
 
-        if new_list.len() == current.len() {
-            // Nothing was removed
+        // Helper: check if a YAML value matches any of the removal targets (case-insensitive).
+        let should_remove = |v: &Value| -> bool {
+            match v {
+                Value::String(s) => values.iter().any(|rm| rm.eq_ignore_ascii_case(s)),
+                Value::Number(n) => values
+                    .iter()
+                    .any(|rm| rm.eq_ignore_ascii_case(&n.to_string())),
+                Value::Bool(b) => values
+                    .iter()
+                    .any(|rm| rm.eq_ignore_ascii_case(&b.to_string())),
+                _ => false,
+            }
+        };
+
+        // If the property is a sequence, filter it in-place, retaining original Value types.
+        // For null / absent / scalar-string fall back to the string-based path.
+        let (before_len, after_len) =
+            if let Some(Value::Sequence(seq)) = props.get_mut(property_name) {
+                let before = seq.len();
+                seq.retain(|v| !should_remove(v));
+                (before, seq.len())
+            } else {
+                let current = extract_list_property(&props, property_name);
+                let before = current.len();
+                let new_list: Vec<String> = current
+                    .into_iter()
+                    .filter(|v| !values.iter().any(|rm| rm.eq_ignore_ascii_case(v)))
+                    .collect();
+                let after = new_list.len();
+                // Write back only if something changed (handled below).
+                if after < before {
+                    if new_list.is_empty() {
+                        // Will be removed below.
+                    } else {
+                        let yaml_list =
+                            Value::Sequence(new_list.into_iter().map(Value::String).collect());
+                        props.insert(property_name.to_owned(), yaml_list);
+                    }
+                }
+                (before, after)
+            };
+
+        if after_len == before_len {
+            // Nothing was removed.
             skipped.push(rel_path.clone());
         } else {
-            if new_list.is_empty() {
+            // If the sequence is now empty (either branch), remove the key entirely.
+            if after_len == 0 {
                 props.remove(property_name);
-            } else {
-                let yaml_list = Value::Sequence(new_list.into_iter().map(Value::String).collect());
-                props.insert(property_name.to_owned(), yaml_list);
             }
             frontmatter::write_frontmatter(full_path, &props)?;
             modified.push(rel_path.clone());
@@ -1352,6 +1391,157 @@ status: draft
         assert!(
             msg.contains("number"),
             "error should mention the type: {msg}"
+        );
+    }
+
+    // Issue 1 — remove_values_from_list_property must preserve non-string element types
+    #[test]
+    fn property_remove_from_list_preserves_numeric_elements() {
+        let tmp = tempfile::tempdir().unwrap();
+        // List contains YAML numbers; removing one must leave the remaining as Value::Number.
+        write_note(
+            tmp.path(),
+            "note.md",
+            "---\nscores:\n  - 42\n  - 7\n  - 99\n---\n",
+        );
+
+        unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "scores",
+                &["7".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let props = frontmatter::read_frontmatter(&tmp.path().join("note.md")).unwrap();
+        let seq = match props.get("scores") {
+            Some(Value::Sequence(s)) => s,
+            other => panic!("expected sequence, got: {other:?}"),
+        };
+        assert_eq!(seq.len(), 2);
+        assert!(
+            matches!(&seq[0], Value::Number(n) if n.as_i64() == Some(42)),
+            "first element should remain number 42, got: {:?}",
+            seq[0]
+        );
+        assert!(
+            matches!(&seq[1], Value::Number(n) if n.as_i64() == Some(99)),
+            "second element should remain number 99, got: {:?}",
+            seq[1]
+        );
+    }
+
+    #[test]
+    fn property_remove_from_list_numeric_element_by_string_value() {
+        // Removing "42" (a string arg) from a list that contains the YAML number 42 should work.
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\nscores:\n  - 42\n  - 7\n---\n");
+
+        let parsed = unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "scores",
+                &["42".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let props = frontmatter::read_frontmatter(&tmp.path().join("note.md")).unwrap();
+        let seq = match props.get("scores") {
+            Some(Value::Sequence(s)) => s,
+            other => panic!("expected sequence, got: {other:?}"),
+        };
+        assert_eq!(seq.len(), 1);
+        assert!(
+            matches!(&seq[0], Value::Number(n) if n.as_i64() == Some(7)),
+            "remaining element should be number 7, got: {:?}",
+            seq[0]
+        );
+    }
+
+    // Issue 2 — add_values_to_list_property must detect numeric duplicates by stringifying
+    #[test]
+    fn property_add_to_list_detects_numeric_duplicate() {
+        // YAML number 42 already in list; adding string "42" must be a no-op (duplicate).
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\nscores:\n  - 42\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "scores",
+                &["42".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            parsed["modified"].as_array().unwrap().len(),
+            0,
+            "file should be skipped — 42 already present as number"
+        );
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+
+        // The list must still contain exactly one element, still a number.
+        let props = frontmatter::read_frontmatter(&tmp.path().join("note.md")).unwrap();
+        let seq = match props.get("scores") {
+            Some(Value::Sequence(s)) => s,
+            other => panic!("expected sequence, got: {other:?}"),
+        };
+        assert_eq!(seq.len(), 1);
+        assert!(
+            matches!(&seq[0], Value::Number(n) if n.as_i64() == Some(42)),
+            "element must remain a number 42, got: {:?}",
+            seq[0]
+        );
+    }
+
+    // Boolean duplicate detection: adding "true" must be detected as a duplicate of
+    // an existing `Value::Bool(true)` element.
+    #[test]
+    fn property_add_to_list_detects_boolean_duplicate() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\nflags:\n  - true\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "flags",
+                &["true".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            parsed["modified"].as_array().unwrap().len(),
+            0,
+            "file should be skipped — true already present as boolean"
+        );
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+
+        // The list must still contain exactly one element, still a bool.
+        let props = frontmatter::read_frontmatter(&tmp.path().join("note.md")).unwrap();
+        let seq = match props.get("flags") {
+            Some(Value::Sequence(s)) => s,
+            other => panic!("expected sequence, got: {other:?}"),
+        };
+        assert_eq!(seq.len(), 1);
+        assert!(
+            matches!(&seq[0], Value::Bool(true)),
+            "element must remain bool true, got: {:?}",
+            seq[0]
         );
     }
 

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -193,6 +193,75 @@ pub fn property_remove(
     }
 }
 
+/// Find files that contain a specific frontmatter property, optionally filtering by value.
+pub fn property_find(
+    dir: &Path,
+    name: &str,
+    value: Option<&str>,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut matching_paths: Vec<String> = Vec::new();
+
+    for (full_path, rel_path) in &files {
+        let props = frontmatter::read_frontmatter(full_path)?;
+        if let Some(yaml_val) = props.get(name) {
+            let matches = match value {
+                None => true,
+                Some(query) => value_matches(yaml_val, query),
+            };
+            if matches {
+                matching_paths.push(rel_path.clone());
+            }
+        }
+    }
+
+    let total = matching_paths.len();
+    let result = serde_json::json!({
+        "property": name,
+        "value": value,
+        "files": matching_paths,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+/// Check if a YAML value matches a query string, using type-aware comparison.
+fn value_matches(yaml_val: &serde_yaml_ng::Value, query: &str) -> bool {
+    use serde_yaml_ng::Value;
+    match yaml_val {
+        Value::String(s) => s.eq_ignore_ascii_case(query),
+        Value::Number(n) => {
+            // Try integer match first, then float
+            if let Some(i) = n.as_i64() {
+                query.parse::<i64>() == Ok(i)
+            } else if let Some(f) = n.as_f64() {
+                query.parse::<f64>() == Ok(f)
+            } else {
+                false
+            }
+        }
+        Value::Bool(b) => match query {
+            "true" => *b,
+            "false" => !b,
+            _ => false,
+        },
+        Value::Sequence(seq) => seq.iter().any(|item| value_matches(item, query)),
+        Value::Null => false,
+        Value::Mapping(_) | Value::Tagged(_) => false,
+    }
+}
+
 /// Helper to resolve a file path or produce a user error outcome.
 fn resolve_or_error(
     dir: &Path,
@@ -436,5 +505,264 @@ status: draft
 
         let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
         assert!(content.contains(body), "body was corrupted:\n{content}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // property_find tests
+    // ---------------------------------------------------------------------------
+
+    fn setup_find_vault() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        // a.md: status=draft (string), priority=3 (number), draft=true (bool), tags=[rust,cli]
+        fs::write(
+            tmp.path().join("a.md"),
+            md!(r#"
+---
+status: draft
+priority: 3
+draft: true
+tags:
+  - rust
+  - cli
+---
+"#),
+        )
+        .unwrap();
+        // b.md: status=done (string), priority=5 (number), draft=false (bool)
+        fs::write(
+            tmp.path().join("b.md"),
+            md!(r#"
+---
+status: done
+priority: 5
+draft: false
+---
+"#),
+        )
+        .unwrap();
+        // c.md: no frontmatter
+        fs::write(tmp.path().join("c.md"), "No frontmatter.\n").unwrap();
+        tmp
+    }
+
+    fn unwrap_success(outcome: CommandOutcome) -> serde_json::Value {
+        match outcome {
+            CommandOutcome::Success(s) => serde_json::from_str(&s).unwrap(),
+            CommandOutcome::UserError(s) => panic!("unexpected user error: {s}"),
+        }
+    }
+
+    fn unwrap_user_error(outcome: CommandOutcome) -> serde_json::Value {
+        match outcome {
+            CommandOutcome::UserError(s) => serde_json::from_str(&s).unwrap(),
+            CommandOutcome::Success(s) => panic!("expected user error, got success: {s}"),
+        }
+    }
+
+    #[test]
+    fn property_find_by_existence() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 2);
+        let files: Vec<&str> = parsed["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(files.iter().any(|f| f.contains("a.md")));
+        assert!(files.iter().any(|f| f.contains("b.md")));
+        assert!(!files.iter().any(|f| f.contains("c.md")));
+    }
+
+    #[test]
+    fn property_find_by_string_value() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                Some("draft"),
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_by_number_value() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "priority", Some("3"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_by_bool_value() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "draft", Some("true"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_in_list() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "tags", Some("rust"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_case_insensitive() {
+        let tmp = setup_find_vault();
+        // "Draft" should match "draft" case-insensitively
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                Some("Draft"),
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("a.md"));
+    }
+
+    #[test]
+    fn property_find_with_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("sub")).unwrap();
+        fs::write(
+            tmp.path().join("sub/x.md"),
+            md!(r#"
+---
+status: draft
+---
+"#),
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("root.md"),
+            md!(r#"
+---
+status: draft
+---
+"#),
+        )
+        .unwrap();
+
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                None,
+                None,
+                Some("sub/*.md"),
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+        assert!(parsed["files"][0].as_str().unwrap().contains("sub/x.md"));
+    }
+
+    #[test]
+    fn property_find_with_file() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, Some("a.md"), None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 1);
+    }
+
+    #[test]
+    fn property_find_no_match() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(
+                tmp.path(),
+                "status",
+                Some("nonexistent-value"),
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+        assert!(parsed["files"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn property_find_value_no_match() {
+        let tmp = setup_find_vault();
+        // Property exists but value doesn't match any file
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "priority", Some("99"), None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+    }
+
+    #[test]
+    fn property_find_nonexistent_property() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "does_not_exist", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+    }
+
+    #[test]
+    fn property_find_file_not_found() {
+        let tmp = setup_find_vault();
+        let parsed = unwrap_user_error(
+            property_find(
+                tmp.path(),
+                "status",
+                None,
+                Some("nope.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["error"], "file not found");
+    }
+
+    #[test]
+    fn property_find_no_frontmatter_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Only a file with no frontmatter
+        fs::write(tmp.path().join("plain.md"), "Just text.\n").unwrap();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+    }
+
+    #[test]
+    fn property_find_empty_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parsed = unwrap_success(
+            property_find(tmp.path(), "status", None, None, None, Format::Json).unwrap(),
+        );
+        assert_eq!(parsed["total"], 0);
+        assert!(parsed["files"].as_array().unwrap().is_empty());
     }
 }

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
 use serde_json::json;
 use serde_yaml_ng::Value;
@@ -23,7 +24,6 @@ fn extract_list_property(
     name: &str,
 ) -> Vec<String> {
     match props.get(name) {
-        None | Some(Value::Null) => vec![],
         Some(Value::Sequence(seq)) => seq
             .iter()
             .filter_map(|v| match v {
@@ -44,6 +44,7 @@ fn extract_list_property(
 }
 
 /// Result type for list-mutation operations.
+#[derive(Debug)]
 pub(crate) struct ListOpResult {
     pub(crate) modified: Vec<String>,
     pub(crate) skipped: Vec<String>,
@@ -52,7 +53,8 @@ pub(crate) struct ListOpResult {
 /// Core logic: add `values` to the list property `property_name` across `files`.
 ///
 /// For each file:
-/// - Reads current list (empty if absent or non-list).
+/// - Checks that the property is absent, null, a string, or a sequence — returns an error for
+///   other types (bool, number, mapping) to prevent silent data loss.
 /// - Appends any value not already present (case-insensitive for strings).
 /// - Writes back if at least one value was added; otherwise marks file as skipped.
 pub(crate) fn add_values_to_list_property(
@@ -65,19 +67,64 @@ pub(crate) fn add_values_to_list_property(
 
     for (full_path, rel_path) in files {
         let mut props = frontmatter::read_frontmatter(full_path)?;
-        let mut current = extract_list_property(&props, property_name);
-        let before_len = current.len();
 
-        for value in values {
-            let already_present = current.iter().any(|v| v.eq_ignore_ascii_case(value));
-            if !already_present {
-                current.push(value.clone());
+        // Guard against silently overwriting non-list scalar types.
+        match props.get(property_name) {
+            None | Some(Value::Null) | Some(Value::String(_)) | Some(Value::Sequence(_)) => {}
+            Some(existing) => {
+                let kind = match existing {
+                    Value::Bool(_) => "boolean",
+                    Value::Number(_) => "number",
+                    Value::Mapping(_) => "mapping",
+                    _ => "unknown",
+                };
+                anyhow::bail!(
+                    "property '{}' in '{}' is a {kind} value, not a list — \
+                     use `property set` to overwrite it explicitly",
+                    property_name,
+                    rel_path
+                );
             }
         }
 
-        if current.len() > before_len {
-            let yaml_list = Value::Sequence(current.into_iter().map(Value::String).collect());
-            props.insert(property_name.to_owned(), yaml_list);
+        // If the property is already a sequence, append directly to preserve element types.
+        // Otherwise fall back to the string-based approach for null / absent / scalar-string.
+        let added_any = match props.get_mut(property_name) {
+            Some(Value::Sequence(seq)) => {
+                let before_len = seq.len();
+                for value in values {
+                    let already_present = seq.iter().any(|v| match v {
+                        Value::String(s) => s.eq_ignore_ascii_case(value),
+                        _ => v.as_str().is_some_and(|s| s.eq_ignore_ascii_case(value)),
+                    });
+                    if !already_present {
+                        seq.push(Value::String(value.clone()));
+                    }
+                }
+                seq.len() > before_len
+            }
+            _ => {
+                // Build a fresh list from the existing string value (if any) plus new values.
+                let mut current = extract_list_property(&props, property_name);
+                let before_len = current.len();
+                for value in values {
+                    let already_present = current.iter().any(|v| v.eq_ignore_ascii_case(value));
+                    if !already_present {
+                        current.push(value.clone());
+                    }
+                }
+                if current.len() > before_len {
+                    let yaml_list =
+                        Value::Sequence(current.into_iter().map(Value::String).collect());
+                    props.insert(property_name.to_owned(), yaml_list);
+                    true
+                } else {
+                    false
+                }
+            }
+        };
+
+        if added_any {
             frontmatter::write_frontmatter(full_path, &props)?;
             modified.push(rel_path.clone());
         } else {
@@ -228,18 +275,15 @@ pub fn property_remove_from_list(
     )))
 }
 
-/// List all properties across all files, or properties of a single file / glob match.
-pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<CommandOutcome> {
-    match path {
-        Some(p) if discovery::is_glob(p) => properties_glob(dir, p, format),
-        Some(p) => properties_single(dir, p, format),
-        None => properties_all(dir, format),
-    }
-}
-
-/// List all unique property names across all `.md` files.
-fn properties_all(dir: &Path, format: Format) -> Result<CommandOutcome> {
-    let files = collect_files(dir, None, None, format)?;
+/// Aggregate summary: unique property names with types and file counts.
+/// Scope is filtered by `--file` / `--glob` (or all files if both are None).
+pub fn properties_summary(
+    dir: &Path,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -249,8 +293,8 @@ fn properties_all(dir: &Path, format: Format) -> Result<CommandOutcome> {
     let mut agg: std::collections::BTreeMap<String, (String, usize)> =
         std::collections::BTreeMap::new();
 
-    for (file, _) in &files {
-        let props = frontmatter::read_frontmatter(file)?;
+    for (fp, _) in &files {
+        let props = frontmatter::read_frontmatter(fp)?;
         for (key, value) in &props {
             agg.entry(key.clone())
                 .and_modify(|entry| entry.1 += 1)
@@ -269,37 +313,15 @@ fn properties_all(dir: &Path, format: Format) -> Result<CommandOutcome> {
     )))
 }
 
-/// List properties of a single file.
-fn properties_single(dir: &Path, path_arg: &str, format: Format) -> Result<CommandOutcome> {
-    let (full_path, rel_path) = match discovery::resolve_file(dir, path_arg) {
-        Ok(r) => r,
-        Err(e) => return Ok(resolve_error_to_outcome(e, format)),
-    };
-
-    let props = frontmatter::read_frontmatter(&full_path)?;
-
-    let prop_map: serde_json::Map<String, serde_json::Value> = props
-        .iter()
-        .map(|(k, v)| {
-            let typ = frontmatter::infer_type(v);
-            let json_val = frontmatter::yaml_to_json(v);
-            (k.clone(), json!({"value": json_val, "type": typ}))
-        })
-        .collect();
-
-    let result = json!({
-        "path": rel_path,
-        "properties": prop_map,
-    });
-
-    Ok(CommandOutcome::Success(crate::output::format_success(
-        format, &result,
-    )))
-}
-
-/// List properties of files matching a glob pattern.
-fn properties_glob(dir: &Path, pattern: &str, format: Format) -> Result<CommandOutcome> {
-    let files = collect_files(dir, None, Some(pattern), format)?;
+/// Per-file detail: each file with its full property key/value pairs.
+/// Scope is filtered by `--file` / `--glob` (or all files if both are None).
+pub fn properties_list(
+    dir: &Path,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -467,19 +489,27 @@ fn value_matches(yaml_val: &serde_yaml_ng::Value, query: &str) -> bool {
             if let Some(i) = n.as_i64() {
                 query.parse::<i64>() == Ok(i)
             } else if let Some(f) = n.as_f64() {
+                // Exact float equality — acceptable for simple YAML frontmatter values
                 query.parse::<f64>() == Ok(f)
             } else {
                 false
             }
         }
-        Value::Bool(b) => match query {
-            "true" => *b,
-            "false" => !b,
-            _ => false,
-        },
+        Value::Bool(b) => {
+            // Accept the same spellings the CLI uses for boolean flags, case-insensitively.
+            let q = query.to_ascii_lowercase();
+            let is_truthy = matches!(q.as_str(), "true" | "yes" | "1");
+            let is_falsy = matches!(q.as_str(), "false" | "no" | "0");
+            if is_truthy {
+                *b
+            } else if is_falsy {
+                !*b
+            } else {
+                false
+            }
+        }
         Value::Sequence(seq) => seq.iter().any(|item| value_matches(item, query)),
-        Value::Null => false,
-        Value::Mapping(_) | Value::Tagged(_) => false,
+        Value::Null | Value::Mapping(_) | Value::Tagged(_) => false,
     }
 }
 
@@ -510,7 +540,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 title: Test
 status: draft
@@ -520,7 +550,7 @@ tags:
   - cli
 ---
 # Hello
-"#),
+"),
         )
         .unwrap();
         fs::write(tmp.path().join("empty.md"), "No frontmatter here.\n").unwrap();
@@ -536,9 +566,10 @@ tags:
     }
 
     #[test]
-    fn properties_all_aggregates() {
+    fn properties_summary_aggregates() {
         let tmp = setup_dir();
-        let (out, ok) = unwrap_output(properties(tmp.path(), None, Format::Json).unwrap());
+        let (out, ok) =
+            unwrap_output(properties_summary(tmp.path(), None, None, Format::Json).unwrap());
         assert!(ok);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
         assert!(!parsed.is_empty());
@@ -548,15 +579,17 @@ tags:
     }
 
     #[test]
-    fn properties_single_file() {
+    fn properties_list_single_file() {
         let tmp = setup_dir();
-        let (out, ok) =
-            unwrap_output(properties(tmp.path(), Some("note.md"), Format::Json).unwrap());
+        let (out, ok) = unwrap_output(
+            properties_list(tmp.path(), Some("note.md"), None, Format::Json).unwrap(),
+        );
         assert!(ok);
-        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(parsed["path"], "note.md");
-        assert_eq!(parsed["properties"]["priority"]["type"], "number");
-        assert_eq!(parsed["properties"]["tags"]["type"], "list");
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0]["path"], "note.md");
+        assert_eq!(parsed[0]["properties"]["priority"]["type"], "number");
+        assert_eq!(parsed[0]["properties"]["tags"]["type"], "list");
     }
 
     #[test]
@@ -678,18 +711,18 @@ tags:
     #[test]
     fn property_set_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = md!(r#"
+        let body = md!(r"
 # Heading
 
 Body content.
-"#);
+");
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 title: Test
 ---
-"#)
+")
             .to_owned()
                 + body,
         )
@@ -704,19 +737,19 @@ title: Test
     #[test]
     fn property_remove_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = md!(r#"
+        let body = md!(r"
 # Heading
 
 Body content.
-"#);
+");
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 title: Test
 status: draft
 ---
-"#)
+")
             .to_owned()
                 + body,
         )
@@ -737,7 +770,7 @@ status: draft
         // a.md: status=draft (string), priority=3 (number), draft=true (bool), tags=[rust,cli]
         fs::write(
             tmp.path().join("a.md"),
-            md!(r#"
+            md!(r"
 ---
 status: draft
 priority: 3
@@ -746,19 +779,19 @@ tags:
   - rust
   - cli
 ---
-"#),
+"),
         )
         .unwrap();
         // b.md: status=done (string), priority=5 (number), draft=false (bool)
         fs::write(
             tmp.path().join("b.md"),
-            md!(r#"
+            md!(r"
 ---
 status: done
 priority: 5
 draft: false
 ---
-"#),
+"),
         )
         .unwrap();
         // c.md: no frontmatter
@@ -871,20 +904,20 @@ draft: false
         fs::create_dir(tmp.path().join("sub")).unwrap();
         fs::write(
             tmp.path().join("sub/x.md"),
-            md!(r#"
+            md!(r"
 ---
 status: draft
 ---
-"#),
+"),
         )
         .unwrap();
         fs::write(
             tmp.path().join("root.md"),
-            md!(r#"
+            md!(r"
 ---
 status: draft
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -985,6 +1018,29 @@ status: draft
         );
         assert_eq!(parsed["total"], 0);
         assert!(parsed["files"].as_array().unwrap().is_empty());
+    }
+
+    // Issue 3 — extended boolean matching for value_matches
+    #[test]
+    fn value_matches_bool_yes_no() {
+        let t = Value::Bool(true);
+        let f = Value::Bool(false);
+        assert!(value_matches(&t, "yes"));
+        assert!(value_matches(&t, "YES"));
+        assert!(!value_matches(&t, "no"));
+        assert!(value_matches(&f, "no"));
+        assert!(value_matches(&f, "NO"));
+        assert!(!value_matches(&f, "yes"));
+    }
+
+    #[test]
+    fn value_matches_bool_zero_one() {
+        let t = Value::Bool(true);
+        let f = Value::Bool(false);
+        assert!(value_matches(&t, "1"));
+        assert!(!value_matches(&t, "0"));
+        assert!(value_matches(&f, "0"));
+        assert!(!value_matches(&f, "1"));
     }
 
     // ---------------------------------------------------------------------------
@@ -1292,5 +1348,80 @@ status: draft
         );
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
         assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+    }
+
+    // Issue 1 — non-list scalar types must not be silently overwritten
+    #[test]
+    fn property_add_to_list_rejects_bool_property() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `draft` is a boolean — add-to-list must return an error
+        write_note(tmp.path(), "note.md", "---\ndraft: true\n---\n");
+
+        let files = vec![(tmp.path().join("note.md"), "note.md".to_owned())];
+        let result = add_values_to_list_property(&files, "draft", &["foo".to_owned()]);
+        assert!(result.is_err(), "expected error for boolean property");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("boolean"),
+            "error should mention the type: {msg}"
+        );
+    }
+
+    #[test]
+    fn property_add_to_list_rejects_number_property() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\npriority: 3\n---\n");
+
+        let files = vec![(tmp.path().join("note.md"), "note.md".to_owned())];
+        let result = add_values_to_list_property(&files, "priority", &["foo".to_owned()]);
+        assert!(result.is_err(), "expected error for number property");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("number"),
+            "error should mention the type: {msg}"
+        );
+    }
+
+    // Issue 2 — existing numeric list elements must be preserved as numbers after append
+    #[test]
+    fn property_add_to_list_preserves_numeric_elements() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `scores` contains numbers; appending a string must not stringify the numbers
+        write_note(tmp.path(), "note.md", "---\nscores:\n  - 42\n  - 7\n---\n");
+
+        unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "scores",
+                &["best".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        // Read back and verify that 42 and 7 are still YAML numbers (not quoted strings)
+        let props = frontmatter::read_frontmatter(&tmp.path().join("note.md")).unwrap();
+        let seq = match props.get("scores") {
+            Some(Value::Sequence(s)) => s,
+            other => panic!("expected sequence, got: {other:?}"),
+        };
+        assert_eq!(seq.len(), 3);
+        assert!(
+            matches!(&seq[0], Value::Number(n) if n.as_i64() == Some(42)),
+            "first element should remain a number 42, got: {:?}",
+            seq[0]
+        );
+        assert!(
+            matches!(&seq[1], Value::Number(n) if n.as_i64() == Some(7)),
+            "second element should remain a number 7, got: {:?}",
+            seq[1]
+        );
+        assert!(
+            matches!(&seq[2], Value::String(s) if s == "best"),
+            "third element should be string 'best', got: {:?}",
+            seq[2]
+        );
     }
 }

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -1,11 +1,232 @@
 use anyhow::Result;
 use serde_json::json;
+use serde_yaml_ng::Value;
 use std::path::Path;
 
 use crate::commands::{FilesOrOutcome, collect_files, resolve_error_to_outcome};
 use crate::discovery;
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
+
+// ---------------------------------------------------------------------------
+// Generic list-property helpers
+// ---------------------------------------------------------------------------
+
+/// Extract a list from any YAML value under `property_name`.
+///
+/// - Sequence → collect string and number items as strings
+/// - String → single-element vec (empty string → empty vec)
+/// - Null / missing → empty vec
+/// - Any other type → empty vec
+fn extract_list_property(
+    props: &std::collections::BTreeMap<String, Value>,
+    name: &str,
+) -> Vec<String> {
+    match props.get(name) {
+        None | Some(Value::Null) => vec![],
+        Some(Value::Sequence(seq)) => seq
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .collect(),
+        Some(Value::String(s)) => {
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![s.clone()]
+            }
+        }
+        _ => vec![],
+    }
+}
+
+/// Result type for list-mutation operations.
+pub(crate) struct ListOpResult {
+    pub(crate) modified: Vec<String>,
+    pub(crate) skipped: Vec<String>,
+}
+
+/// Core logic: add `values` to the list property `property_name` across `files`.
+///
+/// For each file:
+/// - Reads current list (empty if absent or non-list).
+/// - Appends any value not already present (case-insensitive for strings).
+/// - Writes back if at least one value was added; otherwise marks file as skipped.
+pub(crate) fn add_values_to_list_property(
+    files: &[(std::path::PathBuf, String)],
+    property_name: &str,
+    values: &[String],
+) -> Result<ListOpResult> {
+    let mut modified = Vec::new();
+    let mut skipped = Vec::new();
+
+    for (full_path, rel_path) in files {
+        let mut props = frontmatter::read_frontmatter(full_path)?;
+        let mut current = extract_list_property(&props, property_name);
+        let before_len = current.len();
+
+        for value in values {
+            let already_present = current.iter().any(|v| v.eq_ignore_ascii_case(value));
+            if !already_present {
+                current.push(value.clone());
+            }
+        }
+
+        if current.len() > before_len {
+            let yaml_list = Value::Sequence(current.into_iter().map(Value::String).collect());
+            props.insert(property_name.to_owned(), yaml_list);
+            frontmatter::write_frontmatter(full_path, &props)?;
+            modified.push(rel_path.clone());
+        } else {
+            skipped.push(rel_path.clone());
+        }
+    }
+
+    Ok(ListOpResult { modified, skipped })
+}
+
+/// Core logic: remove `values` from the list property `property_name` across `files`.
+///
+/// For each file:
+/// - Reads current list.
+/// - Removes matching values (case-insensitive).
+/// - If list becomes empty, removes the entire key.
+/// - Writes back if at least one value was removed; otherwise marks file as skipped.
+pub(crate) fn remove_values_from_list_property(
+    files: &[(std::path::PathBuf, String)],
+    property_name: &str,
+    values: &[String],
+) -> Result<ListOpResult> {
+    let mut modified = Vec::new();
+    let mut skipped = Vec::new();
+
+    for (full_path, rel_path) in files {
+        let mut props = frontmatter::read_frontmatter(full_path)?;
+        let current = extract_list_property(&props, property_name);
+        let new_list: Vec<String> = current
+            .iter()
+            .filter(|v| !values.iter().any(|rm| rm.eq_ignore_ascii_case(v)))
+            .cloned()
+            .collect();
+
+        if new_list.len() == current.len() {
+            // Nothing was removed
+            skipped.push(rel_path.clone());
+        } else {
+            if new_list.is_empty() {
+                props.remove(property_name);
+            } else {
+                let yaml_list = Value::Sequence(new_list.into_iter().map(Value::String).collect());
+                props.insert(property_name.to_owned(), yaml_list);
+            }
+            frontmatter::write_frontmatter(full_path, &props)?;
+            modified.push(rel_path.clone());
+        }
+    }
+
+    Ok(ListOpResult { modified, skipped })
+}
+
+// ---------------------------------------------------------------------------
+// Public CLI-facing list-property commands
+// ---------------------------------------------------------------------------
+
+/// Add values to a list property in file(s). Creates the list if absent.
+/// Skips duplicates (case-insensitive). Returns a `CommandOutcome` with JSON.
+///
+/// JSON output: `{"property": name, "values": [...], "modified": [...], "skipped": [...], "total": N}`
+pub fn property_add_to_list(
+    dir: &Path,
+    name: &str,
+    values: &[String],
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    if file.is_none() && glob.is_none() {
+        let out = crate::output::format_error(
+            format,
+            "property add-to-list requires --file or --glob",
+            None,
+            Some(
+                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
+            ),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let ListOpResult { modified, skipped } = add_values_to_list_property(&files, name, values)?;
+
+    let total = modified.len() + skipped.len();
+    let result = json!({
+        "property": name,
+        "values": values,
+        "modified": modified,
+        "skipped": skipped,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
+
+/// Remove values from a list property in file(s). Removes the key if list becomes empty.
+///
+/// JSON output: `{"property": name, "values": [...], "modified": [...], "skipped": [...], "total": N}`
+pub fn property_remove_from_list(
+    dir: &Path,
+    name: &str,
+    values: &[String],
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    if file.is_none() && glob.is_none() {
+        let out = crate::output::format_error(
+            format,
+            "property remove-from-list requires --file or --glob",
+            None,
+            Some(
+                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
+            ),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let ListOpResult { modified, skipped } =
+        remove_values_from_list_property(&files, name, values)?;
+
+    let total = modified.len() + skipped.len();
+    let result = json!({
+        "property": name,
+        "values": values,
+        "modified": modified,
+        "skipped": skipped,
+        "total": total,
+    });
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format, &result,
+    )))
+}
 
 /// List all properties across all files, or properties of a single file / glob match.
 pub fn properties(dir: &Path, path: Option<&str>, format: Format) -> Result<CommandOutcome> {
@@ -764,5 +985,312 @@ status: draft
         );
         assert_eq!(parsed["total"], 0);
         assert!(parsed["files"].as_array().unwrap().is_empty());
+    }
+
+    // ---------------------------------------------------------------------------
+    // property_add_to_list / property_remove_from_list unit tests
+    // ---------------------------------------------------------------------------
+
+    fn write_note(dir: &std::path::Path, name: &str, content: &str) {
+        fs::write(dir.join(name), content).unwrap();
+    }
+
+    // --- Happy paths: add ---
+
+    #[test]
+    fn property_add_to_list_creates_new_list() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\ntitle: T\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["property"], "aliases");
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("foo"));
+    }
+
+    #[test]
+    fn property_add_to_list_appends_to_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - bar\n---\n");
+
+        unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["baz".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("bar"));
+        assert!(content.contains("baz"));
+    }
+
+    #[test]
+    fn property_add_to_list_skips_duplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - Foo\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()], // different case
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn property_add_to_list_multiple_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\ntitle: T\n---\n");
+
+        let parsed = unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "authors",
+                &["alice".to_owned(), "bob".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("alice"));
+        assert!(content.contains("bob"));
+    }
+
+    #[test]
+    fn property_add_to_list_to_scalar_string() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Property exists as a scalar string
+        write_note(tmp.path(), "note.md", "---\naliases: old\n---\n");
+
+        unwrap_success(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["new".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("old"));
+        assert!(content.contains("new"));
+    }
+
+    // --- Happy paths: remove ---
+
+    #[test]
+    fn property_remove_from_list_removes_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(
+            tmp.path(),
+            "note.md",
+            "---\naliases:\n  - foo\n  - bar\n---\n",
+        );
+
+        let parsed = unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("foo"));
+        assert!(content.contains("bar"));
+    }
+
+    #[test]
+    fn property_remove_from_list_empties_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(
+            tmp.path(),
+            "note.md",
+            "---\ntitle: T\naliases:\n  - solo\n---\n",
+        );
+
+        unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["solo".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("aliases:"));
+        assert!(content.contains("title:"));
+    }
+
+    #[test]
+    fn property_remove_from_list_case_insensitive() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - Rust\n---\n");
+
+        let parsed = unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["rust".to_owned()], // lowercase
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn property_remove_from_list_multiple_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(
+            tmp.path(),
+            "note.md",
+            "---\naliases:\n  - a\n  - b\n  - c\n---\n",
+        );
+
+        unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["a".to_owned(), "b".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("- a\n") && !content.contains("- b\n"));
+        assert!(content.contains("c"));
+    }
+
+    // --- Unhappy paths ---
+
+    #[test]
+    fn property_add_to_list_requires_file_or_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\ntitle: T\n---\n");
+
+        let parsed = unwrap_user_error(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert!(
+            parsed["error"].as_str().unwrap().contains("--file")
+                || parsed["error"].as_str().unwrap().contains("--glob")
+        );
+    }
+
+    #[test]
+    fn property_remove_from_list_requires_file_or_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - foo\n---\n");
+
+        let parsed = unwrap_user_error(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert!(
+            parsed["error"].as_str().unwrap().contains("--file")
+                || parsed["error"].as_str().unwrap().contains("--glob")
+        );
+    }
+
+    #[test]
+    fn property_add_to_list_file_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let parsed = unwrap_user_error(
+            property_add_to_list(
+                tmp.path(),
+                "aliases",
+                &["foo".to_owned()],
+                Some("nonexistent.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["error"], "file not found");
+    }
+
+    #[test]
+    fn property_remove_from_list_absent_values_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_note(tmp.path(), "note.md", "---\naliases:\n  - bar\n---\n");
+
+        let parsed = unwrap_success(
+            property_remove_from_list(
+                tmp.path(),
+                "aliases",
+                &["nothere".to_owned()],
+                Some("note.md"),
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
     }
 }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -4,6 +4,9 @@ use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use crate::commands::properties::{
+    ListOpResult, add_values_to_list_property, remove_values_from_list_property,
+};
 use crate::commands::{FilesOrOutcome, collect_files};
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
@@ -213,28 +216,8 @@ pub fn tag_add(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
-    let mut modified: Vec<String> = Vec::new();
-    let mut skipped: Vec<String> = Vec::new();
-
-    for (full_path, rel_path) in &files {
-        // Read frontmatter only for the idempotency check
-        let props = frontmatter::read_frontmatter(full_path)?;
-        let tags = extract_tags(&props);
-        let already_has = tags.iter().any(|t| t.eq_ignore_ascii_case(name));
-
-        if already_has {
-            skipped.push(rel_path.clone());
-        } else {
-            // Build updated tags list
-            let mut new_tags = tags;
-            new_tags.push(name.to_owned());
-            let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
-            let mut new_props = props;
-            new_props.insert("tags".to_owned(), yaml_list);
-            frontmatter::write_frontmatter(full_path, &new_props)?;
-            modified.push(rel_path.clone());
-        }
-    }
+    let ListOpResult { modified, skipped } =
+        add_values_to_list_property(&files, "tags", &[name.to_owned()])?;
 
     let total = modified.len() + skipped.len();
     let result = json!({
@@ -280,34 +263,8 @@ pub fn tag_remove(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
-    let mut modified: Vec<String> = Vec::new();
-    let mut skipped: Vec<String> = Vec::new();
-
-    for (full_path, rel_path) in &files {
-        // Read frontmatter only
-        let props = frontmatter::read_frontmatter(full_path)?;
-        let tags = extract_tags(&props);
-        let new_tags: Vec<String> = tags
-            .iter()
-            .filter(|t| !t.eq_ignore_ascii_case(name))
-            .cloned()
-            .collect();
-
-        if new_tags.len() == tags.len() {
-            // Tag was not present — idempotent skip
-            skipped.push(rel_path.clone());
-        } else {
-            let mut new_props = props;
-            if new_tags.is_empty() {
-                new_props.remove("tags");
-            } else {
-                let yaml_list = Value::Sequence(new_tags.into_iter().map(Value::String).collect());
-                new_props.insert("tags".to_owned(), yaml_list);
-            }
-            frontmatter::write_frontmatter(full_path, &new_props)?;
-            modified.push(rel_path.clone());
-        }
-    }
+    let ListOpResult { modified, skipped } =
+        remove_values_from_list_property(&files, "tags", &[name.to_owned()])?;
 
     let total = modified.len() + skipped.len();
     let result = json!({

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -94,10 +94,12 @@ pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
 }
 
 // ---------------------------------------------------------------------------
-// `hyalo tags` — list all unique tags with counts
+// `hyalo tags summary` — aggregate: unique tags with counts
 // ---------------------------------------------------------------------------
 
-pub fn tags_list(
+/// Aggregate summary: unique tag names with file counts.
+/// Scope is filtered by `--file` / `--glob` (or all files if both are None).
+pub fn tags_summary(
     dir: &Path,
     file: Option<&str>,
     glob: Option<&str>,
@@ -133,6 +135,42 @@ pub fn tags_list(
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tags list` — per-file detail: each file with its tags array
+// ---------------------------------------------------------------------------
+
+/// Per-file detail: each file with its tags array.
+/// Scope is filtered by `--file` / `--glob` (or all files if both are None).
+pub fn tags_list(
+    dir: &Path,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut results = Vec::new();
+    for (full_path, rel_path) in &files {
+        let props = frontmatter::read_frontmatter(full_path)?;
+        let tags = extract_tags(&props);
+        let tags_json: Vec<serde_json::Value> =
+            tags.into_iter().map(serde_json::Value::String).collect();
+        results.push(json!({
+            "path": rel_path,
+            "tags": tags_json,
+        }));
+    }
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format,
+        &json!(results),
     )))
 }
 
@@ -375,11 +413,11 @@ mod tests {
 
     #[test]
     fn extract_tags_from_list() {
-        let props = make_props(md!(r#"
+        let props = make_props(md!(r"
 tags:
   - rust
   - cli
-"#));
+"));
         let tags = extract_tags(&props);
         assert_eq!(tags, vec!["rust", "cli"]);
     }
@@ -418,26 +456,26 @@ tags:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("a.md"),
-            md!(r#"
+            md!(r"
 ---
 tags:
   - rust
   - cli
 ---
 # A
-"#),
+"),
         )
         .unwrap();
         fs::write(
             tmp.path().join("b.md"),
-            md!(r#"
+            md!(r"
 ---
 tags:
   - rust
   - iteration
 ---
 # B
-"#),
+"),
         )
         .unwrap();
         fs::write(tmp.path().join("c.md"), "No frontmatter.\n").unwrap();
@@ -445,9 +483,9 @@ tags:
     }
 
     #[test]
-    fn tags_list_all_files() {
+    fn tags_summary_all_files() {
         let tmp = setup_vault();
-        let outcome = tags_list(tmp.path(), None, None, Format::Json).unwrap();
+        let outcome = tags_summary(tmp.path(), None, None, Format::Json).unwrap();
         let out = match outcome {
             CommandOutcome::Success(s) => s,
             CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
@@ -460,6 +498,40 @@ tags:
     }
 
     #[test]
+    fn tags_summary_single_file() {
+        let tmp = setup_vault();
+        let outcome = tags_summary(tmp.path(), Some("a.md"), None, Format::Json).unwrap();
+        let out = match outcome {
+            CommandOutcome::Success(s) => s,
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["total"], 2);
+    }
+
+    // --- tags_list (per-file) command ---
+
+    #[test]
+    fn tags_list_per_file_all_files() {
+        let tmp = setup_vault();
+        let outcome = tags_list(tmp.path(), None, None, Format::Json).unwrap();
+        let out = match outcome {
+            CommandOutcome::Success(s) => s,
+            CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let entries = parsed.as_array().unwrap();
+        // 3 files: a.md, b.md, c.md
+        assert_eq!(entries.len(), 3);
+        let a = entries
+            .iter()
+            .find(|e| e["path"].as_str().unwrap().ends_with("a.md"))
+            .unwrap();
+        let a_tags = a["tags"].as_array().unwrap();
+        assert_eq!(a_tags.len(), 2);
+    }
+
+    #[test]
     fn tags_list_single_file() {
         let tmp = setup_vault();
         let outcome = tags_list(tmp.path(), Some("a.md"), None, Format::Json).unwrap();
@@ -468,7 +540,11 @@ tags:
             CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(parsed["total"], 2);
+        let entries = parsed.as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0]["path"].as_str().unwrap().ends_with("a.md"));
+        let tags = entries[0]["tags"].as_array().unwrap();
+        assert_eq!(tags.len(), 2);
     }
 
     // --- tag_find command ---
@@ -491,12 +567,12 @@ tags:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 tags:
   - inbox/processing
 ---
-"#),
+"),
         )
         .unwrap();
         let outcome = tag_find(tmp.path(), "inbox", None, None, Format::Json).unwrap();
@@ -527,11 +603,11 @@ tags:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 title: Note
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -554,12 +630,12 @@ title: Note
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 tags:
   - rust
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -579,11 +655,11 @@ tags:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 title: Note
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -596,11 +672,11 @@ title: Note
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 title: Note
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -616,13 +692,13 @@ title: Note
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 tags:
   - rust
   - cli
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -646,12 +722,12 @@ tags:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 tags:
   - cli
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -671,13 +747,13 @@ tags:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 title: Note
 tags:
   - rust
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -695,12 +771,12 @@ tags:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(
             tmp.path().join("note.md"),
-            md!(r#"
+            md!(r"
 ---
 tags:
   - rust
 ---
-"#),
+"),
         )
         .unwrap();
 
@@ -714,11 +790,11 @@ tags:
     #[test]
     fn tag_add_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = md!(r#"
+        let body = md!(r"
 # Heading
 
 Some content with [[wikilinks]] and more text.
-"#);
+");
         fs::write(
             tmp.path().join("note.md"),
             format!("---\ntitle: Note\n---\n{body}"),
@@ -734,11 +810,11 @@ Some content with [[wikilinks]] and more text.
     #[test]
     fn tag_remove_preserves_body() {
         let tmp = tempfile::tempdir().unwrap();
-        let body = md!(r#"
+        let body = md!(r"
 # Heading
 
 Some content.
-"#);
+");
         fs::write(
             tmp.path().join("note.md"),
             format!("---\ntags:\n  - rust\n  - cli\n---\n{body}"),
@@ -751,13 +827,13 @@ Some content.
         assert!(content.contains(body), "body was corrupted:\n{content}");
     }
 
-    // --- discover_files used by tags_list (read-only) still works without file/glob ---
+    // --- discover_files used by tags_summary (read-only) still works without file/glob ---
 
     #[test]
-    fn tags_list_no_file_or_glob_reads_all() {
+    fn tags_summary_no_file_or_glob_reads_all() {
         let tmp = setup_vault();
-        // tags_list (read-only) still accepts no --file/--glob
-        let outcome = tags_list(tmp.path(), None, None, Format::Json).unwrap();
+        // tags_summary (read-only) still accepts no --file/--glob
+        let outcome = tags_summary(tmp.path(), None, None, Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::Success(_)));
     }
 }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
 use serde_json::json;
 use serde_yaml_ng::Value;
@@ -7,7 +8,9 @@ use std::path::Path;
 use crate::commands::properties::{
     ListOpResult, add_values_to_list_property, remove_values_from_list_property,
 };
-use crate::commands::{FilesOrOutcome, collect_files};
+use crate::commands::{
+    FilesOrOutcome, build_find_json, build_list_mutation_json, collect_files, require_file_or_glob,
+};
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
 
@@ -53,6 +56,7 @@ pub fn validate_tag(name: &str) -> Result<(), String> {
 ///
 /// Uses byte-level ASCII comparison — safe because tag names are validated to only
 /// contain ASCII characters (letters, digits, `_`, `-`, `/`).
+#[must_use]
 pub fn tag_matches(tag: &str, query: &str) -> bool {
     tag.eq_ignore_ascii_case(query)
         || (tag.len() > query.len()
@@ -70,9 +74,9 @@ pub fn tag_matches(tag: &str, query: &str) -> bool {
 /// - `tags` as a YAML sequence → collect string items
 /// - `tags` as a scalar string → single-element vec
 /// - `tags` as empty sequence → empty vec
+#[must_use]
 pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
     match props.get("tags") {
-        None => vec![],
         Some(Value::Sequence(seq)) => seq
             .iter()
             .filter_map(|v| match v {
@@ -88,7 +92,6 @@ pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
                 vec![s.clone()]
             }
         }
-        Some(Value::Null) => vec![],
         _ => vec![],
     }
 }
@@ -201,8 +204,7 @@ pub fn tag_find(
         }
     }
 
-    let total = matching_paths.len();
-    let result = json!({"tag": name, "files": matching_paths, "total": total});
+    let result = build_find_json("tag", name, None, &matching_paths);
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
@@ -235,17 +237,8 @@ pub fn tag_add(
     }
 
     // Mutation commands require --file or --glob to avoid accidentally touching every file
-    if file.is_none() && glob.is_none() {
-        let out = crate::output::format_error(
-            format,
-            "tag add requires --file or --glob",
-            None,
-            Some(
-                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
-            ),
-            None,
-        );
-        return Ok(CommandOutcome::UserError(out));
+    if let Some(outcome) = require_file_or_glob(file, glob, "tag add", format) {
+        return Ok(outcome);
     }
 
     let files = collect_files(dir, file, glob, format)?;
@@ -257,13 +250,7 @@ pub fn tag_add(
     let ListOpResult { modified, skipped } =
         add_values_to_list_property(&files, "tags", &[name.to_owned()])?;
 
-    let total = modified.len() + skipped.len();
-    let result = json!({
-        "tag": name,
-        "modified": modified,
-        "skipped": skipped,
-        "total": total,
-    });
+    let result = build_list_mutation_json("tag", name, None, None, &modified, &skipped);
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
@@ -282,17 +269,8 @@ pub fn tag_remove(
     format: Format,
 ) -> Result<CommandOutcome> {
     // Mutation commands require --file or --glob to avoid accidentally touching every file
-    if file.is_none() && glob.is_none() {
-        let out = crate::output::format_error(
-            format,
-            "tag remove requires --file or --glob",
-            None,
-            Some(
-                "use --file <path> to target a single file or --glob <pattern> to target multiple files",
-            ),
-            None,
-        );
-        return Ok(CommandOutcome::UserError(out));
+    if let Some(outcome) = require_file_or_glob(file, glob, "tag remove", format) {
+        return Ok(outcome);
     }
 
     let files = collect_files(dir, file, glob, format)?;
@@ -304,13 +282,7 @@ pub fn tag_remove(
     let ListOpResult { modified, skipped } =
         remove_values_from_list_property(&files, "tags", &[name.to_owned()])?;
 
-    let total = modified.len() + skipped.len();
-    let result = json!({
-        "tag": name,
-        "modified": modified,
-        "skipped": skipped,
-        "total": total,
-    });
+    let result = build_list_mutation_json("tag", name, None, None, &modified, &skipped);
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format, &result,
@@ -588,9 +560,8 @@ tags:
     fn tag_find_no_match() {
         let tmp = setup_vault();
         let outcome = tag_find(tmp.path(), "nonexistent", None, None, Format::Json).unwrap();
-        let out = match outcome {
-            CommandOutcome::Success(s) => s,
-            _ => panic!("expected success"),
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success")
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["total"], 0);

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
 use globset::Glob;
 use ignore::WalkBuilder;
@@ -41,7 +42,10 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
         return Err(FileResolveError::NotFound { path: normalized });
     }
 
-    if !normalized.ends_with(".md") {
+    if !std::path::Path::new(&normalized)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+    {
         let hint = format!("{normalized}.md");
         return Err(FileResolveError::MissingExtension {
             path: normalized,
@@ -67,6 +71,7 @@ fn normalize_path(path: &str) -> String {
 }
 
 /// Check if a path argument contains glob characters.
+#[must_use]
 pub fn is_glob(path: &str) -> bool {
     path.contains('*') || path.contains('?') || path.contains('[')
 }
@@ -89,11 +94,12 @@ pub fn match_glob(dir: &Path, files: &[PathBuf], pattern: &str) -> Result<Vec<(P
 }
 
 /// Get the relative path of a file from a directory, using forward slashes on all platforms.
+#[must_use]
 pub fn relative_path(dir: &Path, file: &Path) -> String {
-    let raw = file
-        .strip_prefix(dir)
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|_| file.to_string_lossy().to_string());
+    let raw = file.strip_prefix(dir).map_or_else(
+        |_| file.to_string_lossy().to_string(),
+        |p| p.to_string_lossy().to_string(),
+    );
     // Normalize to forward slashes for consistent output and glob matching on Windows.
     raw.replace('\\', "/")
 }
@@ -121,6 +127,7 @@ impl std::error::Error for FileResolveError {}
 /// Resolve a link target to a file path relative to the vault root.
 /// Tries the target as-is, then with `.md` appended.
 /// Returns the relative path if the file exists, or None.
+#[must_use]
 pub fn resolve_target(dir: &Path, target: &str) -> Option<String> {
     if target.is_empty() {
         return None;
@@ -136,7 +143,10 @@ pub fn resolve_target(dir: &Path, target: &str) -> Option<String> {
         return Some(target.clone());
     }
 
-    if !target.ends_with(".md") {
+    if !std::path::Path::new(&target)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+    {
         let with_ext = format!("{target}.md");
         if dir.join(&with_ext).is_file() {
             return Some(with_ext);
@@ -232,7 +242,9 @@ mod tests {
                 assert_eq!(path, "note");
                 assert_eq!(hint, "note.md");
             }
-            other => panic!("expected MissingExtension, got {other:?}"),
+            other @ FileResolveError::NotFound { .. } => {
+                panic!("expected MissingExtension, got {other:?}")
+            }
         }
     }
 

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
 use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
@@ -13,10 +14,12 @@ pub struct Document {
 }
 
 impl Document {
+    #[must_use]
     pub fn properties(&self) -> &BTreeMap<String, Value> {
         &self.properties
     }
 
+    #[must_use]
     pub fn body(&self) -> &str {
         &self.body
     }
@@ -61,6 +64,7 @@ impl Document {
     }
 
     /// Get a property value by name.
+    #[must_use]
     pub fn get_property(&self, name: &str) -> Option<&Value> {
         self.properties.get(name)
     }
@@ -326,15 +330,14 @@ fn find_closing_delimiter(s: &str) -> Option<usize> {
 }
 
 /// Infer the Obsidian property type from a YAML value.
+#[must_use]
 pub fn infer_type(value: &Value) -> &'static str {
     match value {
         Value::Bool(_) => "checkbox",
         Value::Number(_) => "number",
         Value::Sequence(_) => "list",
         Value::String(s) => infer_string_type(s),
-        Value::Null => "text",
-        Value::Mapping(_) => "text",
-        Value::Tagged(_) => "text",
+        Value::Null | Value::Mapping(_) | Value::Tagged(_) => "text",
     }
 }
 
@@ -357,9 +360,9 @@ fn is_date(s: &str) -> bool {
     let b = s.as_bytes();
     b[4] == b'-'
         && b[7] == b'-'
-        && b[..4].iter().all(|c| c.is_ascii_digit())
-        && b[5..7].iter().all(|c| c.is_ascii_digit())
-        && b[8..10].iter().all(|c| c.is_ascii_digit())
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[8..10].iter().all(u8::is_ascii_digit)
 }
 
 /// Check if a string matches `YYYY-MM-DDThh:mm:ss`.
@@ -373,12 +376,12 @@ fn is_datetime(s: &str) -> bool {
         && b[10] == b'T'
         && b[13] == b':'
         && b[16] == b':'
-        && b[..4].iter().all(|c| c.is_ascii_digit())
-        && b[5..7].iter().all(|c| c.is_ascii_digit())
-        && b[8..10].iter().all(|c| c.is_ascii_digit())
-        && b[11..13].iter().all(|c| c.is_ascii_digit())
-        && b[14..16].iter().all(|c| c.is_ascii_digit())
-        && b[17..19].iter().all(|c| c.is_ascii_digit())
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[8..10].iter().all(u8::is_ascii_digit)
+        && b[11..13].iter().all(u8::is_ascii_digit)
+        && b[14..16].iter().all(u8::is_ascii_digit)
+        && b[17..19].iter().all(u8::is_ascii_digit)
 }
 
 /// Parse a string value into an appropriate YAML Value, optionally forced to a specific type.
@@ -449,7 +452,7 @@ fn infer_value(raw: &str) -> Value {
     Value::String(raw.to_owned())
 }
 
-/// Convert a YAML value to a serde_json::Value for output.
+/// Convert a YAML value to a `serde_json::Value` for output.
 pub fn yaml_to_json(value: &Value) -> serde_json::Value {
     match value {
         Value::Null => serde_json::Value::Null,
@@ -748,10 +751,11 @@ Body.
     // --- Budget boundary tests for skip_frontmatter ---
 
     fn make_frontmatter_with_n_lines(n: usize) -> String {
+        use std::fmt::Write as _;
         // Each content line is "k: v\n" (6 bytes). The closing --- is appended.
         let mut s = String::from("---\n");
         for i in 0..n {
-            s.push_str(&format!("k{i}: v\n"));
+            let _ = writeln!(s, "k{i}: v");
         }
         s.push_str("---\n");
         s

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -494,13 +494,13 @@ mod tests {
 
     #[test]
     fn parse_valid_frontmatter() {
-        let content = md!(r#"
+        let content = md!(r"
 ---
 title: Hello
 status: draft
 ---
 Body text here.
-"#);
+");
         let doc = Document::parse(content).unwrap();
         assert_eq!(doc.properties().len(), 2);
         assert_eq!(
@@ -520,11 +520,11 @@ Body text here.
 
     #[test]
     fn parse_empty_frontmatter() {
-        let content = md!(r#"
+        let content = md!(r"
 ---
 ---
 Body.
-"#);
+");
         let doc = Document::parse(content).unwrap();
         assert!(doc.properties().is_empty());
         assert_eq!(doc.body(), "Body.\n");
@@ -533,11 +533,11 @@ Body.
     #[test]
     fn parse_malformed_frontmatter() {
         // Missing closing delimiter — now returns an error to prevent corruption on write
-        let content = md!(r#"
+        let content = md!(r"
 ---
 title: Broken
 No closing delimiter.
-"#);
+");
         let err = Document::parse(content).unwrap_err();
         assert!(err.to_string().contains("unclosed frontmatter"));
     }
@@ -585,7 +585,7 @@ No closing delimiter.
 
     #[test]
     fn roundtrip_preserves_body() {
-        let content = md!(r#"
+        let content = md!(r"
 ---
 title: Test
 priority: 5
@@ -593,7 +593,7 @@ priority: 5
 # Heading
 
 Paragraph content.
-"#);
+");
         let doc = Document::parse(content).unwrap();
         let serialized = doc.serialize().unwrap();
         let doc2 = Document::parse(&serialized).unwrap();
@@ -610,12 +610,12 @@ Paragraph content.
 
     #[test]
     fn set_and_remove_property() {
-        let mut doc = Document::parse(md!(r#"
+        let mut doc = Document::parse(md!(r"
 ---
 title: Hi
 ---
 Body
-"#))
+"))
         .unwrap();
         doc.set_property("status".into(), Value::String("done".into()));
         assert!(doc.get_property("status").is_some());
@@ -655,11 +655,11 @@ Body
 
     #[test]
     fn file_with_only_frontmatter() {
-        let content = md!(r#"
+        let content = md!(r"
 ---
 title: Only FM
 ---
-"#);
+");
         let doc = Document::parse(content).unwrap();
         assert_eq!(doc.properties().len(), 1);
         assert_eq!(doc.body(), "");
@@ -669,14 +669,15 @@ title: Only FM
 
     #[test]
     fn streaming_valid_frontmatter() {
-        let input = br#"---
+        let input = md!("
+---
 title: Hello
 status: draft
 ---
 # Body that should not be read
 Lots of content here.
-"#;
-        let props = read_frontmatter_from_reader(&input[..]).unwrap();
+");
+        let props = read_frontmatter_from_reader(input.as_bytes()).unwrap();
         assert_eq!(props.len(), 2);
         assert_eq!(props.get("title"), Some(&Value::String("Hello".into())));
         assert_eq!(props.get("status"), Some(&Value::String("draft".into())));
@@ -684,20 +685,22 @@ Lots of content here.
 
     #[test]
     fn streaming_no_frontmatter() {
-        let input = br#"Just a regular file.
+        let input = md!("
+Just a regular file.
 No frontmatter.
-"#;
-        let props = read_frontmatter_from_reader(&input[..]).unwrap();
+");
+        let props = read_frontmatter_from_reader(input.as_bytes()).unwrap();
         assert!(props.is_empty());
     }
 
     #[test]
     fn streaming_empty_frontmatter() {
-        let input = br#"---
+        let input = md!("
+---
 ---
 Body.
-"#;
-        let props = read_frontmatter_from_reader(&input[..]).unwrap();
+");
+        let props = read_frontmatter_from_reader(input.as_bytes()).unwrap();
         assert!(props.is_empty());
     }
 
@@ -705,25 +708,27 @@ Body.
     fn streaming_no_closing_delimiter() {
         // No closing `---` means everything after the opening is read as YAML.
         // If it's not valid YAML, we get an error — which is correct.
-        let input = br#"---
+        let input = md!("
+---
 title: Broken
 Not valid yaml line
-"#;
-        let result = read_frontmatter_from_reader(&input[..]);
+");
+        let result = read_frontmatter_from_reader(input.as_bytes());
         assert!(result.is_err());
 
         // But if the content happens to be valid YAML, it parses fine
-        let input2 = br#"---
+        let input2 = md!("
+---
 title: Works
 status: ok
-"#;
-        let props = read_frontmatter_from_reader(&input2[..]).unwrap();
+");
+        let props = read_frontmatter_from_reader(input2.as_bytes()).unwrap();
         assert_eq!(props.get("title"), Some(&Value::String("Works".into())));
     }
 
     #[test]
     fn streaming_matches_full_parse() {
-        let content = md!(r#"
+        let content = md!(r"
 ---
 title: Test
 priority: 5
@@ -734,7 +739,7 @@ tags:
 # Heading
 
 Body.
-"#);
+");
         let doc = Document::parse(content).unwrap();
         let streamed = read_frontmatter_from_reader(content.as_bytes()).unwrap();
         assert_eq!(doc.properties(), &streamed);

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
 use std::path::Path;
 
@@ -88,6 +89,7 @@ fn try_parse_wikilink_at(text: &str, start: usize) -> Option<(Link, usize)> {
 
 /// Parse the inner content of a wikilink (between [[ and ]]).
 /// Handles: target, target|label, target#heading, target#^block-id
+#[must_use]
 pub fn parse_wikilink(inner: &str) -> Option<Link> {
     if inner.is_empty() {
         return None;
@@ -150,6 +152,7 @@ fn try_parse_markdown_link_at(text: &str, start: usize) -> Option<(Link, usize)>
 }
 
 /// Parse a markdown link's label text and target into a Link.
+#[must_use]
 pub fn parse_markdown_link(label_text: &str, target_raw: &str) -> Option<Link> {
     if target_raw.is_empty() {
         return None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,7 +316,7 @@ enum PropertyAction {
             VALUE MATCHING: If --value is given, the comparison is type-aware:\n\
               - String properties: case-insensitive string comparison.\n\
               - Number properties: numeric comparison (parse --value as a number).\n\
-              - Boolean properties: parse --value as 'true' or 'false'.\n\
+              - Boolean properties: parse --value as true/false/yes/no/1/0 (case-insensitive for words).\n\
               - List properties: match if any element equals --value (case-insensitive for strings).\n\
             SIDE EFFECTS: None (read-only).\n\
             USE WHEN: You need to find files with a particular metadata property or a specific value for that property."

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,15 @@ use hyalo::output::{CommandOutcome, Format};
         Globs use standard syntax: '**/*.md' matches recursively, 'notes/*.md' matches one level.\n\n\
         OUTPUT: Returns JSON by default (--format json). Use --format text for human-readable output. \
         Successful output goes to stdout; errors go to stderr with exit code 1 (user error) or 2 (internal error).\n\n\
-        COMMANDS: Use 'properties'/'tags' to list across files. Use 'property'/'tag' for single-item mutations. \
+        COMMANDS: Use 'properties'/'tags' to list across files. Use 'property' for read/set/remove/find \
+        and list operations (add-to-list, remove-from-list). Use 'tag' for tag-specific find/add/remove. \
         Use 'links' to inspect wikilink targets.",
     after_help = "EXAMPLES:\n  \
         List all properties:        hyalo properties --glob '**/*.md'\n  \
         Set a property:             hyalo property set --name status --value done --file notes/todo.md\n  \
+        Find files by property:     hyalo property find --name status --value draft\n  \
+        Add to a list property:     hyalo property add-to-list --name aliases --value \"My Note\" --file note.md\n  \
+        Remove from a list:         hyalo property remove-from-list --name authors --value Alice --file note.md\n  \
         List tags with counts:      hyalo tags\n  \
         Find files by tag:          hyalo tag find --name project/backend\n  \
         Find broken wikilinks:      hyalo links --file index.md --unresolved"
@@ -56,12 +60,18 @@ enum Commands {
         #[arg(long)]
         glob: Option<String>,
     },
-    /// Read, set, or remove a single frontmatter property on one file
+    /// Read, set, find, or remove frontmatter properties; add/remove items from list properties
     #[command(
-        long_about = "Read, set, or remove a single frontmatter property on one file.\n\n\
-        Subcommands: read, set, remove. Each operates on exactly one property in one file.\n\
-        USE 'read' to get a value, 'set' to create/overwrite, 'remove' to delete.\n\
-        SIDE EFFECTS: 'set' and 'remove' modify the file on disk. 'read' is read-only."
+        long_about = "Read, set, find, or remove frontmatter properties; add/remove items from list properties.\n\n\
+        Subcommands:\n\
+        - read: Get a single property value from one file (read-only).\n\
+        - set: Create or overwrite a property on one file.\n\
+        - remove: Delete a property from one file.\n\
+        - find: Search files by property existence or value (read-only).\n\
+        - add-to-list: Append values to a list property across file(s).\n\
+        - remove-from-list: Remove values from a list property across file(s).\n\
+        SIDE EFFECTS: 'set', 'remove', 'add-to-list', and 'remove-from-list' modify files on disk. \
+        'read' and 'find' are read-only."
     )]
     Property {
         #[command(subcommand)]
@@ -259,6 +269,58 @@ enum PropertyAction {
         #[arg(long, conflicts_with = "file")]
         glob: Option<String>,
     },
+    /// Add values to a list property in file(s) frontmatter (mutates files on disk)
+    #[command(
+        long_about = "Add values to a list property in file(s) frontmatter.\n\n\
+            INPUT: A property name (--name), one or more values (--value, repeatable), and target file(s) via --file or --glob.\n\
+            BEHAVIOR: Reads the current list for the named property (or treats it as empty if absent). \
+            Appends each value that is not already present (comparison is case-insensitive for strings). \
+            If the property does not exist it is created. If it exists as a scalar string it is promoted to a list.\n\
+            IDEMPOTENT: Files where all requested values already exist are reported as 'skipped', not modified.\n\
+            OUTPUT: {\"property\": name, \"values\": [...], \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
+            SIDE EFFECTS: Modifies matched files on disk.\n\
+            USE WHEN: You need to append items to any list-type frontmatter property such as 'tags', 'aliases', or 'authors'."
+    )]
+    AddToList {
+        /// Property name (e.g. 'tags', 'aliases', 'authors')
+        #[arg(long)]
+        name: String,
+        /// Values to add (can be specified multiple times, e.g. --value rust --value cli)
+        #[arg(long, required = true)]
+        value: Vec<String>,
+        /// Target a single file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern for multiple files (e.g. 'notes/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+    /// Remove values from a list property in file(s) frontmatter (mutates files on disk)
+    #[command(
+        long_about = "Remove values from a list property in file(s) frontmatter.\n\n\
+            INPUT: A property name (--name), one or more values (--value, repeatable), and target file(s) via --file or --glob.\n\
+            BEHAVIOR: Reads the current list for the named property and removes any matching values \
+            (comparison is case-insensitive for strings). If the list becomes empty after removal, \
+            the entire property key is deleted from frontmatter.\n\
+            IDEMPOTENT: Files where none of the requested values are present are reported as 'skipped', not an error.\n\
+            OUTPUT: {\"property\": name, \"values\": [...], \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
+            SIDE EFFECTS: Modifies matched files on disk.\n\
+            USE WHEN: You need to remove items from any list-type frontmatter property such as 'tags', 'aliases', or 'authors'."
+    )]
+    RemoveFromList {
+        /// Property name (e.g. 'tags', 'aliases', 'authors')
+        #[arg(long)]
+        name: String,
+        /// Values to remove (can be specified multiple times, e.g. --value rust --value cli)
+        #[arg(long, required = true)]
+        value: Vec<String>,
+        /// Target a single file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern for multiple files (e.g. 'notes/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
 }
 
 fn main() {
@@ -301,6 +363,32 @@ fn main() {
                 dir,
                 name,
                 value.as_deref(),
+                file.as_deref(),
+                glob.as_deref(),
+                format,
+            ),
+            PropertyAction::AddToList {
+                ref name,
+                ref value,
+                ref file,
+                ref glob,
+            } => properties::property_add_to_list(
+                dir,
+                name,
+                value,
+                file.as_deref(),
+                glob.as_deref(),
+                format,
+            ),
+            PropertyAction::RemoveFromList {
+                ref name,
+                ref value,
+                ref file,
+                ref glob,
+            } => properties::property_remove_from_list(
+                dir,
+                name,
+                value,
                 file.as_deref(),
                 glob.as_deref(),
                 format,

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,33 @@ enum PropertyAction {
         #[arg(long)]
         file: String,
     },
+    /// Find files containing a specific frontmatter property (read-only)
+    #[command(
+        long_about = "Find files that contain a specific frontmatter property, optionally matching a value.\n\n\
+            INPUT: A property name (--name), an optional value filter (--value), and an optional file scope (--file or --glob).\n\
+            OUTPUT: List of files whose frontmatter contains the given property (and matching value if --value is provided).\n\
+            VALUE MATCHING: If --value is given, the comparison is type-aware:\n\
+              - String properties: case-insensitive string comparison.\n\
+              - Number properties: numeric comparison (parse --value as a number).\n\
+              - Boolean properties: parse --value as 'true' or 'false'.\n\
+              - List properties: match if any element equals --value (case-insensitive for strings).\n\
+            SIDE EFFECTS: None (read-only).\n\
+            USE WHEN: You need to find files with a particular metadata property or a specific value for that property."
+    )]
+    Find {
+        /// Property name to search for (e.g. 'status', 'priority', 'draft')
+        #[arg(long)]
+        name: String,
+        /// Optional value to match (e.g. 'draft', '3', 'true'). If omitted, matches any file that has the property
+        #[arg(long)]
+        value: Option<String>,
+        /// Search only in this file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern to limit which files to search (e.g. 'docs/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
 }
 
 fn main() {
@@ -265,6 +292,19 @@ fn main() {
             PropertyAction::Remove { ref name, ref file } => {
                 properties::property_remove(dir, name, file, format)
             }
+            PropertyAction::Find {
+                ref name,
+                ref value,
+                ref file,
+                ref glob,
+            } => properties::property_find(
+                dir,
+                name,
+                value.as_deref(),
+                file.as_deref(),
+                glob.as_deref(),
+                format,
+            ),
         },
         Commands::Links {
             ref file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,18 +389,16 @@ enum PropertyAction {
     },
 }
 
+#[allow(clippy::too_many_lines)]
 fn main() {
     let cli = Cli::parse();
 
-    let format = match Format::from_str_opt(&cli.format) {
-        Some(f) => f,
-        None => {
-            eprintln!(
-                "Error: invalid format '{}', expected 'json' or 'text'",
-                cli.format
-            );
-            process::exit(2);
-        }
+    let Some(format) = Format::from_str_opt(&cli.format) else {
+        eprintln!(
+            "Error: invalid format '{}', expected 'json' or 'text'",
+            cli.format
+        );
+        process::exit(2);
     };
 
     let dir = &cli.dir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,14 @@ use hyalo::output::{CommandOutcome, Format};
         and list operations (add-to-list, remove-from-list). Use 'tag' for tag-specific find/add/remove. \
         Use 'links' to inspect wikilink targets.",
     after_help = "EXAMPLES:\n  \
-        List all properties:        hyalo properties --glob '**/*.md'\n  \
+        Aggregate property summary: hyalo properties summary\n  \
+        Per-file property detail:   hyalo properties list --glob '**/*.md'\n  \
         Set a property:             hyalo property set --name status --value done --file notes/todo.md\n  \
         Find files by property:     hyalo property find --name status --value draft\n  \
         Add to a list property:     hyalo property add-to-list --name aliases --value \"My Note\" --file note.md\n  \
         Remove from a list:         hyalo property remove-from-list --name authors --value Alice --file note.md\n  \
-        List tags with counts:      hyalo tags\n  \
+        Aggregate tag summary:      hyalo tags summary\n  \
+        Per-file tag detail:        hyalo tags list --glob 'notes/**/*.md'\n  \
         Find files by tag:          hyalo tag find --name project/backend\n  \
         Find broken wikilinks:      hyalo links --file index.md --unresolved"
 )]
@@ -47,18 +49,17 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// List all frontmatter properties across matched files (read-only, no side effects)
-    #[command(
-        long_about = "List all frontmatter properties across matched files.\n\n\
-            INPUT: Reads .md files matching --glob (or all .md files under --dir if omitted).\n\
-            OUTPUT: For each file, emits every YAML frontmatter key-value pair with its inferred type.\n\
+    /// List frontmatter properties across files — aggregate summary or per-file detail
+    #[command(long_about = "List frontmatter properties across files.\n\n\
+            SUBCOMMANDS:\n\
+            - summary (default): aggregate unique property names with types and file counts.\n\
+            - list: per-file detail — each file with its full key/value pairs.\n\n\
+            INPUT: Reads .md files filtered by --file or --glob (or all .md files if omitted).\n\
             SIDE EFFECTS: None (read-only).\n\
-            USE WHEN: You need to discover what properties exist, audit frontmatter, or find files with specific metadata."
-    )]
+            USE WHEN: You need to discover what properties exist, audit frontmatter, or inspect per-file metadata.")]
     Properties {
-        /// Glob pattern to select files (e.g. '**/*.md', 'notes/*.md'). Omit to scan all .md files
-        #[arg(long)]
-        glob: Option<String>,
+        #[command(subcommand)]
+        action: Option<PropertiesAction>,
     },
     /// Read, set, find, or remove frontmatter properties; add/remove items from list properties
     #[command(
@@ -99,22 +100,18 @@ enum Commands {
         #[arg(long, conflicts_with = "unresolved")]
         resolved: bool,
     },
-    /// List all unique tags with per-tag file counts across matched files (read-only)
-    #[command(
-        long_about = "List all unique tags with per-tag file counts across matched files.\n\n\
+    /// List tags across files — aggregate summary or per-file detail
+    #[command(long_about = "List tags across files.\n\n\
+            SUBCOMMANDS:\n\
+            - summary (default): aggregate unique tag names with file counts. Tags are compared case-insensitively.\n\
+            - list: per-file detail — each file with its tags array.\n\n\
             INPUT: Reads the 'tags' field from YAML frontmatter in matched files.\n\
-            OUTPUT: Each unique tag and how many files contain it. Tags are compared case-insensitively.\n\
             SCOPE: Scans all .md files under --dir unless narrowed with --file or --glob.\n\
             SIDE EFFECTS: None (read-only).\n\
-            USE WHEN: You need to see which tags exist, find popular/orphan tags, or audit tag taxonomy."
-    )]
+            USE WHEN: You need to see which tags exist, find popular/orphan tags, audit tag taxonomy, or inspect per-file tags.")]
     Tags {
-        /// Scan only this file instead of all files
-        #[arg(long, conflicts_with = "glob")]
-        file: Option<String>,
-        /// Glob pattern to filter which files to scan (e.g. 'notes/**/*.md')
-        #[arg(long, conflicts_with = "file")]
-        glob: Option<String>,
+        #[command(subcommand)]
+        action: Option<TagsAction>,
     },
     /// Find, add, or remove tags in file frontmatter
     #[command(long_about = "Find, add, or remove tags in file frontmatter.\n\n\
@@ -125,6 +122,75 @@ enum Commands {
     Tag {
         #[command(subcommand)]
         action: TagAction,
+    },
+}
+
+/// Subcommands for `hyalo properties`
+#[derive(Subcommand)]
+enum PropertiesAction {
+    /// Aggregate: unique property names with types and file counts (default)
+    #[command(
+        long_about = "Aggregate summary of frontmatter properties across matched files.\n\n\
+            OUTPUT: List of unique property names, their inferred type, and how many files contain them.\n\
+            SCOPE: Filtered by --file or --glob; defaults to all .md files under --dir.\n\
+            SIDE EFFECTS: None (read-only)."
+    )]
+    Summary {
+        /// Scan only this file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern to select files (e.g. '**/*.md', 'notes/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+    /// Per-file detail: each file with its property key/value pairs
+    #[command(
+        long_about = "Per-file detail: each matched file with its full frontmatter key/value pairs.\n\n\
+            OUTPUT: Array of objects, each with 'path' and 'properties' (key → {value, type}).\n\
+            SCOPE: Filtered by --file or --glob; defaults to all .md files under --dir.\n\
+            SIDE EFFECTS: None (read-only)."
+    )]
+    List {
+        /// Scan only this file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern to select files (e.g. '**/*.md', 'notes/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+}
+
+/// Subcommands for `hyalo tags`
+#[derive(Subcommand)]
+enum TagsAction {
+    /// Aggregate: unique tag names with file counts (default)
+    #[command(long_about = "Aggregate summary of tags across matched files.\n\n\
+            OUTPUT: Each unique tag and how many files contain it. Tags are compared case-insensitively.\n\
+            SCOPE: Filtered by --file or --glob; defaults to all .md files under --dir.\n\
+            SIDE EFFECTS: None (read-only).")]
+    Summary {
+        /// Scan only this file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern to filter which files to scan (e.g. 'notes/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
+    },
+    /// Per-file detail: each file with its tags array
+    #[command(
+        long_about = "Per-file detail: each matched file with its tags array.\n\n\
+            OUTPUT: Array of objects, each with 'path' and 'tags' (list of tag strings).\n\
+            Files without frontmatter or without a 'tags' key appear with an empty tags array.\n\
+            SCOPE: Filtered by --file or --glob; defaults to all .md files under --dir.\n\
+            SIDE EFFECTS: None (read-only)."
+    )]
+    List {
+        /// Scan only this file
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern to filter which files to scan (e.g. 'notes/**/*.md')
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
     },
 }
 
@@ -340,7 +406,19 @@ fn main() {
     let dir = &cli.dir;
 
     let result = match cli.command {
-        Commands::Properties { ref glob } => properties::properties(dir, glob.as_deref(), format),
+        Commands::Properties { action: ref pa } => match pa {
+            None
+            | Some(PropertiesAction::Summary {
+                file: None,
+                glob: None,
+            }) => properties::properties_summary(dir, None, None, format),
+            Some(PropertiesAction::Summary { file, glob }) => {
+                properties::properties_summary(dir, file.as_deref(), glob.as_deref(), format)
+            }
+            Some(PropertiesAction::List { file, glob }) => {
+                properties::properties_list(dir, file.as_deref(), glob.as_deref(), format)
+            }
+        },
         Commands::Property { action } => match action {
             PropertyAction::Read { ref name, ref file } => {
                 properties::property_read(dir, name, file, format)
@@ -408,9 +486,19 @@ fn main() {
             };
             link_commands::links(dir, file, filter, format)
         }
-        Commands::Tags { ref file, ref glob } => {
-            tag_commands::tags_list(dir, file.as_deref(), glob.as_deref(), format)
-        }
+        Commands::Tags { action: ref ta } => match ta {
+            None
+            | Some(TagsAction::Summary {
+                file: None,
+                glob: None,
+            }) => tag_commands::tags_summary(dir, None, None, format),
+            Some(TagsAction::Summary { file, glob }) => {
+                tag_commands::tags_summary(dir, file.as_deref(), glob.as_deref(), format)
+            }
+            Some(TagsAction::List { file, glob }) => {
+                tag_commands::tags_list(dir, file.as_deref(), glob.as_deref(), format)
+            }
+        },
         Commands::Tag { action } => match action {
             TagAction::Find {
                 ref name,

--- a/src/output.rs
+++ b/src/output.rs
@@ -20,6 +20,7 @@ pub enum CommandOutcome {
 }
 
 impl Format {
+    #[must_use]
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s {
             "json" => Some(Self::Json),
@@ -30,6 +31,7 @@ impl Format {
 }
 
 /// Format a successful JSON value for output.
+#[must_use]
 pub fn format_success(format: Format, value: &serde_json::Value) -> String {
     match format {
         Format::Json => serde_json::to_string_pretty(value).unwrap_or_default(),
@@ -38,6 +40,7 @@ pub fn format_success(format: Format, value: &serde_json::Value) -> String {
 }
 
 /// Format an error for output to stderr.
+#[must_use]
 pub fn format_error(
     format: Format,
     error: &str,

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
 use std::borrow::Cow;
 use std::fs::File;
@@ -92,7 +93,7 @@ where
     Ok(())
 }
 
-/// Detect an opening fence (``` or ~~~) at the start of a line.
+/// Detect an opening fence (triple backtick or `~~~`) at the start of a line.
 /// Returns the fence character and count if found.
 fn detect_opening_fence(line: &str) -> Option<(char, usize)> {
     let trimmed = line.trim_start();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -202,12 +202,12 @@ mod tests {
 
     #[test]
     fn skips_frontmatter() {
-        let input = md!(r#"
+        let input = md!(r"
 ---
 title: Test
 ---
 Hello world
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].0, "Hello world");
@@ -216,10 +216,10 @@ Hello world
 
     #[test]
     fn no_frontmatter() {
-        let input = md!(r#"
+        let input = md!(r"
 Hello world
 Second line
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Hello world");
@@ -230,13 +230,13 @@ Second line
 
     #[test]
     fn skips_backtick_fenced_code_block() {
-        let input = md!(r#"
+        let input = md!(r"
 Before
 ```
 code line
 ```
 After
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -245,13 +245,13 @@ After
 
     #[test]
     fn skips_tilde_fenced_code_block() {
-        let input = md!(r#"
+        let input = md!(r"
 Before
 ~~~
 code line
 ~~~
 After
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -260,13 +260,13 @@ After
 
     #[test]
     fn fenced_code_with_info_string() {
-        let input = md!(r#"
+        let input = md!(r"
 Before
 ```rust
 let x = 1;
 ```
 After
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -276,7 +276,7 @@ After
     #[test]
     fn fence_requires_matching_char_and_count() {
         // Opening with 4 backticks, closing needs >= 4
-        let input = md!(r#"
+        let input = md!(r"
 Before
 ````
 code
@@ -284,7 +284,7 @@ code
 still code
 ````
 After
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -293,7 +293,7 @@ After
 
     #[test]
     fn tilde_fence_not_closed_by_backticks() {
-        let input = md!(r#"
+        let input = md!(r"
 Before
 ~~~
 code
@@ -301,7 +301,7 @@ code
 still code
 ~~~
 After
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].0, "Before");
@@ -328,12 +328,12 @@ After
 
     #[test]
     fn early_abort_with_stop() {
-        let input = md!(r#"
+        let input = md!(r"
 Line 1
 Line 2
 Line 3
 Line 4
-"#);
+");
         let mut result = Vec::new();
         scan_reader(input.as_bytes(), |text, line| {
             result.push((text.to_string(), line));
@@ -349,7 +349,7 @@ Line 4
 
     #[test]
     fn line_numbers_accurate_with_frontmatter() {
-        let input = md!(r#"
+        let input = md!(r"
 ---
 title: T
 tags:
@@ -357,7 +357,7 @@ tags:
 ---
 Line 6
 Line 7
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines[0].1, 6);
         assert_eq!(lines[1].1, 7);
@@ -365,14 +365,14 @@ Line 7
 
     #[test]
     fn line_numbers_accurate_with_code_block() {
-        let input = md!(r#"
+        let input = md!(r"
 Line 1
 ```
 skipped
 skipped
 ```
 Line 6
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines[0], ("Line 1".to_string(), 1));
         assert_eq!(lines[1], ("Line 6".to_string(), 6));
@@ -413,12 +413,12 @@ Line 6
 
     #[test]
     fn first_line_is_code_fence() {
-        let input = md!(r#"
+        let input = md!(r"
 ```
 [[not a link]]
 ```
 After
-"#);
+");
         let lines = collect_lines(input);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].0, "After");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,7 +32,11 @@ pub fn write_tagged(dir: &Path, name: &str, tags: &[&str]) {
     let tags_yaml = if tags.is_empty() {
         "tags: []\n".to_owned()
     } else {
-        let items: String = tags.iter().map(|t| format!("  - {t}\n")).collect();
+        let items = tags.iter().fold(String::new(), |mut s, t| {
+            use std::fmt::Write as _;
+            let _ = writeln!(s, "  - {t}");
+            s
+        });
         format!("tags:\n{items}")
     };
     write_md(

--- a/tests/e2e_errors.rs
+++ b/tests/e2e_errors.rs
@@ -50,12 +50,12 @@ fn error_invalid_yaml() {
     write_md(
         tmp.path(),
         "bad.md",
-        md!(r#"
+        md!(r"
 ---
 : invalid yaml [[[{
 ---
 # Body
-"#),
+"),
     );
 
     let output = hyalo()
@@ -76,11 +76,11 @@ fn error_missing_md_extension() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Test
 ---
-"#),
+"),
     );
 
     let output = hyalo()

--- a/tests/e2e_links.rs
+++ b/tests/e2e_links.rs
@@ -7,14 +7,14 @@ fn setup_vault() -> tempfile::TempDir {
     write_md(
         tmp.path(),
         "note-a.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note A
 ---
 See [[note-b]] and [[nonexistent]].
 
 Also ![[image.png]] embed.
-"#),
+"),
     );
     write_md(
         tmp.path(),
@@ -26,13 +26,13 @@ Also ![[image.png]] embed.
     write_md(
         tmp.path(),
         "code-blocks.md",
-        md!(r#"
+        md!(r"
 Before
 ```
 [[inside code block]]
 ```
 After [[real-link]]
-"#),
+"),
     );
     tmp
 }

--- a/tests/e2e_properties.rs
+++ b/tests/e2e_properties.rs
@@ -13,24 +13,24 @@ fn properties_aggregate() {
     write_md(
         tmp.path(),
         "a.md",
-        md!(r#"
+        md!(r"
 ---
 title: A
 status: draft
 ---
 # A
-"#),
+"),
     );
     write_md(
         tmp.path(),
         "b.md",
-        md!(r#"
+        md!(r"
 ---
 title: B
 priority: 1
 ---
 # B
-"#),
+"),
     );
 
     let output = hyalo()
@@ -84,22 +84,22 @@ fn properties_summary_explicit() {
     write_md(
         tmp.path(),
         "a.md",
-        md!(r#"
+        md!(r"
 ---
 title: A
 status: draft
 ---
-"#),
+"),
     );
     write_md(
         tmp.path(),
         "b.md",
-        md!(r#"
+        md!(r"
 ---
 title: B
 priority: 1
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -121,21 +121,21 @@ fn properties_summary_with_glob() {
     write_md(
         tmp.path(),
         "root.md",
-        md!(r#"
+        md!(r"
 ---
 title: Root
 ---
-"#),
+"),
     );
     write_md(
         tmp.path(),
         "sub/a.md",
-        md!(r#"
+        md!(r"
 ---
 title: Sub A
 only_in_sub: yes
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -159,12 +159,12 @@ fn properties_summary_with_file() {
     write_md(
         tmp.path(),
         "other.md",
-        md!(r#"
+        md!(r"
 ---
 title: Other
 only_in_other: true
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -218,29 +218,29 @@ fn properties_list_with_glob() {
     write_md(
         tmp.path(),
         "root.md",
-        md!(r#"
+        md!(r"
 ---
 title: Root
 ---
-"#),
+"),
     );
     write_md(
         tmp.path(),
         "sub/a.md",
-        md!(r#"
+        md!(r"
 ---
 title: Sub A
 ---
-"#),
+"),
     );
     write_md(
         tmp.path(),
         "sub/b.md",
-        md!(r#"
+        md!(r"
 ---
 title: Sub B
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -263,20 +263,20 @@ fn properties_list_all_files() {
     write_md(
         tmp.path(),
         "a.md",
-        md!(r#"
+        md!(r"
 ---
 title: A
 ---
-"#),
+"),
     );
     write_md(
         tmp.path(),
         "b.md",
-        md!(r#"
+        md!(r"
 ---
 status: draft
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -318,12 +318,12 @@ fn properties_list_text_format() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Hello
 status: draft
 ---
-"#),
+"),
     );
 
     let output = hyalo()

--- a/tests/e2e_properties.rs
+++ b/tests/e2e_properties.rs
@@ -3,31 +3,9 @@ mod common;
 use common::{hyalo, md, sample_frontmatter, write_md};
 use tempfile::TempDir;
 
-#[test]
-fn properties_single_file() {
-    let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "file.md", sample_frontmatter());
-
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["properties", "--glob", "file.md"])
-        .output()
-        .unwrap();
-
-    assert!(output.status.success());
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["path"], "file.md");
-
-    let props = &json["properties"];
-    assert_eq!(props["title"]["type"], "text");
-    assert_eq!(props["title"]["value"], "My Note");
-    assert_eq!(props["priority"]["type"], "number");
-    assert_eq!(props["priority"]["value"], 3);
-    assert_eq!(props["draft"]["type"], "checkbox");
-    assert_eq!(props["draft"]["value"], true);
-    assert_eq!(props["created"]["type"], "date");
-    assert_eq!(props["tags"]["type"], "list");
-}
+// ---------------------------------------------------------------------------
+// `hyalo properties` (bare) — defaults to summary
+// ---------------------------------------------------------------------------
 
 #[test]
 fn properties_aggregate() {
@@ -81,7 +59,161 @@ priority: 1
 }
 
 #[test]
-fn properties_with_glob() {
+fn properties_empty_dir() {
+    let tmp = TempDir::new().unwrap();
+    // No .md files at all
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo properties summary` — explicit summary subcommand
+// ---------------------------------------------------------------------------
+
+#[test]
+fn properties_summary_explicit() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r#"
+---
+title: A
+status: draft
+---
+"#),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r#"
+---
+title: B
+priority: 1
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "summary"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let names: Vec<&str> = json.iter().map(|v| v["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"title"));
+    assert!(names.contains(&"status"));
+}
+
+#[test]
+fn properties_summary_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "root.md",
+        md!(r#"
+---
+title: Root
+---
+"#),
+    );
+    write_md(
+        tmp.path(),
+        "sub/a.md",
+        md!(r#"
+---
+title: Sub A
+only_in_sub: yes
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "summary", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let names: Vec<&str> = json.iter().map(|v| v["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"only_in_sub"));
+    // root.md was excluded, so root-only properties should not appear
+    // (both files share "title", so it may still appear)
+}
+
+#[test]
+fn properties_summary_with_file() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", sample_frontmatter());
+    write_md(
+        tmp.path(),
+        "other.md",
+        md!(r#"
+---
+title: Other
+only_in_other: true
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "summary", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let names: Vec<&str> = json.iter().map(|v| v["name"].as_str().unwrap()).collect();
+    // only_in_other should not appear — note.md was the only file scanned
+    assert!(!names.contains(&"only_in_other"));
+    assert!(names.contains(&"title"));
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo properties list` — per-file detail subcommand
+// ---------------------------------------------------------------------------
+
+#[test]
+fn properties_list_single_file() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "file.md", sample_frontmatter());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "list", "--file", "file.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json.len(), 1);
+    assert_eq!(json[0]["path"], "file.md");
+
+    let props = &json[0]["properties"];
+    assert_eq!(props["title"]["type"], "text");
+    assert_eq!(props["title"]["value"], "My Note");
+    assert_eq!(props["priority"]["type"], "number");
+    assert_eq!(props["priority"]["value"], 3);
+    assert_eq!(props["draft"]["type"], "checkbox");
+    assert_eq!(props["draft"]["value"], true);
+    assert_eq!(props["created"]["type"], "date");
+    assert_eq!(props["tags"]["type"], "list");
+}
+
+#[test]
+fn properties_list_with_glob() {
     let tmp = TempDir::new().unwrap();
     write_md(
         tmp.path(),
@@ -113,7 +245,7 @@ title: Sub B
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["properties", "--glob", "sub/*.md"])
+        .args(["properties", "list", "--glob", "sub/*.md"])
         .output()
         .unwrap();
 
@@ -126,23 +258,62 @@ title: Sub B
 }
 
 #[test]
-fn properties_empty_dir() {
+fn properties_list_all_files() {
     let tmp = TempDir::new().unwrap();
-    // No .md files at all
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r#"
+---
+title: A
+---
+"#),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r#"
+---
+status: draft
+---
+"#),
+    );
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["properties"])
+        .args(["properties", "list"])
         .output()
         .unwrap();
 
     assert!(output.status.success());
     let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(json.is_empty());
+    assert_eq!(json.len(), 2);
+    // Each entry has path and properties
+    assert!(json.iter().all(|e| e["path"].is_string()));
+    assert!(json.iter().all(|e| e["properties"].is_object()));
 }
 
 #[test]
-fn properties_text_format() {
+fn properties_list_file_without_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "list", "--file", "plain.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json.len(), 1);
+    assert_eq!(json[0]["path"], "plain.md");
+    let props = json[0]["properties"].as_object().unwrap();
+    assert!(props.is_empty());
+}
+
+#[test]
+fn properties_list_text_format() {
     let tmp = TempDir::new().unwrap();
     write_md(
         tmp.path(),
@@ -162,7 +333,8 @@ status: draft
             "--format",
             "text",
             "properties",
-            "--glob",
+            "list",
+            "--file",
             "note.md",
         ])
         .output()
@@ -173,22 +345,4 @@ status: draft
     // Text format outputs key: value lines
     assert!(stdout.contains("path:"));
     assert!(stdout.contains("properties:"));
-}
-
-#[test]
-fn properties_file_without_frontmatter() {
-    let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
-
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["properties", "--glob", "plain.md"])
-        .output()
-        .unwrap();
-
-    assert!(output.status.success());
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["path"], "plain.md");
-    let props = json["properties"].as_object().unwrap();
-    assert!(props.is_empty());
 }

--- a/tests/e2e_property_find.rs
+++ b/tests/e2e_property_find.rs
@@ -384,6 +384,46 @@ fn property_find_multiple_files_matching() {
 }
 
 // ---------------------------------------------------------------------------
+// Boolean alias tests — "yes", "no", "1", "0" as value filters
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_find_bool_value_yes() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "draft: true\n");
+    write_with_frontmatter(tmp.path(), "b.md", "draft: false\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "draft", "--value", "yes"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_bool_value_zero() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "active: true\n");
+    write_with_frontmatter(tmp.path(), "b.md", "active: false\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "active", "--value", "0"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("b.md"));
+}
+
+// ---------------------------------------------------------------------------
 // Verify the md! macro is available (it's used in some e2e tests)
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e_property_find.rs
+++ b/tests/e2e_property_find.rs
@@ -1,0 +1,421 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write a markdown file with the given YAML frontmatter string (without delimiters).
+fn write_with_frontmatter(dir: &std::path::Path, name: &str, yaml: &str) {
+    write_md(dir, name, &format!("---\n{yaml}---\n# Body\n"));
+}
+
+// ---------------------------------------------------------------------------
+// Happy path tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_find_by_existence() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\ntitle: A\n");
+    write_with_frontmatter(tmp.path(), "b.md", "title: B\n"); // no status
+    write_md(tmp.path(), "c.md", "No frontmatter.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    let files = json["files"].as_array().unwrap();
+    assert!(files[0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_by_value_string() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: done\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_by_value_number() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "priority: 3\n");
+    write_with_frontmatter(tmp.path(), "b.md", "priority: 5\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "priority", "--value", "3"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_by_value_boolean() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "draft: true\n");
+    write_with_frontmatter(tmp.path(), "b.md", "draft: false\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "draft", "--value", "true"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_in_list_value() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "tags:\n  - rust\n  - cli\n");
+    write_with_frontmatter(tmp.path(), "b.md", "tags:\n  - python\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "tags", "--value", "rust"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_case_insensitive_value() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: Draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: done\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_with_glob_filter() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "sub/a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "root.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(files.iter().any(|f| f.contains("sub/a.md")));
+    assert!(!files.iter().any(|f| f.contains("root.md")));
+}
+
+#[test]
+fn property_find_with_file_filter() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--file", "a.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(json["files"][0].as_str().unwrap().contains("a.md"));
+}
+
+#[test]
+fn property_find_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "find",
+            "--name",
+            "status",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("note.md"));
+}
+
+#[test]
+fn property_find_json_format_structure() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Verify all required fields are present
+    assert!(json["property"].is_string());
+    assert_eq!(json["property"], "status");
+    assert!(json["value"].is_string());
+    assert_eq!(json["value"], "draft");
+    assert!(json["files"].is_array());
+    assert!(json["total"].is_number());
+}
+
+// ---------------------------------------------------------------------------
+// Unhappy path tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_find_no_match_returns_success() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: done\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "find",
+            "--name",
+            "status",
+            "--value",
+            "nonexistent",
+        ])
+        .output()
+        .unwrap();
+
+    // No match is still exit 0 with total: 0
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn property_find_nonexistent_file() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--file", "nope.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("file not found") || stderr.contains("not found"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn property_find_glob_no_match() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "find",
+            "--name",
+            "status",
+            "--glob",
+            "nonexistent/*.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn property_find_empty_vault() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn property_find_no_frontmatter_files() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "No frontmatter here.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn property_find_value_type_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    // priority is a number, searching with a non-numeric string → no match (not an error)
+    write_with_frontmatter(tmp.path(), "note.md", "priority: 3\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "priority", "--value", "high"])
+        .output()
+        .unwrap();
+
+    // Not an error — just no match
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn property_find_json_value_is_null_when_no_value_filter() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "note.md", "status: draft\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // value field should be null when no --value was given
+    assert!(
+        json["value"].is_null(),
+        "expected null, got: {}",
+        json["value"]
+    );
+}
+
+#[test]
+fn property_find_multiple_files_matching() {
+    let tmp = TempDir::new().unwrap();
+    write_with_frontmatter(tmp.path(), "a.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "b.md", "status: draft\n");
+    write_with_frontmatter(tmp.path(), "c.md", "status: done\n");
+    write_md(tmp.path(), "d.md", "No frontmatter.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 2);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(files.iter().any(|f| f.contains("a.md")));
+    assert!(files.iter().any(|f| f.contains("b.md")));
+    assert!(!files.iter().any(|f| f.contains("c.md")));
+    assert!(!files.iter().any(|f| f.contains("d.md")));
+}
+
+// ---------------------------------------------------------------------------
+// Verify the md! macro is available (it's used in some e2e tests)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_find_with_complex_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: My Note
+status: draft
+priority: 2
+draft: true
+tags:
+  - rust
+  - cli
+---
+# Body
+
+Some content.
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["property", "find", "--name", "tags", "--value", "cli"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+}

--- a/tests/e2e_property_find.rs
+++ b/tests/e2e_property_find.rs
@@ -393,7 +393,7 @@ fn property_find_with_complex_frontmatter() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: My Note
 status: draft
@@ -406,7 +406,7 @@ tags:
 # Body
 
 Some content.
-"#),
+"),
     );
 
     let output = hyalo()

--- a/tests/e2e_property_list.rs
+++ b/tests/e2e_property_list.rs
@@ -1,0 +1,498 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn write_with_list(dir: &std::path::Path, name: &str, prop: &str, items: &[&str]) {
+    let list_yaml = if items.is_empty() {
+        format!("{prop}: []\n")
+    } else {
+        let rows: String = items.iter().map(|v| format!("  - {v}\n")).collect();
+        format!("{prop}:\n{rows}")
+    };
+    write_md(dir, name, &format!("---\ntitle: {name}\n{list_yaml}---\n"));
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo property add-to-list` — happy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_to_list_creates_property() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "my-alias",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["property"], "aliases");
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 0);
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("my-alias"));
+}
+
+#[test]
+fn add_to_list_appends_values() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["existing"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "new-one",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("existing"));
+    assert!(content.contains("new-one"));
+}
+
+#[test]
+fn add_to_list_skips_duplicates() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["AlreadyHere"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "alreadyhere", // different case
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 0);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn add_to_list_multiple_values() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "authors",
+            "--value",
+            "alice",
+            "--value",
+            "bob",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("alice"));
+    assert!(content.contains("bob"));
+}
+
+#[test]
+fn add_to_list_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "sub/a.md",
+        md!(r#"
+---
+title: A
+---
+"#),
+    );
+    write_md(
+        tmp.path(),
+        "sub/b.md",
+        md!(r#"
+---
+title: B
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "tags",
+            "--value",
+            "batch",
+            "--glob",
+            "sub/*.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 2);
+    assert_eq!(json["total"], 2);
+}
+
+#[test]
+fn add_to_list_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "alias1",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    // text output should at least mention the property name or value
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo property remove-from-list` — happy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_from_list_removes_values() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["keep", "remove-me"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "remove-me",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("keep"));
+    assert!(!content.contains("remove-me"));
+}
+
+#[test]
+fn remove_from_list_removes_key_when_empty() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["only-one"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "only-one",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(!content.contains("aliases:"));
+    assert!(content.contains("title:"));
+}
+
+#[test]
+fn remove_from_list_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "sub/a.md", "aliases", &["shared", "extra"]);
+    write_with_list(tmp.path(), "sub/b.md", "aliases", &["shared"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "shared",
+            "--glob",
+            "sub/*.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn remove_from_list_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["foo"]);
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "foo",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(!stdout.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Unhappy paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_to_list_without_file_or_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "x",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn remove_from_list_without_file_or_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["foo"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "foo",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn add_to_list_file_not_found() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--value",
+            "x",
+            "--file",
+            "nonexistent.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn remove_from_list_file_not_found() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "x",
+            "--file",
+            "nonexistent.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn remove_from_list_absent_value() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "aliases", &["bar"]);
+
+    // Value "foo" is not in the list — file should be skipped, exit 0
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "aliases",
+            "--value",
+            "foo",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["modified"].as_array().unwrap().len(), 0);
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn add_to_list_no_values_provided() {
+    // Clap enforces --value is required; omitting it should produce a clap error (exit 2)
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "aliases",
+            "--file",
+            "note.md",
+            // No --value provided
+        ])
+        .output()
+        .unwrap();
+
+    // Clap should reject this with non-zero exit
+    assert!(!output.status.success());
+}

--- a/tests/e2e_property_list.rs
+++ b/tests/e2e_property_list.rs
@@ -11,7 +11,11 @@ fn write_with_list(dir: &std::path::Path, name: &str, prop: &str, items: &[&str]
     let list_yaml = if items.is_empty() {
         format!("{prop}: []\n")
     } else {
-        let rows: String = items.iter().map(|v| format!("  - {v}\n")).collect();
+        let rows = items.iter().fold(String::new(), |mut s, v| {
+            use std::fmt::Write as _;
+            let _ = writeln!(s, "  - {v}");
+            s
+        });
         format!("{prop}:\n{rows}")
     };
     write_md(dir, name, &format!("---\ntitle: {name}\n{list_yaml}---\n"));
@@ -27,11 +31,11 @@ fn add_to_list_creates_property() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -117,11 +121,11 @@ fn add_to_list_multiple_values() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -153,20 +157,20 @@ fn add_to_list_with_glob() {
     write_md(
         tmp.path(),
         "sub/a.md",
-        md!(r#"
+        md!(r"
 ---
 title: A
 ---
-"#),
+"),
     );
     write_md(
         tmp.path(),
         "sub/b.md",
-        md!(r#"
+        md!(r"
 ---
 title: B
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -196,11 +200,11 @@ fn add_to_list_text_format() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -349,11 +353,11 @@ fn add_to_list_without_file_or_glob() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -471,11 +475,11 @@ fn add_to_list_no_values_provided() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()

--- a/tests/e2e_property_list.rs
+++ b/tests/e2e_property_list.rs
@@ -468,6 +468,100 @@ fn remove_from_list_absent_value() {
     assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
 }
 
+// Cross-type duplicate: YAML number 42 in list; adding string "42" must be skipped.
+#[test]
+fn add_to_list_skips_numeric_duplicate() {
+    let tmp = TempDir::new().unwrap();
+    // Write a file with a list property that contains the YAML number 42 (no quotes).
+    write_md(
+        tmp.path(),
+        "test.md",
+        "---\ntitle: Test\nscores:\n  - 42\n---\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "add-to-list",
+            "--name",
+            "scores",
+            "--value",
+            "42",
+            "--file",
+            "test.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        0,
+        "file should be skipped — 42 already present as a YAML number"
+    );
+    assert_eq!(json["skipped"].as_array().unwrap().len(), 1);
+
+    // File must be unchanged: still exactly one element.
+    let content = std::fs::read_to_string(tmp.path().join("test.md")).unwrap();
+    // The list should not have a second entry for 42.
+    let occurrences = content.matches("42").count();
+    assert_eq!(
+        occurrences, 1,
+        "expected exactly one '42' in file, got {occurrences}"
+    );
+}
+
+// Removing all items from a list must delete the key entirely from frontmatter.
+#[test]
+fn remove_from_list_removes_key_when_all_removed() {
+    let tmp = TempDir::new().unwrap();
+    write_with_list(tmp.path(), "note.md", "tags", &["a", "b"]);
+
+    // Remove first value.
+    let out1 = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "tags",
+            "--value",
+            "a",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(out1.status.success());
+
+    // Remove second value.
+    let out2 = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "remove-from-list",
+            "--name",
+            "tags",
+            "--value",
+            "b",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(out2.status.success());
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        !content.contains("tags:"),
+        "tags key should be fully removed, got:\n{content}"
+    );
+    // Other frontmatter must survive.
+    assert!(content.contains("title:"));
+}
+
 #[test]
 fn add_to_list_no_values_provided() {
     // Clap enforces --value is required; omitting it should produce a clap error (exit 2)

--- a/tests/e2e_property_list.rs
+++ b/tests/e2e_property_list.rs
@@ -222,9 +222,8 @@ title: Note
         .unwrap();
 
     assert!(output.status.success());
-    // text output should at least mention the property name or value
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(!stdout.is_empty());
+    assert!(stdout.contains("aliases") || stdout.contains("alias1"));
 }
 
 // ---------------------------------------------------------------------------
@@ -337,7 +336,7 @@ fn remove_from_list_text_format() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(!stdout.is_empty());
+    assert!(stdout.contains("aliases") || stdout.contains("foo"));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e_property_remove.rs
+++ b/tests/e2e_property_remove.rs
@@ -179,11 +179,12 @@ only_prop: value
     // File should still be readable and have no properties
     let props_output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["properties", "--glob", "note.md"])
+        .args(["properties", "list", "--file", "note.md"])
         .output()
         .unwrap();
     assert!(props_output.status.success());
-    let json: serde_json::Value = serde_json::from_slice(&props_output.stdout).unwrap();
-    let props = json["properties"].as_object().unwrap();
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&props_output.stdout).unwrap();
+    assert_eq!(json.len(), 1);
+    let props = json[0]["properties"].as_object().unwrap();
     assert!(props.is_empty());
 }

--- a/tests/e2e_property_set.rs
+++ b/tests/e2e_property_set.rs
@@ -9,12 +9,12 @@ fn set_new_property() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Existing
 ---
 # Body
-"#),
+"),
     );
 
     let output = hyalo()
@@ -48,12 +48,12 @@ fn set_overwrite_property() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Old Title
 ---
 # Body
-"#),
+"),
     );
 
     let output = hyalo()
@@ -112,11 +112,11 @@ fn set_infers_number_type() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Test
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -139,11 +139,11 @@ fn set_infers_bool_type() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Test
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -166,11 +166,11 @@ fn set_infers_date_type() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Test
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -200,11 +200,11 @@ fn set_explicit_type() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Test
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -225,7 +225,7 @@ title: Test
 #[test]
 fn set_preserves_body() {
     let tmp = TempDir::new().unwrap();
-    let content = md!(r#"
+    let content = md!(r"
 ---
 title: Test
 ---
@@ -235,7 +235,7 @@ Some paragraph content.
 
 - Item 1
 - Item 2
-"#);
+");
     write_md(tmp.path(), "note.md", content);
 
     let output = hyalo()
@@ -260,13 +260,13 @@ fn set_preserves_other_properties() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Keep Me
 status: draft
 ---
 # Body
-"#),
+"),
     );
 
     let output = hyalo()

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -4,11 +4,11 @@ use common::{hyalo, md, write_md, write_tagged};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
-// `hyalo tags` — list all unique tags with counts
+// `hyalo tags` (bare) — defaults to summary
 // ---------------------------------------------------------------------------
 
 #[test]
-fn tags_all_files() {
+fn tags_bare_defaults_to_summary() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
     write_tagged(tmp.path(), "b.md", &["rust", "iteration"]);
@@ -31,7 +31,50 @@ fn tags_all_files() {
 }
 
 #[test]
-fn tags_with_glob() {
+fn tags_empty_vault() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["tags"].as_array().unwrap().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tags summary` — explicit summary subcommand
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_summary_all_files() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
+    write_tagged(tmp.path(), "b.md", &["rust", "iteration"]);
+    write_md(tmp.path(), "c.md", "No frontmatter.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "summary"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 3); // rust, cli, iteration
+    let tags = json["tags"].as_array().unwrap();
+    let rust = tags.iter().find(|t| t["name"] == "rust").unwrap();
+    assert_eq!(rust["count"], 2);
+    let cli = tags.iter().find(|t| t["name"] == "cli").unwrap();
+    assert_eq!(cli["count"], 1);
+}
+
+#[test]
+fn tags_summary_with_glob() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "sub/a.md", &["alpha"]);
     write_tagged(tmp.path(), "sub/b.md", &["beta"]);
@@ -39,7 +82,7 @@ fn tags_with_glob() {
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["tags", "--glob", "sub/*.md"])
+        .args(["tags", "summary", "--glob", "sub/*.md"])
         .output()
         .unwrap();
 
@@ -58,14 +101,14 @@ fn tags_with_glob() {
 }
 
 #[test]
-fn tags_with_file() {
+fn tags_summary_with_file() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust", "cli"]);
     write_tagged(tmp.path(), "other.md", &["python"]);
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["tags", "--file", "note.md"])
+        .args(["tags", "summary", "--file", "note.md"])
         .output()
         .unwrap();
 
@@ -83,12 +126,12 @@ fn tags_with_file() {
 }
 
 #[test]
-fn tags_empty_vault() {
+fn tags_summary_empty_vault() {
     let tmp = TempDir::new().unwrap();
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .arg("tags")
+        .args(["tags", "summary"])
         .output()
         .unwrap();
 
@@ -99,7 +142,7 @@ fn tags_empty_vault() {
 }
 
 #[test]
-fn tags_text_format() {
+fn tags_summary_text_format() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
@@ -110,6 +153,7 @@ fn tags_text_format() {
             "--format",
             "text",
             "tags",
+            "summary",
         ])
         .output()
         .unwrap();
@@ -117,6 +161,214 @@ fn tags_text_format() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("rust"));
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo tags list` — per-file detail subcommand (new capability)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_list_all_files() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
+    write_tagged(tmp.path(), "b.md", &["iteration"]);
+    write_md(tmp.path(), "c.md", "No frontmatter.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "list"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    // 3 files
+    assert_eq!(json.len(), 3);
+    // Each entry has path and tags
+    assert!(json.iter().all(|e| e["path"].is_string()));
+    assert!(json.iter().all(|e| e["tags"].is_array()));
+
+    let a = json
+        .iter()
+        .find(|e| e["path"].as_str().unwrap().ends_with("a.md"))
+        .unwrap();
+    let a_tags: Vec<&str> = a["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(a_tags.contains(&"rust"));
+    assert!(a_tags.contains(&"cli"));
+}
+
+#[test]
+fn tags_list_with_glob() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "sub/a.md", &["alpha"]);
+    write_tagged(tmp.path(), "sub/b.md", &["beta"]);
+    write_tagged(tmp.path(), "root.md", &["gamma"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "list", "--glob", "sub/*.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    // Only sub/ files
+    assert_eq!(json.len(), 2);
+    let paths: Vec<&str> = json.iter().map(|e| e["path"].as_str().unwrap()).collect();
+    assert!(paths.iter().all(|p| p.starts_with("sub/")));
+    assert!(!paths.iter().any(|p| p.contains("root.md")));
+}
+
+#[test]
+fn tags_list_with_file() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust", "cli"]);
+    write_tagged(tmp.path(), "other.md", &["python"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "list", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json.len(), 1);
+    assert!(json[0]["path"].as_str().unwrap().ends_with("note.md"));
+    let tags: Vec<&str> = json[0]["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(tags.contains(&"rust"));
+    assert!(tags.contains(&"cli"));
+    assert!(!tags.contains(&"python"));
+}
+
+#[test]
+fn tags_list_file_without_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "list", "--file", "plain.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json.len(), 1);
+    assert_eq!(json[0]["path"], "plain.md");
+    assert!(json[0]["tags"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn tags_list_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "tags",
+            "list",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("note.md"));
+    assert!(stdout.contains("rust"));
+}
+
+#[test]
+fn tags_list_glob_no_match() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "list", "--glob", "nonexistent/*.md"])
+        .output()
+        .unwrap();
+
+    // Should exit with error status (user error: no files match pattern)
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_file_without_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn tags_scalar_string_tag() {
+    let tmp = TempDir::new().unwrap();
+    // tags as a scalar string (not a list)
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Note
+tags: rust
+---
+"#),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["tags"][0]["name"], "rust");
+}
+
+#[test]
+fn tags_summary_glob_no_match() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["rust"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "summary", "--glob", "nonexistent/*.md"])
+        .output()
+        .unwrap();
+
+    // Should exit with error status (user error: no files match pattern)
+    assert!(!output.status.success());
 }
 
 // ---------------------------------------------------------------------------
@@ -633,51 +885,8 @@ fn tag_remove_text_format() {
 }
 
 // ---------------------------------------------------------------------------
-// Edge cases
+// More edge cases
 // ---------------------------------------------------------------------------
-
-#[test]
-fn tags_file_without_frontmatter() {
-    let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
-
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
-        .arg("tags")
-        .output()
-        .unwrap();
-
-    assert!(output.status.success());
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["total"], 0);
-}
-
-#[test]
-fn tags_scalar_string_tag() {
-    let tmp = TempDir::new().unwrap();
-    // tags as a scalar string (not a list)
-    write_md(
-        tmp.path(),
-        "note.md",
-        md!(r#"
----
-title: Note
-tags: rust
----
-"#),
-    );
-
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
-        .arg("tags")
-        .output()
-        .unwrap();
-
-    assert!(output.status.success());
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["total"], 1);
-    assert_eq!(json["tags"][0]["name"], "rust");
-}
 
 #[test]
 fn tag_add_to_file_with_no_frontmatter() {
@@ -739,21 +948,6 @@ fn tag_find_file_with_empty_tags_list() {
     assert!(output.status.success());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["total"], 0);
-}
-
-#[test]
-fn tags_glob_no_match() {
-    let tmp = TempDir::new().unwrap();
-    write_tagged(tmp.path(), "note.md", &["rust"]);
-
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["tags", "--glob", "nonexistent/*.md"])
-        .output()
-        .unwrap();
-
-    // Should exit with error status (user error: no files match pattern)
-    assert!(!output.status.success());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -336,12 +336,12 @@ fn tags_scalar_string_tag() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 tags: rust
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -519,11 +519,11 @@ fn tag_add_single_file() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -585,12 +585,12 @@ fn tag_add_creates_tags_property() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
 # Body
-"#),
+"),
     );
 
     let output = hyalo()
@@ -613,11 +613,11 @@ fn tag_add_invalid_name_numeric() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -641,11 +641,11 @@ fn tag_add_invalid_name_with_space() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -663,11 +663,11 @@ fn tag_add_invalid_name_empty() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -685,11 +685,11 @@ fn tag_add_nested_tag_valid() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -729,11 +729,11 @@ fn tag_add_json_format() {
     write_md(
         tmp.path(),
         "note.md",
-        md!(r#"
+        md!(r"
 ---
 title: Note
 ---
-"#),
+"),
     );
 
     let output = hyalo()
@@ -894,10 +894,10 @@ fn tag_add_to_file_with_no_frontmatter() {
     write_md(
         tmp.path(),
         "plain.md",
-        md!(r#"
+        md!(r"
 No frontmatter here.
 # Content
-"#),
+"),
     );
 
     let output = hyalo()


### PR DESCRIPTION
## Summary
- Splits `properties` and `tags` commands into `summary` (aggregate counts) and `list` (per-file detail) subcommands
- Adds `--file` and `--glob` filters consistently to all subcommands — they always mean "scope", never change output shape
- Bare `properties` / `tags` (no subcommand) defaults to `summary` for backwards compatibility
- Includes iter-4 PR review fixes: clippy cleanup, hardened list-ops (reject non-list overwrite, preserve YAML types), boolean matching accepts yes/no/1/0

## Breaking changes
- `properties --glob '*.md'` no longer switches to per-file output — use `properties list --glob '*.md'` instead
- `tags` now has `summary` and `list` subcommands (bare `tags` still works as before)

## Test plan
- [ ] Verify `properties summary` and `properties list` produce different output shapes
- [ ] Verify `tags summary` and `tags list` produce different output shapes
- [ ] Verify bare `properties` / `tags` still work (backwards compat)
- [ ] Verify `--file` and `--glob` work on all 4 subcommands
- [ ] Run `cargo test --workspace` (316 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)