### PR TITLE
Iteration 46: UX polish v2 — 7 dogfood follow-ups

### DIFF
--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -106,6 +106,29 @@ hyalo mv --file backlog/my-item.md --to backlog/done/my-item.md
 hyalo mv --file old-path.md --to new-path.md --dry-run
 ```
 
+## Absolute link resolution (site prefix)
+
+Documentation sites often use root-absolute links like `/docs/guides/setup.md`. Hyalo resolves
+these by stripping a **site prefix** — e.g., with prefix `docs`, the link `/docs/guides/setup.md`
+becomes the vault-relative path `guides/setup.md`.
+
+**Auto-derived by default** from the last path component of `--dir`:
+- `--dir ../vscode-docs/docs` → prefix = `docs`
+- `--dir /home/me/wiki` → prefix = `wiki`
+- `--dir .` → no prefix (absolute links stay unresolved)
+
+**Override when the directory name doesn't match the URL prefix:**
+```bash
+# Directory is "content/" but links use "/docs/..." prefix
+hyalo --site-prefix docs --dir ./content find --fields links
+
+# Disable absolute-link resolution entirely
+hyalo --site-prefix "" find --fields links
+```
+
+Also settable in `.hyalo.toml` as `site_prefix = "docs"`.
+Precedence: `--site-prefix` flag > `.hyalo.toml` > auto-derived from `--dir`.
+
 ## When to use hyalo vs. built-in tools
 
 - **hyalo:** queries, frontmatter reads/mutations, tag management, task toggling, bulk updates, **moving/renaming files**

--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -115,7 +115,7 @@ becomes the vault-relative path `guides/setup.md`.
 **Auto-derived by default** from the last path component of `--dir`:
 - `--dir ../vscode-docs/docs` → prefix = `docs`
 - `--dir /home/me/wiki` → prefix = `wiki`
-- `--dir .` → no prefix (absolute links stay unresolved)
+- `--dir .` → prefix = name of the current directory (e.g. `wiki`)
 
 **Override when the directory name doesn't match the URL prefix:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cargo build --release
 
 ## Usage
 
-All commands accept `-d/--dir <path>` (default: `.`), `--format json|text` (default: `json`), `--jq <FILTER>` (apply a jq expression to the JSON output), and `--hints` (append executable drill-down command suggestions).
+All commands accept `-d/--dir <path>` (default: `.`), `--format json|text` (default: `json`), `--jq <FILTER>` (apply a jq expression to the JSON output), `--hints` (append executable drill-down command suggestions), and `--site-prefix <PREFIX>` (override the site prefix used for resolving root-absolute links).
 
 Most flags have short aliases for quick interactive use:
 
@@ -61,11 +61,36 @@ Place a `.hyalo.toml` file in your working directory to set defaults for global 
 dir = "./my-vault"   # default: "."
 format = "text"      # default: "json"
 hints = true         # default: false
+site_prefix = "docs" # override auto-derived prefix for absolute link resolution
 ```
 
 All fields are optional. CLI flags always take precedence over config values. If `.hyalo.toml` is missing, hyalo silently uses built-in defaults; if the file is present but cannot be read or is malformed/invalid, hyalo warns on stderr and falls back to the built-in defaults.
 
 Use `--no-hints` to explicitly disable hints when the config file enables them.
+
+### Absolute link resolution (site prefix)
+
+Documentation sites often use root-absolute links like `/docs/guides/setup.md`. Hyalo resolves these by stripping a site prefix — turning `/docs/guides/setup.md` into the vault-relative path `guides/setup.md`.
+
+By default, hyalo auto-derives the prefix from the last component of `--dir`:
+
+```
+--dir ../vscode-docs/docs  →  prefix = "docs"   (/docs/foo.md → foo.md)
+--dir /home/me/wiki        →  prefix = "wiki"    (/wiki/foo.md → foo.md)
+--dir .                    →  no prefix           (absolute links stay unresolved)
+```
+
+Override when the directory name doesn't match the URL prefix:
+
+```sh
+# Directory is "content/" but links use "/docs/..." prefix
+hyalo --site-prefix docs --dir ./content find --fields links
+
+# Disable absolute-link resolution entirely
+hyalo --site-prefix "" find --fields links
+```
+
+Precedence: `--site-prefix` flag > `site_prefix` in `.hyalo.toml` > auto-derived from `--dir`.
 
 ### init
 
@@ -358,6 +383,8 @@ Updated 1 link in 1 file:
 ```
 
 Use `--dry-run` to preview which files and links would change without modifying anything.
+
+Root-absolute links (e.g. `/docs/guides/setup.md`) are also rewritten during a move. Hyalo uses the site prefix to map these to vault-relative paths. If `mv` reports 0 links updated but you expect absolute links to be rewritten, check your `--site-prefix` setting (see [Absolute link resolution](#absolute-link-resolution-site-prefix)).
 
 ### Hints
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ By default, hyalo auto-derives the prefix from the last component of `--dir`:
 ```
 --dir ../vscode-docs/docs  →  prefix = "docs"   (/docs/foo.md → foo.md)
 --dir /home/me/wiki        →  prefix = "wiki"    (/wiki/foo.md → foo.md)
