### PR TITLE
Add text output engine and --jq filter flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,10 +121,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -158,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +263,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -273,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hifijson"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
+
+[[package]]
 name = "hyalo"
 version = "0.1.0"
 dependencies = [
@@ -281,11 +347,38 @@ dependencies = [
  "clap",
  "globset",
  "ignore",
+ "jaq-core",
+ "jaq-json",
+ "jaq-std",
  "predicates",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "tempfile",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -335,6 +428,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jaq-core"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77526a72eb79412c29fd141767a6549bbfcb1cb40e00556fe16532d5e878e098"
+dependencies = [
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
+]
+
+[[package]]
+name = "jaq-json"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
+dependencies = [
+ "foldhash",
+ "hifijson",
+ "indexmap",
+ "jaq-core",
+ "jaq-std",
+ "serde_json",
+]
+
+[[package]]
+name = "jaq-std"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c264fe397c981705976c71f1bfe020382b9eda52ae950e57fe885e147bdd67d"
+dependencies = [
+ "aho-corasick",
+ "base64",
+ "chrono",
+ "jaq-core",
+ "libm",
+ "log",
+ "regex-lite",
+ "urlencoding",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +489,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -479,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +652,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -575,6 +737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +801,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
@@ -669,6 +849,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -715,10 +940,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ anyhow = "1"
 clap = { version = "4.6.0", features = ["derive"] }
 globset = "0.4"
 ignore = "0.4"
+jaq-core = "2.2.1"
+jaq-json = { version = "1.1.3", features = ["serde_json"] }
+jaq-std = "2.1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml_ng = "0.10"

--- a/hyalo-knowledgebase/backlog/help-all-flag.md
+++ b/hyalo-knowledgebase/backlog/help-all-flag.md
@@ -1,5 +1,5 @@
 ---
-title: "--help-all flag for comprehensive LLM-friendly CLI reference"
+title: "Enriched --help via clap's two-tier help system"
 type: backlog
 date: 2026-03-21
 status: idea
@@ -12,34 +12,37 @@ tags:
   - discoverability
 ---
 
-# --help-all flag for comprehensive LLM-friendly CLI reference
+# Enriched --help via clap's two-tier help system
 
 ## Problem
 
-The standard `--help` flag shows bare flag and subcommand listings — enough for a human who already knows the tool, but insufficient for an LLM (or a new user) that needs to understand the full CLI surface to generate correct commands. Today an LLM agent has to call `--help` on every subcommand individually, parse each output, and still guess at common workflows and output formats. This wastes tokens and invites mistakes.
+The standard `-h` output shows bare flag and subcommand listings — enough for a human who already knows the tool, but insufficient for an LLM (or a new user) that needs to understand the full CLI surface to generate correct commands. Today an LLM agent has to call `-h` on every subcommand individually, parse each output, and still guess at common workflows and output formats. This wastes tokens and invites mistakes.
 
 ## Proposal
 
-Add a `--help-all` flag to the root `hyalo` command that outputs a single, comprehensive reference covering:
+Instead of adding a custom `--help-all` flag, leverage clap's built-in two-tier help system where `-h` and `--help` produce different levels of detail:
 
-- **All commands and subcommands with their flags** — the full tree, not just top-level.
-- **Practical usage examples** showing common workflows, e.g.:
-  ```sh
-  # Find all files tagged 'rust'
-  hyalo tag find rust
+- **`-h`** stays compact (current behavior) — quick reminder of flags and subcommands.
+- **`--help`** expands to a comprehensive single-page reference using clap's `long_about` and `after_long_help` attributes, covering:
 
-  # List properties of a specific file
-  hyalo property list iterations/iteration-06-outline.md
-  ```
-- **Output format examples** — what JSON, text, and TSV output actually looks like for representative commands, so an LLM can parse the structure without trial and error.
-- **Composability examples** — piping with `--jq`, using `--format tsv` with unix tools like `sort`, `cut`, `awk`.
+  1. **One-liner purpose** — what the command (or subcommand) does in a single sentence.
+  2. **Mental model / key concepts** — frontmatter, properties, tags, vaults, and how they relate.
+  3. **Complete command tree with flags** — the full hierarchy, not just the top level.
+  4. **Cookbook / recipes** — goal-oriented examples mapping intent to command, e.g.:
+     ```sh
+     # Find all files tagged 'rust'
+     hyalo tag find rust
 
-```sh
-hyalo --help-all
-hyalo --help-all --format text   # plain text (default)
-hyalo --help-all --format json   # machine-readable structured reference
-```
+     # List properties of a specific file
+     hyalo property list iterations/iteration-06-outline.md
+
+     # Pipe JSON output through jq
+     hyalo tag find rust --format json --jq '.[].path'
+     ```
+  5. **Output shape examples per command family** — what JSON, text, and TSV output actually looks like for representative commands, so a consumer can parse the structure without trial and error.
+
+This approach requires no new flags or subcommands — it uses clap's existing `long_about`, `after_long_help`, and `long_help` to enrich every level of the command tree.
 
 ## Notes
 
-This is useful for both humans wanting a quick single-page reference and LLMs that need to understand the full CLI surface to generate correct commands. The output should be stable enough to include in system prompts or pipe into an LLM context window. Consider auto-generating it from clap metadata plus hand-written example annotations.
+The markdown-like structured text that `--help` produces is easy to parse for both humans and LLMs, making it useful as a single-page reference or as context piped into an LLM system prompt. The content should be stable enough to snapshot and include verbatim. It can be authored directly in Rust source via clap derive attributes and kept up to date alongside the code.

--- a/hyalo-knowledgebase/backlog/help-all-flag.md
+++ b/hyalo-knowledgebase/backlog/help-all-flag.md
@@ -1,0 +1,45 @@
+---
+title: "--help-all flag for comprehensive LLM-friendly CLI reference"
+type: backlog
+date: 2026-03-21
+status: idea
+priority: medium
+origin: dogfooding iteration-07
+tags:
+  - backlog
+  - cli
+  - llm
+  - discoverability
+---
+
+# --help-all flag for comprehensive LLM-friendly CLI reference
+
+## Problem
+
+The standard `--help` flag shows bare flag and subcommand listings — enough for a human who already knows the tool, but insufficient for an LLM (or a new user) that needs to understand the full CLI surface to generate correct commands. Today an LLM agent has to call `--help` on every subcommand individually, parse each output, and still guess at common workflows and output formats. This wastes tokens and invites mistakes.
+
+## Proposal
+
+Add a `--help-all` flag to the root `hyalo` command that outputs a single, comprehensive reference covering:
+
+- **All commands and subcommands with their flags** — the full tree, not just top-level.
+- **Practical usage examples** showing common workflows, e.g.:
+  ```sh
+  # Find all files tagged 'rust'
+  hyalo tag find rust
+
+  # List properties of a specific file
+  hyalo property list iterations/iteration-06-outline.md
+  ```
+- **Output format examples** — what JSON, text, and TSV output actually looks like for representative commands, so an LLM can parse the structure without trial and error.
+- **Composability examples** — piping with `--jq`, using `--format tsv` with unix tools like `sort`, `cut`, `awk`.
+
+```sh
+hyalo --help-all
+hyalo --help-all --format text   # plain text (default)
+hyalo --help-all --format json   # machine-readable structured reference
+```
+
+## Notes
+
+This is useful for both humans wanting a quick single-page reference and LLMs that need to understand the full CLI surface to generate correct commands. The output should be stable enough to include in system prompts or pipe into an LLM context window. Consider auto-generating it from clap metadata plus hand-written example annotations.

--- a/hyalo-knowledgebase/backlog/outline-text-output.md
+++ b/hyalo-knowledgebase/backlog/outline-text-output.md
@@ -1,14 +1,14 @@
 ---
-title: "Outline text output as indented tree"
-type: backlog
 date: 2026-03-21
-status: ready
-priority: high
 origin: iteration-06 (open task)
+priority: high
+status: completed
 tags:
-  - backlog
-  - outline
-  - cli
+- backlog
+- outline
+- cli
+title: Outline text output as indented tree
+type: backlog
 ---
 
 # Outline text output as indented tree

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -203,6 +203,25 @@ Supports `--file`, `--glob`, and vault-wide mode (unlike `links` which is single
 - New commands can reuse existing types instead of guessing the right `json!()` shape
 - Removed ~50 lines of generic JSON-building helpers from `commands/mod.rs`
 
+## DEC-027: jq Filters via `jaq` for Text Output (2026-03-21)
+
+**Context:** All commands support `--format text` but prior to iteration 7, text output was produced by a generic key=value formatter that was unreadable for nested/typed data (e.g. `properties: [{name=title, type=text, value=My Note}]`).
+
+**Decision:** Use the `jaq` crate (pure-Rust jq interpreter) to transform `serde_json::Value` to human-readable text. Each output type gets a `&'static str` jq filter constant. The filter is looked up by sorting the JSON object's top-level keys into a comma-joined "key signature". Unknown shapes fall back to generic key: value formatting.
+
+**Why jaq:**
+- jq is purpose-built for JSON→text transformation with string interpolation, conditionals, and array iteration
+- Pure Rust — no C deps, no subprocess, fast startup
+- Filters are `&'static str` — changing text format = editing one string constant, no Rust recompile of business logic needed
+- Standard language — no custom DSL to learn or maintain
+
+**Tradeoffs:**
+- Filter re-compilation on every call (acceptable for a CLI tool; no daemon/server use case)
+- Raw string delimiter collision: `"#" * .level` in jq requires `r##"..."##` instead of `r#"..."#` in Rust 2024 edition
+- Filter strings must be tested carefully — jq syntax errors produce `None` and fall back to generic format silently
+
+**Stable versions used:** `jaq-core = "2.2.1"`, `jaq-json = "1.1.3"` (with `serde_json` feature), `jaq-std = "2.1.2"`.
+
 ## DEC-026: Glob `*` Must Not Cross Path Separators (2026-03-21)
 
 **Context:** The `globset` crate's `Glob::new()` defaults to letting `*` match across `/` path separators. This means `*.md` matched `sub/nested.md`, which contradicts standard shell glob semantics and surprises users expecting `*` to match within a single directory only.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -203,6 +203,14 @@ Supports `--file`, `--glob`, and vault-wide mode (unlike `links` which is single
 - New commands can reuse existing types instead of guessing the right `json!()` shape
 - Removed ~50 lines of generic JSON-building helpers from `commands/mod.rs`
 
+## DEC-026: Glob `*` Must Not Cross Path Separators (2026-03-21)
+
+**Context:** The `globset` crate's `Glob::new()` defaults to letting `*` match across `/` path separators. This means `*.md` matched `sub/nested.md`, which contradicts standard shell glob semantics and surprises users expecting `*` to match within a single directory only.
+
+**Decision:** Use `GlobBuilder::literal_separator(true)` when compiling glob patterns in `match_glob()`. This makes `*` match only within a single directory component. Use `**` for recursive matching across directories.
+
+**Why:** Standard shell behavior — `*.md` should match `note.md` but not `sub/note.md`. Users familiar with any shell, ripgrep, fd, or .gitignore expect this. The previous behavior made `--glob "*.md"` equivalent to `--glob "**/*.md"`, removing the ability to scope to a single directory level.
+
 ## DEC-027: jq Filters via `jaq` for Text Output (2026-03-21)
 
 **Context:** All commands support `--format text` but prior to iteration 7, text output was produced by a generic key=value formatter that was unreadable for nested/typed data (e.g. `properties: [{name=title, type=text, value=My Note}]`).
@@ -221,11 +229,3 @@ Supports `--file`, `--glob`, and vault-wide mode (unlike `links` which is single
 - Filter strings must be tested carefully — jq syntax errors produce `None` and fall back to generic format silently
 
 **Stable versions used:** `jaq-core = "2.2.1"`, `jaq-json = "1.1.3"` (with `serde_json` feature), `jaq-std = "2.1.2"`.
-
-## DEC-026: Glob `*` Must Not Cross Path Separators (2026-03-21)
-
-**Context:** The `globset` crate's `Glob::new()` defaults to letting `*` match across `/` path separators. This means `*.md` matched `sub/nested.md`, which contradicts standard shell glob semantics and surprises users expecting `*` to match within a single directory only.
-
-**Decision:** Use `GlobBuilder::literal_separator(true)` when compiling glob patterns in `match_glob()`. This makes `*` match only within a single directory component. Use `**` for recursive matching across directories.
-
-**Why:** Standard shell behavior — `*.md` should match `note.md` but not `sub/note.md`. Users familiar with any shell, ripgrep, fd, or .gitignore expect this. The previous behavior made `--glob "*.md"` equivalent to `--glob "**/*.md"`, removing the ability to scope to a single directory level.

--- a/hyalo-knowledgebase/iteration-plan.md
+++ b/hyalo-knowledgebase/iteration-plan.md
@@ -82,7 +82,7 @@ SQLite or similar index for properties, tags, and links. Incremental updates bas
 Iteration 1 (frontmatter) ──→ Iteration 4 (find needs parser)
 Iteration 2 (link graph)  ──→ Iteration 6 (outline reuses scanner)
 Iteration 2 (link graph)  ──→ Iteration 8 (rename needs links)
-Iterations 1–6             ──→ Iteration 7 (search unifies all)
+Iterations 1–7             ──→ Iteration 8 (search unifies all)
 ```
 
 ## Dogfooding

--- a/hyalo-knowledgebase/iteration-plan.md
+++ b/hyalo-knowledgebase/iteration-plan.md
@@ -50,13 +50,19 @@ Also introduced `src/types.rs` with `#[derive(Serialize)]` structs for all JSON 
 
 **Commands:** `outline`
 
-## Iteration 7 — Search
+## Iteration 7 — Human-Readable Text Output via jaq
 
-Property query syntax, boolean logic, operators. Ties iterations 1–6 together into one query interface.
+Replaced the generic key=value text formatter with proper human-readable output for all commands. Each output type gets a jq filter string executed via the `jaq` crate (pure Rust). Filter lookup is based on sorted top-level JSON keys. Unknown shapes fall back to old generic format. (DEC-027)
+
+**No new commands** — purely output layer change. See [[iterations/iteration-07-text-output]].
+
+## Iteration 8 — Search
+
+Property query syntax, boolean logic, operators. Ties iterations 1–7 together into one query interface.
 
 **Commands:** `search` with `[prop:value]`, `path:`, `file:`, `tag:`, `content:`, `task-todo:`, `task-done:`
 
-## Iteration 8 — Move/Rename with Link Updates
+## Iteration 9 — Move/Rename with Link Updates
 
 Move or rename a file and update all wikilinks across the knowledge base.
 

--- a/hyalo-knowledgebase/iterations/iteration-05-summary-list-refactor.md
+++ b/hyalo-knowledgebase/iterations/iteration-05-summary-list-refactor.md
@@ -1,15 +1,15 @@
 ---
-title: "Iteration 5 — Summary + List Subcommand Refactor"
-type: iteration
-date: 2026-03-21
-tags:
-  - iteration
-  - refactor
-  - cli
-  - properties
-  - tags
-status: in-progress
 branch: iter-5/summary-list-refactor
+date: 2026-03-21
+status: completed
+tags:
+- iteration
+- refactor
+- cli
+- properties
+- tags
+title: Iteration 5 — Summary + List Subcommand Refactor
+type: iteration
 ---
 
 # Iteration 5 — Summary + List Subcommand Refactor

--- a/hyalo-knowledgebase/iterations/iteration-06-outline.md
+++ b/hyalo-knowledgebase/iterations/iteration-06-outline.md
@@ -1,7 +1,7 @@
 ---
 branch: iter-6/outline
 date: 2026-03-21
-status: in-progress
+status: completed
 tags:
 - iteration
 - outline

--- a/hyalo-knowledgebase/iterations/iteration-07-text-output.md
+++ b/hyalo-knowledgebase/iterations/iteration-07-text-output.md
@@ -1,0 +1,55 @@
+---
+branch: iter-7/text-output-jaq
+date: 2026-03-21
+status: completed
+tags:
+- iteration
+- cli
+- output
+title: Iteration 7 — Human-Readable Text Output via jaq
+type: iteration
+---
+
+# Iteration 7 — Human-Readable Text Output via jaq
+
+## Goal
+
+Replace the generic key=value text formatter with proper human-readable output for all commands using jq filter strings executed via the `jaq` crate (pure Rust jq interpreter).
+
+## Motivation
+
+During iteration 6 dogfooding, `--format text` produced output like `properties: [{name=title, type=text, value=My Note}]`. Every text-oriented use case required piping JSON through Python or `jq`. Text output should be immediately useful without post-processing.
+
+## Approach
+
+JSON is the single source of truth. Each output type (typed struct) gets a `&'static str` jq filter. Filters are looked up by computing a "key signature" — the sorted comma-joined top-level keys of the JSON object. Unknown shapes fall back to the old generic formatter. See [[decision-log#DEC-027]].
+
+## Tasks
+
+- [x] Add jaq dependencies to Cargo.toml (`jaq-core = "2.2.1"`, `jaq-json = "1.1.3"` with `serde_json` feature, `jaq-std = "2.1.2"`)
+- [x] Build `apply_jq_filter(filter_code, value) -> Option<String>` in `src/output.rs`
+- [x] Build `key_signature(map) -> String` and `lookup_filter(sig) -> Option<&'static str>`
+- [x] Define jq filter constants for all 16+ output types (PropertyInfo, FileProperties, PropertySummaryEntry, PropertyRemoved, PropertyFindResult, PropertyMutationResult, FileTags, TagSummary, TagSummaryEntry, TagFindResult, TagMutationResult, LinkInfo variants ×4, FileLinks, TaskCount, OutlineSection ×2, FileOutline)
+- [x] Replace `format_value_as_text` with jaq-based renderer
+- [x] Handle list-type property values — join array elements with ", " instead of rendering as JSON
+- [x] Unit tests for `apply_jq_filter`, each filter constant, fallback behavior, array of objects
+- [x] Update existing e2e text tests (3 in e2e_links.rs, 1 in e2e_outline.rs) to assert new format
+- [x] Update existing e2e text tests in e2e_properties.rs, e2e_tags.rs, e2e_property_read.rs
+- [x] Add new e2e text tests: `properties_summary_text_format`, `tag_add_text_format`, `tag_remove_text_format`, `tag_find_text_format` improvements
+- [x] cargo fmt, cargo clippy --all-targets -- -D warnings, cargo test --workspace (all pass)
+- [x] Decision log entry DEC-027
+- [x] Dogfood: all commands with `--format text` against `hyalo-knowledgebase/`
+
+## Key Technical Note
+
+Rust 2024 edition treats `"#` inside `r#"..."#` raw strings as the closing delimiter. The `"#" * .level` jq expression (string multiplication for heading prefix) requires using `r##"..."##` instead.
+
+## Dogfooding Observations
+
+- `--format text properties summary`: clean tabular output with name, type, file count
+- `--format text tags summary`: readable "N unique tags" header with per-tag counts
+- `--format text tags list --glob`: one line per file with comma-joined tags
+- `--format text tag find --name`: shows matching files indented under count line
+- `--format text outline --file`: file path, tags, props, then `#`-prefixed headings with task counts
+- `--format text properties list --file`: file path header, then indented `name (type): value` lines
+- No issues with JSON output path (completely unchanged)

--- a/hyalo-knowledgebase/iterations/iteration-07-text-output.md
+++ b/hyalo-knowledgebase/iterations/iteration-07-text-output.md
@@ -1,5 +1,5 @@
 ---
-branch: iter-7/text-output-jaq
+branch: iter-7/text-output
 date: 2026-03-21
 status: completed
 tags:

--- a/hyalo-knowledgebase/research/cli-structured-output-patterns.md
+++ b/hyalo-knowledgebase/research/cli-structured-output-patterns.md
@@ -1,0 +1,176 @@
+---
+title: CLI Structured Output & Filtering Patterns
+type: research
+date: 2026-03-21
+tags: [cli, output, filtering, ux, structured-data]
+---
+
+# CLI Structured Output & Filtering Patterns
+
+Research into how popular CLIs expose structured output and filtering to users.
+
+## Per-CLI Breakdown
+
+### kubectl
+
+- **Format flag:** `-o` / `--output`
+- **Formats:** `json`, `yaml`, `wide`, `name`, `jsonpath=EXPR`, `custom-columns=SPEC`, `go-template=TMPL`, `go-template-file=FILE`
+- **Query language:** JSONPath (Kubernetes dialect — adds `range`/`end` iteration, no regex support)
+- **Format + filter:** Combined in single flag — `--output=jsonpath='{.items[*].metadata.name}'`
+- **Notable:** JSONPath expression is embedded in the `-o` flag value itself, not a separate flag. Also supports `--sort-by` for ordering.
+- **Examples:**
+  - `kubectl get pods -o json`
+  - `kubectl get pods -o jsonpath='{.items[*].metadata.name}'`
+  - `kubectl get pods -o custom-columns=NAME:.metadata.name,STATUS:.status.phase`
+  - `kubectl get pods -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'`
+
+### gh (GitHub CLI)
+
+- **Format flag:** `--json <field1,field2,...>` (selects fields, outputs JSON)
+- **Filter flag:** `--jq <expression>` (separate flag, jq syntax)
+- **Template flag:** `--template <string>` (separate flag, Go templates)
+- **Query language:** jq (for filtering), Go templates (for formatting)
+- **Format + filter:** Separate flags that compose: `--json` selects fields, then `--jq` or `--template` transforms them
+- **Notable:** `--json` is required before `--jq` or `--template` can be used. The field list in `--json` acts as a projection. This is the most composable design.
+- **Examples:**
+  - `gh pr list --json number,title,author`
+  - `gh pr list --json number,title --jq '.[] | select(.number > 100)'`
+  - `gh pr list --json number,title --template '{{range .}}{{.number}}: {{.title}}{{"\n"}}{{end}}'`
+
+### aws cli
+
+- **Format flag:** `--output json|yaml|yaml-stream|text|table|off`
+- **Filter flag:** `--query <JMESPath expression>` (separate flag)
+- **Query language:** JMESPath
+- **Format + filter:** Separate flags that compose independently
+- **Notable:** `--query` interacts differently with `--output text` (runs per-page) vs JSON/YAML (runs once on full result). `text` output is tab-separated, good for piping to Unix tools. `off` suppresses output entirely (useful for CI/CD).
+- **Examples:**
+  - `aws ec2 describe-instances --output table`
+  - `aws iam list-users --output text --query 'Users[*].[UserName,Arn]'`
+  - `aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,State.Name]' --output json`
+
+### docker
+
+- **Format flag:** `--format <TEMPLATE>` / `-f <TEMPLATE>`
+- **Formats:** `json` (special keyword) or Go template string
+- **Query language:** Go templates (text/template package)
+- **Format + filter:** Combined in single flag — the Go template both selects and formats
+- **Notable:** Separate `--type` flag filters *what* to inspect, not *how* to display. Has a special `json` function inside templates for sub-objects: `{{json .Config}}`.
+- **Examples:**
+  - `docker inspect --format='{{.Config.Image}}' $ID`
+  - `docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $ID`
+  - `docker ps --format 'table {{.Names}}\t{{.Status}}'`
+  - `docker inspect -f 'json' $ID`
+
+### jc
+
+- **Not a CLI with built-in formatting** — it is a *converter* that sits in a pipeline
+- **Usage:** `COMMAND | jc PARSER | jq FILTER`
+- **Alternative:** `jc COMMAND` (magic syntax, wraps the command)
+- **Formats:** JSON output (with `-r` for raw/pre-processed)
+- **100+ parsers** for common commands (ps, ls, dig, netstat, df, etc.) and file formats (CSV, XML, YAML, /etc/passwd)
+- **Notable:** Demonstrates the "pipeline" approach — structured output is a *post-processing step* rather than built into each CLI. Works well with jq downstream.
+
+### gcloud
+
+- **Format flag:** `--format=FORMAT(PROJECTION)`
+- **Formats:** `json`, `yaml`, `table`, `csv`, `value`, `flattened`, `get`, `list`, `config`, `diff`, `object`, `default`, `none`, `disable`
+- **Filter flag:** `--filter=EXPRESSION` (separate flag, gcloud's own filter language)
+- **Query language:** gcloud's own projection/filter DSL (not JMESPath, not jq)
+- **Format + filter:** Separate flags. `--format` controls display *and* can include inline projections: `--format='table(name, zone, status)'`. `--filter` controls which resources are returned.
+- **Notable:** The most complex system. Format and projection are combined in the `--format` flag via parenthesized field lists. `--filter` uses a proprietary expression language with operators like `=`, `!=`, `~` (regex), `AND`/`OR`. Also supports `--flatten` for denormalizing nested arrays.
+- **Examples:**
+  - `gcloud compute instances list --format=json`
+  - `gcloud compute instances list --format='table(name, zone, status)'`
+  - `gcloud compute instances list --format='csv(name, zone)' --filter='status=RUNNING'`
+  - `gcloud compute instances list --format='value(name)'`
+
+### az (Azure CLI)
+
+- **Format flag:** `--output` / `-o`
+- **Formats:** `json` (default), `jsonc` (colorized), `yaml`, `yamlc` (colorized), `table`, `tsv`, `none`
+- **Filter flag:** `--query <JMESPath expression>` (separate flag)
+- **Query language:** JMESPath (same as AWS CLI)
+- **Format + filter:** Separate flags that compose independently
+- **Notable:** Very similar to AWS CLI design. `tsv` output has no guaranteed column ordering unless you use `--query` to project explicitly. `none` suppresses output. Default can be set globally via `az config set core.output=table`. `jsonc`/`yamlc` are nice touches for terminal readability.
+- **Examples:**
+  - `az vm list --output table`
+  - `az vm list --query "[].{resource:resourceGroup, name:name}" --output table`
+  - `az vm list --output tsv --query '[].[id, location, resourceGroup, name]'`
+
+### steampipe / powerpipe
+
+- **Format flag:** `--output`
+- **Formats:** `pretty` (default), `plain`, `brief`, `json`, `csv`, `html`, `md`, `nunit3`, `none`, `pps`/`snapshot`, `asff`
+- **No built-in query/filter flag** — filtering happens in the SQL query itself
+- **Notable:** Steampipe's paradigm is "SQL is the query language" — users write SQL to filter and project data, so the CLI only needs an output format flag. Also has `--export` for saving to files in multiple formats simultaneously.
+- **Examples:**
+  - `steampipe query "select * from aws_s3_bucket" --output json`
+  - `powerpipe benchmark run cis_v120 --output csv`
+
+---
+
+## Pattern Summary
+
+### Flag Naming Conventions
+
+| Pattern | Used by | Flag |
+|---------|---------|------|
+| `--output` / `-o` | kubectl, aws, az, steampipe | Most common for format selection |
+| `--format` | docker, gcloud | Used when format includes templating |
+| `--json` | gh | Dual-purpose: enables JSON mode + selects fields |
+| `--query` | aws, az | For JMESPath filtering |
+| `--jq` | gh | For jq filtering |
+| `--filter` | gcloud | For resource-level filtering |
+| `--template` | gh | For Go template formatting |
+
+### Format vs Filter: Separate or Combined?
+
+| Approach | CLIs | Pros | Cons |
+|----------|------|------|------|
+| **Separate flags** (`--output` + `--query`) | aws, az | Clean separation of concerns; each flag does one thing | Two flags to learn |
+| **Combined in format flag** (`-o jsonpath=EXPR`) | kubectl | Fewer flags, compact | Expression embedded in flag value, less composable |
+| **Three-stage pipeline** (`--json` + `--jq`/`--template`) | gh | Most composable; field selection, filtering, and formatting are independent | Three flags to learn |
+| **Format with inline projection** (`--format='table(f1,f2)'`) | gcloud | Projection is part of display intent | Complex syntax, proprietary DSL |
+| **External pipeline** (`| jc | jq`) | jc | No changes to the CLI itself | Requires external tools |
+
+### Query Language Adoption
+
+| Language | Used by | Complexity | Ecosystem |
+|----------|---------|------------|-----------|
+| **JMESPath** | aws, az | Medium | Python-native, libraries in many languages |
+| **jq** | gh (via --jq) | High | Ubiquitous Unix tool, very powerful |
+| **JSONPath** | kubectl | Medium | Many variants, Kubernetes has its own dialect |
+| **Go templates** | docker, gh, kubectl | Medium | Native to Go ecosystem |
+| **Proprietary DSL** | gcloud | High | Only works with gcloud |
+| **SQL** | steampipe | High (but familiar) | Universal |
+
+### Best Practices Observed
+
+1. **Default to JSON** — aws, az, gh all default to or prominently support JSON. It is the lingua franca of structured CLI output.
+
+2. **Separate format from filter** — The aws/az pattern (`--output` + `--query`) is the most widely replicated. It keeps concerns clean: *what shape* vs *what data*.
+
+3. **Use an established query language** — JMESPath (aws, az) and jq (gh) are the two leaders. Proprietary DSLs (gcloud) create learning burden. JSONPath has too many incompatible dialects.
+
+4. **Offer a human-readable default** — `table` or `text` for interactive use, `json` for scripting. Let users set a global default (az does this well).
+
+5. **Provide `tsv`/`text` for shell scripting** — Tab-separated output pipes cleanly into `cut`, `awk`, `xargs`. aws and az both support this.
+
+6. **Provide `none`/`off` for CI/CD** — Suppress output when only the exit code matters (aws `off`, az `none`).
+
+7. **gh's three-stage design is the most elegant** — `--json fields` (projection) + `--jq expr` (filter/transform) + `--template tmpl` (display) cleanly separates concerns while remaining composable.
+
+8. **Keep format flag values simple** — Prefer `--output json` over `--output=jsonpath='{complex.expression}'`. When expressions are needed, put them in a separate flag.
+
+### Common Output Formats Across CLIs
+
+| Format | Support |
+|--------|---------|
+| JSON | All 8 CLIs |
+| YAML | kubectl, aws, az, gcloud |
+| Table | aws, az, gcloud, docker, steampipe |
+| CSV | gcloud, steampipe |
+| TSV | az |
+| Plain text | kubectl (wide), aws (text) |
+| None/Off | aws, az, steampipe |

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ struct Cli {
     format: String,
 
     /// Apply a jq filter expression to the JSON output of any command.
-    /// The filtered result is printed as plain text. Overrides --format.
+    /// The filtered result is printed as plain text. Incompatible with non-JSON formats (--format text).
     /// Example: --jq '.files[]' or --jq 'map(.name) | join(", ")'
     #[arg(long, global = true, value_name = "FILTER")]
     jq: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 use hyalo::commands::{
     links as link_commands, outline as outline_commands, properties, tags as tag_commands,
 };
-use hyalo::output::{CommandOutcome, Format};
+use hyalo::output::{CommandOutcome, Format, apply_jq_filter_result};
 
 #[derive(Parser)]
 #[command(
@@ -44,6 +44,12 @@ struct Cli {
     /// Output format: "json" (structured, default) or "text" (human-readable). Applies to both stdout and stderr
     #[arg(long, global = true, default_value = "json")]
     format: String,
+
+    /// Apply a jq filter expression to the JSON output of any command.
+    /// The filtered result is printed as plain text. Overrides --format.
+    /// Example: --jq '.files[]' or --jq 'map(.name) | join(", ")'
+    #[arg(long, global = true, value_name = "FILTER")]
+    jq: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -431,6 +437,22 @@ fn main() {
         process::exit(2);
     };
 
+    // --jq operates on JSON, so it conflicts with an explicit --format text.
+    let jq_filter = cli.jq.as_deref();
+    if jq_filter.is_some() && format != Format::Json {
+        eprintln!(
+            "Error: --jq cannot be combined with --format {}",
+            cli.format
+        );
+        eprintln!("  --jq always operates on JSON output; drop --format or use --format json");
+        process::exit(2);
+    }
+    let effective_format = if jq_filter.is_some() {
+        Format::Json
+    } else {
+        format
+    };
+
     let dir = &cli.dir;
 
     let result = match cli.command {
@@ -439,26 +461,36 @@ fn main() {
             | Some(PropertiesAction::Summary {
                 file: None,
                 glob: None,
-            }) => properties::properties_summary(dir, None, None, format),
-            Some(PropertiesAction::Summary { file, glob }) => {
-                properties::properties_summary(dir, file.as_deref(), glob.as_deref(), format)
-            }
+            }) => properties::properties_summary(dir, None, None, effective_format),
+            Some(PropertiesAction::Summary { file, glob }) => properties::properties_summary(
+                dir,
+                file.as_deref(),
+                glob.as_deref(),
+                effective_format,
+            ),
             Some(PropertiesAction::List { file, glob }) => {
-                properties::properties_list(dir, file.as_deref(), glob.as_deref(), format)
+                properties::properties_list(dir, file.as_deref(), glob.as_deref(), effective_format)
             }
         },
         Commands::Property { action } => match action {
             PropertyAction::Read { ref name, ref file } => {
-                properties::property_read(dir, name, file, format)
+                properties::property_read(dir, name, file, effective_format)
             }
             PropertyAction::Set {
                 ref name,
                 ref value,
                 ref prop_type,
                 ref file,
-            } => properties::property_set(dir, name, value, prop_type.as_deref(), file, format),
+            } => properties::property_set(
+                dir,
+                name,
+                value,
+                prop_type.as_deref(),
+                file,
+                effective_format,
+            ),
             PropertyAction::Remove { ref name, ref file } => {
-                properties::property_remove(dir, name, file, format)
+                properties::property_remove(dir, name, file, effective_format)
             }
             PropertyAction::Find {
                 ref name,
@@ -471,7 +503,7 @@ fn main() {
                 value.as_deref(),
                 file.as_deref(),
                 glob.as_deref(),
-                format,
+                effective_format,
             ),
             PropertyAction::AddToList {
                 ref name,
@@ -484,7 +516,7 @@ fn main() {
                 value,
                 file.as_deref(),
                 glob.as_deref(),
-                format,
+                effective_format,
             ),
             PropertyAction::RemoveFromList {
                 ref name,
@@ -497,7 +529,7 @@ fn main() {
                 value,
                 file.as_deref(),
                 glob.as_deref(),
-                format,
+                effective_format,
             ),
         },
         Commands::Links {
@@ -512,19 +544,19 @@ fn main() {
             } else {
                 link_commands::LinkFilter::All
             };
-            link_commands::links(dir, file, filter, format)
+            link_commands::links(dir, file, filter, effective_format)
         }
         Commands::Tags { action: ref ta } => match ta {
             None
             | Some(TagsAction::Summary {
                 file: None,
                 glob: None,
-            }) => tag_commands::tags_summary(dir, None, None, format),
+            }) => tag_commands::tags_summary(dir, None, None, effective_format),
             Some(TagsAction::Summary { file, glob }) => {
-                tag_commands::tags_summary(dir, file.as_deref(), glob.as_deref(), format)
+                tag_commands::tags_summary(dir, file.as_deref(), glob.as_deref(), effective_format)
             }
             Some(TagsAction::List { file, glob }) => {
-                tag_commands::tags_list(dir, file.as_deref(), glob.as_deref(), format)
+                tag_commands::tags_list(dir, file.as_deref(), glob.as_deref(), effective_format)
             }
         },
         Commands::Tag { action } => match action {
@@ -532,26 +564,62 @@ fn main() {
                 ref name,
                 ref file,
                 ref glob,
-            } => tag_commands::tag_find(dir, name, file.as_deref(), glob.as_deref(), format),
+            } => tag_commands::tag_find(
+                dir,
+                name,
+                file.as_deref(),
+                glob.as_deref(),
+                effective_format,
+            ),
             TagAction::Add {
                 ref name,
                 ref file,
                 ref glob,
-            } => tag_commands::tag_add(dir, name, file.as_deref(), glob.as_deref(), format),
+            } => tag_commands::tag_add(
+                dir,
+                name,
+                file.as_deref(),
+                glob.as_deref(),
+                effective_format,
+            ),
             TagAction::Remove {
                 ref name,
                 ref file,
                 ref glob,
-            } => tag_commands::tag_remove(dir, name, file.as_deref(), glob.as_deref(), format),
+            } => tag_commands::tag_remove(
+                dir,
+                name,
+                file.as_deref(),
+                glob.as_deref(),
+                effective_format,
+            ),
         },
         Commands::Outline { ref file, ref glob } => {
-            outline_commands::outline(dir, file.as_deref(), glob.as_deref(), format)
+            outline_commands::outline(dir, file.as_deref(), glob.as_deref(), effective_format)
         }
     };
 
     match result {
         Ok(CommandOutcome::Success(output)) => {
-            println!("{output}");
+            if let Some(filter) = jq_filter {
+                // Parse the JSON output we forced above, then apply the user filter.
+                let value: serde_json::Value = match serde_json::from_str(&output) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("internal error: failed to parse command JSON output: {e}");
+                        process::exit(2);
+                    }
+                };
+                match apply_jq_filter_result(filter, &value) {
+                    Ok(filtered) => println!("{filtered}"),
+                    Err(e) => {
+                        eprintln!("Error: jq filter failed: {e}");
+                        process::exit(1);
+                    }
+                }
+            } else {
+                println!("{output}");
+            }
         }
         Ok(CommandOutcome::UserError(output)) => {
             eprintln!("{output}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -606,14 +606,28 @@ fn main() {
                 let value: serde_json::Value = match serde_json::from_str(&output) {
                     Ok(v) => v,
                     Err(e) => {
-                        eprintln!("internal error: failed to parse command JSON output: {e}");
+                        let msg = hyalo::output::format_error(
+                            format,
+                            "internal error: failed to parse command JSON output",
+                            None,
+                            None,
+                            Some(&e.to_string()),
+                        );
+                        eprintln!("{msg}");
                         process::exit(2);
                     }
                 };
                 match apply_jq_filter_result(filter, &value) {
                     Ok(filtered) => println!("{filtered}"),
                     Err(e) => {
-                        eprintln!("Error: jq filter failed: {e}");
+                        let msg = hyalo::output::format_error(
+                            format,
+                            "jq filter failed",
+                            None,
+                            None,
+                            Some(&e),
+                        );
+                        eprintln!("{msg}");
                         process::exit(1);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,11 @@ struct Cli {
 enum Commands {
     /// List frontmatter properties across files — aggregate summary or per-file detail
     #[command(long_about = "List frontmatter properties across files.\n\n\
-            SUBCOMMANDS:\n\
+            Subcommands:\n\
             - summary (default): aggregate unique property names with types and file counts.\n\
             - list: per-file detail — each file with its full key/value pairs.\n\n\
             INPUT: Reads .md files filtered by --file or --glob (or all .md files if omitted).\n\
+            SCOPE: Scans all .md files under --dir unless narrowed with --file or --glob.\n\
             SIDE EFFECTS: None (read-only).\n\
             USE WHEN: You need to discover what properties exist, audit frontmatter, or inspect per-file metadata.")]
     Properties {
@@ -78,9 +79,11 @@ enum Commands {
         - remove: Delete a property from one file.\n\
         - find: Search files by property existence or value (read-only).\n\
         - add-to-list: Append values to a list property across file(s).\n\
-        - remove-from-list: Remove values from a list property across file(s).\n\
-        SIDE EFFECTS: 'set', 'remove', 'add-to-list', and 'remove-from-list' modify files on disk. \
-        'read' and 'find' are read-only."
+        - remove-from-list: Remove values from a list property across file(s).\n\n\
+        INPUT: Property name (--name) and file (--file) or scope (--glob) depending on subcommand.\n\
+        SCOPE: 'read', 'set', and 'remove' operate on a single --file. 'find', 'add-to-list', and 'remove-from-list' support --file or --glob.\n\
+        SIDE EFFECTS: 'set', 'remove', 'add-to-list', and 'remove-from-list' modify files on disk. 'read' and 'find' are read-only.\n\
+        USE WHEN: You need to read, write, or search frontmatter properties in one or more files."
     )]
     Property {
         #[command(subcommand)]
@@ -90,8 +93,8 @@ enum Commands {
     #[command(
         long_about = "List outgoing [[wikilinks]] from a file and their resolution status.\n\n\
             INPUT: A single markdown file (--file).\n\
-            OUTPUT: Each [[wikilink]] found in the file body, with a boolean indicating whether \
-            the link target resolves to an existing .md file under --dir.\n\
+            OUTPUT: Each [[wikilink]] found in the file body. The 'path' field is the resolved \
+            file path (string) if the link target exists under --dir, or null if unresolved.\n\
             FILTERS: --unresolved returns only broken links. --resolved returns only valid links. \
             Without either flag, returns all links.\n\
             SIDE EFFECTS: None (read-only).\n\
@@ -110,7 +113,7 @@ enum Commands {
     },
     /// List tags across files — aggregate summary or per-file detail
     #[command(long_about = "List tags across files.\n\n\
-            SUBCOMMANDS:\n\
+            Subcommands:\n\
             - summary (default): aggregate unique tag names with file counts. Tags are compared case-insensitively.\n\
             - list: per-file detail — each file with its tags array.\n\n\
             INPUT: Reads the 'tags' field from YAML frontmatter in matched files.\n\
@@ -123,10 +126,16 @@ enum Commands {
     },
     /// Find, add, or remove tags in file frontmatter
     #[command(long_about = "Find, add, or remove tags in file frontmatter.\n\n\
-        Subcommands: find, add, remove.\n\
+        Subcommands:\n\
+        - find: Search files by tag name or prefix (read-only).\n\
+        - add: Append a tag to file(s) frontmatter.\n\
+        - remove: Delete a tag from file(s) frontmatter.\n\n\
+        INPUT: Tag name (--name) and file (--file) or scope (--glob).\n\
+        SCOPE: 'find', 'add', and 'remove' support --file or --glob; defaults to all .md files.\n\
+        SIDE EFFECTS: 'add' and 'remove' modify files on disk. 'find' is read-only.\n\
+        USE WHEN: You need to find files by tag, or add/remove tags across one or more files.\n\
         NESTED TAG MATCHING: Tag names can be hierarchical (e.g. 'project/backend'). \
-        Searching for a parent tag like 'project' matches all children ('project/backend', 'project/frontend').\n\
-        SIDE EFFECTS: 'add' and 'remove' modify files on disk. 'find' is read-only.")]
+        Searching for a parent tag like 'project' matches all children ('project/backend', 'project/frontend').")]
     Tag {
         #[command(subcommand)]
         action: TagAction,

--- a/src/output.rs
+++ b/src/output.rs
@@ -163,7 +163,7 @@ const OUTLINE_SECTION_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-he
 const OUTLINE_SECTION_WITH_TASKS_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-heading)") [\(.tasks.done)/\(.tasks.total)]\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)""##;
 
 /// `FileOutline`: `{file, properties, sections, tags}`
-const FILE_OUTLINE_FILTER: &str = r##""\(.file)\(if (.tags | length) > 0 then "\n  tags: \(.tags | join(", "))" else "" end)\(if (.properties | length) > 0 then "\n  props: \(.properties | map("\(.name)=\(if (.value | type) == "array" then (.value | join(", ")) else .value end)") | join(", "))" else "" end)\n\(.sections | map("\("#" * .level) \(.heading // "(pre-heading)")\(if .tasks then " [\(.tasks.done)/\(.tasks.total)]" else "" end)\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)") | join("\n"))""##;
+const FILE_OUTLINE_FILTER: &str = r##""\(.file)\(if (.tags | length) > 0 then "\n  tags: \(.tags | join(", "))" else "" end)\(if (.properties | length) > 0 then "\n  props: \(.properties | map("\(.name)=\(if (.value | type) == "array" then "[\(.value | join(", "))]" else .value end)") | join(", "))" else "" end)\n\(.sections | map("\("#" * .level) \(.heading // "(pre-heading)")\(if .tasks then " [\(.tasks.done)/\(.tasks.total)]" else "" end)\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)") | join("\n"))""##;
 
 // ---------------------------------------------------------------------------
 // Shape-based filter lookup

--- a/src/output.rs
+++ b/src/output.rs
@@ -230,8 +230,24 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
 /// Apply a jq filter string to a `serde_json::Value` and return the text output.
 ///
 /// Multiple outputs are joined with newlines. On any error (parse or runtime),
-/// returns a fallback generic representation.
+/// returns `None` (used internally by the text formatter, which has its own fallbacks).
 fn apply_jq_filter(filter_code: &str, value: &serde_json::Value) -> Option<String> {
+    run_jq_filter(filter_code, value).ok()
+}
+
+/// Apply a user-supplied jq filter to a `serde_json::Value`.
+///
+/// Returns `Ok(String)` with newline-joined output values on success, or
+/// `Err(String)` with a human-readable description of the parse or runtime error.
+pub fn apply_jq_filter_result(
+    filter_code: &str,
+    value: &serde_json::Value,
+) -> Result<String, String> {
+    run_jq_filter(filter_code, value)
+}
+
+/// Core jq execution logic shared by `apply_jq_filter` and `apply_jq_filter_result`.
+fn run_jq_filter(filter_code: &str, value: &serde_json::Value) -> Result<String, String> {
     let program = File {
         code: filter_code,
         path: (),
@@ -239,11 +255,13 @@ fn apply_jq_filter(filter_code: &str, value: &serde_json::Value) -> Option<Strin
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
     let arena = Arena::default();
 
-    let modules = loader.load(&arena, program).ok()?;
+    let modules = loader
+        .load(&arena, program)
+        .map_err(|errs| format!("jq parse error: {errs:?}"))?;
     let filter = Compiler::default()
         .with_funs(jaq_std::funs().chain(jaq_json::funs()))
         .compile(modules)
-        .ok()?;
+        .map_err(|errs| format!("jq compile error: {errs:?}"))?;
 
     let input = Val::from(value.clone());
     let inputs = RcIter::new(core::iter::empty());
@@ -259,11 +277,11 @@ fn apply_jq_filter(filter_code: &str, value: &serde_json::Value) -> Option<Strin
                 };
                 parts.push(s);
             }
-            Err(_) => return None,
+            Err(e) => return Err(format!("jq runtime error: {e}")),
         }
     }
 
-    Some(parts.join("\n"))
+    Ok(parts.join("\n"))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/output.rs
+++ b/src/output.rs
@@ -416,7 +416,7 @@ mod tests {
         assert!(out.contains("tags"));
         assert!(out.contains("list"));
         // Array values should be joined with ", " not rendered as JSON
-        assert!(out.contains("rust, cli") || out.contains("rust") && out.contains("cli"));
+        assert!(out.contains("rust, cli") || (out.contains("rust") && out.contains("cli")));
         assert!(!out.contains("[\"rust\""));
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -106,16 +106,17 @@ const PROPERTY_INFO_FILTER: &str = r#""\(.name) (\(.type)): \(if (.value | type)
 const FILE_PROPERTIES_FILTER: &str = r#""\(.path)\n\(.properties | map("  \(.name) (\(.type)): \(if (.value | type) == "array" then (.value | join(", ")) else .value end)") | join("\n"))""#;
 
 /// `PropertySummaryEntry`: `{count, name, type}`
-const PROPERTY_SUMMARY_ENTRY_FILTER: &str = r#""\(.name)\t\(.type)\t\(.count) files""#;
+const PROPERTY_SUMMARY_ENTRY_FILTER: &str =
+    r#""\(.name)\t\(.type)\t\(.count) \(if .count == 1 then "file" else "files" end)""#;
 
 /// `PropertyRemoved`: `{path, removed}`
 const PROPERTY_REMOVED_FILTER: &str = r#""Removed \"\(.removed)\" from \(.path)""#;
 
 /// `PropertyFindResult` without value: `{files, property, total}`
-const PROPERTY_FIND_RESULT_FILTER: &str = r#""\(.property): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
+const PROPERTY_FIND_RESULT_FILTER: &str = r#""\(.property): \(.total) \(if .total == 1 then "file" else "files" end)\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
 
 /// `PropertyFindResult` with value: `{files, property, total, value}`
-const PROPERTY_FIND_RESULT_WITH_VALUE_FILTER: &str = r#""\(.property)=\(.value): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
+const PROPERTY_FIND_RESULT_WITH_VALUE_FILTER: &str = r#""\(.property)=\(.value): \(.total) \(if .total == 1 then "file" else "files" end)\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
 
 /// `PropertyMutationResult`: `{modified, property, skipped, total, values}`
 const PROPERTY_MUTATION_RESULT_FILTER: &str = r#""\(.property): \(.modified | length) modified, \(.skipped | length) skipped\(if (.modified | length) > 0 then "\n  modified: \(.modified | join(", "))" else "" end)\(if (.skipped | length) > 0 then "\n  skipped: \(.skipped | join(", "))" else "" end)""#;
@@ -124,20 +125,17 @@ const PROPERTY_MUTATION_RESULT_FILTER: &str = r#""\(.property): \(.modified | le
 const FILE_TAGS_FILTER: &str = r#""\(.path): \(.tags | join(", "))""#;
 
 /// `TagSummary`: `{tags, total}`
-const TAG_SUMMARY_FILTER: &str =
-    r#""\(.total) unique tags\n\(.tags | map("  \(.name)\t\(.count) files") | join("\n"))""#;
+const TAG_SUMMARY_FILTER: &str = r#""\(.total) unique \(if .total == 1 then "tag" else "tags" end)\n\(.tags | map("  \(.name)\t\(.count) \(if .count == 1 then "file" else "files" end)") | join("\n"))""#;
 
 /// `TagSummaryEntry`: `{count, name}`
-const TAG_SUMMARY_ENTRY_FILTER: &str = r#""\(.name)\t\(.count) files""#;
+const TAG_SUMMARY_ENTRY_FILTER: &str =
+    r#""\(.name)\t\(.count) \(if .count == 1 then "file" else "files" end)""#;
 
 /// `TagFindResult` without value: `{files, tag, total}`
-const TAG_FIND_RESULT_FILTER: &str = r#""\(.tag): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
-
-/// `TagFindResult` with value: `{files, tag, total, value}`
-const TAG_FIND_RESULT_WITH_VALUE_FILTER: &str = r#""\(.tag)=\(.value): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
+const TAG_FIND_RESULT_FILTER: &str = r#""\(.tag): \(.total) \(if .total == 1 then "file" else "files" end)\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
 
 /// `TagMutationResult`: `{modified, skipped, tag, total}`
-const TAG_MUTATION_RESULT_FILTER: &str = r#""Tag \"\(.tag)\": \(.modified | length) modified, \(.skipped | length) skipped\(if (.modified | length) > 0 then "\n  modified: \(.modified | join(", "))" else "" end)\(if (.skipped | length) > 0 then "\n  skipped: \(.skipped | join(", "))" else "" end)""#;
+const TAG_MUTATION_RESULT_FILTER: &str = r#""\(.tag): \(.modified | length) modified, \(.skipped | length) skipped\(if (.modified | length) > 0 then "\n  modified: \(.modified | join(", "))" else "" end)\(if (.skipped | length) > 0 then "\n  skipped: \(.skipped | join(", "))" else "" end)""#;
 
 /// `LinkInfo` — just target: `{target}`
 const LINK_INFO_TARGET_FILTER: &str = r#""  \(.target) (unresolved)""#;
@@ -152,7 +150,7 @@ const LINK_INFO_LABEL_FILTER: &str = r#""  \(.target) (unresolved) [\(.label)]""
 const LINK_INFO_FULL_FILTER: &str = r#""  \(.target) → \(.path) [\(.label)]""#;
 
 /// `FileLinks`: `{links, path}`
-const FILE_LINKS_FILTER: &str = r#""\(.path) — \(.links | length) links\(if (.links | length) > 0 then "\n\(.links | map("  \(.target)\(if .path then " → \(.path)" else " (unresolved)" end)\(if .label then " [\(.label)]" else "" end)") | join("\n"))" else "" end)""#;
+const FILE_LINKS_FILTER: &str = r#""\(.path): \(.links | length) \(if (.links | length) == 1 then "link" else "links" end)\(if (.links | length) > 0 then "\n\(.links | map("  \(.target)\(if .path then " → \(.path)" else " (unresolved)" end)\(if .label then " [\(.label)]" else "" end)") | join("\n"))" else "" end)""#;
 
 /// `TaskCount`: `{done, total}`
 const TASK_COUNT_FILTER: &str = r#""[\(.done)/\(.total)]""#;
@@ -201,9 +199,8 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         "tags,total" => Some(TAG_SUMMARY_FILTER),
         // TagSummaryEntry
         "count,name" => Some(TAG_SUMMARY_ENTRY_FILTER),
-        // TagFindResult (with and without value)
+        // TagFindResult
         "files,tag,total" => Some(TAG_FIND_RESULT_FILTER),
-        "files,tag,total,value" => Some(TAG_FIND_RESULT_WITH_VALUE_FILTER),
         // TagMutationResult
         "modified,skipped,tag,total" => Some(TAG_MUTATION_RESULT_FILTER),
         // LinkInfo variants (optional path and label → 4 combos)
@@ -503,7 +500,16 @@ mod tests {
         let val = json!({"files": ["a.md"], "property": "status", "total": 1, "value": "draft"});
         let out = apply_jq_filter(PROPERTY_FIND_RESULT_WITH_VALUE_FILTER, &val).unwrap();
         assert!(out.contains("status=draft"));
-        assert!(out.contains("1 files"));
+        assert!(out.contains("1 file"));
+        assert!(!out.contains("1 files"));
+    }
+
+    #[test]
+    fn property_find_result_with_value_filter_plural() {
+        let val =
+            json!({"files": ["a.md", "b.md"], "property": "status", "total": 2, "value": "draft"});
+        let out = apply_jq_filter(PROPERTY_FIND_RESULT_WITH_VALUE_FILTER, &val).unwrap();
+        assert!(out.contains("2 files"));
     }
 
     #[test]
@@ -562,7 +568,10 @@ mod tests {
             "total": 2
         });
         let out = apply_jq_filter(TAG_MUTATION_RESULT_FILTER, &val).unwrap();
-        assert!(out.contains("\"rust\""));
+        // Format is now "rust: N modified, N skipped" — no Tag prefix, no quotes
+        assert!(out.contains("rust"));
+        assert!(!out.contains("Tag "));
+        assert!(!out.contains("\"rust\""));
         assert!(out.contains("2 modified"));
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use jaq_core::load::{Arena, File, Loader};
+use jaq_core::load::{self, Arena, File, Loader};
 use jaq_core::{Compiler, Ctx, RcIter};
 use jaq_json::Val;
 use serde::Serialize;
@@ -98,10 +98,11 @@ pub fn format_error(
 
 /// `PropertyInfo`: `{name, type, value}`
 /// When value is an array (list type), join elements with ", " for readability.
-const PROPERTY_INFO_FILTER: &str = r#"  "\(.name) (\(.type)): \(if (.value | type) == "array" then (.value | join(", ")) else .value end)""#;
+const PROPERTY_INFO_FILTER: &str = r#""\(.name) (\(.type)): \(if (.value | type) == "array" then (.value | join(", ")) else .value end)""#;
 
 /// `FileProperties`: `{path, properties}`
 /// List-type values are joined with ", " for readability.
+/// Each property line is indented with two spaces for nesting under the file path.
 const FILE_PROPERTIES_FILTER: &str = r#""\(.path)\n\(.properties | map("  \(.name) (\(.type)): \(if (.value | type) == "array" then (.value | join(", ")) else .value end)") | join("\n"))""#;
 
 /// `PropertySummaryEntry`: `{count, name, type}`
@@ -246,6 +247,39 @@ pub fn apply_jq_filter_result(
     run_jq_filter(filter_code, value)
 }
 
+/// Format a jaq load error (lex/parse/IO) into a human-readable string.
+///
+/// `load::Error<&str>` does not implement `Display`, so we extract the first
+/// error's kind and the offending source snippet manually.
+fn format_load_errors(errs: &load::Errors<&str, ()>) -> String {
+    // errs is Vec<(File<&str, ()>, load::Error<&str>)>
+    // We take the first entry and describe its error kind.
+    for (_file, err) in errs {
+        match err {
+            load::Error::Io(ios) => {
+                if let Some((_path, msg)) = ios.first() {
+                    return format!("jq filter error (IO): {msg}");
+                }
+            }
+            load::Error::Lex(lex_errs) => {
+                if let Some((expect, span)) = lex_errs.first() {
+                    return format!(
+                        "jq filter syntax error: expected {} near {:?}",
+                        expect.as_str(),
+                        span
+                    );
+                }
+            }
+            load::Error::Parse(parse_errs) => {
+                if let Some((expect, _token)) = parse_errs.first() {
+                    return format!("jq filter parse error: expected {}", expect.as_str());
+                }
+            }
+        }
+    }
+    "jq filter error: invalid filter syntax".to_owned()
+}
+
 /// Core jq execution logic shared by `apply_jq_filter` and `apply_jq_filter_result`.
 fn run_jq_filter(filter_code: &str, value: &serde_json::Value) -> Result<String, String> {
     let program = File {
@@ -257,11 +291,20 @@ fn run_jq_filter(filter_code: &str, value: &serde_json::Value) -> Result<String,
 
     let modules = loader
         .load(&arena, program)
-        .map_err(|errs| format!("jq parse error: {errs:?}"))?;
+        .map_err(|errs| format_load_errors(&errs))?;
     let filter = Compiler::default()
         .with_funs(jaq_std::funs().chain(jaq_json::funs()))
         .compile(modules)
-        .map_err(|errs| format!("jq compile error: {errs:?}"))?;
+        .map_err(|errs| {
+            // compile::Errors = Vec<(File<S,P>, Vec<(S, Undefined)>)>
+            // Extract the first undefined symbol name for a useful message.
+            let first = errs.iter().flat_map(|(_file, undefs)| undefs.iter()).next();
+            if let Some((name, undef)) = first {
+                format!("jq filter error: undefined {} {:?}", undef.as_str(), name)
+            } else {
+                "jq filter error: compilation failed".to_owned()
+            }
+        })?;
 
     let input = Val::from(value.clone());
     let inputs = RcIter::new(core::iter::empty());
@@ -303,7 +346,7 @@ fn format_value_as_text(value: &serde_json::Value) -> String {
             {
                 return output;
             }
-            // Fallback: generic key=value lines
+            // Fallback: generic key: value lines
             format_object_generic(map)
         }
         other => format_scalar(other),

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,8 @@
 use std::fmt::Write as _;
 
+use jaq_core::load::{Arena, File, Loader};
+use jaq_core::{Compiler, Ctx, RcIter};
+use jaq_json::Val;
 use serde::Serialize;
 use serde_json::json;
 
@@ -89,7 +92,185 @@ pub fn format_error(
     }
 }
 
-/// Format a JSON value as human-readable text.
+// ---------------------------------------------------------------------------
+// jq filter constants — one per output type
+// ---------------------------------------------------------------------------
+
+/// `PropertyInfo`: `{name, type, value}`
+/// When value is an array (list type), join elements with ", " for readability.
+const PROPERTY_INFO_FILTER: &str = r#"  "\(.name) (\(.type)): \(if (.value | type) == "array" then (.value | join(", ")) else .value end)""#;
+
+/// `FileProperties`: `{path, properties}`
+/// List-type values are joined with ", " for readability.
+const FILE_PROPERTIES_FILTER: &str = r#""\(.path)\n\(.properties | map("  \(.name) (\(.type)): \(if (.value | type) == "array" then (.value | join(", ")) else .value end)") | join("\n"))""#;
+
+/// `PropertySummaryEntry`: `{count, name, type}`
+const PROPERTY_SUMMARY_ENTRY_FILTER: &str = r#""\(.name)\t\(.type)\t\(.count) files""#;
+
+/// `PropertyRemoved`: `{path, removed}`
+const PROPERTY_REMOVED_FILTER: &str = r#""Removed \"\(.removed)\" from \(.path)""#;
+
+/// `PropertyFindResult` without value: `{files, property, total}`
+const PROPERTY_FIND_RESULT_FILTER: &str = r#""\(.property): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
+
+/// `PropertyFindResult` with value: `{files, property, total, value}`
+const PROPERTY_FIND_RESULT_WITH_VALUE_FILTER: &str = r#""\(.property)=\(.value): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
+
+/// `PropertyMutationResult`: `{modified, property, skipped, total, values}`
+const PROPERTY_MUTATION_RESULT_FILTER: &str = r#""\(.property): \(.modified | length) modified, \(.skipped | length) skipped\(if (.modified | length) > 0 then "\n  modified: \(.modified | join(", "))" else "" end)\(if (.skipped | length) > 0 then "\n  skipped: \(.skipped | join(", "))" else "" end)""#;
+
+/// `FileTags`: `{path, tags}`
+const FILE_TAGS_FILTER: &str = r#""\(.path): \(.tags | join(", "))""#;
+
+/// `TagSummary`: `{tags, total}`
+const TAG_SUMMARY_FILTER: &str =
+    r#""\(.total) unique tags\n\(.tags | map("  \(.name)\t\(.count) files") | join("\n"))""#;
+
+/// `TagSummaryEntry`: `{count, name}`
+const TAG_SUMMARY_ENTRY_FILTER: &str = r#""\(.name)\t\(.count) files""#;
+
+/// `TagFindResult` without value: `{files, tag, total}`
+const TAG_FIND_RESULT_FILTER: &str = r#""\(.tag): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
+
+/// `TagFindResult` with value: `{files, tag, total, value}`
+const TAG_FIND_RESULT_WITH_VALUE_FILTER: &str = r#""\(.tag)=\(.value): \(.total) files\(if (.files | length) > 0 then "\n\(.files | map("  \(.)") | join("\n"))" else "" end)""#;
+
+/// `TagMutationResult`: `{modified, skipped, tag, total}`
+const TAG_MUTATION_RESULT_FILTER: &str = r#""Tag \"\(.tag)\": \(.modified | length) modified, \(.skipped | length) skipped\(if (.modified | length) > 0 then "\n  modified: \(.modified | join(", "))" else "" end)\(if (.skipped | length) > 0 then "\n  skipped: \(.skipped | join(", "))" else "" end)""#;
+
+/// `LinkInfo` — just target: `{target}`
+const LINK_INFO_TARGET_FILTER: &str = r#""  \(.target) (unresolved)""#;
+
+/// `LinkInfo` with path: `{path, target}`
+const LINK_INFO_PATH_FILTER: &str = r#""  \(.target) → \(.path)""#;
+
+/// `LinkInfo` with label: `{label, target}`
+const LINK_INFO_LABEL_FILTER: &str = r#""  \(.target) (unresolved) [\(.label)]""#;
+
+/// `LinkInfo` with path and label: `{label, path, target}`
+const LINK_INFO_FULL_FILTER: &str = r#""  \(.target) → \(.path) [\(.label)]""#;
+
+/// `FileLinks`: `{links, path}`
+const FILE_LINKS_FILTER: &str = r#""\(.path) — \(.links | length) links\(if (.links | length) > 0 then "\n\(.links | map("  \(.target)\(if .path then " → \(.path)" else " (unresolved)" end)\(if .label then " [\(.label)]" else "" end)") | join("\n"))" else "" end)""#;
+
+/// `TaskCount`: `{done, total}`
+const TASK_COUNT_FILTER: &str = r#""[\(.done)/\(.total)]""#;
+
+/// `OutlineSection` without tasks: `{code_blocks, heading, level, line, links}`
+const OUTLINE_SECTION_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-heading)")\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)""##;
+
+/// `OutlineSection` with tasks: `{code_blocks, heading, level, line, links, tasks}`
+const OUTLINE_SECTION_WITH_TASKS_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-heading)") [\(.tasks.done)/\(.tasks.total)]\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)""##;
+
+/// `FileOutline`: `{file, properties, sections, tags}`
+const FILE_OUTLINE_FILTER: &str = r##""\(.file)\(if (.tags | length) > 0 then "\n  tags: \(.tags | join(", "))" else "" end)\(if (.properties | length) > 0 then "\n  props: \(.properties | map("\(.name)=\(if (.value | type) == "array" then (.value | join(", ")) else .value end)") | join(", "))" else "" end)\n\(.sections | map("\("#" * .level) \(.heading // "(pre-heading)")\(if .tasks then " [\(.tasks.done)/\(.tasks.total)]" else "" end)\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)") | join("\n"))""##;
+
+// ---------------------------------------------------------------------------
+// Shape-based filter lookup
+// ---------------------------------------------------------------------------
+
+/// Compute a sorted comma-joined key signature from a JSON object's top-level keys.
+fn key_signature(map: &serde_json::Map<String, serde_json::Value>) -> String {
+    let mut keys: Vec<&str> = map.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    keys.join(",")
+}
+
+/// Look up the jq filter for a given key signature.
+///
+/// Returns `None` for unknown shapes, which will fall back to generic formatting.
+fn lookup_filter(key_sig: &str) -> Option<&'static str> {
+    match key_sig {
+        // PropertyInfo
+        "name,type,value" => Some(PROPERTY_INFO_FILTER),
+        // FileProperties
+        "path,properties" => Some(FILE_PROPERTIES_FILTER),
+        // PropertySummaryEntry
+        "count,name,type" => Some(PROPERTY_SUMMARY_ENTRY_FILTER),
+        // PropertyRemoved
+        "path,removed" => Some(PROPERTY_REMOVED_FILTER),
+        // PropertyFindResult (with and without value)
+        "files,property,total" => Some(PROPERTY_FIND_RESULT_FILTER),
+        "files,property,total,value" => Some(PROPERTY_FIND_RESULT_WITH_VALUE_FILTER),
+        // PropertyMutationResult
+        "modified,property,skipped,total,values" => Some(PROPERTY_MUTATION_RESULT_FILTER),
+        // FileTags
+        "path,tags" => Some(FILE_TAGS_FILTER),
+        // TagSummary
+        "tags,total" => Some(TAG_SUMMARY_FILTER),
+        // TagSummaryEntry
+        "count,name" => Some(TAG_SUMMARY_ENTRY_FILTER),
+        // TagFindResult (with and without value)
+        "files,tag,total" => Some(TAG_FIND_RESULT_FILTER),
+        "files,tag,total,value" => Some(TAG_FIND_RESULT_WITH_VALUE_FILTER),
+        // TagMutationResult
+        "modified,skipped,tag,total" => Some(TAG_MUTATION_RESULT_FILTER),
+        // LinkInfo variants (optional path and label → 4 combos)
+        "target" => Some(LINK_INFO_TARGET_FILTER),
+        "path,target" => Some(LINK_INFO_PATH_FILTER),
+        "label,target" => Some(LINK_INFO_LABEL_FILTER),
+        "label,path,target" => Some(LINK_INFO_FULL_FILTER),
+        // FileLinks
+        "links,path" => Some(FILE_LINKS_FILTER),
+        // TaskCount
+        "done,total" => Some(TASK_COUNT_FILTER),
+        // OutlineSection (with and without tasks)
+        "code_blocks,heading,level,line,links" => Some(OUTLINE_SECTION_FILTER),
+        "code_blocks,heading,level,line,links,tasks" => Some(OUTLINE_SECTION_WITH_TASKS_FILTER),
+        // FileOutline
+        "file,properties,sections,tags" => Some(FILE_OUTLINE_FILTER),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// jq filter execution engine
+// ---------------------------------------------------------------------------
+
+/// Apply a jq filter string to a `serde_json::Value` and return the text output.
+///
+/// Multiple outputs are joined with newlines. On any error (parse or runtime),
+/// returns a fallback generic representation.
+fn apply_jq_filter(filter_code: &str, value: &serde_json::Value) -> Option<String> {
+    let program = File {
+        code: filter_code,
+        path: (),
+    };
+    let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
+    let arena = Arena::default();
+
+    let modules = loader.load(&arena, program).ok()?;
+    let filter = Compiler::default()
+        .with_funs(jaq_std::funs().chain(jaq_json::funs()))
+        .compile(modules)
+        .ok()?;
+
+    let input = Val::from(value.clone());
+    let inputs = RcIter::new(core::iter::empty());
+    let ctx = Ctx::new([], &inputs);
+
+    let mut parts = Vec::new();
+    for result in filter.run((ctx, input)) {
+        match result {
+            Ok(val) => {
+                let s = match val {
+                    Val::Str(s) => (*s).clone(),
+                    other => serde_json::Value::from(other).to_string(),
+                };
+                parts.push(s);
+            }
+            Err(_) => return None,
+        }
+    }
+
+    Some(parts.join("\n"))
+}
+
+// ---------------------------------------------------------------------------
+// Text formatting
+// ---------------------------------------------------------------------------
+
+/// Format a JSON value as human-readable text using jq filters where available.
 fn format_value_as_text(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::Array(arr) => arr
@@ -97,13 +278,26 @@ fn format_value_as_text(value: &serde_json::Value) -> String {
             .map(format_value_as_text)
             .collect::<Vec<_>>()
             .join("\n"),
-        serde_json::Value::Object(map) => map
-            .iter()
-            .map(|(k, v)| format!("{k}: {}", format_scalar(v)))
-            .collect::<Vec<_>>()
-            .join("\n"),
+        serde_json::Value::Object(map) => {
+            let sig = key_signature(map);
+            if let Some(filter) = lookup_filter(&sig)
+                && let Some(output) = apply_jq_filter(filter, value)
+            {
+                return output;
+            }
+            // Fallback: generic key=value lines
+            format_object_generic(map)
+        }
         other => format_scalar(other),
     }
+}
+
+/// Generic key: value rendering for unknown object shapes.
+fn format_object_generic(map: &serde_json::Map<String, serde_json::Value>) -> String {
+    map.iter()
+        .map(|(k, v)| format!("{k}: {}", format_scalar(v)))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Format a scalar JSON value as text.
@@ -130,6 +324,9 @@ fn format_scalar(value: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    // --- error formatting ---
 
     #[test]
     fn format_json_error() {
@@ -155,15 +352,286 @@ mod tests {
 
     #[test]
     fn format_json_success() {
-        let val = serde_json::json!({"name": "test", "value": 42});
+        let val = json!({"name": "test", "value": 42});
         let out = format_success(Format::Json, &val);
         assert!(out.contains("\"name\": \"test\""));
     }
 
+    // --- apply_jq_filter ---
+
     #[test]
-    fn format_text_success_object() {
-        let val = serde_json::json!({"name": "test", "value": "hello"});
-        let out = format_success(Format::Text, &val);
-        assert!(out.contains("name: test"));
+    fn apply_jq_filter_simple() {
+        let val = json!({"name": "hello", "count": 3});
+        let result = apply_jq_filter(r#""\(.name): \(.count)""#, &val);
+        assert_eq!(result.as_deref(), Some("hello: 3"));
+    }
+
+    #[test]
+    fn apply_jq_filter_array_map() {
+        let val = json!(["a", "b", "c"]);
+        let result = apply_jq_filter(".[]", &val);
+        assert_eq!(result.as_deref(), Some("a\nb\nc"));
+    }
+
+    #[test]
+    fn apply_jq_filter_invalid_returns_none() {
+        let val = json!({"x": 1});
+        let result = apply_jq_filter("this is not valid jq %%%", &val);
+        assert!(result.is_none());
+    }
+
+    // --- property type filters ---
+
+    #[test]
+    fn property_info_filter() {
+        let val = json!({"name": "title", "type": "text", "value": "My Note"});
+        let out = apply_jq_filter(PROPERTY_INFO_FILTER, &val).unwrap();
+        assert!(out.contains("title"));
+        assert!(out.contains("text"));
+        assert!(out.contains("My Note"));
+    }
+
+    #[test]
+    fn property_info_filter_list_value() {
+        let val = json!({"name": "tags", "type": "list", "value": ["rust", "cli"]});
+        let out = apply_jq_filter(PROPERTY_INFO_FILTER, &val).unwrap();
+        assert!(out.contains("tags"));
+        assert!(out.contains("list"));
+        // Array values should be joined with ", " not rendered as JSON
+        assert!(out.contains("rust, cli") || out.contains("rust") && out.contains("cli"));
+        assert!(!out.contains("[\"rust\""));
+    }
+
+    #[test]
+    fn file_properties_filter() {
+        let val = json!({
+            "path": "notes/a.md",
+            "properties": [
+                {"name": "title", "type": "text", "value": "A"},
+                {"name": "status", "type": "text", "value": "draft"}
+            ]
+        });
+        let out = apply_jq_filter(FILE_PROPERTIES_FILTER, &val).unwrap();
+        assert!(out.contains("notes/a.md"));
+        assert!(out.contains("title"));
+        assert!(out.contains("status"));
+        assert!(out.contains("draft"));
+    }
+
+    #[test]
+    fn property_summary_entry_filter() {
+        let val = json!({"count": 7, "name": "title", "type": "text"});
+        let out = apply_jq_filter(PROPERTY_SUMMARY_ENTRY_FILTER, &val).unwrap();
+        assert!(out.contains("title"));
+        assert!(out.contains("text"));
+        assert!(out.contains("7 files"));
+    }
+
+    #[test]
+    fn property_find_result_filter() {
+        let val = json!({"files": ["a.md", "b.md"], "property": "status", "total": 2});
+        let out = apply_jq_filter(PROPERTY_FIND_RESULT_FILTER, &val).unwrap();
+        assert!(out.contains("status"));
+        assert!(out.contains("2 files"));
+        assert!(out.contains("a.md"));
+        assert!(out.contains("b.md"));
+    }
+
+    #[test]
+    fn property_find_result_with_value_filter() {
+        let val = json!({"files": ["a.md"], "property": "status", "total": 1, "value": "draft"});
+        let out = apply_jq_filter(PROPERTY_FIND_RESULT_WITH_VALUE_FILTER, &val).unwrap();
+        assert!(out.contains("status=draft"));
+        assert!(out.contains("1 files"));
+    }
+
+    #[test]
+    fn property_mutation_result_filter() {
+        let val = json!({
+            "modified": ["a.md"],
+            "property": "status",
+            "skipped": [],
+            "total": 1,
+            "values": ["draft"]
+        });
+        let out = apply_jq_filter(PROPERTY_MUTATION_RESULT_FILTER, &val).unwrap();
+        assert!(out.contains("status"));
+        assert!(out.contains("1 modified"));
+        assert!(out.contains("0 skipped"));
+    }
+
+    // --- tag type filters ---
+
+    #[test]
+    fn file_tags_filter() {
+        let val = json!({"path": "note.md", "tags": ["rust", "cli"]});
+        let out = apply_jq_filter(FILE_TAGS_FILTER, &val).unwrap();
+        assert!(out.contains("note.md"));
+        assert!(out.contains("rust"));
+        assert!(out.contains("cli"));
+    }
+
+    #[test]
+    fn tag_summary_filter() {
+        let val = json!({
+            "tags": [{"name": "rust", "count": 3}, {"name": "cli", "count": 1}],
+            "total": 2
+        });
+        let out = apply_jq_filter(TAG_SUMMARY_FILTER, &val).unwrap();
+        assert!(out.contains("2 unique tags"));
+        assert!(out.contains("rust"));
+        assert!(out.contains("3 files"));
+    }
+
+    #[test]
+    fn tag_find_result_filter() {
+        let val = json!({"files": ["a.md", "b.md"], "tag": "rust", "total": 2});
+        let out = apply_jq_filter(TAG_FIND_RESULT_FILTER, &val).unwrap();
+        assert!(out.contains("rust"));
+        assert!(out.contains("2 files"));
+        assert!(out.contains("a.md"));
+    }
+
+    #[test]
+    fn tag_mutation_result_filter() {
+        let val = json!({
+            "modified": ["a.md", "b.md"],
+            "skipped": [],
+            "tag": "rust",
+            "total": 2
+        });
+        let out = apply_jq_filter(TAG_MUTATION_RESULT_FILTER, &val).unwrap();
+        assert!(out.contains("\"rust\""));
+        assert!(out.contains("2 modified"));
+    }
+
+    // --- link type filters ---
+
+    #[test]
+    fn link_info_target_only_filter() {
+        let val = json!({"target": "broken-link"});
+        let out = apply_jq_filter(LINK_INFO_TARGET_FILTER, &val).unwrap();
+        assert!(out.contains("broken-link"));
+        assert!(out.contains("unresolved"));
+    }
+
+    #[test]
+    fn link_info_with_path_filter() {
+        let val = json!({"path": "note-b.md", "target": "note-b"});
+        let out = apply_jq_filter(LINK_INFO_PATH_FILTER, &val).unwrap();
+        assert!(out.contains("note-b"));
+        assert!(out.contains("note-b.md"));
+    }
+
+    #[test]
+    fn file_links_filter() {
+        let val = json!({
+            "links": [
+                {"target": "note-b", "path": "note-b.md"},
+                {"target": "broken"}
+            ],
+            "path": "note-a.md"
+        });
+        let out = apply_jq_filter(FILE_LINKS_FILTER, &val).unwrap();
+        assert!(out.contains("note-a.md"));
+        assert!(out.contains("2 links"));
+        assert!(out.contains("note-b.md"));
+        assert!(out.contains("unresolved"));
+    }
+
+    // --- outline type filters ---
+
+    #[test]
+    fn task_count_filter() {
+        let val = json!({"done": 3, "total": 5});
+        let out = apply_jq_filter(TASK_COUNT_FILTER, &val).unwrap();
+        assert_eq!(out, "[3/5]");
+    }
+
+    #[test]
+    fn outline_section_filter() {
+        let val = json!({
+            "code_blocks": [],
+            "heading": "Introduction",
+            "level": 1,
+            "line": 5,
+            "links": ["[[other]]"]
+        });
+        let out = apply_jq_filter(OUTLINE_SECTION_FILTER, &val).unwrap();
+        assert!(out.contains("#"));
+        assert!(out.contains("Introduction"));
+        assert!(out.contains("[[other]]"));
+    }
+
+    #[test]
+    fn outline_section_with_tasks_filter() {
+        let val = json!({
+            "code_blocks": [],
+            "heading": "Tasks",
+            "level": 2,
+            "line": 10,
+            "links": [],
+            "tasks": {"done": 2, "total": 4}
+        });
+        let out = apply_jq_filter(OUTLINE_SECTION_WITH_TASKS_FILTER, &val).unwrap();
+        assert!(out.contains("##"));
+        assert!(out.contains("Tasks"));
+        assert!(out.contains("[2/4]"));
+    }
+
+    #[test]
+    fn file_outline_filter() {
+        let val = json!({
+            "file": "note.md",
+            "properties": [{"name": "title", "type": "text", "value": "My Note"}],
+            "sections": [
+                {
+                    "code_blocks": [],
+                    "heading": "Intro",
+                    "level": 1,
+                    "line": 5,
+                    "links": []
+                }
+            ],
+            "tags": ["rust", "cli"]
+        });
+        let out = apply_jq_filter(FILE_OUTLINE_FILTER, &val).unwrap();
+        assert!(out.contains("note.md"));
+        assert!(out.contains("rust"));
+        assert!(out.contains("cli"));
+        assert!(out.contains("# Intro"));
+    }
+
+    // --- format_value_as_text integration ---
+
+    #[test]
+    fn format_value_as_text_uses_filter_for_known_shape() {
+        let val = json!({"path": "note.md", "tags": ["rust"]});
+        let out = format_value_as_text(&val);
+        assert!(out.contains("note.md"));
+        assert!(out.contains("rust"));
+        // Should NOT look like "path: note.md" (that's the generic fallback)
+        assert!(!out.contains("path: note.md"));
+    }
+
+    #[test]
+    fn format_value_as_text_falls_back_for_unknown_shape() {
+        let val = json!({"foo": "bar", "baz": 42});
+        let out = format_value_as_text(&val);
+        // Generic fallback: key: value
+        assert!(out.contains("foo: bar") || out.contains("baz: 42"));
+    }
+
+    #[test]
+    fn format_value_as_text_array_of_typed_objects() {
+        let val = json!([
+            {"path": "a.md", "tags": ["rust"]},
+            {"path": "b.md", "tags": ["cli"]}
+        ]);
+        let out = format_value_as_text(&val);
+        assert!(out.contains("a.md"));
+        assert!(out.contains("b.md"));
+        assert!(out.contains("rust"));
+        assert!(out.contains("cli"));
     }
 }

--- a/tests/e2e_jq.rs
+++ b/tests/e2e_jq.rs
@@ -118,6 +118,11 @@ fn jq_with_format_text_errors() {
         .unwrap();
 
     assert!(!output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit code 2 (usage error)"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("--jq cannot be combined with --format text"),

--- a/tests/e2e_jq.rs
+++ b/tests/e2e_jq.rs
@@ -102,6 +102,61 @@ fn jq_works_on_property_find() {
 }
 
 // ---------------------------------------------------------------------------
+// --jq on links and outline commands
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jq_works_on_links() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "source.md",
+        "---\ntitle: Source\n---\nSee [[target]] and [[other]].\n",
+    );
+    write_md(tmp.path(), "target.md", "# Target\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", ".links | length"])
+        .args(["links", "--file", "source.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "2", "expected 2 links, got: {stdout}");
+}
+
+#[test]
+fn jq_works_on_outline() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "doc.md",
+        "# Introduction\n\nSome text.\n\n## Details\n\nMore text.\n\n### Sub\n\nDeep.\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", ".sections | length"])
+        .args(["outline", "--file", "doc.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "3", "expected 3 sections, got: {stdout}");
+}
+
+// ---------------------------------------------------------------------------
 // --jq conflicts with --format text
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e_jq.rs
+++ b/tests/e2e_jq.rs
@@ -168,9 +168,14 @@ fn jq_invalid_filter_exits_nonzero() {
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // Should mention "jq" and give some indication of a syntax/filter problem
     assert!(
-        stderr.contains("jq") || stderr.contains("Error"),
-        "expected error message, got: {stderr}"
+        stderr.contains("jq"),
+        "expected 'jq' in error message, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("syntax") || stderr.contains("filter") || stderr.contains("parse"),
+        "expected description of what went wrong, got: {stderr}"
     );
 }
 
@@ -178,7 +183,7 @@ fn jq_invalid_filter_exits_nonzero() {
 fn jq_runtime_error_exits_nonzero() {
     let tmp = setup_vault();
 
-    // .no_such_field on a non-object path that causes a type error (e.g. trying to iterate null)
+    // Explicit jq runtime error raised via error("deliberate") to verify non-zero exit on runtime failure
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", "error(\"deliberate\")"])
@@ -188,9 +193,41 @@ fn jq_runtime_error_exits_nonzero() {
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // Should mention "jq" and include the error value "deliberate"
     assert!(
-        stderr.contains("jq") || stderr.contains("Error"),
-        "expected error message, got: {stderr}"
+        stderr.contains("jq"),
+        "expected 'jq' in error message, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("deliberate"),
+        "expected the raised error value 'deliberate' in output, got: {stderr}"
+    );
+}
+
+#[test]
+fn jq_filter_error_is_json_when_format_json() {
+    let tmp = setup_vault();
+
+    // With --format json (the default), jq errors should be emitted as structured JSON
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["--jq", "error(\"structured-error\")"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(&stderr)
+        .unwrap_or_else(|_| panic!("expected JSON on stderr for --format json, got: {stderr}"));
+    assert!(
+        parsed.get("error").is_some(),
+        "expected 'error' field in JSON error, got: {stderr}"
+    );
+    assert!(
+        parsed.get("cause").is_some(),
+        "expected 'cause' field in JSON error, got: {stderr}"
     );
 }
 

--- a/tests/e2e_jq.rs
+++ b/tests/e2e_jq.rs
@@ -1,0 +1,215 @@
+mod common;
+
+use common::{hyalo, write_md, write_tagged};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn setup_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
+    write_tagged(tmp.path(), "b.md", &["rust", "iteration"]);
+    write_md(tmp.path(), "c.md", "No frontmatter.\n");
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// Basic filter application
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jq_extracts_total_from_tags_summary() {
+    let tmp = setup_vault();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", ".total"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "3");
+}
+
+#[test]
+fn jq_maps_tag_names_to_array() {
+    let tmp = setup_vault();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", "[.tags[].name] | sort | join(\", \")"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "cli, iteration, rust");
+}
+
+#[test]
+fn jq_works_on_properties_command() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Hello\nstatus: draft\n---\n# Body\n",
+    );
+
+    // `properties summary` returns an array of {count, name, type} objects.
+    // Extract just the property names and sort them.
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", "[.[].name] | sort | join(\", \")"])
+        .args(["properties", "summary"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "status, title");
+}
+
+#[test]
+fn jq_works_on_property_find() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\nstatus: draft\n---\n");
+    write_md(tmp.path(), "b.md", "---\nstatus: done\n---\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", ".files[]"])
+        .args(["property", "find", "--name", "status", "--value", "draft"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.trim().contains("a.md"), "got: {stdout}");
+    assert!(!stdout.contains("b.md"));
+}
+
+// ---------------------------------------------------------------------------
+// --jq conflicts with --format text
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jq_with_format_text_errors() {
+    let tmp = setup_vault();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "text"])
+        .args(["--jq", ".total"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--jq cannot be combined with --format text"),
+        "expected conflict error, got: {stderr}"
+    );
+}
+
+#[test]
+fn jq_with_format_json_works() {
+    let tmp = setup_vault();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["--jq", ".total"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "3");
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jq_invalid_filter_exits_nonzero() {
+    let tmp = setup_vault();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", "this is not %%% valid jq"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("jq") || stderr.contains("Error"),
+        "expected error message, got: {stderr}"
+    );
+}
+
+#[test]
+fn jq_runtime_error_exits_nonzero() {
+    let tmp = setup_vault();
+
+    // .no_such_field on a non-object path that causes a type error (e.g. trying to iterate null)
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", "error(\"deliberate\")"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("jq") || stderr.contains("Error"),
+        "expected error message, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Filter producing multiple output values
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jq_multiple_outputs_joined_by_newline() {
+    let tmp = setup_vault();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--jq", ".tags[].name"])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    // 3 tags, each on its own line
+    assert_eq!(lines.len(), 3, "expected 3 lines, got: {stdout}");
+    assert!(lines.contains(&"rust"));
+    assert!(lines.contains(&"cli"));
+    assert!(lines.contains(&"iteration"));
+}

--- a/tests/e2e_links.rs
+++ b/tests/e2e_links.rs
@@ -149,7 +149,8 @@ fn links_text_format() {
         .args(["links", "--file", "note-a.md"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("target=note-b"));
+        .stdout(predicates::str::contains("note-b"))
+        .stdout(predicates::str::contains("note-a.md"));
 }
 
 #[test]
@@ -210,7 +211,8 @@ fn links_unresolved_text_format() {
         .args(["links", "--file", "note-a.md", "--unresolved"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("target=nonexistent"));
+        .stdout(predicates::str::contains("nonexistent"))
+        .stdout(predicates::str::contains("unresolved"));
 }
 
 #[test]
@@ -260,7 +262,8 @@ fn links_resolved_text_format() {
         .args(["links", "--file", "note-a.md", "--resolved"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("target=note-b"));
+        .stdout(predicates::str::contains("note-b"))
+        .stdout(predicates::str::contains("note-b.md"));
 }
 
 #[test]

--- a/tests/e2e_outline.rs
+++ b/tests/e2e_outline.rs
@@ -284,8 +284,16 @@ fn outline_text_format() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    // Text format should contain key: value pairs
-    assert!(stdout.contains("file:"));
+    // File path appears at the top
+    assert!(stdout.contains("note.md"));
+    // Tags appear in output
+    assert!(stdout.contains("rust"));
+    assert!(stdout.contains("cli"));
+    // Headings appear with # prefix
+    assert!(stdout.contains("# Introduction"));
+    assert!(stdout.contains("## Tasks"));
+    // Task counts appear
+    assert!(stdout.contains("[1/2]"));
 }
 
 // --- Glob no match ---

--- a/tests/e2e_properties.rs
+++ b/tests/e2e_properties.rs
@@ -341,7 +341,55 @@ status: draft
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    // Text format outputs key: value lines
-    assert!(stdout.contains("path:"));
-    assert!(stdout.contains("properties:"));
+    // File path header
+    assert!(stdout.contains("note.md"));
+    // Properties are listed with name (type): value format
+    assert!(stdout.contains("title"));
+    assert!(stdout.contains("Hello"));
+    assert!(stdout.contains("status"));
+    assert!(stdout.contains("draft"));
+}
+
+#[test]
+fn properties_summary_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+status: draft
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+"),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "properties",
+            "summary",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Properties listed with name, type, and count
+    assert!(stdout.contains("title"));
+    assert!(stdout.contains("text"));
+    assert!(stdout.contains("2 files"));
+    assert!(stdout.contains("status"));
 }

--- a/tests/e2e_property_read.rs
+++ b/tests/e2e_property_read.rs
@@ -205,7 +205,7 @@ fn read_text_format() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    // Text format should contain the property name and value
-    assert!(stdout.contains("name:"));
+    // Text format shows: name (type): value
+    assert!(stdout.contains("title"));
     assert!(stdout.contains("My Note"));
 }

--- a/tests/e2e_property_remove.rs
+++ b/tests/e2e_property_remove.rs
@@ -149,6 +149,42 @@ priority: 5
 }
 
 #[test]
+fn property_remove_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!("---
+title: Test
+status: active
+---
+# Body
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "text"])
+        .args([
+            "property", "remove", "--name", "status", "--file", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // PropertyRemoved text format: "Removed "status" from note.md"
+    assert!(
+        stdout.contains("Removed"),
+        "expected 'Removed', got: {stdout}"
+    );
+    assert!(
+        stdout.contains("status"),
+        "expected property name, got: {stdout}"
+    );
+}
+
+#[test]
 fn remove_last_property() {
     let tmp = TempDir::new().unwrap();
     write_md(

--- a/tests/e2e_property_set.rs
+++ b/tests/e2e_property_set.rs
@@ -255,6 +255,68 @@ Some paragraph content.
 }
 
 #[test]
+fn property_set_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Test
+---
+# Body
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "text"])
+        .args([
+            "property", "set", "--name", "status", "--value", "done", "--file", "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // PropertyInfo text format: "status (text): done"
+    assert!(
+        stdout.contains("status"),
+        "expected property name, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("text"),
+        "expected property type, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("done"),
+        "expected property value, got: {stdout}"
+    );
+}
+
+#[test]
+fn set_missing_file_errors() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "property",
+            "set",
+            "--name",
+            "status",
+            "--value",
+            "done",
+            "--file",
+            "nonexistent.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
 fn set_preserves_other_properties() {
     let tmp = TempDir::new().unwrap();
     write_md(

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -167,7 +167,8 @@ fn tags_summary_text_format() {
     assert!(stdout.contains("rust"));
     assert!(stdout.contains("2 files"));
     assert!(stdout.contains("cli"));
-    assert!(stdout.contains("1 files"));
+    assert!(stdout.contains("1 file"));
+    assert!(!stdout.contains("1 files"));
 }
 
 // ---------------------------------------------------------------------------
@@ -516,7 +517,8 @@ fn tag_find_text_format() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     // Tag name and file count shown
     assert!(stdout.contains("rust"));
-    assert!(stdout.contains("1 files"));
+    assert!(stdout.contains("1 file"));
+    assert!(!stdout.contains("1 files"));
     // Matching file listed
     assert!(stdout.contains("note.md"));
 }

--- a/tests/e2e_tags.rs
+++ b/tests/e2e_tags.rs
@@ -145,6 +145,7 @@ fn tags_summary_empty_vault() {
 fn tags_summary_text_format() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
+    write_tagged(tmp.path(), "other.md", &["rust", "cli"]);
 
     let output = hyalo()
         .args([
@@ -160,7 +161,13 @@ fn tags_summary_text_format() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
+    // Shows total unique tags
+    assert!(stdout.contains("unique tags"));
+    // Shows tag names with file counts
     assert!(stdout.contains("rust"));
+    assert!(stdout.contains("2 files"));
+    assert!(stdout.contains("cli"));
+    assert!(stdout.contains("1 files"));
 }
 
 // ---------------------------------------------------------------------------
@@ -270,7 +277,7 @@ fn tags_list_file_without_frontmatter() {
 #[test]
 fn tags_list_text_format() {
     let tmp = TempDir::new().unwrap();
-    write_tagged(tmp.path(), "note.md", &["rust"]);
+    write_tagged(tmp.path(), "note.md", &["rust", "cli"]);
 
     let output = hyalo()
         .args([
@@ -288,8 +295,10 @@ fn tags_list_text_format() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
+    // File path and tags shown together
     assert!(stdout.contains("note.md"));
     assert!(stdout.contains("rust"));
+    assert!(stdout.contains("cli"));
 }
 
 #[test]
@@ -487,6 +496,7 @@ fn tag_find_case_insensitive() {
 fn tag_find_text_format() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
+    write_tagged(tmp.path(), "other.md", &["cli"]);
 
     let output = hyalo()
         .args([
@@ -504,6 +514,10 @@ fn tag_find_text_format() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
+    // Tag name and file count shown
+    assert!(stdout.contains("rust"));
+    assert!(stdout.contains("1 files"));
+    // Matching file listed
     assert!(stdout.contains("note.md"));
 }
 
@@ -879,7 +893,39 @@ fn tag_remove_text_format() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
+    // Tag name shown in output
     assert!(stdout.contains("rust"));
+    // Modified count shown
+    assert!(stdout.contains("1 modified"));
+}
+
+#[test]
+fn tag_add_text_format() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "note.md", &["cli"]);
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "text",
+            "tag",
+            "add",
+            "--name",
+            "rust",
+            "--file",
+            "note.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Tag name shown in output
+    assert!(stdout.contains("rust"));
+    // Modified count shown
+    assert!(stdout.contains("1 modified"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add jaq-based text output engine (`--format text`) for all commands — human-readable output using jq filters dispatched by JSON key signature
- Add `--jq <FILTER>` global flag allowing users to apply custom jq expressions to any command's JSON output
- Error on `--jq` + `--format text` conflict with a helpful message
- Bracket list values in outline properties line to avoid ambiguity
- Add --help-all backlog item and CLI structured output patterns research

## Test plan
- [x] 9 e2e tests for `--jq` flag: scalar extraction, array mapping, multi-output, property commands, conflict error, invalid filter, runtime error
- [x] Text format e2e tests for properties, tags, links, outline commands
- [x] 246 unit tests + 163 e2e tests all passing
- [x] `cargo fmt` / `cargo clippy` / `cargo test` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)