### PR TITLE
Add --section filter to find command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ hyalo find --task todo    # open tasks
 hyalo find --task done    # completed tasks
 hyalo find --task any     # any tasks
 
+# Filter by section heading (case-insensitive whole-string match)
+hyalo find --section "Tasks" --task todo          # open tasks in ## Tasks sections
+hyalo find --section "## Design" "TODO"           # content search scoped to level-2 Design sections
+hyalo find --section "# Introduction" --fields sections  # level-pinned: only # Introduction, not ## Introduction
+hyalo find --section "Tasks" --section "Notes"    # OR: match either section
+
 # Scope to file(s)
 hyalo find --file path/to/note.md
 hyalo find --glob "notes/*.md"

--- a/hyalo-knowledgebase/backlog/section-filter.md
+++ b/hyalo-knowledgebase/backlog/section-filter.md
@@ -4,9 +4,9 @@ origin: dogfooding post-iter-19
 priority: medium
 status: completed
 tags:
-- backlog
-- search
-- cli
+  - backlog
+  - search
+  - cli
 title: Section-scoped filter for find command
 type: backlog
 ---

--- a/hyalo-knowledgebase/backlog/section-filter.md
+++ b/hyalo-knowledgebase/backlog/section-filter.md
@@ -1,14 +1,14 @@
 ---
-title: "Section-scoped filter for find command"
-type: backlog
 date: 2026-03-23
 origin: dogfooding post-iter-19
 priority: medium
-status: planned
+status: completed
 tags:
-  - backlog
-  - search
-  - cli
+- backlog
+- search
+- cli
+title: Section-scoped filter for find command
+type: backlog
 ---
 
 # Section-scoped filter for find command

--- a/hyalo-knowledgebase/iterations/iteration-22-section-filter.md
+++ b/hyalo-knowledgebase/iterations/iteration-22-section-filter.md
@@ -1,0 +1,38 @@
+---
+title: "Section-scoped filter for find command"
+type: iteration
+date: 2026-03-23
+tags:
+  - iteration
+  - search
+  - cli
+status: in-progress
+branch: iter-22/section-filter
+---
+
+# Iteration 22: Section Filter for Find
+
+## Goals
+
+Add `--section HEADING` filter to the `find` command, scoping body-level results (tasks, content matches, sections) to matching headings.
+
+## Tasks
+
+- [x] Create shared `src/heading.rs` module (consolidated heading parser + `SectionFilter` + `build_section_scope`)
+- [x] Replace 3 duplicate heading parsers with shared module
+- [x] Refactor `read --section` to use shared `SectionFilter`
+- [x] Add `--section` CLI arg to `find` command
+- [x] Implement section scope filtering in `find()` (line-range-based, handles nesting)
+- [x] Add unit tests for heading parser, SectionFilter, and scope builder
+- [x] Add e2e tests for section filter (10 tests)
+- [x] Update help texts and README
+- [x] Run code quality gates (fmt, clippy, test)
+- [ ] Create PR
+
+## Matching Semantics
+
+- Without `#` prefix: case-insensitive whole-string match at any heading level
+- With `#` prefix: case-insensitive whole-string match pinned to that level
+- Multiple `--section` values: OR semantics
+- Children included: content under nested subsections is in scope
+- Output `section` field: nearest heading (unchanged behavior)

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -10,11 +10,14 @@ use crate::content_search::ContentSearchVisitor;
 use crate::discovery;
 use crate::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField, extract_tags};
 use crate::frontmatter;
+use crate::heading::{SectionFilter, SectionRange, build_section_scope, in_scope};
 use crate::links::Link;
 use crate::output::{CommandOutcome, Format};
 use crate::scanner::{self, FileVisitor, FrontmatterCollector, ScanAction};
 use crate::tasks::TaskExtractor;
-use crate::types::{ContentMatch, FileObject, FindTaskInfo, LinkInfo, PropertyInfo};
+use crate::types::{
+    ContentMatch, FileObject, FindTaskInfo, LinkInfo, OutlineSection, PropertyInfo,
+};
 
 // ---------------------------------------------------------------------------
 // Public command entry point