---dir .                    →  no prefix           (absolute links stay unresolved)
+--dir .                    →  prefix = current directory name (e.g. "wiki")
 ```
 
 Override when the directory name doesn't match the URL prefix:

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -116,7 +116,7 @@ pub fn append(
     dir: &Path,
     property_args: &[String],
     files: &[String],
-    glob: Option<&str>,
+    globs: &[String],
     where_property_filters: &[PropertyFilter],
     where_tag_filters: &[String],
     format: Format,
@@ -132,7 +132,7 @@ pub fn append(
         return Ok(CommandOutcome::UserError(out));
     }
 
-    if let Some(outcome) = require_file_or_glob(files, glob, "append", format) {
+    if let Some(outcome) = require_file_or_glob(files, globs, "append", format) {
         return Ok(outcome);
     }
 
@@ -156,7 +156,7 @@ pub fn append(
         v
     };
 
-    let files = collect_files(dir, files, glob, format)?;
+    let files = collect_files(dir, files, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -266,7 +266,7 @@ title: Note
             tmp.path(),
             &["aliases=my-note".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -304,7 +304,7 @@ aliases:
             tmp.path(),
             &["aliases=new-name".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -334,7 +334,7 @@ aliases:
             tmp.path(),
             &["aliases=my-note".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -367,7 +367,7 @@ author: Alice
             tmp.path(),
             &["author=Bob".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -398,7 +398,7 @@ author: Alice
             tmp.path(),
             &["author=Alice".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -430,7 +430,7 @@ title: Note
             tmp.path(),
             &["aliases=a".to_owned(), "tags=rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -453,7 +453,7 @@ title: Note
             tmp.path(),
             &["aliases=x".to_owned()],
             &[],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -469,7 +469,7 @@ title: Note
             tmp.path(),
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -486,7 +486,7 @@ title: Note
             tmp.path(),
             &["no-equals-sign".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -503,7 +503,7 @@ title: Note
             tmp.path(),
             &["=value".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -526,7 +526,7 @@ title: Note
             tmp.path(),
             &["aliases=my-note".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -555,7 +555,7 @@ title: Note
             tmp.path(),
             &["aliases=a".to_owned(), "aliases=b".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -589,7 +589,7 @@ title: Note
             tmp.path(),
             &["aliases=draft-copy".to_owned()],
             &[],
-            Some("*.md"),
+            &["*.md".to_owned()],
             &[filter],
             &[],
             Format::Json,
@@ -621,7 +621,7 @@ title: Note
             tmp.path(),
             &["aliases=rust-note".to_owned()],
             &[],
-            Some("*.md"),
+            &["*.md".to_owned()],
             &[],
             &["rust".to_owned()],
             Format::Json,

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -334,6 +334,9 @@ pub fn find(
             obj.links = None;
         }
     }
+    // Note: no strip needed for BacklinksCount — build_file_object only populates
+    // obj.backlinks when fields.backlinks is true. The sort closure queries
+    // link_graph directly when obj.backlinks is None.
 
     // --- Limit ---
     if let Some(n) = limit {

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -47,13 +47,19 @@ pub fn find(
     task_filter: Option<&FindTaskFilter>,
     section_filters: &[SectionFilter],
     files_arg: &[String],
-    glob: Option<&str>,
+    globs: &[String],
     fields: &Fields,
     sort: Option<&SortField>,
     limit: Option<usize>,
     format: Format,
 ) -> Result<CommandOutcome> {
-    let files = collect_files(dir, files_arg, glob, format)?;
+    // Treat --limit 0 as "no limit" (more intuitive than returning zero results).
+    let limit = match limit {
+        Some(0) => None,
+        other => other,
+    };
+
+    let files = collect_files(dir, files_arg, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -61,7 +67,15 @@ pub fn find(
 
     // Normalize empty / whitespace-only pattern to None so that
     // `hyalo find ""` behaves the same as `hyalo find` (no filter).
+    if pattern.is_some_and(|p| p.trim().is_empty()) {
+        eprintln!(
+            "warning: empty body pattern ignored (matches all files); omit the pattern to find all files"
+        );
+    }
     let pattern = pattern.and_then(|p| if p.trim().is_empty() { None } else { Some(p) });
+
+    let sort_needs_backlinks = matches!(sort, Some(SortField::BacklinksCount));
+    let sort_needs_links = matches!(sort, Some(SortField::LinksCount));
 
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
@@ -71,7 +85,7 @@ pub fn find(
         has_content_search,
         has_task_filter,
         has_section_filter,
-    );
+    ) || sort_needs_links;
 
     // Compile the regex once (if any), then clone cheaply per file.
     // Invalid regex is a user error (exit 1), not an internal error (exit 2).
@@ -104,7 +118,7 @@ pub fn find(
     // but `rel_path` in the loop is always forward-slash-normalized
     // (via `discovery::relative_path`), so we normalize here to match.
     let mut link_graph_warned: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let link_graph = if fields.backlinks {
+    let link_graph = if fields.backlinks || sort_needs_backlinks {
         let build = LinkGraph::build(dir, site_prefix)?;
         for (path, msg) in &build.warnings {
             eprintln!("warning: skipping {}: {msg}", path.display());
@@ -126,25 +140,28 @@ pub fn find(
     let can_short_circuit = limit.is_some()
         && files_arg.is_empty()
         && matches!(sort.unwrap_or(&SortField::File), SortField::File)
-        && !fields.backlinks;
+        && !fields.backlinks
+        && !sort_needs_backlinks
+        && !sort_needs_links;
 
     let mut results: Vec<FileObject> = Vec::new();
 
     for (full_path, rel_path) in &files {
         // --- Single-pass scan ---
         let mut fm = FrontmatterCollector::new(body_needed);
-        let mut section_scanner =
-            if body_needed && (fields.sections || fields.links || has_section_filter) {
-                Some(SectionScanner::new())
-            } else {
-                None
-            };
+        let mut section_scanner = if body_needed
+            && (fields.sections || fields.links || sort_needs_links || has_section_filter)
+        {
+            Some(SectionScanner::new())
+        } else {
+            None
+        };
         let mut task_extractor = if body_needed && (fields.tasks || has_task_filter) {
             Some(TaskExtractor::new())
         } else {
             None
         };
-        let mut link_collector = if body_needed && fields.links {
+        let mut link_collector = if body_needed && (fields.links || sort_needs_links) {
             Some(LinkCollector::new())
         } else {
             None
@@ -278,6 +295,44 @@ pub fn find(
     match sort.unwrap_or(&SortField::File) {
         SortField::File => results.sort_by(|a, b| a.file.cmp(&b.file)),
         SortField::Modified => results.sort_by(|a, b| a.modified.cmp(&b.modified)),
+        SortField::BacklinksCount => {
+            // Sort descending by backlink count (most-linked first).
+            results.sort_by(|a, b| {
+                let a_count = a.backlinks.as_ref().map_or_else(
+                    || {
+                        link_graph
+                            .as_ref()
+                            .map_or(0, |g| g.backlinks(&a.file).len())
+                    },
+                    Vec::len,
+                );
+                let b_count = b.backlinks.as_ref().map_or_else(
+                    || {
+                        link_graph
+                            .as_ref()
+                            .map_or(0, |g| g.backlinks(&b.file).len())
+                    },
+                    Vec::len,
+                );
+                b_count.cmp(&a_count)
+            });
+        }
+        SortField::LinksCount => {
+            // Sort descending by outbound link count.
+            results.sort_by(|a, b| {
+                let a_count = a.links.as_ref().map_or(0, Vec::len);
+                let b_count = b.links.as_ref().map_or(0, Vec::len);
+                b_count.cmp(&a_count)
+            });
+        }
+    }
+
+    // Strip internally-computed fields that the user didn't request in --fields.
+    // These were populated only to support sorting by count.
+    if sort_needs_links && !fields.links {
+        for obj in &mut results {
+            obj.links = None;
+        }
     }
 
     // --- Limit ---
@@ -418,7 +473,7 @@ fn build_file_object(
 
     let tasks = if fields.tasks { collected_tasks } else { None };
 
-    let links = if fields.links {
+    let links = if fields.links || link_collector.is_some() {
         link_collector.map(|lc| {
             lc.into_links()
                 .into_iter()
@@ -598,7 +653,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -626,7 +681,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -657,7 +712,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -694,7 +749,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -724,7 +779,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -755,7 +810,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -784,7 +839,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -814,7 +869,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -843,7 +898,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -875,7 +930,7 @@ Just some text here.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -941,7 +996,7 @@ title: Empty Body
                     None,
                     &[],
                     &[],
-                    None,
+                    &[],
                     &fields,
                     None,
                     None,
@@ -965,7 +1020,7 @@ title: Empty Body
                     None,
                     &[],
                     &[],
-                    None,
+                    &[],
                     &fields,
                     None,
                     None,
@@ -1001,7 +1056,7 @@ title: Empty Body
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1035,7 +1090,7 @@ title: Empty Body
                 Some(&FindTaskFilter::Todo),
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1065,7 +1120,7 @@ title: Empty Body
                 Some(&FindTaskFilter::Any),
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1096,7 +1151,7 @@ title: Empty Body
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1130,7 +1185,7 @@ title: Empty Body
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1168,7 +1223,7 @@ title: Empty Body
                 None,
                 &[],
                 &["alpha.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1203,7 +1258,7 @@ title: Empty Body
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 Some(1),
@@ -1233,7 +1288,7 @@ title: Empty Body
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 Some(&SortField::Modified),
                 None,
@@ -1270,7 +1325,7 @@ title: Empty Body
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1298,7 +1353,7 @@ title: Empty Body
             None,
             &[],
             &["does-not-exist.md".to_owned()],
-            None,
+            &[],
             &fields,
             None,
             None,
@@ -1462,7 +1517,7 @@ Just intro, no tasks section.
                 None,
                 &section_filters,
                 &["notes.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1494,7 +1549,7 @@ Just intro, no tasks section.
                 None,
                 &section_filters,
                 &["notes.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1528,7 +1583,7 @@ Just intro, no tasks section.
                 None,
                 &section_filters,
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1561,7 +1616,7 @@ Just intro, no tasks section.
                 None,
                 &section_filters,
                 &["notes.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1600,7 +1655,7 @@ Just intro, no tasks section.
                 None,
                 &section_filters,
                 &["empty.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1652,7 +1707,7 @@ Just intro, no tasks section.
             None,
             &[],
             &[],
-            None,
+            &[],
             &fields,
             None,
             None,
@@ -1687,7 +1742,7 @@ Just intro, no tasks section.
                 None,
                 &[],
                 &["alpha.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1745,7 +1800,7 @@ Just intro, no tasks section.
                 None,
                 &[],
                 &["alpha.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1783,7 +1838,7 @@ Just intro, no tasks section.
                 None,
                 &[],
                 &["alpha.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1822,7 +1877,7 @@ Just intro, no tasks section.
                 None,
                 &[],
                 &["beta.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1854,7 +1909,7 @@ Just intro, no tasks section.
                 None,
                 &[],
                 &[],
-                None,
+                &[],
                 &fields,
                 None,
                 None,
@@ -1888,7 +1943,7 @@ Just intro, no tasks section.
                 None,
                 &[],
                 &["gamma.md".to_owned()],
-                None,
+                &[],
                 &fields,
                 None,
                 None,

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -36,11 +36,11 @@ pub enum FilesOrOutcome {
 pub fn collect_files(
     dir: &Path,
     files: &[String],
-    glob: Option<&str>,
+    globs: &[String],
     format: Format,
 ) -> Result<FilesOrOutcome> {
-    match (files.is_empty(), glob) {
-        (false, None) => {
+    match (files.is_empty(), globs.is_empty()) {
+        (false, true) => {
             // Resolve each file, best-effort: collect successes and errors
             let mut resolved = Vec::new();
             let mut errors = Vec::new();
@@ -72,12 +72,12 @@ pub fn collect_files(
             }
             Ok(FilesOrOutcome::Files(resolved))
         }
-        (true, Some(pattern)) => {
+        (true, false) => {
             let all = discovery::discover_files(dir)?;
-            let matched = discovery::match_glob(dir, &all, pattern)?;
+            let matched = discovery::match_globs(dir, &all, globs)?;
             Ok(FilesOrOutcome::Files(matched))
         }
-        (true, None) => {
+        (true, true) => {
             // Operate on all .md files
             let all = discovery::discover_files(dir)?;
             let with_rel: Vec<(PathBuf, String)> = all
@@ -89,7 +89,7 @@ pub fn collect_files(
                 .collect();
             Ok(FilesOrOutcome::Files(with_rel))
         }
-        (false, Some(_)) => {
+        (false, false) => {
             // Clap enforces mutual exclusivity; this branch is unreachable in practice
             let out = crate::output::format_error(
                 format,
@@ -110,11 +110,11 @@ pub fn collect_files(
 #[must_use]
 pub fn require_file_or_glob(
     files: &[String],
-    glob: Option<&str>,
+    globs: &[String],
     command_name: &str,
     format: Format,
 ) -> Option<CommandOutcome> {
-    if files.is_empty() && glob.is_none() {
+    if files.is_empty() && globs.is_empty() {
         let out = crate::output::format_error(
             format,
             &format!("{command_name} requires --file or --glob"),

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -13,11 +13,11 @@ use serde::Serialize;
 pub fn properties_summary(
     dir: &Path,
     file: Option<&str>,
-    glob: Option<&str>,
+    globs: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     let file_vec: Vec<String> = file.map(|f| vec![f.to_owned()]).unwrap_or_default();
-    let files = collect_files(dir, &file_vec, glob, format)?;
+    let files = collect_files(dir, &file_vec, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -76,7 +76,7 @@ pub fn properties_rename(
     dir: &Path,
     from: &str,
     to: &str,
-    glob: Option<&str>,
+    globs: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     if from == to {
@@ -90,7 +90,7 @@ pub fn properties_rename(
         return Ok(CommandOutcome::UserError(out));
     }
 
-    let files = collect_files(dir, &[], glob, format)?;
+    let files = collect_files(dir, &[], globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -189,7 +189,7 @@ tags:
     fn properties_summary_aggregates() {
         let tmp = setup_dir();
         let (out, ok) =
-            unwrap_output(properties_summary(tmp.path(), None, None, Format::Json).unwrap());
+            unwrap_output(properties_summary(tmp.path(), None, &[], Format::Json).unwrap());
         assert!(ok);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
         assert!(!parsed.is_empty());
@@ -213,7 +213,7 @@ keywords: test
         .unwrap();
 
         let outcome =
-            properties_rename(tmp.path(), "keywords", "Keywords", None, Format::Json).unwrap();
+            properties_rename(tmp.path(), "keywords", "Keywords", &[], Format::Json).unwrap();
         let CommandOutcome::Success(out) = outcome else {
             panic!("expected success")
         };
@@ -241,7 +241,7 @@ title: Note
         .unwrap();
 
         let outcome =
-            properties_rename(tmp.path(), "keywords", "Keywords", None, Format::Json).unwrap();
+            properties_rename(tmp.path(), "keywords", "Keywords", &[], Format::Json).unwrap();
         let CommandOutcome::Success(out) = outcome else {
             panic!("expected success")
         };
@@ -266,7 +266,7 @@ Keywords: other
         .unwrap();
 
         let outcome =
-            properties_rename(tmp.path(), "keywords", "Keywords", None, Format::Json).unwrap();
+            properties_rename(tmp.path(), "keywords", "Keywords", &[], Format::Json).unwrap();
         let CommandOutcome::Success(out) = outcome else {
             panic!("expected success")
         };
@@ -278,7 +278,7 @@ Keywords: other
     #[test]
     fn properties_rename_same_name_error() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome = properties_rename(tmp.path(), "foo", "foo", None, Format::Json).unwrap();
+        let outcome = properties_rename(tmp.path(), "foo", "foo", &[], Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -291,7 +291,7 @@ Keywords: other
         fs::write(tmp.path().join("number.md"), "---\npriority: 3\n---\n").unwrap();
 
         let (out, ok) =
-            unwrap_output(properties_summary(tmp.path(), None, None, Format::Json).unwrap());
+            unwrap_output(properties_summary(tmp.path(), None, &[], Format::Json).unwrap());
         assert!(ok);
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
         let priority_entries: Vec<&serde_json::Value> =
@@ -327,7 +327,7 @@ title: Good Note
         )
         .unwrap();
 
-        let outcome = properties_summary(tmp.path(), None, None, Format::Json).unwrap();
+        let outcome = properties_summary(tmp.path(), None, &[], Format::Json).unwrap();
         let (out, ok) = unwrap_output(outcome);
         assert!(ok, "expected Success, got UserError: {out}");
 

--- a/crates/hyalo-cli/src/commands/remove.rs
+++ b/crates/hyalo-cli/src/commands/remove.rs
@@ -167,7 +167,7 @@ pub fn remove(
     property_args: &[String],
     tag_args: &[String],
     files: &[String],
-    glob: Option<&str>,
+    globs: &[String],
     where_property_filters: &[PropertyFilter],
     where_tag_filters: &[String],
     format: Format,
@@ -183,7 +183,7 @@ pub fn remove(
         return Ok(CommandOutcome::UserError(out));
     }
 
-    if let Some(outcome) = require_file_or_glob(files, glob, "remove", format) {
+    if let Some(outcome) = require_file_or_glob(files, globs, "remove", format) {
         return Ok(outcome);
     }
 
@@ -217,7 +217,7 @@ pub fn remove(
         .map(|arg| parse_kv_optional(arg).expect("already validated"))
         .collect();
 
-    let files = collect_files(dir, files, glob, format)?;
+    let files = collect_files(dir, files, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -390,7 +390,7 @@ status: draft
             &["status".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -427,7 +427,7 @@ title: Note
             &["status".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -461,7 +461,7 @@ status: draft
             &["status=draft".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -495,7 +495,7 @@ status: published
             &["status=draft".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -533,7 +533,7 @@ aliases:
             &["aliases=old-name".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -572,7 +572,7 @@ tags:
             &[],
             &["rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -609,7 +609,7 @@ tags:
             &[],
             &["rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -630,7 +630,7 @@ tags:
             &["status".to_owned()],
             &[],
             &[],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -647,7 +647,7 @@ tags:
             &[],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -676,7 +676,7 @@ tags:
             &["status".to_owned()],
             &["rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -705,7 +705,7 @@ tags:
             &["status".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -737,7 +737,7 @@ priority: low
             &["status".to_owned(), "priority".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -780,7 +780,7 @@ priority: low
             &["priority".to_owned()],
             &[],
             &[],
-            Some("*.md"),
+            &["*.md".to_owned()],
             &[filter],
             &[],
             Format::Json,
@@ -817,7 +817,7 @@ priority: low
             &["status".to_owned()],
             &[],
             &[],
-            Some("*.md"),
+            &["*.md".to_owned()],
             &[],
             &["deprecated".to_owned()],
             Format::Json,

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -141,7 +141,7 @@ pub fn set(
     property_args: &[String],
     tag_args: &[String],
     files: &[String],
-    glob: Option<&str>,
+    globs: &[String],
     where_property_filters: &[PropertyFilter],
     where_tag_filters: &[String],
     format: Format,
@@ -159,7 +159,7 @@ pub fn set(
     }
 
     // Mutation commands require --file or --glob
-    if let Some(outcome) = require_file_or_glob(files, glob, "set", format) {
+    if let Some(outcome) = require_file_or_glob(files, globs, "set", format) {
         return Ok(outcome);
     }
 
@@ -211,7 +211,7 @@ pub fn set(
         v
     };
 
-    let files = collect_files(dir, files, glob, format)?;
+    let files = collect_files(dir, files, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -384,7 +384,7 @@ title: Note
             &["status=done".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -423,7 +423,7 @@ status: draft
             &["status=published".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -453,7 +453,7 @@ status: done
             &["status=done".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -486,7 +486,7 @@ title: Note
             &[],
             &["rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -522,7 +522,7 @@ tags:
             &[],
             &["rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -553,7 +553,7 @@ title: Note
             &["status=done".to_owned()],
             &["rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -575,7 +575,7 @@ title: Note
             &["status=done".to_owned()],
             &[],
             &[],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -592,7 +592,7 @@ title: Note
             &[],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -610,7 +610,7 @@ title: Note
             &["no-equals-sign".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -628,7 +628,7 @@ title: Note
             &[],
             &["1984".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -652,7 +652,7 @@ title: Note
             &["status=done".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -683,7 +683,7 @@ title: Note
             &["status=done".to_owned(), "priority=high".to_owned()],
             &[],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -724,7 +724,7 @@ title: Note
             &["status=done".to_owned()],
             &["rust".to_owned()],
             &["note.md".to_owned()],
-            None,
+            &[],
             &[],
             &[],
             Format::Json,
@@ -759,7 +759,7 @@ title: Note
             &["priority=high".to_owned()],
             &[],
             &[],
-            Some("*.md"),
+            &["*.md".to_owned()],
             &[filter],
             &[],
             Format::Json,
@@ -793,7 +793,7 @@ title: Note
             &["status=reviewed".to_owned()],
             &[],
             &[],
-            Some("*.md"),
+            &["*.md".to_owned()],
             &[],
             &["rust".to_owned()],
             Format::Json,

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -19,12 +19,12 @@ use hyalo_core::types::{
 /// Show a high-level vault summary.
 pub fn summary(
     dir: &Path,
-    glob: Option<&str>,
+    globs: &[String],
     recent: usize,
     depth: Option<usize>,
     format: Format,
 ) -> Result<CommandOutcome> {
-    let files = collect_files(dir, &[], glob, format)?;
+    let files = collect_files(dir, &[], globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -35,7 +35,7 @@ pub fn summary(
     // This avoids a second full-vault scan for orphan detection.
     // When a glob IS active, orphan detection needs a vault-wide link graph
     // (links from outside the glob count), so we do a separate LinkGraph::build.
-    let collect_links = glob.is_none();
+    let collect_links = globs.is_empty();
 
     // Aggregation state
     let mut total_files: usize = 0;
@@ -351,14 +351,14 @@ No tasks here.
     #[test]
     fn summary_file_counts() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         assert_eq!(val["files"]["total"], 3);
     }
 
     #[test]
     fn summary_directory_counts() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let by_dir = val["files"]["by_directory"].as_array().unwrap();
         // Should have "." and "notes"
         assert!(
@@ -376,7 +376,7 @@ No tasks here.
     #[test]
     fn summary_task_counts() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         // a.md: 2 tasks (1 done), b.md: 1 task (0 done), c.md: 0 tasks
         assert_eq!(val["tasks"]["total"], 3);
         assert_eq!(val["tasks"]["done"], 1);
@@ -385,7 +385,7 @@ No tasks here.
     #[test]
     fn summary_property_aggregation() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let props = val["properties"].as_array().unwrap();
         // title appears in all 3 files, status in all 3 files, tags in 2 files
         let title = props.iter().find(|p| p["name"] == "title").unwrap();
@@ -397,7 +397,7 @@ No tasks here.
     #[test]
     fn summary_tag_aggregation() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let total_tags = val["tags"]["total"].as_u64().unwrap();
         // rust and cli are unique tag names
         assert_eq!(total_tags, 2);
@@ -411,7 +411,7 @@ No tasks here.
     #[test]
     fn summary_status_grouping() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let status_groups = val["status"].as_array().unwrap();
         let draft = status_groups
             .iter()
@@ -426,7 +426,7 @@ No tasks here.
     #[test]
     fn summary_recent_files_respects_limit() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 2, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 2, None, Format::Json).unwrap());
         let recent = val["recent_files"].as_array().unwrap();
         // With limit=2, at most 2 recent files
         assert!(recent.len() <= 2);
@@ -435,7 +435,7 @@ No tasks here.
     #[test]
     fn summary_recent_files_have_iso8601_timestamps() {
         let tmp = setup_vault();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let recent = val["recent_files"].as_array().unwrap();
         for entry in recent {
             let modified = entry["modified"].as_str().unwrap();
@@ -451,15 +451,16 @@ No tasks here.
     fn summary_glob_filter() {
         let tmp = setup_vault();
         // Only scan root files, not notes/
-        let val =
-            unwrap_success(summary(tmp.path(), Some("*.md"), 10, None, Format::Json).unwrap());
+        let val = unwrap_success(
+            summary(tmp.path(), &["*.md".to_owned()], 10, None, Format::Json).unwrap(),
+        );
         assert_eq!(val["files"]["total"], 2);
     }
 
     #[test]
     fn summary_text_format() {
         let tmp = setup_vault();
-        let outcome = summary(tmp.path(), None, 10, None, Format::Text).unwrap();
+        let outcome = summary(tmp.path(), &[], 10, None, Format::Text).unwrap();
         match outcome {
             CommandOutcome::Success(s) => {
                 assert!(s.contains("Files:"), "expected 'Files:' in: {s}");
@@ -486,7 +487,7 @@ No tasks here.
     #[test]
     fn summary_depth_zero_collapses_all() {
         let tmp = setup_vault_nested();
-        let val = unwrap_success(summary(tmp.path(), None, 10, Some(0), Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, Some(0), Format::Json).unwrap());
         let by_dir = val["files"]["by_directory"].as_array().unwrap();
         assert_eq!(by_dir.len(), 1);
         assert_eq!(by_dir[0]["directory"], ".");
@@ -496,7 +497,7 @@ No tasks here.
     #[test]
     fn summary_depth_one_shows_top_level() {
         let tmp = setup_vault_nested();
-        let val = unwrap_success(summary(tmp.path(), None, 10, Some(1), Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, Some(1), Format::Json).unwrap());
         let by_dir = val["files"]["by_directory"].as_array().unwrap();
         // "." (1 file) and "notes" (2 files collapsed from notes/ and notes/sub/)
         assert_eq!(by_dir.len(), 2);
@@ -509,7 +510,7 @@ No tasks here.
     #[test]
     fn summary_depth_none_shows_all() {
         let tmp = setup_vault_nested();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let by_dir = val["files"]["by_directory"].as_array().unwrap();
         assert_eq!(by_dir.len(), 3);
         assert!(by_dir.iter().any(|d| d["directory"] == "."));
@@ -522,9 +523,9 @@ No tasks here.
         // Stats (tasks, tags, properties) must be computed from all files regardless of depth
         let tmp = setup_vault_nested();
         let val_no_depth =
-            unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+            unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let val_depth0 =
-            unwrap_success(summary(tmp.path(), None, 10, Some(0), Format::Json).unwrap());
+            unwrap_success(summary(tmp.path(), &[], 10, Some(0), Format::Json).unwrap());
         assert_eq!(val_no_depth["files"]["total"], val_depth0["files"]["total"]);
         assert_eq!(val_no_depth["tasks"], val_depth0["tasks"]);
         assert_eq!(val_no_depth["tags"], val_depth0["tags"]);
@@ -545,7 +546,7 @@ No tasks here.
         .unwrap();
 
         // No glob: single-pass code path
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         let orphan_files: Vec<&str> = val["orphans"]["files"]
             .as_array()
             .unwrap()
@@ -587,8 +588,9 @@ No tasks here.
         .unwrap();
 
         // Passing "*.md" glob activates the separate LinkGraph::build code path.
-        let val =
-            unwrap_success(summary(tmp.path(), Some("*.md"), 10, None, Format::Json).unwrap());
+        let val = unwrap_success(
+            summary(tmp.path(), &["*.md".to_owned()], 10, None, Format::Json).unwrap(),
+        );
         let orphan_files: Vec<&str> = val["orphans"]["files"]
             .as_array()
             .unwrap()
@@ -623,7 +625,7 @@ No tasks here.
             "---\ntitle: Broken\nNo closing delimiter.\n",
         )
         .unwrap();
-        let val = unwrap_success(summary(tmp.path(), None, 10, None, Format::Json).unwrap());
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, Format::Json).unwrap());
         // Only the 3 good files should be counted
         assert_eq!(val["files"]["total"], 3);
     }

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -53,11 +53,11 @@ pub fn validate_tag(name: &str) -> Result<(), String> {
 pub fn tags_summary(
     dir: &Path,
     file: Option<&str>,
-    glob: Option<&str>,
+    globs: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     let file_vec: Vec<String> = file.map(|f| vec![f.to_owned()]).unwrap_or_default();
-    let files = collect_files(dir, &file_vec, glob, format)?;
+    let files = collect_files(dir, &file_vec, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -120,7 +120,7 @@ pub fn tags_rename(
     dir: &Path,
     from: &str,
     to: &str,
-    glob: Option<&str>,
+    globs: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     // Validate both tag names
@@ -144,7 +144,7 @@ pub fn tags_rename(
     }
 
     let file_vec: Vec<String> = Vec::new();
-    let files = collect_files(dir, &file_vec, glob, format)?;
+    let files = collect_files(dir, &file_vec, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
         FilesOrOutcome::Outcome(o) => return Ok(o),
@@ -390,7 +390,7 @@ tags:
     #[test]
     fn tags_summary_all_files() {
         let tmp = setup_vault();
-        let outcome = tags_summary(tmp.path(), None, None, Format::Json).unwrap();
+        let outcome = tags_summary(tmp.path(), None, &[], Format::Json).unwrap();
         let out = match outcome {
             CommandOutcome::Success(s) => s,
             CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
@@ -405,7 +405,7 @@ tags:
     #[test]
     fn tags_summary_single_file() {
         let tmp = setup_vault();
-        let outcome = tags_summary(tmp.path(), Some("a.md"), None, Format::Json).unwrap();
+        let outcome = tags_summary(tmp.path(), Some("a.md"), &[], Format::Json).unwrap();
         let out = match outcome {
             CommandOutcome::Success(s) => s,
             CommandOutcome::UserError(s) => panic!("unexpected error: {s}"),
@@ -420,7 +420,7 @@ tags:
     fn tags_summary_no_file_or_glob_reads_all() {
         let tmp = setup_vault();
         // tags_summary (read-only) still accepts no --file/--glob
-        let outcome = tags_summary(tmp.path(), None, None, Format::Json).unwrap();
+        let outcome = tags_summary(tmp.path(), None, &[], Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::Success(_)));
     }
 
@@ -439,7 +439,7 @@ tags:
         )
         .unwrap();
 
-        let outcome = tags_rename(tmp.path(), "filtering", "filters", None, Format::Json).unwrap();
+        let outcome = tags_rename(tmp.path(), "filtering", "filters", &[], Format::Json).unwrap();
         let CommandOutcome::Success(out) = outcome else {
             panic!("expected success")
         };
@@ -468,7 +468,7 @@ tags:
         )
         .unwrap();
 
-        let outcome = tags_rename(tmp.path(), "filtering", "filters", None, Format::Json).unwrap();
+        let outcome = tags_rename(tmp.path(), "filtering", "filters", &[], Format::Json).unwrap();
         let CommandOutcome::Success(out) = outcome else {
             panic!("expected success")
         };
@@ -497,7 +497,7 @@ tags:
         )
         .unwrap();
 
-        let outcome = tags_rename(tmp.path(), "filtering", "filters", None, Format::Json).unwrap();
+        let outcome = tags_rename(tmp.path(), "filtering", "filters", &[], Format::Json).unwrap();
         let CommandOutcome::Success(out) = outcome else {
             panic!("expected success")
         };
@@ -509,15 +509,14 @@ tags:
     #[test]
     fn tags_rename_same_name_error() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome = tags_rename(tmp.path(), "foo", "foo", None, Format::Json).unwrap();
+        let outcome = tags_rename(tmp.path(), "foo", "foo", &[], Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
     #[test]
     fn tags_rename_invalid_tag_error() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome =
-            tags_rename(tmp.path(), "valid-tag", "invalid tag!", None, Format::Json).unwrap();
+        let outcome = tags_rename(tmp.path(), "1984", "filters", &[], Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -543,7 +542,7 @@ tags:
         )
         .unwrap();
 
-        let outcome = tags_summary(tmp.path(), None, None, Format::Json).unwrap();
+        let outcome = tags_summary(tmp.path(), None, &[], Format::Json).unwrap();
         let out = match outcome {
             CommandOutcome::Success(s) => s,
             CommandOutcome::UserError(s) => panic!("unexpected UserError: {s}"),

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -24,7 +24,7 @@ pub struct HintContext {
     pub source: HintSource,
     /// `None` means "." (default) or came from config — omit from hints.
     pub dir: Option<String>,
-    pub glob: Option<String>,
+    pub glob: Vec<String>,
     /// Explicit `--format` from CLI (not from config).
     pub format: Option<String>,
     /// Explicit `--hints` from CLI (not from config).
@@ -81,7 +81,7 @@ fn build_command_with_glob(ctx: &HintContext, args: &[&str]) -> String {
         parts.push(shell_quote(arg));
     }
     push_global_flags(&mut parts, ctx);
-    if let Some(glob) = &ctx.glob {
+    for glob in &ctx.glob {
         parts.push("--glob".to_owned());
         parts.push(shell_quote(glob));
     }
@@ -268,7 +268,7 @@ mod tests {
         HintContext {
             source,
             dir: None,
-            glob: None,
+            glob: vec![],
             format: None,
             hints: false,
         }
@@ -278,7 +278,7 @@ mod tests {
         HintContext {
             source,
             dir: Some(dir.to_owned()),
-            glob: None,
+            glob: vec![],
             format: None,
             hints: false,
         }
@@ -288,7 +288,7 @@ mod tests {
         HintContext {
             source,
             dir: None,
-            glob: Some(glob.to_owned()),
+            glob: vec![glob.to_owned()],
             format: None,
             hints: false,
         }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -227,7 +227,7 @@ struct Cli {
     /// By default, hyalo auto-derives the prefix from --dir's last path component:
     ///   --dir ../vscode-docs/docs  →  prefix = "docs"
     ///   --dir /home/me/wiki        →  prefix = "wiki"
-    ///   --dir .                    →  no prefix (absolute links stay unresolved)
+    ///   --dir .                    →  prefix = name of the current directory
     ///
     /// Use --site-prefix to override when the directory name doesn't match the URL prefix,
     /// or pass --site-prefix "" to disable absolute-link resolution entirely.

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -29,10 +29,14 @@ use hyalo_core::filter;
         Globs use standard syntax: '**/*.md' matches recursively, 'notes/*.md' matches one level.\n\n\
         OUTPUT: Returns JSON by default (--format json). Use --format text for human-readable output. \
         Successful output goes to stdout; errors go to stderr with exit code 1 (user error) or 2 (internal error).\n\n\
+        ABSOLUTE LINKS: Links like `/docs/page.md` are resolved by stripping a site prefix. \
+        By default the prefix is auto-derived from --dir's last path component (e.g. --dir ../my-site/docs → prefix \"docs\"). \
+        Override with --site-prefix <PREFIX>, or --site-prefix \"\" to disable. Also settable in .hyalo.toml.\n\n\
         CONFIG: Place a .hyalo.toml in the working directory to set defaults:\n\
         \u{00a0} dir = \"vault/\"        # default --dir\n\
-        \u{00a0} format = \"text\"       # example: override --format (CLI default is json)\n\
-        \u{00a0} hints = true           # example: override --hints on (CLI default is off)\n\
+        \u{00a0} format = \"text\"       # default --format (CLI default is json)\n\
+        \u{00a0} hints = true           # default --hints on (CLI default is off)\n\
+        \u{00a0} site_prefix = \"docs\"  # override auto-derived site prefix for absolute links\n\
         CLI flags always take precedence.\n\n\
         See COMMAND REFERENCE below for full syntax of each command.",
     after_help = "EXAMPLES:\n  \
@@ -91,11 +95,12 @@ COMMAND REFERENCE:\n  \
   Init (configuration, one-time setup):\n  \
     hyalo init [--claude] [-d/--dir DIR]\n\n  \
   Global flags (apply to all commands):\n  \
-    -d/--dir <DIR>      Root directory (default: ., override via .hyalo.toml)\n  \
-    --format json|text  Output format (default: json, override via .hyalo.toml)\n  \
-    --jq <FILTER>       Apply a jq expression to JSON output\n  \
-    --hints             Append drill-down hints (default: off, override via .hyalo.toml)\n  \
-    --no-hints          Disable hints (overrides .hyalo.toml)\n\n\
+    -d/--dir <DIR>          Root directory (default: ., override via .hyalo.toml)\n  \
+    --format json|text      Output format (default: json, override via .hyalo.toml)\n  \
+    --jq <FILTER>           Apply a jq expression to JSON output\n  \
+    --hints                 Append drill-down hints (default: off, override via .hyalo.toml)\n  \
+    --no-hints              Disable hints (overrides .hyalo.toml)\n  \
+    --site-prefix <PREFIX>  Override site prefix for absolute link resolution (auto-derived from --dir)\n\n\
 COOKBOOK:\n  \
   # Discover what metadata exists in a vault\n  \
   hyalo properties summary\n  \
@@ -149,7 +154,11 @@ COOKBOOK:\n  \
   # Move a file and update all links\n  \
   hyalo mv --file backlog/old.md --to backlog/done/old.md\n\n  \
   # Preview a move without writing\n  \
-  hyalo mv --file note.md --to archive/note.md --dry-run\n\n\
+  hyalo mv --file note.md --to archive/note.md --dry-run\n\n  \
+  # Override site prefix for absolute link resolution\n  \
+  hyalo --site-prefix docs mv --file old.md --to new.md --dry-run\n\n  \
+  # Disable absolute-link resolution entirely\n  \
+  hyalo --site-prefix '' find --fields links\n\n\
 OUTPUT SHAPES (JSON, default):\n  \
   # find\n  \
   [{\"file\": \"notes/todo.md\", \"modified\": \"2026-03-21T...\",\n   \
@@ -209,9 +218,22 @@ struct Cli {
     #[arg(long, global = true, conflicts_with = "hints")]
     no_hints: bool,
 
-    /// Override the site prefix used when resolving absolute links (e.g. `/docs/page.md`).
-    /// Auto-derived from --dir when not set (uses last path component of the resolved dir).
-    /// Override via .hyalo.toml
+    /// Site prefix for resolving root-absolute links like `/docs/page.md`.
+    ///
+    /// When a markdown file contains a link like `/docs/guides/setup.md`, hyalo strips the
+    /// leading `/<prefix>/` to get the vault-relative path `guides/setup.md`. This is how
+    /// documentation sites (GitHub Pages, VuePress, Docusaurus) map URL paths to file paths.
+    ///
+    /// By default, hyalo auto-derives the prefix from --dir's last path component:
+    ///   --dir ../vscode-docs/docs  →  prefix = "docs"
+    ///   --dir /home/me/wiki        →  prefix = "wiki"
+    ///   --dir .                    →  no prefix (absolute links stay unresolved)
+    ///
+    /// Use --site-prefix to override when the directory name doesn't match the URL prefix,
+    /// or pass --site-prefix "" to disable absolute-link resolution entirely.
+    ///
+    /// Also settable via `site_prefix = "docs"` in .hyalo.toml.
+    /// Precedence: --site-prefix flag > .hyalo.toml > auto-derived from --dir.
     #[arg(long, global = true, value_name = "PREFIX")]
     site_prefix: Option<String>,
 
@@ -263,13 +285,13 @@ enum Commands {
         /// Target file(s) (repeatable). Mutually exclusive with --glob
         #[arg(short, long, conflicts_with = "glob")]
         file: Vec<String>,
-        /// Glob pattern to select files; prefix '!' to negate (e.g. '!**/draft-*' excludes matching files)
+        /// Glob pattern(s) to select files (repeatable); prefix '!' to negate (e.g. '!**/draft-*')
         #[arg(short, long, conflicts_with = "file")]
-        glob: Option<String>,
+        glob: Vec<String>,
         /// Comma-separated list of optional fields to include: properties, properties-typed, tags, sections, tasks, links, backlinks (default: all except properties-typed and backlinks). 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files. Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
         #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
         fields: Vec<String>,
-        /// Sort order: 'file' (default) or 'modified'
+        /// Sort order: 'file' (default), 'modified', 'backlinks_count', or 'links_count'
         #[arg(long)]
         sort: Option<String>,
         /// Maximum number of results to return
@@ -308,7 +330,7 @@ enum Commands {
         - rename: Rename a property key across files (mutates files).")]
     Properties {
         #[command(subcommand)]
-        action: PropertiesAction,
+        action: Option<PropertiesAction>,
     },
     /// Tag operations: summary or bulk rename
     #[command(long_about = "Tag operations across matched files.\n\n\
@@ -317,7 +339,7 @@ enum Commands {
         - rename: Rename a tag across files (mutates files).")]
     Tags {
         #[command(subcommand)]
-        action: TagsAction,
+        action: Option<TagsAction>,
     },
     /// Read, toggle, or set status on a single task checkbox
     #[command(
@@ -344,9 +366,9 @@ enum Commands {
             SIDE EFFECTS: None (read-only).\n\
             USE WHEN: You need a quick overview of a vault's metadata landscape.")]
     Summary {
-        /// Glob pattern to filter which files to include; prefix '!' to negate (e.g. '!**/draft-*')
+        /// Glob pattern(s) to filter which files to include (repeatable); prefix '!' to negate (e.g. '!**/draft-*')
         #[arg(short, long)]
-        glob: Option<String>,
+        glob: Vec<String>,
         /// Number of recent files to show (default: 10)
         #[arg(short = 'n', long, default_value = "10")]
         recent: usize,
@@ -423,9 +445,9 @@ Repeatable (AND).\n\
         /// Target file(s) (repeatable). Mutually exclusive with --glob
         #[arg(short, long, conflicts_with = "glob")]
         file: Vec<String>,
-        /// Glob pattern for multiple files
+        /// Glob pattern(s) for multiple files (repeatable); prefix '!' to negate
         #[arg(short, long, conflicts_with = "file")]
-        glob: Option<String>,
+        glob: Vec<String>,
         /// Filter: only mutate files whose frontmatter property matches (repeatable, AND). Same syntax as find --property
         #[arg(long = "where-property", value_name = "FILTER")]
         where_properties: Vec<String>,
@@ -465,9 +487,9 @@ Repeatable (AND).\n\
         /// Target file(s) (repeatable). Mutually exclusive with --glob
         #[arg(short, long, conflicts_with = "glob")]
         file: Vec<String>,
-        /// Glob pattern for multiple files
+        /// Glob pattern(s) for multiple files (repeatable); prefix '!' to negate
         #[arg(short, long, conflicts_with = "file")]
-        glob: Option<String>,
+        glob: Vec<String>,
         /// Filter: only mutate files whose frontmatter property matches (repeatable, AND). Same syntax as find --property
         #[arg(long = "where-property", value_name = "FILTER")]
         where_properties: Vec<String>,
@@ -517,9 +539,9 @@ Repeatable (AND).\n\
         /// Target file(s) (repeatable). Mutually exclusive with --glob
         #[arg(short, long, conflicts_with = "glob")]
         file: Vec<String>,
-        /// Glob pattern for multiple files
+        /// Glob pattern(s) for multiple files (repeatable); prefix '!' to negate
         #[arg(short, long, conflicts_with = "file")]
-        glob: Option<String>,
+        glob: Vec<String>,
         /// Filter: only mutate files whose frontmatter property matches (repeatable, AND). Same syntax as find --property
         #[arg(long = "where-property", value_name = "FILTER")]
         where_properties: Vec<String>,
@@ -594,9 +616,9 @@ enum PropertiesAction {
         USE WHEN: You need to discover what properties exist or audit frontmatter across a vault."
     )]
     Summary {
-        /// Glob pattern to select files; prefix '!' to negate
+        /// Glob pattern(s) to select files (repeatable); prefix '!' to negate
         #[arg(short, long)]
-        glob: Option<String>,
+        glob: Vec<String>,
     },
     /// Rename a property key across all matched files
     #[command(
@@ -611,9 +633,9 @@ enum PropertiesAction {
         /// Property key to rename to
         #[arg(long)]
         to: String,
-        /// Glob pattern to scope which files to scan; prefix '!' to negate
+        /// Glob pattern(s) to scope which files to scan (repeatable); prefix '!' to negate
         #[arg(short, long)]
-        glob: Option<String>,
+        glob: Vec<String>,
     },
 }
 
@@ -626,9 +648,9 @@ enum TagsAction {
         SIDE EFFECTS: None (read-only).\n\
         USE WHEN: You need to see which tags exist, find popular/orphan tags, or audit tag taxonomy.")]
     Summary {
-        /// Glob pattern to filter which files to scan; prefix '!' to negate
+        /// Glob pattern(s) to filter which files to scan (repeatable); prefix '!' to negate
         #[arg(short, long)]
-        glob: Option<String>,
+        glob: Vec<String>,
     },
     /// Rename a tag across all matched files
     #[command(long_about = "Rename a tag across all matched files.\n\n\
@@ -641,9 +663,9 @@ enum TagsAction {
         /// Tag to rename to
         #[arg(long)]
         to: String,
-        /// Glob pattern to scope which files to scan; prefix '!' to negate
+        /// Glob pattern(s) to scope which files to scan (repeatable); prefix '!' to negate
         #[arg(short, long)]
-        glob: Option<String>,
+        glob: Vec<String>,
     },
 }
 
@@ -843,7 +865,7 @@ fn main() {
                 hints: hints_from_cli,
             }),
             Commands::Properties {
-                action: PropertiesAction::Summary { glob },
+                action: Some(PropertiesAction::Summary { glob }),
             } => Some(HintContext {
                 source: HintSource::PropertiesSummary,
                 dir: dir_hint,
@@ -852,7 +874,7 @@ fn main() {
                 hints: hints_from_cli,
             }),
             Commands::Tags {
-                action: TagsAction::Summary { glob },
+                action: Some(TagsAction::Summary { glob }),
             } => Some(HintContext {
                 source: HintSource::TagsSummary,
                 dir: dir_hint,
@@ -958,7 +980,7 @@ fn main() {
                 task_filter.as_ref(),
                 &section_filters,
                 file,
-                glob.as_deref(),
+                glob,
                 &parsed_fields,
                 sort_field.as_ref(),
                 limit,
@@ -978,26 +1000,32 @@ fn main() {
             frontmatter,
             effective_format,
         ),
-        Commands::Properties { action } => match action {
-            PropertiesAction::Summary { ref glob } => {
-                properties::properties_summary(&dir, None, glob.as_deref(), effective_format)
+        Commands::Properties { action } => {
+            let action = action.unwrap_or(PropertiesAction::Summary { glob: vec![] });
+            match action {
+                PropertiesAction::Summary { ref glob } => {
+                    properties::properties_summary(&dir, None, glob, effective_format)
+                }
+                PropertiesAction::Rename {
+                    ref from,
+                    ref to,
+                    ref glob,
+                } => properties::properties_rename(&dir, from, to, glob, effective_format),
             }
-            PropertiesAction::Rename {
-                ref from,
-                ref to,
-                ref glob,
-            } => properties::properties_rename(&dir, from, to, glob.as_deref(), effective_format),
-        },
-        Commands::Tags { action } => match action {
-            TagsAction::Summary { ref glob } => {
-                tag_commands::tags_summary(&dir, None, glob.as_deref(), effective_format)
+        }
+        Commands::Tags { action } => {
+            let action = action.unwrap_or(TagsAction::Summary { glob: vec![] });
+            match action {
+                TagsAction::Summary { ref glob } => {
+                    tag_commands::tags_summary(&dir, None, glob, effective_format)
+                }
+                TagsAction::Rename {
+                    ref from,
+                    ref to,
+                    ref glob,
+                } => tag_commands::tags_rename(&dir, from, to, glob, effective_format),
             }
-            TagsAction::Rename {
-                ref from,
-                ref to,
-                ref glob,
-            } => tag_commands::tags_rename(&dir, from, to, glob.as_deref(), effective_format),
-        },
+        }
         Commands::Task { action } => match action {
             TaskAction::Read { ref file, line } => {
                 task_commands::task_read(&dir, file, line, effective_format)
@@ -1034,7 +1062,7 @@ fn main() {
             ref glob,
             recent,
             depth,
-        } => summary_commands::summary(&dir, glob.as_deref(), recent, depth, effective_format),
+        } => summary_commands::summary(&dir, glob, recent, depth, effective_format),
         Commands::Set {
             ref properties,
             ref tag,
@@ -1049,7 +1077,7 @@ fn main() {
                 properties,
                 tag,
                 file,
-                glob.as_deref(),
+                glob,
                 &where_prop_filters,
                 where_tags,
                 effective_format,
@@ -1069,7 +1097,7 @@ fn main() {
                 properties,
                 tag,
                 file,
-                glob.as_deref(),
+                glob,
                 &where_prop_filters,
                 where_tags,
                 effective_format,
@@ -1087,7 +1115,7 @@ fn main() {
                 &dir,
                 properties,
                 file,
-                glob.as_deref(),
+                glob,
                 &where_prop_filters,
                 where_tags,
                 effective_format,

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -2207,3 +2207,241 @@ TYPESCRIPT is uppercase
     );
     assert_eq!(matches[0]["text"], "TypeScript is great");
 }
+
+// ---------------------------------------------------------------------------
+// Repeatable --glob tests
+// ---------------------------------------------------------------------------
+
+fn setup_multi_glob_vault() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(tmp.path(), "root.md", "---\ntitle: Root\n---\n# Root\n");
+    write_md(
+        tmp.path(),
+        "sub1/a.md",
+        "---\ntitle: Sub1 A\n---\n# Sub1 A\n",
+    );
+    write_md(
+        tmp.path(),
+        "sub1/b.md",
+        "---\ntitle: Sub1 B\n---\n# Sub1 B\n",
+    );
+    write_md(
+        tmp.path(),
+        "sub2/c.md",
+        "---\ntitle: Sub2 C\n---\n# Sub2 C\n",
+    );
+    write_md(
+        tmp.path(),
+        "sub2/draft.md",
+        "---\ntitle: Sub2 Draft\n---\n# Sub2 Draft\n",
+    );
+    tmp
+}
+
+#[test]
+fn find_repeatable_glob_union_of_two_dirs() {
+    let tmp = setup_multi_glob_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--glob", "sub1/**", "--glob", "sub2/**"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(
+        arr.len(),
+        4,
+        "expected 4 files from sub1 + sub2, got: {files:?}"
+    );
+    assert!(files.contains(&"sub1/a.md"));
+    assert!(files.contains(&"sub1/b.md"));
+    assert!(files.contains(&"sub2/c.md"));
+    assert!(files.contains(&"sub2/draft.md"));
+    assert!(
+        !files.contains(&"root.md"),
+        "root.md should not be included"
+    );
+}
+
+#[test]
+fn find_repeatable_glob_positive_and_negative() {
+    let tmp = setup_multi_glob_vault();
+    // Include all of sub2, but exclude draft.md
+    let (status, json, stderr) =
+        find_json(&tmp, &["--glob", "sub2/**", "--glob", "!sub2/draft.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(arr.len(), 1, "expected only c.md, got: {files:?}");
+    assert!(files.contains(&"sub2/c.md"));
+    assert!(
+        !files.contains(&"sub2/draft.md"),
+        "draft.md should be excluded by negation"
+    );
+}
+
+#[test]
+fn find_repeatable_glob_multiple_negations_only() {
+    // When ALL globs are negations (no positive pattern), start from all files and exclude.
+    let tmp = setup_multi_glob_vault();
+    let (status, json, stderr) =
+        find_json(&tmp, &["--glob", "!sub1/**", "--glob", "!sub2/draft.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    // root.md + sub2/c.md should remain (sub1/** excluded, sub2/draft.md excluded)
+    assert_eq!(arr.len(), 2, "expected root.md + sub2/c.md, got: {files:?}");
+    assert!(files.contains(&"root.md"));
+    assert!(files.contains(&"sub2/c.md"));
+    assert!(
+        !files.contains(&"sub1/a.md"),
+        "sub1 files should be excluded"
+    );
+    assert!(
+        !files.contains(&"sub2/draft.md"),
+        "draft.md should be excluded"
+    );
+}
+
+#[test]
+fn find_repeatable_glob_one_positive_one_negative() {
+    // One inclusive glob and one exclusive glob — should include sub1 files except b.md
+    let tmp = setup_multi_glob_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--glob", "sub1/**", "--glob", "!sub1/b.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(arr.len(), 1, "expected only sub1/a.md, got: {files:?}");
+    assert!(files.contains(&"sub1/a.md"));
+}
+
+#[test]
+fn find_single_glob_backward_compat() {
+    let tmp = setup_multi_glob_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--glob", "sub1/**"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(arr.len(), 2, "expected 2 files in sub1, got: {files:?}");
+    assert!(files.contains(&"sub1/a.md"));
+    assert!(files.contains(&"sub1/b.md"));
+}
+
+// ---------------------------------------------------------------------------
+// --limit 0 = unlimited
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_limit_zero_returns_all_files() {
+    let tmp = setup_vault();
+    let (status_zero, json_zero, stderr) = find_json(&tmp, &["--limit", "0"]);
+    assert!(status_zero.success(), "stderr: {stderr}");
+
+    let (status_all, json_all, _) = find_json(&tmp, &[]);
+    assert!(status_all.success());
+
+    let count_zero = json_zero.as_array().unwrap().len();
+    let count_all = json_all.as_array().unwrap().len();
+    assert_eq!(
+        count_zero, count_all,
+        "--limit 0 should return all files ({count_all}), got {count_zero}"
+    );
+    assert!(count_all > 0, "vault should have files");
+}
+
+// ---------------------------------------------------------------------------
+// Sort by backlinks_count / links_count
+// ---------------------------------------------------------------------------
+
+fn setup_link_vault() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    // a.md links to b and c (2 outbound links)
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\n---\nSee [[b]] and [[c]].\n",
+    );
+    // b.md links to c (1 outbound link)
+    write_md(tmp.path(), "b.md", "---\ntitle: B\n---\nSee [[c]].\n");
+    // c.md has no outbound links (0)
+    write_md(tmp.path(), "c.md", "---\ntitle: C\n---\nNo links here.\n");
+    tmp
+}
+
+#[test]
+fn find_sort_backlinks_count() {
+    let tmp = setup_link_vault();
+    // c has 2 backlinks (from a and b), b has 1 (from a), a has 0
+    let (status, json, stderr) = find_json(
+        &tmp,
+        &["--sort", "backlinks_count", "--fields", "backlinks"],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files.len(), 3, "expected 3 files, got: {files:?}");
+    assert_eq!(files[0], "c.md", "c.md should be first (2 backlinks)");
+    assert_eq!(files[1], "b.md", "b.md should be second (1 backlink)");
+    assert_eq!(files[2], "a.md", "a.md should be last (0 backlinks)");
+}
+
+#[test]
+fn find_sort_links_count() {
+    let tmp = setup_link_vault();
+    // a has 2 outbound links, b has 1, c has 0
+    let (status, json, stderr) = find_json(&tmp, &["--sort", "links_count", "--fields", "links"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files.len(), 3, "expected 3 files, got: {files:?}");
+    assert_eq!(files[0], "a.md", "a.md should be first (2 links)");
+    assert_eq!(files[1], "b.md", "b.md should be second (1 link)");
+    assert_eq!(files[2], "c.md", "c.md should be last (0 links)");
+}
+
+#[test]
+fn find_sort_backlinks_count_without_fields_backlinks() {
+    // Sort by backlinks_count should work even without --fields backlinks
+    let tmp = setup_link_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--sort", "backlinks_count"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files[0], "c.md", "c.md should be first (most backlinks)");
+    // Verify backlinks field is NOT in output (user didn't request it)
+    assert!(
+        arr[0].get("backlinks").is_none(),
+        "backlinks should not appear in output when not in --fields"
+    );
+}
+
+#[test]
+fn find_sort_links_count_without_fields_links() {
+    // Sort by links_count should work even when --fields excludes links
+    let tmp = setup_link_vault();
+    let (status, json, stderr) =
+        find_json(&tmp, &["--sort", "links_count", "--fields", "properties"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files[0], "a.md", "a.md should be first (most links)");
+    // Verify links field is NOT in output (user excluded it via --fields)
+    assert!(
+        arr[0].get("links").is_none(),
+        "links should not appear in output when not in --fields"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Empty body pattern warning
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_empty_body_pattern_warns() {
+    let tmp = setup_vault();
+    let (status, json, stderr) = find_json(&tmp, &[""]);
+    assert!(status.success(), "should succeed: {stderr}");
+    let arr = json.as_array().unwrap();
+    assert!(!arr.is_empty(), "empty pattern should still return files");
+    assert!(
+        stderr.contains("warning"),
+        "stderr should contain a warning about empty pattern, got: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_properties.rs
+++ b/crates/hyalo-cli/tests/e2e_properties.rs
@@ -489,3 +489,35 @@ fn properties_glob_negation_excludes_files() {
         "exclusive_prop should be excluded via negation glob"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Bare `hyalo properties` defaults to summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn properties_bare_defaults_to_summary() {
+    let tmp = tempfile::tempdir().unwrap();
+    common::write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\nstatus: draft\n---\n# A\n",
+    );
+
+    let output = common::hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("properties")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bare `properties` should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // properties summary returns a JSON array of {name, type, count}
+    let arr = json
+        .as_array()
+        .expect("should produce summary array output");
+    assert!(!arr.is_empty(), "should have properties in summary");
+}

--- a/crates/hyalo-cli/tests/e2e_tags.rs
+++ b/crates/hyalo-cli/tests/e2e_tags.rs
@@ -767,3 +767,23 @@ fn tags_glob_negation_excludes_files() {
         "exclusive-tag should be excluded via negation glob"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Bare `hyalo tags` defaults to summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_bare_defaults_to_summary() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("tags")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "bare `tags` should succeed");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 2, "should produce summary output");
+}

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
-use globset::GlobBuilder;
+use globset::{GlobBuilder, GlobSetBuilder};
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
@@ -198,6 +198,98 @@ pub fn match_glob(dir: &Path, files: &[PathBuf], pattern: &str) -> Result<Vec<(P
     Ok(matched)
 }
 
+/// Match discovered files against multiple glob patterns.
+///
+/// Patterns prefixed with `!` (or `\!`) are treated as negations.
+/// - If there are any positive patterns, a file must match at least one.
+/// - If there are no positive patterns, all files start as candidates.
+/// - A file is excluded if it matches any negative pattern.
+///
+/// The glob is matched against paths relative to `dir`.
+pub fn match_globs(
+    dir: &Path,
+    files: &[PathBuf],
+    patterns: &[String],
+) -> Result<Vec<(PathBuf, String)>> {
+    // Normalize `\!` → `!` for each pattern
+    let normalized: Vec<String> = patterns
+        .iter()
+        .map(|p| {
+            if let Some(rest) = p.strip_prefix("\\!") {
+                format!("!{rest}")
+            } else {
+                p.clone()
+            }
+        })
+        .collect();
+
+    // Separate into positive and negative patterns
+    let mut positive: Vec<&str> = Vec::new();
+    let mut negative: Vec<&str> = Vec::new();
+    for p in &normalized {
+        if let Some(neg) = p.strip_prefix('!') {
+            anyhow::ensure!(
+                !neg.is_empty(),
+                "negation glob pattern must not be empty (got '!')"
+            );
+            negative.push(neg);
+        } else {
+            positive.push(p.as_str());
+        }
+    }
+
+    // Build the positive GlobSet (empty means "match all")
+    let positive_set = if positive.is_empty() {
+        None
+    } else {
+        let mut builder = GlobSetBuilder::new();
+        for pat in &positive {
+            builder.add(
+                GlobBuilder::new(pat)
+                    .literal_separator(true)
+                    .build()
+                    .context("invalid glob pattern")?,
+            );
+        }
+        Some(
+            builder
+                .build()
+                .context("failed to build positive globset")?,
+        )
+    };
+
+    // Build the negative GlobSet
+    let negative_set = if negative.is_empty() {
+        None
+    } else {
+        let mut builder = GlobSetBuilder::new();
+        for pat in &negative {
+            builder.add(
+                GlobBuilder::new(pat)
+                    .literal_separator(true)
+                    .build()
+                    .context("invalid glob negation pattern")?,
+            );
+        }
+        Some(
+            builder
+                .build()
+                .context("failed to build negative globset")?,
+        )
+    };
+
+    let mut matched = Vec::new();
+    for file in files {
+        let rel = relative_path(dir, file);
+        let passes_positive = positive_set.as_ref().is_none_or(|gs| gs.is_match(&rel));
+        let passes_negative = negative_set.as_ref().is_none_or(|gs| !gs.is_match(&rel));
+        if passes_positive && passes_negative {
+            matched.push((file.clone(), rel));
+        }
+    }
+    Ok(matched)
+}
+
 /// Get the relative path of a file from a directory, using forward slashes on all platforms.
 #[must_use]
 pub fn relative_path(dir: &Path, file: &Path) -> String {
@@ -250,7 +342,23 @@ pub fn resolve_target(
     }
 
     // Normalize backslashes to forward slashes
-    let target = target.replace('\\', "/");
+    let mut target = target.replace('\\', "/");
+
+    // Strip fragment (#...) and query string (?...) before resolution.
+    // These are URL components that don't correspond to filesystem paths.
+    if let Some(pos) = target.find('#') {
+        target.truncate(pos);
+    }
+    if let Some(pos) = target.find('?') {
+        target.truncate(pos);
+    }
+    // Strip trailing slash (e.g. "docs/page/" → "docs/page")
+    while target.ends_with('/') && target.len() > 1 {
+        target.pop();
+    }
+    if target.is_empty() {
+        return None;
+    }
 
     // Normalize absolute paths using site_prefix (same logic as LinkGraph).
     // `/docs/page.md` with site_prefix "docs" becomes `page.md`.
@@ -516,6 +624,75 @@ mod tests {
         assert_eq!(matched.len(), 1);
     }
 
+    #[test]
+    fn match_globs_multiple_positive_patterns_union() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(
+            tmp.path(),
+            &["root.md", "sub1/a.md", "sub1/b.md", "sub2/c.md"],
+        );
+        let files = discover_files(tmp.path()).unwrap();
+
+        let patterns: Vec<String> = vec!["sub1/**".to_owned(), "sub2/**".to_owned()];
+        let matched = match_globs(tmp.path(), &files, &patterns).unwrap();
+        let rels: Vec<_> = matched.iter().map(|(_, r)| r.as_str()).collect();
+        assert_eq!(matched.len(), 3);
+        assert!(rels.contains(&"sub1/a.md"));
+        assert!(rels.contains(&"sub1/b.md"));
+        assert!(rels.contains(&"sub2/c.md"));
+        assert!(!rels.contains(&"root.md"));
+    }
+
+    #[test]
+    fn match_globs_positive_and_negative() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["sub/keep.md", "sub/draft.md", "root.md"]);
+        let files = discover_files(tmp.path()).unwrap();
+
+        let patterns: Vec<String> = vec!["sub/**".to_owned(), "!sub/draft.md".to_owned()];
+        let matched = match_globs(tmp.path(), &files, &patterns).unwrap();
+        let rels: Vec<_> = matched.iter().map(|(_, r)| r.as_str()).collect();
+        assert_eq!(matched.len(), 1);
+        assert!(rels.contains(&"sub/keep.md"));
+        assert!(!rels.contains(&"sub/draft.md"));
+    }
+
+    #[test]
+    fn match_globs_no_positive_means_all_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["a.md", "b.md", "draft.md"]);
+        let files = discover_files(tmp.path()).unwrap();
+
+        // Only a negation pattern — should return all files except matching ones
+        let patterns: Vec<String> = vec!["!draft.md".to_owned()];
+        let matched = match_globs(tmp.path(), &files, &patterns).unwrap();
+        let rels: Vec<_> = matched.iter().map(|(_, r)| r.as_str()).collect();
+        assert_eq!(matched.len(), 2);
+        assert!(rels.contains(&"a.md"));
+        assert!(rels.contains(&"b.md"));
+        assert!(!rels.contains(&"draft.md"));
+    }
+
+    #[test]
+    fn match_globs_single_pattern_same_as_match_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["a.md", "notes/b.md", "notes/c.md"]);
+        let files = discover_files(tmp.path()).unwrap();
+
+        let single: Vec<String> = vec!["notes/*.md".to_owned()];
+        let matched = match_globs(tmp.path(), &files, &single).unwrap();
+        assert_eq!(matched.len(), 2);
+    }
+
+    #[test]
+    fn match_globs_empty_negation_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["a.md"]);
+        let files = discover_files(tmp.path()).unwrap();
+        let patterns: Vec<String> = vec!["!".to_owned()];
+        assert!(match_globs(tmp.path(), &files, &patterns).is_err());
+    }
+
     fn make_files(dir: &Path, paths: &[&str]) {
         for path in paths {
             let full = dir.join(path);
@@ -740,6 +917,76 @@ mod tests {
             resolve_target(&canonical, "/docs/page", Some("docs")),
             Some("page.md".to_owned())
         );
+    }
+
+    #[test]
+    fn resolve_target_strips_trailing_slash() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(
+            resolve_target(&canonical, "page.md/", None),
+            Some("page.md".to_owned())
+        );
+        assert_eq!(
+            resolve_target(&canonical, "page/", None),
+            Some("page.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_strips_query_string() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(
+            resolve_target(&canonical, "page?foo=bar", None),
+            Some("page.md".to_owned())
+        );
+        assert_eq!(
+            resolve_target(&canonical, "page.md?dv=winzip", None),
+            Some("page.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_strips_fragment() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(
+            resolve_target(&canonical, "page#section", None),
+            Some("page.md".to_owned())
+        );
+        assert_eq!(
+            resolve_target(&canonical, "page.md#heading", None),
+            Some("page.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_strips_query_and_fragment_combined() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        assert_eq!(
+            resolve_target(&canonical, "page?foo=bar#section", None),
+            Some("page.md".to_owned())
+        );
+        // Trailing slash + query + fragment
+        assert_eq!(
+            resolve_target(&canonical, "page/?q=1#top", None),
+            Some("page.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_fragment_only_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["page.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        // "#section" → empty target after stripping → None
+        assert_eq!(resolve_target(&canonical, "#section", None), None);
     }
 
     #[cfg(unix)]

--- a/crates/hyalo-core/src/filter.rs
+++ b/crates/hyalo-core/src/filter.rs
@@ -594,6 +594,8 @@ impl Fields {
 pub enum SortField {
     File,
     Modified,
+    BacklinksCount,
+    LinksCount,
 }
 
 /// Parse a sort field from a string.
@@ -601,8 +603,10 @@ pub fn parse_sort(input: &str) -> Result<SortField> {
     match input {
         "file" => Ok(SortField::File),
         "modified" => Ok(SortField::Modified),
+        "backlinks_count" => Ok(SortField::BacklinksCount),
+        "links_count" => Ok(SortField::LinksCount),
         other => bail!(
-            "unknown sort field {:?}: valid values are 'file' and 'modified'",
+            "unknown sort field {:?}: valid values are 'file', 'modified', 'backlinks_count', 'links_count'",
             other
         ),
     }

--- a/hyalo-knowledgebase/backlog/bare-subcommand-defaults.md
+++ b/hyalo-knowledgebase/backlog/bare-subcommand-defaults.md
@@ -1,0 +1,12 @@
+---
+title: "Bare tags/properties should default to summary subcommand"
+type: backlog
+date: 2026-03-26
+origin: dogfooding v0.4.1
+priority: low
+status: planned
+---
+
+`hyalo tags` and `hyalo properties` exit with code 2 (usage error) instead of defaulting to the `summary` subcommand. This is a friction point — `hyalo tags` is the intuitive first thing to try.
+
+Fix: use clap's `#[command(subcommand_required = false)]` or set `default_subcommand` so that bare `tags` / `properties` runs `summary`. Alternatively, use clap's `#[command(args_conflicts_with_subcommands = false)]` pattern.

