### PR TITLE
Homebrew tap & distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,17 +160,30 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
+
+          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "ERROR: HOMEBREW_TAP_TOKEN secret is not set"
+            exit 1
+          fi
+
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
 
           get_sha() {
-            grep "$1" SHA256SUMS | awk '{print $1}'
+            awk -v file="$1" '$2 == file {print $1}' SHA256SUMS
           }
 
           SHA_MACOS_ARM64=$(get_sha "hyalo-aarch64-apple-darwin.tar.gz")
           SHA_MACOS_X86=$(get_sha "hyalo-x86_64-apple-darwin.tar.gz")
           SHA_LINUX_ARM64=$(get_sha "hyalo-aarch64-unknown-linux-gnu.tar.gz")
           SHA_LINUX_X86=$(get_sha "hyalo-x86_64-unknown-linux-gnu.tar.gz")
+
+          for var in SHA_MACOS_ARM64 SHA_MACOS_X86 SHA_LINUX_ARM64 SHA_LINUX_X86; do
+            if [ -z "${!var}" ]; then
+              echo "ERROR: missing SHA256 checksum for $var"
+              exit 1
+            fi
+          done
 
           cat > formula.rb <<FORMULA
           # typed: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
             cross: true
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 
@@ -139,3 +141,91 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ github.event.release.tag_name }}" artifacts/*
+
+  homebrew:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download SHA256SUMS from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ github.event.release.tag_name }}" \
+            --pattern "SHA256SUMS" --dir .
+
+      - name: Update Homebrew formula
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+
+          get_sha() {
+            grep "$1" SHA256SUMS | awk '{print $1}'
+          }
+
+          SHA_MACOS_ARM64=$(get_sha "hyalo-aarch64-apple-darwin.tar.gz")
+          SHA_MACOS_X86=$(get_sha "hyalo-x86_64-apple-darwin.tar.gz")
+          SHA_LINUX_ARM64=$(get_sha "hyalo-aarch64-unknown-linux-gnu.tar.gz")
+          SHA_LINUX_X86=$(get_sha "hyalo-x86_64-unknown-linux-gnu.tar.gz")
+
+          cat > formula.rb <<FORMULA
+          # typed: false
+          # frozen_string_literal: true
+
+          # Homebrew formula for hyalo — a CLI for exploring and managing Markdown knowledge bases.
+          # Auto-updated by the release workflow in ractive/hyalo.
+          class Hyalo < Formula
+            desc "CLI for exploring and managing Markdown knowledge bases"
+            homepage "https://github.com/ractive/hyalo"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/ractive/hyalo/releases/download/v#{version}/hyalo-aarch64-apple-darwin.tar.gz"
+                sha256 "${SHA_MACOS_ARM64}"
+              end
+
+              on_intel do
+                url "https://github.com/ractive/hyalo/releases/download/v#{version}/hyalo-x86_64-apple-darwin.tar.gz"
+                sha256 "${SHA_MACOS_X86}"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "https://github.com/ractive/hyalo/releases/download/v#{version}/hyalo-aarch64-unknown-linux-gnu.tar.gz"
+                sha256 "${SHA_LINUX_ARM64}"
+              end
+
+              on_intel do
+                url "https://github.com/ractive/hyalo/releases/download/v#{version}/hyalo-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "${SHA_LINUX_X86}"
+              end
+            end
+
+            def install
+              bin.install "hyalo"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/hyalo --version")
+            end
+          end
+          FORMULA
+
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' formula.rb
+
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ractive/homebrew-tap.git" tap
+          cp formula.rb tap/Formula/hyalo.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/hyalo.rb
+          git commit -m "Update hyalo to ${VERSION}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,5 +240,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/hyalo.rb
-          git commit -m "Update hyalo to ${VERSION}"
-          git push
+          if git diff --cached --quiet; then
+            echo "Formula unchanged, skipping commit"
+          else
+            git commit -m "Update hyalo to ${VERSION}"
+            git push
+          fi

--- a/AI_NOTICE
+++ b/AI_NOTICE
@@ -1,0 +1,9 @@
+AI-GENERATED CODE NOTICE
+
+This repository contains code that was generated in whole or in part by AI systems under human supervision.
+
+To the extent that any portions of this code are not subject to copyright protection under applicable law, those portions are provided without restriction. Where copyright does subsist, it is licensed under the terms below.
+
+No representation is made regarding the copyright status of any individual contribution.
+
+See LICENSE for the full license text.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hyalo"
 version = "0.1.0"
 edition = "2024"
