### PR TITLE
Fix 7 bugs found dogfooding against real-world vaults

### DIFF
--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -242,6 +242,7 @@ pub fn find(
             content_matches,
             &canonical_dir,
             link_graph.as_ref(),
+            site_prefix,
         );
 
         results.push(obj);
@@ -344,6 +345,7 @@ fn build_file_object(
     content_matches: Option<Vec<ContentMatch>>,
     canonical_dir: &Path,
     link_graph: Option<&LinkGraph>,
+    site_prefix: Option<&str>,
 ) -> FileObject {
     let properties = if fields.properties {
         let mut map = serde_json::Map::new();
@@ -395,7 +397,7 @@ fn build_file_object(
             lc.into_links()
                 .into_iter()
                 .map(|link| {
-                    let path = discovery::resolve_target(canonical_dir, &link.target);
+                    let path = discovery::resolve_target(canonical_dir, &link.target, site_prefix);
                     LinkInfo {
                         target: link.target,
                         path,

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -59,6 +59,10 @@ pub fn find(
         FilesOrOutcome::Outcome(o) => return Ok(o),
     };
 
+    // Normalize empty / whitespace-only pattern to None so that
+    // `hyalo find ""` behaves the same as `hyalo find` (no filter).
+    let pattern = pattern.and_then(|p| if p.trim().is_empty() { None } else { Some(p) });
+
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
     let has_section_filter = !section_filters.is_empty();
@@ -461,10 +465,11 @@ impl LinkCollector {
 }
 
 impl FileVisitor for LinkCollector {
-    fn on_body_line(&mut self, _raw: &str, cleaned: &str, _line_num: usize) -> ScanAction {
-        // Use `cleaned` (inline code spans stripped) so that links inside
-        // backtick spans are not extracted.
-        hyalo_core::links::extract_links_from_text(cleaned, &mut self.links);
+    fn on_body_line(&mut self, raw: &str, cleaned: &str, _line_num: usize) -> ScanAction {
+        // Use `cleaned` for structural parsing (so links inside backtick spans
+        // are not extracted) but `raw` for label text (so backtick-wrapped
+        // content like [`file.ts`](path) is preserved).
+        hyalo_core::links::extract_links_from_text_with_original(cleaned, raw, &mut self.links);
         ScanAction::Continue
     }
 }
@@ -852,6 +857,134 @@ Just some text here.
         for entry in arr {
             assert!(entry["matches"].is_null(), "matches should be absent");
         }
+    }
+
+    // --- find: empty / whitespace pattern treated as no-filter ---
+
+    /// A vault with two files: one with body content and one with an empty body.
+    fn setup_vault_with_empty_body() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+
+        fs::write(
+            tmp.path().join("has_body.md"),
+            md!(r"
+---
+title: Has Body
+---
+Some content here.
+"),
+        )
+        .unwrap();
+
+        fs::write(
+            tmp.path().join("empty_body.md"),
+            md!(r"
+---
+title: Empty Body
+---
+"),
+        )
+        .unwrap();
+
+        tmp
+    }
+
+    #[test]
+    fn find_empty_string_pattern_matches_all_files() {
+        // `hyalo find ""` must return the same count as `hyalo find`.
+        // Previously, files with empty bodies were excluded because no body
+        // line could match the empty-string pattern, producing an empty
+        // content_matches vec that the filter treated as "no match".
+        let tmp = setup_vault_with_empty_body();
+        let fields = Fields::default();
+
+        let count_no_pattern = {
+            let out = unwrap_success(
+                find(
+                    tmp.path(),
+                    None,
+                    None,
+                    None,
+                    &[],
+                    &[],
+                    None,
+                    &[],
+                    &[],
+                    None,
+                    &fields,
+                    None,
+                    None,
+                    Format::Json,
+                )
+                .unwrap(),
+            );
+            let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+            parsed.as_array().unwrap().len()
+        };
+
+        let count_empty_pattern = {
+            let out = unwrap_success(
+                find(
+                    tmp.path(),
+                    None,
+                    Some(""),
+                    None,
+                    &[],
+                    &[],
+                    None,
+                    &[],
+                    &[],
+                    None,
+                    &fields,
+                    None,
+                    None,
+                    Format::Json,
+                )
+                .unwrap(),
+            );
+            let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+            parsed.as_array().unwrap().len()
+        };
+
+        assert_eq!(
+            count_empty_pattern, count_no_pattern,
+            "empty pattern should return the same files as no pattern"
+        );
+        assert_eq!(count_no_pattern, 2, "vault has 2 files");
+    }
+
+    #[test]
+    fn find_whitespace_only_pattern_matches_all_files() {
+        // `hyalo find "   "` should also be treated as no filter.
+        let tmp = setup_vault_with_empty_body();
+        let fields = Fields::default();
+
+        let out = unwrap_success(
+            find(
+                tmp.path(),
+                None,
+                Some("   "),
+                None,
+                &[],
+                &[],
+                None,
+                &[],
+                &[],
+                None,
+                &fields,
+                None,
+                None,
+                Format::Json,
+            )
+            .unwrap(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(
+            arr.len(),
+            2,
+            "whitespace-only pattern should match all files"
+        );
     }
 
     // --- find: task filter ---

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -49,7 +49,7 @@ pub fn mv(
     };
 
     // 2. Validate target path
-    let new_rel = validate_target(dir, to_arg, format)?;
+    let new_rel = validate_target(dir, to_arg, &old_rel, format)?;
     let new_rel = match new_rel {
         Ok(rel) => rel,
         Err(outcome) => return Ok(outcome),
@@ -100,6 +100,7 @@ pub fn mv(
 fn validate_target(
     dir: &Path,
     to_arg: &str,
+    src_rel: &str,
     format: Format,
 ) -> Result<Result<String, CommandOutcome>> {
     // Normalize forward slashes
@@ -130,6 +131,18 @@ fn validate_target(
             "target path must be relative and within the vault",
             Some(&normalized),
             None,
+            None,
+        );
+        return Ok(Err(CommandOutcome::UserError(out)));
+    }
+
+    // Source and destination must differ
+    if normalized == src_rel {
+        let out = crate::output::format_error(
+            format,
+            "source and destination are the same path",
+            Some(&normalized),
+            Some("choose a different destination path"),
             None,
         );
         return Ok(Err(CommandOutcome::UserError(out)));

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -103,8 +103,12 @@ fn validate_target(
     src_rel: &str,
     format: Format,
 ) -> Result<Result<String, CommandOutcome>> {
-    // Normalize forward slashes
+    // Normalize forward slashes and strip leading "./" for consistent comparison
     let normalized = to_arg.replace('\\', "/");
+    let normalized = normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .to_owned();
 
     // Must end with .md
     if !normalized.ends_with(".md") {

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -196,8 +196,8 @@ pub fn summary(
     // outside the glob still count — a file linked from anywhere is not an orphan.
     // Orphan candidates are restricted to good_files (glob-scoped, parse-error-free).
     let orphans = {
-        let build =
-            LinkGraph::build(dir, None).context("failed to build link graph for orphan detection")?;
+        let build = LinkGraph::build(dir, None)
+            .context("failed to build link graph for orphan detection")?;
         let targets = build.graph.all_targets();
         let sources = build.graph.all_sources();
         let mut orphan_files: Vec<String> = good_files

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -67,23 +67,23 @@ fn push_global_flags(parts: &mut Vec<String>, ctx: &HintContext) {
 /// Build a command that intentionally omits `--glob` (for file-specific hints).
 fn build_command_no_glob(ctx: &HintContext, args: &[&str]) -> String {
     let mut parts: Vec<String> = vec!["hyalo".to_owned()];
-    push_global_flags(&mut parts, ctx);
     for arg in args {
         parts.push(shell_quote(arg));
     }
+    push_global_flags(&mut parts, ctx);
     parts.join(" ")
 }
 
 /// Build a command that propagates `--glob` when present.
 fn build_command_with_glob(ctx: &HintContext, args: &[&str]) -> String {
     let mut parts: Vec<String> = vec!["hyalo".to_owned()];
+    for arg in args {
+        parts.push(shell_quote(arg));
+    }
     push_global_flags(&mut parts, ctx);
     if let Some(glob) = &ctx.glob {
         parts.push("--glob".to_owned());
         parts.push(shell_quote(glob));
-    }
-    for arg in args {
-        parts.push(shell_quote(arg));
     }
     parts.join(" ")
 }
@@ -342,7 +342,7 @@ mod tests {
         let c = ctx_with_dir(HintSource::Summary, "/my/vault");
         assert_eq!(
             build_command_no_glob(&c, &["tags"]),
-            "hyalo --dir /my/vault tags"
+            "hyalo tags --dir /my/vault"
         );
     }
 
@@ -351,7 +351,7 @@ mod tests {
         let c = ctx_with_glob(HintSource::PropertiesSummary, "**/*.md");
         assert_eq!(
             build_command_with_glob(&c, &["properties"]),
-            "hyalo --glob '**/*.md' properties"
+            "hyalo properties --glob '**/*.md'"
         );
     }
 
@@ -381,13 +381,13 @@ mod tests {
         let hints = generate_hints(&c, &data);
         assert!(hints.iter().any(|h| {
             h == "hyalo properties"
-                || (h.starts_with("hyalo --dir ") && h.ends_with(" properties"))
-                || (h.starts_with("hyalo --glob ") && h.ends_with(" properties"))
+                || (h.starts_with("hyalo properties ") && h.contains("--dir "))
+                || (h.starts_with("hyalo properties ") && h.contains("--glob "))
         }));
         assert!(hints.iter().any(|h| {
             h == "hyalo tags"
-                || (h.starts_with("hyalo --dir ") && h.ends_with(" tags"))
-                || (h.starts_with("hyalo --glob ") && h.ends_with(" tags"))
+                || (h.starts_with("hyalo tags ") && h.contains("--dir "))
+                || (h.starts_with("hyalo tags ") && h.contains("--glob "))
         }));
     }
 

--- a/crates/hyalo-cli/tests/e2e_mv.rs
+++ b/crates/hyalo-cli/tests/e2e_mv.rs
@@ -600,3 +600,24 @@ fn mv_wikilink_with_path_from_subdirectory_not_false_positive() {
         "unrelated wikilink was touched: {content}"
     );
 }
+
+#[test]
+fn mv_same_source_and_destination_error() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "Content.\n");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["mv", "--file", "a.md", "--to", "a.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("same path"),
+        "expected 'same path' in stderr, got: {stderr}"
+    );
+    // The file must remain untouched
+    assert!(tmp.path().join("a.md").exists());
+}

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -4,6 +4,8 @@ use globset::GlobBuilder;
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
+use crate::link_graph::strip_site_prefix;
+
 /// Collect all `.md` files under the given directory, respecting `.gitignore` and skipping hidden dirs.
 pub fn discover_files(dir: &Path) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
@@ -223,17 +225,28 @@ impl std::error::Error for FileResolveError {}
 /// `canonical_dir` must be a pre-canonicalized vault path (see `canonicalize_vault_dir`).
 /// Callers iterating over many links should canonicalize once and reuse the result.
 #[must_use]
-pub fn resolve_target(canonical_dir: &Path, target: &str) -> Option<String> {
+pub fn resolve_target(
+    canonical_dir: &Path,
+    target: &str,
+    site_prefix: Option<&str>,
+) -> Option<String> {
     if target.is_empty() {
         return None;
     }
 
-    // Reject path traversal attempts
+    // Normalize backslashes to forward slashes
     let target = target.replace('\\', "/");
-    if target.starts_with('/') || has_parent_traversal(&target) || Path::new(&target).is_absolute()
-    {
-        return None;
-    }
+
+    // Normalize absolute paths using site_prefix (same logic as LinkGraph).
+    // `/docs/page.md` with site_prefix "docs" becomes `page.md`.
+    let target = if target.starts_with('/') {
+        strip_site_prefix(&target, site_prefix)
+    } else {
+        if has_parent_traversal(&target) || Path::new(&target).is_absolute() {
+            return None;
+        }
+        target
+    };
 
     let full = canonical_dir.join(&target);
     if full.is_file() {
@@ -472,7 +485,7 @@ mod tests {
         make_files(tmp.path(), &["note.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "note"),
+            resolve_target(&canonical, "note", None),
             Some("note.md".to_owned())
         );
     }
@@ -483,7 +496,7 @@ mod tests {
         make_files(tmp.path(), &["note.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "note.md"),
+            resolve_target(&canonical, "note.md", None),
             Some("note.md".to_owned())
         );
     }
@@ -494,7 +507,7 @@ mod tests {
         make_files(tmp.path(), &["sub/other.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "sub/other"),
+            resolve_target(&canonical, "sub/other", None),
             Some("sub/other.md".to_owned())
         );
     }
@@ -505,7 +518,7 @@ mod tests {
         make_files(tmp.path(), &["sub/other.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "sub/other.md"),
+            resolve_target(&canonical, "sub/other.md", None),
             Some("sub/other.md".to_owned())
         );
     }
@@ -515,21 +528,21 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["sub/other.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "other"), None);
+        assert_eq!(resolve_target(&canonical, "other", None), None);
     }
 
     #[test]
     fn resolve_target_nonexistent_returns_none() {
         let tmp = tempfile::tempdir().unwrap();
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "nonexistent"), None);
+        assert_eq!(resolve_target(&canonical, "nonexistent", None), None);
     }
 
     #[test]
     fn resolve_target_empty_returns_none() {
         let tmp = tempfile::tempdir().unwrap();
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, ""), None);
+        assert_eq!(resolve_target(&canonical, "", None), None);
     }
 
     #[test]
@@ -537,9 +550,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["note.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "../note"), None);
-        assert_eq!(resolve_target(&canonical, "sub/../../note"), None);
-        assert_eq!(resolve_target(&canonical, "/etc/passwd"), None);
+        assert_eq!(resolve_target(&canonical, "../note", None), None);
+        assert_eq!(resolve_target(&canonical, "sub/../../note", None), None);
+        // /etc/passwd normalizes to "etc/passwd" which doesn't exist in the vault
+        assert_eq!(resolve_target(&canonical, "/etc/passwd", None), None);
     }
 
     #[test]
@@ -548,7 +562,7 @@ mod tests {
         make_files(tmp.path(), &["image.png"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "image.png"),
+            resolve_target(&canonical, "image.png", None),
             Some("image.png".to_owned())
         );
     }
@@ -588,7 +602,7 @@ mod tests {
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
 
         assert_eq!(
-            resolve_target(&canonical, "etc..md"),
+            resolve_target(&canonical, "etc..md", None),
             Some("etc..md".to_owned())
         );
     }
@@ -598,7 +612,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
 
-        assert_eq!(resolve_target(&canonical, "../secret.md"), None);
+        assert_eq!(resolve_target(&canonical, "../secret.md", None), None);
     }
 
     // --- symlink escape tests ---
@@ -630,8 +644,55 @@ mod tests {
         std::os::unix::fs::symlink(outside.path(), vault.path().join("linked")).unwrap();
 
         let canonical = canonicalize_vault_dir(vault.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "linked/secret"), None);
-        assert_eq!(resolve_target(&canonical, "linked/secret.md"), None);
+        assert_eq!(resolve_target(&canonical, "linked/secret", None), None);
+        assert_eq!(resolve_target(&canonical, "linked/secret.md", None), None);
+    }
+
+    // --- site_prefix resolution ---
+
+    #[test]
+    fn resolve_target_absolute_with_site_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(
+            resolve_target(&canonical, "/docs/page.md", Some("docs")),
+            Some("page.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_absolute_no_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(
+            resolve_target(&canonical, "/page.md", None),
+            Some("page.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_absolute_nonmatching_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["other/b.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        // site_prefix "docs" doesn't match "/other/b.md", so strip just the "/"
+        assert_eq!(
+            resolve_target(&canonical, "/other/b.md", Some("docs")),
+            Some("other/b.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_absolute_stem_with_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(
+            resolve_target(&canonical, "/docs/page", Some("docs")),
+            Some("page.md".to_owned())
+        );
     }
 
     #[cfg(unix)]

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -240,7 +240,12 @@ pub fn resolve_target(
     // Normalize absolute paths using site_prefix (same logic as LinkGraph).
     // `/docs/page.md` with site_prefix "docs" becomes `page.md`.
     let target = if target.starts_with('/') {
-        strip_site_prefix(&target, site_prefix)
+        let stripped = strip_site_prefix(&target, site_prefix);
+        // Reject traversal even after prefix stripping (e.g. `/docs/../../etc/passwd`)
+        if has_parent_traversal(&stripped) {
+            return None;
+        }
+        stripped
     } else {
         if has_parent_traversal(&target) || Path::new(&target).is_absolute() {
             return None;

--- a/crates/hyalo-core/src/frontmatter.rs
+++ b/crates/hyalo-core/src/frontmatter.rs
@@ -145,7 +145,7 @@ pub fn write_frontmatter(path: &Path, props: &BTreeMap<String, Value>) -> Result
 ///
 /// Returns `0` if the file has no frontmatter, which means the entire file is body.
 fn find_body_offset(file: &mut File) -> Result<u64> {
-    const MAX_FRONTMATTER_LINES: usize = 100;
+    const MAX_FRONTMATTER_LINES: usize = 200;
     const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
 
     let mut reader = BufReader::new(&mut *file);
@@ -194,7 +194,7 @@ fn find_body_offset(file: &mut File) -> Result<u64> {
 /// (including the opening and closing `---` delimiters). Returns 0 if no frontmatter is present.
 /// The reader is left positioned at the first line after the closing `---`.
 pub fn skip_frontmatter<R: BufRead>(reader: &mut R, first_line: &str) -> Result<usize> {
-    const MAX_FRONTMATTER_LINES: usize = 100;
+    const MAX_FRONTMATTER_LINES: usize = 200;
     const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
 
     if first_line.trim() != "---" {
@@ -229,10 +229,10 @@ pub fn skip_frontmatter<R: BufRead>(reader: &mut R, first_line: &str) -> Result<
 }
 
 /// Parse frontmatter from any buffered reader. Stops reading after the closing `---`.
-/// Bails out if the frontmatter exceeds a reasonable size (100 lines / 8 KB) to avoid
+/// Bails out if the frontmatter exceeds a reasonable size (200 lines / 8 KB) to avoid
 /// buffering an entire file when the closing delimiter is missing.
 fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String, Value>> {
-    const MAX_FRONTMATTER_LINES: usize = 100;
+    const MAX_FRONTMATTER_LINES: usize = 200;
     const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
 
     let mut lines = reader.lines();
@@ -784,8 +784,8 @@ Body.
 
     #[test]
     fn streaming_budget_boundary_lines_at_limit() {
-        // Exactly 100 content lines — must succeed
-        let input = make_frontmatter_with_n_lines(100);
+        // Exactly 200 content lines — must succeed
+        let input = make_frontmatter_with_n_lines(200);
         let mut reader = input.as_bytes();
         // Read and discard the opening "---\n" line, then call skip_frontmatter
         let mut first_line = String::new();
@@ -794,20 +794,20 @@ Body.
         let result = skip_frontmatter(&mut reader, first);
         assert!(
             result.is_ok(),
-            "100 content lines should succeed: {result:?}"
+            "200 content lines should succeed: {result:?}"
         );
     }
 
     #[test]
     fn streaming_budget_boundary_lines_over_limit() {
-        // 101 content lines — must error
-        let input = make_frontmatter_with_n_lines(101);
+        // 201 content lines — must error
+        let input = make_frontmatter_with_n_lines(201);
         let mut reader = input.as_bytes();
         let mut first_line = String::new();
         std::io::BufRead::read_line(&mut reader, &mut first_line).unwrap();
         let first = first_line.trim_end_matches(['\n', '\r']);
         let result = skip_frontmatter(&mut reader, first);
-        assert!(result.is_err(), "101 content lines should fail");
+        assert!(result.is_err(), "201 content lines should fail");
         assert!(
             result
                 .unwrap_err()

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -5,7 +5,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::discovery;
 use crate::frontmatter;
-use crate::links::{Link, LinkKind, extract_links_from_text};
+use crate::links::{Link, LinkKind, extract_links_from_text_with_original};
 use crate::scanner::{self, FileVisitor, ScanAction};
 
 /// A single backlink: a file that links to some target.
@@ -188,11 +188,12 @@ impl LinkGraphVisitor {
 }
 
 impl FileVisitor for LinkGraphVisitor {
-    fn on_body_line(&mut self, _raw: &str, cleaned: &str, line_num: usize) -> ScanAction {
+    fn on_body_line(&mut self, raw: &str, cleaned: &str, line_num: usize) -> ScanAction {
         // Use `cleaned` (inline code and comments stripped) so that [[links]]
         // inside backtick spans are not indexed as real links.
+        // Pass `raw` as original so backtick-wrapped link labels are preserved.
         self.scratch.clear();
-        extract_links_from_text(cleaned, &mut self.scratch);
+        extract_links_from_text_with_original(cleaned, raw, &mut self.scratch);
         for link in self.scratch.drain(..) {
             self.links.push((line_num, link));
         }
@@ -508,10 +509,10 @@ mod tests {
 
     #[test]
     fn frontmatter_too_large_skipped() {
-        // A file with >100 frontmatter content lines (no closing ---) should be skipped.
-        // MAX_FRONTMATTER_LINES is 100; 101 content lines triggers the error.
+        // A file with >200 frontmatter content lines (no closing ---) should be skipped.
+        // MAX_FRONTMATTER_LINES is 200; 201 content lines triggers the error.
         let mut huge_fm = String::from("---\n");
-        for i in 0..101 {
+        for i in 0..201 {
             huge_fm.push_str(&format!("key{i}: value\n"));
         }
         // No closing ---, so scanner bails with "frontmatter too large"

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -214,7 +214,7 @@ impl FileVisitor for LinkGraphVisitor {
 ///
 /// With `site_prefix = None`:
 ///   `/page.md` → `page.md`
-fn strip_site_prefix(target: &str, site_prefix: Option<&str>) -> String {
+pub(crate) fn strip_site_prefix(target: &str, site_prefix: Option<&str>) -> String {
     let without_slash = target.strip_prefix('/').unwrap_or(target);
     if let Some(prefix) = site_prefix {
         // Try stripping "prefix/" from the front

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -19,7 +19,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::link_graph::{LinkGraph, normalize_target, relative_path_between};
-use crate::links::{LinkKind, extract_link_spans};
+use crate::links::{LinkKind, extract_link_spans_with_original};
 use crate::scanner::{FenceTracker, is_comment_fence, strip_inline_code, strip_inline_comments};
 
 // ---------------------------------------------------------------------------
@@ -236,7 +236,7 @@ fn plan_inbound_rewrites(
         // ---- Extract and compare link spans ----
         let stripped_code = strip_inline_code(line);
         let cleaned = strip_inline_comments(stripped_code.as_ref());
-        let spans = extract_link_spans(&cleaned);
+        let spans = extract_link_spans_with_original(&cleaned, line);
 
         for span in spans {
             let matches = match span.kind {
@@ -341,7 +341,7 @@ fn plan_outbound_rewrites(content: &str, old_rel: &str, new_rel: &str) -> Vec<Re
         // ---- Extract markdown link spans only ----
         let stripped_code = strip_inline_code(line);
         let cleaned = strip_inline_comments(stripped_code.as_ref());
-        let spans = extract_link_spans(&cleaned);
+        let spans = extract_link_spans_with_original(&cleaned, line);
 
         for span in spans {
             // Only rewrite markdown links — wikilinks are vault-relative.

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -253,7 +253,8 @@ fn try_parse_markdown_link_span_at(
     let close_bracket = rest.find(']')?;
     // Read label from `original` so backtick-wrapped content is not lost when
     // `text` has had inline code spans replaced with spaces.
-    let label_text = &original[start + 1..start + close_bracket];
+    // Use `.get()` to avoid panic if `original` has a different byte layout.
+    let label_text = original.get(start + 1..start + close_bracket)?;
 
     let after_bracket = start + close_bracket + 1;
     if text.as_bytes().get(after_bracket).copied() != Some(b'(') {
@@ -352,7 +353,8 @@ fn try_parse_markdown_link_at(text: &str, original: &str, start: usize) -> Optio
     let close_bracket = rest.find(']')?;
     // Read label from `original` so backtick-wrapped content is not lost when
     // `text` has had inline code spans replaced with spaces.
-    let label_text = &original[start + 1..start + close_bracket];
+    // Use `.get()` to avoid panic if `original` has a different byte layout.
+    let label_text = original.get(start + 1..start + close_bracket)?;
 
     // Must be immediately followed by (
     let after_bracket = start + close_bracket + 1;

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -60,8 +60,28 @@ pub fn extract_links_from_file(path: &Path) -> Result<Vec<Link>> {
 /// [`strip_inline_code`](crate::scanner::strip_inline_code)), otherwise links
 /// inside code spans will be incorrectly parsed. Existing contents of `out` are
 /// preserved; new links are appended.
+///
+/// Link labels are read from `text`. If the caller has a raw (un-stripped)
+/// version of the same line with the same byte layout, use
+/// [`extract_links_from_text_with_original`] to preserve backtick-wrapped
+/// label content.
 pub fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
-    let bytes = text.as_bytes();
+    extract_links_from_text_with_original(text, text, out);
+}
+
+/// Like [`extract_links_from_text`] but reads link label text from `original`
+/// instead of `cleaned`.
+///
+/// Use this when `cleaned` has had inline code spans replaced with spaces (via
+/// [`strip_inline_code`](crate::scanner::strip_inline_code)) to avoid
+/// mistaking links inside code spans as real links, while still preserving the
+/// backtick-wrapped content in link labels such as `` [`file.ts`](path) ``.
+///
+/// `cleaned` and `original` must describe the same line with identical byte
+/// lengths and identical byte positions for all link syntax characters (`[`,
+/// `]`, `(`, `)`).
+pub fn extract_links_from_text_with_original(cleaned: &str, original: &str, out: &mut Vec<Link>) {
+    let bytes = cleaned.as_bytes();
     let len = bytes.len();
     let mut i = 0;
 
@@ -71,7 +91,7 @@ pub fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
             && i + 3 < len
             && bytes[i + 1] == b'['
             && bytes[i + 2] == b'['
-            && let Some((link, end)) = try_parse_wikilink_at(text, i + 1)
+            && let Some((link, end)) = try_parse_wikilink_at(cleaned, i + 1)
         {
             out.push(link);
             i = end;
@@ -80,7 +100,7 @@ pub fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
         if bytes[i] == b'['
             && i + 1 < len
             && bytes[i + 1] == b'['
-            && let Some((link, end)) = try_parse_wikilink_at(text, i)
+            && let Some((link, end)) = try_parse_wikilink_at(cleaned, i)
         {
             out.push(link);
             i = end;
@@ -91,7 +111,7 @@ pub fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
         // Skip if preceded by `!` — that's image syntax: ![alt](img.png)
         if bytes[i] == b'['
             && (i == 0 || bytes[i - 1] != b'!')
-            && let Some((link, end)) = try_parse_markdown_link_at(text, i)
+            && let Some((link, end)) = try_parse_markdown_link_at(cleaned, original, i)
         {
             out.push(link);
             i = end;
@@ -107,8 +127,28 @@ pub fn extract_links_from_text(text: &str, out: &mut Vec<Link>) {
 /// Works exactly like [`extract_links_from_text`] but returns [`LinkSpan`]
 /// values that carry byte positions for both the full link syntax and the
 /// target substring.  `text` must already be cleaned of inline code spans.
+///
+/// Link labels are read from `text`. If the caller has a raw (un-stripped)
+/// version of the same line with the same byte layout, use
+/// [`extract_link_spans_with_original`] to preserve backtick-wrapped label
+/// content.
 pub fn extract_link_spans(text: &str) -> Vec<LinkSpan> {
-    let bytes = text.as_bytes();
+    extract_link_spans_with_original(text, text)
+}
+
+/// Like [`extract_link_spans`] but reads link label text from `original`
+/// instead of `cleaned`.
+///
+/// Use this when `cleaned` has had inline code spans replaced with spaces (via
+/// [`strip_inline_code`](crate::scanner::strip_inline_code)) to avoid
+/// mistaking links inside code spans as real links, while still preserving
+/// backtick-wrapped content in link labels such as `` [`file.ts`](path) ``.
+///
+/// `cleaned` and `original` must describe the same line with identical byte
+/// lengths and identical byte positions for all link syntax characters (`[`,
+/// `]`, `(`, `)`).
+pub fn extract_link_spans_with_original(cleaned: &str, original: &str) -> Vec<LinkSpan> {
+    let bytes = cleaned.as_bytes();
     let len = bytes.len();
     let mut i = 0;
     let mut out = Vec::new();
@@ -119,7 +159,7 @@ pub fn extract_link_spans(text: &str) -> Vec<LinkSpan> {
             && i + 3 < len
             && bytes[i + 1] == b'['
             && bytes[i + 2] == b'['
-            && let Some((mut span, end)) = try_parse_wikilink_span_at(text, i + 1)
+            && let Some((mut span, end)) = try_parse_wikilink_span_at(cleaned, i + 1)
         {
             // Extend full_start back to the `!`
             span.full_start = i;
@@ -132,7 +172,7 @@ pub fn extract_link_spans(text: &str) -> Vec<LinkSpan> {
         if bytes[i] == b'['
             && i + 1 < len
             && bytes[i + 1] == b'['
-            && let Some((span, end)) = try_parse_wikilink_span_at(text, i)
+            && let Some((span, end)) = try_parse_wikilink_span_at(cleaned, i)
         {
             out.push(span);
             i = end;
@@ -142,7 +182,7 @@ pub fn extract_link_spans(text: &str) -> Vec<LinkSpan> {
         // [text](target) — skip if preceded by `!` (image)
         if bytes[i] == b'['
             && (i == 0 || bytes[i - 1] != b'!')
-            && let Some((span, end)) = try_parse_markdown_link_span_at(text, i)
+            && let Some((span, end)) = try_parse_markdown_link_span_at(cleaned, original, i)
         {
             out.push(span);
             i = end;
@@ -199,11 +239,21 @@ fn try_parse_wikilink_span_at(text: &str, start: usize) -> Option<(LinkSpan, usi
 
 /// Try to parse a markdown link span `[text](target)` at byte position `start`
 /// (the `[`).  Returns the [`LinkSpan`] and the byte position after `)`.
-fn try_parse_markdown_link_span_at(text: &str, start: usize) -> Option<(LinkSpan, usize)> {
+///
+/// `text` drives structural parsing; `original` provides the label text so
+/// that backtick-wrapped content is preserved when `text` has been
+/// inline-code-stripped.
+fn try_parse_markdown_link_span_at(
+    text: &str,
+    original: &str,
+    start: usize,
+) -> Option<(LinkSpan, usize)> {
     let rest = &text[start..];
 
     let close_bracket = rest.find(']')?;
-    let label_text = &rest[1..close_bracket];
+    // Read label from `original` so backtick-wrapped content is not lost when
+    // `text` has had inline code spans replaced with spaces.
+    let label_text = &original[start + 1..start + close_bracket];
 
     let after_bracket = start + close_bracket + 1;
     if text.as_bytes().get(after_bracket).copied() != Some(b'(') {
@@ -291,12 +341,18 @@ pub fn parse_wikilink(inner: &str) -> Option<Link> {
 }
 
 /// Try to parse a markdown-style link [text](target) at position `start`.
-fn try_parse_markdown_link_at(text: &str, start: usize) -> Option<(Link, usize)> {
+///
+/// `text` drives structural parsing; `original` provides the label text so
+/// that backtick-wrapped content is preserved when `text` has been
+/// inline-code-stripped.
+fn try_parse_markdown_link_at(text: &str, original: &str, start: usize) -> Option<(Link, usize)> {
     let rest = &text[start..];
 
     // Find the closing ]
     let close_bracket = rest.find(']')?;
-    let label_text = &rest[1..close_bracket];
+    // Read label from `original` so backtick-wrapped content is not lost when
+    // `text` has had inline code spans replaced with spaces.
+    let label_text = &original[start + 1..start + close_bracket];
 
     // Must be immediately followed by (
     let after_bracket = start + close_bracket + 1;
@@ -690,5 +746,79 @@ mod tests {
         let spans = extract_link_spans(text);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].link.target, "real");
+    }
+
+    // --- Backtick-wrapped label preservation ---
+
+    /// Regression: a label like [`lib/frontmatter.ts`](path) was producing
+    /// all-whitespace label text when the line had been run through
+    /// `strip_inline_code` (which replaces backtick span content with spaces).
+    /// `extract_links_from_text_with_original` fixes this by reading the label
+    /// from the original (un-stripped) line.
+    #[test]
+    fn markdown_link_backtick_label_preserved_with_original() {
+        use crate::scanner::strip_inline_code;
+
+        let original = "[`lib/frontmatter.ts`](/src/frame/lib/frontmatter.ts)";
+        let cleaned = strip_inline_code(original);
+
+        // Sanity-check: strip_inline_code should have replaced the backtick
+        // span content with spaces, so `cleaned` should not equal `original`.
+        assert_ne!(cleaned.as_ref(), original);
+
+        // Without original: label is whitespace (the bug).
+        let mut links_no_orig = Vec::new();
+        extract_links_from_text(cleaned.as_ref(), &mut links_no_orig);
+        assert_eq!(links_no_orig.len(), 1);
+        // The label is all spaces — document the broken behavior for contrast.
+        assert!(
+            links_no_orig[0]
+                .label
+                .as_deref()
+                .unwrap_or("")
+                .trim()
+                .is_empty(),
+            "without original the label should be whitespace (confirming the bug)"
+        );
+
+        // With original: label is the backtick-wrapped text (the fix).
+        let mut links_with_orig = Vec::new();
+        extract_links_from_text_with_original(cleaned.as_ref(), original, &mut links_with_orig);
+        assert_eq!(links_with_orig.len(), 1);
+        assert_eq!(
+            links_with_orig[0].label.as_deref(),
+            Some("`lib/frontmatter.ts`"),
+            "label should preserve the backtick-wrapped content"
+        );
+        assert_eq!(links_with_orig[0].target, "/src/frame/lib/frontmatter.ts");
+    }
+
+    #[test]
+    fn markdown_link_backtick_label_span_preserved_with_original() {
+        use crate::scanner::strip_inline_code;
+
+        let original = "See [`file.ts`](src/file.ts) for details";
+        let cleaned = strip_inline_code(original);
+
+        let spans = extract_link_spans_with_original(cleaned.as_ref(), original);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].link.target, "src/file.ts");
+        assert_eq!(
+            spans[0].link.label.as_deref(),
+            Some("`file.ts`"),
+            "span label should preserve backtick-wrapped content"
+        );
+    }
+
+    #[test]
+    fn extract_links_from_text_backtick_label_without_strip_preserved() {
+        // When the text has NOT been stripped (e.g. raw line from file),
+        // backtick labels should pass through correctly via the regular path.
+        let text = "[`mod.rs`](src/mod.rs)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].label.as_deref(), Some("`mod.rs`"));
+        assert_eq!(links[0].target, "src/mod.rs");
     }
 }

--- a/crates/hyalo-core/src/scanner.rs
+++ b/crates/hyalo-core/src/scanner.rs
@@ -378,7 +378,7 @@ pub fn scan_reader_multi<R: BufRead>(
     // Try to parse frontmatter
     let any_needs_fm = visitors.iter().any(|v| v.needs_frontmatter());
     let (fm_props, fm_lines) = if first_trimmed.trim() == "---" {
-        const MAX_FRONTMATTER_LINES: usize = 100;
+        const MAX_FRONTMATTER_LINES: usize = 200;
         const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
 
         // Read past frontmatter lines, optionally collecting YAML content
@@ -1049,10 +1049,10 @@ Line 2
 
     #[test]
     fn multi_visitor_frontmatter_exceeds_budget_returns_error() {
-        // Build a frontmatter block with 101 content lines and no closing `---`,
-        // which exceeds the 100-line budget enforced by scan_reader_multi.
+        // Build a frontmatter block with 201 content lines and no closing `---`,
+        // which exceeds the 200-line budget enforced by scan_reader_multi.
         let mut input = String::from("---\n");
-        for i in 0..101usize {
+        for i in 0..201usize {
             input.push_str(&format!("k{i}: v\n"));
         }
         // Deliberately omit the closing `---` so the budget is hit before EOF.
@@ -1084,9 +1084,9 @@ Line 2
             }
         }
 
-        // 101 content lines, no closing `---` — must exceed the 100-line budget.
+        // 201 content lines, no closing `---` — must exceed the 200-line budget.
         let mut input = String::from("---\n");
-        for i in 0..101usize {
+        for i in 0..201usize {
             input.push_str(&format!("k{i}: v\n"));
         }
         let mut v = BodyOnly { lines: Vec::new() };


### PR DESCRIPTION
## Summary

- **Absolute-path link resolution**: `resolve_target()` now accepts `site_prefix` and normalizes paths like `/docs/page.md` instead of rejecting them. On VS Code Docs (339 files), resolved links went from 0 → 2,514 out of 2,772.
- **Backtick label preservation**: Links like `` [`file.ts`](path) `` now preserve the backtick-wrapped label text instead of producing whitespace. Uses safe `.get()` indexing to avoid panic on mismatched byte layouts.
- **Frontmatter limit**: Increased from 100 → 200 lines. GitHub Docs has files with 116-196 line frontmatter (long `redirect_from` lists) that were silently skipped.
- **Empty pattern match-all**: `hyalo find ""` now returns the same results as `hyalo find` instead of filtering out files with empty bodies.
- **mv same-path error**: Returns "source and destination are the same path" instead of the misleading "target file already exists". Normalizes `./` prefix for consistent comparison.
- **Hint syntax**: Subcommand args now appear before global flags, producing valid CLI commands.
- **Traversal guard**: `resolve_target` now checks for parent traversal after stripping site prefix to reject crafted paths like `/docs/../../etc/passwd`.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 394 tests pass
- [x] Verified link resolution on VS Code Docs: 2,514/2,772 links resolve (remaining are `/api/...` outside vault)
- [x] Verified backtick labels on GitHub Docs: 0 whitespace-only labels (was 215)
- [x] Verified 3 previously-skipped large-frontmatter files now parse in GitHub Docs
- [x] Verified `find ""` returns same count as `find` on GitHub Docs (3,520)
- [x] Verified `mv --file X --to X` returns clear same-path error
- [x] Verified `summary --hints` produces valid `hyalo properties --hints` syntax
- [x] Copilot review findings addressed (safe indexing, path normalization, traversal guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)