--- a/hyalo-knowledgebase/backlog/empty-body-pattern-matches-all.md
+++ b/hyalo-knowledgebase/backlog/empty-body-pattern-matches-all.md
@@ -1,0 +1,17 @@
+---
+title: "Empty body pattern matches all files — should error or warn"
+type: backlog
+date: 2026-03-26
+origin: dogfooding v0.4.1 on GitHub Docs
+priority: low
+status: planned
+---
+
+`hyalo find ""` returns all 3520 files because empty string is a substring of everything. This is technically correct but surprising — no warning is emitted.
+
+Options:
+1. Error: "body pattern must not be empty" (strictest, may break scripts)
+2. Warn on stderr: "empty body pattern matches all files" (gentle)
+3. Document the behavior and leave as-is
+
+Option 2 (warn) seems best — it's informative without breaking anything.

--- a/hyalo-knowledgebase/backlog/limit-zero-means-unlimited.md
+++ b/hyalo-knowledgebase/backlog/limit-zero-means-unlimited.md
@@ -1,0 +1,12 @@
+---
+title: "--limit 0 should mean unlimited, not zero results"
+type: backlog
+date: 2026-03-26
+origin: dogfooding v0.4.1
+priority: low
+status: planned
+---
+
+`hyalo find --limit 0` returns `[]` (empty array). Most CLI tools treat `--limit 0` as "no limit / unlimited". This is a minor footgun.
+
+Fix: treat `--limit 0` the same as omitting `--limit` entirely. In the find command, convert `Some(0)` to `None` before passing the limit downstream.

