### PR TITLE
Add outline command and typed structs for JSON output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "globset",
  "ignore",
  "predicates",
+ "serde",
  "serde_json",
  "serde_yaml_ng",
  "tempfile",
@@ -524,6 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 clap = { version = "4.6.0", features = ["derive"] }
 globset = "0.4"
 ignore = "0.4"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml_ng = "0.10"
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ hyalo tag remove --name TAG <--file FILE | --glob PATTERN>
 
 **Tag format (Obsidian-compatible):** letters, digits, `_`, `-`, `/`. Must contain at least one non-numeric character. Forward slashes create hierarchy — `tag find --name inbox` matches `inbox`, `inbox/processing`, etc.
 
+### Outline
+
+```sh
+# Structural outline of a single file (returns bare object)
+hyalo outline --file FILE
+
+# Outline of multiple files (returns array)
+hyalo outline --glob PATTERN
+
+# Outline of all .md files under --dir (returns array)
+hyalo outline
+```
+
+Returns per-file: frontmatter properties (with types and values), tags, and a section tree with heading levels, line numbers, wikilinks, task counts (`total`/`done`), and code block languages. Designed for LLM navigation — understand a document's structure without reading the full content.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ cargo build --release
 
 All commands accept `--dir <path>` (default: `.`) and `--format json|text` (default: `json`).
 