@@ -27,6 +30,7 @@ use crate::types::{ContentMatch, FileObject, FindTaskInfo, LinkInfo, PropertyInf
 /// - `property_filters`  — all must match (AND semantics)
 /// - `tag_filters`        — all must be present (AND semantics, nested tag rules)
 /// - `task_filter`        — file-level task presence/status filter
+/// - `section_filters`   — restrict body results to matching sections (OR semantics)
 /// - `file` / `glob`      — scope limiting
 /// - `fields`             — controls which fields appear in each `FileObject`
 /// - `sort`               — sort order; defaults to ascending by file path
@@ -39,6 +43,7 @@ pub fn find(
     property_filters: &[PropertyFilter],
     tag_filters: &[String],
     task_filter: Option<&FindTaskFilter>,
+    section_filters: &[SectionFilter],
     file: Option<&str>,
     glob: Option<&str>,
     fields: &Fields,
@@ -54,7 +59,13 @@ pub fn find(
 
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
-    let body_needed = needs_body(fields, has_content_search, has_task_filter);
+    let has_section_filter = !section_filters.is_empty();
+    let body_needed = needs_body(
+        fields,
+        has_content_search,
+        has_task_filter,
+        has_section_filter,
+    );
 
     // Compile the regex once (if any), then clone cheaply per file.
     // Invalid regex is a user error (exit 1), not an internal error (exit 2).
@@ -78,11 +89,12 @@ pub fn find(
     for (full_path, rel_path) in &files {
         // --- Single-pass scan ---
         let mut fm = FrontmatterCollector::new(body_needed);
-        let mut section_scanner = if body_needed && (fields.sections || fields.links) {
-            Some(SectionScanner::new())
-        } else {
-            None
-        };
+        let mut section_scanner =
+            if body_needed && (fields.sections || fields.links || has_section_filter) {
+                Some(SectionScanner::new())
+            } else {
+                None
+            };
         let mut task_extractor = if body_needed && (fields.tasks || has_task_filter) {
             Some(TaskExtractor::new())
         } else {
@@ -126,10 +138,50 @@ pub fn find(
             continue;
         }
 
+        // --- Consume section scanner to get outline sections ---
+        // Must happen before scope building and before build_file_object.
+        let outline_sections: Option<Vec<OutlineSection>> =
+            section_scanner.map(SectionScanner::into_sections);
+
+        // --- Build section scope ranges (if section filter is active) ---
+        let scope_ranges: Vec<SectionRange> = if has_section_filter {
+            if let Some(ref sections) = outline_sections {
+                build_section_scope(sections, section_filters, usize::MAX)
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        };
+
         // --- Collect tasks (needed for filter and/or output field) ---
         // Consume the extractor now so we can both filter and include in output.
-        let collected_tasks: Option<Vec<FindTaskInfo>> =
+        let mut collected_tasks: Option<Vec<FindTaskInfo>> =
             task_extractor.map(TaskExtractor::into_tasks);
+
+        // --- Collect content matches early so we can apply section scope ---
+        let mut content_matches: Option<Vec<ContentMatch>> =
+            content_visitor.map(|cv| cv.into_matches());
+
+        // --- Apply section scope filter to body results ---
+        if has_section_filter {
+            if scope_ranges.is_empty() {
+                // No section matched — discard all body results
+                if let Some(ref mut tasks) = collected_tasks {
+                    tasks.clear();
+                }
+                if let Some(ref mut matches) = content_matches {
+                    matches.clear();
+                }
+            } else {
+                if let Some(ref mut tasks) = collected_tasks {
+                    tasks.retain(|t| in_scope(&scope_ranges, t.line));
+                }
+                if let Some(ref mut matches) = content_matches {
+                    matches.retain(|m| in_scope(&scope_ranges, m.line));
+                }
+            }
+        }
 
         // --- Apply task filter ---
         if let Some(filter) = task_filter {
@@ -140,7 +192,7 @@ pub fn find(
         }
 
         // --- Apply content search filter ---
-        if has_content_search && content_visitor.as_ref().is_some_and(|cv| !cv.has_matches()) {
+        if has_content_search && content_matches.as_ref().is_some_and(|m| m.is_empty()) {
             continue;
         }
 
@@ -154,10 +206,11 @@ pub fn find(
             &props,
             &tags,
             fields,
-            section_scanner,
+            outline_sections,
+            &scope_ranges,
             collected_tasks,
             link_collector,
-            content_visitor,
+            content_matches,
             dir,
         );
 
@@ -193,8 +246,18 @@ pub fn find(
 // ---------------------------------------------------------------------------
 
 /// Determine whether body scanning is needed at all.
-fn needs_body(fields: &Fields, has_content_search: bool, has_task_filter: bool) -> bool {
-    fields.sections || fields.tasks || fields.links || has_content_search || has_task_filter
+fn needs_body(
+    fields: &Fields,
+    has_content_search: bool,
+    has_task_filter: bool,
+    has_section_filter: bool,
+) -> bool {
+    fields.sections
+        || fields.tasks
+        || fields.links
+        || has_content_search
+        || has_task_filter
+        || has_section_filter
 }
 
 /// Return true if `tasks` satisfy `filter`.
@@ -231,10 +294,11 @@ fn build_file_object(
     props: &BTreeMap<String, serde_yaml_ng::Value>,
     tags: &[String],
     fields: &Fields,
-    section_scanner: Option<SectionScanner>,
+    outline_sections: Option<Vec<OutlineSection>>,
+    scope_ranges: &[SectionRange],
     collected_tasks: Option<Vec<FindTaskInfo>>,
     link_collector: Option<LinkCollector>,
-    content_visitor: Option<ContentSearchVisitor>,
+    content_matches: Option<Vec<ContentMatch>>,
     dir: &Path,
 ) -> FileObject {
     let properties = if fields.properties {
@@ -260,7 +324,12 @@ fn build_file_object(
     };
 
     let sections = if fields.sections {
-        section_scanner.map(SectionScanner::into_sections)
+        outline_sections.map(|mut secs| {
+            if !scope_ranges.is_empty() {
+                secs.retain(|s| in_scope(scope_ranges, s.line));
+            }
+            secs
+        })
     } else {
         None
     };
@@ -285,7 +354,7 @@ fn build_file_object(
         None
     };
 
-    let matches: Option<Vec<ContentMatch>> = content_visitor.map(|cv| cv.into_matches());
+    let matches: Option<Vec<ContentMatch>> = content_matches;
 
     FileObject {
         file: rel_path.to_owned(),
@@ -416,6 +485,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -442,6 +512,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -471,6 +542,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -506,6 +578,7 @@ Just some text here.
                 &[filter],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -534,6 +607,7 @@ Just some text here.
                 &[filter],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -563,6 +637,7 @@ Just some text here.
                 &[],
                 &["cli".to_owned()],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -590,6 +665,7 @@ Just some text here.
                 &[],
                 &["nonexistent-tag".to_owned()],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -618,6 +694,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -645,6 +722,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -675,6 +753,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -705,6 +784,7 @@ Just some text here.
                 &[],
                 &[],
                 Some(&FindTaskFilter::Todo),
+                &[],
                 None,
                 None,
                 &fields,
@@ -733,6 +813,7 @@ Just some text here.
                 &[],
                 &[],
                 Some(&FindTaskFilter::Any),
+                &[],
                 None,
                 None,
                 &fields,
@@ -762,6 +843,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -794,6 +876,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -830,6 +913,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 Some("alpha.md"),
                 None,
                 &fields,
@@ -863,6 +947,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -891,6 +976,7 @@ Just some text here.
                 &[],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -926,6 +1012,7 @@ Just some text here.
                 &[filter],
                 &[],
                 None,
+                &[],
                 None,
                 None,
                 &fields,
@@ -952,6 +1039,7 @@ Just some text here.
             &[],
             &[],
             None,
+            &[],
             Some("does-not-exist.md"),
             None,
             &fields,
@@ -974,7 +1062,7 @@ Just some text here.
             tasks: false,
             links: false,
         };
-        assert!(!needs_body(&fields, false, false));
+        assert!(!needs_body(&fields, false, false, false));
     }
 
     #[test]
@@ -986,7 +1074,7 @@ Just some text here.
             tasks: false,
             links: false,
         };
-        assert!(needs_body(&fields, true, false));
+        assert!(needs_body(&fields, true, false, false));
     }
 
     #[test]
@@ -998,7 +1086,7 @@ Just some text here.
             tasks: false,
             links: false,
         };
-        assert!(needs_body(&fields, false, false));
+        assert!(needs_body(&fields, false, false, false));
     }
 
     // --- matches_task_filter ---
@@ -1047,5 +1135,231 @@ Just some text here.
         let tasks = vec![make_task(false, '~')];
         assert!(matches_task_filter(&tasks, &FindTaskFilter::Status('~')));
         assert!(!matches_task_filter(&tasks, &FindTaskFilter::Status('!')));
+    }
+
+    // --- find: --section filter ---
+
+    fn setup_sectioned_vault() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // File with two top-level sections, tasks only in "Tasks"
+        fs::write(
+            tmp.path().join("notes.md"),
+            md!(r"
+---
+title: Notes
+status: active
+---
+# Introduction
+
+Some intro text.
+
+## Tasks
+
+- [ ] First task
+- [x] Done task
+
+## Background
+
+Background information here.
+"),
+        )
+        .unwrap();
+
+        // File without a Tasks section
+        fs::write(
+            tmp.path().join("empty.md"),
+            md!(r"
+---
+title: Empty
+---
+# Introduction
+
+Just intro, no tasks section.
+"),
+        )
+        .unwrap();
+
+        tmp
+    }
+
+    #[test]
+    fn find_section_filter_restricts_tasks_to_matching_section() {
+        let tmp = setup_sectioned_vault();
+        let fields = Fields::parse(&["tasks".to_owned()]).unwrap();
+        let section_filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                None,
+                &[],
+                &[],
+                None,
+                &section_filters,
+                Some("notes.md"),
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let tasks = arr[0]["tasks"].as_array().unwrap();
+        assert_eq!(tasks.len(), 2, "should have 2 tasks in Tasks section");
+    }
+
+    #[test]
+    fn find_section_filter_no_match_excludes_tasks() {
+        let tmp = setup_sectioned_vault();
+        let fields = Fields::parse(&["tasks".to_owned()]).unwrap();
+        // Filter on a section that does not exist
+        let section_filters = vec![SectionFilter::parse("Nonexistent").unwrap()];
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                None,
+                &[],
+                &[],
+                None,
+                &section_filters,
+                Some("notes.md"),
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        // File is still returned (section filter only scopes body results, not file inclusion)
+        assert_eq!(arr.len(), 1);
+        let tasks = arr[0]["tasks"].as_array().unwrap();
+        assert!(
+            tasks.is_empty(),
+            "tasks outside matched section should be empty"
+        );
+    }
+
+    #[test]
+    fn find_section_filter_restricts_content_matches() {
+        let tmp = setup_sectioned_vault();
+        let fields = Fields::default();
+        // "Background" text only appears in ## Background, not ## Tasks
+        let section_filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                Some("background"),
+                None,
+                &[],
+                &[],
+                None,
+                &section_filters,
+                None,
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        // "background" only appears in ## Background section, not in ## Tasks, so no match
+        assert!(
+            arr.is_empty(),
+            "no files should match: 'background' is not in the Tasks section"
+        );
+    }
+
+    #[test]
+    fn find_section_filter_sections_field_filtered() {
+        let tmp = setup_sectioned_vault();
+        let fields = Fields::parse(&["sections".to_owned()]).unwrap();
+        let section_filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                None,
+                &[],
+                &[],
+                None,
+                &section_filters,
+                Some("notes.md"),
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let sections = arr[0]["sections"].as_array().unwrap();
+        // Only the "Tasks" section (and its heading line) should be included
+        assert!(
+            sections.iter().all(|s| {
+                s["heading"]
+                    .as_str()
+                    .is_some_and(|h| h.eq_ignore_ascii_case("tasks"))
+            }),
+            "sections output should only contain the matched section"
+        );
+    }
+
+    #[test]
+    fn find_section_filter_empty_no_section_returns_file_with_empty_tasks() {
+        let tmp = setup_sectioned_vault();
+        let fields = Fields::parse(&["tasks".to_owned()]).unwrap();
+        let section_filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                None,
+                &[],
+                &[],
+                None,
+                &section_filters,
+                Some("empty.md"),
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        // empty.md has no Tasks section — tasks list should be empty
+        assert_eq!(arr.len(), 1);
+        let tasks = arr[0]["tasks"].as_array().unwrap();
+        assert!(tasks.is_empty());
+    }
+
+    #[test]
+    fn needs_body_true_when_section_filter() {
+        let fields = Fields {
+            properties: false,
+            tags: false,
+            sections: false,
+            tasks: false,
+            links: false,
+        };
+        assert!(needs_body(&fields, false, false, true));
+        assert!(!needs_body(&fields, false, false, false));
     }
 }

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -166,20 +166,14 @@ pub fn find(
         // --- Apply section scope filter to body results ---
         if has_section_filter {
             if scope_ranges.is_empty() {
-                // No section matched — discard all body results
-                if let Some(ref mut tasks) = collected_tasks {
-                    tasks.clear();
-                }
-                if let Some(ref mut matches) = content_matches {
-                    matches.clear();
-                }
-            } else {
-                if let Some(ref mut tasks) = collected_tasks {
-                    tasks.retain(|t| in_scope(&scope_ranges, t.line));
-                }
-                if let Some(ref mut matches) = content_matches {
-                    matches.retain(|m| in_scope(&scope_ranges, m.line));
-                }
+                // No section matched in this file — skip it entirely
+                continue;
+            }
+            if let Some(ref mut tasks) = collected_tasks {
+                tasks.retain(|t| in_scope(&scope_ranges, t.line));
+            }
+            if let Some(ref mut matches) = content_matches {
+                matches.retain(|m| in_scope(&scope_ranges, m.line));
             }
         }
 
@@ -1239,12 +1233,10 @@ Just intro, no tasks section.
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         let arr = parsed.as_array().unwrap();
-        // File is still returned (section filter only scopes body results, not file inclusion)
-        assert_eq!(arr.len(), 1);
-        let tasks = arr[0]["tasks"].as_array().unwrap();
+        // File has no matching section — it is excluded entirely
         assert!(
-            tasks.is_empty(),
-            "tasks outside matched section should be empty"
+            arr.is_empty(),
+            "file with no matching section should be excluded"
         );
     }
 
@@ -1320,7 +1312,7 @@ Just intro, no tasks section.
     }
 
     #[test]
-    fn find_section_filter_empty_no_section_returns_file_with_empty_tasks() {
+    fn find_section_filter_empty_no_section_excludes_file() {
         let tmp = setup_sectioned_vault();
         let fields = Fields::parse(&["tasks".to_owned()]).unwrap();
         let section_filters = vec![SectionFilter::parse("Tasks").unwrap()];
@@ -1344,10 +1336,11 @@ Just intro, no tasks section.
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         let arr = parsed.as_array().unwrap();
-        // empty.md has no Tasks section — tasks list should be empty
-        assert_eq!(arr.len(), 1);
-        let tasks = arr[0]["tasks"].as_array().unwrap();
-        assert!(tasks.is_empty());
+        // empty.md has no Tasks section — it is excluded entirely
+        assert!(
+            arr.is_empty(),
+            "file with no matching section should be excluded"
+        );
     }
 
     #[test]

--- a/src/commands/outline.rs
+++ b/src/commands/outline.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_errors_doc)]
+use crate::heading::parse_atx_heading;
 use crate::links;
 use crate::scanner::{self, FileVisitor, ScanAction};
 use crate::types::{OutlineSection, TaskCount};
@@ -97,7 +98,7 @@ impl FileVisitor for SectionScanner {
         if let Some((level, heading_text)) = parse_atx_heading(raw) {
             let finished = std::mem::replace(
                 &mut self.current,
-                SectionBuilder::new(level, Some(heading_text), line_num),
+                SectionBuilder::new(level, Some(heading_text.to_owned()), line_num),
             );
 
             let should_emit = finished.level > 0
@@ -144,43 +145,6 @@ impl FileVisitor for SectionScanner {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Parse an ATX heading line (`# Heading`, `## Sub`, etc.).
-/// Returns `(level, heading_text)` if the line is a valid ATX heading,
-/// or `None` otherwise.
-pub(crate) fn parse_atx_heading(line: &str) -> Option<(u8, String)> {
-    let bytes = line.as_bytes();
-    if bytes.first() != Some(&b'#') {
-        return None;
-    }
-
-    // Count leading `#` characters (maximum 6 for ATX headings)
-    let level = bytes.iter().take_while(|&&b| b == b'#').count();
-    if level > 6 {
-        return None;
-    }
-
-    let after_hashes = &line[level..];
-
-    // An ATX heading requires either:
-    // - A space (or tab) after the hashes: `## Heading`
-    // - Nothing after the hashes (empty heading): `##`
-    let heading_text = if after_hashes.is_empty() {
-        String::new()
-    } else if after_hashes.starts_with(' ') || after_hashes.starts_with('\t') {
-        // Strip the leading space/tab, then trim trailing spaces and optional closing `#`s
-        let inner = after_hashes[1..].trim_end();
-        // Remove optional trailing `#` sequence (ATX closing sequence)
-        let inner = inner.trim_end_matches('#').trim_end();
-        inner.to_owned()
-    } else {
-        // Characters directly after `#` with no space — not a valid ATX heading
-        return None;
-    };
-
-    #[allow(clippy::cast_possible_truncation)] // level is guaranteed ≤ 6 by the check above
-    Some((level as u8, heading_text))
-}
-
 /// Format a `Link` into a human-readable string for storage in the outline.
 fn format_link_string(link: &links::Link) -> String {
     // Heuristic: targets containing '://' are URLs from markdown links.
@@ -224,58 +188,7 @@ mod tests {
         ss.into_sections()
     }
 
-    // --- parse_atx_heading ---
-
-    #[test]
-    fn heading_level_1() {
-        let h = parse_atx_heading("# Hello").unwrap();
-        assert_eq!(h.0, 1);
-        assert_eq!(h.1, "Hello");
-    }
-
-    #[test]
-    fn heading_level_3() {
-        let h = parse_atx_heading("### Sub section").unwrap();
-        assert_eq!(h.0, 3);
-        assert_eq!(h.1, "Sub section");
-    }
-
-    #[test]
-    fn heading_max_level_6() {
-        let h = parse_atx_heading("###### Deep").unwrap();
-        assert_eq!(h.0, 6);
-        assert_eq!(h.1, "Deep");
-    }
-
-    #[test]
-    fn heading_7_hashes_not_heading() {
-        assert!(parse_atx_heading("####### Too deep").is_none());
-    }
-
-    #[test]
-    fn heading_no_space_not_heading() {
-        assert!(parse_atx_heading("#NoSpace").is_none());
-    }
-
-    #[test]
-    fn heading_empty() {
-        let h = parse_atx_heading("##").unwrap();
-        assert_eq!(h.0, 2);
-        assert_eq!(h.1, "");
-    }
-
-    #[test]
-    fn heading_with_closing_hashes() {
-        let h = parse_atx_heading("## Section ##").unwrap();
-        assert_eq!(h.0, 2);
-        assert_eq!(h.1, "Section");
-    }
-
-    #[test]
-    fn not_a_heading() {
-        assert!(parse_atx_heading("Normal text").is_none());
-        assert!(parse_atx_heading("").is_none());
-    }
+    // parse_atx_heading tests are in src/heading.rs
 
     // --- extract_fence_language ---
 

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::missing_errors_doc)]
 
-use crate::commands::outline::parse_atx_heading;
 use crate::discovery;
 use crate::frontmatter;
+use crate::heading::{SectionFilter, parse_atx_heading};
 use crate::output::{CommandOutcome, Format, format_error, format_success};
 use crate::scanner;
 use anyhow::{Context, Result};
@@ -86,22 +86,11 @@ fn apply_line_range<'a>(lines: &'a [String], range: &LineRange) -> &'a [String] 
 // Section extraction
 // ---------------------------------------------------------------------------
 
-/// Extract all sections matching `query` (case-insensitive exact match on heading text).
-/// If query starts with `#`, parse the heading level and text from it.
-/// Returns a `Vec<Vec<String>>`, where each inner `Vec<String>` contains the lines of a
-/// matched section, from the heading through to (but not including) the next heading of
-/// equal or higher level.
-fn extract_sections(body_lines: &[String], query: &str) -> Vec<Vec<String>> {
-    // Parse query: strip leading `#` characters if present
-    let (query_level, query_text) = if query.starts_with('#') {
-        match parse_atx_heading(query) {
-            Some((level, text)) => (Some(level), text),
-            None => (None, query.to_owned()),
-        }
-    } else {
-        (None, query.to_owned())
-    };
-
+/// Extract all sections matching `filter` (case-insensitive exact match on heading text,
+/// optional level pinning). Returns a `Vec<Vec<String>>`, where each inner `Vec<String>`
+/// contains the lines of a matched section, from the heading through to (but not including)
+/// the next heading of equal or higher level.
+fn extract_sections(body_lines: &[String], filter: &SectionFilter) -> Vec<Vec<String>> {
     let mut sections: Vec<Vec<String>> = Vec::new();
     let mut current_section: Option<(u8, Vec<String>)> = None;
     let mut fence: Option<(char, usize)> = None;
@@ -139,11 +128,7 @@ fn extract_sections(body_lines: &[String], query: &str) -> Vec<Vec<String>> {
                 }
             }
 
-            // Check if this heading matches the query
-            let text_matches = text.eq_ignore_ascii_case(&query_text);
-            let level_matches = query_level.is_none_or(|ql| ql == level);
-
-            if text_matches && level_matches {
+            if filter.matches(level, text) {
                 current_section = Some((level, vec![line.clone()]));
             }
         } else if let Some((_, ref mut lines)) = current_section {
@@ -275,7 +260,19 @@ pub fn run(
 
     // Apply section filter
     if let Some(query) = section {
-        let sections = extract_sections(&content_lines, query);
+        let filter = match SectionFilter::parse(query) {
+            Ok(f) => f,
+            Err(e) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format,
+                    &e,
+                    Some(&rel_path),
+                    None,
+                    None,
+                )));
+            }
+        };
+        let sections = extract_sections(&content_lines, &filter);
         if sections.is_empty() {
             let available = collect_headings(&content_lines);
             let hint = if available.is_empty() {
@@ -472,7 +469,8 @@ mod tests {
             "## Solution".into(),
             "solution text".into(),
         ];
-        let sections = extract_sections(&lines, "Problem");
+        let filter = SectionFilter::parse("Problem").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].len(), 2);
         assert_eq!(sections[0][0], "## Problem");
@@ -482,21 +480,24 @@ mod tests {
     #[test]
     fn extract_section_case_insensitive() {
         let lines: Vec<String> = vec!["## Problem".into(), "text".into(), "## Other".into()];
-        let sections = extract_sections(&lines, "problem");
+        let filter = SectionFilter::parse("problem").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert_eq!(sections.len(), 1);
     }
 
     #[test]
     fn extract_section_with_hashes() {
         let lines: Vec<String> = vec!["## Problem".into(), "text".into(), "## Other".into()];
-        let sections = extract_sections(&lines, "## Problem");
+        let filter = SectionFilter::parse("## Problem").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert_eq!(sections.len(), 1);
     }
 
     #[test]
     fn extract_section_no_match_substring() {
         let lines: Vec<String> = vec!["## Problems".into(), "text".into()];
-        let sections = extract_sections(&lines, "Problem");
+        let filter = SectionFilter::parse("Problem").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert!(sections.is_empty());
     }
 
@@ -509,7 +510,8 @@ mod tests {
             "sub text".into(),
             "## Next".into(),
         ];
-        let sections = extract_sections(&lines, "Section");
+        let filter = SectionFilter::parse("Section").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].len(), 4); // heading + text + sub heading + sub text
     }
@@ -524,7 +526,8 @@ mod tests {
             "## Notes".into(),
             "second notes".into(),
         ];
-        let sections = extract_sections(&lines, "Notes");
+        let filter = SectionFilter::parse("Notes").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert_eq!(sections.len(), 2);
     }
 
@@ -536,7 +539,8 @@ mod tests {
             "## Last".into(),
             "last text".into(),
         ];
-        let sections = extract_sections(&lines, "Last");
+        let filter = SectionFilter::parse("Last").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].len(), 2);
     }
