### PR TITLE
Add read command for displaying file body content

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ hyalo find --fields sections,tasks,links
 hyalo find --sort modified --limit 10
 ```
 
+### read
+
+Read the body content of a markdown file, optionally filtered by section or line range. Defaults to plain text output.
+
+```sh
+# Read full body (text output)
+hyalo read --file path/to/note.md
+
+# Read a specific section
+hyalo read --file path/to/note.md --section "Proposal"
+hyalo read --file path/to/note.md --section "## Proposal"
+
+# Read a line range (1-based, inclusive)
+hyalo read --file path/to/note.md --lines 5:10
+hyalo read --file path/to/note.md --lines 5:
+hyalo read --file path/to/note.md --lines :10
+
+# Show frontmatter only
+hyalo read --file path/to/note.md --frontmatter
+
+# JSON output
+hyalo read --file path/to/note.md --format json
+hyalo read --file path/to/note.md --format json --jq '.content'
+```
+
 ### properties
 
 Aggregate summary of unique property names with inferred types and file counts.

--- a/hyalo-knowledgebase/backlog/read-command.md
+++ b/hyalo-knowledgebase/backlog/read-command.md
@@ -1,15 +1,15 @@
 ---
-title: "Read command — display file body content"
-type: backlog
 date: 2026-03-23
-status: planned
-priority: high
 origin: dogfooding post-iter-10, dogfooding post-iter-19, iteration-13
+priority: high
+status: completed
 tags:
-  - backlog
-  - cli
-  - ux
-  - llm
+- backlog
+- cli
+- ux
+- llm
+title: Read command — display file body content
+type: backlog
 ---
 
 # Read command — display file body content

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod append;
 pub mod find;
 pub mod outline;
 pub mod properties;
+pub mod read;
 pub mod remove;
 pub mod set;
 pub mod summary;

--- a/src/commands/outline.rs
+++ b/src/commands/outline.rs
@@ -147,7 +147,7 @@ impl FileVisitor for SectionScanner {
 /// Parse an ATX heading line (`# Heading`, `## Sub`, etc.).
 /// Returns `(level, heading_text)` if the line is a valid ATX heading,
 /// or `None` otherwise.
