### PR TITLE
Security hardening: symlink escape fix, atomic writes, cargo-deny

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,26 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install security tools
+        run: cargo install cargo-audit cargo-deny --locked
+
+      - name: Audit dependencies for known vulnerabilities
+        run: cargo audit
+
+      - name: Check licenses, advisories, bans, and sources
+        run: cargo deny check
+
   build:
+    needs: security
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +456,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "criterion",
+ "dunce",
  "globset",
  "ignore",
  "jaq-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,12 @@
 name = "hyalo"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4.6.0", features = ["derive"] }
+dunce = "1"
 globset = "0.4"
 ignore = "0.4"
 jaq-core = "2.2.1"
@@ -14,14 +16,14 @@ jaq-json = { version = "1.1.3", features = ["serde_json"] }
 jaq-std = "2.1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-serde_yaml_ng = "0.10"
+serde_yaml_ng = "0.10" # depends on unsafe-libyaml; monitor for pure-Rust alternatives
+tempfile = "3"
 toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
 predicates = "3"
-tempfile = "3"
 
 [profile.bench]
 codegen-units = 1

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,34 @@
+# Configuration for cargo-deny — https://embarkstudios.github.io/cargo-deny/
+#
+# Run locally: cargo deny check
+# Runs automatically in the release workflow as a quality gate.
+
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/hyalo-knowledgebase/iterations/iteration-22-security-hardening.md
+++ b/hyalo-knowledgebase/iterations/iteration-22-security-hardening.md
@@ -1,0 +1,22 @@
+---
+title: "Security Hardening"
+type: iteration
+date: 2026-03-23
+tags:
+  - security
+  - hardening
+status: in-progress
+branch: iter-22/security-hardening
+---
+
+# Iteration 22: Security Hardening
+
+Pre-release security audit found one confirmed exploit and several defense-in-depth improvements.
+
+## Tasks
+
+- [ ] P0: Fix symlink escape in resolve_file and resolve_target (confirmed exploit: write outside vault via --file through symlink)
+- [ ] P2: Atomic file writes via tempfile+persist (crash-safe mutations)
+- [ ] P2: Add regex size limit in content search (defense-in-depth)
+- [ ] P1: Add cargo-audit and cargo-deny to release workflow
+- [ ] P3: Document serde_yaml_ng / unsafe-libyaml awareness

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -76,6 +76,10 @@ pub fn find(
         None => None,
     };
 
