### PR TITLE
Add scanner support for Obsidian %%comment%% blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ hyalo task toggle --file FILE --line N
 hyalo task set-status --file FILE --line N --status CHAR
 ```
 
-Tasks are markdown checkboxes (`- [ ]`, `- [x]`, `- [/]`, etc.) found in the file body. Checkboxes inside fenced code blocks are ignored.
+Tasks are markdown checkboxes (`- [ ]`, `- [x]`, `- [/]`, etc.) found in the file body. Checkboxes inside fenced code blocks and `%%comment%%` blocks are ignored.
 
 ### Summary
 

--- a/hyalo-knowledgebase/backlog/comment-block-handling.md
+++ b/hyalo-knowledgebase/backlog/comment-block-handling.md
@@ -2,7 +2,7 @@
 date: 2026-03-21
 origin: iteration-02 known limitation, DEC-015
 priority: high
-status: ready
+status: done
 tags:
 - backlog
 - scanner

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -103,6 +103,8 @@ Fields (`path`, `hint`, `cause`) are omitted when not applicable. The `cause` fi
 
 **Why:** Adding comment tracking is straightforward (similar to fenced code block tracking) but wasn't needed for the initial link implementation. Documented as a known limitation. Can be added to the scanner in a future iteration since we control all the code.
 
+**Update (2026-03-21):** Resolved in iteration 10. Both block (`%%...%%`) and inline (`%%text%%`) comments are now tracked by the scanner.
+
 ## DEC-016: Single-File Only for `links` and `unresolved` Commands (2026-03-20)
 
 **Decision:** Both `links` and `unresolved` require exactly one file via `--file`. No vault-wide mode, no glob support.

--- a/hyalo-knowledgebase/iterations/iteration-10-comment-block-handling.md
+++ b/hyalo-knowledgebase/iterations/iteration-10-comment-block-handling.md
@@ -1,0 +1,43 @@
+---
+title: "Iteration 10: Comment Block Handling"
+type: iteration
+date: 2026-03-21
+tags:
+  - iteration
+  - scanner
+  - comments
+status: completed
+branch: iter-10/comment-block-handling
+---
+
+# Iteration 10: Comment Block Handling
+
+## Goal
+
+Add Obsidian `%%comment%%` block and inline comment support to the scanner so that links, tasks, and headings inside comments are correctly skipped.
+
+## Tasks
+
+- [x] Add `is_comment_fence` function to detect `%%` block boundaries
+- [x] Add `strip_inline_comments` function to strip `%%text%%` inline comments
+- [x] Modify `dispatch_body_line` to track comment state (multi-visitor scanner)
+- [x] Modify `scan_reader` to track comment state (simple callback scanner)
+- [x] Modify `read_task` in tasks.rs to track comment state
+- [x] Add unit tests for all new and modified functions
+- [x] Add e2e tests for links and tasks with comment blocks
+- [x] Pass all quality gates (fmt, clippy, test)
+- [x] Dogfood with hyalo CLI
+
+## Design
+
+Follows the same pattern as fenced code block tracking:
+
+- **Priority order:** code fence > comment block > normal line
+- **Block comments:** `%%` alone on a line opens/closes (tracked via `in_comment: bool`)
+- **Inline comments:** `%%text%%` stripped with spaces (like `strip_inline_code`)
+- **No visitor events** for comments — they are invisible (unlike code fences which have open/close callbacks)
+
+## References
+
+- [[decision-log#DEC-015]]: originally deferred, now resolved
+- [[backlog/comment-block-handling]]: backlog item (status: done)

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,7 +298,7 @@ enum Commands {
         long_about = "List tasks (checkboxes) across one or more markdown files.\n\n\
             INPUT: Reads .md files filtered by --file or --glob (or all .md files if omitted).\n\
             OUTPUT: Array of objects, each with 'file', 'tasks' array, and 'total' count. Each task has 'line', 'status', 'text', and 'done' fields.\n\
-            SCOPE: Scans all .md files under --dir unless narrowed with --file or --glob. Tasks inside fenced code blocks are skipped.\n\
+            SCOPE: Scans all .md files under --dir unless narrowed with --file or --glob. Tasks inside fenced code blocks and %%comment%% blocks are skipped.\n\
             SIDE EFFECTS: None (read-only).\n\
             USE WHEN: You need to find, list, or count tasks across your vault."
     )]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -263,9 +263,9 @@ pub fn strip_inline_comments(line: &str) -> Cow<'_, str> {
     if result == bytes {
         Cow::Borrowed(line)
     } else {
-        // Only ASCII bytes (percent signs and comment content) were replaced
-        // with ASCII spaces, so the result is always valid UTF-8.
-        Cow::Owned(String::from_utf8(result).expect("replacing ASCII with spaces preserves UTF-8"))
+        // Comment regions are overwritten with ASCII spaces, regardless of their
+        // original contents, so the resulting byte sequence is always valid UTF-8.
+        Cow::Owned(String::from_utf8(result).expect("overwriting comment bytes with spaces preserves UTF-8"))
     }
 }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -36,8 +36,9 @@ where
     let mut line_num: usize = 0;
     let mut buf = String::new();
 
-    // Track fenced code block state — declared early so it's in scope for the first-line check
+    // Track fenced code block and comment block state
     let mut fence: Option<(char, usize)> = None; // (fence_char, fence_count)
+    let mut in_comment = false;
 
     // Read first line to check for frontmatter
     buf.clear();
@@ -50,11 +51,14 @@ where
     let trimmed = buf.trim_end_matches(['\n', '\r']);
     let fm_lines = frontmatter::skip_frontmatter(&mut reader, trimmed)?;
     if fm_lines == 0 {
-        // First line is not frontmatter — check if it opens a code fence
+        // First line is not frontmatter — check if it opens a code fence or comment
         if let Some(f) = detect_opening_fence(trimmed) {
             fence = Some(f);
+        } else if is_comment_fence(trimmed) {
+            in_comment = true;
         } else {
             let cleaned = strip_inline_code(trimmed);
+            let cleaned = strip_inline_comments(&cleaned);
             if visitor(cleaned.as_ref(), line_num) == ScanAction::Stop {
                 return Ok(());
             }
@@ -72,7 +76,7 @@ where
         line_num += 1;
         let line = buf.trim_end_matches(['\n', '\r']);
 
-        // Check for fenced code block boundaries
+        // Check for fenced code block boundaries (highest priority)
         if let Some((fence_char, fence_count)) = fence {
             if is_closing_fence(line, fence_char, fence_count) {
                 fence = None;
@@ -80,13 +84,27 @@ where
             continue; // skip lines inside code blocks
         }
 
+        // Check for comment block boundaries
+        if in_comment {
+            if is_comment_fence(line) {
+                in_comment = false;
+            }
+            continue; // skip lines inside comment blocks
+        }
+
         if let Some(f) = detect_opening_fence(line) {
             fence = Some(f);
             continue;
         }
 
-        // Normal text line — strip inline code spans before passing to visitor
+        if is_comment_fence(line) {
+            in_comment = true;
+            continue;
+        }
+
+        // Normal text line — strip inline code spans and comments before passing to visitor
         let cleaned = strip_inline_code(line);
+        let cleaned = strip_inline_comments(&cleaned);
         if visitor(cleaned.as_ref(), line_num) == ScanAction::Stop {
             return Ok(());
         }
@@ -181,6 +199,74 @@ pub fn strip_inline_code(line: &str) -> Cow<'_, str> {
     // Only ASCII bytes (backticks and code content) were replaced with ASCII spaces,
     // so the result is always valid UTF-8.
     Cow::Owned(String::from_utf8(result).expect("replacing ASCII with spaces preserves UTF-8"))
+}
+
+/// Check if a line is an Obsidian comment fence (`%%` on its own line).
+///
+/// Returns `true` when the trimmed line is exactly `%%`. Lines containing
+/// `%%` with other content (e.g. inline comments like `%%text%%`) are NOT
+/// comment fences.
+pub(crate) fn is_comment_fence(line: &str) -> bool {
+    line.trim() == "%%"
+}
+
+/// Strip inline Obsidian comments (`%%text%%`) from a line, replacing them
+/// (markers inclusive) with spaces to preserve byte positions for downstream
+/// parsing.
+///
+/// Returns a borrowed reference when no `%%` is present (zero allocation).
+/// Unmatched opening `%%` is treated as literal text.
+pub fn strip_inline_comments(line: &str) -> Cow<'_, str> {
+    if !line.contains("%%") {
+        return Cow::Borrowed(line);
+    }
+
+    let bytes = line.as_bytes();
+    let len = bytes.len();
+    let mut result = bytes.to_vec();
+    let mut i = 0;
+
+    while i + 1 < len {
+        if bytes[i] == b'%' && bytes[i + 1] == b'%' {
+            let open = i;
+            i += 2; // skip opening %%
+
+            // If the rest of the line is only whitespace, this is a block fence
+            // marker, not an inline comment — leave it alone.
+            if line[i..].trim().is_empty() {
+                break;
+            }
+
+            // Scan for closing %%
+            let mut found_close = false;
+            while i + 1 < len {
+                if bytes[i] == b'%' && bytes[i + 1] == b'%' {
+                    // Replace open..=i+1 with spaces
+                    for b in &mut result[open..i + 2] {
+                        *b = b' ';
+                    }
+                    i += 2;
+                    found_close = true;
+                    break;
+                }
+                i += 1;
+            }
+            if !found_close {
+                // No closing %% — treat the opening as literal
+                i = open + 2;
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    if result == bytes {
+        Cow::Borrowed(line)
+    } else {
+        // Only ASCII bytes (percent signs and comment content) were replaced
+        // with ASCII spaces, so the result is always valid UTF-8.
+        Cow::Owned(String::from_utf8(result).expect("replacing ASCII with spaces preserves UTF-8"))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -319,6 +405,7 @@ pub fn scan_reader_multi<R: BufRead>(
 
     // --- Phase 2: Body ---
     let mut fence: Option<(char, usize)> = None;
+    let mut in_comment = false;
 
     if fm_lines > 0 {
         line_num = fm_lines;
@@ -326,7 +413,14 @@ pub fn scan_reader_multi<R: BufRead>(
 
     // If the first line was not frontmatter, process it as a body line
     if fm_lines == 0 {
-        dispatch_body_line(&first_trimmed, line_num, visitors, &mut active, &mut fence);
+        dispatch_body_line(
+            &first_trimmed,
+            line_num,
+            visitors,
+            &mut active,
+            &mut fence,
+            &mut in_comment,
+        );
         if !active.iter().any(|&a| a) {
             return Ok(());
         }
@@ -341,7 +435,14 @@ pub fn scan_reader_multi<R: BufRead>(
         line_num += 1;
         let line = buf.trim_end_matches(['\n', '\r']);
 
-        dispatch_body_line(line, line_num, visitors, &mut active, &mut fence);
+        dispatch_body_line(
+            line,
+            line_num,
+            visitors,
+            &mut active,
+            &mut fence,
+            &mut in_comment,
+        );
         if !active.iter().any(|&a| a) {
             break;
         }
@@ -357,7 +458,9 @@ fn dispatch_body_line(
     visitors: &mut [&mut dyn FileVisitor],
     active: &mut [bool],
     fence: &mut Option<(char, usize)>,
+    in_comment: &mut bool,
 ) {
+    // Code fences take highest priority — %% inside a code block is literal.
     if let Some((fence_char, fence_count)) = *fence {
         if is_closing_fence(line, fence_char, fence_count) {
             *fence = None;
@@ -368,6 +471,14 @@ fn dispatch_body_line(
             }
         }
         // Lines inside code blocks are not delivered as body lines
+        return;
+    }
+
+    // Comment blocks — code fences inside comments are ignored.
+    if *in_comment {
+        if is_comment_fence(line) {
+            *in_comment = false;
+        }
         return;
     }
 
@@ -382,9 +493,15 @@ fn dispatch_body_line(
         return;
     }
 
-    // Normal body line
+    if is_comment_fence(line) {
+        *in_comment = true;
+        return;
+    }
+
+    // Normal body line — strip inline comments before delivering to visitors.
+    let cleaned = strip_inline_comments(line);
     for (i, v) in visitors.iter_mut().enumerate() {
-        if active[i] && v.on_body_line(line, line_num) == ScanAction::Stop {
+        if active[i] && v.on_body_line(&cleaned, line_num) == ScanAction::Stop {
             active[i] = false;
         }
     }
@@ -876,5 +993,251 @@ Line 2
     #[test]
     fn extract_fence_language_spaces() {
         assert_eq!(extract_fence_language("```  sh  ", '`', 3), "sh");