+Glob patterns use standard shell semantics: `*` matches within a single directory, `**` matches across directory boundaries. For example, `*.md` matches top-level files only, while `**/*.md` matches all `.md` files recursively.
+
 ### Properties
 
 ```sh

--- a/hyalo-knowledgebase/backlog/backlinks.md
+++ b/hyalo-knowledgebase/backlog/backlinks.md
@@ -1,0 +1,35 @@
+---
+title: "Backlinks — which files link to this one?"
+type: backlog
+date: 2026-03-21
+status: deferred
+priority: medium
+origin: dogfooding iteration-06
+blocked-by: indexing
+tags:
+  - backlog
+  - links
+  - indexing
+---
+
+# Backlinks — which files link to this one?
+
+## Problem
+
+When navigating the knowledgebase, knowing *what links to this file* is as important as knowing *what this file links to*. During iteration 6 dogfooding, we looked at `decision-log.md` and wanted to know which iteration files reference specific decisions. Had to fall back to grep.
+
+## Proposal
+
+```sh
+hyalo backlinks --file decision-log.md
+```
+
+Returns a list of files that contain `[[decision-log]]` or `[[decision-log#DEC-024]]` wikilinks targeting the given file.
+
+## Constraints
+
+Requires scanning all files in the vault for every call — O(n) full-file reads. Already deferred to the indexing iteration (see [[decision-log#DEC-013]]). Without an index, this is too slow for large vaults.
+
+## Workaround
+
+For now, an LLM agent can use external `grep` or the future `search` command with `content:[[decision-log]]`.

--- a/hyalo-knowledgebase/backlog/combined-queries.md
+++ b/hyalo-knowledgebase/backlog/combined-queries.md
@@ -1,0 +1,34 @@
+---
+title: "Combined queries across properties, tags, and content"
+type: backlog
+date: 2026-03-21
+status: planned
+priority: high
+origin: dogfooding iteration-06
+tags:
+  - backlog
+  - search
+  - cli
+---
+
+# Combined queries across properties, tags, and content
+
+## Problem
+
+Finding files that match multiple criteria requires separate CLI calls and manual intersection. Example: "files tagged `iteration` with `status: in-progress`" needs `tag find` + `property find` + scripted intersection. An LLM agent shouldn't need to orchestrate this.
+
+## Proposal
+
+This is what [[iteration-plan#Iteration 7 — Search]] addresses. The `search` command should support:
+
+```sh
+hyalo search 'tag:iteration [status:in-progress]'
+hyalo search '[type:iteration] task-todo:>0'
+hyalo search 'path:research/* content:parallelization'
+```
+
+Boolean AND is implicit (space-separated). Operators on properties (`=`, `!=`, `>`, `<`, `contains`).
+
+## Notes
+
+Already scoped in the iteration plan. This backlog item exists to capture the specific friction point and use case from dogfooding, not to redefine the feature.

--- a/hyalo-knowledgebase/backlog/comment-block-handling.md
+++ b/hyalo-knowledgebase/backlog/comment-block-handling.md
@@ -1,0 +1,34 @@
+---
+title: "Scanner should skip %%comment%% blocks"
+type: backlog
+date: 2026-03-21
+status: ready
+priority: high
+origin: iteration-02 known limitation, DEC-015
+tags:
+  - backlog
+  - scanner
+  - links
+---
+
+# Scanner should skip %%comment%% blocks
+
+## Problem
+
+Obsidian `%%comment%%` blocks are not tracked by the scanner. Links, tags, and tasks inside comments are incorrectly extracted. For example, a commented-out `[[draft-note]]` wikilink shows up in `links` output and in outline sections.
+
+## Proposal
+
+Add comment block state tracking to the scanner, similar to fenced code block tracking. When inside `%%...%%`, skip all link/task/heading extraction.
+
+Multi-line comments: `%%` on its own line opens/closes.
+Inline comments: `%%text%%` on a single line.
+
+## Scope
+
+Small — the scanner already tracks fenced code block state with the same open/close pattern. This is a direct analogue.
+
+## References
+
+- [[decision-log#DEC-015]]: documented as known limitation, explicitly noted as "straightforward to add"
+- [[iteration-02-links]]: listed under Known Limitations

--- a/hyalo-knowledgebase/backlog/outline-brief-mode.md
+++ b/hyalo-knowledgebase/backlog/outline-brief-mode.md
@@ -1,0 +1,45 @@
+---
+title: "Outline --brief flag to omit property values"
+type: backlog
+date: 2026-03-21
+status: idea
+priority: low
+origin: dogfooding iteration-06
+tags:
+  - backlog
+  - outline
+  - cli
+---
+
+# Outline --brief flag to omit property values
+
+## Problem
+
+The `outline` command includes full property values (entire tag lists, long title strings, date values). For LLM navigation — deciding *where* to look — knowing that a file has a `title` (text) and `tags` (list) property is enough. The actual values add noise when scanning many files.
+
+## Proposal
+
+Add `--brief` flag to `outline` that:
+- Shows property names and types only (no values)
+- Omits empty sections (no links, no tasks, no code blocks)
+- Omits empty `code_blocks` and `links` arrays
+
+```json
+{
+  "file": "iterations/iteration-06-outline.md",
+  "properties": [
+    { "name": "title", "type": "text" },
+    { "name": "status", "type": "text" },
+    { "name": "tags", "type": "list" }
+  ],
+  "tags": ["iteration", "outline"],
+  "sections": [
+    { "level": 2, "heading": "Tasks", "line": 104 },
+    { "level": 3, "heading": "Core implementation", "line": 106, "tasks": { "total": 5, "done": 5 } }
+  ]
+}
+```
+
+## Notes
+
+Low priority — the current full output works fine and isn't excessively large for typical vaults. Revisit if vault size grows or token budgets become a concern.

--- a/hyalo-knowledgebase/backlog/outline-text-output.md
+++ b/hyalo-knowledgebase/backlog/outline-text-output.md
@@ -1,0 +1,57 @@
+---
+title: "Outline text output as indented tree"
+type: backlog
+date: 2026-03-21
+status: ready
+priority: high
+origin: iteration-06 (open task)
+tags:
+  - backlog
+  - outline
+  - cli
+---
+
+# Outline text output as indented tree
+
+## Problem
+
+The `outline` command only outputs JSON. When an LLM or human wants a quick structural overview, the JSON is verbose and hard to scan. During iteration 6 dogfooding, we had to pipe JSON through python to get a readable tree view.
+
+## Proposal
+
+Implement `--format text` for the `outline` command. Output an indented tree:
+
+```
+iterations/iteration-06-outline.md
+  title: Iteration 6 — Outline Command (in-progress)
+  tags: iteration, outline, cli, llm
+  # Iteration 6 — Outline Command
+    ## Goal
+    ## Motivation
+    ## Relationship to Prior Work
+      → [[iteration-02-links]], [[iteration-05-summary-list-refactor]]
+    ## Design
+      ### What the outline contains
+      ### Output format [json]
+      ### File targeting
+    ## Tasks
+      ### Core implementation [5/5 ✓]
+      ### Typed structs refactor [3/3 ✓]
+      ### Output formats [1/2]
+      ### Code quality [4/4 ✓]
+      ### Bug fixes [3/3 ✓]
+      ### Documentation [5/5 ✓]
+    ## Design Notes
+```
+
+Design choices:
+- 2-space indent per heading level
+- Task counts inline with completion indicator
+- Links shown with `→` prefix
+- Code block languages in brackets
+- Frontmatter summary on first lines (title, status, tags)
+- Multi-file mode: separate files with blank line
+
+## Notes
+
+This is the one remaining open task from iteration 6. Small scope — could be done as a standalone PR or bundled with another iteration.

--- a/hyalo-knowledgebase/backlog/parallel-file-operations.md
+++ b/hyalo-knowledgebase/backlog/parallel-file-operations.md
@@ -1,0 +1,35 @@
+---
+title: "Parallel file operations with rayon"
+type: backlog
+date: 2026-03-21
+status: ready
+priority: medium
+origin: research/performance-parallelization.md
+tags:
+  - backlog
+  - performance
+  - rayon
+---
+
+# Parallel file operations with rayon
+
+## Problem
+
+All multi-file operations (properties summary, tags summary, outline vault-wide) iterate sequentially. On large vaults (1000+ files), this becomes a bottleneck — each file requires a filesystem read and YAML parse.
+
+## Proposal
+
+Use `rayon` for parallel reads on multi-file paths. Research in [[research/performance-parallelization]] suggests 4-7x speedup on multi-core machines.
+
+Scope:
+- Parallelize `collect_files()` consumers: properties summary/list, tags summary/list, outline vault-wide
+- Single-file commands don't benefit
+- Mutation commands (property set, tag add) should remain sequential for safety
+
+## Trigger
+
+Implement when benchmarks on a real vault show latency above ~200ms for vault-wide commands. Not needed for small vaults (<100 files).
+
+## References
+
+- [[research/performance-parallelization]]: full research with benchmark methodology

--- a/hyalo-knowledgebase/backlog/shortest-path-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/shortest-path-link-resolution.md
@@ -1,0 +1,35 @@
+---
+title: "Obsidian-style shortest-path link resolution"
+type: backlog
+date: 2026-03-21
+status: deferred
+priority: medium
+origin: DEC-014, iteration-plan
+blocked-by: indexing
+tags:
+  - backlog
+  - links
+  - indexing
+---
+
+# Obsidian-style shortest-path link resolution
+
+## Problem
+
+Currently `[[foo]]` resolves only via direct filesystem probes: check `foo` then `foo.md` relative to vault root. Obsidian uses shortest-path resolution — `[[foo]]` can match `sub/deep/foo.md` if it's the only `foo.md` in the vault. This means hyalo marks links as unresolved that Obsidian considers valid.
+
+## Proposal
+
+Implement Obsidian's resolution algorithm:
+1. Exact match at vault root
+2. Shortest unique path match across all vault files
+3. Case-insensitive matching
+
+## Constraints
+
+Requires knowing all files in the vault to find the shortest match — essentially an index. Without it, every link resolution would need a full directory walk. Deferred to the indexing iteration.
+
+## References
+
+- [[decision-log#DEC-014]]: current simple resolution, explicitly defers shortest-path
+- [[iteration-plan#Later — Indexing]]: mentions this as a deferred feature

--- a/hyalo-knowledgebase/backlog/sqlite-indexing.md
+++ b/hyalo-knowledgebase/backlog/sqlite-indexing.md
@@ -1,0 +1,39 @@
+---
+title: "SQLite-backed index for vault-wide operations"
+type: backlog
+date: 2026-03-21
+status: planned
+priority: high
+origin: iteration-plan, DEC-013
+tags:
+  - backlog
+  - indexing
+  - performance
+---
+
+# SQLite-backed index for vault-wide operations
+
+## Problem
+
+Several commands are deferred because they require scanning all vault files on every call — O(n) full-file reads per invocation. Without an index, these operations are too slow for large vaults.
+
+## Proposal
+
+SQLite or similar index for properties, tags, links, and file metadata. Incremental updates based on file mtime. Enables:
+
+- `backlinks` — which files link to a given file
+- `orphans` — files with no incoming links
+- `deadends` — files with no outgoing links
+- Vault-wide task search
+- Shortest-path link resolution (see [[backlog/shortest-path-link-resolution]])
+
+## Trigger
+
+Implement when file scanning becomes a bottleneck on real vaults, or when backlinks/orphans become the next priority feature.
+
+## References
+
+- [[iteration-plan#Later — Indexing]]: scoped in the plan
+- [[decision-log#DEC-013]]: defers backlinks/orphans/deadends to indexing
+- [[decision-log#DEC-021]]: defers vault-wide task search to indexing
+- [[decision-log#DEC-014]]: defers shortest-path resolution to indexing

--- a/hyalo-knowledgebase/backlog/vault-dashboard.md
+++ b/hyalo-knowledgebase/backlog/vault-dashboard.md
@@ -1,0 +1,49 @@
+---
+title: "Vault dashboard — single-call project overview"
+type: backlog
+date: 2026-03-21
+status: idea
+priority: medium
+origin: dogfooding iteration-06
+tags:
+  - backlog
+  - cli
+  - llm
+---
+
+# Vault dashboard — single-call project overview
+
+## Problem
+
+Starting a new session with a knowledgebase requires 3-4 separate commands to understand the current state: `properties summary`, `tags summary`, `outline` on key files, checking which iterations are in progress. An LLM agent's first action is always "orient myself" — this should be one call.
+
+## Proposal
+
+A `dashboard` or `status` command that returns a structured project overview in a single call:
+
+```json
+{
+  "files": { "total": 15, "by_type": { "iteration": 7, "research": 4, "decisions": 1, ... } },
+  "properties": { "unique": 6, "most_common": ["tags", "title", "date"] },
+  "tags": { "unique": 24, "most_common": ["iteration", "properties", "cli"] },
+  "status_overview": {
+    "in-progress": ["iterations/iteration-06-outline.md"],
+    "completed": ["iterations/iteration-01-frontmatter-properties.md", ...],
+    "planned": ["iterations/iteration-07-search.md"]
+  },
+  "tasks": { "total": 87, "done": 72, "open": 15 },
+  "recent_files": ["iterations/iteration-06-outline.md", "decision-log.md"]
+}
+```
+
+## Design considerations
+
+- Uses `status` property if present for the status overview (configurable property name?)
+- `recent_files` based on git mtime or filesystem mtime
+- Task counts aggregated vault-wide (requires full scan — may want to limit to files with `status: in-progress`)
+- Text format: human-readable summary paragraph
+- Could be built on top of existing commands internally (outline + properties + tags)
+
+## Notes
+
+This would be the "entry point" command for LLM agents. Currently the closest equivalent is `outline` on the whole vault, but that's too detailed — it gives document structure, not project state.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -171,9 +171,10 @@ The `summary` subcommand is the default, so `hyalo properties` and `hyalo tags` 
 
 **Decision:** Add an `outline` command that extracts per-section structure:
 - **Headings** with level, text, and line number — the document skeleton
-- **Frontmatter keys with types** — what metadata exists (not values)
+- **Frontmatter properties with names, types, and values** — matching the `properties list` shape
+- **Tags** — list of tag strings from frontmatter
 - **Wikilinks per section** — which section references what (not just "file has links")
-- **Task counts per section** — `total`/`done` per section (null if no tasks)
+- **Task counts per section** — `total`/`done` per section; `tasks` field omitted (not null) when section has no tasks
 - **Code block languages per section** — content type hints
 
 Content before the first heading gets a synthetic `level: 0` section (only if non-empty). ATX headings only — no setext.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -202,3 +202,11 @@ Supports `--file`, `--glob`, and vault-wide mode (unlike `links` which is single
 - JSON output is now compiler-verified — shape mismatches are caught at build time
 - New commands can reuse existing types instead of guessing the right `json!()` shape
 - Removed ~50 lines of generic JSON-building helpers from `commands/mod.rs`
+
+## DEC-026: Glob `*` Must Not Cross Path Separators (2026-03-21)
+
+**Context:** The `globset` crate's `Glob::new()` defaults to letting `*` match across `/` path separators. This means `*.md` matched `sub/nested.md`, which contradicts standard shell glob semantics and surprises users expecting `*` to match within a single directory only.
+
+**Decision:** Use `GlobBuilder::literal_separator(true)` when compiling glob patterns in `match_glob()`. This makes `*` match only within a single directory component. Use `**` for recursive matching across directories.
+
+**Why:** Standard shell behavior — `*.md` should match `note.md` but not `sub/note.md`. Users familiar with any shell, ripgrep, fd, or .gitignore expect this. The previous behavior made `--glob "*.md"` equivalent to `--glob "**/*.md"`, removing the ability to scope to a single directory level.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -164,3 +164,40 @@ The `summary` subcommand is the default, so `hyalo properties` and `hyalo tags` 
 - Callers that used `--file`/`--glob` at the top level must now place them after the subcommand name (e.g. `hyalo properties list --glob '*.md'`)
 - Consistent CLI model: both `properties` and `tags` follow the same `summary`/`list` pattern
 - Shared helpers extracted to avoid duplicating file-discovery logic between the two command groups
+
+## DEC-024: Outline Command — Section-Aware Structural Extraction (2026-03-21)
+
+**Context:** An LLM needs to understand a document's structure without reading it in full. Existing commands answer narrow questions (`properties` → metadata, `tags` → categorization, `links` → flat reference list), but none give the structural skeleton: what sections exist, what each section references, and whether work is complete.
+
+**Decision:** Add an `outline` command that extracts per-section structure:
+- **Headings** with level, text, and line number — the document skeleton
+- **Frontmatter keys with types** — what metadata exists (not values)
+- **Wikilinks per section** — which section references what (not just "file has links")
+- **Task counts per section** — `total`/`done` per section (null if no tasks)
+- **Code block languages per section** — content type hints
+
+Content before the first heading gets a synthetic `level: 0` section (only if non-empty). ATX headings only — no setext.
+
+Supports `--file`, `--glob`, and vault-wide mode (unlike `links` which is single-file per DEC-016) because outline output is lightweight.
+
+**Why:** This gives an LLM a "table of contents with context" — enough to navigate, decide where to edit, and assess completeness without reading the full body. Each piece of enrichment (links, tasks, code blocks) answers a question an LLM would otherwise need a separate command call or full file read for.
+
+**Consequences:**
+- Scanner gains heading extraction capability (ATX headings outside code blocks)
+- New section-aware accumulator pattern for attributing links/tasks/code blocks to their enclosing section
+- Multi-file outline produces an array — consistent with `properties list` and `tags list` output shape
+
+## DEC-025: Typed Structs for JSON Output (2026-03-21)
+
+**Context:** All commands built JSON output dynamically using `serde_json::json!()` macros and manual `serde_json::Map` construction. Shapes were implicit — defined only by the code that constructed them and the tests that parsed them. The outline command needed to reuse the same property and tag shapes as existing commands.
+
+**Decision:** Introduce `src/types.rs` with `#[derive(Serialize)]` structs for all JSON output shapes. Refactor all existing commands to construct typed structs instead of ad-hoc `json!()` values. Add `format_output<T: Serialize>()` to `output.rs` as the standard serialization path.
+
+**Types introduced:** `PropertyInfo`, `FileProperties`, `PropertySummaryEntry`, `PropertyRemoved`, `PropertyFindResult`, `PropertyMutationResult`, `FileTags`, `TagSummary`, `TagSummaryEntry`, `TagFindResult`, `TagMutationResult`, `LinkInfo`, `FileLinks`, `FileOutline`, `OutlineSection`, `TaskCount`.
+
+**Why:** Typed structs guarantee that the outline command's `properties` and `tags` fields are structurally identical to what `properties list` and `tags list` produce — the compiler enforces it. Also removes the `build_find_json` / `build_list_mutation_json` generic helpers that used dynamic key names, replacing them with specific structs per command.
+
+**Consequences:**
+- JSON output is now compiler-verified — shape mismatches are caught at build time
+- New commands can reuse existing types instead of guessing the right `json!()` shape
+- Removed ~50 lines of generic JSON-building helpers from `commands/mod.rs`

--- a/hyalo-knowledgebase/iteration-plan.md
+++ b/hyalo-knowledgebase/iteration-plan.md
@@ -42,23 +42,25 @@ Split `properties` and `tags` into `summary` (aggregate, default) and `list` (pe
 
 **Commands:** `properties summary|list`, `tags summary|list`
 
-## Iteration 6 — Search
+## Iteration 6 — Outline Command + Typed Structs
 
-Property query syntax, boolean logic, operators. Ties iterations 1–5 together into one query interface.
+Section-aware structural extraction for LLM navigation. Headings with line numbers, frontmatter properties with types and values, tags, wikilinks per section, task counts per section, code block languages per section. Supports single-file, glob, and vault-wide modes.
+
+Also introduced `src/types.rs` with `#[derive(Serialize)]` structs for all JSON output shapes, refactoring all existing commands to use typed structs instead of ad-hoc `json!()` macros (DEC-025).
+
+**Commands:** `outline`
+
+## Iteration 7 — Search
+
+Property query syntax, boolean logic, operators. Ties iterations 1–6 together into one query interface.
 
 **Commands:** `search` with `[prop:value]`, `path:`, `file:`, `tag:`, `content:`, `task-todo:`, `task-done:`
 
-## Iteration 7 — Move/Rename with Link Updates
+## Iteration 8 — Move/Rename with Link Updates
 
 Move or rename a file and update all wikilinks across the knowledge base.
 
 **Commands:** `move`, `rename`
-
-## Iteration 8 — Outline & Polish
-
-Heading extraction, output formats (JSON, text, tree), CLI ergonomics.
-
-**Commands:** `outline`
 
 ## Later — Indexing
 
@@ -72,8 +74,9 @@ SQLite or similar index for properties, tags, and links. Incremental updates bas
 
 ```
 Iteration 1 (frontmatter) ──→ Iteration 4 (find needs parser)
-Iteration 2 (link graph)  ──→ Iteration 7 (rename needs links)
-Iterations 1–5             ──→ Iteration 6 (search unifies all)
+Iteration 2 (link graph)  ──→ Iteration 6 (outline reuses scanner)
+Iteration 2 (link graph)  ──→ Iteration 8 (rename needs links)
+Iterations 1–6             ──→ Iteration 7 (search unifies all)
 ```
 
 ## Dogfooding

--- a/hyalo-knowledgebase/iterations/iteration-06-outline.md
+++ b/hyalo-knowledgebase/iterations/iteration-06-outline.md
@@ -125,11 +125,17 @@ Unlike `links` (DEC-016, single-file only), outline supports multi-file mode bec
 - [x] Add e2e tests for `outline --file`, `outline --glob`, and vault-wide mode
 - [x] Run quality gates: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
 
+### Bug fixes
+- [x] Fix glob matching: `*` was crossing `/` path separators (DEC-026). Use `GlobBuilder::literal_separator(true)` so `*.md` matches top-level only, `**/*.md` for recursive.
+- [x] Fix empty fence languages pushed to `code_blocks` (empty info strings now produce no entry)
+- [x] Fix `format_link_string` to preserve `[[target|label]]` format for wikilinks
+
 ### Documentation
 - [x] Add decision log entry DEC-024 for outline command design
 - [x] Add decision log entry DEC-025 for typed structs
+- [x] Add decision log entry DEC-026 for glob literal separator fix
 - [x] Update iteration plan to reflect iteration 6 scope change
-- [x] Update README.md with `outline` command usage
+- [x] Update README.md with `outline` command usage and glob semantics
 
 ## Design Notes
 

--- a/hyalo-knowledgebase/iterations/iteration-06-outline.md
+++ b/hyalo-knowledgebase/iterations/iteration-06-outline.md
@@ -35,13 +35,14 @@ The `outline` command fills this gap. It returns a section-aware table of conten
 ### What the outline contains
 
 **Per file:**
-- `frontmatter_keys` — list of property names present in frontmatter (not values, just keys with types)
+- `properties` — list of frontmatter properties with names, types, AND values (matching the `properties list` shape)
+- `tags` — list of tag strings from frontmatter
 - `sections` — ordered list of sections, each with:
   - `level` — heading level (1–6)
   - `heading` — heading text (stripped of leading `#` and whitespace)
   - `line` — line number in the file (1-based)
   - `links` — wikilinks and markdown links found between this heading and the next
-  - `tasks` — `{ "total": N, "done": N }` if checkboxes exist in the section, `null` otherwise
+  - `tasks` — `{ "total": N, "done": N }` if checkboxes exist in the section; omitted (not `null`) when no tasks
   - `code_blocks` — list of fenced code block languages in the section (e.g. `["rust", "json"]`), empty list if none
 
 Content before the first heading is attributed to a synthetic section with `level: 0` and `heading: null` (only emitted if it contains links, tasks, or code blocks).
@@ -52,20 +53,20 @@ JSON (default):
 ```json
 {
   "file": "iterations/iteration-05-summary-list-refactor.md",
-  "frontmatter_keys": [
-    { "key": "title", "type": "text" },
-    { "key": "date", "type": "date" },
-    { "key": "tags", "type": "list" },
-    { "key": "status", "type": "text" },
-    { "key": "branch", "type": "text" }
+  "properties": [
+    { "name": "title", "type": "text", "value": "Iteration 5 — Summary + List Subcommand Refactor" },
+    { "name": "date", "type": "date", "value": "2026-03-21" },
+    { "name": "tags", "type": "list", "value": ["iteration"] },
+    { "name": "status", "type": "text", "value": "completed" },
+    { "name": "branch", "type": "text", "value": "iter-5/summary-list-refactor" }
   ],
+  "tags": ["iteration"],
   "sections": [
     {
       "level": 1,
       "heading": "Iteration 5 — Summary + List Subcommand Refactor",
       "line": 15,
       "links": [],
-      "tasks": null,
       "code_blocks": []
     },
     {
@@ -73,7 +74,6 @@ JSON (default):
       "heading": "Relationship to iteration-04-property-find",
       "line": 27,
       "links": ["[[iteration-04-property-find]]"],
-      "tasks": null,
       "code_blocks": []
     },
     {

--- a/hyalo-knowledgebase/iterations/iteration-06-outline.md
+++ b/hyalo-knowledgebase/iterations/iteration-06-outline.md
@@ -1,0 +1,140 @@
+---
+branch: iter-6/outline
+date: 2026-03-21
+status: in-progress
+tags:
+- iteration
+- outline
+- cli
+- llm
+title: Iteration 6 — Outline Command
+type: iteration
+---
+
+# Iteration 6 — Outline Command
+
+## Goal
+
+Add an `outline` command that extracts the structural skeleton of markdown files — headings, frontmatter keys, wikilinks per section, and task counts per section — so an LLM can understand a document's structure without reading the full content.
+
+## Motivation
+
+An LLM working with a knowledge base needs to quickly decide *where* to look and *what* a document covers. Existing commands answer narrow questions: `properties` gives metadata, `tags` gives categorization, `links` gives outgoing references. But none answer "what's the structure of this document?"
+
+The `outline` command fills this gap. It returns a section-aware table of contents enriched with just enough context (links, task progress) for an LLM to navigate confidently. This is the "what's in this file?" command.
+
+## Relationship to Prior Work
+
+- Builds on the streaming scanner from [[iteration-02-links]] (heading extraction reuses the code-block-aware line scanner)
+- Reuses `collect_files()` from [[iteration-05-summary-list-refactor]] for `--file`/`--glob` targeting
+- Complements `links` (which gives flat link lists) by adding section context to links
+- Complements `properties` (which gives metadata) by showing body structure
+
+## Design
+
+### What the outline contains
+
+**Per file:**
+- `frontmatter_keys` — list of property names present in frontmatter (not values, just keys with types)
+- `sections` — ordered list of sections, each with:
+  - `level` — heading level (1–6)
+  - `heading` — heading text (stripped of leading `#` and whitespace)
+  - `line` — line number in the file (1-based)
+  - `links` — wikilinks and markdown links found between this heading and the next
+  - `tasks` — `{ "total": N, "done": N }` if checkboxes exist in the section, `null` otherwise
+  - `code_blocks` — list of fenced code block languages in the section (e.g. `["rust", "json"]`), empty list if none
+
+Content before the first heading is attributed to a synthetic section with `level: 0` and `heading: null` (only emitted if it contains links, tasks, or code blocks).
+
+### Output format
+
+JSON (default):
+```json
+{
+  "file": "iterations/iteration-05-summary-list-refactor.md",
+  "frontmatter_keys": [
+    { "key": "title", "type": "text" },
+    { "key": "date", "type": "date" },
+    { "key": "tags", "type": "list" },
+    { "key": "status", "type": "text" },
+    { "key": "branch", "type": "text" }
+  ],
+  "sections": [
+    {
+      "level": 1,
+      "heading": "Iteration 5 — Summary + List Subcommand Refactor",
+      "line": 15,
+      "links": [],
+      "tasks": null,
+      "code_blocks": []
+    },
+    {
+      "level": 2,
+      "heading": "Relationship to iteration-04-property-find",
+      "line": 27,
+      "links": ["[[iteration-04-property-find]]"],
+      "tasks": null,
+      "code_blocks": []
+    },
+    {
+      "level": 2,
+      "heading": "Tasks",
+      "line": 31,
+      "links": [],
+      "tasks": { "total": 8, "done": 8 },
+      "code_blocks": []
+    }
+  ]
+}
+```
+
+Multi-file mode (with `--glob`) wraps results in an array.
+
+Text format: indented tree with heading hierarchy, task counts inline.
+
+### File targeting
+
+Follows DEC-018:
+- `--file` — outline of a single file
+- `--glob` — outlines of all matching files
+- Neither — outlines of all `.md` files under `--dir`
+
+Unlike `links` (DEC-016, single-file only), outline supports multi-file mode because the output is lightweight (no full-body content) and useful for vault-wide structural overview.
+
+## Tasks
+
+### Core implementation
+- [x] Add heading extraction to the streaming scanner (detect ATX headings `# ...` outside code blocks)
+- [x] Implement section-aware accumulator that tracks current heading and collects links, tasks, code block languages per section
+- [x] Extract frontmatter keys with types (reuse existing type inference from `frontmatter.rs`)
+- [x] Build `outline` command with `--file`/`--glob` support using `collect_files()`
+- [x] Handle pre-heading content (level 0 synthetic section, only if non-empty)
+
+### Typed structs refactor
+- [x] Introduce `src/types.rs` with `#[derive(Serialize)]` structs for all JSON output shapes (DEC-025)
+- [x] Refactor `properties`, `tags`, `links` commands to use typed structs instead of `json!()` macros
+- [x] Remove `build_find_json` / `build_list_mutation_json` generic helpers
+
+### Output formats
+- [x] JSON output with the schema described above
+- [ ] Text output as indented tree (2-space indent per heading level, task counts inline)
+
+### Code quality
+- [x] Add unit tests for heading extraction (ATX headings, inside/outside code blocks, edge cases)
+- [x] Add unit tests for section accumulation (links, tasks, code blocks attributed to correct section)
+- [x] Add e2e tests for `outline --file`, `outline --glob`, and vault-wide mode
+- [x] Run quality gates: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`
+
+### Documentation
+- [x] Add decision log entry DEC-024 for outline command design
+- [x] Add decision log entry DEC-025 for typed structs
+- [x] Update iteration plan to reflect iteration 6 scope change
+- [x] Update README.md with `outline` command usage
+
+## Design Notes
+
+- ATX headings only (`# heading`). Setext headings (underlined with `===`/`---`) are not supported — they're rare in Obsidian vaults and complicate streaming parsing.
+- Heading text is returned as-is after stripping `#` prefix and whitespace. Inline formatting (`**bold**`, `*italic*`) is preserved — the LLM can handle it.
+- Links in sections include both `[[wikilinks]]` and `[markdown](links)` — reuse the scanner's existing link extraction.
+- Code block language is the info string after the opening fence (e.g. ` ```rust ` → `"rust"`). Empty info strings produce no entry.
+- The streaming scanner processes files line-by-line, so this command never buffers an entire file body. Frontmatter keys are read separately via `read_frontmatter()`.

--- a/src/commands/links.rs
+++ b/src/commands/links.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
-use serde_json::json;
 use std::path::Path;
 
 use crate::commands::resolve_error_to_outcome;
 use crate::discovery;
 use crate::links;
 use crate::output::{CommandOutcome, Format};
+use crate::types::{FileLinks, LinkInfo};
 
 /// Filter for link resolution status.
 #[derive(Clone, Copy)]
@@ -28,7 +28,7 @@ pub fn links(dir: &Path, file: &str, filter: LinkFilter, format: Format) -> Resu
 
     let extracted = links::extract_links_from_file(&full_path)?;
 
-    let link_values: Vec<serde_json::Value> = extracted
+    let links: Vec<LinkInfo> = extracted
         .iter()
         .map(|link| {
             let resolved = discovery::resolve_target(dir, &link.target);
@@ -39,20 +39,18 @@ pub fn links(dir: &Path, file: &str, filter: LinkFilter, format: Format) -> Resu
             LinkFilter::Resolved => resolved.is_some(),
             LinkFilter::Unresolved => resolved.is_none(),
         })
-        .map(|(link, resolved)| {
-            json!({
-                "target": &link.target,
-                "path": resolved,
-                "label": &link.label,
-            })
+        .map(|(link, resolved)| LinkInfo {
+            target: link.target.clone(),
+            path: resolved,
+            label: link.label.clone(),
         })
         .collect();
-    let result = json!({
-        "path": rel_path,
-        "links": link_values,
-    });
+    let result = FileLinks {
+        path: rel_path,
+        links,
+    };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
+    Ok(CommandOutcome::Success(crate::output::format_output(
         format, &result,
     )))
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 pub mod links;
+pub mod outline;
 pub mod properties;
 pub mod tags;
 
@@ -116,62 +117,6 @@ pub fn unwrap_single_file_result(
     } else {
         serde_json::json!(results)
     }
-}
-
-/// Build the standard JSON output for list-mutation commands
-/// (`property add-to-list`, `property remove-from-list`, `tag add`, `tag remove`).
-///
-/// - `key_name`: top-level key (e.g. `"property"` or `"tag"`)
-/// - `key_value`: the name that was mutated
-/// - `values_label`: label for the list-of-values key (e.g. `"values"`)
-/// - `values`: the values that were requested (may be empty — tags only have one)
-/// - `modified`, `skipped`: file lists from the operation
-#[must_use]
-pub fn build_list_mutation_json(
-    key_name: &str,
-    key_value: &str,
-    values_label: Option<&str>,
-    values: Option<&[String]>,
-    modified: &[String],
-    skipped: &[String],
-) -> serde_json::Value {
-    use serde_json::json;
-    let total = modified.len() + skipped.len();
-    let mut obj = serde_json::Map::new();
-    obj.insert(key_name.to_owned(), json!(key_value));
-    if let (Some(label), Some(vals)) = (values_label, values) {
-        obj.insert(label.to_owned(), json!(vals));
-    }
-    obj.insert("modified".to_owned(), json!(modified));
-    obj.insert("skipped".to_owned(), json!(skipped));
-    obj.insert("total".to_owned(), json!(total));
-    serde_json::Value::Object(obj)
-}
-
-/// Build the standard JSON output for find commands
-/// (`tag find`, `property find`).
-///
-/// - `key_name`: top-level key (e.g. `"tag"` or `"property"`)
-/// - `key_value`: the name that was searched
-/// - `value_filter`: the optional value filter (may be `None`)
-/// - `files`: the matched file paths
-#[must_use]
-pub fn build_find_json(
-    key_name: &str,
-    key_value: &str,
-    value_filter: Option<&str>,
-    files: &[String],
-) -> serde_json::Value {
-    use serde_json::json;
-    let total = files.len();
-    let mut obj = serde_json::Map::new();
-    obj.insert(key_name.to_owned(), json!(key_value));
-    if let Some(v) = value_filter {
-        obj.insert("value".to_owned(), json!(v));
-    }
-    obj.insert("files".to_owned(), json!(files));
-    obj.insert("total".to_owned(), json!(total));
-    serde_json::Value::Object(obj)
 }
 
 /// Convert a `FileResolveError` into a user-facing `CommandOutcome`.

--- a/src/commands/outline.rs
+++ b/src/commands/outline.rs
@@ -272,7 +272,7 @@ fn process_body_line(
 // ---------------------------------------------------------------------------
 
 /// Extract the info-string (language tag) from a fenced code block opening line.
-/// E.g. "```rust" → "rust", "~~~" → ""
+/// E.g. `` ```rust `` → `"rust"`, `~~~` → `""`
 fn extract_fence_language(line: &str, fence_char: char, fence_count: usize) -> String {
     let trimmed = line.trim_start();
     // Skip past the fence chars
@@ -314,6 +314,7 @@ fn parse_atx_heading(line: &str) -> Option<(u8, String)> {
         return None;
     };
 
+    #[allow(clippy::cast_possible_truncation)] // level is guaranteed ≤ 6 by the check above
     Some((level as u8, heading_text))
 }
 

--- a/src/commands/outline.rs
+++ b/src/commands/outline.rs
@@ -1,0 +1,934 @@
+#![allow(clippy::missing_errors_doc)]
+use anyhow::{Context, Result};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use crate::commands::{FilesOrOutcome, collect_files, unwrap_single_file_result};
+use crate::frontmatter;
+use crate::links;
+use crate::output::{CommandOutcome, Format};
+use crate::scanner;
+use crate::types::{FileOutline, OutlineSection, PropertyInfo, TaskCount};
+
+// ---------------------------------------------------------------------------
+// Public command entry point
+// ---------------------------------------------------------------------------
+
+/// Build a full outline for each targeted file.
+///
+/// - `--file`  → returns a bare `FileOutline` object
+/// - `--glob`  → returns an array of `FileOutline` objects
+/// - neither   → all `.md` files under `dir`, returns an array
+pub fn outline(
+    dir: &Path,
+    file: Option<&str>,
+    glob: Option<&str>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = collect_files(dir, file, glob, format)?;
+    let files = match files {
+        FilesOrOutcome::Files(f) => f,
+        FilesOrOutcome::Outcome(o) => return Ok(o),
+    };
+
+    let mut results: Vec<serde_json::Value> = Vec::new();
+    for (full_path, rel_path) in &files {
+        let outline = build_file_outline(full_path, rel_path)?;
+        results.push(serde_json::to_value(outline).unwrap_or_default());
+    }
+
+    let json_output = unwrap_single_file_result(file, results);
+
+    Ok(CommandOutcome::Success(crate::output::format_output(
+        format,
+        &json_output,
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// Core outline builder
+// ---------------------------------------------------------------------------
+
+/// Build a `FileOutline` for a single file.
+fn build_file_outline(path: &Path, rel_path: &str) -> Result<FileOutline> {
+    // Read frontmatter properties
+    let props_raw = frontmatter::read_frontmatter(path)?;
+
+    let properties: Vec<PropertyInfo> = props_raw
+        .iter()
+        .map(|(name, value)| PropertyInfo {
+            name: name.clone(),
+            prop_type: frontmatter::infer_type(value).to_owned(),
+            value: frontmatter::yaml_to_json(value),
+        })
+        .collect();
+
+    // Extract tags from frontmatter
+    let tags = crate::commands::tags::extract_tags(&props_raw);
+
+    // Scan the file body for sections
+    let sections = scan_sections(path)?;
+
+    Ok(FileOutline {
+        file: rel_path.to_owned(),
+        properties,
+        tags,
+        sections,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Section scanning
+// ---------------------------------------------------------------------------
+
+/// State accumulated for the current section being built.
+struct SectionBuilder {
+    level: u8,
+    heading: Option<String>,
+    /// 1-based line number where this section starts (heading line, or 1 for pre-heading)
+    line: usize,
+    links: Vec<String>,
+    task_total: usize,
+    task_done: usize,
+    code_blocks: Vec<String>,
+}
+
+impl SectionBuilder {
+    fn new(level: u8, heading: Option<String>, line: usize) -> Self {
+        Self {
+            level,
+            heading,
+            line,
+            links: Vec::new(),
+            task_total: 0,
+            task_done: 0,
+            code_blocks: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> OutlineSection {
+        let tasks = if self.task_total > 0 {
+            Some(TaskCount {
+                total: self.task_total,
+                done: self.task_done,
+            })
+        } else {
+            None
+        };
+        OutlineSection {
+            level: self.level,
+            heading: self.heading,
+            line: self.line,
+            links: self.links,
+            tasks,
+            code_blocks: self.code_blocks,
+        }
+    }
+}
+
+/// Scan file body line by line, building `OutlineSection` values.
+/// Skips frontmatter, tracks fenced code block state, detects ATX headings,
+/// extracts links, counts task checkboxes, and records code block languages.
+fn scan_sections(path: &Path) -> Result<Vec<OutlineSection>> {
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+
+    let mut line_num: usize = 0;
+    let mut buf = String::new();
+
+    // --- Skip frontmatter ---
+    buf.clear();
+    let n = reader.read_line(&mut buf).context("failed to read line")?;
+    if n == 0 {
+        // Empty file
+        return Ok(Vec::new());
+    }
+    line_num += 1;
+
+    let first_trimmed = buf.trim_end_matches(['\n', '\r']).to_owned();
+    let fm_lines = frontmatter::skip_frontmatter(&mut reader, &first_trimmed)?;
+    if fm_lines > 0 {
+        line_num = fm_lines;
+    }
+
+    // --- Scan body ---
+
+    // Pre-heading section (level 0): collects content before the first heading
+    let mut current = SectionBuilder::new(0, None, 1);
+    let mut sections: Vec<OutlineSection> = Vec::new();
+    // Fenced code block state: (fence_char, fence_count, language)
+    let mut fence: Option<(char, usize, String)> = None;
+
+    // If the first line was not frontmatter, process it now
+    if fm_lines == 0 {
+        process_body_line(
+            &first_trimmed,
+            line_num,
+            &mut current,
+            &mut fence,
+            &mut sections,
+        );
+    }
+
+    loop {
+        buf.clear();
+        let n = reader.read_line(&mut buf).context("failed to read line")?;
+        if n == 0 {
+            break; // EOF
+        }
+        line_num += 1;
+        let line = buf.trim_end_matches(['\n', '\r']);
+
+        process_body_line(line, line_num, &mut current, &mut fence, &mut sections);
+    }
+
+    // Flush the last section
+    let last = current.finish();
+    // Only emit the pre-heading section (level 0) if it has any content
+    let should_emit = last.level > 0
+        || !last.links.is_empty()
+        || last.tasks.is_some()
+        || !last.code_blocks.is_empty();
+    if should_emit {
+        sections.push(last);
+    }
+
+    Ok(sections)
+}
+
+/// Process a single body line, updating the current section builder and
+/// emitting a finished section to `sections` when a new heading is detected.
+fn process_body_line(
+    line: &str,
+    line_num: usize,
+    current: &mut SectionBuilder,
+    fence: &mut Option<(char, usize, String)>,
+    sections: &mut Vec<OutlineSection>,
+) {
+    // --- Fenced code block handling ---
+    if let Some((fence_char, fence_count, _)) = fence.as_ref() {
+        if scanner::is_closing_fence(line, *fence_char, *fence_count) {
+            *fence = None;
+        }
+        // Lines inside a code block are not processed for links/tasks/headings
+        return;
+    }
+
+    // Detect opening fence
+    if let Some((fc, count)) = scanner::detect_opening_fence(line) {
+        let lang = extract_fence_language(line, fc, count);
+        current.code_blocks.push(lang.clone());
+        *fence = Some((fc, count, lang));
+        return;
+    }
+
+    // --- ATX heading detection ---
+    if let Some((level, heading_text)) = parse_atx_heading(line) {
+        // Finish the current section, emitting it only if it has content
+        // (or if it is a named section, i.e. level > 0)
+        let finished = std::mem::replace(
+            current,
+            SectionBuilder::new(level, Some(heading_text), line_num),
+        );
+
+        // Level-0 (pre-heading) sections are only emitted if they have
+        // links, tasks, or code blocks — plain text doesn't count.
+        let should_emit = finished.level > 0
+            || !finished.links.is_empty()
+            || finished.task_total > 0
+            || !finished.code_blocks.is_empty();
+
+        if should_emit {
+            sections.push(finished.finish());
+        }
+
+        return;
+    }
+
+    // --- Normal text line ---
+
+    // Strip inline code spans before extracting links
+    let cleaned = scanner::strip_inline_code(line);
+    let mut line_links: Vec<links::Link> = Vec::new();
+    links::extract_links_from_text(cleaned.as_ref(), &mut line_links);
+
+    for link in line_links {
+        let formatted = format_link_string(&link);
+        current.links.push(formatted);
+    }
+
+    // Count task checkboxes: lines of the form `- [ ] ...` or `- [x] ...` etc.
+    if let Some(done) = detect_task_checkbox(line) {
+        current.task_total += 1;
+        if done {
+            current.task_done += 1;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the info-string (language tag) from a fenced code block opening line.
+/// E.g. "```rust" → "rust", "~~~" → ""
+fn extract_fence_language(line: &str, fence_char: char, fence_count: usize) -> String {
+    let trimmed = line.trim_start();
+    // Skip past the fence chars
+    let after_fence = &trimmed[fence_count * fence_char.len_utf8()..];
+    // The info string runs to end-of-line; trim whitespace
+    after_fence.trim().to_owned()
+}
+
+/// Parse an ATX heading line (`# Heading`, `## Sub`, etc.).
+/// Returns `(level, heading_text)` if the line is a valid ATX heading,
+/// or `None` otherwise.
+fn parse_atx_heading(line: &str) -> Option<(u8, String)> {
+    let bytes = line.as_bytes();
+    if bytes.first() != Some(&b'#') {
+        return None;
+    }
+
+    // Count leading `#` characters (maximum 6 for ATX headings)
+    let level = bytes.iter().take_while(|&&b| b == b'#').count();
+    if level > 6 {
+        return None;
+    }
+
+    let after_hashes = &line[level..];
+
+    // An ATX heading requires either:
+    // - A space (or tab) after the hashes: `## Heading`
+    // - Nothing after the hashes (empty heading): `##`
+    let heading_text = if after_hashes.is_empty() {
+        String::new()
+    } else if after_hashes.starts_with(' ') || after_hashes.starts_with('\t') {
+        // Strip the leading space/tab, then trim trailing spaces and optional closing `#`s
+        let inner = after_hashes[1..].trim_end();
+        // Remove optional trailing `#` sequence (ATX closing sequence)
+        let inner = inner.trim_end_matches('#').trim_end();
+        inner.to_owned()
+    } else {
+        // Characters directly after `#` with no space — not a valid ATX heading
+        return None;
+    };
+
+    Some((level as u8, heading_text))
+}
+
+/// Detect a task checkbox on a line.
+/// Returns `Some(true)` for a completed task, `Some(false)` for an open task,
+/// or `None` if the line is not a task checkbox.
+///
+/// Recognises: `- [ ] ...`, `- [x] ...`, `- [X] ...` (and `*` / `+` bullets).
+fn detect_task_checkbox(line: &str) -> Option<bool> {
+    let trimmed = line.trim_start();
+
+    // Must start with a list marker: `-`, `*`, or `+`
+    let rest = trimmed
+        .strip_prefix("- ")
+        .or_else(|| trimmed.strip_prefix("* "))
+        .or_else(|| trimmed.strip_prefix("+ "))?;
+
+    // Must be followed by `[` then one char then `]`
+    let inner = rest.strip_prefix('[')?;
+    // The checkbox marker is a single character followed by `]`
+    let mut chars = inner.chars();
+    let marker = chars.next()?;
+    let close = chars.next()?;
+    if close != ']' {
+        return None;
+    }
+
+    let done = marker == 'x' || marker == 'X';
+    Some(done)
+}
+
+/// Format a `Link` into a human-readable string for storage in the outline.
+/// Wikilinks: `[[target]]`
+/// Markdown links: `[label](target)` or `[](target)` when no label
+fn format_link_string(link: &links::Link) -> String {
+    // Heuristic: if the target contains `.md` or `/` it's likely a markdown link
+    // that came from `[text](target)` syntax. But we don't have the original syntax
+    // available here — the Link struct doesn't distinguish between wikilinks and
+    // markdown links. We use the label field:
+    // - links::extract_links_from_text sets label for both wikilinks (from `|`) and
+    //   markdown links (from `[text]`).
+    // The simplest consistent representation: wikilinks have no label or a pipe label,
+    // markdown links always have the display text as label.
+    // Without the original syntax we fall back to a simple format:
+    //   [[target]] for no-label links, [[target|label]] for labeled wikilinks
+    //   [label](target) for markdown links.
+    // Since we can't distinguish from the Link struct alone, emit `[[target]]` style
+    // for wikilinks (no label or pipe-separated) and `[label](target)` for markdown.
+    // The underlying Link is produced by the same parser for both — we emit wikilink
+    // format by default (matches the outline spec: `"[[iteration-02-links]]"`).
+    match &link.label {
+        Some(label) if !label.is_empty() => {
+            // Could be from a wikilink [[t|label]] or markdown [label](t).
+            // We can't tell them apart from the Link struct, so use the markdown format
+            // which is more informative for labeled links.
+            format!("[{}]({})", label, link.target)
+        }
+        _ => format!("[[{}]]", link.target),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    macro_rules! md {
+        ($s:expr) => {
+            $s.strip_prefix('\n').unwrap_or($s)
+        };
+    }
+
+    fn unwrap_success(outcome: CommandOutcome) -> String {
+        match outcome {
+            CommandOutcome::Success(s) => s,
+            CommandOutcome::UserError(s) => panic!("expected success, got user error: {s}"),
+        }
+    }
+
+    // --- parse_atx_heading ---
+
+    #[test]
+    fn heading_level_1() {
+        let h = parse_atx_heading("# Hello").unwrap();
+        assert_eq!(h.0, 1);
+        assert_eq!(h.1, "Hello");
+    }
+
+    #[test]
+    fn heading_level_3() {
+        let h = parse_atx_heading("### Sub section").unwrap();
+        assert_eq!(h.0, 3);
+        assert_eq!(h.1, "Sub section");
+    }
+
+    #[test]
+    fn heading_max_level_6() {
+        let h = parse_atx_heading("###### Deep").unwrap();
+        assert_eq!(h.0, 6);
+        assert_eq!(h.1, "Deep");
+    }
+
+    #[test]
+    fn heading_7_hashes_not_heading() {
+        assert!(parse_atx_heading("####### Too deep").is_none());
+    }
+
+    #[test]
+    fn heading_no_space_not_heading() {
+        assert!(parse_atx_heading("#NoSpace").is_none());
+    }
+
+    #[test]
+    fn heading_empty() {
+        let h = parse_atx_heading("##").unwrap();
+        assert_eq!(h.0, 2);
+        assert_eq!(h.1, "");
+    }
+
+    #[test]
+    fn heading_with_closing_hashes() {
+        let h = parse_atx_heading("## Section ##").unwrap();
+        assert_eq!(h.0, 2);
+        assert_eq!(h.1, "Section");
+    }
+
+    #[test]
+    fn not_a_heading() {
+        assert!(parse_atx_heading("Normal text").is_none());
+        assert!(parse_atx_heading("").is_none());
+    }
+
+    // --- detect_task_checkbox ---
+
+    #[test]
+    fn open_task() {
+        assert_eq!(detect_task_checkbox("- [ ] Do something"), Some(false));
+    }
+
+    #[test]
+    fn done_task_lowercase() {
+        assert_eq!(detect_task_checkbox("- [x] Done"), Some(true));
+    }
+
+    #[test]
+    fn done_task_uppercase() {
+        assert_eq!(detect_task_checkbox("- [X] Done"), Some(true));
+    }
+
+    #[test]
+    fn task_with_star_bullet() {
+        assert_eq!(detect_task_checkbox("* [ ] Star bullet"), Some(false));
+    }
+
+    #[test]
+    fn task_with_plus_bullet() {
+        assert_eq!(detect_task_checkbox("+ [ ] Plus bullet"), Some(false));
+    }
+
+    #[test]
+    fn indented_task() {
+        assert_eq!(detect_task_checkbox("  - [ ] Indented"), Some(false));
+    }
+
+    #[test]
+    fn not_a_task() {
+        assert!(detect_task_checkbox("- Just a bullet").is_none());
+        assert!(detect_task_checkbox("Regular text").is_none());
+    }
+
+    // --- extract_fence_language ---
+
+    #[test]
+    fn fence_language_rust() {
+        assert_eq!(extract_fence_language("```rust", '`', 3), "rust");
+    }
+
+    #[test]
+    fn fence_no_language() {
+        assert_eq!(extract_fence_language("```", '`', 3), "");
+    }
+
+    #[test]
+    fn fence_language_with_spaces() {
+        assert_eq!(extract_fence_language("```  sh  ", '`', 3), "sh");
+    }
+
+    // --- format_link_string ---
+
+    #[test]
+    fn format_wikilink_no_label() {
+        let link = links::Link {
+            target: "my-note".to_owned(),
+            label: None,
+        };
+        assert_eq!(format_link_string(&link), "[[my-note]]");
+    }
+
+    #[test]
+    fn format_link_with_label() {
+        let link = links::Link {
+            target: "my-note".to_owned(),
+            label: Some("My Note".to_owned()),
+        };
+        assert_eq!(format_link_string(&link), "[My Note](my-note)");
+    }
+
+    // --- scan_sections ---
+
+    #[test]
+    fn empty_file_produces_no_sections() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("empty.md");
+        fs::write(&path, "").unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn file_with_only_frontmatter_produces_no_sections() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("fm_only.md");
+        fs::write(
+            &path,
+            md!(r"
+---
+title: Test
+---
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn single_heading_produces_one_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Hello
+
+Some text.
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].level, 1);
+        assert_eq!(sections[0].heading.as_deref(), Some("Hello"));
+        assert_eq!(sections[0].line, 1);
+    }
+
+    #[test]
+    fn multiple_headings_produce_multiple_sections() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# First
+
+Text A.
+
+## Sub
+
+Text B.
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].level, 1);
+        assert_eq!(sections[0].heading.as_deref(), Some("First"));
+        assert_eq!(sections[1].level, 2);
+        assert_eq!(sections[1].heading.as_deref(), Some("Sub"));
+    }
+
+    #[test]
+    fn pre_heading_section_emitted_when_has_links() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+See [[some-note]] for details.
+
+# Heading
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        // pre-heading section (level 0) + heading section
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].level, 0);
+        assert_eq!(sections[0].heading, None);
+        assert_eq!(sections[0].links.len(), 1);
+        assert_eq!(sections[0].links[0], "[[some-note]]");
+    }
+
+    #[test]
+    fn pre_heading_section_not_emitted_when_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Heading
+
+Text here.
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].level, 1);
+    }
+
+    #[test]
+    fn links_extracted_per_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Section A
+
+See [[note-a]] and [[note-b]].
+
+# Section B
+
+See [[note-c]].
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].links.len(), 2);
+        assert!(sections[0].links.contains(&"[[note-a]]".to_owned()));
+        assert!(sections[0].links.contains(&"[[note-b]]".to_owned()));
+        assert_eq!(sections[1].links.len(), 1);
+        assert_eq!(sections[1].links[0], "[[note-c]]");
+    }
+
+    #[test]
+    fn tasks_counted_per_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Tasks
+
+- [ ] Open task
+- [x] Done task
+- [X] Also done
+- Regular bullet
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections.len(), 1);
+        let tasks = sections[0].tasks.as_ref().unwrap();
+        assert_eq!(tasks.total, 3);
+        assert_eq!(tasks.done, 2);
+    }
+
+    #[test]
+    fn no_tasks_field_when_no_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Section
+
+Just text, no tasks.
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert!(sections[0].tasks.is_none());
+    }
+
+    #[test]
+    fn code_blocks_tracked_per_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Code Section
+
+```rust
+let x = 1;
+```
+
+~~~python
+print('hello')
+~~~
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].code_blocks.len(), 2);
+        assert!(sections[0].code_blocks.contains(&"rust".to_owned()));
+        assert!(sections[0].code_blocks.contains(&"python".to_owned()));
+    }
+
+    #[test]
+    fn links_inside_code_blocks_not_extracted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Section
+
+```
+[[not-a-link]]
+```
+
+[[real-link]]
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections[0].links.len(), 1);
+        assert_eq!(sections[0].links[0], "[[real-link]]");
+    }
+
+    #[test]
+    fn links_inside_inline_code_not_extracted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+# Section
+
+Use `[[not-a-link]]` and [[real-link]].
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections[0].links.len(), 1);
+        assert_eq!(sections[0].links[0], "[[real-link]]");
+    }
+
+    #[test]
+    fn line_numbers_correct_for_headings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(
+            &path,
+            md!(r"
+---
+title: Test
+---
+# First Heading
+
+## Second Heading
+"),
+        )
+        .unwrap();
+        let sections = scan_sections(&path).unwrap();
+        assert_eq!(sections.len(), 2);
+        // "---", "title: Test", "---" = 3 lines of frontmatter. First heading is line 4.
+        assert_eq!(sections[0].line, 4);
+        // Blank line at 5, second heading at 6
+        assert_eq!(sections[1].line, 6);
+    }
+
+    // --- Full outline command ---
+
+    fn setup_vault() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r"
+---
+title: My Note
+tags:
+  - rust
+  - cli
+---
+# Introduction
+
+See [[other-note]] for context.
+
+## Tasks
+
+- [ ] Write tests
+- [x] Write code
+
+```rust
+fn main() {}
+```
+"),
+        )
+        .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn outline_single_file() {
+        let tmp = setup_vault();
+        let out = unwrap_success(outline(tmp.path(), Some("note.md"), None, Format::Json).unwrap());
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        // Top-level fields
+        assert!(parsed["file"].as_str().unwrap().ends_with("note.md"));
+
+        // Properties
+        let props = parsed["properties"].as_array().unwrap();
+        assert!(props.iter().any(|p| p["name"] == "title"));
+        let title_prop = props.iter().find(|p| p["name"] == "title").unwrap();
+        assert_eq!(title_prop["type"], "text");
+        assert_eq!(title_prop["value"], "My Note");
+
+        // Tags
+        let tags = parsed["tags"].as_array().unwrap();
+        assert!(tags.contains(&serde_json::json!("rust")));
+        assert!(tags.contains(&serde_json::json!("cli")));
+
+        // Sections
+        let sections = parsed["sections"].as_array().unwrap();
+        assert_eq!(sections.len(), 2); // Introduction + Tasks
+
+        let intro = &sections[0];
+        assert_eq!(intro["level"], 1);
+        assert_eq!(intro["heading"], "Introduction");
+        let intro_links = intro["links"].as_array().unwrap();
+        assert_eq!(intro_links.len(), 1);
+        assert_eq!(intro_links[0], "[[other-note]]");
+
+        let tasks_section = &sections[1];
+        assert_eq!(tasks_section["level"], 2);
+        assert_eq!(tasks_section["heading"], "Tasks");
+        let tasks = &tasks_section["tasks"];
+        assert_eq!(tasks["total"], 2);
+        assert_eq!(tasks["done"], 1);
+        let code_blocks = tasks_section["code_blocks"].as_array().unwrap();
+        assert_eq!(code_blocks.len(), 1);
+        assert_eq!(code_blocks[0], "rust");
+    }
+
+    #[test]
+    fn outline_file_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = outline(tmp.path(), Some("nope.md"), None, Format::Json).unwrap();
+        assert!(matches!(result, CommandOutcome::UserError(_)));
+    }
+
+    #[test]
+    fn outline_all_files_returns_array() {
+        let tmp = setup_vault();
+        let out = unwrap_success(outline(tmp.path(), None, None, Format::Json).unwrap());
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed.is_array());
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn outline_no_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("plain.md"),
+            md!(r"
+# Heading
+
+Just text here.
+"),
+        )
+        .unwrap();
+        let out =
+            unwrap_success(outline(tmp.path(), Some("plain.md"), None, Format::Json).unwrap());
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed["properties"].as_array().unwrap().is_empty());
+        assert!(parsed["tags"].as_array().unwrap().is_empty());
+        let sections = parsed["sections"].as_array().unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0]["heading"], "Heading");
+    }
+
+    #[test]
+    fn outline_pre_heading_code_block_emitted() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r"
+```sh
+echo hello
+```
+
+# Section
+"),
+        )
+        .unwrap();
+        let out = unwrap_success(outline(tmp.path(), Some("note.md"), None, Format::Json).unwrap());
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let sections = parsed["sections"].as_array().unwrap();
+        // pre-heading section (level 0) with code block + heading section
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0]["level"], 0);
+        let cb = sections[0]["code_blocks"].as_array().unwrap();
+        assert_eq!(cb.len(), 1);
+        assert_eq!(cb[0], "sh");
+    }
+}

--- a/src/commands/outline.rs
+++ b/src/commands/outline.rs
@@ -35,12 +35,13 @@ pub fn outline(
     let mut results: Vec<serde_json::Value> = Vec::new();
     for (full_path, rel_path) in &files {
         let outline = build_file_outline(full_path, rel_path)?;
-        results.push(serde_json::to_value(outline).unwrap_or_default());
+        results
+            .push(serde_json::to_value(outline).expect("derived Serialize impl should not fail"));
     }
 
     let json_output = unwrap_single_file_result(file, results);
 
-    Ok(CommandOutcome::Success(crate::output::format_output(
+    Ok(CommandOutcome::Success(crate::output::format_success(
         format,
         &json_output,
     )))
@@ -218,7 +219,9 @@ fn process_body_line(
     // Detect opening fence
     if let Some((fc, count)) = scanner::detect_opening_fence(line) {
         let lang = extract_fence_language(line, fc, count);
-        current.code_blocks.push(lang.clone());
+        if !lang.is_empty() {
+            current.code_blocks.push(lang.clone());
+        }
         *fence = Some((fc, count, lang));
         return;
     }
@@ -347,32 +350,23 @@ fn detect_task_checkbox(line: &str) -> Option<bool> {
 }
 
 /// Format a `Link` into a human-readable string for storage in the outline.
-/// Wikilinks: `[[target]]`
-/// Markdown links: `[label](target)` or `[](target)` when no label
 fn format_link_string(link: &links::Link) -> String {
-    // Heuristic: if the target contains `.md` or `/` it's likely a markdown link
-    // that came from `[text](target)` syntax. But we don't have the original syntax
-    // available here — the Link struct doesn't distinguish between wikilinks and
-    // markdown links. We use the label field:
-    // - links::extract_links_from_text sets label for both wikilinks (from `|`) and
-    //   markdown links (from `[text]`).
-    // The simplest consistent representation: wikilinks have no label or a pipe label,
-    // markdown links always have the display text as label.
-    // Without the original syntax we fall back to a simple format:
-    //   [[target]] for no-label links, [[target|label]] for labeled wikilinks
-    //   [label](target) for markdown links.
-    // Since we can't distinguish from the Link struct alone, emit `[[target]]` style
-    // for wikilinks (no label or pipe-separated) and `[label](target)` for markdown.
-    // The underlying Link is produced by the same parser for both — we emit wikilink
-    // format by default (matches the outline spec: `"[[iteration-02-links]]"`).
-    match &link.label {
-        Some(label) if !label.is_empty() => {
-            // Could be from a wikilink [[t|label]] or markdown [label](t).
-            // We can't tell them apart from the Link struct, so use the markdown format
-            // which is more informative for labeled links.
-            format!("[{}]({})", label, link.target)
+    // Heuristic: targets containing '://' are URLs from markdown links.
+    // Targets ending in common extensions with '/' are file paths from markdown links.
+    // Everything else is treated as a wikilink.
+    let is_markdown_link =
+        link.target.contains("://") || (link.target.contains('/') && link.target.contains('.'));
+
+    if is_markdown_link {
+        match &link.label {
+            Some(label) if !label.is_empty() => format!("[{}]({})", label, link.target),
+            _ => format!("[]({})", link.target),
         }
-        _ => format!("[[{}]]", link.target),
+    } else {
+        match &link.label {
+            Some(label) if !label.is_empty() => format!("[[{}|{}]]", link.target, label),
+            _ => format!("[[{}]]", link.target),
+        }
     }
 }
 
@@ -518,12 +512,30 @@ mod tests {
     }
 
     #[test]
-    fn format_link_with_label() {
+    fn format_wikilink_with_label() {
         let link = links::Link {
             target: "my-note".to_owned(),
             label: Some("My Note".to_owned()),
         };
-        assert_eq!(format_link_string(&link), "[My Note](my-note)");
+        assert_eq!(format_link_string(&link), "[[my-note|My Note]]");
+    }
+
+    #[test]
+    fn format_markdown_link_with_label() {
+        let link = links::Link {
+            target: "https://example.com".to_owned(),
+            label: Some("Example".to_owned()),
+        };
+        assert_eq!(format_link_string(&link), "[Example](https://example.com)");
+    }
+
+    #[test]
+    fn format_file_path_link_with_label() {
+        let link = links::Link {
+            target: "docs/some-note.md".to_owned(),
+            label: Some("Some Note".to_owned()),
+        };
+        assert_eq!(format_link_string(&link), "[Some Note](docs/some-note.md)");
     }
 
     // --- scan_sections ---

--- a/src/commands/properties.rs
+++ b/src/commands/properties.rs
@@ -1,16 +1,19 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
-use serde_json::json;
 use serde_yaml_ng::Value;
 use std::path::Path;
 
 use crate::commands::{
-    FilesOrOutcome, build_find_json, build_list_mutation_json, collect_files, require_file_or_glob,
-    resolve_error_to_outcome,
+    FilesOrOutcome, collect_files, require_file_or_glob, resolve_error_to_outcome,
+    unwrap_single_file_result,
 };
 use crate::discovery;
 use crate::frontmatter;
-use crate::output::{CommandOutcome, Format};
+use crate::output::{CommandOutcome, Format, format_output};
+use crate::types::{
+    FileProperties, PropertyFindResult, PropertyInfo, PropertyMutationResult, PropertyRemoved,
+    PropertySummaryEntry,
+};
 
 // ---------------------------------------------------------------------------
 // Generic list-property helpers
@@ -241,18 +244,16 @@ pub fn property_add_to_list(
 
     let ListOpResult { modified, skipped } = add_values_to_list_property(&files, name, values)?;
 
-    let result = build_list_mutation_json(
-        "property",
-        name,
-        Some("values"),
-        Some(values),
-        &modified,
-        &skipped,
-    );
+    let total = modified.len() + skipped.len();
+    let result = PropertyMutationResult {
+        property: name.to_owned(),
+        values: values.to_vec(),
+        modified,
+        skipped,
+        total,
+    };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
-        format, &result,
-    )))
+    Ok(CommandOutcome::Success(format_output(format, &result)))
 }
 
 /// Remove values from a list property in file(s). Removes the key if list becomes empty.
@@ -279,18 +280,16 @@ pub fn property_remove_from_list(
     let ListOpResult { modified, skipped } =
         remove_values_from_list_property(&files, name, values)?;
 
-    let result = build_list_mutation_json(
-        "property",
-        name,
-        Some("values"),
-        Some(values),
-        &modified,
-        &skipped,
-    );
+    let total = modified.len() + skipped.len();
+    let result = PropertyMutationResult {
+        property: name.to_owned(),
+        values: values.to_vec(),
+        modified,
+        skipped,
+        total,
+    };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
-        format, &result,
-    )))
+    Ok(CommandOutcome::Success(format_output(format, &result)))
 }
 
 /// Aggregate summary: unique property names with types and file counts.
@@ -320,15 +319,16 @@ pub fn properties_summary(
         }
     }
 
-    let result: Vec<serde_json::Value> = agg
+    let result: Vec<PropertySummaryEntry> = agg
         .into_iter()
-        .map(|(name, (typ, count))| json!({"name": name, "type": typ, "count": count}))
+        .map(|(name, (prop_type, count))| PropertySummaryEntry {
+            name,
+            prop_type,
+            count,
+        })
         .collect();
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
-        format,
-        &json!(result),
-    )))
+    Ok(CommandOutcome::Success(format_output(format, &result)))
 }
 
 /// Per-file detail: each file with its full property key/value pairs.
@@ -345,26 +345,27 @@ pub fn properties_list(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
-    let mut results = Vec::new();
+    let mut results: Vec<serde_json::Value> = Vec::new();
     for (full_path, rel_path) in &files {
         let props = frontmatter::read_frontmatter(full_path)?;
 
-        let prop_list: Vec<serde_json::Value> = props
+        let properties: Vec<PropertyInfo> = props
             .iter()
-            .map(|(k, v)| {
-                let typ = frontmatter::infer_type(v);
-                let json_val = frontmatter::yaml_to_json(v);
-                json!({"name": k, "value": json_val, "type": typ})
+            .map(|(k, v)| PropertyInfo {
+                name: k.clone(),
+                prop_type: frontmatter::infer_type(v).to_owned(),
+                value: frontmatter::yaml_to_json(v),
             })
             .collect();
 
-        results.push(json!({
-            "path": rel_path,
-            "properties": prop_list,
-        }));
+        let file_props = FileProperties {
+            path: rel_path.clone(),
+            properties,
+        };
+        results.push(serde_json::to_value(file_props).unwrap_or_default());
     }
 
-    let json_output = crate::commands::unwrap_single_file_result(file, results);
+    let json_output = unwrap_single_file_result(file, results);
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
@@ -387,12 +388,12 @@ pub fn property_read(
     let props = frontmatter::read_frontmatter(&full_path)?;
 
     if let Some(value) = props.get(name) {
-        let typ = frontmatter::infer_type(value);
-        let json_val = frontmatter::yaml_to_json(value);
-        let result = json!({"name": name, "value": json_val, "type": typ});
-        Ok(CommandOutcome::Success(crate::output::format_success(
-            format, &result,
-        )))
+        let result = PropertyInfo {
+            name: name.to_owned(),
+            prop_type: frontmatter::infer_type(value).to_owned(),
+            value: frontmatter::yaml_to_json(value),
+        };
+        Ok(CommandOutcome::Success(format_output(format, &result)))
     } else {
         let out =
             crate::output::format_error(format, "property not found", Some(&rel_path), None, None);
@@ -415,18 +416,17 @@ pub fn property_set(
     };
 
     let value = frontmatter::parse_value(raw_value, forced_type)?;
-    let typ = frontmatter::infer_type(&value);
-    let json_val = frontmatter::yaml_to_json(&value);
+    let result = PropertyInfo {
+        name: name.to_owned(),
+        prop_type: frontmatter::infer_type(&value).to_owned(),
+        value: frontmatter::yaml_to_json(&value),
+    };
 
     let mut props = frontmatter::read_frontmatter(&full_path)?;
     props.insert(name.to_owned(), value);
     frontmatter::write_frontmatter(&full_path, &props)?;
 
-    let result = json!({"name": name, "value": json_val, "type": typ});
-
-    Ok(CommandOutcome::Success(crate::output::format_success(
-        format, &result,
-    )))
+    Ok(CommandOutcome::Success(format_output(format, &result)))
 }
 
 /// Remove a property from a file.
@@ -445,10 +445,11 @@ pub fn property_remove(
 
     if props.remove(name).is_some() {
         frontmatter::write_frontmatter(&full_path, &props)?;
-        let result = json!({"removed": name, "path": rel_path});
-        Ok(CommandOutcome::Success(crate::output::format_success(
-            format, &result,
-        )))
+        let result = PropertyRemoved {
+            removed: name.to_owned(),
+            path: rel_path,
+        };
+        Ok(CommandOutcome::Success(format_output(format, &result)))
     } else {
         let out =
             crate::output::format_error(format, "property not found", Some(&rel_path), None, None);
@@ -486,11 +487,15 @@ pub fn property_find(
         }
     }
 
-    let result = build_find_json("property", name, value, &matching_paths);
+    let total = matching_paths.len();
+    let result = PropertyFindResult {
+        property: name.to_owned(),
+        value: value.map(str::to_owned),
+        files: matching_paths,
+        total,
+    };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
-        format, &result,
-    )))
+    Ok(CommandOutcome::Success(format_output(format, &result)))
 }
 
 /// Check if a YAML value matches a query string, using type-aware comparison.

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
-use serde_json::json;
 use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -9,10 +8,11 @@ use crate::commands::properties::{
     ListOpResult, add_values_to_list_property, remove_values_from_list_property,
 };
 use crate::commands::{
-    FilesOrOutcome, build_find_json, build_list_mutation_json, collect_files, require_file_or_glob,
+    FilesOrOutcome, collect_files, require_file_or_glob, unwrap_single_file_result,
 };
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
+use crate::types::{FileTags, TagFindResult, TagMutationResult, TagSummary, TagSummaryEntry};
 
 // ---------------------------------------------------------------------------
 // Tag format validation
@@ -128,15 +128,15 @@ pub fn tags_summary(
         }
     }
 
-    let tags_json: Vec<serde_json::Value> = counts
+    let tags: Vec<TagSummaryEntry> = counts
         .into_iter()
-        .map(|(_, (name, count))| json!({"name": name, "count": count}))
+        .map(|(_, (name, count))| TagSummaryEntry { name, count })
         .collect();
 
-    let total = tags_json.len();
-    let result = json!({"tags": tags_json, "total": total});
+    let total = tags.len();
+    let result = TagSummary { tags, total };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
+    Ok(CommandOutcome::Success(crate::output::format_output(
         format, &result,
     )))
 }
