### PR TITLE
Add benchmark suite and cache compiled jaq filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 .claude/memory
 .claude/agent-memory
 hyalo-knowledgebase/MyNotes.md
-
+bench-results/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +163,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -206,6 +245,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +322,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -312,6 +399,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hifijson"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +449,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "criterion",
  "globset",
  "ignore",
  "jaq-core",
@@ -416,10 +521,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -542,6 +667,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +763,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"
@@ -779,6 +958,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +1117,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1093,6 +1292,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,18 @@ serde_yaml_ng = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2"
+criterion = { version = "0.5", features = ["html_reports"] }
 predicates = "3"
 tempfile = "3"
+
+[profile.bench]
+codegen-units = 1
+lto = true
+
+[[bench]]
+name = "micro"
+harness = false
+
+[[bench]]
+name = "vault"
+harness = false

--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ Tasks: 89/174
 
 In JSON mode, `--hints` wraps the output in `{"data": ..., "hints": [...]}`. Hints are concrete, copy-pasteable commands — no templates or placeholders. Suppressed when combined with `--jq`.
 
+## Benchmarking
+
+On-demand performance benchmarks using [Criterion](https://github.com/bheisler/criterion.rs) and [Hyperfine](https://github.com/sharkdp/hyperfine):
+
+```sh
+cargo bench --bench micro                # pure-function micro-benchmarks
+cargo bench --bench vault                # vault-scale benchmarks (needs obsidian-hub)
+./bench-e2e.sh                           # end-to-end CLI benchmarks
+./bench-e2e.sh target/release/hyalo /tmp/hyalo-baseline   # A/B comparison
+```
+
+See `benches/README.md` for full setup, A/B comparison workflows, profiling with [samply](https://github.com/mstange/samply), and memory measurement.
+
 ## License
 
 MIT

--- a/bench-e2e.sh
+++ b/bench-e2e.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VAULT="${HYALO_BENCH_VAULT:-../obsidian-hub}"
+HYALO="${1:-target/release/hyalo}"
+HYALO_B="${2:-}"  # optional second binary for A/B comparison
+
+if [[ ! -d "$VAULT" ]]; then
+    echo "ERROR: Vault not found at $VAULT. Set HYALO_BENCH_VAULT." >&2
+    exit 1
+fi
+
+if [[ ! -x "$HYALO" ]]; then
+    echo "Building release binary..."
+    cargo build --release
+    HYALO="target/release/hyalo"
+fi
+
+WARMUP=3
+RUNS=10
+OUTDIR="bench-results"
+mkdir -p "$OUTDIR"
+
+run_bench() {
+    local name="$1"; shift
+
+    echo "  $name ..."
+    if [[ -n "$HYALO_B" ]]; then
+        hyperfine \
+            --warmup "$WARMUP" \
+            --runs "$RUNS" \
+            --ignore-failure \
+            --export-markdown "$OUTDIR/${name}.md" \
+            -n "current" "$HYALO --dir $VAULT $*" \
+            -n "baseline" "$HYALO_B --dir $VAULT $*"
+    else
+        hyperfine \
+            --warmup "$WARMUP" \
+            --runs "$RUNS" \
+            --ignore-failure \
+            --export-markdown "$OUTDIR/${name}.md" \
+            -n "$name" "$HYALO --dir $VAULT $*"
+    fi
+}
+
+echo "=== E2E Benchmarks against $VAULT ==="
+echo ""
+
+run_bench "find"              find
+run_bench "find-pattern"      find obsidian
+run_bench "find-property"     find --property title
+run_bench "find-task"         find --task todo
+run_bench "properties"        properties
+run_bench "tags"              tags
+run_bench "summary"           summary
+run_bench "find-json"         find --format json
+run_bench "find-text"         find --format text
+
+echo ""
+echo "Results saved to $OUTDIR/"

--- a/bench-e2e.sh
+++ b/bench-e2e.sh
@@ -25,21 +25,32 @@ run_bench() {
     local name="$1"; shift
 
     echo "  $name ..."
+
+    local current_cmd=( "$HYALO" --dir "$VAULT" "$@" )
+    local current_cmd_str
+    printf -v current_cmd_str '%q ' "${current_cmd[@]}"
+    current_cmd_str=${current_cmd_str% }
+
     if [[ -n "$HYALO_B" ]]; then
+        local baseline_cmd=( "$HYALO_B" --dir "$VAULT" "$@" )
+        local baseline_cmd_str
+        printf -v baseline_cmd_str '%q ' "${baseline_cmd[@]}"
+        baseline_cmd_str=${baseline_cmd_str% }
+
         hyperfine \
             --warmup "$WARMUP" \
             --runs "$RUNS" \
             --ignore-failure \
             --export-markdown "$OUTDIR/${name}.md" \
-            -n "current" "$HYALO --dir $VAULT $*" \
-            -n "baseline" "$HYALO_B --dir $VAULT $*"
+            -n "current" "$current_cmd_str" \
+            -n "baseline" "$baseline_cmd_str"
     else
         hyperfine \
             --warmup "$WARMUP" \
             --runs "$RUNS" \
             --ignore-failure \
             --export-markdown "$OUTDIR/${name}.md" \
-            -n "$name" "$HYALO --dir $VAULT $*"
+            -n "$name" "$current_cmd_str"
     fi
 }
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,186 @@
+# Benchmarks
+
+On-demand performance benchmarks for hyalo. Two types: Criterion micro-benchmarks
+(Rust) and Hyperfine end-to-end CLI benchmarks (shell).
+
+## Quick Start
+
+Step-by-step guide to running benchmarks from scratch.
+
+### 1. Install tools
+
+```bash
+cargo install critcmp          # compare Criterion baselines
+brew install hyperfine          # macOS — or see https://github.com/sharkdp/hyperfine
+```
+
+### 2. Get a test vault
+
+Clone [obsidian-hub](https://github.com/obsidian-community/obsidian-hub) next to
+the hyalo repo (or anywhere you like):
+
+```bash
+cd ..
+git clone https://github.com/obsidian-community/obsidian-hub.git
+cd hyalo
+```
+
+If you place it somewhere else, tell the benchmarks where it is:
+
+```bash
+export HYALO_BENCH_VAULT=/path/to/obsidian-hub
+```
+
+### 3. Run micro-benchmarks
+
+These test pure functions (string parsing, link extraction, etc.) and don't need
+the vault:
+
+```bash
+cargo bench --bench micro
+```
+
+Open `target/criterion/report/index.html` in a browser to see the HTML reports.
+
+### 4. Run vault benchmarks
+
+These test file discovery, frontmatter reading, and full-vault scanning:
+
+```bash
+cargo bench --bench vault
+```
+
+If the vault is not found, these benchmarks print a warning and skip gracefully.
+
+### 5. Run end-to-end CLI benchmarks
+
+Build a release binary first, then run all CLI commands through hyperfine:
+
+```bash
+cargo build --release
+./bench-e2e.sh
+```
+
+Results are saved as markdown tables in `bench-results/`. Each command gets its own
+file (e.g., `bench-results/find.md`, `bench-results/find-text.md`).
+
+### 6. Compare two versions (A/B test)
+
+This is the most useful workflow — measure the impact of an optimization.
+
+**Option A: Hyperfine side-by-side** (quick, compares CLI wall-clock time)
+
+```bash
+# 1. Save the current binary as the baseline
+cargo build --release
+cp target/release/hyalo /tmp/hyalo-before
+
+# 2. Make your changes, then rebuild
+#    ... edit code ...
+cargo build --release
+
+# 3. Race both binaries against each other
+./bench-e2e.sh target/release/hyalo /tmp/hyalo-before
+```
+
+The script runs every command with both binaries and reports which is faster.
+
+**Option B: Criterion baselines** (precise, with statistical analysis)
+
+```bash
+# 1. On main (or before your change): save a named baseline
+git checkout main
+cargo bench -- --save-baseline before
+
+# 2. On your feature branch: save another baseline
+git checkout iter-16/some-optimization
+cargo bench -- --save-baseline after
+
+# 3. Compare — shows % change with confidence intervals
+critcmp before after
+```
+
+**Option C: Git worktrees** (avoids stashing and switching branches)
+
+```bash
+# 1. Create a worktree for the baseline
+git worktree add /tmp/hyalo-main main
+(cd /tmp/hyalo-main && cargo build --release)
+
+# 2. Build the current branch
+cargo build --release
+
+# 3. Race them
+./bench-e2e.sh target/release/hyalo /tmp/hyalo-main/target/release/hyalo
+
+# 4. Clean up
+git worktree remove /tmp/hyalo-main
+```
+
+### 7. Profile with samply (flamegraphs)
+
+[samply](https://github.com/mstange/samply) records a CPU profile and opens it in the
+Firefox Profiler UI — interactive flamegraphs, call trees, and timeline views.
+
+```bash
+cargo install samply
+
+# Record a profile (writes a JSON file, then serves the UI)
+cargo build --release
+samply record target/release/hyalo --dir ../obsidian-hub find --format text
+```
+
+This opens the Firefox Profiler in your browser automatically. Use the tabs:
+- **Flammendiagramm / Flame Graph** — visual breakdown of where time is spent
+- **Aufrufbaum / Call Tree** — hierarchical view with exact sample counts
+- **Stack-Diagramm / Stack Chart** — timeline of stack frames over time
+
+To save a profile for later viewing:
+
+```bash
+# Record without opening the browser
+samply record --save-only -o /tmp/profile.json target/release/hyalo --dir ../obsidian-hub find --format text
+
+# Load it later
+samply load --port 9876 /tmp/profile.json
+# Then open http://localhost:9876 and click "Open the profile in the profiler UI"
+```
+
+### 8. Measure memory usage
+
+No special tooling needed — use the OS time command:
+
+```bash
+# macOS
+command time -l target/release/hyalo --dir ../obsidian-hub find 2>&1 | grep 'maximum resident'
+
+# Linux
+/usr/bin/time -v target/release/hyalo --dir ../obsidian-hub find 2>&1 | grep 'Maximum resident'
+```
+
+## Reference
+
+### What each benchmark file covers
+
+| File | Needs vault? | What it measures |
+|------|:---:|---|
+| `benches/micro.rs` | No | `strip_inline_code`, `strip_inline_comments`, `detect_task_checkbox`, `extract_links_from_text`, `parse_property_filter` |
+| `benches/vault.rs` | Yes | `discover_files`, `read_frontmatter` (sample + all), `scan_file_multi` with multiple visitors |
+| `bench-e2e.sh` | Yes | All CLI commands: `find`, `find <pattern>`, `find --property`, `find --task`, `properties`, `tags`, `summary`, `--format json` vs `--format text` |
+
+### bench-e2e.sh usage
+
+```bash
+./bench-e2e.sh                                    # benchmark current release binary
+./bench-e2e.sh path/to/hyalo                      # benchmark a specific binary
+./bench-e2e.sh path/to/new path/to/old            # A/B comparison
+```
+
+The script builds a release binary automatically if the given path is not executable.
+
+### Tuning
+
+If vault benchmarks are too slow, adjust in the source:
+
+- `sample_size(N)` — number of iterations (default 100, vault benchmarks use 10)
+- `measurement_time(Duration)` — time budget per benchmark (vault benchmarks use 30s)

--- a/benches/micro.rs
+++ b/benches/micro.rs
@@ -1,0 +1,93 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use hyalo::filter::parse_property_filter;
+use hyalo::links::{Link, extract_links_from_text};
+use hyalo::scanner::{strip_inline_code, strip_inline_comments};
+use hyalo::tasks::detect_task_checkbox;
+
+fn bench_strip_inline_code(c: &mut Criterion) {
+    let no_backtick = "This is a regular line with no code spans at all";
+    let with_backtick = "Use `HashMap` and `Vec<String>` for the `cache` field";
+
+    let mut group = c.benchmark_group("strip_inline_code");
+    group.bench_function("no_backticks", |b| {
+        b.iter(|| strip_inline_code(black_box(no_backtick)))
+    });
+    group.bench_function("with_backticks", |b| {
+        b.iter(|| strip_inline_code(black_box(with_backtick)))
+    });
+    group.finish();
+}
+
+fn bench_strip_inline_comments(c: &mut Criterion) {
+    let no_comment = "Regular line without any percent signs";
+    let with_comment = "Visible text %%hidden comment%% more visible text";
+
+    let mut group = c.benchmark_group("strip_inline_comments");
+    group.bench_function("no_comments", |b| {
+        b.iter(|| strip_inline_comments(black_box(no_comment)))
+    });
+    group.bench_function("with_comments", |b| {
+        b.iter(|| strip_inline_comments(black_box(with_comment)))
+    });
+    group.finish();
+}
+
+fn bench_detect_task_checkbox(c: &mut Criterion) {
+    let mut group = c.benchmark_group("detect_task_checkbox");
+    group.bench_function("task_line", |b| {
+        b.iter(|| detect_task_checkbox(black_box("- [ ] Write benchmarks")))
+    });
+    group.bench_function("non_task_line", |b| {
+        b.iter(|| detect_task_checkbox(black_box("Regular paragraph text")))
+    });
+    group.bench_function("indented_task", |b| {
+        b.iter(|| detect_task_checkbox(black_box("    - [x] Nested done task")))
+    });
+    group.finish();
+}
+
+fn bench_extract_links(c: &mut Criterion) {
+    let sparse = "See [[Note A]] for details on this topic.";
+    let dense = "Links: [[A]], [[B|label]], [[C#heading]], [md](d.md), ![[embed]]";
+
+    let mut group = c.benchmark_group("extract_links");
+    group.bench_function("sparse_line", |b| {
+        b.iter(|| {
+            let mut out: Vec<Link> = Vec::new();
+            extract_links_from_text(black_box(sparse), &mut out);
+            out
+        })
+    });
+    group.bench_function("dense_line", |b| {
+        b.iter(|| {
+            let mut out: Vec<Link> = Vec::new();
+            extract_links_from_text(black_box(dense), &mut out);
+            out
+        })
+    });
+    group.finish();
+}
+
+fn bench_parse_property_filter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_property_filter");
+    group.bench_function("equality", |b| {
+        b.iter(|| parse_property_filter(black_box("status=draft")))
+    });
+    group.bench_function("comparison", |b| {
+        b.iter(|| parse_property_filter(black_box("priority>=3")))
+    });
+    group.bench_function("exists", |b| {
+        b.iter(|| parse_property_filter(black_box("title")))
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_strip_inline_code,
+    bench_strip_inline_comments,
+    bench_detect_task_checkbox,
+    bench_extract_links,
+    bench_parse_property_filter,
+);
+criterion_main!(benches);

--- a/benches/vault.rs
+++ b/benches/vault.rs
@@ -57,7 +57,7 @@ fn bench_read_all_frontmatter(c: &mut Criterion) {
     group.bench_function("all_files", |b| {
         b.iter(|| {
             for file in &files {
-                let _ = read_frontmatter(black_box(file));
+                read_frontmatter(black_box(file)).unwrap();
             }
         })
     });
@@ -77,7 +77,8 @@ fn bench_scan_all_files(c: &mut Criterion) {
                 let mut counter = TaskCounter::new();
                 let mut search = ContentSearchVisitor::new("obsidian");
                 let visitors: &mut [&mut dyn FileVisitor] = &mut [&mut counter, &mut search];
-                let _ = scan_file_multi(black_box(file), visitors);
+                scan_file_multi(black_box(file), visitors)
+                    .expect("scan_file_multi failed during benchmark");
             }
         })
     });

--- a/benches/vault.rs
+++ b/benches/vault.rs
@@ -1,0 +1,94 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use hyalo::content_search::ContentSearchVisitor;
+use hyalo::discovery::discover_files;
+use hyalo::frontmatter::read_frontmatter;
+use hyalo::scanner::{FileVisitor, scan_file_multi};
+use hyalo::tasks::TaskCounter;
+
+fn vault_path() -> Option<PathBuf> {
+    let path = std::env::var("HYALO_BENCH_VAULT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("../obsidian-hub"));
+    if path.is_dir() {
+        Some(path)
+    } else {
+        eprintln!(
+            "WARN: vault not found at {}. Set HYALO_BENCH_VAULT. Skipping vault benchmarks.",
+            path.display()
+        );
+        None
+    }
+}
+
+fn bench_discover_files(c: &mut Criterion) {
+    let Some(vault) = vault_path() else { return };
+    c.bench_function("discover_files", |b| {
+        b.iter(|| discover_files(black_box(&vault)).unwrap())
+    });
+}
+
+fn bench_read_frontmatter(c: &mut Criterion) {
+    let Some(vault) = vault_path() else { return };
+    let files = discover_files(&vault).unwrap();
+
+    // Pick a representative sample: first, middle, last
+    let indices = [0, files.len() / 2, files.len().saturating_sub(1)];
+    let mut group = c.benchmark_group("read_frontmatter");
+    for (i, &idx) in indices.iter().enumerate() {
+        if let Some(path) = files.get(idx) {
+            group.bench_function(format!("file_{i}"), |b| {
+                b.iter(|| read_frontmatter(black_box(path)).unwrap())
+            });
+        }
+    }
+    group.finish();
+}
+
+fn bench_read_all_frontmatter(c: &mut Criterion) {
+    let Some(vault) = vault_path() else { return };
+    let files = discover_files(&vault).unwrap();
+
+    let mut group = c.benchmark_group("read_all_frontmatter");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.bench_function("all_files", |b| {
+        b.iter(|| {
+            for file in &files {
+                let _ = read_frontmatter(black_box(file));
+            }
+        })
+    });
+    group.finish();
+}
+
+fn bench_scan_all_files(c: &mut Criterion) {
+    let Some(vault) = vault_path() else { return };
+    let files = discover_files(&vault).unwrap();
+
+    let mut group = c.benchmark_group("scan_all_files");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(30));
+    group.bench_function("multi_visitor", |b| {
+        b.iter(|| {
+            for file in &files {
+                let mut counter = TaskCounter::new();
+                let mut search = ContentSearchVisitor::new("obsidian");
+                let visitors: &mut [&mut dyn FileVisitor] = &mut [&mut counter, &mut search];
+                let _ = scan_file_multi(black_box(file), visitors);
+            }
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_discover_files,
+    bench_read_frontmatter,
+    bench_read_all_frontmatter,
+    bench_scan_all_files,
+);
+criterion_main!(benches);

--- a/hyalo-knowledgebase/iterations/iteration-14-text-output-overhaul.md
+++ b/hyalo-knowledgebase/iterations/iteration-14-text-output-overhaul.md
@@ -7,7 +7,7 @@ tags:
   - cli
   - ux
   - output
-status: in-progress
+status: completed
 branch: iter-14/text-output-overhaul
 ---
 

--- a/hyalo-knowledgebase/iterations/iteration-15-performance-benchmarks.md
+++ b/hyalo-knowledgebase/iterations/iteration-15-performance-benchmarks.md
@@ -1,0 +1,115 @@
+---
+title: "Iteration 15: Performance Benchmark Suite"
+type: iteration
+date: 2026-03-22
+tags:
+  - iteration
+  - performance
+  - benchmarking
+  - criterion
+  - hyperfine
+status: completed
+branch: iter-15/performance-benchmarks
+---
+
+# Iteration 15: Performance Benchmark Suite
+
+Establish a benchmark infrastructure for hyalo using the obsidian-hub vault (6,540 files) as the real-world test bed. This enables data-driven optimization decisions for future iterations (parallelization, indexing, caching).
+
+See [[performance-benchmarking]] for full research and rationale.
+
+## Goals
+
+- Criterion micro-benchmarks for hot-path functions
+- Hyperfine end-to-end CLI benchmarks against obsidian-hub
+- A/B comparison workflow for measuring optimizations
+- Baseline results documented for future comparison
+
+## Tasks
+
+### Setup
+
+- [x] Add `criterion` as a dev-dependency with `html_reports` feature
+- [x] Add bench profile to `Cargo.toml` (`codegen-units = 1`, `lto = true`)
+- [x] Create `benches/` directory structure
+- [x] Make `extract_links_from_text` public for direct benchmarking
+
+### Micro-benchmarks (Criterion) — `benches/micro.rs`
+
+- [x] Benchmark `strip_inline_code()` — zero-copy vs allocation path
+- [x] Benchmark `strip_inline_comments()` — zero-copy vs allocation path
+- [x] Benchmark `detect_task_checkbox()` — task line, non-task, indented
+- [x] Benchmark `extract_links_from_text()` — sparse vs dense links
+- [x] Benchmark `parse_property_filter()` — equality, comparison, exists
+
+### Vault benchmarks (Criterion) — `benches/vault.rs`
+
+- [x] Benchmark `discover_files()` on obsidian-hub
+- [x] Benchmark `read_frontmatter()` on sample files
+- [x] Benchmark `read_all_frontmatter()` on full vault
+- [x] Benchmark `scan_file_multi()` with TaskCounter + ContentSearchVisitor
+
+### End-to-end benchmarks (Hyperfine) — `bench-e2e.sh`
+
+- [x] Write `bench-e2e.sh` with A/B comparison support
+- [x] Benchmark: `find` (full vault scan)
+- [x] Benchmark: `find <pattern>` (content search)
+- [x] Benchmark: `find --property`, `find --task` (filtered)
+- [x] Benchmark: `properties`, `tags`, `summary` (aggregation)
+- [x] Benchmark: `--format json` vs `--format text` (output overhead)
+- [x] Export results as markdown to `bench-results/`
+
+### Documentation — `benches/README.md`
+
+- [x] Document prerequisites (critcmp, hyperfine)
+- [x] Document micro and vault benchmark usage
+- [x] Document A/B comparison workflow (criterion baselines, hyperfine side-by-side, git worktrees)
+- [x] Document memory measurement (macOS `time -l`, Linux `/usr/bin/time -v`)
+
+### jaq filter caching — A/B test case
+
+- [x] Save baseline binary before optimization
+- [x] Implement `JaqFilterCache` in `output.rs` — `HashMap<String, Filter<Native<Val>>>`
+- [x] Thread cache through `format_value_as_text` → `apply_jq_filter`
+- [x] Measure improvement: `find --format text` 2.82x faster (2.91s → 1.03s on 6540 files)
+- [x] Document results in knowledgebase
+
+## Acceptance criteria
+
+- [x] `cargo bench --bench micro` runs and generates HTML reports
+- [x] `cargo bench --bench vault` runs vault benchmarks (skips gracefully if vault absent)
+- [x] `./bench-e2e.sh` runs hyperfine benchmarks and exports markdown
+- [x] A/B comparison demonstrated with jaq caching optimization
+- [x] Results documented in knowledgebase
+
+## Deliberately excluded
+
+- **dhat / memory profiling** — `time -l` documented in README instead
+- **Scaling groups** — `discover_files()` always walks full vault; slicing adds complexity without value
+- **`write_frontmatter` benchmarks** — writes are rare; would need tempdir setup
+- **CI integration** — on-demand only for now
+
+## Results: Initial Baseline (2026-03-22)
+
+### E2E (obsidian-hub, 6540 files, with jaq cache)
+
+| Command | Mean | σ |
+|---------|------|---|
+| `find` | 454ms | ±5ms |
+| `find obsidian` (pattern) | 512ms | ±14ms |
+| `find --property title` | 284ms | ±2ms |
+| `find --task todo` | 295ms | ±7ms |
+| `properties` | 55ms | ±9ms |
+| `tags` | 51ms | ±2ms |
+| `summary` | 227ms | ±3ms |
+| `find --format json` | 452ms | ±4ms |
+| `find --format text` | 1.043s | ±17ms |
+
+### jaq cache A/B comparison
+
+| Metric | Before | After | Speedup |
+|--------|--------|-------|---------|
+| `find --format text` | 2.91s | 1.03s | **2.82x** |
+| `find --format json` | 451ms | 452ms | 1.00x (no change) |
+
+The text/json gap narrowed from 6.4x to 2.3x. The remaining ~580ms delta is jaq filter *execution* overhead (running the compiled filter per value), not compilation.

--- a/src/links.rs
+++ b/src/links.rs
@@ -24,7 +24,7 @@ pub fn extract_links_from_file(path: &Path) -> Result<Vec<Link>> {
 }
 
 /// Extract links from a text segment (already cleaned of inline code spans).
-pub(crate) fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
+pub fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
     let bytes = text.as_bytes();
     let len = bytes.len();
     let mut i = 0;

--- a/src/links.rs
+++ b/src/links.rs
@@ -23,7 +23,12 @@ pub fn extract_links_from_file(path: &Path) -> Result<Vec<Link>> {
     Ok(links)
 }
 
-/// Extract links from a text segment (already cleaned of inline code spans).
+/// Extract links from a text segment and append them to `out`.
+///
+/// `text` must already be cleaned of inline code spans (e.g. via
+/// [`strip_inline_code`](crate::scanner::strip_inline_code)), otherwise links
+/// inside code spans will be incorrectly parsed. Existing contents of `out` are
+/// preserved; new links are appended.
 pub fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
     let bytes = text.as_bytes();
     let len = bytes.len();

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,10 +1,23 @@
+use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use jaq_core::load::{self, Arena, File, Loader};
-use jaq_core::{Compiler, Ctx, RcIter};
+use jaq_core::{Compiler, Ctx, Native, RcIter};
 use jaq_json::Val;
 use serde::Serialize;
 use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Filter cache
+// ---------------------------------------------------------------------------
+
+/// Cache of compiled jaq filters, keyed by filter source string.
+///
+/// `Filter<Native<Val>>` is fully owned (no lifetime parameters) and `Clone`,
+/// so it can be stored directly in a `HashMap`. The `Arena` used during
+/// `Loader::load` is a temporary scratch pad — once `compile` returns, the
+/// `Filter` no longer borrows from it.
+type JaqFilterCache = HashMap<String, jaq_core::Filter<Native<Val>>>;
 
 /// Output format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,7 +52,10 @@ impl Format {
 pub fn format_success(format: Format, value: &serde_json::Value) -> String {
     match format {
         Format::Json => serde_json::to_string_pretty(value).unwrap_or_default(),
-        Format::Text => format_value_as_text(value),
+        Format::Text => {
+            let mut cache = JaqFilterCache::new();
+            format_value_as_text(value, &mut cache)
+        }
     }
 }
 
@@ -73,7 +89,8 @@ pub fn format_with_hints(format: Format, value: &serde_json::Value, hints: &[Str
             serde_json::to_string_pretty(&envelope).unwrap_or_default()
         }
         Format::Text => {
-            let mut text = format_value_as_text(value);
+            let mut cache = JaqFilterCache::new();
+            let mut text = format_value_as_text(value, &mut cache);
             text.push('\n');
             for hint in hints {
                 text.push_str("\n  -> ");
@@ -262,13 +279,21 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
 
 /// Apply a jq filter string to a `serde_json::Value` and return the text output.
 ///
-/// Multiple outputs are joined with newlines. On any error (parse or runtime),
-/// returns `None` (used internally by the text formatter, which has its own fallbacks).
-fn apply_jq_filter(filter_code: &str, value: &serde_json::Value) -> Option<String> {
-    run_jq_filter(filter_code, value).ok()
+/// Looks up or compiles the filter in `cache`. Multiple outputs are joined with
+/// newlines. On any error (parse or runtime), returns `None` (used internally
+/// by the text formatter, which has its own fallbacks).
+fn apply_jq_filter(
+    filter_code: &str,
+    value: &serde_json::Value,
+    cache: &mut JaqFilterCache,
+) -> Option<String> {
+    run_jq_filter_cached(filter_code, value, cache).ok()
 }
 
 /// Apply a user-supplied jq filter to a `serde_json::Value`.
+///
+/// Compiles the filter on every call. For repeated use across many values,
+/// prefer the cached path via [`format_success`] / [`format_value_as_text`].
 ///
 /// Returns `Ok(String)` with newline-joined output values on success, or
 /// `Err(String)` with a human-readable description of the parse or runtime error.
@@ -276,7 +301,8 @@ pub fn apply_jq_filter_result(
     filter_code: &str,
     value: &serde_json::Value,
 ) -> Result<String, String> {
-    run_jq_filter(filter_code, value)
+    let filter = compile_jq_filter(filter_code)?;
+    execute_jq_filter(&filter, value)
 }
 
 /// Format a jaq load error (lex/parse/IO) into a human-readable string.
@@ -312,8 +338,11 @@ fn format_load_errors(errs: &load::Errors<&str, ()>) -> String {
     "jq filter error: invalid filter syntax".to_owned()
 }
 
-/// Core jq execution logic shared by `apply_jq_filter` and `apply_jq_filter_result`.
-fn run_jq_filter(filter_code: &str, value: &serde_json::Value) -> Result<String, String> {
+/// Compile a jq filter string into a reusable `Filter`.
+///
+/// The `Arena` used during loading is a temporary scratch pad and is dropped
+/// after this function returns — `Filter<Native<Val>>` owns all its data.
+fn compile_jq_filter(filter_code: &str) -> Result<jaq_core::Filter<Native<Val>>, String> {
     let program = File {
         code: filter_code,
         path: (),
@@ -324,7 +353,8 @@ fn run_jq_filter(filter_code: &str, value: &serde_json::Value) -> Result<String,
     let modules = loader
         .load(&arena, program)
         .map_err(|errs| format_load_errors(&errs))?;
-    let filter = Compiler::default()
+
+    Compiler::default()
         .with_funs(jaq_std::funs().chain(jaq_json::funs()))
         .compile(modules)
         .map_err(|errs| {
@@ -336,8 +366,14 @@ fn run_jq_filter(filter_code: &str, value: &serde_json::Value) -> Result<String,
             } else {
                 "jq filter error: compilation failed".to_owned()
             }
-        })?;
+        })
+}
 
+/// Execute a pre-compiled jq filter against a JSON value and return the text output.
+fn execute_jq_filter(
+    filter: &jaq_core::Filter<Native<Val>>,
+    value: &serde_json::Value,
+) -> Result<String, String> {
     let input = Val::from(value.clone());
     let inputs = RcIter::new(core::iter::empty());
     let ctx = Ctx::new([], &inputs);
@@ -357,6 +393,19 @@ fn run_jq_filter(filter_code: &str, value: &serde_json::Value) -> Result<String,
     }
 
     Ok(parts.join("\n"))
+}
+
+/// Look up or compile a jq filter from `cache`, then execute it against `value`.
+fn run_jq_filter_cached(
+    filter_code: &str,
+    value: &serde_json::Value,
+    cache: &mut JaqFilterCache,
+) -> Result<String, String> {
+    let filter = match cache.entry(filter_code.to_owned()) {
+        std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+        std::collections::hash_map::Entry::Vacant(e) => e.insert(compile_jq_filter(filter_code)?),
+    };
+    execute_jq_filter(filter, value)
 }
 
 // ---------------------------------------------------------------------------
@@ -431,7 +480,7 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
 // ---------------------------------------------------------------------------
 
 /// Format a JSON value as human-readable text using jq filters where available.
-fn format_value_as_text(value: &serde_json::Value) -> String {
+fn format_value_as_text(value: &serde_json::Value, cache: &mut JaqFilterCache) -> String {
     match value {
         serde_json::Value::Array(arr) => {
             // Use blank-line separator between FileObjects for readability.
@@ -441,51 +490,54 @@ fn format_value_as_text(value: &serde_json::Value) -> String {
                 .is_some_and(|m| m.contains_key("file") && m.contains_key("modified"));
             let sep = if is_file_objects { "\n\n" } else { "\n" };
             arr.iter()
-                .map(format_value_as_text)
+                .map(|v| format_value_as_text(v, cache))
                 .collect::<Vec<_>>()
                 .join(sep)
         }
         serde_json::Value::Object(map) => {
             let sig = key_signature(map);
             if let Some(filter) = lookup_filter(&sig)
-                && let Some(output) = apply_jq_filter(filter, value)
+                && let Some(output) = apply_jq_filter(filter, value, cache)
             {
                 return output;
             }
             // FileObject: dynamically compose filter from present fields.
             if map.contains_key("file") && map.contains_key("modified") {
                 let filter = build_file_object_filter(map);
-                if let Some(output) = apply_jq_filter(&filter, value) {
+                if let Some(output) = apply_jq_filter(&filter, value, cache) {
                     return output;
                 }
             }
             // Fallback: generic key: value lines
-            format_object_generic(map)
+            format_object_generic(map, cache)
         }
-        other => format_scalar(other),
+        other => format_scalar(other, cache),
     }
 }
 
 /// Generic key: value rendering for unknown object shapes.
-fn format_object_generic(map: &serde_json::Map<String, serde_json::Value>) -> String {
+fn format_object_generic(
+    map: &serde_json::Map<String, serde_json::Value>,
+    cache: &mut JaqFilterCache,
+) -> String {
     map.iter()
-        .map(|(k, v)| format!("{k}: {}", format_value_as_text(v)))
+        .map(|(k, v)| format!("{k}: {}", format_value_as_text(v, cache)))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
 /// Format a scalar JSON value as text.
-fn format_scalar(value: &serde_json::Value) -> String {
+fn format_scalar(value: &serde_json::Value, cache: &mut JaqFilterCache) -> String {
     match value {
         serde_json::Value::String(s) => s.clone(),
         serde_json::Value::Number(n) => n.to_string(),
         serde_json::Value::Bool(b) => b.to_string(),
         serde_json::Value::Null => "null".to_owned(),
         serde_json::Value::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(format_scalar).collect();
+            let items: Vec<String> = arr.iter().map(|v| format_scalar(v, cache)).collect();
             items.join(", ")
         }
-        serde_json::Value::Object(_) => format_value_as_text(value),
+        serde_json::Value::Object(_) => format_value_as_text(value, cache),
     }
 }
 
@@ -493,6 +545,19 @@ fn format_scalar(value: &serde_json::Value) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // Convenience wrappers so individual tests don't have to construct a cache.
+    fn jq(filter: &str, val: &serde_json::Value) -> Option<String> {
+        apply_jq_filter(filter, val, &mut JaqFilterCache::new())
+    }
+
+    fn fmt(val: &serde_json::Value) -> String {
+        format_value_as_text(val, &mut JaqFilterCache::new())
+    }
+
+    fn scalar(val: &serde_json::Value) -> String {
+        format_scalar(val, &mut JaqFilterCache::new())
+    }
 
     // --- error formatting ---
 
@@ -530,21 +595,21 @@ mod tests {
     #[test]
     fn apply_jq_filter_simple() {
         let val = json!({"name": "hello", "count": 3});
-        let result = apply_jq_filter(r#""\(.name): \(.count)""#, &val);
+        let result = jq(r#""\(.name): \(.count)""#, &val);
         assert_eq!(result.as_deref(), Some("hello: 3"));
     }
 
     #[test]
     fn apply_jq_filter_array_map() {
         let val = json!(["a", "b", "c"]);
-        let result = apply_jq_filter(".[]", &val);
+        let result = jq(".[]", &val);
         assert_eq!(result.as_deref(), Some("a\nb\nc"));
     }
 
     #[test]
     fn apply_jq_filter_invalid_returns_none() {
         let val = json!({"x": 1});
-        let result = apply_jq_filter("this is not valid jq %%%", &val);
+        let result = jq("this is not valid jq %%%", &val);
         assert!(result.is_none());
     }
 
@@ -553,7 +618,7 @@ mod tests {
     #[test]
     fn property_info_filter() {
         let val = json!({"name": "title", "type": "text", "value": "My Note"});
-        let out = apply_jq_filter(PROPERTY_INFO_FILTER, &val).unwrap();
+        let out = jq(PROPERTY_INFO_FILTER, &val).unwrap();
         assert!(out.contains("title"));
         assert!(out.contains("text"));
         assert!(out.contains("My Note"));
@@ -562,7 +627,7 @@ mod tests {
     #[test]
     fn property_info_filter_list_value() {
         let val = json!({"name": "tags", "type": "list", "value": ["rust", "cli"]});
-        let out = apply_jq_filter(PROPERTY_INFO_FILTER, &val).unwrap();
+        let out = jq(PROPERTY_INFO_FILTER, &val).unwrap();
         assert!(out.contains("tags"));
         assert!(out.contains("list"));
         // Array values should be wrapped in brackets and joined with ", "
@@ -573,7 +638,7 @@ mod tests {
     #[test]
     fn property_summary_entry_filter() {
         let val = json!({"count": 7, "name": "title", "type": "text"});
-        let out = apply_jq_filter(PROPERTY_SUMMARY_ENTRY_FILTER, &val).unwrap();
+        let out = jq(PROPERTY_SUMMARY_ENTRY_FILTER, &val).unwrap();
         assert!(out.contains("title"));
         assert!(out.contains("text"));
         assert!(out.contains("7 files"));
@@ -585,7 +650,7 @@ mod tests {
             "tags": [{"name": "rust", "count": 3}, {"name": "cli", "count": 1}],
             "total": 2
         });
-        let out = apply_jq_filter(TAG_SUMMARY_FILTER, &val).unwrap();
+        let out = jq(TAG_SUMMARY_FILTER, &val).unwrap();
         assert!(out.contains("2 unique tags"));
         assert!(out.contains("rust"));
         assert!(out.contains("3 files"));
@@ -596,7 +661,7 @@ mod tests {
     #[test]
     fn link_info_target_only_filter() {
         let val = json!({"target": "broken-link"});
-        let out = apply_jq_filter(LINK_INFO_TARGET_FILTER, &val).unwrap();
+        let out = jq(LINK_INFO_TARGET_FILTER, &val).unwrap();
         assert!(out.contains("broken-link"));
         assert!(out.contains("unresolved"));
     }
@@ -604,7 +669,7 @@ mod tests {
     #[test]
     fn link_info_with_path_filter() {
         let val = json!({"path": "note-b.md", "target": "note-b"});
-        let out = apply_jq_filter(LINK_INFO_PATH_FILTER, &val).unwrap();
+        let out = jq(LINK_INFO_PATH_FILTER, &val).unwrap();
         assert!(out.contains("note-b"));
         assert!(out.contains("note-b.md"));
     }
@@ -614,7 +679,7 @@ mod tests {
     #[test]
     fn task_count_filter() {
         let val = json!({"done": 3, "total": 5});
-        let out = apply_jq_filter(TASK_COUNT_FILTER, &val).unwrap();
+        let out = jq(TASK_COUNT_FILTER, &val).unwrap();
         assert_eq!(out, "[3/5]");
     }
 
@@ -627,7 +692,7 @@ mod tests {
             "line": 5,
             "links": ["[[other]]"]
         });
-        let out = apply_jq_filter(OUTLINE_SECTION_FILTER, &val).unwrap();
+        let out = jq(OUTLINE_SECTION_FILTER, &val).unwrap();
         assert!(out.contains("#"));
         assert!(out.contains("Introduction"));
         assert!(out.contains("[[other]]"));
@@ -643,7 +708,7 @@ mod tests {
             "links": [],
             "tasks": {"done": 2, "total": 4}
         });
-        let out = apply_jq_filter(OUTLINE_SECTION_WITH_TASKS_FILTER, &val).unwrap();
+        let out = jq(OUTLINE_SECTION_WITH_TASKS_FILTER, &val).unwrap();
         assert!(out.contains("##"));
         assert!(out.contains("Tasks"));
         assert!(out.contains("[2/4]"));
@@ -660,7 +725,7 @@ mod tests {
             "status": "x",
             "text": "Write the tests"
         });
-        let out = apply_jq_filter(FIND_TASK_INFO_FILTER, &val).unwrap();
+        let out = jq(FIND_TASK_INFO_FILTER, &val).unwrap();
         assert!(out.contains("[x]"));
         assert!(out.contains("Write the tests"));
         assert!(out.contains("line 42"));
@@ -676,7 +741,7 @@ mod tests {
             "status": " ",
             "text": "Review PR"
         });
-        let out = apply_jq_filter(FIND_TASK_INFO_FILTER, &val).unwrap();
+        let out = jq(FIND_TASK_INFO_FILTER, &val).unwrap();
         assert!(out.contains("[ ]"));
         assert!(out.contains("Review PR"));
         assert!(out.contains("line 7"));
@@ -693,7 +758,7 @@ mod tests {
             "status": "x",
             "text": "Ship it"
         });
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("[x]"));
         assert!(out.contains("Ship it"));
         assert!(
@@ -711,7 +776,7 @@ mod tests {
             "section": "Background",
             "text": "This is the matching line"
         });
-        let out = apply_jq_filter(CONTENT_MATCH_FILTER, &val).unwrap();
+        let out = jq(CONTENT_MATCH_FILTER, &val).unwrap();
         assert!(out.contains("line 15"));
         assert!(out.contains("Background"));
         assert!(out.contains("This is the matching line"));
@@ -724,7 +789,7 @@ mod tests {
             "section": "Intro",
             "text": "hello world"
         });
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("line 3"));
         assert!(out.contains("hello world"));
         assert!(!out.contains("line: 3"), "should not use generic fallback");
@@ -742,7 +807,7 @@ mod tests {
             "total": 2,
             "value": "done"
         });
-        let out = apply_jq_filter(PROPERTY_VALUE_MUTATION_FILTER, &val).unwrap();
+        let out = jq(PROPERTY_VALUE_MUTATION_FILTER, &val).unwrap();
         assert!(out.contains("status=done"));
         assert!(out.contains("2/2 modified"));
         assert!(out.contains("note-a.md"));
@@ -758,7 +823,7 @@ mod tests {
             "total": 1,
             "value": "high"
         });
-        let out = apply_jq_filter(PROPERTY_VALUE_MUTATION_FILTER, &val).unwrap();
+        let out = jq(PROPERTY_VALUE_MUTATION_FILTER, &val).unwrap();
         assert!(out.contains("priority=high"));
         assert!(out.contains("0/1 modified"));
         // No file paths should appear when nothing was modified
@@ -774,7 +839,7 @@ mod tests {
             "total": 1,
             "value": "done"
         });
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("status=done"));
         assert!(
             !out.contains("modified: "),
@@ -791,7 +856,7 @@ mod tests {
             "skipped": [],
             "total": 1
         });
-        let out = apply_jq_filter(PROPERTY_MUTATION_FILTER, &val).unwrap();
+        let out = jq(PROPERTY_MUTATION_FILTER, &val).unwrap();
         assert!(out.contains("draft"));
         assert!(out.contains("1/1 modified"));
         assert!(out.contains("note.md"));
@@ -806,7 +871,7 @@ mod tests {
             "tag": "rust",
             "total": 3
         });
-        let out = apply_jq_filter(TAG_MUTATION_FILTER, &val).unwrap();
+        let out = jq(TAG_MUTATION_FILTER, &val).unwrap();
         assert!(out.contains("rust"));
         assert!(out.contains("2/3 modified"));
         assert!(out.contains("a.md"));
@@ -822,7 +887,7 @@ mod tests {
             "tag": "cli",
             "total": 1
         });
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("cli"));
         assert!(!out.contains("tag: cli"), "should not use generic fallback");
     }
@@ -836,7 +901,7 @@ mod tests {
             serde_json::from_str(r#"{"file": "notes/foo.md", "modified": "2024-01-01"}"#).unwrap();
         let filter = build_file_object_filter(&map);
         let val = json!({"file": "notes/foo.md", "modified": "2024-01-01"});
-        let out = apply_jq_filter(&filter, &val).unwrap();
+        let out = jq(&filter, &val).unwrap();
         assert!(out.contains("notes/foo.md"));
         assert!(out.contains("2024-01-01"));
     }
@@ -849,7 +914,7 @@ mod tests {
         .unwrap();
         let filter = build_file_object_filter(&map);
         let val = json!({"file": "foo.md", "modified": "2024-01-01", "tags": ["rust", "cli"]});
-        let out = apply_jq_filter(&filter, &val).unwrap();
+        let out = jq(&filter, &val).unwrap();
         assert!(out.contains("foo.md"));
         assert!(out.contains("tags: [rust, cli]"));
     }
@@ -866,7 +931,7 @@ mod tests {
             "modified": "2024-01-01",
             "properties": [{"name": "status", "type": "text", "value": "done"}]
         });
-        let out = apply_jq_filter(&filter, &val).unwrap();
+        let out = jq(&filter, &val).unwrap();
         assert!(out.contains("foo.md"));
         assert!(out.contains("status (text): done"));
     }
@@ -883,7 +948,7 @@ mod tests {
             "modified": "2024-01-01",
             "tasks": [{"done": true, "line": 5, "section": "Goals", "status": "x", "text": "Ship it"}]
         });
-        let out = apply_jq_filter(&filter, &val).unwrap();
+        let out = jq(&filter, &val).unwrap();
         assert!(out.contains("foo.md"));
         assert!(out.contains("tasks:"));
         assert!(out.contains("[x] Ship it"));
@@ -902,7 +967,7 @@ mod tests {
             "modified": "2024-01-01",
             "matches": [{"line": 3, "section": "Intro", "text": "hello world"}]
         });
-        let out = apply_jq_filter(&filter, &val).unwrap();
+        let out = jq(&filter, &val).unwrap();
         assert!(out.contains("foo.md"));
         assert!(out.contains("matches:"));
         assert!(out.contains("line 3 (Intro): hello world"));
@@ -920,7 +985,7 @@ mod tests {
             "modified": "2024-01-01",
             "links": [{"target": "bar", "path": "bar.md"}]
         });
-        let out = apply_jq_filter(&filter, &val).unwrap();
+        let out = jq(&filter, &val).unwrap();
         assert!(out.contains("foo.md"));
         assert!(out.contains("links:"));
         assert!(out.contains("bar → bar.md"));
@@ -938,7 +1003,7 @@ mod tests {
             "modified": "2024-01-01",
             "links": [{"target": "missing"}]
         });
-        let out = apply_jq_filter(&filter, &val).unwrap();
+        let out = jq(&filter, &val).unwrap();
         assert!(out.contains("missing (unresolved)"));
     }
 
@@ -947,7 +1012,7 @@ mod tests {
     #[test]
     fn file_object_text_rendering_minimal() {
         let val = json!({"file": "notes/foo.md", "modified": "2024-01-15"});
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("notes/foo.md"));
         assert!(out.contains("2024-01-15"));
         // Should not look like generic fallback
@@ -966,7 +1031,7 @@ mod tests {
                 {"done": true, "line": 20, "section": "Done", "status": "x", "text": "Write docs"}
             ]
         });
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("notes/project.md"));
         assert!(out.contains("tags: [rust, work]"));
         assert!(out.contains("status (text): active"));