+    }
+
+    // --- Comment block tests (simple callback scanner) ---
+
+    #[test]
+    fn skips_multiline_comment_block() {
+        let input = md!(r"
+Before
+%%
+commented [[link]]
+- [ ] hidden task
+%%
+After
+");
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].0, "Before");
+        assert_eq!(lines[1].0, "After");
+    }
+
+    #[test]
+    fn multiline_comment_preserves_line_numbers() {
+        let input = md!(r"
+Line 1
+%%
+skipped
+skipped
+%%
+Line 6
+");
+        let lines = collect_lines(input);
+        assert_eq!(lines[0], ("Line 1".to_string(), 1));
+        assert_eq!(lines[1], ("Line 6".to_string(), 6));
+    }
+
+    #[test]
+    fn inline_comment_stripped() {
+        let input = "See %%[[not a link]]%% and [[real link]]\n";
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 1);
+        assert!(!lines[0].0.contains("not a link"));
+        assert!(lines[0].0.contains("[[real link]]"));
+    }
+
+    #[test]
+    fn comment_inside_code_fence_ignored() {
+        let input = md!(r"
+Before
+```
+%%
+not a comment
+%%
+```
+After
+");
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].0, "Before");
+        assert_eq!(lines[1].0, "After");
+    }
+
+    #[test]
+    fn code_fence_inside_comment_ignored() {
+        let input = md!(r"
+Before
+%%
+```
+not code
+```
+%%
+After
+");
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].0, "Before");
+        assert_eq!(lines[1].0, "After");
+    }
+
+    #[test]
+    fn unmatched_inline_comment_treated_as_literal() {
+        let input = "See %%open and [[link]]\n";
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].0.contains("[[link]]"));
+    }
+
+    #[test]
+    fn comment_on_first_line() {
+        let input = md!(r"
+%%
+hidden
+%%
+Visible
+");
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].0, "Visible");
+    }
+
+    #[test]
+    fn empty_inline_comment() {
+        let input = "before %%%% after\n";
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 1);
+        // %%%% = open %% + close %% with empty content, all replaced with spaces
+        assert!(!lines[0].0.contains("%%"));
+        assert!(lines[0].0.contains("before"));
+        assert!(lines[0].0.contains("after"));
+    }
+
+    #[test]
+    fn nested_percent_signs_in_inline_comment() {
+        let input = "a %%content with % inside%% b\n";
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 1);
+        assert!(!lines[0].0.contains("content"));
+        assert!(lines[0].0.contains("a "));
+        assert!(lines[0].0.contains(" b"));
+    }
+
+    // --- Comment block tests (multi-visitor scanner) ---
+
+    #[test]
+    fn multi_visitor_skips_comment_block() {
+        let input = md!(r"
+Line 1
+%%
+commented [[link]]
+- [ ] hidden task
+%%
+Line 6
+");
+        let mut body = BodyCollector::new();
+        scan_reader_multi(input.as_bytes(), &mut [&mut body]).unwrap();
+
+        assert_eq!(body.lines.len(), 2);
+        assert_eq!(body.lines[0].0, "Line 1");
+        assert_eq!(body.lines[0].1, 1);
+        assert_eq!(body.lines[1].0, "Line 6");
+        assert_eq!(body.lines[1].1, 6);
+    }
+
+    #[test]
+    fn multi_visitor_comment_inside_fence_ignored() {
+        let input = md!(r"
+Line 1
+```
+%%
+not a comment
+%%
+```
+Line 8
+");
+        let mut body = BodyCollector::new();
+        let mut fences = FenceCounter::new();
+        scan_reader_multi(input.as_bytes(), &mut [&mut body, &mut fences]).unwrap();
+
+        assert_eq!(body.lines.len(), 2);
+        assert_eq!(body.lines[0].0, "Line 1");
+        assert_eq!(body.lines[1].0, "Line 8");
+
+        // Code fence events should still fire normally
+        assert_eq!(fences.opens.len(), 1);
+        assert_eq!(fences.closes.len(), 1);
+    }
+
+    #[test]
+    fn multi_visitor_fence_inside_comment_ignored() {
+        let input = md!(r"
+Line 1
+%%
+```rust
+not code
+```
+%%
+Line 8
+");
+        let mut body = BodyCollector::new();
+        let mut fences = FenceCounter::new();
+        scan_reader_multi(input.as_bytes(), &mut [&mut body, &mut fences]).unwrap();
+
+        assert_eq!(body.lines.len(), 2);
+        assert_eq!(body.lines[0].0, "Line 1");
+        assert_eq!(body.lines[1].0, "Line 8");
+
+        // No fence events — the ``` lines were inside a comment
+        assert_eq!(fences.opens.len(), 0);
+        assert_eq!(fences.closes.len(), 0);
+    }
+
+    #[test]
+    fn multi_visitor_inline_comment_stripped() {
+        let input = "See %%[[hidden]]%% and [[visible]]\n";
+        let mut body = BodyCollector::new();
+        scan_reader_multi(input.as_bytes(), &mut [&mut body]).unwrap();
+
+        assert_eq!(body.lines.len(), 1);
+        assert!(!body.lines[0].0.contains("hidden"));
+        assert!(body.lines[0].0.contains("[[visible]]"));
+    }
+
+    // --- is_comment_fence unit tests ---
+
+    #[test]
+    fn is_comment_fence_basic() {
+        assert!(is_comment_fence("%%"));
+        assert!(is_comment_fence("  %%  "));
+        assert!(is_comment_fence("\t%%"));
+    }
+
+    #[test]
+    fn is_comment_fence_rejects_inline() {
+        assert!(!is_comment_fence("%%inline%%"));
+        assert!(!is_comment_fence("text %% more"));
+        assert!(!is_comment_fence("%%content"));
+        assert!(!is_comment_fence("content%%"));
+    }
+
+    // --- strip_inline_comments unit tests ---
+
+    #[test]
+    fn strip_inline_comments_no_change() {
+        let line = "no comments here";
+        let result = strip_inline_comments(line);
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result.as_ref(), line);
+    }
+
+    #[test]
+    fn strip_inline_comments_basic() {
+        let result = strip_inline_comments("a %%hidden%% b");
+        assert_eq!(result.as_ref(), "a            b");
+    }
+
+    #[test]
+    fn strip_inline_comments_multiple() {
+        let result = strip_inline_comments("%%a%% mid %%b%%");
+        assert!(!result.contains('a'));
+        assert!(result.contains("mid"));
+        assert!(!result.contains('b'));
+    }
+
+    #[test]
+    fn strip_inline_comments_unmatched() {
+        let result = strip_inline_comments("a %%open");
+        assert_eq!(result.as_ref(), "a %%open");
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -284,8 +284,8 @@ pub trait FileVisitor {
         ScanAction::Continue
     }
 
-    /// Called for each body line outside fenced code blocks.
-    /// Receives the **raw** line text (not stripped of inline code).
+    /// Called for each body line outside fenced code blocks and comment blocks.
+    /// Inline `%%comment%%` spans are stripped; inline code spans are **not**.
     fn on_body_line(&mut self, _raw: &str, _line_num: usize) -> ScanAction {
         ScanAction::Continue
     }
@@ -1239,5 +1239,20 @@ Line 8
     fn strip_inline_comments_unmatched() {
         let result = strip_inline_comments("a %%open");
         assert_eq!(result.as_ref(), "a %%open");
+    }
+
+    #[test]
+    fn strip_inline_comments_trailing_double_percent() {
+        // Trailing `%%` with nothing after it looks like a block fence marker,
+        // not an inline comment opener — leave it as-is.
+        let result = strip_inline_comments("text%%");
+        assert_eq!(result.as_ref(), "text%%");
+    }
+
+    #[test]
+    fn strip_inline_comments_triple_percent() {
+        // `%%%` = opening `%%` + lone `%` — no matching close, treated as literal.
+        let result = strip_inline_comments("a %%% b");
+        assert_eq!(result.as_ref(), "a %%% b");
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -215,6 +215,7 @@ pub fn read_task(path: &Path, line: usize) -> Result<Option<TaskInfo>> {
     }
 
     let mut fence: Option<(char, usize)> = None;
+    let mut in_comment = false;
 
     // Process first line if not frontmatter
     if fm_lines == 0 {
@@ -222,6 +223,9 @@ pub fn read_task(path: &Path, line: usize) -> Result<Option<TaskInfo>> {
             if let Some(f) = scanner::detect_opening_fence(&first_trimmed) {
                 fence = Some(f);
                 // A fence opener is never a task
+            } else if scanner::is_comment_fence(&first_trimmed) {
+                in_comment = true;
+                // A comment fence is never a task
             } else {
                 let info =
                     detect_task_checkbox(&first_trimmed).map(|(status_char, done)| TaskInfo {
@@ -234,6 +238,8 @@ pub fn read_task(path: &Path, line: usize) -> Result<Option<TaskInfo>> {
             }
         } else if let Some(f) = scanner::detect_opening_fence(&first_trimmed) {
             fence = Some(f);
+        } else if scanner::is_comment_fence(&first_trimmed) {
+            in_comment = true;
         }
     }
 
@@ -246,7 +252,7 @@ pub fn read_task(path: &Path, line: usize) -> Result<Option<TaskInfo>> {
         line_num += 1;
         let line_str = buf.trim_end_matches(['\n', '\r']);
 
-        // Handle fenced code block
+        // Handle fenced code block (highest priority)
         if let Some((fence_char, fence_count)) = fence {
             if scanner::is_closing_fence(line_str, fence_char, fence_count) {
                 fence = None;
@@ -260,11 +266,36 @@ pub fn read_task(path: &Path, line: usize) -> Result<Option<TaskInfo>> {
             continue;
         }
 
+        // Handle comment block
+        if in_comment {
+            if scanner::is_comment_fence(line_str) {
+                in_comment = false;
+            }
+            if line_num == line {
+                return Ok(None); // inside comment block
+            }
+            if line_num > line {
+                break;
+            }
+            continue;
+        }
+
         if let Some(f) = scanner::detect_opening_fence(line_str) {
             if line_num == line {
                 return Ok(None); // fence opener is not a task
             }
             fence = Some(f);
+            if line_num > line {
+                break;
+            }
+            continue;
+        }
+
+        if scanner::is_comment_fence(line_str) {
+            if line_num == line {
+                return Ok(None); // comment fence is not a task
+            }
+            in_comment = true;
             if line_num > line {
                 break;
             }
@@ -846,5 +877,68 @@ Regular text.
         let result = set_task_status(&path, 1, 'x');
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not a task"));
+    }
+
+    // --- Comment block handling ---
+
+    #[test]
+    fn extract_tasks_skips_comment_blocks() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        fs::write(
+            &path,
+            md!(r"
+- [ ] Before comment
+%%
+- [ ] Inside comment — ignored
+- [x] Also inside — ignored
+%%
+- [x] After comment
+"),
+        )
+        .unwrap();
+
+        let tasks = extract_tasks(&path).unwrap();
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0].text, "Before comment");
+        assert_eq!(tasks[1].text, "After comment");
+    }
+
+    #[test]
+    fn count_tasks_skips_comment_blocks() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        fs::write(
+            &path,
+            md!(r"
+- [ ] Visible 1
+%%
+- [ ] Hidden
+- [x] Hidden done
+%%
+- [x] Visible 2
+"),
+        )
+        .unwrap();
+
+        let count = count_tasks(&path).unwrap();
+        assert_eq!(count.total, 2);
+        assert_eq!(count.done, 1);
+    }
+
+    #[test]
+    fn read_task_returns_none_inside_comment() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        fs::write(&path, "%%\n- [ ] Inside comment\n%%\n- [ ] Real task\n").unwrap();
+
+        // Line 2 is inside the comment block
+        let task = read_task(&path, 2).unwrap();
+        assert!(task.is_none());
+
+        // Line 4 is a real task
+        let task = read_task(&path, 4).unwrap();
+        assert!(task.is_some());
+        assert_eq!(task.unwrap().text, "Real task");
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -941,4 +941,15 @@ Regular text.
         assert!(task.is_some());
         assert_eq!(task.unwrap().text, "Real task");
     }
+
+    #[test]
+    fn read_task_returns_none_when_first_line_is_comment_fence() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        fs::write(&path, "%%\n- [ ] Inside comment\n%%\n").unwrap();
+
+        // Line 1 is the opening comment fence — not a task
+        let task = read_task(&path, 1).unwrap();
+        assert!(task.is_none());
+    }
 }

--- a/tests/e2e_links.rs
+++ b/tests/e2e_links.rs
@@ -335,3 +335,59 @@ fn links_unclosed_wikilink_in_file() {
     let links = parsed["links"].as_array().unwrap();
     assert!(links.is_empty());
 }
+
+// --- Comment block handling ---
+
+#[test]
+fn links_skips_comment_blocks() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "comments.md",
+        md!(r"
+Before [[visible-link]]
+%%
+[[hidden-link]]
+%%
+After [[another-visible]]
+"),
+    );
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["links", "--file", "comments.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let links = parsed["links"].as_array().unwrap();
+    let targets: Vec<&str> = links
+        .iter()
+        .map(|l| l["target"].as_str().unwrap())
+        .collect();
+    assert!(targets.contains(&"visible-link"));
+    assert!(targets.contains(&"another-visible"));
+    assert!(!targets.contains(&"hidden-link"));
+    assert_eq!(links.len(), 2);
+}
+
+#[test]
+fn links_skips_inline_comments() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "inline-comments.md",
+        "See %%[[hidden]]%% and [[visible]]\n",
+    );
+    let output = hyalo()
+        .args(["--dir", &tmp.path().display().to_string()])
+        .args(["links", "--file", "inline-comments.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let links = parsed["links"].as_array().unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0]["target"], "visible");
+}

--- a/tests/e2e_tasks.rs
+++ b/tests/e2e_tasks.rs
@@ -852,3 +852,35 @@ fn task_set_status_file_not_found() {
     assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
 }
+
+// --- Comment block handling ---
+
+#[test]
+fn tasks_skips_comment_blocks() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "comments.md",
+        md!(r"
+- [ ] Visible task
+%%
+- [ ] Hidden task
+- [x] Hidden done
+%%
+- [x] Another visible
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tasks", "--file", "comments.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let tasks = parsed["tasks"].as_array().unwrap();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0]["text"], "Visible task");
+    assert_eq!(tasks[1]["text"], "Another visible");
+}


### PR DESCRIPTION
## Summary

- Add `is_comment_fence` and `strip_inline_comments` functions to the scanner, following the same pattern as fenced code block tracking
- Block comments (`%%` on own line) and inline comments (`%%text%%`) are now correctly skipped — links, tasks, and headings inside comments are no longer extracted
- Both the simple callback scanner and multi-visitor scanner handle comment state, as does `read_task` in tasks.rs
- Resolves high-priority backlog item `comment-block-handling` and updates DEC-015

## Test plan

- [x] 2 unit tests for `is_comment_fence` (valid + rejects inline)
- [x] 4 unit tests for `strip_inline_comments` (no-op, basic, multiple, unmatched)
- [x] 7 unit tests for simple scanner comment handling (block, line numbers, inline, fence interactions, first line, empty)
- [x] 4 unit tests for multi-visitor scanner comment handling (block, fence-in-comment, comment-in-fence, inline)
- [x] 3 unit tests for tasks comment handling (extract, count, read_task)
- [x] 3 e2e tests (links block, links inline, tasks block)
- [x] Dogfooded with `hyalo links/tasks/outline` on a file with comment blocks — verified correct exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)