### PR TITLE
Add Claude Code skill and hyalo init command

### DIFF
--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: hyalo
+user_invocable: false
+description: >
+  Use the hyalo CLI instead of Read/Edit/Grep/Glob when working with markdown (.md) files
+  that have YAML frontmatter. This skill MUST be consulted whenever Claude is working with
+  markdown documentation directories, knowledgebases, wikis, notes, Obsidian-compatible
+  collections, Zettelkasten systems, iteration plans, or any collection of .md files with
+  frontmatter. Trigger this skill when: searching or filtering markdown files by content,
+  tags, or properties; reading or modifying YAML frontmatter; managing tags or metadata
+  across documents; toggling task checkboxes in markdown; getting an overview of a
+  documentation directory; querying document properties or status fields; bulk-updating
+  metadata across many markdown files; or when you find yourself repeatedly using
+  Grep/Glob/Read on .md files. Even if the user does not mention "hyalo" by name, use this
+  skill whenever the task involves structured markdown documents with frontmatter.
+---
+
+# Hyalo CLI — Preferred Tool for Markdown with Frontmatter
+
+Hyalo is a fast CLI for querying and mutating YAML frontmatter, tags, tasks, and structure
+in directories of markdown files. Its killer features are combined filtering (e.g.
+`hyalo find -e "regex" --property status!=done --tag feature`) which you can't easily
+replicate with Grep/Glob, and bulk mutations (`hyalo set --where-property`) that replace
+multiple Read + Edit calls.
+
+Filters combine freely — content regex + property conditions + tag + section + task status
+in a single call, something impossible with Grep/Glob alone:
+
+```bash
+hyalo find -e "pattern" --property status!=completed --tag iteration --section "Tasks" --task todo
+```
+
+Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports:
+
+```bash
+hyalo find --property status=in-progress --fields tasks \
+  --jq 'map({file, done: ([.tasks[] | select(.status == "x")] | length), total: (.tasks | length)})'
+```
+
+**Run `hyalo --help` and `hyalo <command> --help` to learn the full API.**
+
+## Setup (run once per project)
+
+ALWAYS run `which hyalo` as your very first step. Do not skip this.
+
+- **Not on PATH?** Inform the user: "The `hyalo` CLI is not installed. You can install it
+  from https://github.com/ractive/hyalo." Fall back to Read/Edit/Grep/Glob.
+- **On PATH?** Check for `.hyalo.toml` in the project root. If it exists, hyalo is
+  configured — the `dir` setting means you don't need `--dir` on every command.
+- **No `.hyalo.toml` but a directory with many `.md` files?** (e.g. `docs/`, `knowledgebase/`,
+  `wiki/`, `notes/`, `content/`, or any folder with 10+ markdown files) Suggest creating one:
+  ```toml
+  dir = "docs"
+  ```
+
+**After confirming hyalo works**, add a line to the project's `CLAUDE.md` so future
+conversations use hyalo without needing this skill:
+
+```
+Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.
+```
+
+This one-line instruction saves tokens in every future conversation.
+
+## When to use hyalo vs. built-in tools
+
+- **hyalo:** queries, frontmatter reads/mutations, tag management, task toggling, bulk updates
+- **Edit tool:** body prose changes (rewriting paragraphs) that hyalo can't handle
+- **Write tool:** creating brand new markdown files
+
+Start with `hyalo summary --format text` to orient yourself in a new directory.
+
+## Available commands
+
+- **find** — search/filter by text, regex, property, tag, task status
+- **read** — extract body content, a section, or line range
+- **summary** — directory overview: file counts, tags, tasks, recent files
+- **properties** — list property names and types
+- **tags** — list tags with counts
+- **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates)
+- **remove** — delete properties or tags
+- **append** — add to list properties
+- **task** — read, toggle, or set status on checkboxes
+
+## The --format text flag
+
+Use `--format text` for compact, low-token output designed for LLM consumption — less noise
+than JSON, fewer tokens. Reach for it when orienting yourself or scanning results.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ All fields are optional. CLI flags always take precedence over config values. If
 
 Use `--no-hints` to explicitly disable hints when the config file enables them.
 