--- a/hyalo-knowledgebase/backlog/query-string-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/query-string-link-resolution.md
@@ -1,0 +1,12 @@
+---
+title: "Strip query strings and fragments from link targets before resolution"
+type: backlog
+date: 2026-03-26
+origin: dogfooding v0.4.1 on VS Code Docs (setup/windows.md links to /docs/?dv=winzip)
+priority: low
+status: planned
+---
+
+Link `/docs/?dv=winzip` is not resolved because the `?dv=winzip` query string is included in the path lookup. Similarly, `#fragment` anchors should be stripped.
+
+Fix in `resolve_target` in `discovery.rs`: strip `?...` and `#...` suffixes from the target string before attempting file lookup.

--- a/hyalo-knowledgebase/backlog/repeatable-glob-flag.md
+++ b/hyalo-knowledgebase/backlog/repeatable-glob-flag.md
@@ -1,0 +1,17 @@
+---
+title: "Repeatable --glob flag for combining include and exclude patterns"
+type: backlog
+date: 2026-03-26
+origin: dogfooding v0.4.0 (ISSUE-7) and v0.4.1 confirmed
+priority: medium
+status: planned
+---
+
+`--glob` cannot be passed multiple times. Users want `--glob 'rest/**' --glob '!rest/**/index.md'` to include + exclude in one call. Currently errors with "cannot be used multiple times".
+
+Workaround: brace expansion `--glob '{rest,graphql}/**'` works for simple cases but can't combine positive and negative patterns.
+
+The `globset` crate already supports `GlobSet` for matching multiple patterns in a single pass. The main changes are:
+- Change clap arg from `Option<String>` to `Vec<String>`
+- Update `match_glob` in `discovery.rs` to accept `&[String]` and build a `GlobSet`
+- Separate positive and negative patterns, apply both filters

