### PR TITLE
Add --where-property and --where-tag filters to mutation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ hyalo set --property status=done --file path/to/note.md
 hyalo set --property status=active --glob "notes/*.md"
 hyalo set --tag cli --file path/to/note.md
 hyalo set --property status=done --tag reviewed --file path/to/note.md
+
+# Bulk-update: set status on files matching a filter
+hyalo set --property status=completed --where-property status=done --glob '**/*.md'
+
+# Add tag to files matching a tag filter
+hyalo set --tag reviewed --where-tag research --glob '**/*.md'
 ```
 
 ### remove
@@ -124,6 +130,9 @@ hyalo remove --property status --file path/to/note.md          # remove property
 hyalo remove --property tags=serde --file path/to/note.md      # remove value from list
 hyalo remove --tag cli --file path/to/note.md
 hyalo remove --property status --glob "draft/*.md"
+
+# Remove tag from files matching a property filter
+hyalo remove --tag deprecated --where-property status=completed --glob '**/*.md'
 ```
 
 `remove --property K` (no value) removes the property entirely. `remove --property K=V` removes V from a list property, or removes the property if it is a scalar matching V.
@@ -135,6 +144,9 @@ Append values to list properties, promoting scalars to lists if needed.
 ```sh
 hyalo append --property tags=serde --file path/to/note.md
 hyalo append --property tags=serde --glob "crates/*.md"
+
+# Append to list property on files matching a tag
+hyalo append --property aliases=old-name --where-tag renamed --glob '**/*.md'
 ```
 
 ### task

--- a/hyalo-knowledgebase/backlog/frontmatter-reformatting.md
+++ b/hyalo-knowledgebase/backlog/frontmatter-reformatting.md
@@ -1,0 +1,45 @@
+---
+title: "Frontmatter reformatting on write (key order, list indentation, quotes)"
+type: backlog
+date: 2026-03-23
+status: planned
+priority: low
+origin: dogfooding iteration-20
+tags:
+  - backlog
+  - frontmatter
+  - ux
+---
+
+# Frontmatter reformatting on write
+
+## Problem
+
+Any mutation (`set`, `remove`, `append`) rewrites the YAML frontmatter block, causing three cosmetic changes:
+
+1. **Key reordering** — `BTreeMap` sorts alphabetically, so `title, type, date, status` becomes `date, status, title, type`
+2. **List indentation** — `  - item` (indented) becomes `- item` (non-indented)
+3. **Quote stripping** — `"value"` becomes `value` when quotes aren't syntactically necessary
+
+An add/remove cycle reformats the file even though the net content is unchanged. All changes are semantically identical — no data loss.
+
+## Root cause
+
+- Key ordering: `BTreeMap<String, Value>` sorts keys. Original insertion order is lost at parse time.
+- List/quote formatting: `serde_yaml_ng::to_string()` uses its own serialization rules with no configuration for style.
+- Accepted in DEC-006: "serde_yaml_ng cannot preserve formatting. Obsidian itself rewrites frontmatter on save."
+
+## Possible fixes
+
+| Issue | Approach | Effort |
+|-------|----------|--------|
+| Key ordering | Replace `BTreeMap` with `IndexMap` (preserves insertion order) | Medium (~4-6h) |
+| List indentation | Raw YAML preservation or post-processing | High |
+| Quote style | Raw YAML preservation or different library | High |
+
+## Notes
+
+- The IndexMap swap fixes the most visible issue with moderate effort
+- List indentation and quoting require either raw byte-level YAML manipulation or a different YAML library — both high risk
+- `serde_yml` is unsafe (RUSTSEC-2025-0068), `yaml-rust2` doesn't preserve formatting either
+- The current behavior is deterministic — running the same mutation twice produces identical output

--- a/hyalo-knowledgebase/backlog/inline-mutation-on-find.md
+++ b/hyalo-knowledgebase/backlog/inline-mutation-on-find.md
@@ -1,14 +1,14 @@
 ---
-title: "Inline mutation on find results (find-and-set)"
-type: backlog
 date: 2026-03-23
-status: planned
-priority: low
 origin: dogfooding post-iter-19
+priority: low
+status: completed
 tags:
-  - backlog
-  - cli
-  - ux
+- backlog
+- cli
+- ux
+title: Inline mutation on find results (find-and-set)
+type: backlog
 ---
 
 # Inline mutation on find results (find-and-set)

--- a/hyalo-knowledgebase/iterations/iteration-20-where-filters.md
+++ b/hyalo-knowledgebase/iterations/iteration-20-where-filters.md
@@ -1,0 +1,46 @@
+---
+title: "Iteration 20: --where-property and --where-tag filters on mutation commands"
+type: iteration
+date: 2026-03-23
+status: completed
+branch: iter-20/where-filters
+tags:
+  - iteration
+  - cli
+  - ux
+  - llm
+---
+
+# Iteration 20: --where-property and --where-tag filters on mutation commands
+
+## Goal
+
+Enable single-command bulk mutations without shell pipelines. LLMs (the primary consumers) struggle with `find | xargs set` patterns — this iteration adds inline filter flags to `set`, `remove`, and `append` so an LLM can express "find files matching X, mutate Y" in one call.
+
+## Changes
+
+- [x] Extract `matches_frontmatter_filters()` into `src/filter.rs` as shared function
+- [x] Refactor `find` command to use the shared filter function
+- [x] Add `--where-property` and `--where-tag` CLI flags to `set`, `remove`, `append`
+- [x] Wire filter parsing and validation in `main.rs` dispatch
+- [x] Apply where-filters in per-file loop of all three mutation commands
+- [x] Update `long_about` help text for all three mutation commands
+- [x] Update `after_long_help` cookbook and command reference
+- [x] Update `README.md` with examples
+- [x] Add unit tests for `matches_frontmatter_filters()` in `filter.rs`
+- [x] Add unit tests in `set.rs`, `remove.rs`, `append.rs`
+- [x] Add e2e tests covering scalar match, list-element match, nested tag match, combined AND, no-match, operators
+
+## Design decisions
+
+- Flag names `--where-property` / `--where-tag` mirror `find`'s `--property` / `--tag` with `where-` prefix
+- AND semantics across all where-filters (same as `find`)
+- Full filter operator support: `=`, `!=`, `>`, `>=`, `<`, `<=`, existence
+- List-element matching: `--where-property tags=cli` matches `tags: [cli, rust]`
+- Nested tag matching: `--where-tag project` matches `project/backend`
+- `--file`/`--glob` still required — where-filters narrow within the file set, not replace targeting
+- Filtered-out files are simply skipped (not counted in modified or skipped)
+
+## Backlog item
+
+Resolves [[inline-mutation-on-find]]