+### init
+
+Initialize hyalo in the current project. Creates a `.hyalo.toml` config file with a `dir` setting pointing to your markdown directory.
+
+```sh
+# Basic init — creates .hyalo.toml
+hyalo init
+
+# Specify the markdown directory explicitly
+hyalo init --dir my-vault
+
+# Also set up Claude Code integration (skill + CLAUDE.md hint)
+hyalo init --claude
+```
+
+Without `--dir`, hyalo auto-detects common documentation directories (`docs/`, `knowledgebase/`, `wiki/`, `notes/`, `content/`, `pages/`) by looking for a subdirectory that contains `.md` files. Falls back to `.` if none is found.
+
+With `--claude`, hyalo additionally:
+- Creates `.claude/skills/hyalo/SKILL.md` so Claude Code automatically uses hyalo for markdown operations
+- Appends a hyalo usage hint to `.claude/CLAUDE.md`
+
+All steps are idempotent — existing files are skipped, and duplicate hints are not added.
+
 ### find
 
 Search and filter files. Returns an array of file objects, each containing frontmatter properties, tags, sections, tasks, and links.

--- a/hyalo-knowledgebase/backlog/claude-plugin-distribution.md
+++ b/hyalo-knowledgebase/backlog/claude-plugin-distribution.md
@@ -1,0 +1,48 @@
+---
+title: Claude Code plugin distribution for hyalo skill
+type: backlog
+date: 2026-03-23
+origin: skill packaging initiative
+priority: medium
+status: planned
+tags:
+  - backlog
+  - cli
+  - llm
+  - ux
+---
+
+## Problem
+
+Currently, to use the hyalo Claude Code skill, users must run `hyalo init --claude` in their project to generate `.claude/skills/hyalo/SKILL.md`. This requires having hyalo installed first and manually setting up each project. There is no way to distribute the skill as a standalone package that users can install directly into Claude Code.
+
+## Proposal
+
+Publish hyalo's Claude Code skill as a plugin package that can be installed via Claude Code's plugin system:
+
+```bash
+claude /plugin install --github-repo ractive/hyalo-claude-plugin
+```
+
+This requires:
+
+1. **Create a dedicated GitHub repository** (`ractive/hyalo-claude-plugin`) to host the plugin
+2. **Create a `plugin.json` manifest** at the repo root describing the plugin metadata, skill files, and dependencies
+3. **Include the SKILL.md** and any reference files the skill needs
+4. **Document installation** in both the plugin repo README and the main hyalo README
+
+## Benefits
+
+- Users can install the skill without having hyalo on PATH yet — the skill itself will prompt them to install the CLI
+- Single command to add hyalo intelligence to any Claude Code project
+- Plugin updates propagate automatically (depending on Claude Code's update mechanism)
+- Lowers the barrier to entry: discover the plugin, install it, then install the CLI when prompted
+
+## Acceptance Criteria
+
+- [ ] GitHub repository `ractive/hyalo-claude-plugin` exists
+- [ ] `plugin.json` manifest with correct schema is present at repo root
+- [ ] SKILL.md is included and matches the latest version from the main repo
+- [ ] `claude /plugin install --github-repo ractive/hyalo-claude-plugin` successfully installs the skill
+- [ ] Installed skill triggers correctly on knowledgebase-related prompts
+- [ ] Main hyalo README documents the plugin install option alongside `hyalo init --claude`

--- a/hyalo-knowledgebase/iterations/iteration-32-claude-code-skill-init-command.md
+++ b/hyalo-knowledgebase/iterations/iteration-32-claude-code-skill-init-command.md
@@ -1,0 +1,34 @@
+---
+branch: worktree-sunny-gliding-glade
+date: 2026-03-23
+status: in-progress
+tags:
+- iteration
+- cli
+- claude
+- skill
+title: 'Iteration 32: Claude Code Skill & Init Command'
+type: iteration
+---
+
+# Iteration 32: Claude Code Skill & Init Command
+
+## Goal
+
+Add a Claude Code skill (SKILL.md) for hyalo and implement a `hyalo init` command that bootstraps a new knowledgebase directory, with an optional `--claude` flag for Claude Code integration.
+
+## Tasks
+
+### Claude Code skill
+- [x] Create hyalo Claude Code skill (SKILL.md)
+- [x] Add skill to repo (.claude/skills/hyalo/)
+
+### Init command
+- [x] Implement `hyalo init` command
+- [x] Implement `hyalo init --claude` for Claude Code integration
+- [x] Auto-detect common documentation directories
+- [x] E2e tests for init command
+- [x] Add init command to README
+
+### Backlog
+- [ ] Create backlog item for plugin distribution

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -157,7 +157,7 @@ pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
     } else {
         let skill_dir = skill_path
             .parent()
-            .expect("skill path always has a parent directory");
+            .context("skill path has no parent directory")?;
         fs::create_dir_all(skill_dir)
             .with_context(|| format!("failed to create directory {}", skill_dir.display()))?;
         fs::write(&skill_path, SKILL_CONTENT)
@@ -184,7 +184,7 @@ pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
         // Create the file and any parent directories.
         let claude_dir = claude_md_path
             .parent()
-            .expect("CLAUDE.md path always has a parent directory");
+            .context("CLAUDE.md path has no parent directory")?;
         fs::create_dir_all(claude_dir)
             .with_context(|| format!("failed to create directory {}", claude_dir.display()))?;
         let content = format!("{CLAUDE_MD_HINT}\n");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,303 @@
+#![allow(clippy::missing_errors_doc)]
+use anyhow::{Context, Result};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+use crate::output::CommandOutcome;
+
+// ---------------------------------------------------------------------------
+// Embedded skill content
+// ---------------------------------------------------------------------------
+
+const SKILL_CONTENT: &str = r#"---
+name: hyalo
+user_invocable: false
+description: >
+  Use the hyalo CLI instead of Read/Edit/Grep/Glob when working with markdown (.md) files
+  that have YAML frontmatter. This skill MUST be consulted whenever Claude is working with
+  markdown documentation directories, knowledgebases, wikis, notes, Obsidian-compatible
+  collections, Zettelkasten systems, iteration plans, or any collection of .md files with
+  frontmatter. Trigger this skill when: searching or filtering markdown files by content,
+  tags, or properties; reading or modifying YAML frontmatter; managing tags or metadata
+  across documents; toggling task checkboxes in markdown; getting an overview of a
+  documentation directory; querying document properties or status fields; bulk-updating
+  metadata across many markdown files; or when you find yourself repeatedly using
+  Grep/Glob/Read on .md files. Even if the user does not mention "hyalo" by name, use this
+  skill whenever the task involves structured markdown documents with frontmatter.
+---
+
+# Hyalo CLI — Preferred Tool for Markdown with Frontmatter
+
+Hyalo is a fast CLI for querying and mutating YAML frontmatter, tags, tasks, and structure
+in directories of markdown files. Its killer features are combined filtering (e.g.
+`hyalo find -e "regex" --property status!=done --tag feature`) which you can't easily
+replicate with Grep/Glob, and bulk mutations (`hyalo set --where-property`) that replace
+multiple Read + Edit calls.
+
+Filters combine freely — content regex + property conditions + tag + section + task status
+in a single call, something impossible with Grep/Glob alone:
+
+```bash
+hyalo find -e "pattern" --property status!=completed --tag iteration --section "Tasks" --task todo
+```
+
+Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports:
+
+```bash
+hyalo find --property status=in-progress --fields tasks \
+  --jq 'map({file, done: ([.tasks[] | select(.status == "x")] | length), total: (.tasks | length)})'
+```
+
+**Run `hyalo --help` and `hyalo <command> --help` to learn the full API.**
+
+## Setup (run once per project)
+
+ALWAYS run `which hyalo` as your very first step. Do not skip this.
+
+- **Not on PATH?** Inform the user: "The `hyalo` CLI is not installed. You can install it
+  from https://github.com/ractive/hyalo." Fall back to Read/Edit/Grep/Glob.
+- **On PATH?** Check for `.hyalo.toml` in the project root. If it exists, hyalo is
+  configured — the `dir` setting means you don't need `--dir` on every command.
+- **No `.hyalo.toml` but a directory with many `.md` files?** (e.g. `docs/`, `knowledgebase/`,
+  `wiki/`, `notes/`, `content/`, or any folder with 10+ markdown files) Suggest creating one:
+  ```toml
+  dir = "docs"
+  ```
+
+**After confirming hyalo works**, add a line to the project's `CLAUDE.md` so future
+conversations use hyalo without needing this skill:
+
+```
+Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.
+```
+
+This one-line instruction saves tokens in every future conversation.
+
+## When to use hyalo vs. built-in tools
+
+- **hyalo:** queries, frontmatter reads/mutations, tag management, task toggling, bulk updates
+- **Edit tool:** body prose changes (rewriting paragraphs) that hyalo can't handle
+- **Write tool:** creating brand new markdown files
+
+Start with `hyalo summary --format text` to orient yourself in a new directory.
+
+## Available commands
+
+- **find** — search/filter by text, regex, property, tag, task status
+- **read** — extract body content, a section, or line range
+- **summary** — directory overview: file counts, tags, tasks, recent files
+- **properties** — list property names and types
+- **tags** — list tags with counts
+- **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates)
+- **remove** — delete properties or tags
+- **append** — add to list properties
+- **task** — read, toggle, or set status on a single task checkbox
+
+## The --format text flag
+
+Use `--format text` for compact, low-token output designed for LLM consumption — less noise
+than JSON, fewer tokens. Reach for it when orienting yourself or scanning results.
+"#;
+
+const CLAUDE_MD_HINT: &str = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.";
+
+/// Common documentation directory names to scan for when no `--dir` is given.
+const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "content", "pages"];
+
+// ---------------------------------------------------------------------------
+// Public command entry point
+// ---------------------------------------------------------------------------
+
+/// Initialize hyalo configuration and optional Claude Code integration.
+///
+/// - `dir`: explicit value for the `dir` key in `.hyalo.toml`; when `None` the
+///   function auto-detects a common doc directory.
+/// - `claude`: when `true`, also installs the hyalo skill and appends a hint
+///   line to `.claude/CLAUDE.md`.
+pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
+    let cwd = std::env::current_dir().context("failed to determine current working directory")?;
+    let mut summary = String::new();
+
+    // ------------------------------------------------------------------
+    // Step 1: create .hyalo.toml
+    // ------------------------------------------------------------------
+    let toml_path = cwd.join(".hyalo.toml");
+    if toml_path.exists() {
+        writeln!(summary, "skipped  .hyalo.toml (already exists)").unwrap();
+    } else {
+        let dir_value = match dir {
+            Some(d) => d.to_owned(),
+            None => auto_detect_dir(&cwd),
+        };
+        let toml_content = format!("dir = \"{dir_value}\"\n");
+        fs::write(&toml_path, &toml_content)
+            .with_context(|| format!("failed to write {}", toml_path.display()))?;
+        writeln!(summary, "created  .hyalo.toml  (dir = \"{dir_value}\")").unwrap();
+    }
+
+    if !claude {
+        return Ok(CommandOutcome::Success(summary.trim_end().to_owned()));
+    }
+
+    // ------------------------------------------------------------------
+    // Step 2: create .claude/skills/hyalo/SKILL.md
+    // ------------------------------------------------------------------
+    let skill_path = cwd
+        .join(".claude")
+        .join("skills")
+        .join("hyalo")
+        .join("SKILL.md");
+    if skill_path.exists() {
+        writeln!(
+            summary,
+            "skipped  .claude/skills/hyalo/SKILL.md (already exists)"
+        )
+        .unwrap();
+    } else {
+        let skill_dir = skill_path
+            .parent()
+            .expect("skill path always has a parent directory");
+        fs::create_dir_all(skill_dir)
+            .with_context(|| format!("failed to create directory {}", skill_dir.display()))?;
+        fs::write(&skill_path, SKILL_CONTENT)
+            .with_context(|| format!("failed to write {}", skill_path.display()))?;
+        writeln!(summary, "created  .claude/skills/hyalo/SKILL.md").unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Step 3: append hyalo hint to .claude/CLAUDE.md (no duplicates)
+    // ------------------------------------------------------------------
+    let claude_md_path = cwd.join(".claude").join("CLAUDE.md");
+    if claude_md_path.exists() {
+        let existing = fs::read_to_string(&claude_md_path)
+            .with_context(|| format!("failed to read {}", claude_md_path.display()))?;
+        if existing.contains(CLAUDE_MD_HINT) {
+            writeln!(summary, "skipped  .claude/CLAUDE.md (hint already present)").unwrap();
+        } else {
+            let appended = append_line_to_file_content(&existing, CLAUDE_MD_HINT);
+            fs::write(&claude_md_path, appended)
+                .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
+            writeln!(summary, "updated  .claude/CLAUDE.md (appended hyalo hint)").unwrap();
+        }
+    } else {
+        // Create the file and any parent directories.
+        let claude_dir = claude_md_path
+            .parent()
+            .expect("CLAUDE.md path always has a parent directory");
+        fs::create_dir_all(claude_dir)
+            .with_context(|| format!("failed to create directory {}", claude_dir.display()))?;
+        let content = format!("{CLAUDE_MD_HINT}\n");
+        fs::write(&claude_md_path, content)
+            .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
+        writeln!(summary, "created  .claude/CLAUDE.md (with hyalo hint)").unwrap();
+    }
+
+    Ok(CommandOutcome::Success(summary.trim_end().to_owned()))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Scan CWD for the first common doc directory that exists and contains `.md` files.
+/// Falls back to `"."` if none found.
+fn auto_detect_dir(cwd: &Path) -> String {
+    for candidate in CANDIDATE_DIRS {
+        let candidate_path = cwd.join(candidate);
+        if candidate_path.is_dir() && dir_contains_md(&candidate_path) {
+            return (*candidate).to_owned();
+        }
+    }
+    ".".to_owned()
+}
+
+/// Returns `true` if `dir` contains at least one `.md` file (non-recursive).
+fn dir_contains_md(dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .path()
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("md"))
+    })
+}
+
+/// Append `line` to `content`, ensuring there is exactly one trailing newline before it
+/// and one after it.
+fn append_line_to_file_content(content: &str, line: &str) -> String {
+    let mut result = content.trim_end_matches('\n').to_owned();
+    result.push('\n');
+    result.push('\n');
+    result.push_str(line);
+    result.push('\n');
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_adds_blank_line_separator() {
+        let content = "# Existing\n\nSome content.\n";
+        let result = append_line_to_file_content(content, "New hint");
+        assert_eq!(result, "# Existing\n\nSome content.\n\nNew hint\n");
+    }
+
+    #[test]
+    fn append_handles_trailing_newlines() {
+        let content = "# Existing\n\n";
+        let result = append_line_to_file_content(content, "New hint");
+        assert_eq!(result, "# Existing\n\nNew hint\n");
+    }
+
+    #[test]
+    fn append_handles_empty_content() {
+        // Empty content: trim_end_matches('\n') leaves "", then we add \n + \n + hint + \n
+        let result = append_line_to_file_content("", "New hint");
+        assert_eq!(result, "\n\nNew hint\n");
+    }
+
+    #[test]
+    fn dir_contains_md_detects_md_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(!dir_contains_md(tmp.path()));
+        fs::write(tmp.path().join("note.md"), "# Hello").unwrap();
+        assert!(dir_contains_md(tmp.path()));
+    }
+
+    #[test]
+    fn auto_detect_dir_falls_back_to_dot() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, ".");
+    }
+
+    #[test]
+    fn auto_detect_dir_finds_docs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::write(tmp.path().join("docs").join("note.md"), "# Hello").unwrap();
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, "docs");
+    }
+
+    #[test]
+    fn auto_detect_dir_skips_empty_candidate() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // docs exists but is empty — should fall through to knowledgebase
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::create_dir_all(tmp.path().join("knowledgebase")).unwrap();
+        fs::write(tmp.path().join("knowledgebase").join("note.md"), "# Hello").unwrap();
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, "knowledgebase");
+    }
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -10,95 +10,7 @@ use crate::output::CommandOutcome;
 // Embedded skill content
 // ---------------------------------------------------------------------------
 
