### PR TITLE
Normalize JSON API: consistent object shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .obsidian
 .claude/memory
 .claude/agent-memory
+hyalo-knowledgebase/MyNotes.md
+

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -104,6 +104,20 @@ pub fn require_file_or_glob(
     }
 }
 
+/// If `--file` was used (single-file mode), unwrap a one-element results Vec into a bare
+/// JSON object. Otherwise return the full array.
+#[must_use]
+pub fn unwrap_single_file_result(
+    file: Option<&str>,
+    mut results: Vec<serde_json::Value>,
+) -> serde_json::Value {
+    if file.is_some() && results.len() == 1 {
+        results.pop().unwrap_or_default()
+    } else {
+        serde_json::json!(results)
+    }
+}
+
 /// Build the standard JSON output for list-mutation commands
 /// (`property add-to-list`, `property remove-from-list`, `tag add`, `tag remove`).
 ///

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -364,11 +364,7 @@ pub fn properties_list(
         }));
     }
 
-    let json_output = if file.is_some() && results.len() == 1 {
-        results.into_iter().next().unwrap()
-    } else {
-        json!(results)
-    };
+    let json_output = crate::commands::unwrap_single_file_result(file, results);
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -349,24 +349,30 @@ pub fn properties_list(
     for (full_path, rel_path) in &files {
         let props = frontmatter::read_frontmatter(full_path)?;
 
-        let prop_map: serde_json::Map<String, serde_json::Value> = props
+        let prop_list: Vec<serde_json::Value> = props
             .iter()
             .map(|(k, v)| {
                 let typ = frontmatter::infer_type(v);
                 let json_val = frontmatter::yaml_to_json(v);
-                (k.clone(), json!({"value": json_val, "type": typ}))
+                json!({"name": k, "value": json_val, "type": typ})
             })
             .collect();
 
         results.push(json!({
             "path": rel_path,
-            "properties": prop_map,
+            "properties": prop_list,
         }));
     }
 
+    let json_output = if file.is_some() && results.len() == 1 {
+        results.into_iter().next().unwrap()
+    } else {
+        json!(results)
+    };
+
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
-        &json!(results),
+        &json_output,
     )))
 }
 
@@ -597,11 +603,12 @@ tags:
             properties_list(tmp.path(), Some("note.md"), None, Format::Json).unwrap(),
         );
         assert!(ok);
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0]["path"], "note.md");
-        assert_eq!(parsed[0]["properties"]["priority"]["type"], "number");
-        assert_eq!(parsed[0]["properties"]["tags"]["type"], "list");
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["path"], "note.md");
+        let props = parsed["properties"].as_array().unwrap();
+        let find_prop = |name: &str| props.iter().find(|p| p["name"] == name).unwrap();
+        assert_eq!(find_prop("priority")["type"], "number");
+        assert_eq!(find_prop("tags")["type"], "list");
     }
 
     #[test]

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -171,9 +171,15 @@ pub fn tags_list(
         }));
     }
 
+    let json_output = if file.is_some() && results.len() == 1 {
+        results.into_iter().next().unwrap()
+    } else {
+        json!(results)
+    };
+
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
-        &json!(results),
+        &json_output,
     )))
 }
 
@@ -512,10 +518,8 @@ tags:
             CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let entries = parsed.as_array().unwrap();
-        assert_eq!(entries.len(), 1);
-        assert!(entries[0]["path"].as_str().unwrap().ends_with("a.md"));
-        let tags = entries[0]["tags"].as_array().unwrap();
+        assert!(parsed["path"].as_str().unwrap().ends_with("a.md"));
+        let tags = parsed["tags"].as_array().unwrap();
         assert_eq!(tags.len(), 2);
     }
 

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -171,11 +171,7 @@ pub fn tags_list(
         }));
     }
 
-    let json_output = if file.is_some() && results.len() == 1 {
-        results.into_iter().next().unwrap()
-    } else {
-        json!(results)
-    };
+    let json_output = crate::commands::unwrap_single_file_result(file, results);
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,

--- a/tests/e2e_properties.rs
+++ b/tests/e2e_properties.rs
@@ -197,19 +197,19 @@ fn properties_list_single_file() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json.len(), 1);
-    assert_eq!(json[0]["path"], "file.md");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["path"], "file.md");
 
