### PR TITLE
Improve text output readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Organize in subfolders. Use `[[wikilinks]]` for cross-references. Keep Obsidian-
 
 ## Dogfooding
 After an iteration or before starting one, build hyalo with "cargo build --release".
-Then use target/release/hyalo to work with the documentation in `./hyalo-knowledgebase/`. Mention issues you have using it, propose features you'd like to have.
+Then use target/release/hyalo to work with the documentation in `./hyalo-knowledgebase/` to dogfood what you did. Mention issues you have using it, propose features you'd like to have.
 
 **Always use hyalo for knowledgebase interactions — never use Edit/Read/Grep directly:**
 - **Read**: `hyalo find`, `hyalo summary`, `hyalo properties`, `hyalo tags`

--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ Add `--hints` to any read-only command to get suggested drill-down commands:
 
 ```
 $ hyalo summary --format text --hints
-Files: 32 total (.: 5, backlog: 7, iterations: 12, research: 8)
+Files: 32 total
+  ".": 5
+  "backlog": 7
+  "iterations": 12
+  "research": 8
 Properties: 8 unique
 Tags: 15 unique
 Status: completed (10), in-progress (2), planned (2)

--- a/hyalo-knowledgebase/backlog/parallel-file-operations.md
+++ b/hyalo-knowledgebase/backlog/parallel-file-operations.md
@@ -2,8 +2,8 @@
 title: "Parallel file operations with rayon"
 type: backlog
 date: 2026-03-21
-status: ready
-priority: medium
+status: shelved
+priority: low
 origin: research/performance-parallelization.md
 tags:
   - backlog
@@ -28,8 +28,13 @@ Scope:
 
 ## Trigger
 
-Implement when benchmarks on a real vault show latency above ~200ms for vault-wide commands. Not needed for small vaults (<100 files).
+Revisit when users report latency on vaults >20,000 files, or when per-file processing becomes heavier (indexing, link graph). For current vault sizes, sequential processing is fast enough.
+
+## Iteration 18 outcome
+
+Implemented and benchmarked — only 1-2x speedup on 6,540 files (I/O-dominated workload on SSD). Shelved due to poor complexity-to-gain ratio. Branch `iter-18/parallel-processing` has the full working implementation. See [[iterations/iteration-18-parallel-processing]] for details.
 
 ## References
 
-- [[research/performance-parallelization]]: full research with benchmark methodology
+- [[research/performance-parallelization]]: full research with benchmark results
+- [[iterations/iteration-18-parallel-processing]]: iteration details and decision rationale

--- a/hyalo-knowledgebase/iterations/iteration-14-text-output-overhaul.md
+++ b/hyalo-knowledgebase/iterations/iteration-14-text-output-overhaul.md
@@ -50,15 +50,17 @@ This keeps the single rendering path through jaq — no special Rust-side format
 
 ### `find` — FileObject (per file)
 ```
-iterations/iteration-12-cli-redesign.md  (2026-03-22T16:18:20Z)
-  branch (text): iter-12/cli-redesign
-  date (date): 2026-03-22
-  status (text): completed
-  title (text): Iteration 12: CLI Redesign
-  tags: iteration, cli, search
-  # Iteration 12: CLI Redesign
-  ## Goal
-  ## Tasks [17/17]
+"iterations/iteration-12-cli-redesign.md"  (2026-03-22T16:18:20Z)
+  properties:
+    branch (text): iter-12/cli-redesign
+    date (date): 2026-03-22
+    status (text): completed
+    title (text): Iteration 12: CLI Redesign
+  tags: [iteration, cli, search]
+  sections:
+    # Iteration 12: CLI Redesign
+    ## Goal
+    ## Tasks [17/17]
   tasks:
     [x] Design `FileObject` struct (line 167)
     [ ] Some open task (line 42)