-const SKILL_CONTENT: &str = r#"---
-name: hyalo
-user_invocable: false
-description: >
-  Use the hyalo CLI instead of Read/Edit/Grep/Glob when working with markdown (.md) files
-  that have YAML frontmatter. This skill MUST be consulted whenever Claude is working with
-  markdown documentation directories, knowledgebases, wikis, notes, Obsidian-compatible
-  collections, Zettelkasten systems, iteration plans, or any collection of .md files with
-  frontmatter. Trigger this skill when: searching or filtering markdown files by content,
-  tags, or properties; reading or modifying YAML frontmatter; managing tags or metadata
-  across documents; toggling task checkboxes in markdown; getting an overview of a
-  documentation directory; querying document properties or status fields; bulk-updating
-  metadata across many markdown files; or when you find yourself repeatedly using
-  Grep/Glob/Read on .md files. Even if the user does not mention "hyalo" by name, use this
-  skill whenever the task involves structured markdown documents with frontmatter.
----
-
-# Hyalo CLI — Preferred Tool for Markdown with Frontmatter
-
-Hyalo is a fast CLI for querying and mutating YAML frontmatter, tags, tasks, and structure
-in directories of markdown files. Its killer features are combined filtering (e.g.
-`hyalo find -e "regex" --property status!=done --tag feature`) which you can't easily
-replicate with Grep/Glob, and bulk mutations (`hyalo set --where-property`) that replace
-multiple Read + Edit calls.
-
-Filters combine freely — content regex + property conditions + tag + section + task status
-in a single call, something impossible with Grep/Glob alone:
-
-```bash
-hyalo find -e "pattern" --property status!=completed --tag iteration --section "Tasks" --task todo
-```
-
-Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports:
-
-```bash
-hyalo find --property status=in-progress --fields tasks \
-  --jq 'map({file, done: ([.tasks[] | select(.status == "x")] | length), total: (.tasks | length)})'
-```
-
-**Run `hyalo --help` and `hyalo <command> --help` to learn the full API.**
-
-## Setup (run once per project)
-
-ALWAYS run `which hyalo` as your very first step. Do not skip this.
-
-- **Not on PATH?** Inform the user: "The `hyalo` CLI is not installed. You can install it
-  from https://github.com/ractive/hyalo." Fall back to Read/Edit/Grep/Glob.
-- **On PATH?** Check for `.hyalo.toml` in the project root. If it exists, hyalo is
-  configured — the `dir` setting means you don't need `--dir` on every command.
-- **No `.hyalo.toml` but a directory with many `.md` files?** (e.g. `docs/`, `knowledgebase/`,
-  `wiki/`, `notes/`, `content/`, or any folder with 10+ markdown files) Suggest creating one:
-  ```toml
-  dir = "docs"
-  ```
-
-**After confirming hyalo works**, add a line to the project's `CLAUDE.md` so future
-conversations use hyalo without needing this skill:
-
-```
-Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.
-```
-
-This one-line instruction saves tokens in every future conversation.
-
-## When to use hyalo vs. built-in tools
-
-- **hyalo:** queries, frontmatter reads/mutations, tag management, task toggling, bulk updates
-- **Edit tool:** body prose changes (rewriting paragraphs) that hyalo can't handle
-- **Write tool:** creating brand new markdown files
-
-Start with `hyalo summary --format text` to orient yourself in a new directory.
-
-## Available commands
-
-- **find** — search/filter by text, regex, property, tag, task status
-- **read** — extract body content, a section, or line range
-- **summary** — directory overview: file counts, tags, tasks, recent files
-- **properties** — list property names and types
-- **tags** — list tags with counts
-- **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates)
-- **remove** — delete properties or tags
-- **append** — add to list properties
-- **task** — read, toggle, or set status on a single task checkbox
-
-## The --format text flag
-
-Use `--format text` for compact, low-token output designed for LLM consumption — less noise
-than JSON, fewer tokens. Reach for it when orienting yourself or scanning results.
-"#;
+const SKILL_CONTENT: &str = include_str!("../../.claude/skills/hyalo/SKILL.md");
 
 const CLAUDE_MD_HINT: &str = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.";
 
