### PR TITLE
Add hyalo-dream skill and knowledgebase rules

### DIFF
--- a/.claude/rules/knowledgebase.md
+++ b/.claude/rules/knowledgebase.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "hyalo-knowledgebase/**"
+---
+Prefer `hyalo` CLI for operations on files in this directory:
+- **Search/filter**: `hyalo find` instead of Grep/Glob
+- **Read frontmatter/metadata**: `hyalo find --file`, `hyalo properties`, `hyalo tags`
+- **Read content/sections**: `hyalo read --file <path>` or `hyalo read --section "Heading"`
+- **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append`
+- **Move/rename**: `hyalo mv` (rewrites links across the vault)
+
+Fall back to Edit for body prose changes, Write for new files, and Read when
+hyalo doesn't cover the operation (e.g., reading raw markdown for rewriting).
+
+Use `--format text` for compact output. Run `hyalo <command> --help` if unsure.

--- a/.claude/skills/hyalo-dream/SKILL.md
+++ b/.claude/skills/hyalo-dream/SKILL.md
@@ -43,12 +43,16 @@ hyalo summary --format text
 
 # 2. Full snapshot — one scan that captures everything. Save to a temp file so you can
 #    run many jq filters without re-scanning the filesystem each time.
-hyalo find --fields properties,tags,sections,tasks,links,backlinks > /tmp/hyalo-dream-snapshot.json
+HYALO_DREAM_SNAPSHOT="$(mktemp "${TMPDIR:-/tmp}/hyalo-dream-snapshot.XXXXXX.json")"
+hyalo find --fields properties,tags,sections,tasks,links,backlinks > "${HYALO_DREAM_SNAPSHOT}"
 ```
 
 The snapshot contains every file's properties, tags, sections, tasks, links, and
 backlinks. All detection queries in Phase 3 should use `jq` on this file rather than
 running separate `hyalo find` calls. This turns ~15 disk scans into 1.
+
+**Important:** All subsequent `jq` commands in this skill reference `${HYALO_DREAM_SNAPSHOT}`
+instead of a hardcoded path.
 
 Also grab the tag vocabulary for inconsistency detection:
 ```bash
@@ -73,7 +77,7 @@ git log --oneline --since="4 weeks ago" -- "*.rs" | head -30
 
 Extract non-completed iterations and their branches from the snapshot:
 ```bash
-jq 'map(select(.properties.type == "iteration" and .properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.type == "iteration" and .properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})' ${HYALO_DREAM_SNAPSHOT}
 ```
 
 For each non-completed iteration that has a branch, check if that branch was merged:
@@ -85,7 +89,10 @@ git log --oneline --merges --all | grep "<branch-name>"
 
 Check what was recently worked on from Claude's perspective:
 ```bash
-MEMORY_DIR=$(find ~/.claude/projects/ -path "*/memory/MEMORY.md" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+MEMORY_FILE=$(find ~/.claude/projects/ -path "*/memory/MEMORY.md" -print -quit 2>/dev/null)
+if [ -n "$MEMORY_FILE" ]; then
+  MEMORY_DIR=$(dirname "$MEMORY_FILE")
+fi
 ```
 
 If found, query it with hyalo:
@@ -112,7 +119,7 @@ All queries below run on the cached snapshot — no additional disk scans needed
 
 ### Broken links
 ```bash
-jq '[.[] | {file: .file, broken: [.links[] | select(.path == null)] | map(.target)} | select(.broken | length > 0)]' /tmp/hyalo-dream-snapshot.json
+jq '[.[] | {file: .file, broken: [.links[] | select(.path == null)] | map(.target)} | select(.broken | length > 0)]' ${HYALO_DREAM_SNAPSHOT}
 ```
 For each broken link, try to find the intended target:
 - Search for the filename in `done/` subdirectories (common after archiving)
@@ -124,7 +131,7 @@ exist at all).
 
 ### Orphan files
 ```bash
-jq 'map(select(.backlinks | length == 0)) | map(.file)' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.backlinks | length == 0)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
 ```
 Not all orphans are problems. Expect these to be legitimately orphaned:
 - Top-level files (SEED.md, project-pitch.md, decision-log.md)
@@ -136,19 +143,19 @@ Focus on **actionable orphans**: active/planned items that should be cross-refer
 ### Stale statuses
 ```bash
 # In-progress items — should any be completed?