@@ -553,7 +557,8 @@ mod tests {
             "after code".into(),
             "## Next".into(),
         ];
-        let sections = extract_sections(&lines, "Proposal");
+        let filter = SectionFilter::parse("Proposal").unwrap();
+        let sections = extract_sections(&lines, &filter);
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].len(), 7); // heading + intro + code block (4 lines) + after code
         assert!(sections[0].contains(&"# This is a comment, not a heading".to_owned()));

--- a/src/content_search.rs
+++ b/src/content_search.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use regex::Regex;
 
+use crate::heading::parse_atx_heading;
 use crate::scanner::{FileVisitor, ScanAction};
 use crate::types::ContentMatch;
 
@@ -89,7 +90,7 @@ impl ContentSearchVisitor {
 impl FileVisitor for ContentSearchVisitor {
     fn on_body_line(&mut self, raw: &str, line_num: usize) -> ScanAction {
         // Check for ATX heading and update section context.
-        if let Some((level, heading_text)) = detect_heading(raw) {
+        if let Some((level, heading_text)) = parse_atx_heading(raw) {
             self.current_section = format!("{} {}", "#".repeat(level as usize), heading_text);
         }
 
@@ -103,26 +104,6 @@ impl FileVisitor for ContentSearchVisitor {
         }
 
         ScanAction::Continue
-    }
-}
-
-/// Parse an ATX heading line and return `(level, heading_text)`.
-/// Returns `None` if the line is not a valid ATX heading.
-fn detect_heading(line: &str) -> Option<(u8, &str)> {
-    if !line.starts_with('#') {
-        return None;
-    }
-    let level = line.bytes().take_while(|&b| b == b'#').count();
-    if level > 6 {
-        return None;
-    }
-    let rest = &line[level..];
-    if rest.is_empty() {
-        Some((level as u8, ""))
-    } else if rest.starts_with(' ') || rest.starts_with('\t') {
-        Some((level as u8, rest[1..].trim_end_matches('#').trim()))
-    } else {
-        None
     }
 }
 

--- a/src/heading.rs
+++ b/src/heading.rs
@@ -1,0 +1,446 @@
+//! Shared ATX heading parser and section-scoped filtering.
+//!
+//! Consolidates heading detection (previously duplicated across `content_search`,
+//! `tasks`, and `commands::outline`) and provides [`SectionFilter`] for the
+//! `--section` CLI flag used by `find` and `read`.
+
+use crate::types::OutlineSection;
+
+// ---------------------------------------------------------------------------
+// ATX heading parser
+// ---------------------------------------------------------------------------
+
+/// Parse an ATX heading line (`# Heading`, `## Sub`, etc.).
+///
+/// Returns `(level, heading_text)` where level is 1–6 and heading_text has
+/// leading/trailing whitespace and optional closing `#` sequences stripped.
+/// Returns `None` if the line is not a valid ATX heading.
+pub fn parse_atx_heading(line: &str) -> Option<(u8, &str)> {
+    let bytes = line.as_bytes();
+    if bytes.first() != Some(&b'#') {
+        return None;
+    }
+
+    let level = bytes.iter().take_while(|&&b| b == b'#').count();
+    if level > 6 {
+        return None;
+    }
+
+    let rest = &line[level..];
+
+    let text = if rest.is_empty() {
+        ""
+    } else if rest.starts_with(' ') || rest.starts_with('\t') {
+        rest[1..].trim_end_matches('#').trim()
+    } else {
+        return None;
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    Some((level as u8, text))
+}
+
+// ---------------------------------------------------------------------------
+// SectionFilter
+// ---------------------------------------------------------------------------
+
+/// A parsed `--section` filter value.
+///
+/// Supports two forms:
+/// - `"Foo"` — match heading text case-insensitively at any level
+/// - `"## Foo"` — match heading text case-insensitively at exactly level 2
+#[derive(Debug, Clone)]
+pub struct SectionFilter {
+    /// If `Some`, match only headings at this exact level.
+    level: Option<u8>,
+    /// Heading text to match (lowercased for case-insensitive comparison).
+    text: String,
+}
+
+impl SectionFilter {
+    /// Parse a `--section` value into a `SectionFilter`.
+    ///
+    /// Returns an error if the value contains a `#` prefix that doesn't parse
+    /// as a valid ATX heading (e.g. `"####### Too deep"`).
+    pub fn parse(input: &str) -> Result<Self, String> {
+        if input.starts_with('#') {
+            match parse_atx_heading(input) {
+                Some((level, text)) => Ok(Self {
+                    level: Some(level),
+                    text: text.to_ascii_lowercase(),
+                }),
+                None => Err(format!(
+                    "invalid section filter: {input:?} (starts with '#' but is not a valid heading)"
+                )),
+            }
+        } else {
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                return Err("section filter must not be empty".to_owned());
+            }
+            Ok(Self {
+                level: None,
+                text: trimmed.to_ascii_lowercase(),
+            })
+        }
+    }
+
+    /// Check if a heading matches this filter.
+    ///
+    /// - Case-insensitive whole-string match on heading text.
+    /// - If `level` is set, heading level must match exactly.
+    #[must_use]
+    pub fn matches(&self, heading_level: u8, heading_text: &str) -> bool {
+        let level_ok = self.level.is_none_or(|l| l == heading_level);
+        let text_ok = heading_text.eq_ignore_ascii_case(&self.text);
+        level_ok && text_ok
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section scope builder
+// ---------------------------------------------------------------------------
+
+/// An inclusive line range `[start, end]` representing a section's scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SectionRange {
+    /// 1-based start line (the heading line itself).
+    pub start: usize,
+    /// 1-based end line (inclusive). Content up to and including this line is in scope.
+    pub end: usize,
+}
+
+impl SectionRange {
+    /// Check if a 1-based line number falls within this range.
+    #[must_use]
+    pub fn contains_line(&self, line: usize) -> bool {
+        line >= self.start && line <= self.end
+    }
+}
+
+/// Build line ranges for all sections matching any of the given filters.
+///
+/// Walks the outline and, for each heading that matches a filter, opens a scope
+/// that extends until the next heading of **equal or higher** level (exclusive)
+/// or end-of-file. Child (deeper) headings are included in the parent's scope.
+///
+/// `total_lines` is the total number of body lines in the file (used to close
+/// the final scope). Pass `usize::MAX` if unknown.
+#[must_use]
+pub fn build_section_scope(
+    sections: &[OutlineSection],
+    filters: &[SectionFilter],
+    total_lines: usize,
+) -> Vec<SectionRange> {
+    if filters.is_empty() || sections.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ranges: Vec<SectionRange> = Vec::new();
+
+    for (i, sec) in sections.iter().enumerate() {
+        let heading_text = match &sec.heading {
+            Some(h) => h.as_str(),
+            None => continue, // pre-heading section has no heading to match
+        };
+
+        if !filters.iter().any(|f| f.matches(sec.level, heading_text)) {
+            continue;
+        }
+
+        // Find the end of this section: next heading at equal or higher level
+        let end = sections
+            .iter()
+            .skip(i + 1)
+            .find(|s| s.level <= sec.level)
+            .map_or(total_lines, |s| s.line.saturating_sub(1));
+
+        ranges.push(SectionRange {
+            start: sec.line,
+            end,
+        });
+    }
+
+    ranges
+}
+
+/// Check if a line falls within any of the given section ranges.
+#[must_use]
+pub fn in_scope(ranges: &[SectionRange], line: usize) -> bool {
+    ranges.iter().any(|r| r.contains_line(line))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::TaskCount;
+
+    // --- parse_atx_heading ---
+
+    #[test]
+    fn heading_level_1() {
+        let (level, text) = parse_atx_heading("# Hello").unwrap();
+        assert_eq!(level, 1);
+        assert_eq!(text, "Hello");
+    }
+
+    #[test]
+    fn heading_level_3() {
+        let (level, text) = parse_atx_heading("### Sub section").unwrap();
+        assert_eq!(level, 3);
+        assert_eq!(text, "Sub section");
+    }
+
+    #[test]
+    fn heading_max_level_6() {
+        let (level, text) = parse_atx_heading("###### Deep").unwrap();
+        assert_eq!(level, 6);
+        assert_eq!(text, "Deep");
+    }
+
+    #[test]
+    fn heading_7_hashes_not_heading() {
+        assert!(parse_atx_heading("####### Too deep").is_none());
+    }
+
+    #[test]
+    fn heading_no_space_not_heading() {
+        assert!(parse_atx_heading("#NoSpace").is_none());
+    }
+
+    #[test]
+    fn heading_empty() {
+        let (level, text) = parse_atx_heading("##").unwrap();
+        assert_eq!(level, 2);
+        assert_eq!(text, "");
+    }
+
+    #[test]
+    fn heading_with_closing_hashes() {
+        let (level, text) = parse_atx_heading("## Section ##").unwrap();
+        assert_eq!(level, 2);
+        assert_eq!(text, "Section");
+    }
+
+    #[test]
+    fn not_a_heading() {
+        assert!(parse_atx_heading("Normal text").is_none());
+        assert!(parse_atx_heading("").is_none());
+    }
+
+    #[test]
+    fn heading_with_tab_separator() {
+        let (level, text) = parse_atx_heading("#\tTabbed").unwrap();
+        assert_eq!(level, 1);
+        assert_eq!(text, "Tabbed");
+    }
+
+    // --- SectionFilter::parse ---
+
+    #[test]
+    fn parse_plain_text() {
+        let f = SectionFilter::parse("Tasks").unwrap();
+        assert!(f.level.is_none());
+        assert_eq!(f.text, "tasks");
+    }
+
+    #[test]
+    fn parse_with_hashes() {
+        let f = SectionFilter::parse("## Design").unwrap();
+        assert_eq!(f.level, Some(2));
+        assert_eq!(f.text, "design");
+    }
+
+    #[test]
+    fn parse_level_1() {
+        let f = SectionFilter::parse("# Top").unwrap();
+        assert_eq!(f.level, Some(1));
+        assert_eq!(f.text, "top");
+    }
+
+    #[test]
+    fn parse_empty_errors() {
+        assert!(SectionFilter::parse("").is_err());
+        assert!(SectionFilter::parse("  ").is_err());
+    }
+
+    #[test]
+    fn parse_invalid_heading_errors() {
+        assert!(SectionFilter::parse("####### Too deep").is_err());
+    }
+
+    #[test]
+    fn parse_hash_no_space_errors() {
+        assert!(SectionFilter::parse("#NoSpace").is_err());
+    }
+
+    // --- SectionFilter::matches ---
+
+    #[test]
+    fn matches_any_level() {
+        let f = SectionFilter::parse("Tasks").unwrap();
+        assert!(f.matches(1, "Tasks"));
+        assert!(f.matches(2, "Tasks"));
+        assert!(f.matches(3, "tasks"));
+        assert!(f.matches(6, "TASKS"));
+    }
+
+    #[test]
+    fn matches_pinned_level() {
+        let f = SectionFilter::parse("## Tasks").unwrap();
+        assert!(f.matches(2, "Tasks"));
+        assert!(f.matches(2, "tasks"));
+        assert!(!f.matches(1, "Tasks"));
+        assert!(!f.matches(3, "Tasks"));
+    }
+
+    #[test]
+    fn no_partial_match() {
+        let f = SectionFilter::parse("Task").unwrap();
+        assert!(!f.matches(2, "Tasks"));
+        assert!(!f.matches(2, "My Task"));
+    }
+
+    // --- build_section_scope ---
+
+    fn make_section(level: u8, heading: &str, line: usize) -> OutlineSection {
+        OutlineSection {
+            level,
+            heading: Some(heading.to_owned()),
+            line,
+            links: Vec::new(),
+            tasks: None,
+            code_blocks: Vec::new(),
+        }
+    }
+
+    fn make_pre_heading(line: usize) -> OutlineSection {
+        OutlineSection {
+            level: 0,
+            heading: None,
+            line,
+            links: Vec::new(),
+            tasks: None,
+            code_blocks: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn scope_single_match() {
+        // ## Tasks (line 5) ... ## Other (line 10) ... EOF at 20
+        let sections = vec![make_section(2, "Tasks", 5), make_section(2, "Other", 10)];
+        let filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 20);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0], SectionRange { start: 5, end: 9 });
+    }
+
+    #[test]
+    fn scope_includes_children() {
+        // ## Tasks (line 5) -> ### Subtasks (line 8) -> ## Other (line 15)
+        let sections = vec![
+            make_section(2, "Tasks", 5),
+            make_section(3, "Subtasks", 8),
+            make_section(2, "Other", 15),
+        ];
+        let filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 20);
+        assert_eq!(ranges.len(), 1);
+        // Tasks scope: 5..14 (up to but not including ## Other at 15)
+        assert_eq!(ranges[0], SectionRange { start: 5, end: 14 });
+        // Line 8 (### Subtasks) and line 12 are within scope
+        assert!(in_scope(&ranges, 8));
+        assert!(in_scope(&ranges, 12));
+        // Line 15 (## Other) is NOT in scope
+        assert!(!in_scope(&ranges, 15));
+    }
+
+    #[test]
+    fn scope_multiple_matches_in_one_doc() {
+        // # Alpha (line 1) -> ## Tasks (line 3) -> # Beta (line 8) -> ## Tasks (line 10) -> EOF 15
+        let sections = vec![
+            make_section(1, "Alpha", 1),
+            make_section(2, "Tasks", 3),
+            make_section(1, "Beta", 8),
+            make_section(2, "Tasks", 10),
+        ];
+        let filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 15);
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0], SectionRange { start: 3, end: 7 });
+        assert_eq!(ranges[1], SectionRange { start: 10, end: 15 });
+    }
+
+    #[test]
+    fn scope_last_section_extends_to_eof() {
+        let sections = vec![make_section(2, "Tasks", 5)];
+        let filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 50);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0], SectionRange { start: 5, end: 50 });
+    }
+
+    #[test]
+    fn scope_no_match_returns_empty() {
+        let sections = vec![make_section(2, "Other", 5)];
+        let filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 20);
+        assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn scope_pre_heading_never_matches() {
+        let sections = vec![make_pre_heading(1), make_section(2, "Tasks", 5)];
+        let filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 20);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, 5);
+    }
+
+    #[test]
+    fn scope_or_semantics_multiple_filters() {
+        let sections = vec![
+            make_section(2, "Tasks", 3),
+            make_section(2, "Notes", 8),
+            make_section(2, "Other", 12),
+        ];
+        let filters = vec![
+            SectionFilter::parse("Tasks").unwrap(),
+            SectionFilter::parse("Notes").unwrap(),
+        ];
+        let ranges = build_section_scope(&sections, &filters, 20);
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0], SectionRange { start: 3, end: 7 });
+        assert_eq!(ranges[1], SectionRange { start: 8, end: 11 });
+    }
+
+    #[test]
+    fn scope_level_pinned_filter() {
+        let sections = vec![make_section(1, "Tasks", 1), make_section(2, "Tasks", 5)];
+        let filters = vec![SectionFilter::parse("## Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 20);
+        // Should only match the level-2 heading
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, 5);
+    }
+
+    #[test]
+    fn scope_with_task_counts() {
+        // Ensure OutlineSection with task counts still works
+        let sections = vec![OutlineSection {
+            level: 2,
+            heading: Some("Tasks".to_owned()),
+            line: 5,
+            links: Vec::new(),
+            tasks: Some(TaskCount { total: 3, done: 1 }),
+            code_blocks: Vec::new(),
+        }];
+        let filters = vec![SectionFilter::parse("Tasks").unwrap()];
+        let ranges = build_section_scope(&sections, &filters, 20);
+        assert_eq!(ranges.len(), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod content_search;
 pub mod discovery;
 pub mod filter;
 pub mod frontmatter;
+pub mod heading;
 pub mod hints;
 pub mod links;
 pub mod output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,8 +179,9 @@ enum Commands {
             - --property K=V: frontmatter property filter (supports =, !=, >, >=, <, <=, or bare name for existence)\n\
             - --tag T: tag filter (supports nested matching: 'project' matches 'project/backend')\n\
             - --task STATUS: task presence filter ('todo', 'done', 'any', or a single status char)\n\
-            - --section HEADING: section scope filter (restrict body results to matching sections; case-insensitive \
-whole-string match; use leading '#' to pin heading level, e.g. '## Tasks'). Repeatable (OR).\n\n\
+            - --section HEADING: section scope filter (exclude files without a matching section; within matching \
+files, restrict tasks and content matches to the section scope; case-insensitive whole-string match; use \
+leading '#' to pin heading level, e.g. '## Tasks'). Repeatable (OR). Nested subsections are included.\n\n\
             OUTPUT: Always returns a JSON array of file objects, even with --file.\n\
             FIELDS: Use --fields to limit which fields appear (default: all).\n\
             SIDE EFFECTS: None (read-only).")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,9 @@ enum Commands {
             - --regexp/-e REGEX: regex body text search (case-insensitive by default; mutually exclusive with PATTERN)\n\
             - --property K=V: frontmatter property filter (supports =, !=, >, >=, <, <=, or bare name for existence)\n\
             - --tag T: tag filter (supports nested matching: 'project' matches 'project/backend')\n\
-            - --task STATUS: task presence filter ('todo', 'done', 'any', or a single status char)\n\n\
+            - --task STATUS: task presence filter ('todo', 'done', 'any', or a single status char)\n\
+            - --section HEADING: section scope filter (restrict body results to matching sections; case-insensitive \
+whole-string match; use leading '#' to pin heading level, e.g. '## Tasks'). Repeatable (OR).\n\n\
             OUTPUT: Always returns a JSON array of file objects, even with --file.\n\
             FIELDS: Use --fields to limit which fields appear (default: all).\n\
             SIDE EFFECTS: None (read-only).")]
@@ -198,6 +200,10 @@ enum Commands {
         /// Task presence filter: 'todo', 'done', 'any', or a single status character
         #[arg(long, value_name = "STATUS")]
         task: Option<String>,
+        /// Section heading filter: restrict body results to matching sections (case-insensitive whole-string match;
+        /// use leading '#' to pin heading level, e.g. '## Tasks'). Repeatable (OR)
+        #[arg(long = "section", value_name = "HEADING")]
+        sections: Vec<String>,
         /// Scan only this file (still returns an array)
         #[arg(long, conflicts_with = "glob")]
         file: Option<String>,
@@ -589,6 +595,7 @@ fn main() {
             ref properties,
             ref tag,
             ref task,
+            ref sections,
             ref file,
             ref glob,
             ref fields,
@@ -633,6 +640,18 @@ fn main() {
                 }
                 None => None,
             };
+            // Parse section filters
+            let section_filters: Vec<hyalo::heading::SectionFilter> = match sections
+                .iter()
+                .map(|s| hyalo::heading::SectionFilter::parse(s))
+                .collect::<Result<Vec<_>, _>>()
+            {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    process::exit(1);
+                }
+            };
 
             find_commands::find(
                 &dir,
@@ -641,6 +660,7 @@ fn main() {
                 &prop_filters,
                 tag,
                 task_filter.as_ref(),
+                &section_filters,
                 file.as_deref(),
                 glob.as_deref(),
                 &parsed_fields,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -10,6 +10,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use crate::frontmatter;
+use crate::heading::parse_atx_heading;
 use crate::scanner::{self, FileVisitor, ScanAction};
 use crate::types::{TaskCount, TaskInfo};
 
@@ -203,7 +204,7 @@ impl FileVisitor for TaskExtractor {
     fn on_body_line(&mut self, raw: &str, line_num: usize) -> ScanAction {
         // Track current heading
         if raw.starts_with('#')
-            && let Some((level, text)) = detect_atx_heading(raw)
+            && let Some((level, text)) = parse_atx_heading(raw)
         {
             self.current_section = format!("{} {}", "#".repeat(level as usize), text);
         }
@@ -218,30 +219,6 @@ impl FileVisitor for TaskExtractor {
             });
         }
         ScanAction::Continue
-    }
-}
-
-/// Parse an ATX heading line (`# Heading`, `## Sub`, etc.).
-/// Returns `(level, heading_text)` or `None`.
-fn detect_atx_heading(line: &str) -> Option<(u8, &str)> {
-    let bytes = line.as_bytes();
-    if bytes.first() != Some(&b'#') {
-        return None;
-    }
-    let level = bytes.iter().take_while(|&&b| b == b'#').count();
-    if level > 6 {
-        return None;
-    }
-    let rest = &line[level..];
-    if rest.is_empty() {
-        #[allow(clippy::cast_possible_truncation)]
-        Some((level as u8, ""))
-    } else if rest.starts_with(' ') || rest.starts_with('\t') {
-        let text = rest[1..].trim_end_matches('#').trim();
-        #[allow(clippy::cast_possible_truncation)]
-        Some((level as u8, text))
-    } else {
-        None
     }
 }
 

--- a/tests/e2e_find.rs
+++ b/tests/e2e_find.rs
@@ -952,6 +952,7 @@ Some notes with a TODO marker.
     );
 
     // other.md — has a Tasks section too (tests multi-file matching)
+    // Also has a ## Introduction (level-2) to test level-pinning against doc.md's # Introduction (level-1)
     write_md(
         tmp.path(),
         "other.md",
@@ -962,6 +963,10 @@ title: Other
 # Overview
 
 Overview text.
+
+## Introduction
+
+A level-2 introduction section.
 
 ## Tasks
 
@@ -1072,27 +1077,21 @@ fn section_filter_case_insensitive() {
 #[test]
 fn section_filter_level_pinned() {
     let tmp = setup_section_vault();
-    // "# Introduction" should only match level-1 heading, not ## Introduction
+    // doc.md has "# Introduction" (level 1); other.md has "## Introduction" (level 2).
+    // Using "# Introduction" should match only doc.md (level-pinned to 1) and exclude other.md.
     let (status, json, _) = find_json(
         &tmp,
-        &[
-            "--section",
-            "# Introduction",
-            "--file",
-            "doc.md",
-            "--fields",
-            "sections",
-        ],
+        &["--section", "# Introduction", "--fields", "sections"],
     );
     assert!(status.success());
     let arr = json.as_array().unwrap();
-    assert_eq!(arr.len(), 1);
-    let sections = arr[0]["sections"].as_array().unwrap();
-    // Only the level-1 Introduction section should be returned
-    assert!(
-        sections.iter().all(|s| s["level"].as_u64().unwrap() == 1
-            || s["heading"].as_str().unwrap() != "Introduction")
+    // Only doc.md should be returned — other.md's ## Introduction is level 2, not level 1
+    assert_eq!(
+        arr.len(),
+        1,
+        "only doc.md should match a level-1 Introduction filter"
     );
+    assert_eq!(arr[0]["file"].as_str().unwrap(), "doc.md");
 }
 
 #[test]

--- a/tests/e2e_find.rs
+++ b/tests/e2e_find.rs
@@ -912,3 +912,258 @@ fn find_glob_no_match_exits_1() {
     assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
 }
+
+// ---------------------------------------------------------------------------
+// --section filter tests
+// ---------------------------------------------------------------------------
+
+fn setup_section_vault() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // doc.md — multiple sections, nested subsections, tasks in different sections
+    write_md(
+        tmp.path(),
+        "doc.md",
+        md!(r"
+---
+title: Doc
+tags:
+  - test
+---
+# Introduction
+
+Intro text here.
+
+## Tasks
+
+- [ ] First task
+- [x] Second task
+
+### Subtasks
+
+- [ ] Nested task
+
+## Notes
+
+Some notes with a TODO marker.
+
+- [ ] Note task
+"),
+    );
+
+    // other.md — has a Tasks section too (tests multi-file matching)
+    write_md(
+        tmp.path(),
+        "other.md",
+        md!(r"
+---
+title: Other
+---
+# Overview
+
+Overview text.
+
+## Tasks
+
+- [ ] Other task
+- [x] Done task
+
+## Design
+
+Design details with TODO items.
+"),
+    );
+
+    tmp
+}
+
+#[test]
+fn section_filter_scopes_tasks() {
+    let tmp = setup_section_vault();
+    let (status, json, _) = find_json(
+        &tmp,
+        &["--section", "Tasks", "--task", "todo", "--fields", "tasks"],
+    );
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    // Both files have ## Tasks sections with open tasks
+    assert_eq!(arr.len(), 2);
+    for entry in arr {
+        let tasks = entry["tasks"].as_array().unwrap();
+        for task in tasks {
+            // All returned tasks must be in a section that starts with Tasks-related headings
+            let section = task["section"].as_str().unwrap();
+            assert!(
+                section.contains("Tasks") || section.contains("Subtasks"),
+                "unexpected section: {section}"
+            );
+        }
+    }
+}
+
+#[test]
+fn section_filter_includes_nested_children() {
+    let tmp = setup_section_vault();
+    let (status, json, _) = find_json(
+        &tmp,
+        &[
+            "--section",
+            "Tasks",
+            "--task",
+            "any",
+            "--fields",
+            "tasks",
+            "--file",
+            "doc.md",
+        ],
+    );
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let tasks = arr[0]["tasks"].as_array().unwrap();
+    // Should include: First task, Second task (## Tasks), Nested task (### Subtasks)
+    // Should NOT include: Note task (## Notes)
+    assert_eq!(tasks.len(), 3);
+    let texts: Vec<&str> = tasks.iter().map(|t| t["text"].as_str().unwrap()).collect();
+    assert!(texts.contains(&"First task"));
+    assert!(texts.contains(&"Second task"));
+    assert!(texts.contains(&"Nested task"));
+}
+
+#[test]
+fn section_filter_nearest_heading_in_output() {
+    let tmp = setup_section_vault();
+    let (status, json, _) = find_json(
+        &tmp,
+        &[
+            "--section",
+            "Tasks",
+            "--task",
+            "any",
+            "--fields",
+            "tasks",
+            "--file",
+            "doc.md",
+        ],
+    );
+    assert!(status.success());
+    let tasks = json.as_array().unwrap()[0]["tasks"].as_array().unwrap();
+    // The nested task should show "### Subtasks" as its section, not "## Tasks"
+    let nested = tasks
+        .iter()
+        .find(|t| t["text"].as_str().unwrap() == "Nested task")
+        .unwrap();
+    assert_eq!(nested["section"].as_str().unwrap(), "### Subtasks");
+}
+
+#[test]
+fn section_filter_case_insensitive() {
+    let tmp = setup_section_vault();
+    let (status, json, _) = find_json(
+        &tmp,
+        &["--section", "tasks", "--task", "any", "--fields", "tasks"],
+    );
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    // Should still match ## Tasks sections
+    assert_eq!(arr.len(), 2);
+}
+
+#[test]
+fn section_filter_level_pinned() {
+    let tmp = setup_section_vault();
+    // "# Introduction" should only match level-1 heading, not ## Introduction
+    let (status, json, _) = find_json(
+        &tmp,
+        &[
+            "--section",
+            "# Introduction",
+            "--file",
+            "doc.md",
+            "--fields",
+            "sections",
+        ],
+    );
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let sections = arr[0]["sections"].as_array().unwrap();
+    // Only the level-1 Introduction section should be returned
+    assert!(
+        sections.iter().all(|s| s["level"].as_u64().unwrap() == 1
+            || s["heading"].as_str().unwrap() != "Introduction")
+    );
+}
+
+#[test]
+fn section_filter_or_semantics() {
+    let tmp = setup_section_vault();
+    let (status, json, _) = find_json(
+        &tmp,
+        &[
+            "--section",
+            "Tasks",
+            "--section",
+            "Notes",
+            "--task",
+            "any",
+            "--fields",
+            "tasks",
+            "--file",
+            "doc.md",
+        ],
+    );
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let tasks = arr[0]["tasks"].as_array().unwrap();
+    // Should include tasks from both Tasks and Notes sections
+    let texts: Vec<&str> = tasks.iter().map(|t| t["text"].as_str().unwrap()).collect();
+    assert!(texts.contains(&"First task"));
+    assert!(texts.contains(&"Note task"));
+}
+
+#[test]
+fn section_filter_no_match_excludes_file() {
+    let tmp = setup_section_vault();
+    let (status, json, _) = find_json(&tmp, &["--section", "Nonexistent", "--task", "any"]);
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    // No files should match since no section named "Nonexistent" exists
+    assert!(arr.is_empty());
+}
+
+#[test]
+fn section_filter_content_search_scoped() {
+    let tmp = setup_section_vault();
+    let (status, json, _) = find_json(&tmp, &["--section", "Notes", "TODO", "--file", "doc.md"]);
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let matches = arr[0]["matches"].as_array().unwrap();
+    // The TODO in Notes section should be found
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0]["section"].as_str().unwrap(), "## Notes");
+}
+
+#[test]
+fn section_filter_content_search_excludes_other_sections() {
+    let tmp = setup_section_vault();
+    // "TODO" appears in both Notes and Design, but --section "Notes" should only find it in Notes
+    let (status, json, _) = find_json(&tmp, &["--section", "Notes", "TODO", "--file", "other.md"]);
+    assert!(status.success());
+    let arr = json.as_array().unwrap();
+    // other.md has no ## Notes section, so it shouldn't match
+    assert!(arr.is_empty());
+}
+
+#[test]
+fn section_filter_invalid_exits_1() {
+    let tmp = setup_section_vault();
+    let mut cmd = hyalo();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["find", "--section", "####### Too deep"]);
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+}


### PR DESCRIPTION
## Summary

- Add `--section HEADING` filter to `hyalo find` that scopes body-level results (tasks, content matches, sections) to matching headings
- Consolidate three duplicate ATX heading parsers (`content_search.rs`, `tasks.rs`, `outline.rs`) into a shared `src/heading.rs` module
- Refactor `read --section` to use the shared `SectionFilter` type for DRY matching logic
- Matching semantics: case-insensitive whole-string match; optional `#` prefix pins heading level; child sections included; multiple `--section` values use OR

## Test plan

- [x] 17 unit tests in `heading.rs` (parser, SectionFilter::parse, SectionFilter::matches, build_section_scope with nesting/multi-match/EOF)
- [x] 6 unit tests in `find.rs` (section-scoped tasks, content matches, sections field filtering)
- [x] 10 e2e tests: scoped tasks, nested children, nearest heading output, case insensitivity, level pinning, OR semantics, no-match exclusion, content search scoping, invalid input
- [x] All 730 tests pass, cargo fmt clean, cargo clippy clean
- [x] Dogfooded: `hyalo find --section Tasks --task todo` against hyalo-knowledgebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)