@@ -130,7 +42,8 @@ pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
             Some(d) => d.to_owned(),
             None => auto_detect_dir(&cwd),
         };
-        let toml_content = format!("dir = \"{dir_value}\"\n");
+        let escaped = dir_value.replace('\\', "\\\\").replace('"', "\\\"");
+        let toml_content = format!("dir = \"{escaped}\"\n");
         fs::write(&toml_path, &toml_content)
             .with_context(|| format!("failed to write {}", toml_path.display()))?;
         writeln!(summary, "created  .hyalo.toml  (dir = \"{dir_value}\")").unwrap();
@@ -226,8 +139,8 @@ fn dir_contains_md(dir: &Path) -> bool {
     })
 }
 
-/// Append `line` to `content`, ensuring there is exactly one trailing newline before it
-/// and one after it.
+/// Append `line` to `content`, separated by a blank line. Strips trailing newlines from
+/// `content` first, then adds `\n\n` (blank-line separator) before `line` and a final `\n`.
 fn append_line_to_file_content(content: &str, line: &str) -> String {
     let mut result = content.trim_end_matches('\n').to_owned();
     result.push('\n');

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 pub mod append;
 pub mod find;
+pub mod init;
 pub mod outline;
 pub mod properties;
 pub mod read;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ use std::process;
 use clap::{Parser, Subcommand};
 
 use hyalo::commands::{
-    append as append_commands, find as find_commands, properties, read as read_commands,
-    remove as remove_commands, set as set_commands, summary as summary_commands,
-    tags as tag_commands, tasks as task_commands,
+    append as append_commands, find as find_commands, init as init_commands, properties,
+    read as read_commands, remove as remove_commands, set as set_commands,
+    summary as summary_commands, tags as tag_commands, tasks as task_commands,
 };
 use hyalo::filter;
 use hyalo::hints::{HintContext, HintSource, generate_hints};
@@ -396,6 +396,18 @@ Repeatable (AND).\n\
         #[arg(long = "where-tag", value_name = "TAG")]
         where_tags: Vec<String>,
     },
