### PR TITLE
Fix backlinks fatal error on malformed frontmatter

### DIFF
--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -34,10 +34,13 @@ pub fn backlinks(dir: &Path, file_arg: &str, format: Format) -> Result<CommandOu
     };
 
     // Build the in-memory link graph
-    let graph = LinkGraph::build(dir)?;
+    let build = LinkGraph::build(dir)?;
+    for (path, msg) in &build.warnings {
+        eprintln!("warning: skipping {}: {msg}", path.display());
+    }
 
     // Look up backlinks — try with and without .md since wikilinks may use either
-    let entries = graph.backlinks(&rel);
+    let entries = build.graph.backlinks(&rel);
 
     let items: Vec<BacklinkItem> = entries
         .iter()

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -94,8 +94,14 @@ pub fn find(
 
     // Build the link graph lazily — only when backlinks field is requested.
     // This requires scanning all files in the vault so it's opt-in.
+    // Warnings for skipped files are emitted here; the per-file scan loop
+    // below will also skip these files independently, so no duplicates.
     let link_graph = if fields.backlinks {
-        Some(LinkGraph::build(dir)?)
+        let build = LinkGraph::build(dir)?;
+        for (path, msg) in &build.warnings {
+            eprintln!("warning: skipping {}: {msg}", path.display());
+        }
+        Some(build.graph)
     } else {
         None
     };

--- a/crates/hyalo-cli/tests/e2e_errors.rs
+++ b/crates/hyalo-cli/tests/e2e_errors.rs
@@ -176,6 +176,104 @@ title: OK
     );
 }
 