@@ -983,7 +1048,7 @@ mod tests {
             {"file": "a.md", "modified": "2024-01-01"},
             {"file": "b.md", "modified": "2024-01-02"}
         ]);
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("a.md"));
         assert!(out.contains("b.md"));
         // Should have a blank line between entries
@@ -999,7 +1064,7 @@ mod tests {
             {"count": 1, "name": "status", "type": "text"},
             {"count": 3, "name": "title", "type": "text"}
         ]);
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("status"));
         assert!(out.contains("title"));
         // Should NOT have a blank line separator
@@ -1016,7 +1081,7 @@ mod tests {
         // A nested object with a known shape should get its filter applied,
         // not the k=v flat format.
         let inner = json!({"count": 2, "name": "status", "type": "text"});
-        let out = format_scalar(&inner);
+        let out = scalar(&inner);
         // Should NOT look like the old "count=2, name=status, type=text" format.
         assert!(
             !out.contains("count=2"),
@@ -1033,7 +1098,7 @@ mod tests {
     fn format_value_as_text_uses_filter_for_known_shape() {
         // PropertySummaryEntry has a known shape: {count, name, type}
         let val = json!({"count": 3, "name": "status", "type": "text"});
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("status"));
         assert!(out.contains("3 files"));
         // Should NOT look like "count: 3" (that's the generic fallback)
@@ -1043,7 +1108,7 @@ mod tests {
     #[test]
     fn format_value_as_text_falls_back_for_unknown_shape() {
         let val = json!({"foo": "bar", "baz": 42});
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         // Generic fallback: key: value
         assert!(out.contains("foo: bar") || out.contains("baz: 42"));
     }
@@ -1054,7 +1119,7 @@ mod tests {
             {"path": "a.md", "tags": ["rust"]},
             {"path": "b.md", "tags": ["cli"]}
         ]);
-        let out = format_value_as_text(&val);
+        let out = fmt(&val);
         assert!(out.contains("a.md"));
         assert!(out.contains("b.md"));
         assert!(out.contains("rust"));

--- a/src/output.rs
+++ b/src/output.rs
@@ -401,10 +401,11 @@ fn run_jq_filter_cached(
     value: &serde_json::Value,
     cache: &mut JaqFilterCache,
 ) -> Result<String, String> {
-    let filter = match cache.entry(filter_code.to_owned()) {
-        std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
-        std::collections::hash_map::Entry::Vacant(e) => e.insert(compile_jq_filter(filter_code)?),
-    };
+    if let Some(filter) = cache.get_mut(filter_code) {
+        return execute_jq_filter(filter, value);
+    }
+    let compiled = compile_jq_filter(filter_code)?;
+    let filter = cache.entry(filter_code.to_owned()).or_insert(compiled);
     execute_jq_filter(filter, value)
 }
 


### PR DESCRIPTION
## Summary

- Add Criterion micro-benchmarks (`benches/micro.rs`) for hot-path string parsing functions and vault-scale benchmarks (`benches/vault.rs`) for discovery, frontmatter reading, and multi-visitor scanning
- Add Hyperfine e2e benchmark script (`bench-e2e.sh`) with A/B comparison support for all CLI commands against obsidian-hub (6540 files)
- Cache compiled jaq filters in `output.rs` using a `HashMap<String, Filter>` — eliminates recompilation of the same filter string on every call to `format_value_as_text`
- `find --format text` on obsidian-hub: **2.91s → 1.03s (2.82x faster)**, no regression on `--format json`
- Document benchmarking workflow in `benches/README.md`: Criterion, Hyperfine, samply profiling, A/B comparison via critcmp/worktrees, memory measurement

## Test plan

- [x] `cargo bench --bench micro` runs all micro-benchmarks and produces HTML reports
- [x] `cargo bench --bench vault` runs vault benchmarks (skips gracefully if vault absent)
- [x] `./bench-e2e.sh` runs all e2e benchmarks and exports markdown to `bench-results/`
- [x] A/B comparison with hyperfine confirms 2.82x speedup on `find --format text`
- [x] `cargo test --workspace` — all 582 tests pass (existing output.rs tests cover the cached path)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)