### PR TITLE
Fix remaining dogfooding issues (ISSUE-5, ISSUE-6, read validation)

### DIFF
--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -99,12 +99,14 @@ pub fn find(
 
     // Build the link graph lazily — only when backlinks field is requested.
     // This requires scanning all files in the vault so it's opt-in.
-    // Warnings for skipped files are emitted here; the per-file scan loop
-    // below will also skip these files independently, so no duplicates.
+    // Collect warned paths so the per-file scan loop below can skip duplicate warnings.
+    let mut link_graph_warned: std::collections::HashSet<std::path::PathBuf> =
+        std::collections::HashSet::new();
     let link_graph = if fields.backlinks {
         let build = LinkGraph::build(dir, site_prefix)?;
         for (path, msg) in &build.warnings {
             eprintln!("warning: skipping {}: {msg}", path.display());
+            link_graph_warned.insert(path.clone());
         }
         Some(build.graph)
     } else {
@@ -159,7 +161,11 @@ pub fn find(
         match scan_result {
             Ok(()) => {}
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel_path}: {e}");
+                // Only warn if the link graph build hasn't already warned for this path.
+                // The link graph uses relative paths; rel_path here is also relative.
+                if !link_graph_warned.contains(std::path::Path::new(rel_path)) {
+                    eprintln!("warning: skipping {rel_path}: {e}");
+                }
                 continue;
             }
             Err(e) => return Err(e),

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -99,14 +99,16 @@ pub fn find(
 
     // Build the link graph lazily — only when backlinks field is requested.
     // This requires scanning all files in the vault so it's opt-in.
-    // Collect warned paths so the per-file scan loop below can skip duplicate warnings.
-    let mut link_graph_warned: std::collections::HashSet<std::path::PathBuf> =
-        std::collections::HashSet::new();
+    // Collect warned paths (as forward-slash strings) so the per-file scan loop
+    // below can skip duplicate warnings.  PathBuf uses backslashes on Windows,
+    // but `rel_path` in the loop is always forward-slash-normalized
+    // (via `discovery::relative_path`), so we normalize here to match.
+    let mut link_graph_warned: std::collections::HashSet<String> = std::collections::HashSet::new();
     let link_graph = if fields.backlinks {
         let build = LinkGraph::build(dir, site_prefix)?;
         for (path, msg) in &build.warnings {
             eprintln!("warning: skipping {}: {msg}", path.display());
-            link_graph_warned.insert(path.clone());
+            link_graph_warned.insert(path.to_string_lossy().replace('\\', "/"));
         }
         Some(build.graph)
     } else {
@@ -162,8 +164,8 @@ pub fn find(
             Ok(()) => {}
             Err(e) if frontmatter::is_parse_error(&e) => {
                 // Only warn if the link graph build hasn't already warned for this path.
-                // The link graph uses relative paths; rel_path here is also relative.
-                if !link_graph_warned.contains(std::path::Path::new(rel_path)) {
+                // Both are forward-slash-normalized relative strings.
+                if !link_graph_warned.contains(rel_path.as_str()) {
                     eprintln!("warning: skipping {rel_path}: {e}");
                 }
                 continue;

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -224,10 +224,22 @@ pub fn run(
         None
     };
 
-    // Read frontmatter if requested
+    // Read frontmatter if requested.  Parse errors (e.g. unclosed `---`) are
+    // user errors (exit 1), not internal errors (exit 2).
     let fm_value = if frontmatter_flag {
-        let props = frontmatter::read_frontmatter(&full_path)?;
-        Some(props)
+        match frontmatter::read_frontmatter(&full_path) {
+            Ok(props) => Some(props),
+            Err(e) if frontmatter::is_parse_error(&e) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format,
+                    &e.to_string(),
+                    Some(&rel_path),
+                    None,
+                    None,
+                )));
+            }
+            Err(e) => return Err(e),
+        }
     } else {
         None
     };

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -721,6 +721,16 @@ fn main() {
     let format_from_cli = cli.format.is_some();
     let hints_from_cli = cli.hints;
     let dir = cli.dir.unwrap_or(config.dir);
+
+    // Validate that --dir is not a file path
+    if dir.is_file() {
+        eprintln!(
+            "Error: --dir path '{}' is a file, not a directory. Use --file to target a single file.",
+            dir.display()
+        );
+        process::exit(1);
+    }
+
     // Derive site_prefix for absolute link resolution: when dir != ".",
     // absolute links like `/docs/page.md` are resolved by stripping `/<dir>/`.
     let site_prefix_owned = {

--- a/crates/hyalo-cli/tests/e2e_errors.rs
+++ b/crates/hyalo-cli/tests/e2e_errors.rs
@@ -235,6 +235,48 @@ title: Target
     assert_eq!(backlinks.len(), 1, "source.md should link to target.md");
 }
 
+/// `hyalo find --fields links,backlinks` must warn exactly once for a broken file,
+/// not twice (once from link graph build, once from the per-file scan loop).
+#[test]
+fn error_find_links_backlinks_warning_deduplicated() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "bad.md",
+        "---\nunclosed frontmatter without closing delimiter\n",
+    );
+    write_md(
+        tmp.path(),
+        "good.md",
+        md!(r"
+---
+title: Good
+---
+# Good
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--fields", "links,backlinks"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected graceful skip; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    // The warning for bad.md must appear exactly once
+    let warning_count = stderr.matches("bad.md").count();
+    assert_eq!(
+        warning_count, 1,
+        "expected exactly one warning for bad.md, got {warning_count}; full stderr:\n{stderr}"
+    );
+}
+
 /// `hyalo find --fields backlinks` must also gracefully skip broken files
 /// during link graph construction.
 #[test]

--- a/crates/hyalo-cli/tests/e2e_errors.rs
+++ b/crates/hyalo-cli/tests/e2e_errors.rs
@@ -341,3 +341,45 @@ fn error_text_format() {
     assert!(stderr.contains("Error:"));
     assert!(stderr.contains("file not found"));
 }
+
+#[test]
+fn error_dir_pointing_to_file() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Test
+---
+# Body
+"),
+    );
+    let file_path = tmp.path().join("note.md");
+
+    let output = hyalo()
+        .args(["--dir", file_path.to_str().unwrap()])
+        .args(["find"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("Error:"),
+        "expected 'Error:' in stderr; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("is a file, not a directory"),
+        "expected helpful message; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--file"),
+        "expected hint about --file; got: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_read.rs
+++ b/crates/hyalo-cli/tests/e2e_read.rs
@@ -612,9 +612,10 @@ fn read_frontmatter_broken_errors() {
         .output()
         .unwrap();
 
-    assert!(
-        !output.status.success(),
-        "expected failure for broken frontmatter; stdout: {}",
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1 (user error) for broken frontmatter; stdout: {}",
         String::from_utf8_lossy(&output.stdout)
     );
     let stderr = String::from_utf8(output.stderr).unwrap();

--- a/crates/hyalo-cli/tests/e2e_read.rs
+++ b/crates/hyalo-cli/tests/e2e_read.rs
@@ -590,3 +590,64 @@ fn read_section_json_output() {
     assert!(content.contains("Solution text."));
     assert!(content.contains("Nested details."));
 }
+
+// ---------------------------------------------------------------------------
+// --frontmatter with broken frontmatter
+// ---------------------------------------------------------------------------
+
+/// `read --frontmatter` on a file with no closing `---` must error, not silently
+/// fabricate a result.
+#[test]
+fn read_frontmatter_broken_errors() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "broken.md",
+        "---\ntitle: Unclosed\nNo closing delimiter here\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "broken.md", "--frontmatter"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected failure for broken frontmatter; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("unclosed frontmatter"),
+        "expected 'unclosed frontmatter' error; got: {stderr}"
+    );
+}
+
+/// `read --frontmatter` on a file with valid frontmatter must still work correctly.
+#[test]
+fn read_frontmatter_valid_works() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "valid.md",
+        "---\ntitle: Good File\nstatus: ok\n---\n# Body\n",
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "valid.md", "--frontmatter"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected success for valid frontmatter; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("title: Good File"),
+        "expected frontmatter in output; got: {stdout}"
+    );
+}

--- a/crates/hyalo-core/src/frontmatter.rs
+++ b/crates/hyalo-core/src/frontmatter.rs
@@ -246,7 +246,9 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
     let mut yaml = String::new();
     let mut line_count = 0;
     let mut closed = false;
+    let mut has_content_lines = false;
     for line in lines {
+        has_content_lines = true;
         let line = line.context("failed to read line")?;
         if line.trim() == "---" {
             closed = true;
@@ -263,6 +265,14 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
     }
 
     if !closed {
+        // A file whose entire content is exactly `---` (with or without a trailing
+        // newline) has no lines after the opening delimiter.  Both `"---"` and `"---\n"`
+        // produce zero iterations in the `lines()` loop because the line iterator
+        // consumes the terminator but yields nothing more.  This mirrors
+        // `extract_frontmatter`'s treatment of those inputs as "no frontmatter".
+        if !has_content_lines {
+            return Ok(BTreeMap::new());
+        }
         anyhow::bail!(
             "unclosed frontmatter: file starts with `---` but no closing `---` was found"
         );
@@ -286,10 +296,19 @@ fn extract_frontmatter(content: &str) -> Result<(Option<&str>, &str)> {
     }
 
     let after_opening = &content[3..];
-    // The opening `---` must be followed by a newline (or be exactly `---`)
+    // The opening `---` must be followed by a newline (or be exactly `---`).
+    // If after stripping the newline the rest is empty, the file is exactly
+    // `---` or `---\n` — no frontmatter content or closing delimiter follows,
+    // so treat as "no frontmatter" (consistent with the streaming reader path).
     let after_opening = if let Some(rest) = after_opening.strip_prefix('\n') {
+        if rest.is_empty() {
+            return Ok((None, content));
+        }
         rest
     } else if let Some(rest) = after_opening.strip_prefix("\r\n") {
+        if rest.is_empty() {
+            return Ok((None, content));
+        }
         rest
     } else if after_opening.is_empty() {
         // File is exactly `---` with nothing after
@@ -768,6 +787,37 @@ status: ok
                 .to_string()
                 .contains("unclosed frontmatter"),
             "expected unclosed frontmatter error for valid-YAML-but-unclosed file"
+        );
+    }
+
+    #[test]
+    fn streaming_solo_dash_is_no_frontmatter() {
+        // A file whose entire content is exactly `---` (no trailing newline) must be
+        // treated as "no frontmatter" — consistent with `extract_frontmatter`.
+        let result = read_frontmatter_from_reader("---".as_bytes());
+        assert!(
+            result.is_ok(),
+            "expected Ok for bare `---`, got: {result:?}"
+        );
+        assert!(
+            result.unwrap().is_empty(),
+            "expected empty map for bare `---`"
+        );
+
+        // Same for `---\n` — indistinguishable from `---` in a line-based reader.
+        let result = read_frontmatter_from_reader("---\n".as_bytes());
+        assert!(result.is_ok(), "expected Ok for `---\\n`, got: {result:?}");
+        assert!(
+            result.unwrap().is_empty(),
+            "expected empty map for `---\\n`"
+        );
+
+        // A file with `---` followed by actual content but no closing delimiter
+        // must still error (not silently become "no frontmatter").
+        let result = read_frontmatter_from_reader("---\ntitle: X\n".as_bytes());
+        assert!(
+            result.is_err(),
+            "expected Err for unclosed frontmatter with content"
         );
     }
 

--- a/crates/hyalo-core/src/frontmatter.rs
+++ b/crates/hyalo-core/src/frontmatter.rs
@@ -245,9 +245,11 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
 
     let mut yaml = String::new();
     let mut line_count = 0;
+    let mut closed = false;
     for line in lines {
         let line = line.context("failed to read line")?;
         if line.trim() == "---" {
+            closed = true;
             break;
         }
         line_count += 1;
@@ -258,6 +260,12 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
         }
         yaml.push_str(&line);
         yaml.push('\n');
+    }
+
+    if !closed {
+        anyhow::bail!(
+            "unclosed frontmatter: file starts with `---` but no closing `---` was found"
+        );
     }
 
     if yaml.trim().is_empty() {
@@ -730,8 +738,7 @@ Body.
 
     #[test]
     fn streaming_no_closing_delimiter() {
-        // No closing `---` means everything after the opening is read as YAML.
-        // If it's not valid YAML, we get an error — which is correct.
+        // No closing `---` must always error — even if the YAML content is valid.
         let input = md!("
 ---
 title: Broken
@@ -739,15 +746,29 @@ Not valid yaml line
 ");
         let result = read_frontmatter_from_reader(input.as_bytes());
         assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unclosed frontmatter"),
+            "expected unclosed frontmatter error"
+        );
 
-        // But if the content happens to be valid YAML, it parses fine
+        // Also errors even when the content happens to be valid YAML
         let input2 = md!("
 ---
 title: Works
 status: ok
 ");
-        let props = read_frontmatter_from_reader(input2.as_bytes()).unwrap();
-        assert_eq!(props.get("title"), Some(&Value::String("Works".into())));
+        let result2 = read_frontmatter_from_reader(input2.as_bytes());
+        assert!(result2.is_err());
+        assert!(
+            result2
+                .unwrap_err()
+                .to_string()
+                .contains("unclosed frontmatter"),
+            "expected unclosed frontmatter error for valid-YAML-but-unclosed file"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Three small fixes from v0.4.1 dogfooding, each in its own commit:

- **ISSUE-5**: `--dir path/to/file.md` now errors with a clear message instead of silently treating the file as a 1-file vault
- **ISSUE-6**: Warnings (e.g., "skipping X: unclosed frontmatter") no longer appear twice when using `--fields links,backlinks` — deduplication via HashSet of already-warned paths
- **read --frontmatter validation**: `read --frontmatter` on a file with unclosed frontmatter now errors instead of silently fabricating a closing `---` delimiter

## Test plan
- [x] 403 tests pass
- [x] cargo fmt / clippy clean
- [x] `--dir file.md` exits 1 with helpful error message
- [x] `find --fields links,backlinks` with broken file shows warning exactly once
- [x] `read --frontmatter` on broken file errors; on valid file works

🤖 Generated with [Claude Code](https://claude.com/claude-code)