--- a/hyalo-knowledgebase/backlog/sort-by-backlinks-count.md
+++ b/hyalo-knowledgebase/backlog/sort-by-backlinks-count.md
@@ -1,0 +1,18 @@
+---
+title: "Add backlinks_count and links_count as sort fields"
+type: backlog
+date: 2026-03-26
+origin: dogfooding v0.4.1 on GitHub Docs and VS Code Docs
+priority: medium
+status: planned
+---
+
+`find --sort backlinks_count` errors with "unknown sort field". Only `file` and `modified` are valid. This makes it impossible to natively find the most-linked-to files — users must pipe through jq.
+
+Add two new `SortField` variants:
+- `backlinks_count` — sort by number of inbound links (requires backlinks computation)
+- `links_count` — sort by number of outbound links
+
+Naming convention: snake_case to match existing JSON field names (`total_links_updated`, `dry_run`).
+
+When `--sort backlinks_count` is used, backlinks must be computed even if `--fields` doesn't include `backlinks`. This disables `--limit` short-circuit (same as when backlinks are explicitly requested).

--- a/hyalo-knowledgebase/backlog/trailing-slash-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/trailing-slash-link-resolution.md
@@ -1,0 +1,12 @@
+---
+title: "Strip trailing slash from link targets before resolution"
+type: backlog
+date: 2026-03-26
+origin: dogfooding v0.4.1 on VS Code Docs (languages/rust.md links to /docs/debugtest/debugging.md/)
+priority: low
+status: planned
+---
+
+Link `/docs/debugtest/debugging.md/` (with trailing `/`) fails to resolve even though `debugtest/debugging.md` exists. The trailing slash should be stripped before resolution.
+
+Fix in `resolve_target` in `discovery.rs`: trim trailing `/` from the target string early in the function.