+    /// Initialize hyalo configuration and optional tool integrations
+    #[command(
+        long_about = "Create .hyalo.toml and optionally set up Claude Code integration.\n\n\
+            Without flags, creates a .hyalo.toml config file.\n\
+            With --claude, also installs the hyalo skill for Claude Code.\n\n\
+            Use the global --dir flag to specify the markdown directory to record in .hyalo.toml."
+    )]
+    Init {
+        /// Set up Claude Code integration (skill + CLAUDE.md hint)
+        #[arg(long)]
+        claude: bool,
+    },
     /// Append values to list properties in file(s) frontmatter, promoting scalars to lists
     #[command(
         long_about = "Append values to list properties in file(s) frontmatter.\n\n\
@@ -520,6 +532,27 @@ fn parse_where_filters(
 #[allow(clippy::too_many_lines)]
 fn main() {
     let cli = Cli::parse();
+
+    // `init` operates on CWD directly and needs no config or format resolution.
+    // Dispatch it before the rest of the setup.
+    // The global --dir flag is used as the dir value for .hyalo.toml.
+    if let Commands::Init { claude } = cli.command {
+        let init_dir = cli.dir.as_deref().and_then(|p| p.to_str());
+        match init_commands::run_init(init_dir, claude) {
+            Ok(CommandOutcome::Success(output)) => {
+                println!("{output}");
+                process::exit(0);
+            }
+            Ok(CommandOutcome::UserError(output)) => {
+                eprintln!("{output}");
+                process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("Error: {e}");
+                process::exit(2);
+            }
+        }
+    }
 
     // Load per-project config from .hyalo.toml in CWD
     let config = hyalo::config::load_config();
@@ -814,6 +847,8 @@ fn main() {
                 effective_format,
             )
         }
