### PR TITLE
Add --field backlinks to find command

### DIFF
--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -47,7 +47,8 @@ hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
 
 The `--fields` flag controls which data is returned. Available fields: `properties`,
 `properties-typed`, `tags`, `sections`, `tasks`, `links`, `backlinks`. All fields except
-`backlinks` are included by default. The `backlinks` field is opt-in because it requires
+`properties-typed` and `backlinks` are included by default. Both are opt-in: `properties-typed`
+returns a `[{name, type, value}]` array instead of a `{key: value}` map; `backlinks` requires
 scanning all files to build the link graph. Each backlink entry contains `source` (file path),
 `line` (line number), and an optional `label`.
 

--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -45,6 +45,18 @@ hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
 
 `--glob` supports negation with `!` prefix to exclude files: `--glob '!**/draft-*'`.
 
+The `--fields` flag controls which data is returned. Available fields: `properties`,
+`properties-typed`, `tags`, `sections`, `tasks`, `links`, `backlinks`. All fields except
+`backlinks` are included by default. The `backlinks` field is opt-in because it requires
+scanning all files to build the link graph. Each backlink entry contains `source` (file path),
+`line` (line number), and an optional `label`.
+
+```bash
+hyalo find --fields backlinks --file my-note.md       # see who links to this note
+hyalo find --fields backlinks --jq 'map(select(.backlinks | length == 0))' # find orphan notes
+hyalo find --fields properties,backlinks              # combine with other fields
+```
+
 Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports
 (requires JSON format — do not combine with `--format text`):
 

--- a/README.md
+++ b/README.md
@@ -138,10 +138,12 @@ hyalo find --file a.md --file b.md
 hyalo find --glob "notes/*.md"
 hyalo find --glob '!**/draft-*'      # exclude files matching a pattern (glob negation)
 
-# Control returned fields (default: all)
+# Control returned fields (default: all except backlinks)
 hyalo find --fields properties,tags
 hyalo find --fields sections,tasks,links
 hyalo find --fields properties-typed     # [{name, type, value}] array instead of {key: value} map
+hyalo find --fields backlinks --file my-note.md    # show who links to this note
+hyalo find --fields properties,backlinks           # combine with other fields
 
 # Sort and limit
 hyalo find --sort modified --limit 10

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ hyalo find --file a.md --file b.md
 hyalo find --glob "notes/*.md"
 hyalo find --glob '!**/draft-*'      # exclude files matching a pattern (glob negation)
 
-# Control returned fields (default: all except backlinks)
+# Control returned fields (default: all except properties-typed and backlinks)
 hyalo find --fields properties,tags
 hyalo find --fields sections,tasks,links
 hyalo find --fields properties-typed     # [{name, type, value}] array instead of {key: value} map

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -1661,8 +1661,8 @@ Just intro, no tasks section.
         let arr = parsed.as_array().unwrap();
         for entry in arr {
             assert!(
-                entry["backlinks"].is_null(),
-                "backlinks should not be included by default"
+                !entry.as_object().unwrap().contains_key("backlinks"),
+                "backlinks key should be absent by default, not just null"
             );
         }
     }

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -12,11 +12,12 @@ use hyalo_core::discovery;
 use hyalo_core::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField, extract_tags};
 use hyalo_core::frontmatter;
 use hyalo_core::heading::{SectionFilter, SectionRange, build_section_scope, in_scope};
+use hyalo_core::link_graph::LinkGraph;
 use hyalo_core::links::Link;
 use hyalo_core::scanner::{self, FileVisitor, FrontmatterCollector, ScanAction};
 use hyalo_core::tasks::TaskExtractor;
 use hyalo_core::types::{
-    ContentMatch, FileObject, FindTaskInfo, LinkInfo, OutlineSection, PropertyInfo,
+    BacklinkInfo, ContentMatch, FileObject, FindTaskInfo, LinkInfo, OutlineSection, PropertyInfo,
 };
 
 // ---------------------------------------------------------------------------