-jq 'map(select(.properties.status == "in-progress")) | map({file, date: .properties.date, branch: .properties.branch})' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.status == "in-progress")) | map({file, date: .properties.date, branch: .properties.branch})' ${HYALO_DREAM_SNAPSHOT}
 
 # Planned items where all tasks are done
-jq 'map(select(.properties.status == "planned" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.status == "planned" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
 
 # In-progress items sorted by date (oldest first — possibly stale)
-jq 'map(select(.properties.status == "in-progress" and .properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.status == "in-progress" and .properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})' ${HYALO_DREAM_SNAPSHOT}
 ```
 Cross-reference with git merges from Phase 2. If the branch was merged, update status.
 
 ### Stale backlog items
 ```bash
-jq 'map(select(.properties.status == "planned" and .properties.type == "backlog")) | map({file, title: .properties.title})' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.status == "planned" and .properties.type == "backlog")) | map({file, title: .properties.title})' ${HYALO_DREAM_SNAPSHOT}
 ```
 Compare each planned backlog item against merged iterations and recent git history.
 If the feature clearly shipped (in a different iteration or under a different name),
@@ -156,8 +163,8 @@ flag it.
 
 ### Missing metadata
 ```bash
-jq 'map(select(.properties.status == null)) | map(.file)' /tmp/hyalo-dream-snapshot.json
-jq 'map(select(.properties.type == null)) | map(.file)' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.status == null)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
+jq 'map(select(.properties.type == null)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
 ```
 
 ### Tag inconsistencies
@@ -169,7 +176,7 @@ more files.
 ### Task completion vs status mismatch
 ```bash
 # Completed items with unchecked tasks — systemic or one-off?