+        // `Init` is handled as an early return before this match is reached.
+        Commands::Init { .. } => unreachable!("Init is dispatched before this match reached"),
     };
 
     match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,20 +538,21 @@ fn main() {
     // The global --dir flag is used as the dir value for .hyalo.toml.
     if let Commands::Init { claude } = cli.command {
         let init_dir = cli.dir.as_deref().and_then(|p| p.to_str());
-        match init_commands::run_init(init_dir, claude) {
+        let code = match init_commands::run_init(init_dir, claude) {
             Ok(CommandOutcome::Success(output)) => {
                 println!("{output}");
-                process::exit(0);
+                0
             }
             Ok(CommandOutcome::UserError(output)) => {
                 eprintln!("{output}");
-                process::exit(1);
+                1
             }
             Err(e) => {
                 eprintln!("Error: {e}");
-                process::exit(2);
+                2
             }
-        }
+        };
+        process::exit(code);
     }
 
     // Load per-project config from .hyalo.toml in CWD

--- a/tests/e2e_init.rs
+++ b/tests/e2e_init.rs
@@ -1,0 +1,318 @@
+mod common;
+
+use common::hyalo;
+use std::fs;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// .hyalo.toml creation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_creates_hyalo_toml() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let toml_path = tmp.path().join(".hyalo.toml");
+    assert!(toml_path.exists(), ".hyalo.toml should have been created");
+
+    let content = fs::read_to_string(&toml_path).unwrap();
+    assert!(
+        content.contains("dir ="),
+        ".hyalo.toml should contain a dir setting; got: {content}"
+    );
+}
+
+#[test]
+fn init_does_not_overwrite_existing_toml() {
+    let tmp = TempDir::new().unwrap();
+    let original = "dir = \"my-vault\"\n";
+    fs::write(tmp.path().join(".hyalo.toml"), original).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("skipped"),
+        "expected 'skipped' in stdout; got: {stdout}"
+    );
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert_eq!(
+        content, original,
+        ".hyalo.toml should not have been modified"
+    );
+}
+
+#[test]
+fn init_with_dir_flag() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--dir", "docs"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        content.contains("dir = \"docs\""),
+        ".hyalo.toml should contain dir = \"docs\"; got: {content}"
+    );
+}
+
+#[test]
+fn init_auto_detects_docs_dir() {
+    let tmp = TempDir::new().unwrap();
+    // Create docs/ with a .md file so auto-detection picks it up
+    fs::create_dir_all(tmp.path().join("docs")).unwrap();
+    fs::write(tmp.path().join("docs").join("note.md"), "# Hello").unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        content.contains("dir = \"docs\""),
+        "should have auto-detected docs/; got: {content}"
+    );
+}
+
+#[test]
+fn init_falls_back_to_dot_when_no_doc_dir() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        content.contains("dir = \".\""),
+        "should have defaulted to .; got: {content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --claude flag: skill creation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_claude_creates_skill() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let skill_path = tmp
+        .path()
+        .join(".claude")
+        .join("skills")
+        .join("hyalo")
+        .join("SKILL.md");
+    assert!(skill_path.exists(), "SKILL.md should have been created");
+
+    let content = fs::read_to_string(&skill_path).unwrap();
+    assert!(
+        content.contains("hyalo"),
+        "SKILL.md should contain hyalo content; got: {content}"
+    );
+    assert!(
+        content.contains("name: hyalo"),
+        "SKILL.md should have frontmatter name field; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_skips_existing_skill() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join(".claude").join("skills").join("hyalo");
+    fs::create_dir_all(&skill_dir).unwrap();
+    let skill_path = skill_dir.join("SKILL.md");
+    let original = "---\nname: custom\n---\n";
+    fs::write(&skill_path, original).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("skipped"),
+        "expected 'skipped' in stdout for existing SKILL.md; got: {stdout}"
+    );
+
+    // Content should not have been overwritten
+    let content = fs::read_to_string(&skill_path).unwrap();
+    assert_eq!(content, original);
+}
+
+// ---------------------------------------------------------------------------
+// --claude flag: CLAUDE.md creation and update
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_claude_creates_claude_md() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let claude_md_path = tmp.path().join(".claude").join("CLAUDE.md");
+    assert!(
+        claude_md_path.exists(),
+        ".claude/CLAUDE.md should have been created"
+    );
+
+    let content = fs::read_to_string(&claude_md_path).unwrap();
+    assert!(
+        content.contains("hyalo"),
+        ".claude/CLAUDE.md should contain hyalo hint; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_appends_to_existing_claude_md() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    let claude_md_path = claude_dir.join("CLAUDE.md");
+    let original = "# Project Instructions\n\nSome existing content.\n";
+    fs::write(&claude_md_path, original).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("updated"),
+        "expected 'updated' in stdout; got: {stdout}"
+    );
+
+    let content = fs::read_to_string(&claude_md_path).unwrap();
+    // Original content must still be present
+    assert!(
+        content.contains("Some existing content."),
+        "original content should be preserved; got: {content}"
+    );
+    // Hint must have been appended
+    assert!(
+        content.contains("hyalo"),
+        "hyalo hint should have been appended; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_no_duplicate_in_claude_md() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    let claude_md_path = claude_dir.join("CLAUDE.md");
+    // Pre-populate with the exact hint line
+    let original = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.\n";
+    fs::write(&claude_md_path, original).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("skipped"),
+        "expected 'skipped' when hint already present; got: {stdout}"
+    );
+
+    // The file should still contain exactly one copy of the hint
+    let content = fs::read_to_string(&claude_md_path).unwrap();
+    let occurrences = content.matches("hyalo --help").count();
+    assert_eq!(
+        occurrences, 1,
+        "hint should appear exactly once; got {occurrences} times in: {content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Summary output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_prints_summary_of_actions() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(!stdout.is_empty(), "stdout should contain a summary");
+    // Should mention the toml and the skill at minimum
+    assert!(
+        stdout.contains(".hyalo.toml"),
+        "summary should mention .hyalo.toml; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("SKILL.md"),
+        "summary should mention SKILL.md; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("CLAUDE.md"),
+        "summary should mention CLAUDE.md; got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add a Claude Code skill (`.claude/skills/hyalo/SKILL.md`) that auto-triggers when Claude works with markdown documentation directories, teaching it to use `hyalo` CLI instead of raw Read/Grep/Glob tools
- Implement `hyalo init` command that bootstraps `.hyalo.toml` with auto-detected markdown directory
- Implement `hyalo init --claude` flag that additionally installs the skill and appends a usage hint to `.claude/CLAUDE.md`
- Add backlog item for future Claude Code plugin distribution

## Test plan

- [x] 11 e2e tests covering all init scenarios (config creation, dir auto-detect, claude flag, idempotency, no-duplicate hints)
- [x] 6 unit tests for init internals (doc dir detection, CLAUDE.md line appending)
- [x] All 755 existing tests still pass
- [x] `cargo fmt` + `cargo clippy` clean
- [x] `hyalo init --help` displays correct usage
- [ ] Manual: run `hyalo init --claude` in a fresh temp directory and verify all files created

🤖 Generated with [Claude Code](https://claude.com/claude-code)