-fn parse_atx_heading(line: &str) -> Option<(u8, String)> {
+pub fn parse_atx_heading(line: &str) -> Option<(u8, String)> {
     let bytes = line.as_bytes();
     if bytes.first() != Some(&b'#') {
         return None;

--- a/src/commands/outline.rs
+++ b/src/commands/outline.rs
@@ -147,7 +147,7 @@ impl FileVisitor for SectionScanner {
 /// Parse an ATX heading line (`# Heading`, `## Sub`, etc.).
 /// Returns `(level, heading_text)` if the line is a valid ATX heading,
 /// or `None` otherwise.
-pub fn parse_atx_heading(line: &str) -> Option<(u8, String)> {
+pub(crate) fn parse_atx_heading(line: &str) -> Option<(u8, String)> {
     let bytes = line.as_bytes();
     if bytes.first() != Some(&b'#') {
         return None;

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -88,8 +88,9 @@ fn apply_line_range<'a>(lines: &'a [String], range: &LineRange) -> &'a [String] 
 
 /// Extract all sections matching `query` (case-insensitive exact match on heading text).
 /// If query starts with `#`, parse the heading level and text from it.
-/// Returns a Vec of (heading_text, lines) pairs. Each section includes lines from
-/// the heading through to (but not including) the next heading of equal or higher level.
+/// Returns a `Vec<Vec<String>>`, where each inner `Vec<String>` contains the lines of a
+/// matched section, from the heading through to (but not including) the next heading of
+/// equal or higher level.
 fn extract_sections(body_lines: &[String], query: &str) -> Vec<Vec<String>> {
     // Parse query: strip leading `#` characters if present
     let (query_level, query_text) = if query.starts_with('#') {
@@ -318,7 +319,7 @@ pub fn run(
                 out.push_str("---\n");
                 if !props.is_empty() {
                     let yaml = serde_yaml_ng::to_string(props)
-                        .unwrap_or_else(|_| "# (failed to serialize)\n".to_owned());
+                        .context("failed to serialize frontmatter as YAML")?;
                     out.push_str(&yaml);
                 }
                 out.push_str("---\n");

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -1,0 +1,560 @@
+#![allow(clippy::missing_errors_doc)]
+
+use crate::commands::outline::parse_atx_heading;
+use crate::discovery;
+use crate::frontmatter;
+use crate::output::{CommandOutcome, Format, format_error, format_success};
+use crate::scanner;
+use anyhow::{Context, Result};
+use std::io::BufRead;
+use std::path::Path;
+
+// ---------------------------------------------------------------------------
+// Line range parsing
+// ---------------------------------------------------------------------------
+
+/// Inclusive 1-based line range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LineRange {
+    /// 1-based start (inclusive). `None` means from the beginning.
+    start: Option<usize>,
+    /// 1-based end (inclusive). `None` means to the end.
+    end: Option<usize>,
+}
+
+/// Parse a line range string like `5:10`, `5:`, `:10`, or `5`.
+fn parse_line_range(s: &str) -> Result<LineRange, String> {
+    if let Some((left, right)) = s.split_once(':') {
+        let start = if left.is_empty() {
+            None
+        } else {
+            let n = left
+                .parse::<usize>()
+                .map_err(|_| format!("invalid line number: {left}"))?;
+            if n == 0 {
+                return Err("line numbers are 1-based".to_owned());
+            }
+            Some(n)
+        };
+        let end = if right.is_empty() {
+            None
+        } else {
+            let n = right
+                .parse::<usize>()
+                .map_err(|_| format!("invalid line number: {right}"))?;
+            if n == 0 {
+                return Err("line numbers are 1-based".to_owned());
+            }
+            Some(n)
+        };
+        if let (Some(s), Some(e)) = (start, end)
+            && s > e
+        {
+            return Err(format!("start ({s}) must be <= end ({e})"));
+        }
+        Ok(LineRange { start, end })
+    } else {
+        let n = s
+            .parse::<usize>()
+            .map_err(|_| format!("invalid line number: {s}"))?;
+        if n == 0 {
+            return Err("line numbers are 1-based".to_owned());
+        }
+        Ok(LineRange {
+            start: Some(n),
+            end: Some(n),
+        })
+    }
+}
+
+/// Apply a line range to a slice of lines, returning the selected sub-slice.
+/// Line numbers are 1-based and inclusive. Out-of-range values are clamped.
+fn apply_line_range<'a>(lines: &'a [String], range: &LineRange) -> &'a [String] {
+    let len = lines.len();
+    if len == 0 {
+        return lines;
+    }
+    let start_idx = range.start.unwrap_or(1).saturating_sub(1).min(len);
+    let end_idx = range.end.unwrap_or(len).min(len);
+    if start_idx >= end_idx {
+        return &lines[0..0];
+    }
+    &lines[start_idx..end_idx]
+}
+
+// ---------------------------------------------------------------------------
+// Section extraction
+// ---------------------------------------------------------------------------
+
+/// Extract all sections matching `query` (case-insensitive exact match on heading text).
+/// If query starts with `#`, parse the heading level and text from it.
+/// Returns a Vec of (heading_text, lines) pairs. Each section includes lines from
+/// the heading through to (but not including) the next heading of equal or higher level.
+fn extract_sections(body_lines: &[String], query: &str) -> Vec<Vec<String>> {
+    // Parse query: strip leading `#` characters if present
+    let (query_level, query_text) = if query.starts_with('#') {
+        match parse_atx_heading(query) {
+            Some((level, text)) => (Some(level), text),
+            None => (None, query.to_owned()),
+        }
+    } else {
+        (None, query.to_owned())
+    };
+
+    let mut sections: Vec<Vec<String>> = Vec::new();
+    let mut current_section: Option<(u8, Vec<String>)> = None;
+    let mut fence: Option<(char, usize)> = None;
+
+    for line in body_lines {
+        // Track code fences — headings inside code blocks are not real headings
+        if let Some((fence_char, fence_count)) = fence {
+            if scanner::is_closing_fence(line, fence_char, fence_count) {
+                fence = None;
+            }
+            if let Some((_, ref mut lines)) = current_section {
+                lines.push(line.clone());
+            }
+            continue;
+        }
+        if let Some(f) = scanner::detect_opening_fence(line) {
+            fence = Some(f);
+            if let Some((_, ref mut lines)) = current_section {
+                lines.push(line.clone());
+            }
+            continue;
+        }
+
+        if let Some((level, text)) = parse_atx_heading(line) {
+            // Flush current section if a heading of equal or higher level is encountered
+            if let Some((sec_level, sec_lines)) = current_section.take() {
+                if level <= sec_level {
+                    sections.push(sec_lines);
+                } else {
+                    // Lower-level heading (deeper nesting) — still part of current section
+                    let mut lines = sec_lines;
+                    lines.push(line.clone());
+                    current_section = Some((sec_level, lines));
+                    continue;
+                }
+            }
+
+            // Check if this heading matches the query
+            let text_matches = text.eq_ignore_ascii_case(&query_text);
+            let level_matches = query_level.is_none_or(|ql| ql == level);
+
+            if text_matches && level_matches {
+                current_section = Some((level, vec![line.clone()]));
+            }
+        } else if let Some((_, ref mut lines)) = current_section {
+            lines.push(line.clone());
+        }
+    }
+
+    // Flush final section
+    if let Some((_, lines)) = current_section {
+        sections.push(lines);
+    }
+
+    sections
+}
+
+/// Collect all heading texts from body lines (for error messages).
+fn collect_headings(body_lines: &[String]) -> Vec<String> {
+    let mut fence: Option<(char, usize)> = None;
+    let mut headings = Vec::new();
+    for line in body_lines {
+        if let Some((fence_char, fence_count)) = fence {
+            if scanner::is_closing_fence(line, fence_char, fence_count) {
+                fence = None;
+            }
+            continue;
+        }
+        if let Some(f) = scanner::detect_opening_fence(line) {
+            fence = Some(f);
+            continue;
+        }
+        if let Some((level, text)) = parse_atx_heading(line) {
+            let hashes = "#".repeat(level as usize);
+            headings.push(format!("{hashes} {text}"));
+        }
+    }
+    headings
+}
+
+// ---------------------------------------------------------------------------
+// Read body lines from file (raw, no stripping)
+// ---------------------------------------------------------------------------
+
+/// Read the raw body lines from a markdown file, skipping frontmatter.
+/// Returns the lines with their trailing newlines stripped.
+fn read_body_lines(path: &Path) -> Result<Vec<String>> {
+    let file =
+        std::fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut reader = std::io::BufReader::new(file);
+
+    // Read first line to check for frontmatter
+    let mut first_line = String::new();
+    let n = reader
+        .read_line(&mut first_line)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+
+    let first_trimmed = first_line.trim_end_matches(['\n', '\r']);
+    let fm_lines = frontmatter::skip_frontmatter(&mut reader, first_trimmed)?;
+
+    let mut lines = Vec::new();
+
+    if fm_lines == 0 {
+        // No frontmatter — first line is body content
+        lines.push(first_trimmed.to_owned());
+    }
+
+    for line_result in reader.lines() {
+        let line = line_result.with_context(|| format!("failed to read {}", path.display()))?;
+        lines.push(line);
+    }
+
+    Ok(lines)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+pub fn run(
+    dir: &Path,
+    file: &str,
+    section: Option<&str>,
+    lines: Option<&str>,
+    frontmatter_flag: bool,
+    format: Format,
+) -> Result<CommandOutcome> {
+    // Resolve file
+    let (full_path, rel_path) = match discovery::resolve_file(dir, file) {
+        Ok(r) => r,
+        Err(e) => return Ok(super::resolve_error_to_outcome(e, format)),
+    };
+
+    // Parse line range early so we fail fast on bad input
+    let line_range = if let Some(range_str) = lines {
+        match parse_line_range(range_str) {
+            Ok(r) => Some(r),
+            Err(msg) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format,
+                    &msg,
+                    None,
+                    Some("expected format: 5:10, 5:, :10, or 5"),
+                    None,
+                )));
+            }
+        }
+    } else {
+        None
+    };
+
+    // Read frontmatter if requested
+    let fm_value = if frontmatter_flag {
+        let props = frontmatter::read_frontmatter(&full_path)?;
+        Some(props)
+    } else {
+        None
+    };
+
+    // Determine what content to return
+    let need_body = section.is_some() || !frontmatter_flag || line_range.is_some();
+
+    let mut content_lines: Vec<String> = if need_body {
+        read_body_lines(&full_path)?
+    } else {
+        Vec::new()
+    };
+
+    // Apply section filter
+    if let Some(query) = section {
+        let sections = extract_sections(&content_lines, query);
+        if sections.is_empty() {
+            let available = collect_headings(&content_lines);
+            let hint = if available.is_empty() {
+                "this file has no headings".to_owned()
+            } else {
+                format!("available sections: {}", available.join(", "))
+            };
+            return Ok(CommandOutcome::UserError(format_error(
+                format,
+                &format!("section not found: {query}"),
+                Some(&rel_path),
+                Some(&hint),
+                None,
+            )));
+        }
+
+        // Join multiple matching sections with a blank line separator
+        content_lines = Vec::new();
+        for (i, sec) in sections.iter().enumerate() {
+            if i > 0 {
+                content_lines.push(String::new());
+            }
+            content_lines.extend_from_slice(sec);
+        }
+    }
+
+    // Apply line range
+    if let Some(ref range) = line_range {
+        let sliced = apply_line_range(&content_lines, range);
+        content_lines = sliced.to_vec();
+    }
+
+    // Format output
+    let content_str = content_lines.join("\n");
+
+    match format {
+        Format::Text => {
+            let mut out = String::new();
+            if let Some(ref props) = fm_value {
+                // Render frontmatter as YAML
+                out.push_str("---\n");
+                if !props.is_empty() {
+                    let yaml = serde_yaml_ng::to_string(props)
+                        .unwrap_or_else(|_| "# (failed to serialize)\n".to_owned());
+                    out.push_str(&yaml);
+                }
+                out.push_str("---\n");
+                if need_body && !content_str.is_empty() {
+                    out.push('\n');
+                }
+            }
+            if need_body {
+                out.push_str(&content_str);
+                // Ensure trailing newline for pipe-friendliness
+                if !out.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+            Ok(CommandOutcome::Success(out))
+        }
+        Format::Json => {
+            let mut obj = serde_json::json!({ "file": rel_path });
+            if let Some(props) = fm_value {
+                let json_val = serde_json::to_value(&props)
+                    .context("failed to serialize frontmatter as JSON")?;
+                obj["frontmatter"] = json_val;
+            }
+            if need_body {
+                obj["content"] = serde_json::json!(content_str);
+            }
+            Ok(CommandOutcome::Success(format_success(format, &obj)))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- parse_line_range --
+
+    #[test]
+    fn range_single_line() {
+        assert_eq!(
+            parse_line_range("5").unwrap(),
+            LineRange {
+                start: Some(5),
+                end: Some(5)
+            }
+        );
+    }
+
+    #[test]
+    fn range_full() {
+        assert_eq!(
+            parse_line_range("5:10").unwrap(),
+            LineRange {
+                start: Some(5),
+                end: Some(10)
+            }
+        );
+    }
+
+    #[test]
+    fn range_open_start() {
+        assert_eq!(
+            parse_line_range(":10").unwrap(),
+            LineRange {
+                start: None,
+                end: Some(10)
+            }
+        );
+    }
+
+    #[test]
+    fn range_open_end() {
+        assert_eq!(
+            parse_line_range("5:").unwrap(),
+            LineRange {
+                start: Some(5),
+                end: None
+            }
+        );
+    }
+
+    #[test]
+    fn range_zero_is_error() {
+        assert!(parse_line_range("0").is_err());
+        assert!(parse_line_range("0:5").is_err());
+        assert!(parse_line_range("5:0").is_err());
+    }
+
+    #[test]
+    fn range_inverted_is_error() {
+        assert!(parse_line_range("10:5").is_err());
+    }
+
+    #[test]
+    fn range_non_numeric_is_error() {
+        assert!(parse_line_range("abc").is_err());
+        assert!(parse_line_range("a:b").is_err());
+    }
+
+    // -- apply_line_range --
+
+    #[test]
+    fn apply_range_to_lines() {
+        let lines: Vec<String> = (1..=10).map(|i| format!("line {i}")).collect();
+        let range = LineRange {
+            start: Some(3),
+            end: Some(5),
+        };
+        let result = apply_line_range(&lines, &range);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], "line 3");
+        assert_eq!(result[2], "line 5");
+    }
+
+    #[test]
+    fn apply_range_clamps_high_end() {
+        let lines: Vec<String> = (1..=3).map(|i| format!("line {i}")).collect();
+        let range = LineRange {
+            start: Some(2),
+            end: Some(100),
+        };
+        let result = apply_line_range(&lines, &range);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn apply_range_empty_lines() {
+        let lines: Vec<String> = Vec::new();
+        let range = LineRange {
+            start: Some(1),
+            end: Some(5),
+        };
+        let result = apply_line_range(&lines, &range);
+        assert!(result.is_empty());
+    }
+
+    // -- extract_sections --
+
+    #[test]
+    fn extract_section_exact_match() {
+        let lines: Vec<String> = vec![
+            "# Title".into(),
+            "intro".into(),
+            "## Problem".into(),
+            "problem text".into(),
+            "## Solution".into(),
+            "solution text".into(),
+        ];
+        let sections = extract_sections(&lines, "Problem");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].len(), 2);
+        assert_eq!(sections[0][0], "## Problem");
+        assert_eq!(sections[0][1], "problem text");
+    }
+
+    #[test]
+    fn extract_section_case_insensitive() {
+        let lines: Vec<String> = vec!["## Problem".into(), "text".into(), "## Other".into()];
+        let sections = extract_sections(&lines, "problem");
+        assert_eq!(sections.len(), 1);
+    }
+
+    #[test]
+    fn extract_section_with_hashes() {
+        let lines: Vec<String> = vec!["## Problem".into(), "text".into(), "## Other".into()];
+        let sections = extract_sections(&lines, "## Problem");
+        assert_eq!(sections.len(), 1);
+    }
+
+    #[test]
+    fn extract_section_no_match_substring() {
+        let lines: Vec<String> = vec!["## Problems".into(), "text".into()];
+        let sections = extract_sections(&lines, "Problem");
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn extract_section_includes_nested() {
+        let lines: Vec<String> = vec![
+            "## Section".into(),
+            "text".into(),
+            "### Subsection".into(),
+            "sub text".into(),
+            "## Next".into(),
+        ];
+        let sections = extract_sections(&lines, "Section");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].len(), 4); // heading + text + sub heading + sub text
+    }
+
+    #[test]
+    fn extract_section_multiple_matches() {
+        let lines: Vec<String> = vec![
+            "## Notes".into(),
+            "first notes".into(),
+            "## Other".into(),
+            "other".into(),
+            "## Notes".into(),
+            "second notes".into(),
+        ];
+        let sections = extract_sections(&lines, "Notes");
+        assert_eq!(sections.len(), 2);
+    }
+
+    #[test]
+    fn extract_section_at_end_of_file() {
+        let lines: Vec<String> = vec![
+            "## First".into(),
+            "text".into(),
+            "## Last".into(),
+            "last text".into(),
+        ];
+        let sections = extract_sections(&lines, "Last");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].len(), 2);
+    }
+
+    #[test]
+    fn extract_section_skips_headings_in_code_blocks() {
+        let lines: Vec<String> = vec![
+            "## Proposal".into(),
+            "intro".into(),
+            "```sh".into(),
+            "# This is a comment, not a heading".into(),
+            "echo hello".into(),
+            "```".into(),
+            "after code".into(),
+            "## Next".into(),
+        ];
+        let sections = extract_sections(&lines, "Proposal");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].len(), 7); // heading + intro + code block (4 lines) + after code
+        assert!(sections[0].contains(&"# This is a comment, not a heading".to_owned()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ use std::process;
 use clap::{Parser, Subcommand};
 
 use hyalo::commands::{
-    append as append_commands, find as find_commands, properties, remove as remove_commands,
-    set as set_commands, summary as summary_commands, tags as tag_commands, tasks as task_commands,
+    append as append_commands, find as find_commands, properties, read as read_commands,
+    remove as remove_commands, set as set_commands, summary as summary_commands,
+    tags as tag_commands, tasks as task_commands,
 };
 use hyalo::filter;
 use hyalo::hints::{HintContext, HintSource, generate_hints};
@@ -27,6 +28,7 @@ use hyalo::output::{CommandOutcome, Format, apply_jq_filter_result, format_with_
         CONFIG: Place a .hyalo.toml in the working directory to set defaults for --dir, --format, and --hints. CLI flags always take precedence.\n\n\
         COMMANDS:\n\
           find        Search and filter files by text, properties, tags, or tasks\n\
+          read        Read file body content, optionally filtered by section or line range\n\
           set         Set (create or overwrite) properties and add tags\n\
           remove      Remove properties or tags from file(s)\n\
           append      Append values to list properties\n\
@@ -39,6 +41,8 @@ use hyalo::output::{CommandOutcome, Format, apply_jq_filter_result, format_with_
         Filter by tag:                hyalo find --tag project\n  \
         Filter by task status:        hyalo find --task todo\n  \
         Full-text search:             hyalo find 'meeting notes'\n  \
+        Read file content:            hyalo read --file notes/todo.md\n  \
+        Read a section:               hyalo read --file notes/todo.md --section Proposal\n  \
         Set a property:               hyalo set --property status=done --file notes/todo.md\n  \
         Bulk-set with filter:         hyalo set --property status=done --where-property status=draft --glob '**/*.md'\n  \
         Add a tag across files:       hyalo set --tag reviewed --glob 'research/**/*.md'\n  \
@@ -55,6 +59,8 @@ COMMAND REFERENCE:\n  \
   Find (search and filter, read-only):\n  \
     hyalo find [PATTERN | --regexp/-e REGEX] [--property K=V ...] [--tag T ...] [--task STATUS]\n  \
                [--file F | --glob G] [--fields ...] [--sort ...] [--limit N]\n\n  \
+  Read (display file body content, read-only):\n  \
+    hyalo read --file F [--section HEADING] [--lines RANGE] [--frontmatter]\n\n  \
   Set (create or overwrite, mutates files):\n  \
     hyalo set  --property K=V [--property ...] [--tag T ...] [--file F | --glob G] [--where-property FILTER ...] [--where-tag T ...]\n\n  \
   Remove (delete properties/tags, mutates files):\n  \
@@ -207,6 +213,28 @@ enum Commands {
         /// Maximum number of results to return
         #[arg(long)]
         limit: Option<usize>,
+    },
+    /// Read file body content, optionally filtered by section or line range (read-only)
+    #[command(long_about = "Read the body content of a markdown file.\n\n\
+            Returns the raw text after the YAML frontmatter block. Use --section to extract a \
+            specific section by heading, --lines to slice a line range, and --frontmatter to \
+            include the YAML frontmatter.\n\n\
+            OUTPUT: Plain text by default (--format text is the default for this command). \
+            Use --format json for {\"file\": \"...\", \"content\": \"...\"}.\n\
+            SIDE EFFECTS: None (read-only).")]
+    Read {
+        /// Target file (relative to --dir)
+        #[arg(long)]
+        file: String,
+        /// Extract only the section(s) under this heading (case-insensitive exact match)
+        #[arg(long)]
+        section: Option<String>,
+        /// Slice output by line range: 5:10, 5:, :10, or 5 (1-based, inclusive, relative to output)
+        #[arg(long)]
+        lines: Option<String>,
+        /// Include the YAML frontmatter in output
+        #[arg(long)]
+        frontmatter: bool,
     },
     /// Show unique property names with types and file counts across matched files (read-only)
     #[command(
@@ -483,6 +511,17 @@ fn main() {
 
     // --jq operates on JSON, so it conflicts with an explicit --format text.
     let jq_filter = cli.jq.as_deref();
+
+    // `read` defaults to text output (unlike other commands which default to json).
+    // Skip the override when --jq is active (jq needs JSON).
+    let format = if !format_from_cli
+        && jq_filter.is_none()
+        && matches!(cli.command, Commands::Read { .. })
+    {
+        Format::Text
+    } else {
+        format
+    };
     if jq_filter.is_some() && format != Format::Json {
         eprintln!(
             "Error: --jq cannot be combined with --format {}",
@@ -610,6 +649,19 @@ fn main() {
                 effective_format,
             )
         }
+        Commands::Read {
+            ref file,
+            ref section,
+            ref lines,
+            frontmatter,
+        } => read_commands::run(
+            &dir,
+            file,
+            section.as_deref(),
+            lines.as_deref(),
+            frontmatter,
+            effective_format,
+        ),
         Commands::Properties { ref glob } => {
             properties::properties_summary(&dir, None, glob.as_deref(), effective_format)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,7 @@ enum Commands {
         /// Extract only the section(s) under this heading (case-insensitive exact match)
         #[arg(long)]
         section: Option<String>,
-        /// Slice output by line range: 5:10, 5:, :10, or 5 (1-based, inclusive, relative to output)
+        /// Slice output by line range: 5:10, 5:, :10, or 5 (1-based, inclusive, relative to body content)
         #[arg(long)]
         lines: Option<String>,
         /// Include the YAML frontmatter in output

--- a/tests/e2e_read.rs
+++ b/tests/e2e_read.rs
@@ -1,0 +1,505 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+fn setup() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r#"
+---
+title: Test Note
+status: draft
+tags:
+  - cli
+  - rust
+---
+# Heading One
+
+First paragraph.
+
+## Problem
+
+Problem text line 1.
+Problem text line 2.
+
+## Solution
+
+Solution text.
+
+### Details
+
+Nested details.
+
+## Problem
+
+Second problem section.
+"#),
+    );
+
+    write_md(
+        tmp.path(),
+        "no-frontmatter.md",
+        md!(r#"
+# Just a file
+
+No frontmatter here.
+"#),
+    );
+
+    write_md(tmp.path(), "empty.md", "");
+
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// Basic read
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_full_body_text() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("# Heading One"));
+    assert!(stdout.contains("First paragraph."));
+    assert!(stdout.contains("## Problem"));
+    assert!(stdout.contains("## Solution"));
+    // Should NOT contain frontmatter
+    assert!(!stdout.contains("title: Test Note"));
+    assert!(!stdout.contains("---"));
+}
+
+#[test]
+fn read_full_body_json() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["file"], "note.md");
+    let content = json["content"].as_str().unwrap();
+    assert!(content.contains("# Heading One"));
+    assert!(content.contains("Problem text"));
+    // No frontmatter key unless --frontmatter
+    assert!(json.get("frontmatter").is_none());
+}
+
+#[test]
+fn read_defaults_to_text_format() {
+    let tmp = setup();
+    // Without --format, read should output plain text (not JSON)
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Text output should NOT be valid JSON
+    assert!(serde_json::from_str::<serde_json::Value>(&stdout).is_err());
+    assert!(stdout.contains("# Heading One"));
+}
+
+// ---------------------------------------------------------------------------
+// --section
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_section_exact_match() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--section", "Solution"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("## Solution"));
+    assert!(stdout.contains("Solution text."));
+    assert!(stdout.contains("### Details"));
+    assert!(stdout.contains("Nested details."));
+    // Should NOT contain Problem section
+    assert!(!stdout.contains("Problem text"));
+}
+
+#[test]
+fn read_section_with_hashes() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--section", "## Solution"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("## Solution"));
+    assert!(stdout.contains("Solution text."));
+}
+
+#[test]
+fn read_section_case_insensitive() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--section", "solution"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("## Solution"));
+}
+
+#[test]
+fn read_section_multiple_matches() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--section", "Problem"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Problem text line 1."));
+    assert!(stdout.contains("Second problem section."));
+}
+
+#[test]
+fn read_section_no_match() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--section", "Nonexistent"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("section not found"));
+}
+
+#[test]
+fn read_section_no_substring_match() {
+    let tmp = setup();
+    // "Prob" should NOT match "Problem" (exact match only)
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--section", "Prob"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("section not found"));
+}
+
+// ---------------------------------------------------------------------------
+// --lines
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_lines_range() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "read", "--file", "note.md", "--lines", "1:3", "--format", "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let content = json["content"].as_str().unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines[0], "# Heading One");
+    assert_eq!(lines[2], "First paragraph.");
+    assert_eq!(lines.len(), 3);
+}
+
+#[test]
+fn read_lines_single() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "read", "--file", "note.md", "--lines", "1", "--format", "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let content = json["content"].as_str().unwrap();
+    assert_eq!(content, "# Heading One");
+}
+
+#[test]
+fn read_lines_open_end() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--lines", "1:"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should contain all body lines
+    assert!(stdout.contains("# Heading One"));
+    assert!(stdout.contains("Second problem section."));
+}
+
+#[test]
+fn read_lines_open_start() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--lines", ":2"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 2);
+}
+
+#[test]
+fn read_lines_invalid() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--lines", "abc"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// --frontmatter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_frontmatter_only() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--frontmatter"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("---"));
+    assert!(stdout.contains("title: Test Note"));
+    // Should NOT contain body
+    assert!(!stdout.contains("# Heading One"));
+}
+
+#[test]
+fn read_frontmatter_with_section() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "read",
+            "--file",
+            "note.md",
+            "--frontmatter",
+            "--section",
+            "Solution",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("title: Test Note"));
+    assert!(stdout.contains("## Solution"));
+}
+
+#[test]
+fn read_frontmatter_json() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "read",
+            "--file",
+            "note.md",
+            "--frontmatter",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["frontmatter"]["title"], "Test Note");
+    assert_eq!(json["frontmatter"]["status"], "draft");
+}
+
+#[test]
+fn read_frontmatter_with_lines() {
+    let tmp = setup();
+    // --frontmatter + --lines should show frontmatter + sliced body
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "read",
+            "--file",
+            "note.md",
+            "--frontmatter",
+            "--lines",
+            "1:2",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("title: Test Note"));
+    assert!(stdout.contains("# Heading One"));
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_file_not_found() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "missing.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("file not found"));
+}
+
+#[test]
+fn read_file_requires_file_flag() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read"])
+        .output()
+        .unwrap();
+
+    // clap should reject this
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_no_frontmatter_file() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "no-frontmatter.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("# Just a file"));
+    assert!(stdout.contains("No frontmatter here."));
+}
+
+#[test]
+fn read_empty_file() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "empty.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+}
+
+#[test]
+fn read_with_jq_explicit_json() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "read", "--file", "note.md", "--format", "json", "--jq", ".file",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(stdout.trim(), "note.md");
+}
+
+#[test]
+fn read_with_jq_auto_promotes_to_json() {
+    let tmp = setup();
+    // --jq without --format json should auto-promote to JSON (not error)
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--jq", ".file"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(stdout.trim(), "note.md");
+}
+
+#[test]
+fn read_section_json_output() {
+    let tmp = setup();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "read",
+            "--file",
+            "note.md",
+            "--section",
+            "Solution",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let content = json["content"].as_str().unwrap();
+    assert!(content.contains("Solution text."));
+    assert!(content.contains("Nested details."));
+}


### PR DESCRIPTION
## Summary
- New `hyalo read --file <FILE>` command that displays the raw body content of a markdown file (excluding frontmatter)
- Optional `--section HEADING` flag to extract specific section(s) by exact heading match (case-insensitive), with code-fence awareness
- Optional `--lines RANGE` flag to slice output by line range (e.g. `5:10`, `5:`, `:10`, `5`)
- Optional `--frontmatter` flag to include the YAML frontmatter block in output
- Defaults to text output (unlike other commands), auto-promotes to JSON when `--jq` is used

## Test plan
- [x] 25 e2e tests covering: full body read, section filtering, line ranges, frontmatter, error cases, JSON output, jq integration
- [x] 8 unit tests for line range parsing, section extraction, code fence handling
- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all 465+ tests pass
- [x] Manual dogfooding against hyalo-knowledgebase with `cargo build --release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)