@@ -159,21 +159,20 @@ pub fn tags_list(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
-    let mut results = Vec::new();
+    let mut results: Vec<serde_json::Value> = Vec::new();
     for (full_path, rel_path) in &files {
         let props = frontmatter::read_frontmatter(full_path)?;
         let tags = extract_tags(&props);
-        let tags_json: Vec<serde_json::Value> =
-            tags.into_iter().map(serde_json::Value::String).collect();
-        results.push(json!({
-            "path": rel_path,
-            "tags": tags_json,
-        }));
+        let entry = FileTags {
+            path: rel_path.clone(),
+            tags,
+        };
+        results.push(serde_json::to_value(entry).unwrap_or_default());
     }
 
-    let json_output = crate::commands::unwrap_single_file_result(file, results);
+    let json_output = unwrap_single_file_result(file, results);
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
+    Ok(CommandOutcome::Success(crate::output::format_output(
         format,
         &json_output,
     )))
@@ -206,9 +205,15 @@ pub fn tag_find(
         }
     }
 
-    let result = build_find_json("tag", name, None, &matching_paths);
+    let total = matching_paths.len();
+    let result = TagFindResult {
+        tag: name.to_owned(),
+        value: None,
+        files: matching_paths,
+        total,
+    };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
+    Ok(CommandOutcome::Success(crate::output::format_output(
         format, &result,
     )))
 }