--- a/hyalo-knowledgebase/iterations/iteration-46-ux-polish-v2.md
+++ b/hyalo-knowledgebase/iterations/iteration-46-ux-polish-v2.md
@@ -1,0 +1,76 @@
+---
+title: "Iteration 46 — UX Polish v2 (Dogfood v0.4.1 Follow-ups)"
+type: iteration
+date: 2026-03-26
+tags:
+  - iteration
+  - ux
+  - dogfooding
+status: planned
+branch: iter-46/ux-polish-v2
+---
+
+# Iteration 46 — UX Polish v2
+
+## Goal
+
+Address all UX issues and minor bugs found during v0.4.1 dogfooding on GitHub Docs (3520 files) and VS Code Docs (339 files). All items are small, self-contained fixes.
+
+## Backlog items
+
+- [[backlog/repeatable-glob-flag]]
+- [[backlog/sort-by-backlinks-count]]
+- [[backlog/trailing-slash-link-resolution]]
+- [[backlog/query-string-link-resolution]]
+- [[backlog/limit-zero-means-unlimited]]
+- [[backlog/bare-subcommand-defaults]]
+- [[backlog/empty-body-pattern-matches-all]]
+
+## Tasks
+
+### Repeatable --glob (medium)
+- [ ] Change `--glob` clap arg from `Option<String>` to `Vec<String>` across all commands
+- [ ] Update `match_glob` in `discovery.rs` to accept multiple patterns via `GlobSet`
+- [ ] Separate positive and negative patterns; apply positive first, then filter out negatives
+- [ ] Update `collect_files` in `commands/mod.rs` to handle `Vec<String>`
+- [ ] E2e tests: multiple globs, mixed positive+negative, single glob backward compat
+- [ ] Update help text and README
+
+### Sort by backlinks_count / links_count (medium)
+- [ ] Add `BacklinksCount` and `LinksCount` variants to `SortField` enum in `filter.rs`
+- [ ] Accept `backlinks_count` and `links_count` in `parse_sort`
+- [ ] In find command: force backlinks computation when sort is `BacklinksCount`
+- [ ] Disable `--limit` short-circuit when sort is `BacklinksCount` or `LinksCount`
+- [ ] E2e tests: sort by both new fields, verify ordering
+
+### Link resolution: trailing slash and query strings (low)
+- [ ] In `resolve_target` (`discovery.rs`): strip trailing `/` from target
+- [ ] In `resolve_target`: strip `?...` query string and `#...` fragment before lookup
+- [ ] Unit tests for both edge cases
+
+### --limit 0 = unlimited (low)
+- [ ] In find command: convert `Some(0)` to `None` before passing limit
+- [ ] E2e test: `--limit 0` returns all files
+
+### Bare tags/properties defaults to summary (low)
+- [ ] Make `summary` the default subcommand for `tags` and `properties`
+- [ ] E2e tests: bare `hyalo tags` and `hyalo properties` produce summary output
+
+### Empty body pattern warning (low)
+- [ ] Emit stderr warning when body pattern is empty string
+- [ ] E2e test: `find ""` warns on stderr, still returns results
+
+### Quality gates
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+
+## Acceptance Criteria
+
+- [ ] `--glob` is repeatable: `--glob 'a/**' --glob '!a/**/index.md'` works
+- [ ] `--sort backlinks_count` and `--sort links_count` produce correctly ordered results
+- [ ] Trailing-slash and query-string links resolve correctly
+- [ ] `--limit 0` behaves as unlimited
+- [ ] Bare `hyalo tags` and `hyalo properties` default to summary
+- [ ] Empty body pattern emits a warning
+- [ ] All quality gates pass

