### PR TITLE
Return empty result for non-matching globs

### DIFF
--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -74,21 +74,6 @@ pub fn collect_files(
         (true, Some(pattern)) => {
             let all = discovery::discover_files(dir)?;
             let matched = discovery::match_glob(dir, &all, pattern)?;
-            if matched.is_empty() {
-                let hint = if pattern.starts_with('!') {
-                    Some("negation glob excluded all files")
-                } else {
-                    None
-                };
-                let out = crate::output::format_error(
-                    format,
-                    "no files match pattern",
-                    Some(pattern),
-                    hint,
-                    None,
-                );
-                return Ok(FilesOrOutcome::Outcome(CommandOutcome::UserError(out)));
-            }
             Ok(FilesOrOutcome::Files(matched))
         }
         (true, None) => {

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -31,7 +31,8 @@ pub enum FilesOrOutcome {
 }
 
 /// Resolve the set of files to operate on based on `--file` / `--glob` / all files.
-/// Returns a user-error outcome for invalid inputs (file not found, no glob matches).
+/// Returns a user-error outcome for invalid inputs (e.g. file not found).
+/// A glob that matches no files returns an empty file list with exit 0, not an error.
 pub fn collect_files(
     dir: &Path,
     files: &[String],

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -1013,6 +1013,10 @@ fn find_glob_no_match_returns_empty_array() {
         0,
         "non-matching glob should return empty array"
     );
+    assert!(
+        stderr.is_empty(),
+        "non-matching glob should produce no stderr output; got: {stderr}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -1001,15 +1001,18 @@ fn find_sort_bogus_exits_1() {
 }
 
 #[test]
-fn find_glob_no_match_exits_1() {
+fn find_glob_no_match_returns_empty_array() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
-    cmd.args(["find", "--glob", "nonexistent/**/*.md"]);
-    let output = cmd.output().unwrap();
-
-    assert!(!output.status.success());
-    assert_eq!(output.status.code(), Some(1));
+    let (status, json, stderr) = find_json(&tmp, &["--glob", "nonexistent/**/*.md"]);
+    assert!(
+        status.success(),
+        "non-matching glob should exit 0; stderr: {stderr}"
+    );
+    assert_eq!(
+        json.as_array().unwrap().len(),
+        0,
+        "non-matching glob should return empty array"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/tests/e2e_properties.rs
+++ b/crates/hyalo-cli/tests/e2e_properties.rs
@@ -169,7 +169,10 @@ fn properties_glob_no_match() {
         .output()
         .unwrap();
 
-    assert!(!output.status.success());
+    assert!(
+        output.status.success(),
+        "non-matching glob should exit 0, not error"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/tests/e2e_properties.rs
+++ b/crates/hyalo-cli/tests/e2e_properties.rs
@@ -169,9 +169,19 @@ fn properties_glob_no_match() {
         .output()
         .unwrap();
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         output.status.success(),
-        "non-matching glob should exit 0, not error"
+        "non-matching glob should exit 0, not error; stderr: {stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        json.as_array().is_some_and(|a| a.is_empty()),
+        "non-matching glob should return empty array; got: {json}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "non-matching glob should produce no stderr output; got: {stderr}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_tags.rs
+++ b/crates/hyalo-cli/tests/e2e_tags.rs
@@ -84,7 +84,10 @@ fn tags_glob_no_match() {
         .output()
         .unwrap();
 
-    assert!(!output.status.success());
+    assert!(
+        output.status.success(),
+        "non-matching glob should exit 0, not error"
+    );
 }
 
 #[test]

--- a/crates/hyalo-cli/tests/e2e_tags.rs
+++ b/crates/hyalo-cli/tests/e2e_tags.rs
@@ -84,9 +84,23 @@ fn tags_glob_no_match() {
         .output()
         .unwrap();
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         output.status.success(),
-        "non-matching glob should exit 0, not error"
+        "non-matching glob should exit 0, not error; stderr: {stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["total"], 0,
+        "non-matching glob should return total 0; got: {json}"
+    );
+    assert!(
+        json["tags"].as_array().is_some_and(|a| a.is_empty()),
+        "non-matching glob should return empty tags array; got: {json}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "non-matching glob should produce no stderr output; got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Non-matching `--glob` patterns now return empty `[]` with exit 0 instead of `{"error": ...}` with exit 1
- Makes hyalo composable in scripts/pipelines where no results is a valid state, not an error
- Removed the empty-match guard in `collect_files`; updated 3 existing tests

## Test plan
- [x] 403 tests pass
- [x] cargo fmt / clippy clean
- [x] `find --glob 'nonexistent/**'` returns `[]` with exit 0
- [x] `backlinks` and `tags` with non-matching globs also return empty results

🤖 Generated with [Claude Code](https://claude.com/claude-code)