@@ -252,9 +257,15 @@ pub fn tag_add(
     let ListOpResult { modified, skipped } =
         add_values_to_list_property(&files, "tags", &[name.to_owned()])?;
 
-    let result = build_list_mutation_json("tag", name, None, None, &modified, &skipped);
+    let total = modified.len() + skipped.len();
+    let result = TagMutationResult {
+        tag: name.to_owned(),
+        modified,
+        skipped,
+        total,
+    };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
+    Ok(CommandOutcome::Success(crate::output::format_output(
         format, &result,
     )))
 }
@@ -284,9 +295,15 @@ pub fn tag_remove(
     let ListOpResult { modified, skipped } =
         remove_values_from_list_property(&files, "tags", &[name.to_owned()])?;
 
-    let result = build_list_mutation_json("tag", name, None, None, &modified, &skipped);
+    let total = modified.len() + skipped.len();
+    let result = TagMutationResult {
+        tag: name.to_owned(),
+        modified,
+        skipped,
+        total,
+    };
 
-    Ok(CommandOutcome::Success(crate::output::format_success(
+    Ok(CommandOutcome::Success(crate::output::format_output(
         format, &result,
     )))
 }

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -167,12 +167,12 @@ pub fn tags_list(
             path: rel_path.clone(),
             tags,
         };
-        results.push(serde_json::to_value(entry).unwrap_or_default());
+        results.push(serde_json::to_value(entry).expect("derived Serialize impl should not fail"));
     }
 
     let json_output = unwrap_single_file_result(file, results);
 
-    Ok(CommandOutcome::Success(crate::output::format_output(
+    Ok(CommandOutcome::Success(crate::output::format_success(
         format,
         &json_output,
     )))

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
-use globset::Glob;
+use globset::GlobBuilder;
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
@@ -79,7 +79,9 @@ pub fn is_glob(path: &str) -> bool {
 /// Match discovered files against a glob pattern.
 /// The glob is matched against paths relative to `dir`.
 pub fn match_glob(dir: &Path, files: &[PathBuf], pattern: &str) -> Result<Vec<(PathBuf, String)>> {
-    let glob = Glob::new(pattern)
+    let glob = GlobBuilder::new(pattern)
+        .literal_separator(true)
+        .build()
         .context("invalid glob pattern")?
         .compile_matcher();
 
@@ -201,6 +203,20 @@ mod tests {
 
         let matched_all = match_glob(tmp.path(), &files, "**/*.md").unwrap();
         assert_eq!(matched_all.len(), 3);
+    }
+
+    #[test]
+    fn glob_star_does_not_cross_slash() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["a.md", "b.md", "sub/c.md", "sub/deep/d.md"]);
+        let files = discover_files(tmp.path()).unwrap();
+
+        let star = match_glob(tmp.path(), &files, "*.md").unwrap();
+        // *.md should NOT match sub/c.md or sub/deep/d.md
+        assert_eq!(star.len(), 2);
+
+        let double_star = match_glob(tmp.path(), &files, "**/*.md").unwrap();
+        assert_eq!(double_star.len(), 4);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod frontmatter;
 pub mod links;
 pub mod output;
 pub mod scanner;
+pub mod types;

--- a/src/links.rs
+++ b/src/links.rs
@@ -24,7 +24,7 @@ pub fn extract_links_from_file(path: &Path) -> Result<Vec<Link>> {
 }
 
 /// Extract links from a text segment (already cleaned of inline code spans).
-fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
+pub(crate) fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
     let bytes = text.as_bytes();
     let len = bytes.len();
     let mut i = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ use std::process;
 
 use clap::{Parser, Subcommand};
 
-use hyalo::commands::{links as link_commands, properties, tags as tag_commands};
+use hyalo::commands::{
+    links as link_commands, outline as outline_commands, properties, tags as tag_commands,
+};
 use hyalo::output::{CommandOutcome, Format};
 
 #[derive(Parser)]
@@ -122,6 +124,34 @@ enum Commands {
     Tag {
         #[command(subcommand)]
         action: TagAction,
+    },
+    /// Build a structural outline of one or more markdown files (read-only)
+    #[command(
+        long_about = "Build a structural outline of one or more markdown files.\n\n\
+            OUTPUT: For each file, returns a 'FileOutline' object containing:\n\
+            - 'file': relative path to the file\n\
+            - 'properties': frontmatter key/value pairs with inferred types\n\
+            - 'tags': tag list extracted from frontmatter\n\
+            - 'sections': ordered list of document sections, each with:\n\
+                - 'level': heading depth (1-6); 0 = pre-heading content\n\
+                - 'heading': heading text (null for level-0 pre-heading section)\n\
+                - 'line': 1-based line number of the heading\n\
+                - 'links': internal [[wikilinks]] and [label](target) links found in the section\n\
+                - 'tasks': checkbox counts ({total, done}) — omitted if the section has no tasks\n\
+                - 'code_blocks': list of fenced code block language tags found in the section\n\
+            INPUT: Single file via --file (returns bare object), glob via --glob (returns array),\n\
+            or all .md files under --dir when neither is provided (returns array).\n\
+            SIDE EFFECTS: None (read-only).\n\
+            USE WHEN: You need to understand document structure, extract navigation data, \
+            audit which sections contain tasks or links, or build a document map."
+    )]
+    Outline {
+        /// Markdown file to outline (relative to --dir); returns a bare object
+        #[arg(long, conflicts_with = "glob")]
+        file: Option<String>,
+        /// Glob pattern to select multiple files (e.g. '**/*.md'); returns an array
+        #[arg(long, conflicts_with = "file")]
+        glob: Option<String>,
     },
 }
 
@@ -514,6 +544,9 @@ fn main() {
                 ref glob,
             } => tag_commands::tag_remove(dir, name, file.as_deref(), glob.as_deref(), format),
         },
+        Commands::Outline { ref file, ref glob } => {
+            outline_commands::outline(dir, file.as_deref(), glob.as_deref(), format)
+        }
     };
 
     match result {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 
+use serde::Serialize;
 use serde_json::json;
 
 /// Output format.
@@ -37,6 +38,16 @@ pub fn format_success(format: Format, value: &serde_json::Value) -> String {
         Format::Json => serde_json::to_string_pretty(value).unwrap_or_default(),
         Format::Text => format_value_as_text(value),
     }
+}
+
+/// Format any `Serialize` type for output.
+///
+/// Converts the value to `serde_json::Value` first so that the text formatter
+/// can operate on a uniform representation.
+#[must_use]
+pub fn format_output<T: Serialize>(format: Format, value: &T) -> String {
+    let json = serde_json::to_value(value).unwrap_or_default();
+    format_success(format, &json)
 }
 
 /// Format an error for output to stderr.

--- a/src/output.rs
+++ b/src/output.rs
@@ -46,7 +46,7 @@ pub fn format_success(format: Format, value: &serde_json::Value) -> String {
 /// can operate on a uniform representation.
 #[must_use]
 pub fn format_output<T: Serialize>(format: Format, value: &T) -> String {
-    let json = serde_json::to_value(value).unwrap_or_default();
+    let json = serde_json::to_value(value).expect("derived Serialize impl should not fail");
     format_success(format, &json)
 }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -95,7 +95,7 @@ where
 
 /// Detect an opening fence (triple backtick or `~~~`) at the start of a line.
 /// Returns the fence character and count if found.
-fn detect_opening_fence(line: &str) -> Option<(char, usize)> {
+pub(crate) fn detect_opening_fence(line: &str) -> Option<(char, usize)> {
     let trimmed = line.trim_start();
     let fence_char = trimmed.as_bytes().first().copied()?;
     if fence_char != b'`' && fence_char != b'~' {
@@ -111,7 +111,7 @@ fn detect_opening_fence(line: &str) -> Option<(char, usize)> {
 }
 
 /// Check if a line is a closing fence matching the opening fence.
-fn is_closing_fence(line: &str, fence_char: char, min_count: usize) -> bool {
+pub(crate) fn is_closing_fence(line: &str, fence_char: char, min_count: usize) -> bool {
     let trimmed = line.trim_start();
     let count = trimmed.chars().take_while(|&c| c == fence_char).count();
     if count < min_count {
@@ -124,7 +124,7 @@ fn is_closing_fence(line: &str, fence_char: char, min_count: usize) -> bool {
 /// Strip inline code spans from a line, replacing their content with spaces
 /// to preserve byte positions for link parsing.
 /// Returns a borrowed reference when no backticks are present (zero allocation).
-fn strip_inline_code(line: &str) -> Cow<'_, str> {
+pub(crate) fn strip_inline_code(line: &str) -> Cow<'_, str> {
     if !line.contains('`') {
         return Cow::Borrowed(line);
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,170 @@
+//! Typed structs for all JSON output shapes.
+//!
+//! Every command serializes one of these types (or a `Vec` of them) as its
+//! JSON response.  Using concrete types instead of ad-hoc `json!()` macros
+//! ensures that the outline command, properties, tags, and links all share
+//! the same shapes for overlapping data (e.g. `PropertyInfo`).
+
+use serde::Serialize;
+
+// ---------------------------------------------------------------------------
+// Property types (shared by properties list/read/set and outline)
+// ---------------------------------------------------------------------------
+
+/// A single frontmatter property with its inferred type and value.
+/// Used by `properties list`, `property read`, `property set`, and `outline`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PropertyInfo {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub prop_type: String,
+    pub value: serde_json::Value,
+}
+
+/// A file with its frontmatter properties.
+/// Used by `properties list` (per-file detail).
+#[derive(Debug, Clone, Serialize)]
+pub struct FileProperties {
+    pub path: String,
+    pub properties: Vec<PropertyInfo>,
+}
+
+/// Aggregate property summary entry.
+/// Used by `properties summary`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PropertySummaryEntry {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub prop_type: String,
+    pub count: usize,
+}
+
+/// Result of removing a property.
+#[derive(Debug, Clone, Serialize)]
+pub struct PropertyRemoved {
+    pub removed: String,
+    pub path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Tag types (shared by tags list/summary and outline)
+// ---------------------------------------------------------------------------
+
+/// A file with its tags.
+/// Used by `tags list` (per-file detail).
+#[derive(Debug, Clone, Serialize)]
+pub struct FileTags {
+    pub path: String,
+    pub tags: Vec<String>,
+}
+
+/// Aggregate tag summary.
+/// Used by `tags summary`.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagSummary {
+    pub tags: Vec<TagSummaryEntry>,
+    pub total: usize,
+}
+
+/// A single tag with its file count.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagSummaryEntry {
+    pub name: String,
+    pub count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Link types (shared by links command and outline)
+// ---------------------------------------------------------------------------
+
+/// A single link with its resolution status.
+/// Used by `links` command.
+#[derive(Debug, Clone, Serialize)]
+pub struct LinkInfo {
+    pub target: String,
+    pub path: Option<String>,
+    pub label: Option<String>,
+}
+
+/// A file with its outgoing links.
+/// Used by `links` command.
+#[derive(Debug, Clone, Serialize)]
+pub struct FileLinks {
+    pub path: String,
+    pub links: Vec<LinkInfo>,
+}
+
+// ---------------------------------------------------------------------------
+// Find / mutation result types
+// ---------------------------------------------------------------------------
+
+/// Result of a `property find` command.
+#[derive(Debug, Clone, Serialize)]
+pub struct PropertyFindResult {
+    pub property: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    pub files: Vec<String>,
+    pub total: usize,
+}
+
+/// Result of a `tag find` command.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagFindResult {
+    pub tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    pub files: Vec<String>,
+    pub total: usize,
+}
+
+/// Result of a `property add-to-list` or `property remove-from-list` command.
+#[derive(Debug, Clone, Serialize)]
+pub struct PropertyMutationResult {
+    pub property: String,
+    pub values: Vec<String>,
+    pub modified: Vec<String>,
+    pub skipped: Vec<String>,
+    pub total: usize,
+}
+
+/// Result of a `tag add` or `tag remove` command.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagMutationResult {
+    pub tag: String,
+    pub modified: Vec<String>,
+    pub skipped: Vec<String>,
+    pub total: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Outline types (new in iteration 6)
+// ---------------------------------------------------------------------------
+
+/// Task checkbox counts within a section.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskCount {
+    pub total: usize,
+    pub done: usize,
+}
+
+/// A single section in the document outline.
+#[derive(Debug, Clone, Serialize)]
+pub struct OutlineSection {
+    pub level: u8,
+    pub heading: Option<String>,
+    pub line: usize,
+    pub links: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<TaskCount>,
+    pub code_blocks: Vec<String>,
+}
+
+/// Full outline of a single file.
+#[derive(Debug, Clone, Serialize)]
+pub struct FileOutline {
+    pub file: String,
+    pub properties: Vec<PropertyInfo>,
+    pub tags: Vec<String>,
+    pub sections: Vec<OutlineSection>,
+}

--- a/tests/e2e_outline.rs
+++ b/tests/e2e_outline.rs
@@ -1,0 +1,336 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+
+fn setup_vault() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: My Note
+tags:
+  - rust
+  - cli
+---
+# Introduction
+
+See [[other-note]] for context.
+
+## Tasks
+
+- [ ] Write tests
+- [x] Write code
+- Regular bullet
+
+```rust
+fn main() {}
+```
+"),
+    );
+    write_md(
+        tmp.path(),
+        "plain.md",
+        md!(r"
+# Plain Heading
+
+Just text here.
+"),
+    );
+    write_md(tmp.path(), "empty.md", "");
+    write_md(
+        tmp.path(),
+        "sub/nested.md",
+        md!(r"
+---
+title: Nested
+---
+# Nested Section
+
+[[note]]
+"),
+    );
+    tmp
+}
+
+// --- outline --file (single file, returns bare object) ---
+
+#[test]
+fn outline_single_file_json() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--file", "note.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    // Bare object, not an array
+    assert!(parsed.is_object());
+    assert_eq!(parsed["file"], "note.md");
+
+    // Properties use the same shape as `properties list`
+    let props = parsed["properties"].as_array().unwrap();
+    let title_prop = props.iter().find(|p| p["name"] == "title").unwrap();
+    assert_eq!(title_prop["type"], "text");
+    assert_eq!(title_prop["value"], "My Note");
+
+    // Tags
+    let tags = parsed["tags"].as_array().unwrap();
+    assert!(tags.contains(&serde_json::json!("rust")));
+    assert!(tags.contains(&serde_json::json!("cli")));
+
+    // Sections
+    let sections = parsed["sections"].as_array().unwrap();
+    assert_eq!(sections.len(), 2); // Introduction + Tasks
+
+    // Introduction section
+    let intro = &sections[0];
+    assert_eq!(intro["level"], 1);
+    assert_eq!(intro["heading"], "Introduction");
+    let intro_links = intro["links"].as_array().unwrap();
+    assert_eq!(intro_links.len(), 1);
+    assert_eq!(intro_links[0], "[[other-note]]");
+    assert!(intro["tasks"].is_null()); // no tasks in this section
+
+    // Tasks section
+    let tasks_section = &sections[1];
+    assert_eq!(tasks_section["level"], 2);
+    assert_eq!(tasks_section["heading"], "Tasks");
+    assert_eq!(tasks_section["tasks"]["total"], 2);
+    assert_eq!(tasks_section["tasks"]["done"], 1);
+    let code_blocks = tasks_section["code_blocks"].as_array().unwrap();
+    assert_eq!(code_blocks.len(), 1);
+    assert_eq!(code_blocks[0], "rust");
+}
+
+// --- outline --glob (multi-file, returns array) ---
+
+#[test]
+fn outline_glob_returns_array() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--glob", "*.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    // Array of file outlines
+    assert!(parsed.is_array());
+    let arr = parsed.as_array().unwrap();
+    // All 4 files match: note.md, plain.md, empty.md, sub/nested.md
+    // (*.md matches .md extension at any depth in this glob implementation)
+    assert_eq!(arr.len(), 4);
+
+    // Each element has the FileOutline shape
+    for item in arr {
+        assert!(item["file"].is_string());
+        assert!(item["properties"].is_array());
+        assert!(item["tags"].is_array());
+        assert!(item["sections"].is_array());
+    }
+}
+
+// --- outline vault-wide (no --file or --glob) ---
+
+#[test]
+fn outline_vault_wide_returns_array() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert!(parsed.is_array());
+    let arr = parsed.as_array().unwrap();
+    // All 4 files: note.md, plain.md, empty.md, sub/nested.md
+    assert_eq!(arr.len(), 4);
+}
+
+// --- File not found ---
+
+#[test]
+fn outline_file_not_found() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--file", "nonexistent.md"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(parsed["error"], "file not found");
+}
+
+// --- No frontmatter ---
+
+#[test]
+fn outline_no_frontmatter() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--file", "plain.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert!(parsed["properties"].as_array().unwrap().is_empty());
+    assert!(parsed["tags"].as_array().unwrap().is_empty());
+    let sections = parsed["sections"].as_array().unwrap();
+    assert_eq!(sections.len(), 1);
+    assert_eq!(sections[0]["heading"], "Plain Heading");
+}
+
+// --- Empty file ---
+
+#[test]
+fn outline_empty_file() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--file", "empty.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert!(parsed["properties"].as_array().unwrap().is_empty());
+    assert!(parsed["tags"].as_array().unwrap().is_empty());
+    assert!(parsed["sections"].as_array().unwrap().is_empty());
+}
+
+// --- Pre-heading section only emitted with content ---
+
+#[test]
+fn outline_pre_heading_section_with_links() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+See [[some-note]] for details.
+
+# Heading
+"),
+    );
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--file", "note.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let sections = parsed["sections"].as_array().unwrap();
+    assert_eq!(sections.len(), 2); // pre-heading + heading
+    assert_eq!(sections[0]["level"], 0);
+    assert!(sections[0]["heading"].is_null());
+    assert_eq!(sections[0]["links"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn outline_no_pre_heading_section_when_only_text() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Test
+---
+# Heading
+
+Text here.
+"),
+    );
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--file", "note.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let sections = parsed["sections"].as_array().unwrap();
+    assert_eq!(sections.len(), 1);
+    assert_eq!(sections[0]["level"], 1);
+}
+
+// --- Text format ---
+
+#[test]
+fn outline_text_format() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["--format", "text"])
+        .args(["outline", "--file", "note.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Text format should contain key: value pairs
+    assert!(stdout.contains("file:"));
+}
+
+// --- Glob no match ---
+
+#[test]
+fn outline_glob_no_match() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--glob", "nonexistent/**/*.md"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+    assert_eq!(parsed["error"], "no files match pattern");
+}
+
+// --- Code blocks inside code fences not counted as headings ---
+
+#[test]
+fn outline_heading_inside_code_block_ignored() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+# Real Heading
+
+```markdown
+# Fake heading inside code block
+```
+"),
+    );
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["outline", "--file", "note.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let sections = parsed["sections"].as_array().unwrap();
+    assert_eq!(sections.len(), 1); // Only the real heading
+    assert_eq!(sections[0]["heading"], "Real Heading");
+}