@@ -90,6 +91,14 @@ pub fn find(
     // Canonicalize the vault directory once so that resolve_target (called
     // per-link inside the loop) can avoid repeated canonicalization.
     let canonical_dir = discovery::canonicalize_vault_dir(dir)?;
+
+    // Build the link graph lazily — only when backlinks field is requested.
+    // This requires scanning all files in the vault so it's opt-in.
+    let link_graph = if fields.backlinks {
+        Some(LinkGraph::build(dir)?)
+    } else {
+        None
+    };
 
     let mut results: Vec<FileObject> = Vec::new();
 
@@ -221,6 +230,7 @@ pub fn find(
             link_collector,
             content_matches,
             &canonical_dir,
+            link_graph.as_ref(),
         );
 
         results.push(obj);
@@ -322,6 +332,7 @@ fn build_file_object(
     link_collector: Option<LinkCollector>,
     content_matches: Option<Vec<ContentMatch>>,
     canonical_dir: &Path,
+    link_graph: Option<&LinkGraph>,
 ) -> FileObject {
     let properties = if fields.properties {
         let mut map = serde_json::Map::new();
@@ -388,6 +399,24 @@ fn build_file_object(
 
     let matches: Option<Vec<ContentMatch>> = content_matches;
 
+    let backlinks = if fields.backlinks {
+        let entries = link_graph
+            .map(|graph| graph.backlinks(rel_path))
+            .unwrap_or_default();
+        Some(
+            entries
+                .into_iter()
+                .map(|e| BacklinkInfo {
+                    source: e.source.to_string_lossy().into_owned(),
+                    line: e.line,
+                    label: e.link.label.clone(),
+                })
+                .collect(),
+        )
+    } else {
+        None
+    };
+
     FileObject {
         file: rel_path.to_owned(),
         modified: modified.to_owned(),
@@ -397,6 +426,7 @@ fn build_file_object(
         sections,
         tasks,
         links,
+        backlinks,
         matches,
     }
 }
@@ -1095,6 +1125,7 @@ Just some text here.
             sections: false,
             tasks: false,
             links: false,
+            backlinks: false,
         };
         assert!(!needs_body(&fields, false, false, false));
     }
@@ -1108,6 +1139,7 @@ Just some text here.
             sections: false,
             tasks: false,
             links: false,
+            backlinks: false,
         };
         assert!(needs_body(&fields, true, false, false));
     }
@@ -1121,6 +1153,7 @@ Just some text here.
             sections: true,
             tasks: false,
             links: false,
+            backlinks: false,
         };
         assert!(needs_body(&fields, false, false, false));
     }
@@ -1394,6 +1427,7 @@ Just intro, no tasks section.
             sections: false,
             tasks: false,
             links: false,
+            backlinks: false,
         };
         assert!(needs_body(&fields, false, false, true));
         assert!(!needs_body(&fields, false, false, false));
@@ -1565,5 +1599,101 @@ Just intro, no tasks section.
             .expect("status property missing");
         assert_eq!(status["type"], "text");
         assert_eq!(status["value"], "planned");