--- a/src/commands/append.rs
+++ b/src/commands/append.rs
@@ -22,6 +22,7 @@ pub struct AppendPropertyResult {
     pub modified: Vec<String>,
     pub skipped: Vec<String>,
     pub total: usize,
+    pub scanned: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +161,7 @@ pub fn append(
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
+    let scanned = files.len();
 
     // Per-property result accumulators: (modified, skipped)
     let mut prop_results: Vec<(Vec<String>, Vec<String>)> =
@@ -213,6 +215,7 @@ pub fn append(
             modified,
             skipped,
             total,
+            scanned,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -597,6 +600,9 @@ title: Note
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        // 2 files scanned, 1 passed the where-filter
+        assert_eq!(parsed["scanned"].as_u64().unwrap(), 2);
+        assert!(parsed["scanned"].as_u64().unwrap() > parsed["total"].as_u64().unwrap());
 
         let match_content = fs::read_to_string(tmp.path().join("match.md")).unwrap();
         assert!(match_content.contains("draft-copy"));
@@ -626,6 +632,9 @@ title: Note
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        // 2 files scanned, 1 passed the where-filter
+        assert_eq!(parsed["scanned"].as_u64().unwrap(), 2);
+        assert!(parsed["scanned"].as_u64().unwrap() > parsed["total"].as_u64().unwrap());
 
         let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
         assert!(tagged_content.contains("rust-note"));

--- a/src/commands/append.rs
+++ b/src/commands/append.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::commands::set::parse_kv;
 use crate::commands::{FilesOrOutcome, collect_files, require_file_or_glob};
+use crate::filter::{self, PropertyFilter};
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
 
@@ -115,6 +116,8 @@ pub fn append(
     property_args: &[String],
     file: Option<&str>,
     glob: Option<&str>,
+    where_property_filters: &[PropertyFilter],
+    where_tag_filters: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     if property_args.is_empty() {
@@ -172,6 +175,12 @@ pub fn append(
             }
             Err(e) => return Err(e),
         };
+
+        // Apply --where-* filters: skip files that don't match
+        if !filter::matches_frontmatter_filters(&props, where_property_filters, where_tag_filters) {
+            continue;
+        }
+
         let mut file_changed = false;
 
         for (i, (name, raw_value, new_val)) in parsed_args.iter().enumerate() {
@@ -255,6 +264,8 @@ title: Note
             &["aliases=my-note".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -291,6 +302,8 @@ aliases:
             &["aliases=new-name".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -319,6 +332,8 @@ aliases:
             &["aliases=my-note".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -350,6 +365,8 @@ author: Alice
             &["author=Bob".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -379,6 +396,8 @@ author: Alice
             &["author=Alice".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -409,6 +428,8 @@ title: Note
             &["aliases=a".to_owned(), "tags=rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -430,6 +451,8 @@ title: Note
             &["aliases=x".to_owned()],
             None,
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -439,7 +462,16 @@ title: Note
     #[test]
     fn append_requires_at_least_one_property() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome = append(tmp.path(), &[], Some("note.md"), None, Format::Json).unwrap();
+        let outcome = append(
+            tmp.path(),
+            &[],
+            Some("note.md"),
+            None,
+            &[],
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -452,6 +484,8 @@ title: Note
             &["no-equals-sign".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -467,6 +501,8 @@ title: Note
             &["=value".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -488,6 +524,8 @@ title: Note
             &["aliases=my-note".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -515,6 +553,8 @@ title: Note
             &["aliases=a".to_owned(), "aliases=b".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -527,5 +567,69 @@ title: Note
         let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
         assert!(content.contains('a'));
         assert!(content.contains('b'));
+    }
+
+    #[test]
+    fn append_where_property_filter_skips_nonmatching() {
+        // Only files matching --where-property are mutated.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("match.md"), "---\nstatus: draft\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("no-match.md"),
+            "---\nstatus: published\n---\n",
+        )
+        .unwrap();
+
+        use crate::filter::parse_property_filter;
+        let filter = parse_property_filter("status=draft").unwrap();
+        let outcome = append(
+            tmp.path(),
+            &["aliases=draft-copy".to_owned()],
+            None,
+            Some("*.md"),
+            &[filter],
+            &[],
+            Format::Json,
+        )
+        .unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let match_content = fs::read_to_string(tmp.path().join("match.md")).unwrap();
+        assert!(match_content.contains("draft-copy"));
+        let no_match_content = fs::read_to_string(tmp.path().join("no-match.md")).unwrap();
+        assert!(!no_match_content.contains("draft-copy"));
+    }
+
+    #[test]
+    fn append_where_tag_filter_skips_nonmatching() {
+        // Only files with the required tag are mutated.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("tagged.md"), "---\ntags:\n  - rust\n---\n").unwrap();
+        fs::write(tmp.path().join("untagged.md"), "---\ntitle: Other\n---\n").unwrap();
+
+        let outcome = append(
+            tmp.path(),
+            &["aliases=rust-note".to_owned()],
+            None,
+            Some("*.md"),
+            &[],
+            &["rust".to_owned()],
+            Format::Json,
+        )
+        .unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
+        assert!(tagged_content.contains("rust-note"));
+        let untagged_content = fs::read_to_string(tmp.path().join("untagged.md")).unwrap();
+        assert!(!untagged_content.contains("rust-note"));
     }
 }

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -120,12 +120,11 @@ pub fn find(
 
         let props = fm.into_props();
 
-        // --- Apply frontmatter-based filters (early exit) ---
-        if !filter::matches_frontmatter_filters(&props, property_filters, tag_filters) {
+        // --- Extract tags once and apply filters ---
+        let tags = extract_tags(&props);
+        if !filter::matches_filters_with_tags(&props, property_filters, &tags, tag_filters) {
             continue;
         }
-
-        let tags = extract_tags(&props);
 
         // --- Collect tasks (needed for filter and/or output field) ---
         // Consume the extractor now so we can both filter and include in output.

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -5,11 +5,10 @@ use std::path::Path;
 use std::time::SystemTime;
 
 use crate::commands::outline::SectionScanner;
-use crate::commands::tags::extract_tags;
 use crate::commands::{FilesOrOutcome, collect_files};
 use crate::content_search::ContentSearchVisitor;
 use crate::discovery;
-use crate::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField};
+use crate::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField, extract_tags};
 use crate::frontmatter;
 use crate::links::Link;
 use crate::output::{CommandOutcome, Format};

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -9,7 +9,7 @@ use crate::commands::tags::extract_tags;
 use crate::commands::{FilesOrOutcome, collect_files};
 use crate::content_search::ContentSearchVisitor;
 use crate::discovery;
-use crate::filter::{Fields, FindTaskFilter, PropertyFilter, SortField};
+use crate::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField};
 use crate::frontmatter;
 use crate::links::Link;
 use crate::output::{CommandOutcome, Format};
@@ -122,17 +122,11 @@ pub fn find(
         let props = fm.into_props();
 
         // --- Apply frontmatter-based filters (early exit) ---
-        if !property_filters.iter().all(|f| f.matches(&props)) {
+        if !filter::matches_frontmatter_filters(&props, property_filters, tag_filters) {
             continue;
         }
 
         let tags = extract_tags(&props);
-        if !tag_filters.iter().all(|q| {
-            tags.iter()
-                .any(|t| crate::commands::tags::tag_matches(t, q))
-        }) {
-            continue;
-        }
 
         // --- Collect tasks (needed for filter and/or output field) ---
         // Consume the extractor now so we can both filter and include in output.

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -24,6 +24,7 @@ pub struct RemovePropertyResult {
     pub modified: Vec<String>,
     pub skipped: Vec<String>,
     pub total: usize,
+    pub scanned: usize,
 }
 
 /// Result of a `remove --tag T` operation across files.
@@ -33,6 +34,7 @@ pub struct RemoveTagResult {
     pub modified: Vec<String>,
     pub skipped: Vec<String>,
     pub total: usize,
+    pub scanned: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -220,6 +222,7 @@ pub fn remove(
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
+    let scanned = files.len();
 
     // Per-property result accumulators: (modified, skipped)
     let mut prop_results: Vec<(Vec<String>, Vec<String>)> =
@@ -288,6 +291,7 @@ pub fn remove(
             modified,
             skipped,
             total,
+            scanned,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -301,6 +305,7 @@ pub fn remove(
             modified,
             skipped,
             total,
+            scanned,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -786,6 +791,9 @@ priority: low
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        // 2 files scanned, 1 passed the where-filter
+        assert_eq!(parsed["scanned"].as_u64().unwrap(), 2);
+        assert!(parsed["scanned"].as_u64().unwrap() > parsed["total"].as_u64().unwrap());
 
         let match_content = fs::read_to_string(tmp.path().join("match.md")).unwrap();
         assert!(!match_content.contains("priority:"));
@@ -820,6 +828,9 @@ priority: low
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        // 2 files scanned, 1 passed the where-filter
+        assert_eq!(parsed["scanned"].as_u64().unwrap(), 2);
+        assert!(parsed["scanned"].as_u64().unwrap() > parsed["total"].as_u64().unwrap());
 
         let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
         assert!(!tagged_content.contains("status:"));

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::commands::tags::validate_tag;
 use crate::commands::{FilesOrOutcome, collect_files, require_file_or_glob};
+use crate::filter::{self, PropertyFilter};
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
 
@@ -158,12 +159,15 @@ fn remove_tag_in_memory(props: &mut std::collections::BTreeMap<String, Value>, t
 /// - `tag_args`:      zero or more tag name strings to remove
 /// - Requires `--file` or `--glob`
 /// - At least one of `property_args` or `tag_args` must be non-empty
+#[allow(clippy::too_many_arguments)]
 pub fn remove(
     dir: &Path,
     property_args: &[String],
     tag_args: &[String],
     file: Option<&str>,
     glob: Option<&str>,
+    where_property_filters: &[PropertyFilter],
+    where_tag_filters: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     if property_args.is_empty() && tag_args.is_empty() {
@@ -234,6 +238,12 @@ pub fn remove(
             }
             Err(e) => return Err(e),
         };
+
+        // Apply --where-* filters: skip files that don't match
+        if !filter::matches_frontmatter_filters(&props, where_property_filters, where_tag_filters) {
+            continue;
+        }
+
         let mut file_changed = false;
 
         // Apply all --property mutations
@@ -376,6 +386,8 @@ status: draft
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -411,6 +423,8 @@ title: Note
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -443,6 +457,8 @@ status: draft
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -475,6 +491,8 @@ status: published
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -511,6 +529,8 @@ aliases:
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -548,6 +568,8 @@ tags:
             &["rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -583,6 +605,8 @@ tags:
             &["rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -602,6 +626,8 @@ tags:
             &[],
             None,
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -611,7 +637,17 @@ tags:
     #[test]
     fn remove_requires_at_least_one_arg() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome = remove(tmp.path(), &[], &[], Some("note.md"), None, Format::Json).unwrap();
+        let outcome = remove(
+            tmp.path(),
+            &[],
+            &[],
+            Some("note.md"),
+            None,
+            &[],
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -636,6 +672,8 @@ tags:
             &["rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -663,6 +701,8 @@ tags:
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -693,6 +733,8 @@ priority: low
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -709,5 +751,79 @@ priority: low
         assert!(!content.contains("status:"));
         assert!(!content.contains("priority:"));
         assert!(content.contains("title:"));
+    }
+
+    #[test]
+    fn remove_where_property_filter_skips_nonmatching() {
+        // Only files matching --where-property are mutated.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("match.md"),
+            "---\nstatus: draft\npriority: low\n---\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("no-match.md"),
+            "---\nstatus: published\npriority: low\n---\n",
+        )
+        .unwrap();
+
+        use crate::filter::parse_property_filter;
+        let filter = parse_property_filter("status=draft").unwrap();
+        let outcome = remove(
+            tmp.path(),
+            &["priority".to_owned()],
+            &[],
+            None,
+            Some("*.md"),
+            &[filter],
+            &[],
+            Format::Json,
+        )
+        .unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let match_content = fs::read_to_string(tmp.path().join("match.md")).unwrap();
+        assert!(!match_content.contains("priority:"));
+        let no_match_content = fs::read_to_string(tmp.path().join("no-match.md")).unwrap();
+        assert!(no_match_content.contains("priority:"));
+    }
+
+    #[test]
+    fn remove_where_tag_filter_skips_nonmatching() {
+        // Only files with the required tag are mutated.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("tagged.md"),
+            "---\ntags:\n  - deprecated\nstatus: old\n---\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("untagged.md"), "---\nstatus: old\n---\n").unwrap();
+
+        let outcome = remove(
+            tmp.path(),
+            &["status".to_owned()],
+            &[],
+            None,
+            Some("*.md"),
+            &[],
+            &["deprecated".to_owned()],
+            Format::Json,
+        )
+        .unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
+        assert!(!tagged_content.contains("status:"));
+        let untagged_content = fs::read_to_string(tmp.path().join("untagged.md")).unwrap();
+        assert!(untagged_content.contains("status:"));
     }
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -5,6 +5,7 @@ use serde_yaml_ng::Value;
 use std::path::Path;
 
 use crate::commands::{FilesOrOutcome, collect_files, require_file_or_glob};
+use crate::filter::{self, PropertyFilter};
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
 
@@ -132,12 +133,15 @@ fn add_tag_in_memory(
 /// - `tag_args`:      zero or more tag name strings
 /// - Requires `--file` or `--glob`
 /// - At least one of `property_args` or `tag_args` must be non-empty
+#[allow(clippy::too_many_arguments)]
 pub fn set(
     dir: &Path,
     property_args: &[String],
     tag_args: &[String],
     file: Option<&str>,
     glob: Option<&str>,
+    where_property_filters: &[PropertyFilter],
+    where_tag_filters: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     // At least one mutation target required
@@ -228,6 +232,12 @@ pub fn set(
             }
             Err(e) => return Err(e),
         };
+
+        // Apply --where-* filters: skip files that don't match
+        if !filter::matches_frontmatter_filters(&props, where_property_filters, where_tag_filters) {
+            continue;
+        }
+
         let mut file_changed = false;
 
         // Apply all --property mutations
@@ -370,6 +380,8 @@ title: Note
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -405,6 +417,8 @@ status: draft
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -433,6 +447,8 @@ status: done
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -463,6 +479,8 @@ title: Note
             &["rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -497,6 +515,8 @@ tags:
             &["rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -526,6 +546,8 @@ title: Note
             &["rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -546,6 +568,8 @@ title: Note
             &[],
             None,
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -555,7 +579,17 @@ title: Note
     #[test]
     fn set_requires_at_least_one_arg() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome = set(tmp.path(), &[], &[], Some("note.md"), None, Format::Json).unwrap();
+        let outcome = set(
+            tmp.path(),
+            &[],
+            &[],
+            Some("note.md"),
+            None,
+            &[],
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -569,6 +603,8 @@ title: Note
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -585,6 +621,8 @@ title: Note
             &["1984".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -607,6 +645,8 @@ title: Note
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -636,6 +676,8 @@ title: Note
             &[],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -675,6 +717,8 @@ title: Note
             &["rust".to_owned()],
             Some("note.md"),
             None,
+            &[],
+            &[],
             Format::Json,
         )
         .unwrap();
@@ -687,5 +731,72 @@ title: Note
         let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
         assert!(content.contains("status: done"));
         assert!(content.contains("rust"));
+    }
+
+    #[test]
+    fn set_where_property_filter_skips_nonmatching() {
+        // Files that don't match --where-property are not mutated.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("match.md"), "---\nstatus: draft\n---\n").unwrap();
+        fs::write(
+            tmp.path().join("no-match.md"),
+            "---\nstatus: published\n---\n",
+        )
+        .unwrap();
+
+        use crate::filter::parse_property_filter;
+        let filter = parse_property_filter("status=draft").unwrap();
+        let outcome = set(
+            tmp.path(),
+            &["priority=high".to_owned()],
+            &[],
+            None,
+            Some("*.md"),
+            &[filter],
+            &[],
+            Format::Json,
+        )
+        .unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+
+        let match_content = fs::read_to_string(tmp.path().join("match.md")).unwrap();
+        assert!(match_content.contains("priority: high"));
+        let no_match_content = fs::read_to_string(tmp.path().join("no-match.md")).unwrap();
+        assert!(!no_match_content.contains("priority"));
+    }
+
+    #[test]
+    fn set_where_tag_filter_skips_nonmatching() {
+        // Files without the required tag are not mutated.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("tagged.md"), "---\ntags:\n  - rust\n---\n").unwrap();
+        fs::write(tmp.path().join("untagged.md"), "---\ntitle: Other\n---\n").unwrap();
+
+        let outcome = set(
+            tmp.path(),
+            &["status=reviewed".to_owned()],
+            &[],
+            None,
+            Some("*.md"),
+            &[],
+            &["rust".to_owned()],
+            Format::Json,
+        )
+        .unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+
+        let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
+        assert!(tagged_content.contains("status: reviewed"));
+        let untagged_content = fs::read_to_string(tmp.path().join("untagged.md")).unwrap();
+        assert!(!untagged_content.contains("status"));
     }
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -21,6 +21,7 @@ pub struct SetPropertyResult {
     pub modified: Vec<String>,
     pub skipped: Vec<String>,
     pub total: usize,
+    pub scanned: usize,
 }
 
 /// Result of a `set --tag T` operation across files.
@@ -30,6 +31,7 @@ pub struct SetTagResult {
     pub modified: Vec<String>,
     pub skipped: Vec<String>,
     pub total: usize,
+    pub scanned: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -214,6 +216,7 @@ pub fn set(
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
+    let scanned = files.len();
 
     // Per-property result accumulators: (modified, skipped)
     let mut prop_results: Vec<(Vec<String>, Vec<String>)> =
@@ -283,6 +286,7 @@ pub fn set(
             modified,
             skipped,
             total,
+            scanned,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -295,6 +299,7 @@ pub fn set(
             modified,
             skipped,
             total,
+            scanned,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -393,6 +398,8 @@ title: Note
         assert_eq!(parsed["property"], "status");
         assert_eq!(parsed["value"], "done");
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["scanned"].as_u64().unwrap(), 1);
+        assert_eq!(parsed["scanned"], parsed["total"]);
 
         let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
         assert!(content.contains("status: done"));
@@ -458,6 +465,7 @@ status: done
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
         assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["scanned"], parsed["total"]);
     }
 
     #[test]
@@ -763,6 +771,9 @@ title: Note
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
         assert_eq!(parsed["skipped"].as_array().unwrap().len(), 0);
+        // 2 files scanned, 1 passed the where-filter (total = modified + skipped)
+        assert_eq!(parsed["scanned"].as_u64().unwrap(), 2);
+        assert!(parsed["scanned"].as_u64().unwrap() > parsed["total"].as_u64().unwrap());
 
         let match_content = fs::read_to_string(tmp.path().join("match.md")).unwrap();
         assert!(match_content.contains("priority: high"));
@@ -793,6 +804,9 @@ title: Note
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 1);
+        // 2 files scanned, 1 passed the where-filter
+        assert_eq!(parsed["scanned"].as_u64().unwrap(), 2);
+        assert!(parsed["scanned"].as_u64().unwrap() > parsed["total"].as_u64().unwrap());
 
         let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
         assert!(tagged_content.contains("status: reviewed"));

--- a/src/commands/summary.rs
+++ b/src/commands/summary.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::time::SystemTime;
 
-use crate::commands::tags::extract_tags;
 use crate::commands::{FilesOrOutcome, collect_files};
+use crate::filter::extract_tags;
 use crate::frontmatter::{infer_type, yaml_to_json};
 use crate::output::{CommandOutcome, Format};
 use crate::scanner::{FrontmatterCollector, scan_file_multi};

--- a/src/commands/tags.rs
+++ b/src/commands/tags.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
-use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::commands::{FilesOrOutcome, collect_files};
+use crate::filter::extract_tags;
 use crate::frontmatter;
 use crate::output::{CommandOutcome, Format};
 use crate::types::{TagSummary, TagSummaryEntry};
@@ -40,55 +40,6 @@ pub fn validate_tag(name: &str) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Nested tag matching
-// ---------------------------------------------------------------------------
-
-/// Returns true if `tag` matches the query under Obsidian's nested tag rules.
-/// A tag matches if it equals the query or starts with `query/` (case-insensitive).
-///
-/// Uses byte-level ASCII comparison — safe because tag names are validated to only
-/// contain ASCII characters (letters, digits, `_`, `-`, `/`).
-#[must_use]
-pub fn tag_matches(tag: &str, query: &str) -> bool {
-    tag.eq_ignore_ascii_case(query)
-        || (tag.len() > query.len()
-            && tag.as_bytes()[query.len()] == b'/'
-            && tag[..query.len()].eq_ignore_ascii_case(query))
-}
-
-// ---------------------------------------------------------------------------
-// Tag extraction
-// ---------------------------------------------------------------------------
-
-/// Extract the `tags` list from a parsed frontmatter map.
-/// Handles:
-/// - Missing `tags` key → empty vec
-/// - `tags` as a YAML sequence → collect string items
-/// - `tags` as a scalar string → single-element vec
-/// - `tags` as empty sequence → empty vec
-#[must_use]
-pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
-    match props.get("tags") {
-        Some(Value::Sequence(seq)) => seq
-            .iter()
-            .filter_map(|v| match v {
-                Value::String(s) => Some(s.clone()),
-                Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-            .collect(),
-        Some(Value::String(s)) => {
-            if s.is_empty() {
-                vec![]
-            } else {
-                vec![s.clone()]
-            }
-        }
-        _ => vec![],
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -150,6 +101,8 @@ pub fn tags_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::filter::tag_matches;
+    use serde_yaml_ng::Value;
     use std::fs;
 
     macro_rules! md {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,6 +2,8 @@ use anyhow::{Result, bail};
 use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 
+use crate::commands::tags::{extract_tags, tag_matches};
+
 /// Comparison operator for property filters.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FilterOp {
@@ -139,6 +141,35 @@ impl PropertyFilter {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the frontmatter properties satisfy all property and tag filters.
+///
+/// All property filters are evaluated with AND semantics (every filter must pass).
+/// All tag filters are evaluated with AND semantics (every query tag must be present).
+/// Empty filter slices always pass.
+pub fn matches_frontmatter_filters(
+    props: &BTreeMap<String, Value>,
+    property_filters: &[PropertyFilter],
+    tag_filters: &[String],
+) -> bool {
+    if !property_filters.iter().all(|f| f.matches(props)) {
+        return false;
+    }
+    if !tag_filters.is_empty() {
+        let tags = extract_tags(props);
+        if !tag_filters
+            .iter()
+            .all(|q| tags.iter().any(|t| tag_matches(t, q)))
+        {
+            return false;
+        }
+    }
+    true
+}
+
+// ---------------------------------------------------------------------------
 
 /// Case-insensitive equality check between a YAML value and a string filter value.
 fn yaml_value_eq(yaml: &Value, filter: &str) -> bool {
@@ -591,5 +622,97 @@ mod tests {
     fn sort_unknown_errors() {
         assert!(parse_sort("name").is_err());
         assert!(parse_sort("").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // matches_frontmatter_filters
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn matches_frontmatter_filters_empty_filters() {
+        // No filters → always true, regardless of props content.
+        let p = props(&[("status", Value::String("anything".into()))]);
+        assert!(matches_frontmatter_filters(&p, &[], &[]));
+
+        let empty = props(&[]);
+        assert!(matches_frontmatter_filters(&empty, &[], &[]));
+    }
+
+    #[test]
+    fn matches_frontmatter_filters_scalar_property() {
+        let p = props(&[("status", Value::String("planned".into()))]);
+        let filters = [parse_property_filter("status=planned").unwrap()];
+
+        assert!(matches_frontmatter_filters(&p, &filters, &[]));
+
+        let no_match = [parse_property_filter("status=completed").unwrap()];
+        assert!(!matches_frontmatter_filters(&p, &no_match, &[]));
+    }
+
+    #[test]
+    fn matches_frontmatter_filters_list_property() {
+        // Value is a YAML sequence — filter matches any element.
+        let p = props(&[(
+            "tags",
+            Value::Sequence(vec![
+                Value::String("rust".into()),
+                Value::String("cli".into()),
+            ]),
+        )]);
+        let filters = [parse_property_filter("tags=rust").unwrap()];
+        assert!(matches_frontmatter_filters(&p, &filters, &[]));
+
+        let filters_cli = [parse_property_filter("tags=cli").unwrap()];
+        assert!(matches_frontmatter_filters(&p, &filters_cli, &[]));
+
+        let no_match = [parse_property_filter("tags=python").unwrap()];
+        assert!(!matches_frontmatter_filters(&p, &no_match, &[]));
+    }
+
+    #[test]
+    fn matches_frontmatter_filters_tag_match() {
+        // Nested tag: query "inbox" matches tag "inbox/processing".
+        let p = props(&[(
+            "tags",
+            Value::Sequence(vec![Value::String("inbox/processing".into())]),
+        )]);
+        let tag_filters = vec!["inbox".to_owned()];
+        assert!(matches_frontmatter_filters(&p, &[], &tag_filters));
+
+        // Exact match also works.
+        let exact = vec!["inbox/processing".to_owned()];
+        assert!(matches_frontmatter_filters(&p, &[], &exact));
+
+        // Non-matching query.
+        let miss = vec!["project".to_owned()];
+        assert!(!matches_frontmatter_filters(&p, &[], &miss));
+    }
+
+    #[test]
+    fn matches_frontmatter_filters_combined_and() {
+        // Both property and tag filters must pass.
+        let p = props(&[
+            ("status", Value::String("done".into())),
+            ("tags", Value::Sequence(vec![Value::String("rust".into())])),
+        ]);
+        let prop_filters = [parse_property_filter("status=done").unwrap()];
+        let tag_filters = vec!["rust".to_owned()];
+
+        assert!(matches_frontmatter_filters(&p, &prop_filters, &tag_filters));
+
+        // Prop matches but tag doesn't.
+        let wrong_tag = vec!["python".to_owned()];
+        assert!(!matches_frontmatter_filters(&p, &prop_filters, &wrong_tag));
+
+        // Tag matches but prop doesn't.
+        let wrong_prop = [parse_property_filter("status=pending").unwrap()];
+        assert!(!matches_frontmatter_filters(&p, &wrong_prop, &tag_filters));
+    }
+
+    #[test]
+    fn matches_frontmatter_filters_no_match() {
+        let p = props(&[("status", Value::String("active".into()))]);
+        let filters = [parse_property_filter("status=archived").unwrap()];
+        assert!(!matches_frontmatter_filters(&p, &filters, &[]));
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,7 +2,50 @@ use anyhow::{Result, bail};
 use serde_yaml_ng::Value;
 use std::collections::BTreeMap;
 
-use crate::commands::tags::{extract_tags, tag_matches};
+// ---------------------------------------------------------------------------
+// Tag extraction and matching
+// ---------------------------------------------------------------------------
+
+/// Extract the `tags` list from a parsed frontmatter map.
+/// Handles:
+/// - Missing `tags` key → empty vec
+/// - `tags` as a YAML sequence → collect string items
+/// - `tags` as a scalar string → single-element vec
+/// - `tags` as empty sequence → empty vec
+#[must_use]
+pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
+    match props.get("tags") {
+        Some(Value::Sequence(seq)) => seq
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .collect(),
+        Some(Value::String(s)) => {
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![s.clone()]
+            }
+        }
+        _ => vec![],
+    }
+}
+
+/// Returns true if `tag` matches the query under Obsidian's nested tag rules.
+/// A tag matches if it equals the query or starts with `query/` (case-insensitive).
+///
+/// Uses byte-level ASCII comparison — safe because tag names are validated to only
+/// contain ASCII characters (letters, digits, `_`, `-`, `/`).
+#[must_use]
+pub fn tag_matches(tag: &str, query: &str) -> bool {
+    tag.eq_ignore_ascii_case(query)
+        || (tag.len() > query.len()
+            && tag.as_bytes()[query.len()] == b'/'
+            && tag[..query.len()].eq_ignore_ascii_case(query))
+}
 
 /// Comparison operator for property filters.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -35,10 +35,11 @@ pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
 }
 
 /// Returns true if `tag` matches the query under Obsidian's nested tag rules.
-/// A tag matches if it equals the query or starts with `query/` (case-insensitive).
+/// A tag matches if it equals the query or starts with `query/` (case-insensitive,
+/// using ASCII-only case folding via `eq_ignore_ascii_case`).
 ///
-/// Uses byte-level ASCII comparison — safe because tag names are validated to only
-/// contain ASCII characters (letters, digits, `_`, `-`, `/`).
+/// Matching is performed at the byte level and is intended for tags that use
+/// ASCII-compatible characters (letters, digits, `_`, `-`, `/`).
 #[must_use]
 pub fn tag_matches(tag: &str, query: &str) -> bool {
     tag.eq_ignore_ascii_case(query)
@@ -192,6 +193,9 @@ impl PropertyFilter {
 /// All property filters are evaluated with AND semantics (every filter must pass).
 /// All tag filters are evaluated with AND semantics (every query tag must be present).
 /// Empty filter slices always pass.
+///
+/// Extracts tags internally. If the caller already has tags (e.g. for output),
+/// use [`matches_filters_with_tags`] to avoid double extraction.
 pub fn matches_frontmatter_filters(
     props: &BTreeMap<String, Value>,
     property_filters: &[PropertyFilter],
@@ -202,14 +206,35 @@ pub fn matches_frontmatter_filters(
     }
     if !tag_filters.is_empty() {
         let tags = extract_tags(props);
-        if !tag_filters
-            .iter()
-            .all(|q| tags.iter().any(|t| tag_matches(t, q)))
-        {
-            return false;
-        }
+        return matches_tag_filters(&tags, tag_filters);
     }
     true
+}
+
+/// Like [`matches_frontmatter_filters`] but accepts pre-extracted tags.
+///
+/// Use this when the caller needs the tags for other purposes (e.g. output)
+/// to avoid extracting them twice.
+pub fn matches_filters_with_tags(
+    props: &BTreeMap<String, Value>,
+    property_filters: &[PropertyFilter],
+    tags: &[String],
+    tag_filters: &[String],
+) -> bool {
+    if !property_filters.iter().all(|f| f.matches(props)) {
+        return false;
+    }
+    if !tag_filters.is_empty() {
+        return matches_tag_filters(tags, tag_filters);
+    }
+    true
+}
+
+/// Check that all tag filter queries match at least one tag.
+fn matches_tag_filters(tags: &[String], tag_filters: &[String]) -> bool {
+    tag_filters
+        .iter()
+        .all(|q| tags.iter().any(|t| tag_matches(t, q)))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ COOKBOOK:\n  \
   hyalo set --tag reviewed --glob 'research/**/*.md'\n\n  \
   # Bulk-update a property across matching files\n  \
   hyalo set --property status=in-progress --where-property status=draft --glob '**/*.md'\n\n  \
-  # Add a tag to files matching a property filter\n  \
+  # Add a tag to files matching a tag filter\n  \
   hyalo set --tag reviewed --where-tag research --glob '**/*.md'\n\n  \
   # Append to a list property\n  \
   hyalo append --property aliases='My Note' --file note.md\n\n  \
@@ -277,8 +277,9 @@ enum Commands {
             or:          {\"tag\": T, \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
             FILTERS (optional, narrow which files are mutated):\n\
             - --where-property FILTER: only mutate files whose frontmatter matches (same syntax as find --property: \
-K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). If the property is a list, matches if any element matches. \
-Repeatable (AND).\n\
+K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). Quote filters containing > or < to prevent \
+shell redirection (e.g. --where-property 'priority>=3'). If the property is a list, matches if any \
+element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk.\n\
@@ -319,8 +320,9 @@ Repeatable (AND).\n\
             or:          {\"tag\": T, \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
             FILTERS (optional, narrow which files are mutated):\n\
             - --where-property FILTER: only mutate files whose frontmatter matches (same syntax as find --property: \
-K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). If the property is a list, matches if any element matches. \
-Repeatable (AND).\n\
+K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). Quote filters containing > or < to prevent \
+shell redirection (e.g. --where-property 'priority>=3'). If the property is a list, matches if any \
+element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk.\n\
@@ -359,8 +361,9 @@ Repeatable (AND).\n\
             Each result: {\"property\": K, \"value\": V, \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
             FILTERS (optional, narrow which files are mutated):\n\
             - --where-property FILTER: only mutate files whose frontmatter matches (same syntax as find --property: \
-K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). If the property is a list, matches if any element matches. \
-Repeatable (AND).\n\
+K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). Quote filters containing > or < to prevent \
+shell redirection (e.g. --where-property 'priority>=3'). If the property is a list, matches if any \
+element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk.\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,6 +421,32 @@ enum TaskAction {
     },
 }
 
+/// Parse `--where-property` filters and validate `--where-tag` names.
+/// Exits with code 1 on invalid input.
+fn parse_where_filters(
+    where_properties: &[String],
+    where_tags: &[String],
+) -> Vec<filter::PropertyFilter> {
+    let filters = match where_properties
+        .iter()
+        .map(|s| filter::parse_property_filter(s))
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+    for tag in where_tags {
+        if let Err(msg) = hyalo::commands::tags::validate_tag(tag) {
+            eprintln!("Error: {msg}");
+            process::exit(1);
+        }
+    }
+    filters
+}
+
 #[allow(clippy::too_many_lines)]
 fn main() {
     let cli = Cli::parse();
@@ -630,23 +656,7 @@ fn main() {
             ref where_properties,
             ref where_tags,
         } => {
-            let where_prop_filters: Vec<filter::PropertyFilter> = match where_properties
-                .iter()
-                .map(|s| filter::parse_property_filter(s))
-                .collect::<Result<Vec<_>, _>>()
-            {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    process::exit(1);
-                }
-            };
-            for tag_str in where_tags {
-                if let Err(msg) = hyalo::commands::tags::validate_tag(tag_str) {
-                    eprintln!("Error: {msg}");
-                    process::exit(1);
-                }
-            }
+            let where_prop_filters = parse_where_filters(where_properties, where_tags);
             set_commands::set(
                 &dir,
                 properties,
@@ -666,23 +676,7 @@ fn main() {
             ref where_properties,
             ref where_tags,
         } => {
-            let where_prop_filters: Vec<filter::PropertyFilter> = match where_properties
-                .iter()
-                .map(|s| filter::parse_property_filter(s))
-                .collect::<Result<Vec<_>, _>>()
-            {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    process::exit(1);
-                }
-            };
-            for tag_str in where_tags {
-                if let Err(msg) = hyalo::commands::tags::validate_tag(tag_str) {
-                    eprintln!("Error: {msg}");
-                    process::exit(1);
-                }
-            }
+            let where_prop_filters = parse_where_filters(where_properties, where_tags);
             remove_commands::remove(
                 &dir,
                 properties,
@@ -701,23 +695,7 @@ fn main() {
             ref where_properties,
             ref where_tags,
         } => {
-            let where_prop_filters: Vec<filter::PropertyFilter> = match where_properties
-                .iter()
-                .map(|s| filter::parse_property_filter(s))
-                .collect::<Result<Vec<_>, _>>()
-            {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    process::exit(1);
-                }
-            };
-            for tag_str in where_tags {
-                if let Err(msg) = hyalo::commands::tags::validate_tag(tag_str) {
-                    eprintln!("Error: {msg}");
-                    process::exit(1);
-                }
-            }
+            let where_prop_filters = parse_where_filters(where_properties, where_tags);
             append_commands::append(
                 &dir,
                 properties,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ use hyalo::output::{CommandOutcome, Format, apply_jq_filter_result, format_with_
         Filter by task status:        hyalo find --task todo\n  \
         Full-text search:             hyalo find 'meeting notes'\n  \
         Set a property:               hyalo set --property status=done --file notes/todo.md\n  \
+        Bulk-set with filter:         hyalo set --property status=done --where-property status=draft --glob '**/*.md'\n  \
         Add a tag across files:       hyalo set --tag reviewed --glob 'research/**/*.md'\n  \
         Remove a property:            hyalo remove --property status --file notes/todo.md\n  \
         Remove a tag from files:      hyalo remove --tag draft --glob '**/*.md'\n  \
@@ -55,11 +56,11 @@ COMMAND REFERENCE:\n  \
     hyalo find [PATTERN | --regexp/-e REGEX] [--property K=V ...] [--tag T ...] [--task STATUS]\n  \
                [--file F | --glob G] [--fields ...] [--sort ...] [--limit N]\n\n  \
   Set (create or overwrite, mutates files):\n  \
-    hyalo set  --property K=V [--property ...] [--tag T ...] [--file F | --glob G]\n\n  \
+    hyalo set  --property K=V [--property ...] [--tag T ...] [--file F | --glob G] [--where-property FILTER ...] [--where-tag T ...]\n\n  \
   Remove (delete properties/tags, mutates files):\n  \
-    hyalo remove --property K [--property K=V ...] [--tag T ...] [--file F | --glob G]\n\n  \
+    hyalo remove --property K [--property K=V ...] [--tag T ...] [--file F | --glob G] [--where-property FILTER ...] [--where-tag T ...]\n\n  \
   Append (add to list properties, mutates files):\n  \
-    hyalo append --property K=V [--property ...] [--file F | --glob G]\n\n  \
+    hyalo append --property K=V [--property ...] [--file F | --glob G] [--where-property FILTER ...] [--where-tag T ...]\n\n  \
   Properties (aggregate summary, read-only):\n  \
     hyalo properties [--glob G]   Unique property names, types, and file counts\n\n  \
   Tags (aggregate summary, read-only):\n  \
@@ -92,9 +93,10 @@ COOKBOOK:\n  \
   hyalo find --fields links --jq '[.[] | select(.links | map(select(.path == null)) | length > 0)]'\n\n  \
   # Tag all research notes in a folder\n  \
   hyalo set --tag reviewed --glob 'research/**/*.md'\n\n  \
-  # Bulk-update a property across files\n  \
-  hyalo find --property status=draft --jq '.[].file' \\\n    \
-    | xargs -I{} hyalo set --property status=in-progress --file {}\n\n  \
+  # Bulk-update a property across matching files\n  \
+  hyalo set --property status=in-progress --where-property status=draft --glob '**/*.md'\n\n  \
+  # Add a tag to files matching a property filter\n  \
+  hyalo set --tag reviewed --where-tag research --glob '**/*.md'\n\n  \
   # Append to a list property\n  \
   hyalo append --property aliases='My Note' --file note.md\n\n  \
   # Quick vault overview\n  \
@@ -273,6 +275,12 @@ enum Commands {
             OUTPUT: A single result object if one mutation was requested; an array if multiple.\n\
             Each result: {\"property\": K, \"value\": V, \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
             or:          {\"tag\": T, \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
+            FILTERS (optional, narrow which files are mutated):\n\
+            - --where-property FILTER: only mutate files whose frontmatter matches (same syntax as find --property: \
+K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). If the property is a list, matches if any element matches. \
+Repeatable (AND).\n\
+            - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
+Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk.\n\
             USE WHEN: You need to create or overwrite frontmatter properties or add tags, \
             possibly across many files at once."
@@ -290,6 +298,12 @@ enum Commands {
         /// Glob pattern for multiple files
         #[arg(long, conflicts_with = "file")]
         glob: Option<String>,
+        /// Filter: only mutate files whose frontmatter property matches (repeatable, AND). Same syntax as find --property
+        #[arg(long = "where-property", value_name = "FILTER")]
+        where_properties: Vec<String>,
+        /// Filter: only mutate files with this tag (repeatable, AND). Same syntax as find --tag
+        #[arg(long = "where-tag", value_name = "TAG")]
+        where_tags: Vec<String>,
     },
     /// Remove frontmatter properties and/or tags from file(s)
     #[command(
@@ -303,6 +317,12 @@ enum Commands {
             OUTPUT: A single result object if one mutation was requested; an array if multiple.\n\
             Each result: {\"property\": K, [\"value\": V,] \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
             or:          {\"tag\": T, \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
+            FILTERS (optional, narrow which files are mutated):\n\
+            - --where-property FILTER: only mutate files whose frontmatter matches (same syntax as find --property: \
+K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). If the property is a list, matches if any element matches. \
+Repeatable (AND).\n\
+            - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
+Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk.\n\
             USE WHEN: You need to delete properties or remove tags from one or more files."
     )]
@@ -319,6 +339,12 @@ enum Commands {
         /// Glob pattern for multiple files
         #[arg(long, conflicts_with = "file")]
         glob: Option<String>,
+        /// Filter: only mutate files whose frontmatter property matches (repeatable, AND). Same syntax as find --property
+        #[arg(long = "where-property", value_name = "FILTER")]
+        where_properties: Vec<String>,
+        /// Filter: only mutate files with this tag (repeatable, AND). Same syntax as find --tag
+        #[arg(long = "where-tag", value_name = "TAG")]
+        where_tags: Vec<String>,
     },
     /// Append values to list properties in file(s) frontmatter, promoting scalars to lists
     #[command(
@@ -331,6 +357,12 @@ enum Commands {
             - Property is a mapping: returns an error.\n\
             OUTPUT: A single result object if one mutation was requested; an array if multiple.\n\
             Each result: {\"property\": K, \"value\": V, \"modified\": [...], \"skipped\": [...], \"total\": N}\n\
+            FILTERS (optional, narrow which files are mutated):\n\
+            - --where-property FILTER: only mutate files whose frontmatter matches (same syntax as find --property: \
+K=V, K!=V, K>=V, K<=V, K>V, K<V, or K for existence). If the property is a list, matches if any element matches. \
+Repeatable (AND).\n\
+            - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
+Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk.\n\
             USE WHEN: You need to append items to list-type properties such as 'aliases' or 'authors' \
             without overwriting the existing list."
@@ -345,6 +377,12 @@ enum Commands {
         /// Glob pattern for multiple files
         #[arg(long, conflicts_with = "file")]
         glob: Option<String>,
+        /// Filter: only mutate files whose frontmatter property matches (repeatable, AND). Same syntax as find --property
+        #[arg(long = "where-property", value_name = "FILTER")]
+        where_properties: Vec<String>,
+        /// Filter: only mutate files with this tag (repeatable, AND). Same syntax as find --tag
+        #[arg(long = "where-tag", value_name = "TAG")]
+        where_tags: Vec<String>,
     },
 }
 
@@ -589,38 +627,107 @@ fn main() {
             ref tag,
             ref file,
             ref glob,
-        } => set_commands::set(
-            &dir,
-            properties,
-            tag,
-            file.as_deref(),
-            glob.as_deref(),
-            effective_format,
-        ),
+            ref where_properties,
+            ref where_tags,
+        } => {
+            let where_prop_filters: Vec<filter::PropertyFilter> = match where_properties
+                .iter()
+                .map(|s| filter::parse_property_filter(s))
+                .collect::<Result<Vec<_>, _>>()
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    process::exit(1);
+                }
+            };
+            for tag_str in where_tags {
+                if let Err(msg) = hyalo::commands::tags::validate_tag(tag_str) {
+                    eprintln!("Error: {msg}");
+                    process::exit(1);
+                }
+            }
+            set_commands::set(
+                &dir,
+                properties,
+                tag,
+                file.as_deref(),
+                glob.as_deref(),
+                &where_prop_filters,
+                where_tags,
+                effective_format,
+            )
+        }
         Commands::Remove {
             ref properties,
             ref tag,
             ref file,
             ref glob,
-        } => remove_commands::remove(
-            &dir,
-            properties,
-            tag,
-            file.as_deref(),
-            glob.as_deref(),
-            effective_format,
-        ),
+            ref where_properties,
+            ref where_tags,
+        } => {
+            let where_prop_filters: Vec<filter::PropertyFilter> = match where_properties
+                .iter()
+                .map(|s| filter::parse_property_filter(s))
+                .collect::<Result<Vec<_>, _>>()
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    process::exit(1);
+                }
+            };
+            for tag_str in where_tags {
+                if let Err(msg) = hyalo::commands::tags::validate_tag(tag_str) {
+                    eprintln!("Error: {msg}");
+                    process::exit(1);
+                }
+            }
+            remove_commands::remove(
+                &dir,
+                properties,
+                tag,
+                file.as_deref(),
+                glob.as_deref(),
+                &where_prop_filters,
+                where_tags,
+                effective_format,
+            )
+        }
         Commands::Append {
             ref properties,
             ref file,
             ref glob,
-        } => append_commands::append(
-            &dir,
-            properties,
-            file.as_deref(),
-            glob.as_deref(),
-            effective_format,
-        ),
+            ref where_properties,
+            ref where_tags,
+        } => {
+            let where_prop_filters: Vec<filter::PropertyFilter> = match where_properties
+                .iter()
+                .map(|s| filter::parse_property_filter(s))
+                .collect::<Result<Vec<_>, _>>()
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    process::exit(1);
+                }
+            };
+            for tag_str in where_tags {
+                if let Err(msg) = hyalo::commands::tags::validate_tag(tag_str) {
+                    eprintln!("Error: {msg}");
+                    process::exit(1);
+                }
+            }
+            append_commands::append(
+                &dir,
+                properties,
+                file.as_deref(),
+                glob.as_deref(),
+                &where_prop_filters,
+                where_tags,
+                effective_format,
+            )
+        }
     };
 
     match result {

--- a/src/output.rs
+++ b/src/output.rs
@@ -206,21 +206,24 @@ const CONTENT_MATCH_FILTER: &str = r#""  line \(.line) (\(.section)): \(.text)""
 
 /// Mutation result with `property` + `value` fields:
 /// covers `SetPropertyResult`, `AppendPropertyResult`, and `RemovePropertyResult` (with value).
-/// Key signature: `modified,property,skipped,total,value`
-/// Format: `property=value: N/T modified` followed by quoted file paths on separate lines.
-const PROPERTY_VALUE_MUTATION_FILTER: &str = r#""\(.property)=\(.value): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
+/// Key signature: `modified,property,scanned,skipped,total,value`
+/// Format: `property=value: N/T modified (S scanned)` when filters narrowed the set,
+/// or `property=value: N/T modified` when scanned == total.
+const PROPERTY_VALUE_MUTATION_FILTER: &str = r#""\(.property)=\(.value): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `property` only (no value field):
 /// covers `RemovePropertyResult` (without value).
-/// Key signature: `modified,property,skipped,total`
-/// Format: `property: N/T modified` followed by quoted file paths on separate lines.
-const PROPERTY_MUTATION_FILTER: &str = r#""\(.property): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
+/// Key signature: `modified,property,scanned,skipped,total`
+/// Format: `property: N/T modified (S scanned)` when filters narrowed the set,
+/// or `property: N/T modified` when scanned == total.
+const PROPERTY_MUTATION_FILTER: &str = r#""\(.property): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `tag` field:
 /// covers `SetTagResult` and `RemoveTagResult`.
-/// Key signature: `modified,skipped,tag,total`
-/// Format: `tag: N/T modified` followed by quoted file paths on separate lines.
-const TAG_MUTATION_FILTER: &str = r#""\(.tag): \(.modified | length)/\(.total) modified\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
+/// Key signature: `modified,scanned,skipped,tag,total`
+/// Format: `tag: N/T modified (S scanned)` when filters narrowed the set,
+/// or `tag: N/T modified` when scanned == total.
+const TAG_MUTATION_FILTER: &str = r#""\(.tag): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 // ---------------------------------------------------------------------------
 // Shape-based filter lookup
@@ -268,11 +271,11 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         "files,properties,recent_files,status,tags,tasks" => Some(VAULT_SUMMARY_FILTER),
         // Mutation results with property + value (SetPropertyResult, AppendPropertyResult,
         // RemovePropertyResult with value)
-        "modified,property,skipped,total,value" => Some(PROPERTY_VALUE_MUTATION_FILTER),
+        "modified,property,scanned,skipped,total,value" => Some(PROPERTY_VALUE_MUTATION_FILTER),
         // Mutation results with property only (RemovePropertyResult without value)
-        "modified,property,skipped,total" => Some(PROPERTY_MUTATION_FILTER),
+        "modified,property,scanned,skipped,total" => Some(PROPERTY_MUTATION_FILTER),
         // Mutation results with tag (SetTagResult, RemoveTagResult)
-        "modified,skipped,tag,total" => Some(TAG_MUTATION_FILTER),
+        "modified,scanned,skipped,tag,total" => Some(TAG_MUTATION_FILTER),
         _ => None,
     }
 }
@@ -805,9 +808,11 @@ mod tests {
     #[test]
     fn property_value_mutation_filter_with_modified() {
         // SetPropertyResult / AppendPropertyResult / RemovePropertyResult (with value)
+        // scanned == total: no "(N scanned)" suffix
         let val = json!({
             "modified": ["note-a.md", "note-b.md"],
             "property": "status",
+            "scanned": 2,
             "skipped": [],
             "total": 2,
             "value": "done"
@@ -815,6 +820,10 @@ mod tests {
         let out = jq(PROPERTY_VALUE_MUTATION_FILTER, &val).unwrap();
         assert!(out.contains("status=done"));
         assert!(out.contains("2/2 modified"));
+        assert!(
+            !out.contains("scanned"),
+            "no scanned suffix when scanned == total"
+        );
         assert!(out.contains("note-a.md"));
         assert!(out.contains("note-b.md"));
     }
@@ -824,6 +833,7 @@ mod tests {
         let val = json!({
             "modified": [],
             "property": "priority",
+            "scanned": 1,
             "skipped": ["note-a.md"],
             "total": 1,
             "value": "high"
@@ -836,10 +846,28 @@ mod tests {
     }
 
     #[test]
+    fn property_value_mutation_filter_with_where_filter() {
+        // scanned > total: "(N scanned)" suffix should appear
+        let val = json!({
+            "modified": ["note-a.md"],
+            "property": "status",
+            "scanned": 5,
+            "skipped": [],
+            "total": 1,
+            "value": "done"
+        });
+        let out = jq(PROPERTY_VALUE_MUTATION_FILTER, &val).unwrap();
+        assert!(out.contains("status=done"));
+        assert!(out.contains("1/1 modified"));
+        assert!(out.contains("(5 scanned)"));
+    }
+
+    #[test]
     fn property_value_mutation_via_format_value_as_text() {
         let val = json!({
             "modified": ["notes/a.md"],
             "property": "status",
+            "scanned": 1,
             "skipped": [],
             "total": 1,
             "value": "done"
@@ -854,24 +882,46 @@ mod tests {
 
     #[test]
     fn property_mutation_filter_no_value() {
-        // RemovePropertyResult without value
+        // RemovePropertyResult without value; scanned == total
         let val = json!({
             "modified": ["note.md"],
             "property": "draft",
+            "scanned": 1,
             "skipped": [],
             "total": 1
         });
         let out = jq(PROPERTY_MUTATION_FILTER, &val).unwrap();
         assert!(out.contains("draft"));
         assert!(out.contains("1/1 modified"));
+        assert!(
+            !out.contains("scanned"),
+            "no scanned suffix when scanned == total"
+        );
         assert!(out.contains("note.md"));
     }
 
     #[test]
+    fn property_mutation_filter_no_value_with_where_filter() {
+        // RemovePropertyResult without value; scanned > total
+        let val = json!({
+            "modified": ["note.md"],
+            "property": "draft",
+            "scanned": 7,
+            "skipped": [],
+            "total": 1
+        });
+        let out = jq(PROPERTY_MUTATION_FILTER, &val).unwrap();
+        assert!(out.contains("draft"));
+        assert!(out.contains("1/1 modified"));
+        assert!(out.contains("(7 scanned)"));
+    }
+
+    #[test]
     fn tag_mutation_filter_with_modified() {
-        // SetTagResult / RemoveTagResult
+        // SetTagResult / RemoveTagResult; scanned == total
         let val = json!({
             "modified": ["a.md", "b.md"],
+            "scanned": 3,
             "skipped": ["c.md"],
             "tag": "rust",
             "total": 3
@@ -879,15 +929,36 @@ mod tests {
         let out = jq(TAG_MUTATION_FILTER, &val).unwrap();
         assert!(out.contains("rust"));
         assert!(out.contains("2/3 modified"));
+        assert!(
+            !out.contains("scanned"),
+            "no scanned suffix when scanned == total"
+        );
         assert!(out.contains("a.md"));
         assert!(out.contains("b.md"));
         assert!(!out.contains("c.md"));
     }
 
     #[test]
+    fn tag_mutation_filter_with_where_filter() {
+        // scanned > total: "(N scanned)" suffix
+        let val = json!({
+            "modified": ["a.md"],
+            "scanned": 10,
+            "skipped": [],
+            "tag": "rust",
+            "total": 1
+        });
+        let out = jq(TAG_MUTATION_FILTER, &val).unwrap();
+        assert!(out.contains("rust"));
+        assert!(out.contains("1/1 modified"));
+        assert!(out.contains("(10 scanned)"));
+    }
+
+    #[test]
     fn tag_mutation_via_format_value_as_text() {
         let val = json!({
             "modified": [],
+            "scanned": 1,
             "skipped": ["note.md"],
             "tag": "cli",
             "total": 1

--- a/src/output.rs
+++ b/src/output.rs
@@ -207,22 +207,22 @@ const CONTENT_MATCH_FILTER: &str = r#""  line \(.line) (\(.section)): \(.text)""
 /// Mutation result with `property` + `value` fields:
 /// covers `SetPropertyResult`, `AppendPropertyResult`, and `RemovePropertyResult` (with value).
 /// Key signature: `modified,property,scanned,skipped,total,value`
-/// Format: `property=value: N/T modified (S scanned)` when filters narrowed the set,
-/// or `property=value: N/T modified` when scanned == total.
+/// Format: `property=value: N/T modified (S scanned)` when not all scanned files were
+/// processed (e.g. where-filters or parse errors), or `property=value: N/T modified` otherwise.
 const PROPERTY_VALUE_MUTATION_FILTER: &str = r#""\(.property)=\(.value): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `property` only (no value field):
 /// covers `RemovePropertyResult` (without value).
 /// Key signature: `modified,property,scanned,skipped,total`
-/// Format: `property: N/T modified (S scanned)` when filters narrowed the set,
-/// or `property: N/T modified` when scanned == total.
+/// Format: `property: N/T modified (S scanned)` when not all scanned files were
+/// processed (e.g. where-filters or parse errors), or `property: N/T modified` otherwise.
 const PROPERTY_MUTATION_FILTER: &str = r#""\(.property): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `tag` field:
 /// covers `SetTagResult` and `RemoveTagResult`.
 /// Key signature: `modified,scanned,skipped,tag,total`
-/// Format: `tag: N/T modified (S scanned)` when filters narrowed the set,
-/// or `tag: N/T modified` when scanned == total.
+/// Format: `tag: N/T modified (S scanned)` when not all scanned files were
+/// processed (e.g. where-filters or parse errors), or `tag: N/T modified` otherwise.
 const TAG_MUTATION_FILTER: &str = r#""\(.tag): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e_append.rs
+++ b/tests/e2e_append.rs
@@ -164,6 +164,135 @@ author: Alice
 }
 
 // ---------------------------------------------------------------------------
+// --where-property / --where-tag filter tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn append_where_property_match() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "target.md",
+        md!(r"
+---
+title: Target
+status: review
+aliases:
+  - original-name
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "skip.md",
+        md!(r"
+---
+title: Skip
+status: draft
+aliases:
+  - other-name
+---
+"),
+    );
+
+    let (status, json, stderr) = append_json(
+        &tmp,
+        &[
+            "--property",
+            "aliases=canonical-name",
+            "--where-property",
+            "status=review",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected 1 modified: {json}"
+    );
+    assert_eq!(
+        json["skipped"].as_array().unwrap().len(),
+        0,
+        "expected 0 skipped (skip.md was filtered out, not skipped): {json}"
+    );
+
+    let target_content = fs::read_to_string(tmp.path().join("target.md")).unwrap();
+    assert!(
+        target_content.contains("canonical-name"),
+        "target.md should have alias appended:\n{target_content}"
+    );
+    assert!(
+        target_content.contains("original-name"),
+        "target.md should retain original alias:\n{target_content}"
+    );
+
+    let skip_content = fs::read_to_string(tmp.path().join("skip.md")).unwrap();
+    assert!(
+        !skip_content.contains("canonical-name"),
+        "skip.md should be untouched:\n{skip_content}"
+    );
+}
+
+#[test]
+fn append_where_tag_match() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "tagged.md",
+        md!(r"
+---
+title: Tagged
+tags:
+  - backend
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "untagged.md",
+        md!(r"
+---
+title: Untagged
+---
+"),
+    );
+
+    let (status, json, stderr) = append_json(
+        &tmp,
+        &[
+            "--property",
+            "aliases=backend-note",
+            "--where-tag",
+            "backend",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected only tagged file to be modified: {json}"
+    );
+
+    let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
+    assert!(
+        tagged_content.contains("backend-note"),
+        "tagged.md should have alias appended:\n{tagged_content}"
+    );
+
+    let untagged_content = fs::read_to_string(tmp.path().join("untagged.md")).unwrap();
+    assert!(
+        !untagged_content.contains("backend-note"),
+        "untagged.md should be untouched:\n{untagged_content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Guard: --file or --glob required
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e_remove.rs
+++ b/tests/e2e_remove.rs
@@ -211,6 +211,132 @@ tags:
 }
 
 // ---------------------------------------------------------------------------
+// --where-property / --where-tag filter tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_where_property_match() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "target.md",
+        md!(r"
+---
+title: Target
+status: draft
+legacy: true
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "keep.md",
+        md!(r"
+---
+title: Keep
+status: published
+legacy: true
+---
+"),
+    );
+
+    let (status, json, stderr) = remove_json(
+        &tmp,
+        &[
+            "--property",
+            "legacy",
+            "--where-property",
+            "status=draft",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected 1 modified: {json}"
+    );
+    assert_eq!(
+        json["skipped"].as_array().unwrap().len(),
+        0,
+        "expected 0 skipped (keep.md was filtered out, not skipped): {json}"
+    );
+
+    let target_content = fs::read_to_string(tmp.path().join("target.md")).unwrap();
+    assert!(
+        !target_content.contains("legacy"),
+        "target.md should have legacy removed:\n{target_content}"
+    );
+
+    let keep_content = fs::read_to_string(tmp.path().join("keep.md")).unwrap();
+    assert!(
+        keep_content.contains("legacy: true"),
+        "keep.md should be untouched:\n{keep_content}"
+    );
+}
+
+#[test]
+fn remove_where_tag_match() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "tagged.md",
+        md!(r"
+---
+title: Tagged
+status: old
+tags:
+  - rust
+  - cli
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "untagged.md",
+        md!(r"
+---
+title: Untagged
+status: old
+---
+"),
+    );
+
+    let (status, json, stderr) = remove_json(
+        &tmp,
+        &[
+            "--property",
+            "status",
+            "--where-tag",
+            "rust",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected only tagged file to be modified: {json}"
+    );
+
+    let tagged_content = fs::read_to_string(tmp.path().join("tagged.md")).unwrap();
+    assert!(
+        !tagged_content.contains("status:"),
+        "tagged.md should have status removed:\n{tagged_content}"
+    );
+
+    let untagged_content = fs::read_to_string(tmp.path().join("untagged.md")).unwrap();
+    assert!(
+        untagged_content.contains("status: old"),
+        "untagged.md should be untouched:\n{untagged_content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Guard: --file or --glob required
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e_set.rs
+++ b/tests/e2e_set.rs
@@ -353,6 +353,354 @@ title: Note
 }
 
 // ---------------------------------------------------------------------------
+// --where-property / --where-tag filter tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_where_property_scalar_match() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "done.md",
+        md!(r"
+---
+title: Done
+status: done
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "active.md",
+        md!(r"
+---
+title: Active
+status: active
+---
+"),
+    );
+
+    let (status, json, stderr) = set_json(
+        &tmp,
+        &[
+            "--property",
+            "status=completed",
+            "--where-property",
+            "status=done",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected 1 modified: {json}"
+    );
+    assert_eq!(
+        json["skipped"].as_array().unwrap().len(),
+        0,
+        "expected 0 skipped: {json}"
+    );
+
+    let done_content = fs::read_to_string(tmp.path().join("done.md")).unwrap();
+    assert!(
+        done_content.contains("status: completed"),
+        "done.md should be updated:\n{done_content}"
+    );
+
+    let active_content = fs::read_to_string(tmp.path().join("active.md")).unwrap();
+    assert!(
+        active_content.contains("status: active"),
+        "active.md should be untouched:\n{active_content}"
+    );
+    assert!(
+        !active_content.contains("completed"),
+        "active.md should not have been modified:\n{active_content}"
+    );
+}
+
+#[test]
+fn set_where_property_list_match() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+tags:
+  - cli
+  - rust
+---
+"),
+    );
+
+    let (status, json, stderr) = set_json(
+        &tmp,
+        &[
+            "--property",
+            "reviewed=true",
+            "--where-property",
+            "tags=cli",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected list element match to produce 1 modified: {json}"
+    );
+
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("reviewed: true"),
+        "file should have been mutated:\n{content}"
+    );
+}
+
+#[test]
+fn set_where_tag_nested_match() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "backend.md",
+        md!(r"
+---
+title: Backend
+tags:
+  - project/backend
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "research.md",
+        md!(r"
+---
+title: Research
+tags:
+  - research
+---
+"),
+    );
+
+    let (status, json, stderr) = set_json(
+        &tmp,
+        &[
+            "--property",
+            "checked=true",
+            "--where-tag",
+            "project",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected only the nested-tag file to be modified: {json}"
+    );
+
+    let backend_content = fs::read_to_string(tmp.path().join("backend.md")).unwrap();
+    assert!(
+        backend_content.contains("checked: true"),
+        "backend.md should be modified:\n{backend_content}"
+    );
+
+    let research_content = fs::read_to_string(tmp.path().join("research.md")).unwrap();
+    assert!(
+        !research_content.contains("checked"),
+        "research.md should be untouched:\n{research_content}"
+    );
+}
+
+#[test]
+fn set_where_combined_and() {
+    let tmp = TempDir::new().unwrap();
+    // Matches both filters: status=active AND tagged with rust
+    write_md(
+        tmp.path(),
+        "both.md",
+        md!(r"
+---
+title: Both
+status: active
+tags:
+  - rust
+---
+"),
+    );
+    // Matches property but not tag
+    write_md(
+        tmp.path(),
+        "prop_only.md",
+        md!(r"
+---
+title: PropOnly
+status: active
+tags:
+  - python
+---
+"),
+    );
+    // Matches tag but not property
+    write_md(
+        tmp.path(),
+        "tag_only.md",
+        md!(r"
+---
+title: TagOnly
+status: draft
+tags:
+  - rust
+---
+"),
+    );
+
+    let (status, json, stderr) = set_json(
+        &tmp,
+        &[
+            "--property",
+            "processed=true",
+            "--where-property",
+            "status=active",
+            "--where-tag",
+            "rust",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected only 1 file matching both filters: {json}"
+    );
+
+    let both_content = fs::read_to_string(tmp.path().join("both.md")).unwrap();
+    assert!(
+        both_content.contains("processed: true"),
+        "both.md should be modified:\n{both_content}"
+    );
+
+    let prop_only = fs::read_to_string(tmp.path().join("prop_only.md")).unwrap();
+    assert!(
+        !prop_only.contains("processed"),
+        "prop_only.md should be untouched:\n{prop_only}"
+    );
+
+    let tag_only = fs::read_to_string(tmp.path().join("tag_only.md")).unwrap();
+    assert!(
+        !tag_only.contains("processed"),
+        "tag_only.md should be untouched:\n{tag_only}"
+    );
+}
+
+#[test]
+fn set_where_no_matches() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+status: active
+---
+"),
+    );
+
+    let (status, json, stderr) = set_json(
+        &tmp,
+        &[
+            "--property",
+            "status=done",
+            "--where-property",
+            "status=nonexistent",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        0,
+        "expected 0 modified when no files match filter: {json}"
+    );
+
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("status: active"),
+        "note.md should be untouched:\n{content}"
+    );
+}
+
+#[test]
+fn set_where_property_operator() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "low.md",
+        md!(r"
+---
+title: Low
+priority: 2
+---
+"),
+    );
+    write_md(
+        tmp.path(),
+        "high.md",
+        md!(r"
+---
+title: High
+priority: 5
+---
+"),
+    );
+
+    let (status, json, stderr) = set_json(
+        &tmp,
+        &[
+            "--property",
+            "urgent=true",
+            "--where-property",
+            "priority>=3",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected only high-priority file to be modified: {json}"
+    );
+
+    let high_content = fs::read_to_string(tmp.path().join("high.md")).unwrap();
+    assert!(
+        high_content.contains("urgent: true"),
+        "high.md should be modified:\n{high_content}"
+    );
+
+    let low_content = fs::read_to_string(tmp.path().join("low.md")).unwrap();
+    assert!(
+        !low_content.contains("urgent"),
+        "low.md should be untouched:\n{low_content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Malformed YAML resilience
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `--where-property` and `--where-tag` flags to `set`, `remove`, and `append` commands, enabling single-command bulk mutations without shell pipelines
- Extract shared `matches_frontmatter_filters()` into `filter.rs`, refactor `find` to use it
- Full filter operator support (`=`, `!=`, `>`, `>=`, `<`, `<=`, existence), list-element matching, and nested tag matching
- Update help text (long_about, cookbook, command reference) and README with examples

## Test plan

- [x] Unit tests for `matches_frontmatter_filters()` — scalar, list, tag, combined AND, empty filters
- [x] Unit tests in set/remove/append for where-filter skip behavior
- [x] E2E: `--where-property` scalar match (only matching files mutated)
- [x] E2E: `--where-property` list-element match (`tags: [cli, rust]` matched by `tags=cli`)
- [x] E2E: `--where-tag` nested match (`project/backend` matched by `project`)
- [x] E2E: combined `--where-property` + `--where-tag` AND semantics
- [x] E2E: no matches — success with zero modified
- [x] E2E: operator filters (`priority>=3`)
- [x] Manual smoke test on live knowledgebase
- [x] All 649 tests pass, clippy clean, fmt clean