--- a/tests/e2e_outline.rs
+++ b/tests/e2e_outline.rs
@@ -124,9 +124,8 @@ fn outline_glob_returns_array() {
     // Array of file outlines
     assert!(parsed.is_array());
     let arr = parsed.as_array().unwrap();
-    // All 4 files match: note.md, plain.md, empty.md, sub/nested.md
-    // (*.md matches .md extension at any depth in this glob implementation)
-    assert_eq!(arr.len(), 4);
+    // *.md matches only top-level files (literal_separator prevents * crossing /)
+    assert_eq!(arr.len(), 3);
 
     // Each element has the FileOutline shape
     for item in arr {


### PR DESCRIPTION
## Summary

- **Typed structs** (`src/types.rs`): Introduced `#[derive(Serialize)]` structs for all JSON output shapes across every command. Refactored `properties`, `tags`, and `links` to use them — compiler now enforces shape consistency (DEC-025)
- **Outline command**: New `outline` command extracts per-file structural skeleton — headings with line numbers, frontmatter properties/tags, wikilinks per section, task counts per section, code block languages (DEC-024)
- **Single/multi-file modes**: `--file` returns bare object, `--glob` or no args returns array — consistent with existing commands
- Removed ~50 lines of generic `build_find_json`/`build_list_mutation_json` helpers, replaced by specific typed structs

## Test plan

- [x] 38 unit tests for outline: heading parsing, task detection, fence language extraction, link formatting, section scanning edge cases
- [x] 11 e2e tests for outline: `--file`, `--glob`, vault-wide, file-not-found, empty file, no frontmatter, pre-heading sections, text format, headings inside code blocks
- [x] All 324 existing tests pass unchanged (typed structs produce identical JSON output)
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 372 tests pass
- [x] Dogfooded on `hyalo-knowledgebase/` — outline output verified on iteration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)