+    // Canonicalize the vault directory once so that resolve_target (called
+    // per-link inside the loop) can avoid repeated canonicalization.
+    let canonical_dir = discovery::canonicalize_vault_dir(dir)?;
+
     let mut results: Vec<FileObject> = Vec::new();
 
     for (full_path, rel_path) in &files {
@@ -161,7 +165,7 @@ pub fn find(
             collected_tasks,
             link_collector,
             content_visitor,
-            dir,
+            &canonical_dir,
         );
 
         results.push(obj);
@@ -227,6 +231,10 @@ fn format_modified(path: &Path) -> Result<String> {
 use super::format_iso8601;
 
 /// Build a `FileObject` from the already-scanned data.
+///
+/// `canonical_dir` must be a pre-canonicalized vault path (see
+/// `discovery::canonicalize_vault_dir`). It is passed directly to
+/// `resolve_target` to avoid per-link re-canonicalization.
 #[allow(clippy::too_many_arguments)]
 fn build_file_object(
     rel_path: &str,
@@ -238,7 +246,7 @@ fn build_file_object(
     collected_tasks: Option<Vec<FindTaskInfo>>,
     link_collector: Option<LinkCollector>,
     content_visitor: Option<ContentSearchVisitor>,
-    dir: &Path,
+    canonical_dir: &Path,
 ) -> FileObject {
     let properties = if fields.properties {
         Some(
@@ -275,7 +283,7 @@ fn build_file_object(
             lc.into_links()
                 .into_iter()
                 .map(|link| {
-                    let path = discovery::resolve_target(dir, &link.target);
+                    let path = discovery::resolve_target(canonical_dir, &link.target);
                     LinkInfo {
                         target: link.target,
                         path,

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -61,7 +61,10 @@ pub fn find(
     let compiled_regex = match regexp {
         Some(re) => {
             let effective = format!("(?i){re}");
-            match regex::Regex::new(&effective) {
+            match regex::RegexBuilder::new(&effective)
+                .size_limit(1 << 20)
+                .build()
+            {
                 Ok(r) => Some(r),
                 Err(e) => {
                     return Ok(CommandOutcome::UserError(format!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -175,6 +175,15 @@ pub fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> Comman
         FileResolveError::NotFound { path } => CommandOutcome::UserError(
             crate::output::format_error(format, "file not found", Some(&path), None, None),
         ),
+        FileResolveError::OutsideVault { path } => {
+            CommandOutcome::UserError(crate::output::format_error(
+                format,
+                "file resolves outside vault boundary",
+                Some(&path),
+                None,
+                None,
+            ))
+        }
     }
 }
 

--- a/src/content_search.rs
+++ b/src/content_search.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 
 use crate::scanner::{FileVisitor, ScanAction};
 use crate::types::ContentMatch;
@@ -43,7 +43,9 @@ impl ContentSearchVisitor {
     #[must_use = "returns a compiled regex visitor; call has no side effects"]
     pub fn regex(pattern: &str) -> Result<Self> {
         let effective = format!("(?i){pattern}");
-        let re = Regex::new(&effective)
+        let re = RegexBuilder::new(&effective)
+            .size_limit(1 << 20) // 1 MiB — generous for real patterns, prevents pathological ones
+            .build()
             .with_context(|| format!("invalid regular expression: {pattern}"))?;
         Ok(Self {
             mode: SearchMode::Regex(re),
@@ -332,5 +334,16 @@ mod tests {
     fn regex_no_match_returns_empty() {
         let matches = run_regex_visitor("Nothing here\n", r"\d{4}-\d{2}-\d{2}");
         assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn regex_rejects_oversized_pattern() {
+        // A huge alternation that exceeds the 1 MiB compiled-size limit
+        let huge = (0..50_000)
+            .map(|i| format!("word{i}"))
+            .collect::<Vec<_>>()
+            .join("|");
+        let result = ContentSearchVisitor::regex(&huge);
+        assert!(result.is_err(), "oversized pattern should be rejected");
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -58,6 +58,12 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
         return Err(FileResolveError::NotFound { path: normalized });
     }
 
+    // After confirming the file exists, canonicalize to resolve symlinks and
+    // verify the real path stays within the vault directory.
+    ensure_within_vault(dir, &full).map_err(|_| FileResolveError::OutsideVault {
+        path: normalized.clone(),
+    })?;
+
     Ok((full, normalized))
 }
 
@@ -69,6 +75,24 @@ fn has_parent_traversal(path: &str) -> bool {
     Path::new(path)
         .components()
         .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+/// Verify that `full` resolves to a path within `dir` after following symlinks.
+///
+/// Uses `dunce::canonicalize` to resolve symlinks and normalize the path, then
+/// checks that the canonical path starts with the canonical vault directory.
+/// This prevents symlink-based escapes where a link inside the vault points
+/// to a file outside it.
+fn ensure_within_vault(dir: &Path, full: &Path) -> Result<()> {
+    let canonical_dir = dunce::canonicalize(dir)
+        .with_context(|| format!("failed to canonicalize vault dir: {}", dir.display()))?;
+    let canonical_full = dunce::canonicalize(full)
+        .with_context(|| format!("failed to canonicalize path: {}", full.display()))?;
+    anyhow::ensure!(
+        canonical_full.starts_with(&canonical_dir),
+        "path resolves outside vault boundary"
+    );
+    Ok(())
 }
 
 /// Normalize a path argument: strip leading `./`, normalize separators to forward slashes.
@@ -121,6 +145,7 @@ pub fn relative_path(dir: &Path, file: &Path) -> String {
 pub enum FileResolveError {
     NotFound { path: String },
     MissingExtension { path: String, hint: String },
+    OutsideVault { path: String },
 }
 
 impl std::fmt::Display for FileResolveError {
@@ -129,6 +154,9 @@ impl std::fmt::Display for FileResolveError {
             Self::NotFound { path } => write!(f, "file not found: {path}"),
             Self::MissingExtension { path, hint } => {
                 write!(f, "file not found: {path} (did you mean {hint}?)")
+            }
+            Self::OutsideVault { path } => {
+                write!(f, "file resolves outside vault boundary: {path}")
             }
         }
     }
@@ -152,8 +180,12 @@ pub fn resolve_target(dir: &Path, target: &str) -> Option<String> {
         return None;
     }
 
-    if dir.join(&target).is_file() {
-        return Some(target.clone());
+    let full = dir.join(&target);
+    if full.is_file() {
+        if ensure_within_vault(dir, &full).is_ok() {
+            return Some(target.clone());
+        }
+        return None;
     }
 
     if !std::path::Path::new(&target)
@@ -161,8 +193,12 @@ pub fn resolve_target(dir: &Path, target: &str) -> Option<String> {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
     {
         let with_ext = format!("{target}.md");
-        if dir.join(&with_ext).is_file() {
-            return Some(with_ext);
+        let full = dir.join(&with_ext);
+        if full.is_file() {
+            if ensure_within_vault(dir, &full).is_ok() {
+                return Some(with_ext);
+            }
+            return None;
         }
     }
 
@@ -269,7 +305,7 @@ mod tests {
                 assert_eq!(path, "note");
                 assert_eq!(hint, "note.md");
             }
-            other @ FileResolveError::NotFound { .. } => {
+            other => {
                 panic!("expected MissingExtension, got {other:?}")
             }
         }
@@ -439,5 +475,53 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         assert_eq!(resolve_target(tmp.path(), "../secret.md"), None);
+    }
+
+    // --- symlink escape tests ---
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_file_rejects_symlink_escape() {
+        let vault = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("secret.md"), "# Secret").unwrap();
+
+        // Create a symlink inside vault that points outside
+        std::os::unix::fs::symlink(outside.path(), vault.path().join("linked")).unwrap();
+
+        let err = resolve_file(vault.path(), "linked/secret.md").unwrap_err();
+        assert!(
+            matches!(err, FileResolveError::OutsideVault { .. }),
+            "expected OutsideVault, got {err:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_target_rejects_symlink_escape() {
+        let vault = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("secret.md"), "# Secret").unwrap();
+
+        std::os::unix::fs::symlink(outside.path(), vault.path().join("linked")).unwrap();
+
+        assert_eq!(resolve_target(vault.path(), "linked/secret"), None);
+        assert_eq!(resolve_target(vault.path(), "linked/secret.md"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_file_allows_symlink_within_vault() {
+        let vault = tempfile::tempdir().unwrap();
+        let subdir = vault.path().join("notes");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(subdir.join("real.md"), "# Real").unwrap();
+
+        // Symlink within the vault is fine
+        std::os::unix::fs::symlink(&subdir, vault.path().join("alias")).unwrap();
+
+        let (path, rel) = resolve_file(vault.path(), "alias/real.md").unwrap();
+        assert!(path.is_file());
+        assert_eq!(rel, "alias/real.md");
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -60,9 +60,22 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
 
     // After confirming the file exists, canonicalize to resolve symlinks and
     // verify the real path stays within the vault directory.
-    ensure_within_vault(dir, &full).map_err(|_| FileResolveError::OutsideVault {
+    let canonical_dir = canonicalize_vault_dir(dir).map_err(|_| FileResolveError::NotFound {
         path: normalized.clone(),
     })?;
+    match ensure_within_vault(&canonical_dir, &full) {
+        Ok(true) => {}
+        Ok(false) => {
+            return Err(FileResolveError::OutsideVault {
+                path: normalized.clone(),
+            });
+        }
+        Err(_) => {
+            // Canonicalization of the target failed (permission error, symlink loop, etc.).
+            // Do not claim "outside vault" — the path simply could not be resolved.
+            return Err(FileResolveError::NotFound { path: normalized });
+        }
+    }
 
     Ok((full, normalized))
 }
@@ -77,22 +90,29 @@ fn has_parent_traversal(path: &str) -> bool {
         .any(|c| matches!(c, std::path::Component::ParentDir))
 }
 
-/// Verify that `full` resolves to a path within `dir` after following symlinks.
+/// Canonicalize the vault directory once.
 ///
-/// Uses `dunce::canonicalize` to resolve symlinks and normalize the path, then
-/// checks that the canonical path starts with the canonical vault directory.
-/// This prevents symlink-based escapes where a link inside the vault points
-/// to a file outside it.
-fn ensure_within_vault(dir: &Path, full: &Path) -> Result<()> {
-    let canonical_dir = dunce::canonicalize(dir)
-        .with_context(|| format!("failed to canonicalize vault dir: {}", dir.display()))?;
+/// Callers that invoke `ensure_within_vault` in a loop should call this once
+/// upfront and pass the result to every `ensure_within_vault` call, avoiding
+/// repeated canonicalization of the same directory.
+pub fn canonicalize_vault_dir(dir: &Path) -> Result<PathBuf> {
+    dunce::canonicalize(dir)
+        .with_context(|| format!("failed to canonicalize vault dir: {}", dir.display()))
+}
+
+/// Verify that `full` resolves to a path within `canonical_dir` after following symlinks.
+///
+/// Accepts an already-canonicalized vault directory to avoid re-canonicalizing
+/// on every call (important when called in a per-link loop).
+///
+/// Returns:
+/// - `Ok(true)`  — `full` is within the vault
+/// - `Ok(false)` — `full` resolves outside the vault boundary
+/// - `Err(_)`    — `full` could not be canonicalized (permission error, symlink loop, etc.)
+fn ensure_within_vault(canonical_dir: &Path, full: &Path) -> Result<bool> {
     let canonical_full = dunce::canonicalize(full)
         .with_context(|| format!("failed to canonicalize path: {}", full.display()))?;
-    anyhow::ensure!(
-        canonical_full.starts_with(&canonical_dir),
-        "path resolves outside vault boundary"
-    );
-    Ok(())
+    Ok(canonical_full.starts_with(canonical_dir))
 }
 
 /// Normalize a path argument: strip leading `./`, normalize separators to forward slashes.
@@ -166,9 +186,12 @@ impl std::error::Error for FileResolveError {}
 
 /// Resolve a link target to a file path relative to the vault root.
 /// Tries the target as-is, then with `.md` appended.
-/// Returns the relative path if the file exists, or None.
+/// Returns the relative path if the file exists within the vault, or None.
+///
+/// `canonical_dir` must be a pre-canonicalized vault path (see `canonicalize_vault_dir`).
+/// Callers iterating over many links should canonicalize once and reuse the result.
 #[must_use]
-pub fn resolve_target(dir: &Path, target: &str) -> Option<String> {
+pub fn resolve_target(canonical_dir: &Path, target: &str) -> Option<String> {
     if target.is_empty() {
         return None;
     }
@@ -180,9 +203,10 @@ pub fn resolve_target(dir: &Path, target: &str) -> Option<String> {
         return None;
     }
 
-    let full = dir.join(&target);
+    let full = canonical_dir.join(&target);
     if full.is_file() {
-        if ensure_within_vault(dir, &full).is_ok() {
+        // Ok(true) = within vault; Ok(false) or Err = reject
+        if ensure_within_vault(canonical_dir, &full).unwrap_or(false) {
             return Some(target.clone());
         }
         return None;
@@ -193,9 +217,9 @@ pub fn resolve_target(dir: &Path, target: &str) -> Option<String> {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
     {
         let with_ext = format!("{target}.md");
-        let full = dir.join(&with_ext);
+        let full = canonical_dir.join(&with_ext);
         if full.is_file() {
-            if ensure_within_vault(dir, &full).is_ok() {
+            if ensure_within_vault(canonical_dir, &full).unwrap_or(false) {
                 return Some(with_ext);
             }
             return None;
@@ -357,8 +381,9 @@ mod tests {
     fn resolve_target_stem_appends_md() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["note.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(tmp.path(), "note"),
+            resolve_target(&canonical, "note"),
             Some("note.md".to_owned())
         );
     }
@@ -367,8 +392,9 @@ mod tests {
     fn resolve_target_explicit_md_extension() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["note.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(tmp.path(), "note.md"),
+            resolve_target(&canonical, "note.md"),
             Some("note.md".to_owned())
         );
     }
@@ -377,8 +403,9 @@ mod tests {
     fn resolve_target_subpath_stem() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["sub/other.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(tmp.path(), "sub/other"),
+            resolve_target(&canonical, "sub/other"),
             Some("sub/other.md".to_owned())
         );
     }
@@ -387,8 +414,9 @@ mod tests {
     fn resolve_target_subpath_with_extension() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["sub/other.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(tmp.path(), "sub/other.md"),
+            resolve_target(&canonical, "sub/other.md"),
             Some("sub/other.md".to_owned())
         );
     }
@@ -397,36 +425,41 @@ mod tests {
     fn resolve_target_bare_stem_does_not_match_subdirectory() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["sub/other.md"]);
-        assert_eq!(resolve_target(tmp.path(), "other"), None);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(resolve_target(&canonical, "other"), None);
     }
 
     #[test]
     fn resolve_target_nonexistent_returns_none() {
         let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(resolve_target(tmp.path(), "nonexistent"), None);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(resolve_target(&canonical, "nonexistent"), None);
     }
 
     #[test]
     fn resolve_target_empty_returns_none() {
         let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(resolve_target(tmp.path(), ""), None);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(resolve_target(&canonical, ""), None);
     }
 
     #[test]
     fn resolve_target_rejects_traversal() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["note.md"]);
-        assert_eq!(resolve_target(tmp.path(), "../note"), None);
-        assert_eq!(resolve_target(tmp.path(), "sub/../../note"), None);
-        assert_eq!(resolve_target(tmp.path(), "/etc/passwd"), None);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(resolve_target(&canonical, "../note"), None);
+        assert_eq!(resolve_target(&canonical, "sub/../../note"), None);
+        assert_eq!(resolve_target(&canonical, "/etc/passwd"), None);
     }
 
     #[test]
     fn resolve_target_non_md_file_exact_match() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["image.png"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(tmp.path(), "image.png"),
+            resolve_target(&canonical, "image.png"),
             Some("image.png".to_owned())
         );
     }
@@ -463,9 +496,10 @@ mod tests {
     fn resolve_target_accepts_dotdot_in_filename() {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["etc..md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
 
         assert_eq!(
-            resolve_target(tmp.path(), "etc..md"),
+            resolve_target(&canonical, "etc..md"),
             Some("etc..md".to_owned())
         );
     }
@@ -473,8 +507,9 @@ mod tests {
     #[test]
     fn resolve_target_rejects_parent_traversal_segment() {
         let tmp = tempfile::tempdir().unwrap();
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
 
-        assert_eq!(resolve_target(tmp.path(), "../secret.md"), None);
+        assert_eq!(resolve_target(&canonical, "../secret.md"), None);
     }
 
     // --- symlink escape tests ---
@@ -505,8 +540,9 @@ mod tests {
 
         std::os::unix::fs::symlink(outside.path(), vault.path().join("linked")).unwrap();
 
-        assert_eq!(resolve_target(vault.path(), "linked/secret"), None);
-        assert_eq!(resolve_target(vault.path(), "linked/secret.md"), None);
+        let canonical = canonicalize_vault_dir(vault.path()).unwrap();
+        assert_eq!(resolve_target(&canonical, "linked/secret"), None);
+        assert_eq!(resolve_target(&canonical, "linked/secret.md"), None);
     }
 
     #[cfg(unix)]

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -134,7 +134,8 @@ pub fn write_frontmatter(path: &Path, props: &BTreeMap<String, Value>) -> Result
     out.extend_from_slice(&body_bytes);
 
     // --- Step 4: write atomically ---
-    std::fs::write(path, &out).with_context(|| format!("failed to write {}", path.display()))?;
+    crate::fs_util::atomic_write(path, &out)
+        .with_context(|| format!("failed to write {}", path.display()))?;
 
     Ok(())
 }

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -50,8 +50,10 @@ mod tests {
 
     #[test]
     fn atomic_write_fails_if_parent_missing() {
-        let target = Path::new("/nonexistent/dir/file.txt");
-        let err = atomic_write(target, b"data").unwrap_err();
+        let tmp = tempfile::tempdir().unwrap();
+        // The "missing" subdirectory does not exist, so the temp file cannot be created.
+        let target = tmp.path().join("missing").join("file.txt");
+        let err = atomic_write(&target, b"data").unwrap_err();
         assert!(
             err.to_string().contains("failed to create temp file"),
             "got: {err}"

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,0 +1,60 @@
+#![allow(clippy::missing_errors_doc)]
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+/// Write data to a file atomically.
+///
+/// Creates a temporary file in the same directory as `path`, writes all data,
+/// then renames it into place. This ensures that a crash mid-write never leaves
+/// a truncated or corrupted file — the original is either fully replaced or
+/// left untouched.
+pub fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("cannot determine parent directory for atomic write")?;
+
+    let mut tmp = NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temp file in {}", parent.display()))?;
+
+    tmp.write_all(data)
+        .with_context(|| format!("failed to write temp file for {}", path.display()))?;
+
+    tmp.persist(path)
+        .with_context(|| format!("failed to persist temp file to {}", path.display()))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_write_creates_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("output.txt");
+        atomic_write(&target, b"hello world").unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn atomic_write_overwrites_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("output.txt");
+        std::fs::write(&target, "old content").unwrap();
+        atomic_write(&target, b"new content").unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new content");
+    }
+
+    #[test]
+    fn atomic_write_fails_if_parent_missing() {
+        let target = Path::new("/nonexistent/dir/file.txt");
+        let err = atomic_write(target, b"data").unwrap_err();
+        assert!(
+            err.to_string().contains("failed to create temp file"),
+            "got: {err}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod content_search;
 pub mod discovery;
 pub mod filter;
 pub mod frontmatter;
+pub mod fs_util;
 pub mod hints;
 pub mod links;
 pub mod output;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -502,7 +502,7 @@ pub fn toggle_task(path: &Path, line: usize) -> Result<TaskInfo> {
         parts.join("\n")
     };
 
-    std::fs::write(path, &new_content)
+    crate::fs_util::atomic_write(path, new_content.as_bytes())
         .with_context(|| format!("failed to write {}", path.display()))?;
 
     Ok(info)
@@ -542,7 +542,7 @@ pub fn set_task_status(path: &Path, line: usize, status: char) -> Result<TaskInf
         parts.join("\n")
     };
 
-    std::fs::write(path, &new_content)
+    crate::fs_util::atomic_write(path, new_content.as_bytes())
         .with_context(|| format!("failed to write {}", path.display()))?;
 
     Ok(info)


### PR DESCRIPTION
## Summary

Pre-release security audit found one confirmed exploit and several defense-in-depth improvements:

- **P0 — Symlink escape fix**: `resolve_file()` and `resolve_target()` now canonicalize paths after joining and verify the resolved path stays within the vault boundary. Previously, a symlink inside the vault could be used to read/write files outside it via `--file`. Adds `dunce` crate for cross-platform canonicalization.
- **P2 — Atomic file writes**: New `fs_util::atomic_write()` using `tempfile::NamedTempFile` + `persist()` replaces `std::fs::write` in all 3 mutation sites (frontmatter, task toggle, task set-status). Prevents file corruption on crash.
- **P2 — Regex size limit**: User-supplied `--regexp` patterns now have a 1 MiB compiled-size limit via `RegexBuilder::size_limit()`, preventing pathological memory allocation.
- **P1 — Security tools in release workflow**: New `security` job in `release.yml` runs `cargo audit` + `cargo deny check` before builds. Adds `deny.toml` with license/advisory/source policy.
- **P3 — Document `serde_yaml_ng` dependency**: Comment noting `unsafe-libyaml` backing, to monitor for pure-Rust alternatives.

## Test plan

- [x] Unit tests: symlink escape blocked for both `resolve_file` and `resolve_target` (`#[cfg(unix)]`)
- [x] Unit test: symlinks within vault still work
- [x] Unit tests: `atomic_write` creates, overwrites, and fails gracefully
- [x] Unit test: oversized regex pattern rejected
- [x] Manual verification: symlink exploit no longer works end-to-end
- [x] `cargo audit` passes (0 vulnerabilities)
- [x] `cargo deny check` passes locally
- [x] All 702 existing tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)