+/// `hyalo backlinks` must gracefully skip files with broken frontmatter
+/// instead of fatally erroring. Exit 0, warning on stderr, good files indexed.
+#[test]
+fn error_backlinks_malformed_yaml_graceful_skip() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "bad.md",
+        "---\nunclosed frontmatter without closing delimiter\n",
+    );
+    write_md(
+        tmp.path(),
+        "source.md",
+        md!(r"
+---
+title: Source
+---
+See [[target]]
+"),
+    );
+    write_md(
+        tmp.path(),
+        "target.md",
+        md!(r"
+---
+title: Target
+---
+# Target
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["backlinks", "--file", "target.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected graceful skip; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("warning: skipping"),
+        "expected warning on stderr; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("bad.md"),
+        "warning should name the bad file; got: {stderr}"
+    );
+
+    // The good link should still be found
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    let backlinks = json["backlinks"].as_array().unwrap();
+    assert_eq!(backlinks.len(), 1, "source.md should link to target.md");
+}
+
+/// `hyalo find --fields backlinks` must also gracefully skip broken files
+/// during link graph construction.
+#[test]
+fn error_find_backlinks_field_malformed_yaml_graceful_skip() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "bad.md",
+        "---\nunclosed frontmatter without closing delimiter\n",
+    );
+    write_md(
+        tmp.path(),
+        "good.md",
+        md!(r"
+---
+title: Good
+---
+# Good
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--fields", "backlinks"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected graceful skip; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("warning: skipping"),
+        "expected warning on stderr; got: {stderr}"
+    );
+}
+
 #[test]
 fn error_missing_md_extension() {
     let tmp = TempDir::new().unwrap();

--- a/crates/hyalo-cli/tests/e2e_errors.rs
+++ b/crates/hyalo-cli/tests/e2e_errors.rs
@@ -179,7 +179,7 @@ title: OK
 /// `hyalo backlinks` must gracefully skip files with broken frontmatter
 /// instead of fatally erroring. Exit 0, warning on stderr, good files indexed.
 #[test]
-fn error_backlinks_malformed_yaml_graceful_skip() {
+fn error_backlinks_unclosed_frontmatter_graceful_skip() {
     let tmp = TempDir::new().unwrap();
     write_md(
         tmp.path(),
@@ -238,7 +238,7 @@ title: Target
 /// `hyalo find --fields backlinks` must also gracefully skip broken files
 /// during link graph construction.
 #[test]
-fn error_find_backlinks_field_malformed_yaml_graceful_skip() {
+fn error_find_backlinks_field_unclosed_frontmatter_graceful_skip() {
     let tmp = TempDir::new().unwrap();
     write_md(
         tmp.path(),

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::missing_errors_doc)]
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 
 use crate::discovery;
+use crate::frontmatter;
 use crate::links::{Link, LinkKind, extract_links_from_text};
 use crate::scanner::{self, FileVisitor, ScanAction, strip_inline_code};
 
@@ -37,8 +38,15 @@ impl LinkGraph {
             let rel = file.strip_prefix(dir).unwrap_or(file).to_path_buf();
 
             let mut visitor = LinkGraphVisitor::new(rel);
-            scanner::scan_file_multi(file, &mut [&mut visitor])
-                .with_context(|| format!("scanning {}", file.display()))?;
+            match scanner::scan_file_multi(file, &mut [&mut visitor]) {
+                Ok(()) => {}
+                Err(e) if frontmatter::is_parse_error(&e) => {
+                    let rel_display = file.strip_prefix(dir).unwrap_or(file).display();
+                    eprintln!("warning: skipping {rel_display}: {e}");
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
 
             for (line, mut link) in visitor.links {
                 // Normalize markdown link targets that contain path separators
@@ -373,10 +381,46 @@ mod tests {
 
     #[test]
     fn malformed_frontmatter_skipped() {
-        // With needs_frontmatter=false, malformed YAML shouldn't cause errors
+        // With needs_frontmatter=false, malformed YAML is never parsed — no error
         let vault = create_vault(&[("a.md", "---\n: bad yaml [[\n---\n[[b]]\n")]);
         let graph = LinkGraph::build(vault.path()).unwrap();
         assert_eq!(graph.backlinks("b").len(), 1);
+    }
+
+    #[test]
+    fn unclosed_frontmatter_skipped() {
+        // Unclosed frontmatter triggers an error even with needs_frontmatter=false.
+        // The link graph builder should warn-and-skip, not fatally error.
+        let vault = create_vault(&[
+            ("good.md", "---\ntitle: Good\n---\n[[target]]\n"),
+            (
+                "bad.md",
+                "---\nunclosed frontmatter without closing delimiter\n",
+            ),
+            ("also_good.md", "---\ntitle: Also Good\n---\n[[target]]\n"),
+        ]);
+        let graph = LinkGraph::build(vault.path()).unwrap();
+
+        // Both good files should contribute their links
+        let bl = graph.backlinks("target");
+        assert_eq!(bl.len(), 2, "both good files should link to target");
+    }
+
+    #[test]
+    fn frontmatter_too_large_skipped() {
+        // A file with >100 frontmatter lines (no closing ---) should be skipped.
+        let mut huge_fm = String::from("---\n");
+        for i in 0..102 {
+            huge_fm.push_str(&format!("key{i}: value\n"));
+        }
+        // No closing ---, so scanner bails with "frontmatter too large"
+        huge_fm.push_str("[[target]]\n");
+
+        let vault = create_vault(&[("good.md", "[[target]]\n"), ("huge.md", &huge_fm)]);
+        let graph = LinkGraph::build(vault.path()).unwrap();
+
+        let bl = graph.backlinks("target");
+        assert_eq!(bl.len(), 1, "good file should still be indexed");
     }
 
     #[test]

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -37,12 +37,11 @@ impl LinkGraph {
         for file in &files {
             let rel = file.strip_prefix(dir).unwrap_or(file).to_path_buf();
 
-            let mut visitor = LinkGraphVisitor::new(rel);
+            let mut visitor = LinkGraphVisitor::new(rel.clone());
             match scanner::scan_file_multi(file, &mut [&mut visitor]) {
                 Ok(()) => {}
                 Err(e) if frontmatter::is_parse_error(&e) => {
-                    let rel_display = file.strip_prefix(dir).unwrap_or(file).display();
-                    eprintln!("warning: skipping {rel_display}: {e}");
+                    eprintln!("warning: skipping {}: {e}", rel.display());
                     continue;
                 }
                 Err(e) => return Err(e),
@@ -408,9 +407,10 @@ mod tests {
 
     #[test]
     fn frontmatter_too_large_skipped() {
-        // A file with >100 frontmatter lines (no closing ---) should be skipped.
+        // A file with >100 frontmatter content lines (no closing ---) should be skipped.
+        // MAX_FRONTMATTER_LINES is 100; 101 content lines triggers the error.
         let mut huge_fm = String::from("---\n");
-        for i in 0..102 {
+        for i in 0..101 {
             huge_fm.push_str(&format!("key{i}: value\n"));
         }
         // No closing ---, so scanner bails with "frontmatter too large"

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -19,6 +19,14 @@ pub struct BacklinkEntry {
     pub link: Link,
 }
 
+/// Result of building a link graph, including any files that were skipped.
+pub struct LinkGraphBuild {
+    /// The built link graph.
+    pub graph: LinkGraph,
+    /// Files that were skipped due to parse errors, with the error message.
+    pub warnings: Vec<(PathBuf, String)>,
+}
+
 /// In-memory reverse index mapping link targets to their sources.
 ///
 /// Keys are normalized target strings (as they appear in `[[target]]` or
@@ -30,9 +38,13 @@ pub struct LinkGraph {
 
 impl LinkGraph {
     /// Build a link graph by scanning all `.md` files under `dir`.
-    pub fn build(dir: &Path) -> Result<Self> {
+    ///
+    /// Files with malformed frontmatter are skipped and reported in
+    /// `LinkGraphBuild::warnings` so callers can decide how to surface them.
+    pub fn build(dir: &Path) -> Result<LinkGraphBuild> {
         let files = discovery::discover_files(dir)?;
         let mut index: HashMap<String, Vec<BacklinkEntry>> = HashMap::new();
+        let mut warnings: Vec<(PathBuf, String)> = Vec::new();
 
         for file in &files {
             let rel = file.strip_prefix(dir).unwrap_or(file).to_path_buf();
@@ -41,7 +53,7 @@ impl LinkGraph {
             match scanner::scan_file_multi(file, &mut [&mut visitor]) {
                 Ok(()) => {}
                 Err(e) if frontmatter::is_parse_error(&e) => {
-                    eprintln!("warning: skipping {}: {e}", rel.display());
+                    warnings.push((rel, e.to_string()));
                     continue;
                 }
                 Err(e) => return Err(e),
@@ -73,7 +85,10 @@ impl LinkGraph {
             }
         }
 
-        Ok(Self { index })
+        Ok(LinkGraphBuild {
+            graph: Self { index },
+            warnings,
+        })
     }
 
     /// Look up all files that link to the given target.
@@ -244,7 +259,8 @@ mod tests {
             ("b.md", "---\ntitle: B\n---\nSee [[a]] and [[c]]\n"),
             ("c.md", "---\ntitle: C\n---\nNo links here\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl_b = graph.backlinks("b");
         assert_eq!(bl_b.len(), 1);
@@ -270,7 +286,8 @@ mod tests {
             // `../a.md` from `sub/` resolves to `a.md` at the vault root.
             ("sub/b.md", "Back to [a](../a.md)\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         // Down-path links are stored normalized (no change needed).
         let bl = graph.backlinks("sub/b.md");
@@ -291,7 +308,8 @@ mod tests {
             ("assets/img.md", "# Image\n"),
             ("notes/page.md", "See [img](../assets/img.md)\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl = graph.backlinks("assets/img.md");
         assert_eq!(bl.len(), 1);
@@ -310,7 +328,8 @@ mod tests {
             ("target.md", "# Target\n"),
             ("sub/a.md", "[link](../target.md)\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl = graph.backlinks("target.md");
         assert_eq!(bl.len(), 1);
@@ -336,7 +355,8 @@ mod tests {
     #[test]
     fn build_graph_with_alias() {
         let vault = create_vault(&[("a.md", "See [[b|my note B]]\n")]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl = graph.backlinks("b");
         assert_eq!(bl.len(), 1);
@@ -349,7 +369,8 @@ mod tests {
             ("a.md", "Link to [[notes]]\n"),
             ("b.md", "Link to [text](notes.md)\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         // Query with .md finds both the .md link and the bare wikilink
         let bl = graph.backlinks("notes.md");
@@ -363,7 +384,8 @@ mod tests {
     #[test]
     fn links_inside_code_blocks_ignored() {
         let vault = create_vault(&[("a.md", "---\ntitle: A\n---\n```\n[[b]]\n```\nReal [[c]]\n")]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         assert!(graph.backlinks("b").is_empty());
         assert_eq!(graph.backlinks("c").len(), 1);
@@ -372,17 +394,19 @@ mod tests {
     #[test]
     fn links_inside_inline_code_ignored() {
         let vault = create_vault(&[("a.md", "Use `[[b]]` syntax and [[c]]\n")]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         assert!(graph.backlinks("b").is_empty());
         assert_eq!(graph.backlinks("c").len(), 1);
     }
 
     #[test]
-    fn malformed_frontmatter_skipped() {
-        // With needs_frontmatter=false, malformed YAML is never parsed — no error
+    fn malformed_yaml_ignored_when_frontmatter_not_needed() {
+        // With needs_frontmatter=false, malformed YAML is never parsed — file is still indexed
         let vault = create_vault(&[("a.md", "---\n: bad yaml [[\n---\n[[b]]\n")]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
         assert_eq!(graph.backlinks("b").len(), 1);
     }
 
@@ -398,10 +422,14 @@ mod tests {
             ),
             ("also_good.md", "---\ntitle: Also Good\n---\n[[target]]\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+
+        // Warning should mention the bad file
+        assert_eq!(build.warnings.len(), 1);
+        assert!(build.warnings[0].0.to_str().unwrap().contains("bad.md"));
 
         // Both good files should contribute their links
-        let bl = graph.backlinks("target");
+        let bl = build.graph.backlinks("target");
         assert_eq!(bl.len(), 2, "both good files should link to target");
     }
 
@@ -417,7 +445,8 @@ mod tests {
         huge_fm.push_str("[[target]]\n");
 
         let vault = create_vault(&[("good.md", "[[target]]\n"), ("huge.md", &huge_fm)]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl = graph.backlinks("target");
         assert_eq!(bl.len(), 1, "good file should still be indexed");
@@ -426,7 +455,8 @@ mod tests {
     #[test]
     fn empty_vault() {
         let vault = create_vault(&[]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
         assert!(graph.backlinks("anything").is_empty());
     }
 
@@ -479,7 +509,8 @@ mod tests {
                 "---\ntitle: Iter 1\n---\nSee [[backlog/item]]\n",
             ),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl = graph.backlinks("backlog/item");
         assert_eq!(bl.len(), 1, "backlinks('backlog/item') should find 1 link");
@@ -500,7 +531,8 @@ mod tests {
             ("backlog/item.md", "Content\n"),
             ("a.md", "See [[backlog/item.md]]\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl = graph.backlinks("backlog/item.md");
         assert_eq!(bl.len(), 1);
@@ -517,7 +549,8 @@ mod tests {
             ("other/target.md", "Content\n"),
             ("sub/source.md", "See [[other/target]]\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         // Must find the backlink via vault-relative path
         let bl = graph.backlinks("other/target");
@@ -540,7 +573,8 @@ mod tests {
             ("target.md", "Content\n"),
             ("sub/source.md", "See [link](../target.md)\n"),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl = graph.backlinks("target.md");
         assert_eq!(
@@ -562,7 +596,8 @@ mod tests {
                 "Wiki: [[docs/a]] and md: [link](../notes/b.md)\n",
             ),
         ]);
-        let graph = LinkGraph::build(vault.path()).unwrap();
+        let build = LinkGraph::build(vault.path()).unwrap();
+        let graph = build.graph;
 
         let bl_a = graph.backlinks("docs/a");
         assert_eq!(bl_a.len(), 1, "wikilink to docs/a should be found");

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -66,7 +66,11 @@ pub struct RewritePlan {
 /// `dir`.
 pub fn plan_mv(dir: &Path, old_rel: &str, new_rel: &str) -> Result<Vec<RewritePlan>> {
     // Step 1: build link graph to discover inbound links.
-    let graph = LinkGraph::build(dir).context("building link graph")?;
+    let build = LinkGraph::build(dir).context("building link graph")?;
+    for (path, msg) in &build.warnings {
+        eprintln!("warning: skipping {}: {msg}", path.display());
+    }
+    let graph = build.graph;
 
     let old_stem = old_rel.strip_suffix(".md").unwrap_or(old_rel);
     let new_stem = new_rel.strip_suffix(".md").unwrap_or(new_rel);

--- a/hyalo-knowledgebase/backlog/backlinks-fatal-on-malformed-frontmatter.md
+++ b/hyalo-knowledgebase/backlog/backlinks-fatal-on-malformed-frontmatter.md
@@ -1,0 +1,41 @@
+---
+title: "Backlinks scanner treats malformed frontmatter as fatal error"
+type: backlog
+date: 2026-03-25
+origin: dogfooding v0.3.1 against docs/content (3,517 files)
+priority: critical
+status: planned
+tags: [backlog, backlinks, robustness]
+---
+
+# Backlinks scanner treats malformed frontmatter as fatal error
+
+## Problem
+
+The `backlinks` command and `--fields backlinks` in `find` use a different code path (link graph builder) that treats malformed frontmatter as a hard error (exit code 2). All other commands (`find`, `summary`, `properties`, `tags`) gracefully skip broken files with stderr warnings.
+
+This makes backlinks completely unusable on any vault containing even one malformed file. The docs/content corpus (3,517 files) has 4 files with bad frontmatter — enough to block all backlinks operations.
+
+## Repro
+
+```bash
+hyalo backlinks --dir /path/to/docs/content --file actions/get-started/quickstart.md
+# => Error: scanning .../admin/index.md (exit 2)
+
+hyalo find --dir /path/to/docs/content --fields backlinks --jq 'length'
+# => same fatal error
+```
+
+Meanwhile `hyalo find --dir /path/to/docs/content --jq 'length'` works fine (skips the 4 bad files with warnings).
+
+## Proposed fix
+
+The link graph scanner should use the same graceful skip-and-warn strategy as the normal file scanner. When a file has malformed frontmatter, emit a warning to stderr, exclude it from the link graph, and continue processing.
+
+## Acceptance criteria
+
+- [ ] `backlinks` command completes on vaults with malformed files (warns and skips)
+- [ ] `--fields backlinks` in `find` completes on vaults with malformed files
+- [ ] Exit code is 0 when broken files are skipped
+- [ ] Warning messages include the file path
+- [ ] E2e test: backlinks on a vault with a broken file succeeds

--- a/hyalo-knowledgebase/backlog/glob-negation-escaping-bug.md
+++ b/hyalo-knowledgebase/backlog/glob-negation-escaping-bug.md
@@ -1,0 +1,46 @@
+---
+date: 2026-03-25
+origin: dogfooding v0.3.1 against vscode-docs/docs
+priority: medium
+status: not-a-bug
+tags:
+- backlog
+- bug
+- filtering
+- glob
+title: Glob negation !pattern broken — exclamation mark gets backslash-escaped
+type: backlog
+---
+
+# Glob negation !pattern broken
+
+## Problem
+
+`hyalo find --glob '!copilot/**/*.md'` fails with:
+
+```
+{"error": "no files match pattern", "path": "\\!copilot/**/*.md"}
+```
+
+The `!` prefix is being backslash-escaped before being passed to the glob matcher. The help text and cookbook both advertise glob negation as a feature, but it doesn't work.
+
+## Repro
+
+```bash
+hyalo find --dir /path/to/vscode-docs/docs --glob '!copilot/**/*.md'
+# => error: no files match pattern "\\!copilot/**/*.md"
+
+hyalo find --dir /path/to/vscode-docs/docs --glob '!copilot/'
+# => same error
+```
+
+## Proposed fix
+
+The glob negation parser should strip the `!` prefix before passing to the glob library, and invert the match result. Check whether the escaping happens in clap argument parsing or in hyalo's glob handling code.
+
+## Acceptance criteria
+
+- [ ] `--glob '!pattern'` correctly excludes matching files
+- [ ] Combining positive and negative globs works (e.g. `--glob 'copilot/**' --glob '!copilot/overview.md'`)
+- [ ] Help text example for negation actually works
+- [ ] E2e test covers glob negation

--- a/hyalo-knowledgebase/backlog/glob-negation-escaping-bug.md
+++ b/hyalo-knowledgebase/backlog/glob-negation-escaping-bug.md
@@ -34,13 +34,6 @@ hyalo find --dir /path/to/vscode-docs/docs --glob '!copilot/'
 # => same error
 ```
 
-## Proposed fix
+## Resolution
 
-The glob negation parser should strip the `!` prefix before passing to the glob library, and invert the match result. Check whether the escaping happens in clap argument parsing or in hyalo's glob handling code.
-
-## Acceptance criteria
-
-- [ ] `--glob '!pattern'` correctly excludes matching files
-- [ ] Combining positive and negative globs works (e.g. `--glob 'copilot/**' --glob '!copilot/overview.md'`)
-- [ ] Help text example for negation actually works
-- [ ] E2e test covers glob negation
+**Not a bug.** The `!` character triggers zsh history expansion when not properly quoted, and Claude Code's Bash tool was escaping it as `\!`. With proper single quotes (`'!pattern'`), glob negation works correctly. Verified in iteration 40.

--- a/hyalo-knowledgebase/iterations/iteration-40-backlinks-robustness.md
+++ b/hyalo-knowledgebase/iterations/iteration-40-backlinks-robustness.md
@@ -1,0 +1,44 @@
+---
+branch: iter-40/backlinks-robustness
+date: 2026-03-25
+status: in-progress
+tags:
+- iteration
+- backlinks
+- robustness
+- bug-fix
+title: Iteration 40 — Backlinks Robustness
+type: iteration
+---
+
+# Iteration 40 — Backlinks Robustness
+
+## Goal
+
+Make the backlinks/link-graph code path as robust as the rest of the scanner. Currently, `LinkGraph::build` treats any scan error as fatal via `?`, while every other command (`find`, `summary`) uses `is_parse_error` to warn-and-skip malformed files.
+
+## Backlog items
+
+- [[backlog/backlinks-fatal-on-malformed-frontmatter]] (critical)
+- ~~[[backlog/glob-negation-escaping-bug]]~~ — not a bug; glob negation works fine, the `!` was being shell-escaped by zsh history expansion
+
+## Tasks
+
+### Backlinks error recovery
+- [x] Identify where the link graph scanner diverges from the normal scanner's error handling
+- [x] Apply the same warn-and-skip strategy to the link graph builder
+- [x] `backlinks` command completes on vaults with malformed files
+- [x] `--fields backlinks` in `find` completes on vaults with malformed files
+- [x] Warning messages include file path, exit code is 0
+- [x] E2e test: backlinks on vault with a broken frontmatter file
+
+### Quality gates
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`
+- [ ] Dogfood: `hyalo find --fields backlinks --dir ../docs/content` succeeds
+
+## Acceptance Criteria
+
+- [ ] Backlinks works on docs/content (3,517 files, 4 malformed) without fatal errors
+- [x] All quality gates pass


### PR DESCRIPTION
## Summary

- `LinkGraph::build` treated any scan error as fatal via `?`, causing `backlinks` and `find --fields backlinks` to abort on vaults with even one malformed file
- Applied the same `is_parse_error` warn-and-skip pattern used by `find` and `summary` — broken files emit a stderr warning and are excluded from the link graph
- Closed backlog item `glob-negation-escaping-bug` as not-a-bug (shell escaping of `!` in zsh, not a hyalo issue)

## Test plan

- [x] Unit tests: `unclosed_frontmatter_skipped`, `frontmatter_too_large_skipped` — verify link graph builds successfully when vault contains broken files
- [x] E2e test: `backlinks` command on vault with broken frontmatter → exit 0, warning on stderr, good links indexed
- [x] E2e test: `find --fields backlinks` on vault with broken frontmatter → exit 0, warning on stderr
- [x] `cargo fmt` / `cargo clippy` / `cargo test --workspace` — all pass
- [ ] Dogfood: `hyalo find --fields backlinks --dir ../docs/content` on 3,517-file corpus with 4 malformed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)