+license = "MIT"
 publish = false
 
 [dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+AI-GENERATED CODE NOTICE
+
+This repository contains code that was generated in whole or in part by AI systems under human supervision.
+
+To the extent that any portions of this code are not subject to copyright protection under applicable law, those portions are provided without restriction. Where copyright does subsist, it is licensed under the terms below.
+
+No representation is made regarding the copyright status of any individual contribution.
+
+---
+
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,3 @@
-AI-GENERATED CODE NOTICE
-
-This repository contains code that was generated in whole or in part by AI systems under human supervision.
-
-To the extent that any portions of this code are not subject to copyright protection under applicable law, those portions are provided without restriction. Where copyright does subsist, it is licensed under the terms below.
-
-No representation is made regarding the copyright status of any individual contribution.
-
----
-
 MIT License
 
 Copyright (c) 2026 ractive

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ brew install ractive/tap/hyalo
 ### Cargo
 
 ```sh
-cargo install hyalo
+cargo install --git https://github.com/ractive/hyalo.git --locked
 ```
 
 ### Manual download

--- a/README.md
+++ b/README.md
@@ -271,6 +271,14 @@ cargo bench --bench vault                # vault-scale benchmarks (needs obsidia
 
 See `benches/README.md` for full setup, A/B comparison workflows, profiling with [samply](https://github.com/mstange/samply), and memory measurement.
 
+## Releasing
+
+1. Bump the version in `Cargo.toml`
+2. Commit: `git commit -am "Bump version to X.Y.Z"`
+3. Create a GitHub release with tag `vX.Y.Z` (must match `Cargo.toml`)
+
+The [release workflow](.github/workflows/release.yml) automatically builds binaries for all platforms, uploads them to the release, and updates the Homebrew formula.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 A self-contained command line tool for exploring and managing Markdown knowledge bases. Compatible with [Obsidian](https://obsidian.md/) vaults — no running Obsidian instance required.
 
+## Installation
+
+### Homebrew (macOS & Linux)
+
+```sh
+brew tap ractive/tap
+brew install ractive/tap/hyalo
+```
+
+### Cargo
+
+```sh
+cargo install hyalo
+```
+
+### Manual download
+
+Download pre-built binaries from the [GitHub Releases](https://github.com/ractive/hyalo/releases) page.
+
 ## Build
 
 ```sh

--- a/hyalo-knowledgebase/iterations/iteration-31-homebrew-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-31-homebrew-distribution.md
@@ -1,7 +1,7 @@
 ---
 branch: iter-31/homebrew-distribution
 date: 2026-03-23
-status: planned
+status: in-progress
 tags:
 - iteration
 - distribution
@@ -19,27 +19,27 @@ Set up a Homebrew tap so macOS (and Linux Homebrew) users can `brew install ract
 ## Tasks
 
 ### Create Homebrew tap repository
-- [ ] Create `ractive/homebrew-tap` repository on GitHub
-- [ ] Add initial `Formula/hyalo.rb` with placeholder version
-- [ ] Formula should download the correct binary for the platform (macOS ARM64, macOS x86_64, Linux x86_64)
-- [ ] Include SHA256 checksums (from the SHA256SUMS artifact added in iter-25)
+- [x] Create `ractive/homebrew-tap` repository on GitHub
+- [x] Add initial `Formula/hyalo.rb` with placeholder version
+- [x] Formula should download the correct binary for the platform (macOS ARM64, macOS x86_64, Linux x86_64)
+- [x] Include SHA256 checksums (from the SHA256SUMS artifact added in iter-25)
 
 ### Auto-update workflow
-- [ ] Add a job to the release workflow (`release.yml`) that updates the Homebrew formula after binaries are uploaded
-- [ ] Use `mislav/bump-homebrew-formula-action` or a custom script that:
+- [x] Add a job to the release workflow (`release.yml`) that updates the Homebrew formula after binaries are uploaded
+- [x] Use `mislav/bump-homebrew-formula-action` or a custom script that:
   - Downloads SHA256SUMS from the release
   - Updates version, URL, and sha256 in the formula
   - Commits and pushes to the tap repo
-- [ ] Requires a PAT or fine-grained token with push access to the tap repo
+- [x] Requires a PAT or fine-grained token with push access to the tap repo
 
 ### Test
-- [ ] `brew tap ractive/tap`
+- [x] `brew tap ractive/tap`
 - [ ] `brew install ractive/tap/hyalo`
 - [ ] `hyalo --help` works from Homebrew-installed binary
 - [ ] Test on both ARM64 and Intel Mac if possible
 
 ### Documentation
-- [ ] Add installation instructions to README.md (Homebrew, cargo install, manual download)
+- [x] Add installation instructions to README.md (Homebrew, cargo install, manual download)
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- Created `ractive/homebrew-tap` repository with `Formula/hyalo.rb` supporting macOS ARM64/x86_64 and Linux ARM64/x86_64
- Added `x86_64-apple-darwin` (macOS Intel) build target to the release matrix
- Added `homebrew` job to release workflow that auto-updates the formula with correct version and SHA256 checksums after each release
- Added MIT LICENSE file (matching hoppy project) and `license = "MIT"` to Cargo.toml
- Added Installation section to README with Homebrew, Cargo, and manual download methods

## Setup required
A `HOMEBREW_TAP_TOKEN` secret must be configured in the hyalo repo settings — a GitHub PAT (or fine-grained token) with push access to `ractive/homebrew-tap`.

## Test plan
- [x] `brew tap ractive/tap` succeeds and formula is recognized
- [x] `brew info ractive/tap/hyalo` shows correct metadata
- [ ] `brew install ractive/tap/hyalo` works after first release with real checksums
- [ ] Formula auto-updates on next GitHub Release
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass