### PR TITLE
Add orphan detection to summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ hyalo tags rename --from old-tag --to new-tag --glob "notes/*.md"
 
 ### summary
 
-High-level vault overview: file counts, property and tag aggregates, status groups, tasks, and recently modified files.
+High-level vault overview: file counts, property and tag aggregates, status groups, tasks, orphan files (no inbound links), and recently modified files.
 
 ```sh
 hyalo summary
@@ -213,6 +213,7 @@ hyalo summary --recent 5          # control how many recent files to show (defau
 hyalo summary --depth 1           # collapse subdirectories beyond depth 1
 hyalo summary --format text
 hyalo summary --jq '.tasks.total'
+hyalo summary --jq '.orphans.files'  # list files with no inbound links
 hyalo summary --format text --hints
 ```
 
@@ -373,6 +374,10 @@ Properties: 8 unique
 Tags: 15 unique
 Status: completed (10), in-progress (2), planned (2)
 Tasks: 89/174
+Orphans: 3
+  "backlog/old-idea.md"
+  "research/scratch.md"
+  "research/unused-ref.md"
 
   -> hyalo --dir . properties summary
   -> hyalo --dir . tags summary

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ hyalo tags rename --from old-tag --to new-tag --glob "notes/*.md"
 
 ### summary
 
-High-level vault overview: file counts, property and tag aggregates, status groups, tasks, orphan files (no inbound links), and recently modified files.
+High-level vault overview: file counts, property and tag aggregates, status groups, tasks, orphan files (fully isolated — no links in or out), and recently modified files.
 
 ```sh
 hyalo summary
@@ -213,7 +213,7 @@ hyalo summary --recent 5          # control how many recent files to show (defau
 hyalo summary --depth 1           # collapse subdirectories beyond depth 1
 hyalo summary --format text
 hyalo summary --jq '.tasks.total'
-hyalo summary --jq '.orphans.files'  # list files with no inbound links
+hyalo summary --jq '.orphans.files'  # list fully isolated files (no links in or out)
 hyalo summary --format text --hints
 ```
 

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -188,17 +188,19 @@ pub fn summary(
         })
         .collect();
 
-    // Build orphan list: files with no inbound links
+    // Build orphan list: files with no inbound AND no outbound links (fully isolated)
     let orphans = {
         let build = LinkGraph::build(dir)?;
         let targets = build.graph.all_targets();
+        let sources = build.graph.all_sources();
         let mut orphan_files: Vec<String> = files
             .iter()
             .map(|(_, rel)| rel.as_str())
             .filter(|rel| {
-                // Check both with and without .md extension against the target set
                 let without_md = rel.strip_suffix(".md").unwrap_or(rel);
-                !targets.contains(rel) && !targets.contains(without_md)
+                let has_inbound = targets.contains(rel) || targets.contains(without_md);
+                let has_outbound = sources.contains(*rel);
+                !has_inbound && !has_outbound
             })
             .map(String::from)
             .collect();

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -8,11 +8,12 @@ use crate::commands::{FilesOrOutcome, collect_files};
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::filter::extract_tags;
 use hyalo_core::frontmatter::{infer_type, yaml_to_json};
+use hyalo_core::link_graph::LinkGraph;
 use hyalo_core::scanner::{FrontmatterCollector, scan_file_multi};
 use hyalo_core::tasks::TaskCounter;
 use hyalo_core::types::{
-    DirectoryCount, FileCounts, PropertySummaryEntry, RecentFile, StatusGroup, TagSummary,
-    TagSummaryEntry, TaskCount, VaultSummary,
+    DirectoryCount, FileCounts, OrphanSummary, PropertySummaryEntry, RecentFile, StatusGroup,
+    TagSummary, TagSummaryEntry, TaskCount, VaultSummary,
 };
 
 /// Show a high-level vault summary.
@@ -187,8 +188,31 @@ pub fn summary(
         })
         .collect();
 