-    let props = &json[0]["properties"];
-    assert_eq!(props["title"]["type"], "text");
-    assert_eq!(props["title"]["value"], "My Note");
-    assert_eq!(props["priority"]["type"], "number");
-    assert_eq!(props["priority"]["value"], 3);
-    assert_eq!(props["draft"]["type"], "checkbox");
-    assert_eq!(props["draft"]["value"], true);
-    assert_eq!(props["created"]["type"], "date");
-    assert_eq!(props["tags"]["type"], "list");
+    let props = json["properties"].as_array().unwrap();
+    let find_prop = |name: &str| props.iter().find(|p| p["name"] == name).unwrap();
+    assert_eq!(find_prop("title")["type"], "text");
+    assert_eq!(find_prop("title")["value"], "My Note");
+    assert_eq!(find_prop("priority")["type"], "number");
+    assert_eq!(find_prop("priority")["value"], 3);
+    assert_eq!(find_prop("draft")["type"], "checkbox");
+    assert_eq!(find_prop("draft")["value"], true);
+    assert_eq!(find_prop("created")["type"], "date");
+    assert_eq!(find_prop("tags")["type"], "list");
 }
 
 #[test]
@@ -290,7 +290,7 @@ status: draft
     assert_eq!(json.len(), 2);
     // Each entry has path and properties
     assert!(json.iter().all(|e| e["path"].is_string()));
-    assert!(json.iter().all(|e| e["properties"].is_object()));
+    assert!(json.iter().all(|e| e["properties"].is_array()));
 }
 
 #[test]
@@ -305,10 +305,9 @@ fn properties_list_file_without_frontmatter() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json.len(), 1);
-    assert_eq!(json[0]["path"], "plain.md");
-    let props = json[0]["properties"].as_object().unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["path"], "plain.md");
+    let props = json["properties"].as_array().unwrap();
     assert!(props.is_empty());
 }
 

--- a/tests/e2e_property_remove.rs
+++ b/tests/e2e_property_remove.rs
@@ -183,8 +183,7 @@ only_prop: value
         .output()
         .unwrap();
     assert!(props_output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&props_output.stdout).unwrap();
-    assert_eq!(json.len(), 1);
-    let props = json[0]["properties"].as_object().unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&props_output.stdout).unwrap();
+    let props = json["properties"].as_array().unwrap();
     assert!(props.is_empty());
 }

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -237,10 +237,9 @@ fn tags_list_with_file() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json.len(), 1);
-    assert!(json[0]["path"].as_str().unwrap().ends_with("note.md"));
-    let tags: Vec<&str> = json[0]["tags"]
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["path"].as_str().unwrap().ends_with("note.md"));
+    let tags: Vec<&str> = json["tags"]
         .as_array()
         .unwrap()
         .iter()
@@ -263,10 +262,9 @@ fn tags_list_file_without_frontmatter() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json.len(), 1);
-    assert_eq!(json[0]["path"], "plain.md");
-    assert!(json[0]["tags"].as_array().unwrap().is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["path"], "plain.md");
+    assert!(json["tags"].as_array().unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **properties list**: changed `properties` field from a map (`{"title": {"type": "text", ...}}`) to an array of objects (`[{"name": "title", "type": "text", ...}]`), matching the shape returned by `property read`
- **--file returns object, not array**: `properties list --file` and `tags list --file` now return the object directly instead of wrapping it in a one-element array; `--glob` and no-filter continue to return arrays
- Audited all other commands (`links`, `summary`, `find`, mutation commands) — no further inconsistencies found

## Test plan
- [x] All 182 unit tests pass
- [x] All e2e tests pass (properties, tags, links, property-read/set/remove/find, errors)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean (zero warnings)
- [ ] Verify `hyalo properties list --file <file>` returns a single JSON object
- [ ] Verify `hyalo properties list --glob '*.md'` returns an array
- [ ] Verify `hyalo tags list --file <file>` returns a single JSON object
- [ ] Verify `hyalo tags list --glob '*.md'` returns an array

🤖 Generated with [Claude Code](https://claude.com/claude-code)