--- a/hyalo-knowledgebase/iterations/iteration-18-parallel-processing.md
+++ b/hyalo-knowledgebase/iterations/iteration-18-parallel-processing.md
@@ -1,0 +1,57 @@
+---
+title: "Iteration 18: Parallel Processing (shelved)"
+type: iteration
+date: 2026-03-22
+tags:
+  - iteration
+  - performance
+  - parallelization
+  - rayon
+status: shelved
+branch: iter-18/parallel-processing
+---
+
+# Iteration 18: Parallel Processing (shelved)
+
+Attempted to add parallel file processing to all read-only multi-file commands using rayon `par_iter()`. Implementation was completed and all tests passed, but benchmarks showed the complexity-to-gain ratio was not worth it. Branch left open for future reference.
+
+## What was built
+
+- `rayon = "1"` dependency
+- Shared `par_process_files<T, F>` utility in `src/parallel.rs` with `FileResult::Ok(T)` / `FileResult::Skipped` enum
+- Parallelized `find`, `properties`, `tags`, `summary` commands using the shared utility
+- All 593 tests passing, clippy clean
+
+## Benchmark results (obsidian-hub, 6,540 files, Apple Silicon, SSD)
+
+| Command | Sequential | Parallel | Speedup |
+|---------|-----------|----------|---------|
+| `find` (all) | ~195ms | 185ms | 1.05x |
+| `find` (content search) | ~215ms | 207ms | 1.04x |
+| `properties` | ~135ms | 95ms | 1.4x |
+| `tags` | ~135ms | 98ms | 1.4x |
+| `summary` | ~195ms | 98ms | 2.0x |
+
+## Why shelved
+
+- **Modest speedup**: 1-2x on a 6,540-file vault, not the 4-6x estimated from napkin math
+- **I/O-dominated workload**: on SSD with warm page cache, the OS readahead already pipelines I/O; rayon adds thread pool overhead that eats into gains
+- **Added complexity**: new dependency (rayon + 4 transitive crates), new module, new abstraction (`FileResult` enum), closures replacing straightforward for-loops in every command
+- **Small vaults unaffected**: for typical vaults (<1,000 files), commands already complete in <50ms — parallelism adds overhead for no perceptible benefit
+
+## Learnings
+
+- Embarrassingly parallel ≠ automatically fast. When the bottleneck is filesystem I/O on a fast SSD, thread-level parallelism has diminishing returns because the OS already does readahead and the kernel serializes I/O anyway
+- The estimated speedups from [[research/performance-parallelization]] were overly optimistic — they assumed CPU-bound work, but frontmatter parsing is cheap relative to `open()` + `read()` syscalls
+- For real gains on large vaults, an **index** (SQLite with mtime-based invalidation) would eliminate scanning entirely, which is a fundamentally different approach than parallelizing the scan
+- If revisiting: only parallelize `find` and `summary` (the two commands with meaningful gains), skip `properties`/`tags` (already fast enough)
+
+## Tasks
+
+- [x] Add rayon dependency to Cargo.toml
+- [x] Create shared `par_process_files` utility in `src/parallel.rs`
+- [x] Parallelize `find`, `properties`, `tags`, `summary` commands
+- [x] All quality gates pass (fmt, clippy, tests)
+- [x] Dogfood with hyalo-knowledgebase
+- [x] Run benchmarks against obsidian-hub — results underwhelming
+- [x] Decision: shelve, keep branch for reference

--- a/hyalo-knowledgebase/research/performance-parallelization.md
+++ b/hyalo-knowledgebase/research/performance-parallelization.md
@@ -1,78 +1,84 @@
 ---
 title: "Performance: Parallel File Operations"
 type: research
-date: 2026-03-20
+date: 2026-03-22
 tags:
   - performance
   - parallelization
   - rayon
+  - research
 ---
 
 # Performance: Parallel File Operations
 
-## Current State (Iteration 1)
+## Current State
 
-All file operations are **sequential**. Commands like `properties` (no `--path`) and glob-matched `properties` iterate over every `.md` file one at a time:
+All file operations are **sequential**. Commands like `properties`, `tags`, `find`, and `summary` iterate over every `.md` file one at a time:
 
 ```
 discover_files(dir)  →  Vec<PathBuf>  (sequential walk)
     ↓
 for file in files {
-    read_frontmatter(file)  →  sequential I/O per file
+    read_frontmatter(file)  or  scan_file_multi(file)  →  sequential I/O per file
 }
 ```
 
