### PR TITLE
Add per-project .hyalo.toml config file

### DIFF
--- a/.hyalo.toml
+++ b/.hyalo.toml
@@ -1,0 +1,1 @@
+dir = "hyalo-knowledgebase"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ Organize in subfolders. Use `[[wikilinks]]` for cross-references. Keep Obsidian-
 After an iteration or before starting one, build hyalo with "cargo build --release".
 Then use target/release/hyalo to work with the documentation in `./hyalo-knowledgebase/`. Mention issues you have using it, propose features you'd like to have.
 
+**Always use hyalo for knowledgebase interactions — never use Edit/Read/Grep directly:**
+- **Read**: `hyalo find`, `hyalo summary`, `hyalo properties`, `hyalo tags`
+- **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append` (e.g., `hyalo set --property status=completed --file iterations/iteration-16-robustness.md`)
+- Only fall back to Edit for body content changes (markdown prose, task checkboxes) that hyalo can't handle
+
 **Iteration file rules:**
 - Always name `iteration-NN-slug.md` — no standalone plan files
 - Frontmatter must include: `title`, `type: iteration`, `date`, `tags`, `status`, `branch`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -903,6 +904,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +976,47 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typed-arena"
@@ -1204,6 +1255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ jaq-std = "2.1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml_ng = "0.10"
+toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ All commands accept `--dir <path>` (default: `.`), `--format json|text` (default
 
 Glob patterns use standard shell semantics: `*` matches within a single directory, `**` matches across directory boundaries. For example, `*.md` matches top-level files only, while `**/*.md` matches all `.md` files recursively.
 
+### Configuration
+
+Place a `.hyalo.toml` file in your working directory to set defaults for global flags:
+
+```toml
+# .hyalo.toml
+dir = "./my-vault"   # default: "."
+format = "text"      # default: "json"
+hints = true         # default: false
+```
+
+All fields are optional. CLI flags always take precedence over config values. Missing or malformed config files are handled gracefully — hyalo warns on stderr and falls back to built-in defaults.
+
+Use `--no-hints` to explicitly disable hints when the config file enables them.
+
 ### find
 
 Search and filter files. Returns an array of file objects, each containing frontmatter properties, tags, sections, tasks, and links.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ format = "text"      # default: "json"
 hints = true         # default: false
 ```
 
-All fields are optional. CLI flags always take precedence over config values. Missing or malformed config files are handled gracefully — hyalo warns on stderr and falls back to built-in defaults.
+All fields are optional. CLI flags always take precedence over config values. If `.hyalo.toml` is missing, hyalo silently uses built-in defaults; if the file is present but cannot be read or is malformed/invalid, hyalo warns on stderr and falls back to the built-in defaults.
 
 Use `--no-hints` to explicitly disable hints when the config file enables them.
 

--- a/hyalo-knowledgebase/iterations/iteration-16-robustness.md
+++ b/hyalo-knowledgebase/iterations/iteration-16-robustness.md
@@ -7,7 +7,7 @@ tags:
   - robustness
   - error-handling
   - path-resolution
-status: in-progress
+status: completed
 branch: iter-16/robustness
 ---
 

--- a/hyalo-knowledgebase/iterations/iteration-17-config-file.md
+++ b/hyalo-knowledgebase/iterations/iteration-17-config-file.md
@@ -1,0 +1,80 @@
+---
+title: "Iteration 17: Per-Project Config File (.hyalo.toml)"
+type: iteration
+date: 2026-03-22
+tags:
+  - iteration
+  - config
+  - cli
+  - ux
+status: completed
+branch: iter-17/config-file
+---
+
+# Iteration 17: Per-Project Config File (.hyalo.toml)
+
+Add a per-project `.hyalo.toml` config file that sets defaults for CLI args (`dir`, `format`, `hints`), so users don't have to repeat flags on every invocation.
+
+## Config format
+
+```toml
+# .hyalo.toml (in CWD)
+dir = "./my-vault"   # default: "."
+format = "text"      # default: "json"
+hints = true         # default: false
+```
+
+## Tasks
+
+### Config module (`src/config.rs`)
+
+- [x] Add `toml = "0.8"` dependency to `Cargo.toml`
+- [x] Create `src/config.rs` with `ConfigFile` (serde, `deny_unknown_fields`) and `ResolvedDefaults` structs
+- [x] Implement `load_config()` — reads `.hyalo.toml` from CWD, graceful fallback on errors
+- [x] Implement `load_config_from(dir)` — testable variant with explicit directory
+- [x] Add `pub mod config` to `src/lib.rs`
+- [x] Unit test: missing config returns defaults
+- [x] Unit test: full config overrides all defaults
+- [x] Unit test: partial config merges with defaults
+- [x] Unit test: malformed TOML returns defaults with warning
+- [x] Unit test: unknown fields returns defaults (deny_unknown_fields)
+- [x] Unit test: invalid format value passed through (validation is caller's job)
+
+### CLI integration (`src/main.rs`)
+
+- [x] Change `Cli.dir` to `Option<PathBuf>` (remove `default_value`)
+- [x] Change `Cli.format` to `Option<String>` (remove `default_value`)
+- [x] Add `--hints` / `--no-hints` flag pair (replaces `Option<bool>`)
+- [x] Load config at start of `main()`, merge with CLI args (CLI wins)
+- [x] Update help text to mention `.hyalo.toml`
+- [x] Inline hint context construction (removed `build_hint_context` function)
+- [x] Only propagate CLI-explicit flags into drill-down hints (not config values)
+- [x] Add CONFIG paragraph to `--help` long description
+- [x] Add Configuration section to README.md
+
+### E2E tests (`tests/e2e_config.rs`)
+
+- [x] Config sets default format
+- [x] CLI `--format` overrides config format
+- [x] Config sets default dir
+- [x] CLI `--dir` overrides config dir
+- [x] Missing config uses hardcoded defaults
+- [x] Malformed config warns on stderr, still succeeds
+- [x] Config sets `hints = true`
+- [x] CLI `--no-hints` overrides config hints
+
+### Quality gates
+
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`
+- [x] Build release and dogfood
+
+## Acceptance criteria
+
+- `.hyalo.toml` in CWD sets defaults for `dir`, `format`, `hints`
+- CLI args always override config values
+- Missing config file is silent — no warning, no error
+- Malformed config warns on stderr but does not abort
+- Unknown fields in config warn (catches typos)
+- All existing tests still pass

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,165 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Raw deserialized representation of `.hyalo.toml`.
+///
+/// All fields are optional so that a partial config file is valid.
+/// Unknown fields are rejected via `deny_unknown_fields` so that typos
+/// are caught early rather than silently ignored.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfigFile {
+    dir: Option<String>,
+    format: Option<String>,
+    hints: Option<bool>,
+}
+
+/// Resolved configuration with all defaults applied.
+#[derive(Debug, PartialEq)]
+pub struct ResolvedDefaults {
+    pub dir: PathBuf,
+    pub format: String,
+    pub hints: bool,
+}
+
+impl ResolvedDefaults {
+    fn hardcoded() -> Self {
+        Self {
+            dir: PathBuf::from("."),
+            format: "json".to_owned(),
+            hints: false,
+        }
+    }
+}
+
+/// Load configuration from `.hyalo.toml` in the current working directory.
+///
+/// Missing file → silent, returns hardcoded defaults.
+/// I/O error (not NotFound) → prints a warning, returns defaults.
+/// Malformed TOML or unknown fields → prints a warning, returns defaults.
+/// Valid config → merges with defaults (config values take precedence).
+pub fn load_config() -> ResolvedDefaults {
+    match std::env::current_dir() {
+        Ok(cwd) => load_config_from(&cwd),
+        Err(e) => {
+            eprintln!("warning: could not read .hyalo.toml: {e}");
+            ResolvedDefaults::hardcoded()
+        }
+    }
+}
+
+/// Load configuration from `.hyalo.toml` inside `dir`.
+///
+/// This variant accepts an explicit directory to make it testable without
+/// relying on the process working directory.
+pub fn load_config_from(dir: &Path) -> ResolvedDefaults {
+    let path = dir.join(".hyalo.toml");
+
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return ResolvedDefaults::hardcoded();
+        }
+        Err(e) => {
+            eprintln!("warning: could not read .hyalo.toml: {e}");
+            return ResolvedDefaults::hardcoded();
+        }
+    };
+
+    let cfg: ConfigFile = match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("warning: malformed .hyalo.toml: {e}");
+            return ResolvedDefaults::hardcoded();
+        }
+    };
+
+    let defaults = ResolvedDefaults::hardcoded();
+    ResolvedDefaults {
+        dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
+        format: cfg.format.unwrap_or(defaults.format),
+        hints: cfg.hints.unwrap_or(defaults.hints),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn make_temp() -> TempDir {
+        tempfile::tempdir().expect("failed to create temp dir")
+    }
+
+    #[test]
+    fn missing_config_returns_defaults() {
+        let dir = make_temp();
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved, ResolvedDefaults::hardcoded());
+    }
+
+    #[test]
+    fn valid_full_config() {
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            r#"
+dir = "notes"
+format = "text"
+hints = true
+"#,
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved.dir, PathBuf::from("notes"));
+        assert_eq!(resolved.format, "text");
+        assert!(resolved.hints);
+    }
+
+    #[test]
+    fn partial_config_merges_with_defaults() {
+        let dir = make_temp();
+        fs::write(dir.path().join(".hyalo.toml"), "hints = true\n").unwrap();
+
+        let resolved = load_config_from(dir.path());
+        // Only hints overridden; dir and format stay at defaults.
+        assert_eq!(resolved.dir, PathBuf::from("."));
+        assert_eq!(resolved.format, "json");
+        assert!(resolved.hints);
+    }
+
+    #[test]
+    fn malformed_toml_returns_defaults() {
+        let dir = make_temp();
+        fs::write(dir.path().join(".hyalo.toml"), "this is not { valid toml").unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved, ResolvedDefaults::hardcoded());
+    }
+
+    #[test]
+    fn unknown_fields_returns_defaults() {
+        let dir = make_temp();
+        fs::write(dir.path().join(".hyalo.toml"), "unknown_key = \"value\"\n").unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved, ResolvedDefaults::hardcoded());
+    }
+
+    #[test]
+    fn invalid_format_value_passed_through() {
+        let dir = make_temp();
+        fs::write(dir.path().join(".hyalo.toml"), "format = \"xml\"\n").unwrap();
+
+        // config.rs does not validate the format string — that is the caller's job.
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved.format, "xml");
+        assert_eq!(resolved.dir, PathBuf::from("."));
+        assert!(!resolved.hints);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,7 @@ pub fn load_config() -> ResolvedDefaults {
     match std::env::current_dir() {
         Ok(cwd) => load_config_from(&cwd),
         Err(e) => {
-            eprintln!("warning: could not read .hyalo.toml: {e}");
+            eprintln!("warning: could not determine current directory to locate .hyalo.toml: {e}");
             ResolvedDefaults::hardcoded()
         }
     }

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -15,11 +15,19 @@ pub enum HintSource {
 }
 
 /// Global flags to propagate into generated hint commands.
+///
+/// Each `Option` field is `Some` only when the user passed the flag explicitly
+/// on the CLI. Values that came from `.hyalo.toml` config are omitted so that
+/// the copy-pasted hint command inherits the same config automatically.
 pub struct HintContext {
     pub source: HintSource,
-    /// `None` means "." (default) — omit from hints to keep them short.
+    /// `None` means "." (default) or came from config — omit from hints.
     pub dir: Option<String>,
     pub glob: Option<String>,
+    /// Explicit `--format` from CLI (not from config).
+    pub format: Option<String>,
+    /// Explicit `--hints` from CLI (not from config).
+    pub hints: bool,
 }
 
 /// Generate concrete drill-down hints from a command's JSON output.
@@ -39,14 +47,25 @@ pub fn generate_hints(ctx: &HintContext, data: &serde_json::Value) -> Vec<String
 // Command builder
 // ---------------------------------------------------------------------------
 
-/// Build a command that intentionally omits `--glob` (for file-specific hints).
-fn build_command_no_glob(ctx: &HintContext, args: &[&str]) -> String {
-    // We need a stripped context — easiest is to inline the logic without glob.
-    let mut parts: Vec<String> = vec!["hyalo".to_owned()];
+/// Push the global flags that were explicitly passed on the CLI.
+fn push_global_flags(parts: &mut Vec<String>, ctx: &HintContext) {
     if let Some(dir) = &ctx.dir {
         parts.push("--dir".to_owned());
         parts.push(shell_quote(dir));
     }
+    if let Some(fmt) = &ctx.format {
+        parts.push("--format".to_owned());
+        parts.push(shell_quote(fmt));
+    }
+    if ctx.hints {
+        parts.push("--hints".to_owned());
+    }
+}
+
+/// Build a command that intentionally omits `--glob` (for file-specific hints).
+fn build_command_no_glob(ctx: &HintContext, args: &[&str]) -> String {
+    let mut parts: Vec<String> = vec!["hyalo".to_owned()];
+    push_global_flags(&mut parts, ctx);
     for arg in args {
         parts.push(shell_quote(arg));
     }
@@ -56,20 +75,14 @@ fn build_command_no_glob(ctx: &HintContext, args: &[&str]) -> String {
 /// Build a command that propagates `--glob` when present.
 fn build_command_with_glob(ctx: &HintContext, args: &[&str]) -> String {
     let mut parts: Vec<String> = vec!["hyalo".to_owned()];
-
-    if let Some(dir) = &ctx.dir {
-        parts.push("--dir".to_owned());
-        parts.push(shell_quote(dir));
-    }
+    push_global_flags(&mut parts, ctx);
     if let Some(glob) = &ctx.glob {
         parts.push("--glob".to_owned());
         parts.push(shell_quote(glob));
     }
-
     for arg in args {
         parts.push(shell_quote(arg));
     }
-
     parts.join(" ")
 }
 
@@ -216,6 +229,8 @@ mod tests {
             source,
             dir: None,
             glob: None,
+            format: None,
+            hints: false,
         }
     }
 
@@ -224,6 +239,8 @@ mod tests {
             source,
             dir: Some(dir.to_owned()),
             glob: None,
+            format: None,
+            hints: false,
         }
     }
 
@@ -232,6 +249,8 @@ mod tests {
             source,
             dir: None,
             glob: Some(glob.to_owned()),
+            format: None,
+            hints: false,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod config;
 pub mod content_search;
 pub mod discovery;
 pub mod filter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,7 @@ fn main() {
     // can omit it when the user relies on .hyalo.toml.
     let dir_from_cli = cli.dir.is_some();
     let format_from_cli = cli.format.is_some();
-    let hints_from_cli = cli.hints || cli.no_hints;
+    let hints_from_cli = cli.hints;
     let dir = cli.dir.unwrap_or(config.dir);
     let format_str = cli.format.unwrap_or(config.format);
     let hints_flag = if cli.hints {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use hyalo::output::{CommandOutcome, Format, apply_jq_filter_result, format_with_
         Globs use standard syntax: '**/*.md' matches recursively, 'notes/*.md' matches one level.\n\n\
         OUTPUT: Returns JSON by default (--format json). Use --format text for human-readable output. \
         Successful output goes to stdout; errors go to stderr with exit code 1 (user error) or 2 (internal error).\n\n\
+        CONFIG: Place a .hyalo.toml in the working directory to set defaults for --dir, --format, and --hints. CLI flags always take precedence.\n\n\
         COMMANDS:\n\
           find        Search and filter files by text, properties, tags, or tasks\n\
           set         Set (create or overwrite) properties and add tags\n\
@@ -70,10 +71,11 @@ COMMAND REFERENCE:\n  \
     hyalo task toggle     --file F --line N           Toggle completion\n  \
     hyalo task set-status --file F --line N --status C\n\n  \
   Global flags (apply to all commands):\n  \
-    --dir <DIR>         Root directory (default: .)\n  \
-    --format json|text  Output format (default: json)\n  \
+    --dir <DIR>         Root directory (default: ., override via .hyalo.toml)\n  \
+    --format json|text  Output format (default: json, override via .hyalo.toml)\n  \
     --jq <FILTER>       Apply a jq expression to JSON output\n  \
-    --hints             Append drill-down command hints to output\n\n\
+    --hints             Append drill-down hints (default: off, override via .hyalo.toml)\n  \
+    --no-hints          Disable hints (overrides .hyalo.toml)\n\n\
 COOKBOOK:\n  \
   # Discover what metadata exists in a vault\n  \
   hyalo properties\n  \
@@ -125,13 +127,15 @@ OUTPUT SHAPES (JSON, default):\n  \
   # --format text produces human-readable output on all commands"
 )]
 struct Cli {
-    /// Root directory for resolving all --file and --glob paths. Defaults to current directory
-    #[arg(long, global = true, default_value = ".")]
-    dir: PathBuf,
+    /// Root directory for resolving all --file and --glob paths.
+    /// Default: "." (Override via .hyalo.toml)
+    #[arg(long, global = true)]
+    dir: Option<PathBuf>,
 
-    /// Output format: "json" (structured, default) or "text" (human-readable). Applies to both stdout and stderr
-    #[arg(long, global = true, default_value = "json")]
-    format: String,
+    /// Output format: "json" or "text".
+    /// Default: "json" (Override via .hyalo.toml)
+    #[arg(long, global = true)]
+    format: Option<String>,
 
     /// Apply a jq filter expression to the JSON output of any command.
     /// The filtered result is printed as plain text. Incompatible with non-JSON formats (--format text).
@@ -142,9 +146,14 @@ struct Cli {
     /// Append drill-down command hints to the output.
     /// Text mode: '-> hyalo ...' lines — concrete, copy-pasteable commands.
     /// JSON mode: wraps in {"data": ..., "hints": [...]}.
-    /// Suppressed when --jq is active
+    /// Suppressed when --jq is active.
+    /// Override via .hyalo.toml
     #[arg(long, global = true)]
     hints: bool,
+
+    /// Disable hints even when enabled in .hyalo.toml
+    #[arg(long, global = true, conflicts_with = "hints")]
+    no_hints: bool,
 
     #[command(subcommand)]
     command: Commands,
@@ -370,43 +379,33 @@ enum TaskAction {
     },
 }
 
-/// Build a `HintContext` from the parsed command, or `None` for mutation commands
-/// (set, remove, append, toggle, etc.) where drill-down hints don't make sense.
-fn build_hint_context(command: &Commands, dir: &std::path::Path) -> Option<HintContext> {
-    let dir_str = dir.to_str().map(|s| s.to_owned());
-    // Only pass --dir to hints if it's not the default "."
-    let dir_opt = dir_str.filter(|s| s != ".");
-
-    match command {
-        Commands::Summary { glob, .. } => Some(HintContext {
-            source: HintSource::Summary,
-            dir: dir_opt,
-            glob: glob.clone(),
-        }),
-        Commands::Properties { glob } => Some(HintContext {
-            source: HintSource::PropertiesSummary,
-            dir: dir_opt,
-            glob: glob.clone(),
-        }),
-        Commands::Tags { glob } => Some(HintContext {
-            source: HintSource::TagsSummary,
-            dir: dir_opt,
-            glob: glob.clone(),
-        }),
-        Commands::Find { .. } => None, // TODO: add HintSource::Find with find-relevant hints
-        Commands::Task { .. } => None,
-        Commands::Set { .. } | Commands::Remove { .. } | Commands::Append { .. } => None,
-    }
-}
-
 #[allow(clippy::too_many_lines)]
 fn main() {
     let cli = Cli::parse();
 
-    let Some(format) = Format::from_str_opt(&cli.format) else {
+    // Load per-project config from .hyalo.toml in CWD
+    let config = hyalo::config::load_config();
+
+    // Merge: CLI args override config, config overrides hardcoded defaults.
+    // Track whether --dir was explicitly passed (not from config) so hints
+    // can omit it when the user relies on .hyalo.toml.
+    let dir_from_cli = cli.dir.is_some();
+    let format_from_cli = cli.format.is_some();
+    let hints_from_cli = cli.hints || cli.no_hints;
+    let dir = cli.dir.unwrap_or(config.dir);
+    let format_str = cli.format.unwrap_or(config.format);
+    let hints_flag = if cli.hints {
+        true
+    } else if cli.no_hints {
+        false
+    } else {
+        config.hints
+    };
+
+    let Some(format) = Format::from_str_opt(&format_str) else {
         eprintln!(
             "Error: invalid format '{}', expected 'json' or 'text'",
-            cli.format
+            format_str
         );
         process::exit(2);
     };
@@ -416,25 +415,59 @@ fn main() {
     if jq_filter.is_some() && format != Format::Json {
         eprintln!(
             "Error: --jq cannot be combined with --format {}",
-            cli.format
+            format_str
         );
         eprintln!("  --jq always operates on JSON output; drop --format or use --format json");
         process::exit(2);
     }
     // When --jq or --hints is active, force JSON internally so we can re-parse the output.
     // The user-requested format is applied afterwards.
-    let hints_active = cli.hints && jq_filter.is_none();
+    let hints_active = hints_flag && jq_filter.is_none();
     let effective_format = if jq_filter.is_some() || hints_active {
         Format::Json
     } else {
         format
     };
 
-    let dir = &cli.dir;
+    // Build hint context before the command dispatch.
+    // Only include CLI-explicit flags in hints — config values are inherited
+    // automatically when the user runs the hint command from the same CWD.
+    let hint_ctx = if hints_flag && jq_filter.is_none() {
+        let dir_hint = if dir_from_cli {
+            dir.to_str().map(|s| s.to_owned()).filter(|s| s != ".")
+        } else {
+            None
+        };
+        let format_hint = if format_from_cli {
+            Some(format_str.clone())
+        } else {
+            None
+        };
 
-    // Build hint context before the command dispatch (which moves cli.command fields).
-    let hint_ctx = if cli.hints && jq_filter.is_none() {
-        build_hint_context(&cli.command, dir)
+        match &cli.command {
+            Commands::Summary { glob, .. } => Some(HintContext {
+                source: HintSource::Summary,
+                dir: dir_hint,
+                glob: glob.clone(),
+                format: format_hint,
+                hints: hints_from_cli,
+            }),
+            Commands::Properties { glob } => Some(HintContext {
+                source: HintSource::PropertiesSummary,
+                dir: dir_hint,
+                glob: glob.clone(),
+                format: format_hint,
+                hints: hints_from_cli,
+            }),
+            Commands::Tags { glob } => Some(HintContext {
+                source: HintSource::TagsSummary,
+                dir: dir_hint,
+                glob: glob.clone(),
+                format: format_hint,
+                hints: hints_from_cli,
+            }),
+            _ => None,
+        }
     } else {
         None
     };
@@ -491,7 +524,7 @@ fn main() {
             };
 
             find_commands::find(
-                dir,
+                &dir,
                 pattern.as_deref(),
                 &prop_filters,
                 tag,
@@ -505,17 +538,17 @@ fn main() {
             )
         }
         Commands::Properties { ref glob } => {
-            properties::properties_summary(dir, None, glob.as_deref(), effective_format)
+            properties::properties_summary(&dir, None, glob.as_deref(), effective_format)
         }
         Commands::Tags { ref glob } => {
-            tag_commands::tags_summary(dir, None, glob.as_deref(), effective_format)
+            tag_commands::tags_summary(&dir, None, glob.as_deref(), effective_format)
         }
         Commands::Task { action } => match action {
             TaskAction::Read { ref file, line } => {
-                task_commands::task_read(dir, file, line, effective_format)
+                task_commands::task_read(&dir, file, line, effective_format)
             }
             TaskAction::Toggle { ref file, line } => {
-                task_commands::task_toggle(dir, file, line, effective_format)
+                task_commands::task_toggle(&dir, file, line, effective_format)
             }
             TaskAction::SetStatus {
                 ref file,
@@ -534,7 +567,7 @@ fn main() {
                     process::exit(1);
                 }
                 task_commands::task_set_status(
-                    dir,
+                    &dir,
                     file,
                     line,
                     status.chars().next().unwrap(),
@@ -543,7 +576,7 @@ fn main() {
             }
         },
         Commands::Summary { ref glob, recent } => {
-            summary_commands::summary(dir, glob.as_deref(), recent, effective_format)
+            summary_commands::summary(&dir, glob.as_deref(), recent, effective_format)
         }
         Commands::Set {
             ref properties,
@@ -551,7 +584,7 @@ fn main() {
             ref file,
             ref glob,
         } => set_commands::set(
-            dir,
+            &dir,
             properties,
             tag,
             file.as_deref(),
@@ -564,7 +597,7 @@ fn main() {
             ref file,
             ref glob,
         } => remove_commands::remove(
-            dir,
+            &dir,
             properties,
             tag,
             file.as_deref(),
@@ -576,7 +609,7 @@ fn main() {
             ref file,
             ref glob,
         } => append_commands::append(
-            dir,
+            &dir,
             properties,
             file.as_deref(),
             glob.as_deref(),

--- a/tests/e2e_config.rs
+++ b/tests/e2e_config.rs
@@ -1,0 +1,257 @@
+mod common;
+
+use std::fs;
+
+use common::{hyalo, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Fixture helper
+// ---------------------------------------------------------------------------
+
+/// Write a minimal valid markdown file with frontmatter.
+fn write_note(dir: &std::path::Path, name: &str) {
+    write_md(
+        dir,
+        name,
+        "---\ntitle: Test Note\n---\n# Hello\n\nSome content.\n",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// format config key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_sets_default_format() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
+    write_note(tmp.path(), "note.md");
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["summary"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    // Text format uses "Files:" label, JSON does not
+    assert!(
+        stdout.contains("Files:"),
+        "expected text-format output; got: {stdout}"
+    );
+}
+
+#[test]
+fn cli_format_overrides_config() {
+    let tmp = TempDir::new().unwrap();
+    // Config says text, but CLI arg forces json
+    fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
+    write_note(tmp.path(), "note.md");
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    // JSON output starts with '{'
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "expected JSON output; got: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// dir config key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_sets_default_dir() {
+    let tmp = TempDir::new().unwrap();
+    // Note is inside vault/, config points dir at vault/
+    fs::write(tmp.path().join(".hyalo.toml"), "dir = \"vault\"\n").unwrap();
+    write_note(tmp.path(), "vault/note.md");
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        // No --dir flag: relies on config's dir = "vault"
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {stdout}"));
+    // Should find the file inside vault/
+    assert_eq!(
+        json["files"]["total"].as_u64().unwrap(),
+        1,
+        "config dir should point at vault/ which contains one file"
+    );
+}
+
+#[test]
+fn cli_dir_overrides_config() {
+    let tmp = TempDir::new().unwrap();
+    // Config points at "wrong/" which is empty; CLI --dir points at actual vault
+    fs::write(tmp.path().join(".hyalo.toml"), "dir = \"wrong\"\n").unwrap();
+    fs::create_dir_all(tmp.path().join("wrong")).unwrap();
+    write_note(tmp.path(), "vault/note.md");
+
+    let vault_path = tmp.path().join("vault");
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args([
+            "--dir",
+            vault_path.to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {stdout}"));
+    // CLI --dir wins; should scan vault/, not wrong/
+    assert_eq!(
+        json["files"]["total"].as_u64().unwrap(),
+        1,
+        "CLI --dir should override config dir, finding file in vault/"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Missing config → hardcoded defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_config_uses_defaults() {
+    let tmp = TempDir::new().unwrap();
+    // No .hyalo.toml written — hardcoded defaults apply (format=json, dir=., hints=false)
+    write_note(tmp.path(), "note.md");
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["summary"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    // Default format is JSON
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "expected JSON output (default format); got: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Malformed config → warning on stderr, hardcoded defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_config_warns_on_stderr() {
+    let tmp = TempDir::new().unwrap();
+    // Invalid TOML — not a valid key = value pair
+    fs::write(tmp.path().join(".hyalo.toml"), "{{invalid\n").unwrap();
+    write_note(tmp.path(), "note.md");
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Command must still succeed (falls back to defaults)
+    assert!(output.status.success(), "stderr: {stderr}");
+    // Hardcoded defaults still produce valid JSON
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "expected JSON fallback output; got: {stdout}"
+    );
+    // A warning must be emitted
+    assert!(
+        stderr.to_lowercase().contains("warning"),
+        "expected warning on stderr for malformed config; got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// hints config key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_sets_hints_true() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(".hyalo.toml"), "hints = true\n").unwrap();
+    write_note(tmp.path(), "note.md");
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {stdout}"));
+    // hints = true → output wrapped in {"data": ..., "hints": [...]}
+    assert!(
+        json.get("hints").is_some(),
+        "expected hints envelope in output when config sets hints = true; got: {stdout}"
+    );
+    assert!(
+        json.get("data").is_some(),
+        "expected data envelope in output when config sets hints = true; got: {stdout}"
+    );
+}
+
+#[test]
+fn cli_hints_false_overrides_config() {
+    let tmp = TempDir::new().unwrap();
+    // Config enables hints; explicit --no-hints should disable them
+    fs::write(tmp.path().join(".hyalo.toml"), "hints = true\n").unwrap();
+    write_note(tmp.path(), "note.md");
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["summary", "--format", "json", "--no-hints"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {stdout}"));
+    // --no-hints → no envelope; direct summary fields
+    assert!(
+        json.get("hints").is_none(),
+        "hints envelope should be absent when --no-hints overrides config; got: {stdout}"
+    );
+    assert!(
+        json.get("files").is_some(),
+        "expected direct summary fields (no envelope); got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `.hyalo.toml` per-project config file support — reads from CWD to set defaults for `--dir`, `--format`, and `--hints`
- CLI flags always take precedence over config values; missing/malformed config handled gracefully with stderr warnings
- Add `--no-hints` flag to explicitly disable hints when config enables them
- Drill-down hints only propagate CLI-explicit flags — config-sourced values omitted so copy-pasted commands inherit the same config from CWD
- Document config in README.md and `--help` output

## Test plan
- [x] 6 unit tests in `src/config.rs` (missing file, full/partial config, malformed TOML, unknown fields, invalid format passthrough)
- [x] 8 e2e tests in `tests/e2e_config.rs` (config sets format/dir/hints, CLI overrides each, missing config, malformed config warning)
- [x] All 607 existing tests pass
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean
- [x] Release build dogfooded against `hyalo-knowledgebase/`
- [ ] Verify `--hints` / `--no-hints` work as expected in interactive use
- [ ] Verify `.hyalo.toml` with `dir` pointing at a vault works from a different CWD

🤖 Generated with [Claude Code](https://claude.com/claude-code)