### PR TITLE
Add release profile optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,12 @@ assert_cmd = "2"
 criterion = { version = "0.5", features = ["html_reports"] }
 predicates = "3"
 
+[profile.release]
+codegen-units = 1
+lto = true
+panic = "abort"
+strip = true
+
 [profile.bench]
 codegen-units = 1
 lto = true

--- a/hyalo-knowledgebase/iterations/iteration-25-release-profile-quick-wins.md
+++ b/hyalo-knowledgebase/iterations/iteration-25-release-profile-quick-wins.md
@@ -1,0 +1,28 @@
+---
+branch: iter-25/release-profile-quick-wins
+date: 2026-03-23
+status: completed
+tags:
+- iteration
+- performance
+- binary-size
+- release
+title: 'Iteration 25: Release Profile Quick Wins'
+type: iteration
+---
+
+# Iteration 25: Release Profile Quick Wins
+
+The release binary is 5.8 MB with no `[profile.release]` optimizations. The bench profile already uses `lto = true` + `codegen-units = 1`, proving these work. Apply the same (plus strip and panic=abort) to the release profile for a smaller, faster binary.
+
+## Tasks
+
+- [x] Add `[profile.release]` to Cargo.toml with: `strip = true`, `lto = true`, `codegen-units = 1`, `panic = "abort"`
+- [x] Measure binary size reduction (before vs after)
+- [x] Verify all cross-platform CI targets still build (review release.yml for compatibility)
+- [x] Run e2e tests to confirm no behavioral regressions
+- [x] Update release.yml if any changes needed for new profile
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`
+- [x] Build release and dogfood


### PR DESCRIPTION
## Summary
- Add `[profile.release]` to Cargo.toml with `lto = true`, `strip = true`, `codegen-units = 1`, `panic = "abort"`
- Reduces release binary size from 5.8 MB to 3.0 MB (48% reduction)
- No code changes — build configuration only; all existing tests pass

## Test plan
- [x] `cargo fmt` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 17 test suites pass
- [x] Built release binary and dogfooded `hyalo summary`, `hyalo find`
- [x] Reviewed release.yml — all cross-platform targets use `cargo build --release` which picks up the new profile automatically; no workflow changes needed