-For a typical Obsidian vault with 100–500 files, this is fast enough (<100ms). For large vaults (5,000+ files), this becomes a bottleneck — each file requires an `open()` + `read()` syscall, and the CPU sits idle waiting for I/O between files.
+For a typical Obsidian vault with 100-500 files, this is fast enough (<50ms). For large vaults (5,000+ files), latency reaches 100-200ms.
 
-## Opportunity: rayon for Parallel File Reads
+## Experiment: rayon `par_iter()` (Iteration 18)
 
-The `properties_all` aggregation and `properties_glob` paths are embarrassingly parallel — each file read is independent, and the aggregation step is a simple merge.
+Full implementation on branch `iter-18/parallel-processing`. Replaced sequential for-loops with `par_iter().map().collect()` in all four read-only multi-file commands.
 
 ### Approach
 
-```rust
-use rayon::prelude::*;
+Created a shared utility `par_process_files<T, F>`:
 
-// Replace sequential loop:
-let results: Vec<_> = files
-    .par_iter()
-    .map(|file| frontmatter::read_frontmatter(file))
-    .collect::<Result<Vec<_>>>()?;
+```rust
+pub enum FileResult<T> { Ok(T), Skipped }
+
+pub fn par_process_files<T, F>(files: &[(PathBuf, String)], f: F) -> Result<Vec<T>>
+where
+    T: Send,
+    F: Fn(&Path, &str) -> Result<FileResult<T>> + Sync,
 ```
 
-### Expected Impact
+Each command provides a closure for per-file work. Errors propagated after parallel phase; skipped files (malformed YAML) emit warnings via `eprintln!`.
 
-| Vault size | Sequential (est.) | Parallel (est., 8 cores) | Speedup |
-|---|---|---|---|
-| 100 files | ~20ms | ~5ms | ~4x |
-| 1,000 files | ~200ms | ~30ms | ~6x |
-| 10,000 files | ~2s | ~300ms | ~6-7x |
+### Actual Benchmark Results (obsidian-hub, 6,540 files, Apple Silicon SSD)
 
-The speedup is sub-linear because:
-- I/O bandwidth is shared (SSD throughput is the ceiling)
-- Thread pool overhead for small workloads
-- The aggregation step is sequential
+| Command | Sequential | Parallel (rayon) | Speedup |
+|---------|-----------|-----------------|---------|
+| `find` (all) | ~195ms | 185ms | **1.05x** |
+| `find` (content) | ~215ms | 207ms | **1.04x** |
+| `properties` | ~135ms | 95ms | **1.4x** |
+| `tags` | ~135ms | 98ms | **1.4x** |
+| `summary` | ~195ms | 98ms | **2.0x** |
 
-### Implementation Notes
+### Why the Estimates Were Wrong
 
-- **Dependency:** `rayon = "1"` (~30s additional compile time, widely used, no transitive bloat)
-- **Error handling:** `par_iter().map().collect::<Result<Vec<_>>>()` short-circuits on first error, same as sequential
-- **Thread safety:** `read_frontmatter` is already `Send + Sync` — no shared mutable state
-- **Aggregation:** The `BTreeMap` merge after parallel reads stays sequential but is CPU-bound and fast
-- **Scope:** Only parallelize multi-file read paths (`properties_all`, `properties_glob`). Single-file commands (`property read/set/remove`) don't benefit.
+Original estimates predicted 4-7x speedup. The actual speedup was 1-2x because:
 
-### When to Implement
+1. **I/O-dominated, not CPU-dominated**: frontmatter parsing (`serde_yaml_ng`) is fast (~15µs per file). The bottleneck is `open()` + `read()` syscalls, which the OS already pipelines via readahead on SSDs
+2. **Warm page cache**: on repeated runs (and during normal use), files are already in the kernel page cache. The kernel serializes physical I/O regardless of thread count
+3. **Thread pool overhead**: rayon's work-stealing pool has non-trivial per-task overhead that offsets gains on cheap tasks
+4. **Small per-file work**: each file takes ~20-30µs to process. At this granularity, scheduling overhead is a significant fraction of useful work
 
-- Not needed for iteration 1 (correctness and API surface are the priority)
-- Consider for iteration 4 (search) where query performance across all files matters
-- Definitely needed if/when indexing (iteration plan: "Later") is deferred and full-scan remains the primary access pattern
+### Conclusion
 
-### Alternative: Indexing
+**Not worth the complexity for current vault sizes.** The added dependency (rayon + 4 transitive crates), new abstraction, and closure-based control flow don't justify 1-2x speedup when commands already complete in <200ms.
 
-For truly large vaults (50,000+ files), parallelization alone won't suffice. A persistent index (SQLite, see [[iteration-plan]]) that maps properties/tags/links with incremental mtime-based updates would eliminate the need to scan files at all. Parallelization and indexing are complementary — parallel reads for cold cache, index for warm.
+### When to Revisit
+
+- If users report latency on vaults >20,000 files
+- If per-file processing becomes heavier (e.g., full-text indexing, link graph construction)
+- If targeting cold cache scenarios (first run after reboot) where I/O parallelism helps more
+
+### Better Alternative: Indexing
+
+For truly large vaults, a persistent index (SQLite with mtime-based invalidation) would eliminate scanning entirely. This is fundamentally better than parallelizing the scan — O(1) lookups vs O(n) parallel reads. Parallelization and indexing are complementary: parallel reads for cold index rebuilds, index for warm queries.
 
 ## Other Performance Notes
 
-- **Streaming reader is already optimal for single-file reads.** `read_frontmatter` stops at the closing `---` and never reads the body. No further optimization needed there.
-- **`discover_files` uses the `ignore` crate** which is already fast (same engine as ripgrep). Parallelizing the walk itself is possible (`WalkBuilder::build_parallel()`) but unlikely to matter until vault sizes exceed 50,000 files.
-- **Avoid `String` allocations in hot loops.** The `properties_all` aggregation clones property keys for the `BTreeMap` entry API. With rayon, consider pre-sizing or using a `DashMap` for concurrent insertion, though the sequential merge may be simpler and fast enough.
+- **Streaming reader is already optimal for single-file reads.** `read_frontmatter` stops at the closing `---` and never reads the body
+- **`discover_files` uses the `ignore` crate** (same engine as ripgrep). Parallelizing the walk (`WalkBuilder::build_parallel()`) is unlikely to matter for <50,000 files
+- **Sequential baselines are already fast**: `properties`/`tags` complete in ~55ms on 6,540 files, `find`/`summary` in ~200ms

--- a/src/output.rs
+++ b/src/output.rs
@@ -160,25 +160,29 @@ const TAG_SUMMARY_ENTRY_FILTER: &str =
     r#""\(.name)\t\(.count) \(if .count == 1 then "file" else "files" end)""#;
 
 /// `LinkInfo` — just target: `{target}`
-const LINK_INFO_TARGET_FILTER: &str = r#""  \(.target) (unresolved)""#;
+/// Format: `  "target" (unresolved)`
+const LINK_INFO_TARGET_FILTER: &str = r#""  \"\(.target)\" (unresolved)""#;
 
 /// `LinkInfo` with path: `{path, target}`
-const LINK_INFO_PATH_FILTER: &str = r#""  \(.target) → \(.path)""#;
+/// Format: `  "target" → "path"`
+const LINK_INFO_PATH_FILTER: &str = r#""  \"\(.target)\" → \"\(.path)\"""#;
 
 /// `LinkInfo` with label: `{label, target}`
-const LINK_INFO_LABEL_FILTER: &str = r#""  \(.target) (unresolved) [\(.label)]""#;
+/// Format: `  "target" (unresolved) [label]`
+const LINK_INFO_LABEL_FILTER: &str = r#""  \"\(.target)\" (unresolved) [\(.label)]""#;
 
 /// `LinkInfo` with path and label: `{label, path, target}`
-const LINK_INFO_FULL_FILTER: &str = r#""  \(.target) → \(.path) [\(.label)]""#;
+/// Format: `  "target" → "path" [label]`
+const LINK_INFO_FULL_FILTER: &str = r#""  \"\(.target)\" → \"\(.path)\" [\(.label)]""#;
 
 /// `TaskCount`: `{done, total}`
 const TASK_COUNT_FILTER: &str = r#""[\(.done)/\(.total)]""#;
 
 /// `OutlineSection` without tasks: `{code_blocks, heading, level, line, links}`
-const OUTLINE_SECTION_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-heading)")\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)""##;
+const OUTLINE_SECTION_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-heading)")\(if (.links | length) > 0 then "\n\(.links | map("  → \"\(.)\"") | join("\n"))" else "" end)""##;
 
 /// `OutlineSection` with tasks: `{code_blocks, heading, level, line, links, tasks}`
-const OUTLINE_SECTION_WITH_TASKS_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-heading)") [\(.tasks.done)/\(.tasks.total)]\(if (.links | length) > 0 then "\n  → \(.links | join(", "))" else "" end)""##;
+const OUTLINE_SECTION_WITH_TASKS_FILTER: &str = r##""\("#" * .level) \(.heading // "(pre-heading)") [\(.tasks.done)/\(.tasks.total)]\(if (.links | length) > 0 then "\n\(.links | map("  → \"\(.)\"") | join("\n"))" else "" end)""##;
 
 /// `TaskInfo`: `{done, line, status, text}`
 const TASK_INFO_FILTER: &str =
@@ -186,10 +190,10 @@ const TASK_INFO_FILTER: &str =
 
 /// `TaskReadResult`: `{done, file, line, status, text}`
 const TASK_READ_RESULT_FILTER: &str =
-    r#""\(.file):\(.line) [\(.status)] \(.text)\(if .done then " (done)" else "" end)""#;
+    r#""\"\(.file)\":\(.line) [\(.status)] \(.text)\(if .done then " (done)" else "" end)""#;
 
 /// `VaultSummary`: `{files, properties, recent_files, status, tags, tasks}`
-const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then " (\(.files.by_directory | map("\(.directory): \(.count)") | join(", ")))" else "" end)\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nRecent: \(if (.recent_files | length) > 0 then (.recent_files | map(.path) | join(", ")) else "(none)" end)""#;
+const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
 
 /// `FindTaskInfo`: `{done, line, section, status, text}`
 /// Format: `  [x] text (line N, section)` or `  [ ] text (line N, section)`
@@ -203,20 +207,20 @@ const CONTENT_MATCH_FILTER: &str = r#""  line \(.line) (\(.section)): \(.text)""
 /// Mutation result with `property` + `value` fields:
 /// covers `SetPropertyResult`, `AppendPropertyResult`, and `RemovePropertyResult` (with value).
 /// Key signature: `modified,property,skipped,total,value`
-/// Format: `property=value: N/T modified` followed by modified file paths.
-const PROPERTY_VALUE_MUTATION_FILTER: &str = r#""\(.property)=\(.value): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \(.)") | join("\n"))" else "" end)""#;
+/// Format: `property=value: N/T modified` followed by quoted file paths on separate lines.
+const PROPERTY_VALUE_MUTATION_FILTER: &str = r#""\(.property)=\(.value): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `property` only (no value field):
 /// covers `RemovePropertyResult` (without value).
 /// Key signature: `modified,property,skipped,total`
-/// Format: `property: N/T modified` followed by modified file paths.
-const PROPERTY_MUTATION_FILTER: &str = r#""\(.property): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \(.)") | join("\n"))" else "" end)""#;
+/// Format: `property: N/T modified` followed by quoted file paths on separate lines.
+const PROPERTY_MUTATION_FILTER: &str = r#""\(.property): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `tag` field:
 /// covers `SetTagResult` and `RemoveTagResult`.
 /// Key signature: `modified,skipped,tag,total`
-/// Format: `tag: N/T modified` followed by modified file paths.
-const TAG_MUTATION_FILTER: &str = r#""\(.tag): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \(.)") | join("\n"))" else "" end)""#;
+/// Format: `tag: N/T modified` followed by quoted file paths on separate lines.
+const TAG_MUTATION_FILTER: &str = r#""\(.tag): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 // ---------------------------------------------------------------------------
 // Shape-based filter lookup
@@ -427,12 +431,12 @@ fn run_jq_filter_cached(
 /// in `run_jq_filter` would affect `FileObject` rendering.
 fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) -> String {
     // Header: file path and modified timestamp — always present.
-    let mut parts = vec![r#""\(.file)  (\(.modified))""#.to_owned()];
+    let mut parts = vec![r#""\"\(.file)\"  (\(.modified))""#.to_owned()];
 
-    // Properties: each rendered as "  name (type): value"
+    // Properties: header then each as "    name (type): value"
     if map.contains_key("properties") {
         parts.push(
-            r#"if .properties then (.properties | map("  \(.name) (\(.type)): \(if (.value | type) == "array" then "[" + (.value | join(", ")) + "]" else .value end)") | join("\n")) else empty end"#.to_owned(),
+            r#"if .properties then "  properties:\n\(.properties | map("    \(.name) (\(.type)): \(if (.value | type) == "array" then "[" + (.value | join(", ")) + "]" else .value end)") | join("\n"))" else empty end"#.to_owned(),
         );
     }
 
@@ -444,11 +448,11 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
         );
     }
 
-    // Sections: each as "  ## Heading [done/total]" or "  ## Heading"
+    // Sections: header then each as "    ## Heading [done/total]" or "    ## Heading"
     // Note: uses r##"..."## because the jq filter contains the sequence "#" (hash-quoted).
     if map.contains_key("sections") {
         parts.push(
-            r##"if .sections then (.sections | map("  \("#" * .level) \(.heading // "(pre-heading)")\(if .tasks then " [\(.tasks.done)/\(.tasks.total)]" else "" end)") | join("\n")) else empty end"##.to_owned(),
+            r##"if .sections then "  sections:\n\(.sections | map("    \("#" * .level) \(.heading // "(pre-heading)")\(if .tasks then " [\(.tasks.done)/\(.tasks.total)]" else "" end)") | join("\n"))" else empty end"##.to_owned(),
         );
     }
 
@@ -466,10 +470,10 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
         );
     }
 
-    // Links: header then each as "    target → path" or "    target (unresolved)"
+    // Links: header then each as "    \"target\" → \"path\"" or "    \"target\" (unresolved)"
     if map.contains_key("links") {
         parts.push(
-            r#"if (.links | length) > 0 then "  links:\n\(.links | map("    \(.target)\(if .path then " → \(.path)" else " (unresolved)" end)") | join("\n"))" else empty end"#.to_owned(),
+            r#"if (.links | length) > 0 then "  links:\n\(.links | map("    \"\(.target)\"\(if .path then " → \"\(.path)\"" else " (unresolved)" end)") | join("\n"))" else empty end"#.to_owned(),
         );
     }
 
@@ -934,6 +938,7 @@ mod tests {
         });
         let out = jq(&filter, &val).unwrap();
         assert!(out.contains("foo.md"));
+        assert!(out.contains("properties:"));
         assert!(out.contains("status (text): done"));
     }
 
@@ -954,6 +959,24 @@ mod tests {
         assert!(out.contains("tasks:"));
         assert!(out.contains("[x] Ship it"));
         assert!(out.contains("line 5"));
+    }
+
+    #[test]
+    fn build_file_object_filter_with_sections() {
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(
+            r#"{"file": "foo.md", "modified": "2024-01-01", "sections": [{"code_blocks": 0, "heading": "Intro", "level": 1, "line": 1, "links": []}]}"#,
+        )
+        .unwrap();
+        let filter = build_file_object_filter(&map);
+        let val = json!({
+            "file": "foo.md",
+            "modified": "2024-01-01",
+            "sections": [{"code_blocks": 0, "heading": "Intro", "level": 1, "line": 1, "links": []}]
+        });
+        let out = jq(&filter, &val).unwrap();
+        assert!(out.contains("foo.md"));
+        assert!(out.contains("sections:"));
+        assert!(out.contains("# Intro"));
     }
 
     #[test]
@@ -989,7 +1012,7 @@ mod tests {
         let out = jq(&filter, &val).unwrap();
         assert!(out.contains("foo.md"));
         assert!(out.contains("links:"));
-        assert!(out.contains("bar → bar.md"));
+        assert!(out.contains(r#""bar" → "bar.md""#));
     }
 
     #[test]
@@ -1005,7 +1028,7 @@ mod tests {
             "links": [{"target": "missing"}]
         });
         let out = jq(&filter, &val).unwrap();
-        assert!(out.contains("missing (unresolved)"));
+        assert!(out.contains(r#""missing" (unresolved)"#));
     }
 
     // --- FileObject text rendering through format_value_as_text ---
@@ -1034,8 +1057,9 @@ mod tests {
         });
         let out = fmt(&val);
         assert!(out.contains("notes/project.md"));
-        assert!(out.contains("tags: [rust, work]"));
+        assert!(out.contains("properties:"));
         assert!(out.contains("status (text): active"));
+        assert!(out.contains("tags: [rust, work]"));
         assert!(out.contains("tasks:"));
         assert!(out.contains("[ ] Fix bug"));
         assert!(out.contains("[x] Write docs"));

--- a/src/output.rs
+++ b/src/output.rs
@@ -436,7 +436,7 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
     // Properties: header then each as "    name (type): value"
     if map.contains_key("properties") {
         parts.push(
-            r#"if .properties then "  properties:\n\(.properties | map("    \(.name) (\(.type)): \(if (.value | type) == "array" then "[" + (.value | join(", ")) + "]" else .value end)") | join("\n"))" else empty end"#.to_owned(),
+            r#"if (.properties | length) > 0 then "  properties:\n\(.properties | map("    \(.name) (\(.type)): \(if (.value | type) == "array" then "[" + (.value | join(", ")) + "]" else .value end)") | join("\n"))" else empty end"#.to_owned(),
         );
     }
 
@@ -452,7 +452,7 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
     // Note: uses r##"..."## because the jq filter contains the sequence "#" (hash-quoted).
     if map.contains_key("sections") {
         parts.push(
-            r##"if .sections then "  sections:\n\(.sections | map("    \("#" * .level) \(.heading // "(pre-heading)")\(if .tasks then " [\(.tasks.done)/\(.tasks.total)]" else "" end)") | join("\n"))" else empty end"##.to_owned(),
+            r##"if (.sections | length) > 0 then "  sections:\n\(.sections | map("    \("#" * .level) \(.heading // "(pre-heading)")\(if .tasks then " [\(.tasks.done)/\(.tasks.total)]" else "" end)") | join("\n"))" else empty end"##.to_owned(),
         );
     }
 

--- a/tests/e2e_find.rs
+++ b/tests/e2e_find.rs
@@ -618,6 +618,15 @@ fn find_text_format_file_object_structure() {
 
     // File path as header
     assert!(stdout.contains("alpha.md"), "file path header: {stdout}");
+    // Group labels
+    assert!(
+        stdout.contains("properties:"),
+        "properties group label: {stdout}"
+    );
+    assert!(
+        stdout.contains("sections:"),
+        "sections group label: {stdout}"
+    );
     // Properties with type annotations
     assert!(
         stdout.contains("title (text): Alpha"),
@@ -702,7 +711,11 @@ fn find_text_format_fields_properties_only() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
 
-    // Should have properties
+    // Should have properties with group label
+    assert!(
+        stdout.contains("properties:"),
+        "properties group label: {stdout}"
+    );
     assert!(
         stdout.contains("title (text): Alpha"),
         "property present: {stdout}"


### PR DESCRIPTION
## Summary
- Quote all file/directory paths in `--format text` output so names with spaces are unambiguous
- Put directory lists, recent files, and outline links on separate indented lines instead of comma-joined single lines
- Add `properties:` and `sections:` group labels to FileObject output, matching existing `tasks:`, `matches:`, `links:` pattern
- Update doc comments, README example, and iteration-14 target output to match

## Test plan
- [x] New unit test `build_file_object_filter_with_sections` for sections group label
- [x] Updated unit tests assert `properties:` label in file object output
- [x] Updated e2e tests assert `properties:` and `sections:` group labels
- [x] All 421 unit + e2e tests pass
- [x] Manual verification against obsidian-hub vault (6520 files)
- [x] Verified `summary`, `find`, `task read`, `set`, `remove` text output

🤖 Generated with [Claude Code](https://claude.com/claude-code)