-jq 'map(select(.properties.status == "completed" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) > 0)) | map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.status == "completed" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) > 0)) | map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})' ${HYALO_DREAM_SNAPSHOT}
 ```
 If many completed items have unchecked tasks, this is a workflow pattern — note it once
 in the report rather than listing every file.
@@ -248,5 +255,5 @@ delta: statuses changed, links fixed, tags normalized, files moved.
   wikilink text in prose, adding cross-reference lines).
 - **Batch similar findings**: if 15 completed items have unchecked tasks, say that once
   with the count. The report should be scannable in 30 seconds.
-- **Minimize disk scans**: use the `/tmp/hyalo-dream-snapshot.json` for all read queries.
+- **Minimize disk scans**: use the `${HYALO_DREAM_SNAPSHOT}` for all read queries.
   Only call `hyalo find` again if you need data not in the snapshot.

--- a/.claude/skills/hyalo-dream/SKILL.md
+++ b/.claude/skills/hyalo-dream/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: hyalo-dream
+description: >
+  Perform a reflective consolidation pass over a hyalo-managed knowledgebase directory —
+  detecting structural issues, fixing broken links, flagging stale content, normalizing
+  metadata, and reporting what changed. Use this skill when the user says /hyalo-dream,
+  "consolidate the knowledgebase", "clean up the KB", "run KB hygiene", "dream", or
+  "what needs attention in the knowledgebase". Also use when the user asks about
+  knowledgebase health, broken links, orphan files, stale iterations, or metadata
+  inconsistencies.
+context: fork
+disable-model-invocation: true
+---
+
+# Hyalo Dream — Knowledgebase Consolidation
+
+You are performing a dream — a reflective pass over a knowledgebase. Your job is to
+detect issues, fix what you can, and report what needs human attention. Think of this
+as a librarian doing a periodic shelf-read: checking that everything is filed correctly,
+cross-references work, and nothing is gathering dust in the wrong place.
+
+This process has 5 phases. Take your time — a thorough dream is worth more than a fast
+one. A few minutes is fine.
+
+## Before you start
+
+Locate the hyalo binary:
+```bash
+which hyalo 2>/dev/null || echo "target/release/hyalo"
+```
+
+Confirm `.hyalo.toml` exists in the project root to determine the KB directory. If it
+doesn't exist, ask the user which directory to consolidate.
+
+## Phase 1 — Orient and snapshot
+
+Get the lay of the land with two commands. The first gives you the overview, the second
+gives you the full dataset you'll query throughout the rest of the dream.
+
+```bash
+# 1. High-level overview (baseline for the final health dashboard)
+hyalo summary --format text
+
+# 2. Full snapshot — one scan that captures everything. Save to a temp file so you can
+#    run many jq filters without re-scanning the filesystem each time.
+hyalo find --fields properties,tags,sections,tasks,links,backlinks > /tmp/hyalo-dream-snapshot.json
+```
+
+The snapshot contains every file's properties, tags, sections, tasks, links, and
+backlinks. All detection queries in Phase 3 should use `jq` on this file rather than
+running separate `hyalo find` calls. This turns ~15 disk scans into 1.
+
+Also grab the tag vocabulary for inconsistency detection:
+```bash
+hyalo tags summary --format text
+```
+
+## Phase 2 — Gather recent signal
+
+Before looking for issues, understand what happened recently. This context is what
+makes the dream valuable — it tells you what *should* have changed in the KB, so you
+can spot what didn't.
+
+### Git history
+
+```bash
+# What branches were merged recently? What iteration branches shipped?
+git log --oneline --merges --since="4 weeks ago"
+
+# What areas of code changed? (helps identify which features shipped)
+git log --oneline --since="4 weeks ago" -- "*.rs" | head -30
+```
+
+Extract non-completed iterations and their branches from the snapshot:
+```bash
+jq 'map(select(.properties.type == "iteration" and .properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})' /tmp/hyalo-dream-snapshot.json
+```
+
+For each non-completed iteration that has a branch, check if that branch was merged:
+```bash
+git log --oneline --merges --all | grep "<branch-name>"
+```
+
+### Claude's auto-memory
+
+Check what was recently worked on from Claude's perspective:
+```bash
+MEMORY_DIR=$(find ~/.claude/projects/ -path "*/memory/MEMORY.md" 2>/dev/null | head -1 | xargs dirname 2>/dev/null)
+```
+
+If found, query it with hyalo:
+```bash
+hyalo --dir "$MEMORY_DIR" find --property type=project --format text
+hyalo --dir "$MEMORY_DIR" find --property type=feedback --format text
+```
+
+Look for:
+- Project memories mentioning iterations/features that shipped — cross-reference with KB
+- Stale project memories that reference outdated plans (note for the report, but
+  don't modify memory files — that's Claude's own territory)
+
+### Recent KB changes
+
+```bash
+git log --oneline --since="4 weeks ago" -- "hyalo-knowledgebase/" | head -20
+git log --diff-filter=A --name-only --since="4 weeks ago" -- "hyalo-knowledgebase/"
+```
+
+## Phase 3 — Detect structural issues
+
+All queries below run on the cached snapshot — no additional disk scans needed.
+
+### Broken links
+```bash
+jq '[.[] | {file: .file, broken: [.links[] | select(.path == null)] | map(.target)} | select(.broken | length > 0)]' /tmp/hyalo-dream-snapshot.json
+```
+For each broken link, try to find the intended target:
+- Search for the filename in `done/` subdirectories (common after archiving)
+- If the target is in the same directory as the source, try with the directory prefix
+- Check if the target exists under a slightly different name
+
+Categorize as: **resolvable** (target exists elsewhere) vs **truly broken** (doesn't
+exist at all).
+
+### Orphan files
+```bash
+jq 'map(select(.backlinks | length == 0)) | map(.file)' /tmp/hyalo-dream-snapshot.json
+```
+Not all orphans are problems. Expect these to be legitimately orphaned:
+- Top-level files (SEED.md, project-pitch.md, decision-log.md)
+- Research documents (standalone reports)
+- Older completed items in `done/` directories
+
+Focus on **actionable orphans**: active/planned items that should be cross-referenced.
+
+### Stale statuses
+```bash
+# In-progress items — should any be completed?
+jq 'map(select(.properties.status == "in-progress")) | map({file, date: .properties.date, branch: .properties.branch})' /tmp/hyalo-dream-snapshot.json
+
+# Planned items where all tasks are done
+jq 'map(select(.properties.status == "planned" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)' /tmp/hyalo-dream-snapshot.json
+
+# In-progress items sorted by date (oldest first — possibly stale)
+jq 'map(select(.properties.status == "in-progress" and .properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})' /tmp/hyalo-dream-snapshot.json
+```
+Cross-reference with git merges from Phase 2. If the branch was merged, update status.
+
+### Stale backlog items
+```bash
+jq 'map(select(.properties.status == "planned" and .properties.type == "backlog")) | map({file, title: .properties.title})' /tmp/hyalo-dream-snapshot.json
+```
+Compare each planned backlog item against merged iterations and recent git history.
+If the feature clearly shipped (in a different iteration or under a different name),
+flag it.
+
+### Missing metadata
+```bash
+jq 'map(select(.properties.status == null)) | map(.file)' /tmp/hyalo-dream-snapshot.json
+jq 'map(select(.properties.type == null)) | map(.file)' /tmp/hyalo-dream-snapshot.json
+```
+
+### Tag inconsistencies
+Review the `hyalo tags summary` output from Phase 1. Look for near-duplicates:
+singular/plural (`filter`/`filters`), hyphenation variants (`bugfix`/`bug-fix`),
+abbreviations (`perf`/`performance`). The canonical form should be the one used by
+more files.
+
+### Task completion vs status mismatch
+```bash
+# Completed items with unchecked tasks — systemic or one-off?
+jq 'map(select(.properties.status == "completed" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) > 0)) | map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})' /tmp/hyalo-dream-snapshot.json
+```
+If many completed items have unchecked tasks, this is a workflow pattern — note it once
+in the report rather than listing every file.
+
+## Phase 4 — Consolidate
+
+Fix what you can. Be conservative — prefer fixing metadata over deleting files. For
+each change, note what you did and why.
+
+### Fix broken links
+For resolvable broken links (target moved to `done/` etc.), update the wikilink text
+in the source file. Use the snapshot to confirm the correct path, then Edit the source
+file.
+
+For truly broken links (target never existed), leave them and report them.
+
+### Update stale statuses
+If an iteration's branch was merged:
+```bash
+hyalo set --property status=completed --file <path>
+```
+
+If a backlog item's feature clearly shipped:
+```bash
+hyalo set --property status=completed --file <path>
+```
+
+Only update when the evidence is clear. When uncertain, flag it in the report.
+
+### Archive completed items
+If completed items are in a top-level directory and a `done/` subfolder exists:
+```bash
+hyalo mv --file <old-path> --to <done-subdir/filename> --dry-run
+```
+Review the dry-run output. If correct, execute without `--dry-run`.
+
+### Normalize tags
+```bash
+hyalo tags rename --from <variant> --to <canonical>
+```
+
+### Add missing cross-references
+If a backlog item was implemented by an iteration but neither links to the other,
+add a `[[wikilink]]`. Only where the relationship is clear and useful.
+
+## Phase 5 — Report
+
+Summarize everything. Structure as:
+
+### Changes made
+One line per change with reasoning:
+```
+- Set status=completed on iteration-43.md (branch iter-43/data-quality merged in abc1234)
+- Moved iteration-46.md to iterations/done/ (completed, all tasks verified)
+- Renamed tag: bugfix → bug-fix (2 files, matching existing convention)
+- Fixed 5 broken links in research/dogfooding-v0.4.1-consolidated.md (same-dir targets)
+```
+
+### Issues requiring human attention
+Things you detected but couldn't (or shouldn't) fix unilaterally. Keep it concise —
+one line per issue with enough context to act on.
+
+### KB health dashboard
+Re-run `hyalo summary --format text` and compare with Phase 1 baseline. Report the
+delta: statuses changed, links fixed, tags normalized, files moved.
+
+## Ground rules
+
+- **Conservative by default**: when in doubt, report rather than change.
+- **Never delete files or body content**: update frontmatter, fix links, move files,
+  suggest changes — but the user decides what to throw away.
+- **Explain every change**: include the evidence (commit hash, task counts, etc.).
+- **Don't modify Claude's memory files**: report stale memories but don't edit them.
+- **Use hyalo for mutations**: `hyalo set`/`remove` for frontmatter, `hyalo tags rename`
+  for tags, `hyalo mv` for moves. Fall back to Edit only for body content (fixing
+  wikilink text in prose, adding cross-reference lines).
+- **Batch similar findings**: if 15 completed items have unchecked tasks, say that once
+  with the count. The report should be scannable in 30 seconds.
+- **Minimize disk scans**: use the `/tmp/hyalo-dream-snapshot.json` for all read queries.
+  Only call `hyalo find` again if you need data not in the snapshot.

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -26,8 +26,8 @@ const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "con
 ///
 /// - `dir`: explicit value for the `dir` key in `.hyalo.toml`; when `None` the
 ///   function auto-detects a common doc directory.
-/// - `claude`: when `true`, also installs the hyalo skill and appends a hint
-///   line to `.claude/CLAUDE.md`.
+/// - `claude`: when `true`, also installs the hyalo and hyalo-dream skills and
+///   appends a hint line to `.claude/CLAUDE.md`.
 pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
     let cwd = std::env::current_dir().context("failed to determine current working directory")?;
     let mut summary = String::new();

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -11,6 +11,7 @@ use crate::output::CommandOutcome;
 // ---------------------------------------------------------------------------
 
 const SKILL_CONTENT: &str = include_str!("../../../../.claude/skills/hyalo/SKILL.md");
+const DREAM_SKILL_CONTENT: &str = include_str!("../../../../.claude/skills/hyalo-dream/SKILL.md");
 
 const CLAUDE_MD_HINT: &str = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.";
 
@@ -79,7 +80,32 @@ pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
     }
 
     // ------------------------------------------------------------------
-    // Step 3: append hyalo hint to .claude/CLAUDE.md (no duplicates)
+    // Step 3: create .claude/skills/hyalo-dream/SKILL.md
+    // ------------------------------------------------------------------
+    let dream_skill_path = cwd
+        .join(".claude")
+        .join("skills")
+        .join("hyalo-dream")
+        .join("SKILL.md");
+    if dream_skill_path.exists() {
+        writeln!(
+            summary,
+            "skipped  .claude/skills/hyalo-dream/SKILL.md (already exists)"
+        )
+        .unwrap();
+    } else {
+        let dream_skill_dir = dream_skill_path
+            .parent()
+            .context("dream skill path has no parent directory")?;
+        fs::create_dir_all(dream_skill_dir)
+            .with_context(|| format!("failed to create directory {}", dream_skill_dir.display()))?;
+        fs::write(&dream_skill_path, DREAM_SKILL_CONTENT)
+            .with_context(|| format!("failed to write {}", dream_skill_path.display()))?;
+        writeln!(summary, "created  .claude/skills/hyalo-dream/SKILL.md").unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Step 4: append hyalo hint to .claude/CLAUDE.md (no duplicates)
     // ------------------------------------------------------------------
     let claude_md_path = cwd.join(".claude").join("CLAUDE.md");
     if claude_md_path.exists() {

--- a/crates/hyalo-cli/tests/e2e_init.rs
+++ b/crates/hyalo-cli/tests/e2e_init.rs
@@ -186,6 +186,79 @@ fn init_claude_skips_existing_skill() {
 }
 
 // ---------------------------------------------------------------------------
+// --claude flag: hyalo-dream skill creation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_claude_creates_dream_skill() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let dream_skill_path = tmp
+        .path()
+        .join(".claude")
+        .join("skills")
+        .join("hyalo-dream")
+        .join("SKILL.md");
+    assert!(
+        dream_skill_path.exists(),
+        "hyalo-dream SKILL.md should have been created"
+    );
+
+    let content = fs::read_to_string(&dream_skill_path).unwrap();
+    assert!(
+        content.contains("name: hyalo-dream"),
+        "SKILL.md should have frontmatter name field; got: {content}"
+    );
+    assert!(
+        content.contains("Knowledgebase Consolidation"),
+        "SKILL.md should contain dream skill content"
+    );
+}
+
+#[test]
+fn init_claude_skips_existing_dream_skill() {
+    let tmp = TempDir::new().unwrap();
+    let dream_skill_dir = tmp
+        .path()
+        .join(".claude")
+        .join("skills")
+        .join("hyalo-dream");
+    fs::create_dir_all(&dream_skill_dir).unwrap();
+    let dream_skill_path = dream_skill_dir.join("SKILL.md");
+    let original = "---\nname: custom-dream\n---\n";
+    fs::write(&dream_skill_path, original).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("skipped"),
+        "expected 'skipped' for existing dream SKILL.md; got: {stdout}"
+    );
+
+    let content = fs::read_to_string(&dream_skill_path).unwrap();
+    assert_eq!(
+        content, original,
+        "dream SKILL.md should not be overwritten"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // --claude flag: CLAUDE.md creation and update
 // ---------------------------------------------------------------------------
 
@@ -308,8 +381,12 @@ fn init_prints_summary_of_actions() {
         "summary should mention .hyalo.toml; got: {stdout}"
     );
     assert!(
-        stdout.contains("SKILL.md"),
-        "summary should mention SKILL.md; got: {stdout}"
+        stdout.contains("skills/hyalo/SKILL.md"),
+        "summary should mention hyalo SKILL.md; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("skills/hyalo-dream/SKILL.md"),
+        "summary should mention hyalo-dream SKILL.md; got: {stdout}"
     );
     assert!(
         stdout.contains("CLAUDE.md"),


### PR DESCRIPTION
## Summary
- **hyalo-dream skill**: A `/hyalo-dream` slash command that performs knowledgebase consolidation in 5 phases — orient, gather git/memory signal, detect structural issues, consolidate, and report. Uses a batched snapshot approach (one `hyalo find` scan cached to `/tmp`, then multiple `jq` queries) to minimize disk I/O.
- **Knowledgebase rules file**: `.claude/rules/knowledgebase.md` with `paths: ["hyalo-knowledgebase/**"]` that auto-injects hyalo CLI preference when Claude touches KB files — soft enforcement with explicit fallback guidance.
- **init --claude**: Now installs both `hyalo` and `hyalo-dream` skills, with skip-if-exists behavior and e2e tests.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test --workspace` — all 1,158 tests pass (including 2 new e2e tests for dream skill init)
- [x] Manual `hyalo init --claude` in fresh directory creates all 4 files
- [x] Dry-run tested hyalo-dream skill 3 times on real KB — found real issues (stale statuses, broken links, tag inconsistencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)