--- a/hyalo-knowledgebase/iterations/iteration-46-ux-polish-v2.md
+++ b/hyalo-knowledgebase/iterations/iteration-46-ux-polish-v2.md
@@ -1,13 +1,13 @@
 ---
-title: "Iteration 46 — UX Polish v2 (Dogfood v0.4.1 Follow-ups)"
-type: iteration
-date: 2026-03-26
-tags:
-  - iteration
-  - ux
-  - dogfooding
-status: planned
 branch: iter-46/ux-polish-v2
+date: 2026-03-26
+status: in-progress
+tags:
+- iteration
+- ux
+- dogfooding
+title: Iteration 46 — UX Polish v2 (Dogfood v0.4.1 Follow-ups)
+type: iteration
 ---
 
 # Iteration 46 — UX Polish v2


### PR DESCRIPTION
## Summary

- **Repeatable `--glob`**: accepts multiple patterns (`--glob 'a/**' --glob '!a/**/index.md'`); positive patterns union, negative patterns exclude
- **Sort by `backlinks_count` / `links_count`**: new `--sort` values, descending order; auto-computes link graph without exposing it in output unless `--fields` requests it
- **Link resolution**: strips trailing `/`, `?query`, and `#fragment` from targets before resolving (fixes VS Code Docs and GitHub Docs link patterns)
- **`--limit 0` = unlimited**: treats zero as "no limit" instead of returning empty results
- **Bare `hyalo tags` / `hyalo properties`**: defaults to `summary` subcommand instead of erroring
- **Empty body pattern warning**: `find ""` emits a stderr warning instead of silently matching all files

## Test plan

- [x] 5 unit tests for `match_globs` (positive, negative, mixed, empty)
- [x] 4 e2e tests for repeatable `--glob` (union, positive+negative, multiple negations, single backward compat)
- [x] 5 unit tests for `resolve_target` (trailing slash, query string, fragment, combined, fragment-only)
- [x] 4 e2e tests for sort by `backlinks_count` / `links_count` (with and without `--fields`)
- [x] 1 e2e test for `--limit 0`
- [x] 2 e2e tests for bare `tags` / `properties`
- [x] 1 e2e test for empty body pattern warning
- [x] All 424 tests pass, clippy clean, fmt clean
- [x] Release binary dogfooded against `hyalo-knowledgebase/` (81 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)