+    // Build orphan list: files with no inbound links
+    let orphans = {
+        let build = LinkGraph::build(dir)?;
+        let targets = build.graph.all_targets();
+        let mut orphan_files: Vec<String> = files
+            .iter()
+            .map(|(_, rel)| rel.as_str())
+            .filter(|rel| {
+                // Check both with and without .md extension against the target set
+                let without_md = rel.strip_suffix(".md").unwrap_or(rel);
+                !targets.contains(rel) && !targets.contains(without_md)
+            })
+            .map(String::from)
+            .collect();
+        orphan_files.sort();
+        let total = orphan_files.len();
+        OrphanSummary {
+            total,
+            files: orphan_files,
+        }
+    };
+
     let vault_summary = VaultSummary {
         files: file_counts,
+        orphans,
         properties,
         tags,
         status,

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::commands::{FilesOrOutcome, collect_files};
@@ -45,6 +45,8 @@ pub fn summary(
     let mut done_tasks: usize = 0;
     // (mtime_secs_as_i64_negated, rel_path) for sorting most-recent first
     let mut recent_entries: Vec<(i64, String)> = Vec::new();
+    // Track successfully processed files for orphan detection (excludes parse-error files)
+    let mut good_files: Vec<(PathBuf, PathBuf)> = Vec::new();
 
     for (full_path, rel_path) in &files {
         total_files += 1;
@@ -70,6 +72,7 @@ pub fn summary(
             }
             Err(e) => return Err(e),
         }
+        good_files.push((full_path.clone(), PathBuf::from(rel_path)));
         *dir_counts.entry(dir_key).or_insert(0) += 1;
         let props = fm.into_props();
         let TaskCount { total, done } = counter.into_count();
@@ -188,21 +191,25 @@ pub fn summary(
         })
         .collect();
 
-    // Build orphan list: files with no inbound AND no outbound links (fully isolated)
+    // Build orphan list: files with no inbound AND no outbound links (fully isolated).
+    // Reuses the already-collected file list to avoid a second directory traversal.
+    // Only considers successfully parsed files (excludes files skipped due to parse errors).
     let orphans = {
-        let build = LinkGraph::build(dir)?;
+        let build = LinkGraph::build_from_files(&good_files)
+            .context("failed to build link graph for orphan detection")?;
         let targets = build.graph.all_targets();
         let sources = build.graph.all_sources();
-        let mut orphan_files: Vec<String> = files
+        let mut orphan_files: Vec<String> = good_files
             .iter()
-            .map(|(_, rel)| rel.as_str())
+            .map(|(_, rel)| rel.to_string_lossy())
             .filter(|rel| {
-                let without_md = rel.strip_suffix(".md").unwrap_or(rel);
-                let has_inbound = targets.contains(rel) || targets.contains(without_md);
-                let has_outbound = sources.contains(*rel);
+                let rel_str: &str = rel.as_ref();
+                let without_md = rel_str.strip_suffix(".md").unwrap_or(rel_str);
+                let has_inbound = targets.contains(rel_str) || targets.contains(without_md);
+                let has_outbound = sources.contains(rel_str);
                 !has_inbound && !has_outbound
             })
-            .map(String::from)
+            .map(|rel| rel.into_owned())
             .collect();
         orphan_files.sort();
         let total = orphan_files.len();

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -192,11 +192,12 @@ pub fn summary(
         .collect();
 
     // Build orphan list: files with no inbound AND no outbound links (fully isolated).
-    // Reuses the already-collected file list to avoid a second directory traversal.
-    // Only considers successfully parsed files (excludes files skipped due to parse errors).
+    // The link graph is built vault-wide (not glob-filtered) so that links from files
+    // outside the glob still count — a file linked from anywhere is not an orphan.
+    // Orphan candidates are restricted to good_files (glob-scoped, parse-error-free).
     let orphans = {
-        let build = LinkGraph::build_from_files(&good_files)
-            .context("failed to build link graph for orphan detection")?;
+        let build =
+            LinkGraph::build(dir).context("failed to build link graph for orphan detection")?;
         let targets = build.graph.all_targets();
         let sources = build.graph.all_sources();
         let mut orphan_files: Vec<String> = good_files

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -201,7 +201,7 @@ const TASK_INFO_FILTER: &str =
 const TASK_READ_RESULT_FILTER: &str =
     r#""\"\(.file)\":\(.line) [\(.status)] \(.text)\(if .done then " (done)" else "" end)""#;
 
-/// `VaultSummary`: `{files, properties, recent_files, status, tags, tasks}`
+/// `VaultSummary`: `{files, orphans, properties, recent_files, status, tags, tasks}`
 const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nOrphans: \(.orphans.total)\(if (.orphans.files | length) > 0 then "\n\(.orphans.files | map("  \"\(.)\"") | join("\n"))" else "" end)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
 
 /// `FindTaskInfo`: `{done, line, section, status, text}`

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -202,7 +202,7 @@ const TASK_READ_RESULT_FILTER: &str =
     r#""\"\(.file)\":\(.line) [\(.status)] \(.text)\(if .done then " (done)" else "" end)""#;
 
 /// `VaultSummary`: `{files, properties, recent_files, status, tags, tasks}`
-const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
+const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nOrphans: \(.orphans.total)\(if (.orphans.files | length) > 0 then "\n\(.orphans.files | map("  \"\(.)\"") | join("\n"))" else "" end)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
 
 /// `FindTaskInfo`: `{done, line, section, status, text}`
 /// Format: `  [x] text (line N, section)` or `  [ ] text (line N, section)`
@@ -277,7 +277,7 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         // TaskReadResult
         "done,file,line,status,text" => Some(TASK_READ_RESULT_FILTER),
         // VaultSummary
-        "files,properties,recent_files,status,tags,tasks" => Some(VAULT_SUMMARY_FILTER),
+        "files,orphans,properties,recent_files,status,tags,tasks" => Some(VAULT_SUMMARY_FILTER),
         // Mutation results with property + value (SetPropertyResult, AppendPropertyResult,
         // RemovePropertyResult with value)
         "modified,property,scanned,skipped,total,value" => Some(PROPERTY_VALUE_MUTATION_FILTER),

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -555,7 +555,8 @@ fn summary_json_has_orphans_field() {
 fn summary_orphans_detects_unlinked_files() {
     let tmp = TempDir::new().unwrap();
 
-    // a.md links to b, so b is NOT an orphan. a and c are orphans (nothing links to them).
+    // a.md links to b, so a has outbound (not orphan) and b has inbound (not orphan).
+    // Only c.md is fully isolated (no links in or out).
     write_md(
         tmp.path(),
         "a.md",

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -603,12 +603,19 @@ No links to me
     let orphans = json["orphans"]["files"].as_array().unwrap();
     let orphan_paths: Vec<&str> = orphans.iter().map(|v| v.as_str().unwrap()).collect();
 
-    // a.md and c.md are orphans (nothing links to them)
-    assert!(orphan_paths.contains(&"a.md"), "a.md should be orphan");
+    // c.md is the only orphan: no inbound AND no outbound links
     assert!(orphan_paths.contains(&"c.md"), "c.md should be orphan");
-    // b.md is linked from a.md, so NOT an orphan
-    assert!(!orphan_paths.contains(&"b.md"), "b.md should NOT be orphan");
-    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 2);
+    // a.md has outbound links (to b), so NOT an orphan
+    assert!(
+        !orphan_paths.contains(&"a.md"),
+        "a.md should NOT be orphan (has outbound)"
+    );
+    // b.md has inbound links (from a), so NOT an orphan
+    assert!(
+        !orphan_paths.contains(&"b.md"),
+        "b.md should NOT be orphan (has inbound)"
+    );
+    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 1);
 }
 
 #[test]

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -762,6 +762,80 @@ fn summary_orphans_empty_vault() {
 }
 
 // ---------------------------------------------------------------------------
+// Orphan + glob interaction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_orphans_glob_uses_vault_wide_links() {
+    let tmp = TempDir::new().unwrap();
+
+    // root.md (outside glob) links to notes/a.md (inside glob).
+    // notes/b.md has no links at all.
+    write_md(
+        tmp.path(),
+        "root.md",
+        md!(r"
+---
+title: Root
+---
+See [[notes/a]]
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes/a.md",
+        md!(r"
+---
+title: A
+---
+Content
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes/b.md",
+        md!(r"
+---
+title: B
+---
+No links
+"),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--glob",
+            "notes/*.md",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Summary only counts glob-matched files
+    assert_eq!(json["files"]["total"].as_u64().unwrap(), 2);
+
+    let orphans = json["orphans"]["files"].as_array().unwrap();
+    let orphan_paths: Vec<&str> = orphans.iter().map(|v| v.as_str().unwrap()).collect();
+
+    // notes/a.md is linked from root.md (outside glob) — NOT an orphan
+    assert!(
+        !orphan_paths.contains(&"notes/a.md"),
+        "notes/a.md should NOT be orphan (linked from outside glob)"
+    );
+    // notes/b.md has no links in or out — orphan
+    assert!(
+        orphan_paths.contains(&"notes/b.md"),
+        "notes/b.md should be orphan"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Glob negation
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -357,6 +357,7 @@ fn summary_text_format() {
     assert!(text.contains("Tags:"));
     assert!(text.contains("Status:"));
     assert!(text.contains("Tasks: 2/4"));
+    assert!(text.contains("Orphans:"));
     assert!(text.contains("Recent:"));
 }
 
@@ -524,6 +525,232 @@ fn summary_recent_zero() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert!(json["recent_files"].as_array().unwrap().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Glob negation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_json_has_orphans_field() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["orphans"]["total"].is_number());
+    assert!(json["orphans"]["files"].is_array());
+}
+
+#[test]
+fn summary_orphans_detects_unlinked_files() {
+    let tmp = TempDir::new().unwrap();
+
+    // a.md links to b, so b is NOT an orphan. a and c are orphans (nothing links to them).
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+See [[b]]
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+Content
+"),
+    );
+    write_md(
+        tmp.path(),
+        "c.md",
+        md!(r"
+---
+title: C
+---
+No links to me
+"),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let orphans = json["orphans"]["files"].as_array().unwrap();
+    let orphan_paths: Vec<&str> = orphans.iter().map(|v| v.as_str().unwrap()).collect();
+
+    // a.md and c.md are orphans (nothing links to them)
+    assert!(orphan_paths.contains(&"a.md"), "a.md should be orphan");
+    assert!(orphan_paths.contains(&"c.md"), "c.md should be orphan");
+    // b.md is linked from a.md, so NOT an orphan
+    assert!(!orphan_paths.contains(&"b.md"), "b.md should NOT be orphan");
+    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 2);
+}
+
+#[test]
+fn summary_orphans_no_orphans_when_all_linked() {
+    let tmp = TempDir::new().unwrap();
+
+    // Circular links: a→b, b→a — neither is an orphan
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+See [[b]]
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+See [[a]]
+"),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 0);
+    assert!(json["orphans"]["files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn summary_orphans_all_orphans_when_no_links() {
+    let tmp = TempDir::new().unwrap();
+
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+No links
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+No links
+"),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Both files are orphans
+    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 2);
+    assert_eq!(json["orphans"]["files"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn summary_orphans_text_format() {
+    let tmp = TempDir::new().unwrap();
+
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+No links
+"),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let text = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        text.contains("Orphans: 1"),
+        "expected 'Orphans: 1' in: {text}"
+    );
+    assert!(
+        text.contains("\"a.md\""),
+        "expected orphan file listed in: {text}"
+    );
+}
+
+#[test]
+fn summary_orphans_empty_vault() {
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 0);
+    assert!(json["orphans"]["files"].as_array().unwrap().is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -92,10 +92,19 @@ impl LinkGraph {
     }
 
     /// Return the set of all normalized link targets that have at least one
-    /// inbound link.  Used by `summary` to compute orphan files (files that
-    /// nothing links to).
+    /// inbound link.
     pub fn all_targets(&self) -> HashSet<&str> {
         self.index.keys().map(String::as_str).collect()
+    }
+
+    /// Return the set of all files that contain at least one outbound link.
+    /// Paths are vault-relative (e.g. `"notes/a.md"`).
+    pub fn all_sources(&self) -> HashSet<String> {
+        self.index
+            .values()
+            .flatten()
+            .map(|entry| entry.source.to_string_lossy().into_owned())
+            .collect()
     }
 
     /// Look up all files that link to the given target.

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 
 use crate::discovery;
@@ -89,6 +89,13 @@ impl LinkGraph {
             graph: Self { index },
             warnings,
         })
+    }
+
+    /// Return the set of all normalized link targets that have at least one
+    /// inbound link.  Used by `summary` to compute orphan files (files that
+    /// nothing links to).
+    pub fn all_targets(&self) -> HashSet<&str> {
+        self.index.keys().map(String::as_str).collect()
     }
 
     /// Look up all files that link to the given target.

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -43,17 +43,30 @@ impl LinkGraph {
     /// `LinkGraphBuild::warnings` so callers can decide how to surface them.
     pub fn build(dir: &Path) -> Result<LinkGraphBuild> {
         let files = discovery::discover_files(dir)?;
+        let pairs: Vec<(PathBuf, PathBuf)> = files
+            .into_iter()
+            .map(|f| {
+                let rel = f.strip_prefix(dir).unwrap_or(&f).to_path_buf();
+                (f, rel)
+            })
+            .collect();
+        Self::build_from_files(&pairs)
+    }
+
+    /// Build a link graph from a pre-collected list of `(absolute_path, relative_path)` pairs.
+    ///
+    /// Use this when the caller already has the file list (e.g. from `collect_files`)
+    /// to avoid a redundant directory traversal.
+    pub fn build_from_files(files: &[(PathBuf, PathBuf)]) -> Result<LinkGraphBuild> {
         let mut index: HashMap<String, Vec<BacklinkEntry>> = HashMap::new();
         let mut warnings: Vec<(PathBuf, String)> = Vec::new();
 
-        for file in &files {
-            let rel = file.strip_prefix(dir).unwrap_or(file).to_path_buf();
-
+        for (full_path, rel) in files {
             let mut visitor = LinkGraphVisitor::new(rel.clone());
-            match scanner::scan_file_multi(file, &mut [&mut visitor]) {
+            match scanner::scan_file_multi(full_path, &mut [&mut visitor]) {
                 Ok(()) => {}
                 Err(e) if frontmatter::is_parse_error(&e) => {
-                    warnings.push((rel, e.to_string()));
+                    warnings.push((rel.clone(), e.to_string()));
                     continue;
                 }
                 Err(e) => return Err(e),
@@ -93,17 +106,21 @@ impl LinkGraph {
 
     /// Return the set of all normalized link targets that have at least one
     /// inbound link.
-    pub fn all_targets(&self) -> HashSet<&str> {
-        self.index.keys().map(String::as_str).collect()
+    pub fn all_targets(&self) -> HashSet<String> {
+        self.index.keys().cloned().collect()
     }
 
     /// Return the set of all files that contain at least one outbound link.
-    /// Paths are vault-relative (e.g. `"notes/a.md"`).
+    /// Paths are vault-relative with forward slashes (e.g. `"notes/a.md"`).
     pub fn all_sources(&self) -> HashSet<String> {
         self.index
             .values()
             .flatten()
-            .map(|entry| entry.source.to_string_lossy().into_owned())
+            .map(|entry| {
+                // Normalize to forward slashes for consistent cross-platform comparison
+                // with vault-relative paths from discovery.
+                entry.source.to_string_lossy().replace('\\', "/")
+            })
             .collect()
     }
 

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -129,11 +129,19 @@ pub struct TaskReadResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct VaultSummary {
     pub files: FileCounts,
+    pub orphans: OrphanSummary,
     pub properties: Vec<PropertySummaryEntry>,
     pub tags: TagSummary,
     pub status: Vec<StatusGroup>,
     pub tasks: TaskCount,
     pub recent_files: Vec<RecentFile>,
+}
+
+/// Files with no inbound links (nothing links to them).
+#[derive(Debug, Clone, Serialize)]
+pub struct OrphanSummary {
+    pub total: usize,
+    pub files: Vec<String>,
 }
 
 /// File counts by directory.

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -137,7 +137,8 @@ pub struct VaultSummary {
     pub recent_files: Vec<RecentFile>,
 }
 
-/// Files with no inbound links (nothing links to them).
+/// Fully isolated files: no inbound links (nothing links to them) and no
+/// outbound links (they don't link to anything).
 #[derive(Debug, Clone, Serialize)]
 pub struct OrphanSummary {
     pub total: usize,

--- a/hyalo-knowledgebase/backlog/date-aware-comparison.md
+++ b/hyalo-knowledgebase/backlog/date-aware-comparison.md
@@ -1,14 +1,14 @@
 ---
-title: "Date-aware property comparison"
-type: backlog
 date: 2026-03-23
-status: planned
-priority: low
 origin: dogfooding vscode-docs vault
+priority: low
+status: wont-do
 tags:
-  - backlog
-  - cli
-  - filtering
+- backlog
+- cli
+- filtering
+title: Date-aware property comparison
+type: backlog
 ---
 
 # Date-aware property comparison

--- a/hyalo-knowledgebase/iterations/iteration-43-data-quality.md
+++ b/hyalo-knowledgebase/iterations/iteration-43-data-quality.md
@@ -1,31 +1,35 @@
 ---
-title: "Iteration 43 — Data Quality & Write Fidelity"
-type: iteration
+branch: iter-43/data-quality
 date: 2026-03-25
 status: planned
-branch: iter-43/data-quality
-tags: [iteration, data-quality, frontmatter, filtering]
+tags:
+- iteration
+- data-quality
+- frontmatter
+title: Iteration 43 — Data Quality & Write Fidelity
+type: iteration
 ---
 
 # Iteration 43 — Data Quality & Write Fidelity
 
 ## Goal
 
-Improve data quality tooling and write fidelity: date-aware property comparisons, inconsistency detection for controlled-vocabulary properties, and reduced frontmatter reformatting on mutations.
+Improve data quality tooling and write fidelity: orphan detection in summary, inconsistency detection for controlled-vocabulary properties, and reduced frontmatter reformatting on mutations.
 
 ## Backlog items
 
-- [[backlog/date-aware-comparison]] (low)
 - [[backlog/status-inconsistency-detection]] (low)
 - [[backlog/frontmatter-reformatting]] (low)
 
 ## Tasks
 
-### Date-aware comparison
-- [ ] Detect date-like values on both sides of property comparisons
-- [ ] Parse common date formats (ISO 8601, MM/DD/YYYY, YYYY-MM-DD)
-- [ ] Compare as dates when both sides parse successfully, fall back to string comparison
-- [ ] E2e test: date comparisons produce chronologically correct results
+### Orphan detection in summary
+- [x] Add `all_targets()` method to `LinkGraph`
+- [x] Add `OrphanSummary` type and extend `VaultSummary`
+- [x] Compute orphans (files with no inbound links) in summary command
+- [x] Update text formatter to display orphans
+- [x] E2e tests for orphan detection
+- [x] Update README documentation
 
 ### Status inconsistency detection
 - [ ] Add lint/validation mode (e.g. `hyalo lint` or `hyalo properties --warn-rare`)
@@ -45,7 +49,7 @@ Improve data quality tooling and write fidelity: date-aware property comparisons
 
 ## Acceptance Criteria
 
-- [ ] Date comparisons work correctly on non-ISO date formats
+- [x] Orphan files (no inbound links) reported in summary
 - [ ] Inconsistency detection flags rare property values
 - [ ] Frontmatter key order preserved on mutation
 - [ ] All quality gates pass

--- a/hyalo-knowledgebase/iterations/iteration-43-data-quality.md
+++ b/hyalo-knowledgebase/iterations/iteration-43-data-quality.md
@@ -26,7 +26,7 @@ Improve data quality tooling and write fidelity: orphan detection in summary, in
 ### Orphan detection in summary
 - [x] Add `all_targets()` method to `LinkGraph`
 - [x] Add `OrphanSummary` type and extend `VaultSummary`
-- [x] Compute orphans (files with no inbound links) in summary command
+- [x] Compute orphans (fully isolated files — no links in or out) in summary command
 - [x] Update text formatter to display orphans
 - [x] E2e tests for orphan detection
 - [x] Update README documentation
@@ -49,7 +49,7 @@ Improve data quality tooling and write fidelity: orphan detection in summary, in
 
 ## Acceptance Criteria
 
-- [x] Orphan files (no inbound links) reported in summary
+- [x] Fully isolated orphan files (no links in or out) reported in summary
 - [ ] Inconsistency detection flags rare property values
 - [ ] Frontmatter key order preserved on mutation
 - [ ] All quality gates pass


### PR DESCRIPTION
## Summary
- Add orphan file detection (fully isolated files — no inbound AND no outbound links) to `hyalo summary`
- Extend `LinkGraph` with `all_targets()` and `all_sources()` methods to identify connected files
- Add `OrphanSummary` type to `VaultSummary` with total count and file list, rendered in both JSON and text formats
- Remove date-aware comparison from iteration 43 scope (marked wont-do in backlog)

## Test plan
- [x] 6 new e2e tests: orphan detection, no orphans, all orphans, text format, empty vault, JSON field presence
- [x] Existing `summary_text_format` test updated to assert `Orphans:` line
- [x] All 385+ unit tests pass
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all clean
- [x] Manual dogfood: `hyalo summary --format text` on hyalo-knowledgebase reports 34 orphan files

🤖 Generated with [Claude Code](https://claude.com/claude-code)