+    }
+
+    // --- find: backlinks field ---
+
+    #[test]
+    fn find_fields_backlinks_shows_incoming_links() {
+        let tmp = setup_vault();
+        // alpha.md links to [[beta]], so beta should have a backlink from alpha
+        let fields = Fields::parse(&["backlinks".to_owned()]).unwrap();
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                None,
+                &[],
+                &[],
+                None,
+                &[],
+                &["beta.md".to_owned()],
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        let beta = &arr[0];
+        let backlinks = beta["backlinks"].as_array().unwrap();
+        assert_eq!(backlinks.len(), 1);
+        assert_eq!(backlinks[0]["source"], "alpha.md");
+        assert!(backlinks[0]["line"].as_u64().unwrap() > 0);
+    }
+
+    #[test]
+    fn find_fields_backlinks_not_included_by_default() {
+        let tmp = setup_vault();
+        let fields = Fields::default();
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                None,
+                &[],
+                &[],
+                None,
+                &[],
+                &[],
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        for entry in arr {
+            assert!(
+                entry["backlinks"].is_null(),
+                "backlinks should not be included by default"
+            );
+        }
+    }
+
+    #[test]
+    fn find_fields_backlinks_empty_when_no_incoming() {
+        let tmp = setup_vault();
+        // gamma has no frontmatter and nobody links to it
+        let fields = Fields::parse(&["backlinks".to_owned()]).unwrap();
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                None,
+                &[],
+                &[],
+                None,
+                &[],
+                &["gamma.md".to_owned()],
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        let gamma = &arr[0];
+        let backlinks = gamma["backlinks"].as_array().unwrap();
+        assert!(backlinks.is_empty());
     }
 }

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -406,10 +406,13 @@ fn build_file_object(
         Some(
             entries
                 .into_iter()
-                .map(|e| BacklinkInfo {
-                    source: e.source.to_string_lossy().into_owned(),
-                    line: e.line,
-                    label: e.link.label.clone(),
+                .map(|e| {
+                    let source = e.source.to_string_lossy().replace('\\', "/");
+                    BacklinkInfo {
+                        source,
+                        line: e.line,
+                        label: e.link.label.clone(),
+                    }
                 })
                 .collect(),
         )

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -247,7 +247,7 @@ enum Commands {
         /// Glob pattern to select files; prefix '!' to negate (e.g. '!**/draft-*' excludes matching files)
         #[arg(short, long, conflicts_with = "file")]
         glob: Option<String>,
-        /// Comma-separated list of optional fields to include: properties, properties-typed, tags, sections, tasks, links (default: all). 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array
+        /// Comma-separated list of optional fields to include: properties, properties-typed, tags, sections, tasks, links, backlinks (default: all except backlinks). 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files
         #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
         fields: Vec<String>,
         /// Sort order: 'file' (default) or 'modified'

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -247,7 +247,7 @@ enum Commands {
         /// Glob pattern to select files; prefix '!' to negate (e.g. '!**/draft-*' excludes matching files)
         #[arg(short, long, conflicts_with = "file")]
         glob: Option<String>,
-        /// Comma-separated list of optional fields to include: properties, properties-typed, tags, sections, tasks, links, backlinks (default: all except backlinks). 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files
+        /// Comma-separated list of optional fields to include: properties, properties-typed, tags, sections, tasks, links, backlinks (default: all except properties-typed and backlinks). 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files
         #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
         fields: Vec<String>,
         /// Sort order: 'file' (default) or 'modified'

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -584,8 +584,8 @@ fn find_fields_backlinks_not_included_by_default() {
 
     for entry in json.as_array().unwrap() {
         assert!(
-            entry["backlinks"].is_null(),
-            "backlinks should not be included by default"
+            !entry.as_object().unwrap().contains_key("backlinks"),
+            "backlinks key should be absent by default, not just null"
         );
     }
 }

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -528,6 +528,7 @@ fn find_fields_properties_and_tags_only() {
         assert!(entry["sections"].is_null(), "sections should be absent");
         assert!(entry["tasks"].is_null(), "tasks should be absent");
         assert!(entry["links"].is_null(), "links should be absent");
+        assert!(entry["backlinks"].is_null(), "backlinks should be absent");
     }
 }
 
@@ -555,6 +556,38 @@ fn find_fields_tasks_only() {
         alpha["tasks"].is_array(),
         "alpha should have tasks array when tasks field requested"
     );
+}
+
+#[test]
+fn find_fields_backlinks_shows_incoming_links() {
+    let tmp = setup_vault();
+    // alpha.md links to [[beta]], so beta should have a backlink from alpha
+    let (status, json, stderr) = find_json(&tmp, &["--fields", "backlinks", "--file", "beta.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let beta = &arr[0];
+    let backlinks = beta["backlinks"]
+        .as_array()
+        .expect("backlinks should be an array");
+    assert_eq!(backlinks.len(), 1, "beta should have 1 backlink from alpha");
+    assert_eq!(backlinks[0]["source"], "alpha.md");
+    assert!(backlinks[0]["line"].as_u64().unwrap() > 0);
+}
+
+#[test]
+fn find_fields_backlinks_not_included_by_default() {
+    let tmp = setup_vault();
+    let (status, json, stderr) = find_json(&tmp, &[]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    for entry in json.as_array().unwrap() {
+        assert!(
+            entry["backlinks"].is_null(),
+            "backlinks should not be included by default"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/filter.rs
+++ b/crates/hyalo-core/src/filter.rs
@@ -519,7 +519,8 @@ impl Fields {
     /// Parse a fields selection from a list of `--fields` argument values.
     ///
     /// Each element may be a comma-separated list of field names. An empty
-    /// slice returns the default (all fields enabled).
+    /// slice returns the default (all standard fields enabled; `properties-typed` and `backlinks`
+    /// are opt-in).
     pub fn parse(input: &[String]) -> Result<Fields> {
         if input.is_empty() {
             return Ok(Fields::default());

--- a/crates/hyalo-core/src/filter.rs
+++ b/crates/hyalo-core/src/filter.rs
@@ -497,6 +497,8 @@ pub struct Fields {
     pub sections: bool,
     pub tasks: bool,
     pub links: bool,
+    /// Backlinks are opt-in only: building the link graph requires scanning all files.
+    pub backlinks: bool,
 }
 
 impl Default for Fields {
@@ -508,6 +510,7 @@ impl Default for Fields {
             sections: true,
             tasks: true,
             links: true,
+            backlinks: false,
         }
     }
 }
@@ -529,6 +532,7 @@ impl Fields {
             sections: false,
             tasks: false,
             links: false,
+            backlinks: false,
         };
 
         for item in input {
@@ -544,8 +548,9 @@ impl Fields {
                     "sections" => fields.sections = true,
                     "tasks" => fields.tasks = true,
                     "links" => fields.links = true,
+                    "backlinks" => fields.backlinks = true,
                     unknown => bail!(
-                        "unknown field {:?}: valid fields are properties, properties-typed, tags, sections, tasks, links",
+                        "unknown field {:?}: valid fields are properties, properties-typed, tags, sections, tasks, links, backlinks",
                         unknown
                     ),
                 }

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -62,6 +62,16 @@ pub struct LinkInfo {
     pub label: Option<String>,
 }
 
+/// A single backlink: another file that links to this one.
+/// Used by `find` (backlinks field).
+#[derive(Debug, Clone, Serialize)]
+pub struct BacklinkInfo {
+    pub source: String,
+    pub line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Outline types
 // ---------------------------------------------------------------------------
@@ -195,6 +205,8 @@ pub struct FileObject {
     pub tasks: Option<Vec<FindTaskInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<LinkInfo>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backlinks: Option<Vec<BacklinkInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matches: Option<Vec<ContentMatch>>,
 }


### PR DESCRIPTION
## Summary
- Add `backlinks` as a new `--field` option for the `find` command, leveraging the in-memory link graph from iter-39
- The field is opt-in (not included by default) since it requires scanning all files to build the link graph
- Each backlink entry includes `source` (file path), `line` (line number), and optional `label`
- Update README.md and SKILL.md with documentation and usage examples

## Test plan
- [x] 3 unit tests: incoming links, not-included-by-default, empty-when-no-incoming
- [x] 2 e2e tests: backlinks shows incoming links, not included by default
- [x] Existing tests updated with `backlinks: false` field — all 327 tests pass
- [x] `cargo fmt` / `cargo clippy` / `cargo test` all clean