### PR TITLE
Iteration 47: Snapshot index for repeated queries

### DIFF
--- a/.claude/skills/hyalo-dream/SKILL.md
+++ b/.claude/skills/hyalo-dream/SKILL.md
@@ -34,29 +34,23 @@ doesn't exist, ask the user which directory to consolidate.
 
 ## Phase 1 — Orient and snapshot
 
-Get the lay of the land with two commands. The first gives you the overview, the second
-gives you the full dataset you'll query throughout the rest of the dream.
+Get the lay of the land and create a snapshot index for fast repeated queries.
 
 ```bash
 # 1. High-level overview (baseline for the final health dashboard)
 hyalo summary --format text
 
-# 2. Full snapshot — one scan that captures everything. Save to a temp file so you can
-#    run many jq filters without re-scanning the filesystem each time.
-HYALO_DREAM_SNAPSHOT="$(mktemp "${TMPDIR:-/tmp}/hyalo-dream-snapshot.XXXXXX.json")"
-hyalo find --fields properties,tags,sections,tasks,links,backlinks > "${HYALO_DREAM_SNAPSHOT}"
+# 2. Create snapshot index (one scan, reused by all subsequent queries)
+hyalo create-index
 ```
 
-The snapshot contains every file's properties, tags, sections, tasks, links, and
-backlinks. All detection queries in Phase 3 should use `jq` on this file rather than
-running separate `hyalo find` calls. This turns ~15 disk scans into 1.
-
-**Important:** All subsequent `jq` commands in this skill reference `${HYALO_DREAM_SNAPSHOT}`
-instead of a hardcoded path.
+The snapshot index captures every file's metadata in a binary file (`.hyalo-index`).
+All read-only queries in Phase 2 and Phase 3 should use `--index .hyalo-index` to
+avoid repeated disk scans. For complex reshaping, combine hyalo filtering with `--jq`.
 
 Also grab the tag vocabulary for inconsistency detection:
 ```bash
-hyalo tags summary --format text
+hyalo tags summary --format text --index .hyalo-index
 ```
 
 ## Phase 2 — Gather recent signal
@@ -75,9 +69,9 @@ git log --oneline --merges --since="4 weeks ago"
 git log --oneline --since="4 weeks ago" -- "*.rs" | head -30
 ```
 
-Extract non-completed iterations and their branches from the snapshot:
+Extract non-completed iterations and their branches from the index:
 ```bash
-jq 'map(select(.properties.type == "iteration" and .properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --property type=iteration --index .hyalo-index --jq 'map(select(.properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})'
 ```
 
 For each non-completed iteration that has a branch, check if that branch was merged:
@@ -95,7 +89,7 @@ if [ -n "$MEMORY_FILE" ]; then
 fi
 ```
 
-If found, query it with hyalo:
+If found, query it with hyalo (memory files are outside the vault, so no --index here):
 ```bash
 hyalo --dir "$MEMORY_DIR" find --property type=project --format text
 hyalo --dir "$MEMORY_DIR" find --property type=feedback --format text
@@ -115,11 +109,11 @@ git log --diff-filter=A --name-only --since="4 weeks ago" -- "hyalo-knowledgebas
 
 ## Phase 3 — Detect structural issues
 
-All queries below run on the cached snapshot — no additional disk scans needed.
+All queries below use `--index .hyalo-index` — no additional disk scans needed.
 
 ### Broken links
 ```bash
-jq '[.[] | {file: .file, broken: [.links[] | select(.path == null)] | map(.target)} | select(.broken | length > 0)]' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --fields links --index .hyalo-index --jq '[.[] | {file: .file, broken: [.links[] | select(.path == null)] | map(.target)} | select(.broken | length > 0)]'
 ```
 For each broken link, try to find the intended target:
 - Search for the filename in `done/` subdirectories (common after archiving)
@@ -131,7 +125,7 @@ exist at all).
 
 ### Orphan files
 ```bash
-jq 'map(select(.backlinks | length == 0)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --fields backlinks --index .hyalo-index --jq 'map(select(.backlinks | length == 0)) | map(.file)'
 ```
 Not all orphans are problems. Expect these to be legitimately orphaned:
 - Top-level files (SEED.md, project-pitch.md, decision-log.md)
@@ -143,19 +137,19 @@ Focus on **actionable orphans**: active/planned items that should be cross-refer
 ### Stale statuses
 ```bash
 # In-progress items — should any be completed?
-jq 'map(select(.properties.status == "in-progress")) | map({file, date: .properties.date, branch: .properties.branch})' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --property status=in-progress --index .hyalo-index --jq 'map({file, date: .properties.date, branch: .properties.branch})'
 
 # Planned items where all tasks are done
-jq 'map(select(.properties.status == "planned" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --property status=planned --index .hyalo-index --jq 'map(select((.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)'
 
 # In-progress items sorted by date (oldest first — possibly stale)
-jq 'map(select(.properties.status == "in-progress" and .properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --property status=in-progress --index .hyalo-index --jq 'map(select(.properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})'
 ```
 Cross-reference with git merges from Phase 2. If the branch was merged, update status.
 
 ### Stale backlog items
 ```bash
-jq 'map(select(.properties.status == "planned" and .properties.type == "backlog")) | map({file, title: .properties.title})' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --property status=planned --property type=backlog --index .hyalo-index --jq 'map({file, title: .properties.title})'
 ```
 Compare each planned backlog item against merged iterations and recent git history.
 If the feature clearly shipped (in a different iteration or under a different name),
@@ -163,8 +157,8 @@ flag it.
 
 ### Missing metadata
 ```bash
-jq 'map(select(.properties.status == null)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
-jq 'map(select(.properties.type == null)) | map(.file)' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --property '!status' --index .hyalo-index --jq 'map(.file)'
+hyalo find --property '!type' --index .hyalo-index --jq 'map(.file)'
 ```
 
 ### Tag inconsistencies
@@ -176,10 +170,19 @@ more files.
 ### Task completion vs status mismatch
 ```bash
 # Completed items with unchecked tasks — systemic or one-off?
-jq 'map(select(.properties.status == "completed" and (.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) > 0)) | map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})' ${HYALO_DREAM_SNAPSHOT}
+hyalo find --property status=completed --task todo --index .hyalo-index --jq 'map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})'
 ```
 If many completed items have unchecked tasks, this is a workflow pattern — note it once
 in the report rather than listing every file.
+
+## Drop the index before mutations
+
+Before executing any changes, drop the snapshot index. It is stale once files change,
+and mutation commands always scan from disk anyway.
+
+```bash
+hyalo drop-index
+```
 
 ## Phase 4 — Consolidate
 
@@ -240,8 +243,9 @@ Things you detected but couldn't (or shouldn't) fix unilaterally. Keep it concis
 one line per issue with enough context to act on.
 
 ### KB health dashboard
-Re-run `hyalo summary --format text` and compare with Phase 1 baseline. Report the
-delta: statuses changed, links fixed, tags normalized, files moved.
+Re-run `hyalo summary --format text` (fresh scan after mutations — no `--index`) and
+compare with Phase 1 baseline. Report the delta: statuses changed, links fixed, tags
+normalized, files moved.
 
 ## Ground rules
 
@@ -255,5 +259,5 @@ delta: statuses changed, links fixed, tags normalized, files moved.
   wikilink text in prose, adding cross-reference lines).
 - **Batch similar findings**: if 15 completed items have unchecked tasks, say that once
   with the count. The report should be scannable in 30 seconds.
-- **Minimize disk scans**: use the `${HYALO_DREAM_SNAPSHOT}` for all read queries.
-  Only call `hyalo find` again if you need data not in the snapshot.
+- **Minimize disk scans**: use `--index .hyalo-index` for all read-only queries.
+  Drop the index before Phase 4 mutations.

--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -152,6 +152,8 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **task** — read, toggle, or set status on checkboxes
 - **mv** — move/rename a file and rewrite all inbound links across the vault (`--dry-run` to preview)
 - **backlinks** — reverse link lookup: lists all files that link to a given file
+- **create-index** — build a snapshot index for faster repeated read-only queries
+- **drop-index** — delete a snapshot index file created with create-index
 
 ## The --format text flag
 
@@ -178,3 +180,29 @@ hyalo backlinks --file iterations/iteration-37-bulk-mutations.md --format json
 
 Supports `--format text` (default, compact) and `--format json`. Useful for impact analysis
 (what depends on this file?), finding orphan pages, and navigating link structure.
+
+## Snapshot index for batch queries
+
+When running many read-only queries (e.g., during a dream/consolidation pass or any multi-step
+analysis), create a snapshot index first to avoid repeated disk scans:
+
+```bash
+# Create the index (one scan, reused by all subsequent queries)
+hyalo create-index
+
+# All read-only queries use the index — no disk scan
+hyalo find --property status=in-progress --index .hyalo-index
+hyalo summary --index .hyalo-index
+hyalo tags summary --index .hyalo-index
+hyalo backlinks --file some-note.md --index .hyalo-index
+
+# Drop the index when done
+hyalo drop-index
+```
+
+The index is **ephemeral** — create it, use it, drop it within the same session. It becomes
+stale the moment any file in the vault changes. Never persist it across sessions.
+
+**For mixed read/write workflows:** gather all information with `--index` first, then drop the
+index, then execute mutations. Mutation commands (`set`, `remove`, `append`, `task`, `mv`,
+`tags rename`, `properties rename`) ignore `--index` — they always scan fresh from disk.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .claude/worktrees
 hyalo-knowledgebase/MyNotes.md
 bench-results/
+.hyalo-index

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .claude/worktrees
 hyalo-knowledgebase/MyNotes.md
 bench-results/
-.hyalo-index
+*.hyalo-index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "globset",
  "hyalo-core",
  "jaq-core",
  "jaq-json",
@@ -478,6 +479,7 @@ dependencies = [
  "globset",
  "ignore",
  "regex",
+ "rmp-serde",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -840,6 +842,25 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "dunce",
  "globset",
  "ignore",
+ "libc",
  "regex",
  "rmp-serde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 dunce = "1"
 globset = "0.4"
 ignore = "0.4"
+libc = "0.2"
 jaq-core = "2.2.1"
 jaq-json = { version = "1.1.3", features = ["serde_json"] }
 jaq-std = "2.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ jaq-json = { version = "1.1.3", features = ["serde_json"] }
 jaq-std = "2.1.2"
 predicates = "3"
 regex = "1"
+rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml_ng = "0.10"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cargo build --release
 
 ## Usage
 
-All commands accept `-d/--dir <path>` (default: `.`), `--format json|text` (default: `json`), `--jq <FILTER>` (apply a jq expression to the JSON output), `--hints` (append executable drill-down command suggestions), and `--site-prefix <PREFIX>` (override the site prefix used for resolving root-absolute links).
+All commands accept `-d/--dir <path>` (default: `.`), `--format json|text` (default: `json`), `--jq <FILTER>` (apply a jq expression to the JSON output), `--hints` (append executable drill-down command suggestions), `--site-prefix <PREFIX>` (override the site prefix used for resolving root-absolute links), and `--index <PATH>` (use a pre-built snapshot index instead of scanning files from disk — read-only commands use it; mutation commands ignore it; falls back to disk scan if the index is incompatible).
 
 Most flags have short aliases for quick interactive use:
 
@@ -413,6 +413,31 @@ Orphans: 3
 ```
 
 In JSON mode, `--hints` wraps the output in `{"data": ..., "hints": [...]}`. Hints are concrete, copy-pasteable commands — no templates or placeholders. Suppressed when combined with `--jq`.
+
+## Snapshot Index
+
+The snapshot index is a MessagePack file that captures a point-in-time snapshot of the vault's metadata (frontmatter, tags, sections, tasks, links) for faster repeated queries. It is **short-lived and ephemeral** — it becomes stale as soon as any file in the vault is modified.
+
+**Usage:**
+
+```sh
+# Create the index (one disk scan)
+hyalo create-index
+
+# Run read-only queries against the index (no disk scan)
+hyalo find --property status=in-progress --index .hyalo-index
+hyalo summary --index .hyalo-index
+hyalo tags summary --index .hyalo-index
+
+# Drop the index when done
+hyalo drop-index
+```
+
+**When to use:** workflows that run many read-only queries in a short window — CI pipelines, automation scripts, LLM tool loops. Create the index at the start, query against it, then drop it.
+
+**Staleness:** the index is a frozen snapshot. Mutation commands (`set`, `remove`, `append`, `task`, `mv`, `tags rename`, `properties rename`) always scan from disk and ignore `--index`. If your workflow mixes reads and writes, do all reads first with the index, drop it, then execute mutations.
+
+Never commit `.hyalo-index` files to version control — they are throwaway artifacts.
 
 ## Benchmarking
 

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -16,6 +16,7 @@ clap = { workspace = true, features = ["derive"] }
 jaq-core = { workspace = true }
 jaq-json = { workspace = true }
 jaq-std = { workspace = true }
+globset = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::discovery;
+use hyalo_core::index::VaultIndex;
 use hyalo_core::link_graph::{LinkGraph, is_self_link};
 
 #[derive(Serialize)]
@@ -48,6 +49,57 @@ pub fn backlinks(
     // Self-links are kept in the core graph so that `mv` can rewrite them.
     let entries: Vec<_> = build
         .graph
+        .backlinks(&rel)
+        .into_iter()
+        .filter(|e| !is_self_link(e, &rel))
+        .collect();
+
+    let items: Vec<BacklinkItem> = entries
+        .iter()
+        .map(|e| BacklinkItem {
+            source: e.source.to_string_lossy().replace('\\', "/"),
+            line: e.line,
+            target: e.link.target.clone(),
+            label: e.link.label.clone(),
+        })
+        .collect();
+
+    let total = items.len();
+    let result = BacklinkResult {
+        file: rel,
+        backlinks: items,
+        total,
+    };
+
+    let output = match format {
+        Format::Json => serde_json::to_string_pretty(&result)?,
+        Format::Text => format_text(&result),
+    };
+
+    Ok(CommandOutcome::Success(output))
+}
+
+/// Run `hyalo backlinks --file <path>` using pre-scanned index data.
+///
+/// `dir` is still needed to resolve the `file_arg` to a vault-relative path via
+/// `discovery::resolve_file`. Link lookup is done against `index.link_graph()`.
+pub fn backlinks_from_index(
+    index: &dyn VaultIndex,
+    file_arg: &str,
+    dir: &Path,
+    format: Format,
+) -> Result<CommandOutcome> {
+    // Resolve the file argument to a relative path (same as in `backlinks`)
+    let (_full_path, rel) = match discovery::resolve_file(dir, file_arg) {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(crate::commands::resolve_error_to_outcome(e, format));
+        }
+    };
+
+    let graph = index.link_graph();
+
+    let entries: Vec<_> = graph
         .backlinks(&rel)
         .into_iter()
         .filter(|e| !is_self_link(e, &rel))

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -1,0 +1,77 @@
+#![allow(clippy::missing_errors_doc)]
+use anyhow::Result;
+use hyalo_core::discovery;
+use hyalo_core::index::{ScannedIndex, SnapshotIndex, VaultIndex, find_stale_indexes};
+use std::path::{Path, PathBuf};
+
+use crate::output::{CommandOutcome, Format, format_success};
+
+/// Build a snapshot index from disk and write it to `output` (default:
+/// `<dir>/.hyalo-index`).
+///
+/// Prints warnings for any skipped files, then reports the path and file count
+/// on success.
+pub fn create_index(
+    dir: &Path,
+    site_prefix: Option<&str>,
+    output: Option<&Path>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    // Discover all markdown files
+    let all = discovery::discover_files(dir)?;
+    let files: Vec<(PathBuf, String)> = all
+        .into_iter()
+        .map(|p| {
+            let rel = discovery::relative_path(dir, &p);
+            (p, rel)
+        })
+        .collect();
+
+    // Build the scanned index
+    let build = ScannedIndex::build(&files, site_prefix)?;
+
+    // Warn about skipped files
+    for w in &build.warnings {
+        eprintln!("warning: skipped {}: {}", w.rel_path, w.message);
+    }
+
+    // Determine output path
+    let index_path = match output {
+        Some(p) => p.to_path_buf(),
+        None => dir.join(".hyalo-index"),
+    };
+
+    // Serialize vault_dir as a canonical string (fall back to raw display)
+    let vault_dir_str = std::fs::canonicalize(dir)
+        .unwrap_or_else(|_| dir.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
+
+    // Save the snapshot
+    SnapshotIndex::save(&build.index, &index_path, &vault_dir_str, site_prefix)?;
+
+    // Check for stale indexes in the same directory
+    if let Ok(stale) = find_stale_indexes(dir) {
+        for (stale_path, stale_vault, stale_ts) in stale {
+            // Don't warn about the file we just wrote
+            if stale_path == index_path {
+                continue;
+            }
+            eprintln!(
+                "warning: stale index at {} (vault: {}, created: {})",
+                stale_path.display(),
+                stale_vault,
+                stale_ts,
+            );
+        }
+    }
+
+    let file_count = build.index.entries().len();
+    let result = serde_json::json!({
+        "path": index_path.display().to_string(),
+        "files_indexed": file_count,
+        "warnings": build.warnings.len(),
+    });
+
+    Ok(CommandOutcome::Success(format_success(format, &result)))
+}

--- a/crates/hyalo-cli/src/commands/drop_index.rs
+++ b/crates/hyalo-cli/src/commands/drop_index.rs
@@ -14,19 +14,23 @@ pub fn drop_index(dir: &Path, path: Option<&Path>, format: Format) -> Result<Com
         None => dir.join(".hyalo-index"),
     };
 
-    if !index_path.exists() {
-        let out = crate::output::format_error(
-            format,
-            "index file not found",
-            Some(&index_path.display().to_string()),
-            Some("create one with `hyalo create-index`"),
-            None,
-        );
-        return Ok(CommandOutcome::UserError(out));
+    match std::fs::remove_file(&index_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let out = crate::output::format_error(
+                format,
+                "index file not found",
+                Some(&index_path.display().to_string()),
+                Some("create one with `hyalo create-index`"),
+                None,
+            );
+            return Ok(CommandOutcome::UserError(out));
+        }
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("failed to delete index file: {}", index_path.display()));
+        }
     }
-
-    std::fs::remove_file(&index_path)
-        .with_context(|| format!("failed to delete index file: {}", index_path.display()))?;
 
     let result = serde_json::json!({
         "deleted": index_path.display().to_string(),

--- a/crates/hyalo-cli/src/commands/drop_index.rs
+++ b/crates/hyalo-cli/src/commands/drop_index.rs
@@ -1,0 +1,36 @@
+#![allow(clippy::missing_errors_doc)]
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::output::{CommandOutcome, Format, format_success};
+
+/// Delete a snapshot index file.
+///
+/// If `path` is `None`, defaults to `<dir>/.hyalo-index`.
+/// Returns a user error if the file does not exist.
+pub fn drop_index(dir: &Path, path: Option<&Path>, format: Format) -> Result<CommandOutcome> {
+    let index_path: PathBuf = match path {
+        Some(p) => p.to_path_buf(),
+        None => dir.join(".hyalo-index"),
+    };
+
+    if !index_path.exists() {
+        let out = crate::output::format_error(
+            format,
+            "index file not found",
+            Some(&index_path.display().to_string()),
+            Some("create one with `hyalo create-index`"),
+            None,
+        );
+        return Ok(CommandOutcome::UserError(out));
+    }
+
+    std::fs::remove_file(&index_path)
+        .with_context(|| format!("failed to delete index file: {}", index_path.display()))?;
+
+    let result = serde_json::json!({
+        "deleted": index_path.display().to_string(),
+    });
+
+    Ok(CommandOutcome::Success(format_success(format, &result)))
+}

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -462,13 +462,19 @@ fn filter_index_entries<'a>(
     let filtered: Vec<&IndexEntry> = entries
         .iter()
         .filter(|e| {
+            // When files_arg is non-empty, an entry also passes if it is listed
+            // explicitly — this handles the case where both files_arg and globs
+            // are present (OR semantics between the two inclusion criteria).
+            let passes_files = !files_arg.is_empty() && files_arg.iter().any(|f| f == &e.rel_path);
             let passes_positive = positive_set
                 .as_ref()
                 .is_none_or(|gs| gs.is_match(&e.rel_path));
             let passes_negative = negative_set
                 .as_ref()
                 .is_none_or(|gs| !gs.is_match(&e.rel_path));
-            passes_positive && passes_negative
+            // An entry is included if it matches files_arg OR (matches positive
+            // globs AND is not excluded by a negative glob).
+            passes_files || (passes_positive && passes_negative)
         })
         .collect();
 
@@ -800,8 +806,8 @@ pub fn find_from_index(
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
         .into_iter()
-        .map(|obj| serde_json::to_value(obj).expect("derived Serialize impl should not fail"))
-        .collect();
+        .map(|obj| serde_json::to_value(obj).context("failed to serialize find result"))
+        .collect::<Result<_>>()?;
 
     if format == crate::output::Format::Text && json_array.is_empty() {
         eprintln!("warning: No files matched.");

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
+use globset::{GlobBuilder, GlobSetBuilder};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::time::SystemTime;
@@ -12,6 +13,7 @@ use hyalo_core::discovery;
 use hyalo_core::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField, extract_tags};
 use hyalo_core::frontmatter;
 use hyalo_core::heading::{SectionFilter, SectionRange, build_section_scope, in_scope};
+use hyalo_core::index::{IndexEntry, VaultIndex};
 use hyalo_core::link_graph::{LinkGraph, is_self_link};
 use hyalo_core::links::Link;
 use hyalo_core::scanner::{self, FileVisitor, FrontmatterCollector, ScanAction};
@@ -353,6 +355,454 @@ pub fn find(
     // LLM (or script) cannot distinguish from a silent failure.  Emit an
     // explicit notice on stderr so the caller knows the query succeeded but
     // matched nothing.  JSON mode keeps the empty array on stdout unchanged.
+    if format == crate::output::Format::Text && json_array.is_empty() {
+        eprintln!("warning: No files matched.");
+    }
+
+    let json_output = serde_json::Value::Array(json_array);
+
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format,
+        &json_output,
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// find_from_index — index-backed variant
+// ---------------------------------------------------------------------------
+
+/// Filter index entries by optional `--file` and `--glob` scoping arguments.
+///
+/// - When both are empty, all entries are returned.
+/// - `files_arg` entries are matched by exact `rel_path` equality.
+/// - `globs` patterns use the same globset semantics as `discovery::match_globs`
+///   (positive patterns require a match; negative `!pat` patterns exclude matches).
+fn filter_index_entries<'a>(
+    entries: &'a [IndexEntry],
+    files_arg: &[String],
+    globs: &[String],
+) -> Result<Vec<&'a IndexEntry>> {
+    if files_arg.is_empty() && globs.is_empty() {
+        return Ok(entries.iter().collect());
+    }
+
+    if !files_arg.is_empty() && globs.is_empty() {
+        // Exact path matching (same order as `files_arg` for explicit file lists)
+        let filtered: Vec<&IndexEntry> = entries
+            .iter()
+            .filter(|e| files_arg.iter().any(|f| f == &e.rel_path))
+            .collect();
+        return Ok(filtered);
+    }
+
+    // Glob filtering — build positive/negative glob sets (same logic as discovery::match_globs)
+    let normalized: Vec<String> = globs
+        .iter()
+        .map(|p| {
+            if let Some(rest) = p.strip_prefix("\\!") {
+                format!("!{rest}")
+            } else {
+                p.clone()
+            }
+        })
+        .collect();
+
+    let mut positive: Vec<&str> = Vec::new();
+    let mut negative: Vec<&str> = Vec::new();
+    for p in &normalized {
+        if let Some(neg) = p.strip_prefix('!') {
+            anyhow::ensure!(
+                !neg.is_empty(),
+                "negation glob pattern must not be empty (got '!')"
+            );
+            negative.push(neg);
+        } else {
+            positive.push(p.as_str());
+        }
+    }
+
+    let positive_set = if positive.is_empty() {
+        None
+    } else {
+        let mut builder = GlobSetBuilder::new();
+        for pat in &positive {
+            builder.add(
+                GlobBuilder::new(pat)
+                    .literal_separator(true)
+                    .build()
+                    .context("invalid glob pattern")?,
+            );
+        }
+        Some(
+            builder
+                .build()
+                .context("failed to build positive globset")?,
+        )
+    };
+
+    let negative_set = if negative.is_empty() {
+        None
+    } else {
+        let mut builder = GlobSetBuilder::new();
+        for pat in &negative {
+            builder.add(
+                GlobBuilder::new(pat)
+                    .literal_separator(true)
+                    .build()
+                    .context("invalid glob negation pattern")?,
+            );
+        }
+        Some(
+            builder
+                .build()
+                .context("failed to build negative globset")?,
+        )
+    };
+
+    let filtered: Vec<&IndexEntry> = entries
+        .iter()
+        .filter(|e| {
+            let passes_positive = positive_set
+                .as_ref()
+                .is_none_or(|gs| gs.is_match(&e.rel_path));
+            let passes_negative = negative_set
+                .as_ref()
+                .is_none_or(|gs| !gs.is_match(&e.rel_path));
+            passes_positive && passes_negative
+        })
+        .collect();
+
+    Ok(filtered)
+}
+
+/// Find files using pre-scanned index data.
+///
+/// This is the index-backed variant of [`find`]. It accepts `&dyn VaultIndex`
+/// instead of a directory to scan, and uses `dir` only for:
+/// - Content search (disk I/O is still required to read file bodies when
+///   `pattern` or `regexp` is specified)
+/// - Link path resolution (`discovery::resolve_target`)
+///
+/// All other data (properties, tags, sections, tasks, outbound links) comes
+/// directly from `IndexEntry` values. Backlinks are resolved via
+/// `index.link_graph()` rather than a new `LinkGraph::build`.
+#[allow(clippy::too_many_arguments)]
+pub fn find_from_index(
+    index: &dyn VaultIndex,
+    dir: &Path,
+    site_prefix: Option<&str>,
+    pattern: Option<&str>,
+    regexp: Option<&str>,
+    property_filters: &[PropertyFilter],
+    tag_filters: &[String],
+    task_filter: Option<&FindTaskFilter>,
+    section_filters: &[SectionFilter],
+    files_arg: &[String],
+    globs: &[String],
+    fields: &Fields,
+    sort: Option<&SortField>,
+    limit: Option<usize>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    // Treat --limit 0 as "no limit"
+    let limit = match limit {
+        Some(0) => None,
+        other => other,
+    };
+
+    // Normalize empty pattern
+    if pattern.is_some_and(|p| p.trim().is_empty()) {
+        eprintln!(
+            "warning: empty body pattern ignored (matches all files); omit the pattern to find all files"
+        );
+    }
+    let pattern = pattern.and_then(|p| if p.trim().is_empty() { None } else { Some(p) });
+
+    let sort_needs_backlinks = matches!(sort, Some(SortField::BacklinksCount));
+    let sort_needs_links = matches!(sort, Some(SortField::LinksCount));
+
+    let has_content_search = pattern.is_some() || regexp.is_some();
+    let has_task_filter = task_filter.is_some();
+    let has_section_filter = !section_filters.is_empty();
+
+    // Compile regex once (if any)
+    let compiled_regex = match regexp {
+        Some(re) => {
+            let effective = format!("(?i){re}");
+            match regex::RegexBuilder::new(&effective)
+                .size_limit(1 << 20)
+                .build()
+            {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    return Ok(CommandOutcome::UserError(format!(
+                        "invalid regular expression: {re}\n{e}"
+                    )));
+                }
+            }
+        }
+        None => None,
+    };
+
+    // Canonicalize the vault directory for link resolution
+    let canonical_dir = discovery::canonicalize_vault_dir(dir)?;
+
+    // Filter entries by --file / --glob scoping
+    let scoped_entries = filter_index_entries(index.entries(), files_arg, globs)?;
+
+    // Use the index's pre-built link graph for backlinks
+    let link_graph_ref = if fields.backlinks || sort_needs_backlinks {
+        Some(index.link_graph())
+    } else {
+        None
+    };
+
+    let can_short_circuit = limit.is_some()
+        && files_arg.is_empty()
+        && matches!(sort.unwrap_or(&SortField::File), SortField::File)
+        && !fields.backlinks
+        && !sort_needs_backlinks
+        && !sort_needs_links;
+
+    let mut results: Vec<FileObject> = Vec::new();
+
+    for entry in &scoped_entries {
+        // --- Metadata filters using pre-indexed data ---
+        if !filter::matches_filters_with_tags(
+            &entry.properties,
+            property_filters,
+            &entry.tags,
+            tag_filters,
+        ) {
+            continue;
+        }
+
+        // --- Build section scopes from pre-indexed sections ---
+        let scope_ranges: Vec<SectionRange> = if has_section_filter {
+            build_section_scope(&entry.sections, section_filters, usize::MAX)
+        } else {
+            Vec::new()
+        };
+
+        if has_section_filter && scope_ranges.is_empty() {
+            // No matching section in this file — skip entirely
+            continue;
+        }
+
+        // --- Task filter using pre-indexed tasks ---
+        let mut collected_tasks: Option<Vec<FindTaskInfo>> = if fields.tasks || has_task_filter {
+            let mut tasks = entry.tasks.clone();
+            if has_section_filter {
+                tasks.retain(|t| in_scope(&scope_ranges, t.line));
+            }
+            Some(tasks)
+        } else {
+            None
+        };
+
+        if let Some(filter) = task_filter {
+            let tasks_slice: &[FindTaskInfo] = collected_tasks.as_deref().unwrap_or(&[]);
+            if !matches_task_filter(tasks_slice, filter) {
+                continue;
+            }
+        }
+
+        // --- Content search: requires disk I/O ---
+        let content_matches: Option<Vec<ContentMatch>> = if has_content_search {
+            let full_path = dir.join(&entry.rel_path);
+            let mut content_visitor = if let Some(ref re) = compiled_regex {
+                ContentSearchVisitor::from_compiled(re.clone())
+            } else {
+                // pattern is Some at this point since has_content_search is true
+                ContentSearchVisitor::new(pattern.unwrap())
+            };
+            // Re-scan just this file for content (frontmatter already in index)
+            let scan_result =
+                hyalo_core::scanner::scan_file_multi(&full_path, &mut [&mut content_visitor]);
+            match scan_result {
+                Ok(()) => {}
+                Err(e) if hyalo_core::frontmatter::is_parse_error(&e) => {
+                    eprintln!("warning: skipping {}: {e}", entry.rel_path);
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+            let mut matches = content_visitor.into_matches();
+            if has_section_filter {
+                matches.retain(|m| in_scope(&scope_ranges, m.line));
+            }
+            Some(matches)
+        } else {
+            None
+        };
+
+        // Drop tasks from collected_tasks if not needed in output (filter already applied)
+        if !fields.tasks {
+            collected_tasks = None;
+        }
+
+        // Filter: content search must have at least one match
+        if has_content_search && content_matches.as_ref().is_some_and(|m| m.is_empty()) {
+            continue;
+        }
+
+        // --- Build sections field ---
+        let outline_sections: Option<Vec<OutlineSection>> = if fields.sections {
+            let mut secs = entry.sections.clone();
+            if !scope_ranges.is_empty() {
+                secs.retain(|s| in_scope(&scope_ranges, s.line));
+            }
+            Some(secs)
+        } else {
+            None
+        };
+
+        // --- Build links field from pre-indexed link data ---
+        let links = if fields.links || sort_needs_links {
+            Some(
+                entry
+                    .links
+                    .iter()
+                    .map(|(_, link)| {
+                        let path =
+                            discovery::resolve_target(&canonical_dir, &link.target, site_prefix);
+                        LinkInfo {
+                            target: link.target.clone(),
+                            path,
+                            label: link.label.clone(),
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            None
+        };
+
+        // --- Build properties fields ---
+        let properties = if fields.properties {
+            let mut map = serde_json::Map::new();
+            for (name, value) in entry
+                .properties
+                .iter()
+                .filter(|(n, _)| n.as_str() != "tags")
+            {
+                map.insert(name.clone(), hyalo_core::frontmatter::yaml_to_json(value));
+            }
+            Some(map)
+        } else {
+            None
+        };
+
+        let properties_typed = if fields.properties_typed {
+            Some(
+                entry
+                    .properties
+                    .iter()
+                    .filter(|(name, _)| name.as_str() != "tags")
+                    .map(|(name, value)| PropertyInfo {
+                        name: name.clone(),
+                        prop_type: hyalo_core::frontmatter::infer_type(value).to_owned(),
+                        value: hyalo_core::frontmatter::yaml_to_json(value),
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        let tags_field = if fields.tags {
+            Some(entry.tags.clone())
+        } else {
+            None
+        };
+
+        // --- Backlinks from pre-built link graph ---
+        let backlinks = if fields.backlinks {
+            let entries_bl = link_graph_ref
+                .map(|graph| graph.backlinks(&entry.rel_path))
+                .unwrap_or_default();
+            Some(
+                entries_bl
+                    .into_iter()
+                    .filter(|e| !is_self_link(e, &entry.rel_path))
+                    .map(|e| {
+                        let source = e.source.to_string_lossy().replace('\\', "/");
+                        BacklinkInfo {
+                            source,
+                            line: e.line,
+                            label: e.link.label.clone(),
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            None
+        };
+
+        let obj = FileObject {
+            file: entry.rel_path.clone(),
+            modified: entry.modified.clone(),
+            properties,
+            properties_typed,
+            tags: tags_field,
+            sections: outline_sections,
+            tasks: collected_tasks,
+            links,
+            backlinks,
+            matches: content_matches,
+        };
+
+        results.push(obj);
+
+        if can_short_circuit && results.len() >= limit.unwrap() {
+            break;
+        }
+    }
+
+    // --- Sort ---
+    match sort.unwrap_or(&SortField::File) {
+        SortField::File => results.sort_by(|a, b| a.file.cmp(&b.file)),
+        SortField::Modified => results.sort_by(|a, b| a.modified.cmp(&b.modified)),
+        SortField::BacklinksCount => {
+            results.sort_by(|a, b| {
+                let a_count = a.backlinks.as_ref().map_or_else(
+                    || link_graph_ref.map_or(0, |g| g.backlinks(&a.file).len()),
+                    Vec::len,
+                );
+                let b_count = b.backlinks.as_ref().map_or_else(
+                    || link_graph_ref.map_or(0, |g| g.backlinks(&b.file).len()),
+                    Vec::len,
+                );
+                b_count.cmp(&a_count)
+            });
+        }
+        SortField::LinksCount => {
+            results.sort_by(|a, b| {
+                let a_count = a.links.as_ref().map_or(0, Vec::len);
+                let b_count = b.links.as_ref().map_or(0, Vec::len);
+                b_count.cmp(&a_count)
+            });
+        }
+    }
+
+    // Strip internally-computed links field if user didn't request it
+    if sort_needs_links && !fields.links {
+        for obj in &mut results {
+            obj.links = None;
+        }
+    }
+
+    // --- Limit ---
+    if let Some(n) = limit {
+        results.truncate(n);
+    }
+
+    // --- Serialize ---
+    let json_array: Vec<serde_json::Value> = results
+        .into_iter()
+        .map(|obj| serde_json::to_value(obj).expect("derived Serialize impl should not fail"))
+        .collect();
+
     if format == crate::output::Format::Text && json_array.is_empty() {
         eprintln!("warning: No files matched.");
     }

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -377,7 +377,7 @@ pub fn find(
 /// - `files_arg` entries are matched by exact `rel_path` equality.
 /// - `globs` patterns use the same globset semantics as `discovery::match_globs`
 ///   (positive patterns require a match; negative `!pat` patterns exclude matches).
-fn filter_index_entries<'a>(
+pub fn filter_index_entries<'a>(
     entries: &'a [IndexEntry],
     files_arg: &[String],
     globs: &[String],

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::missing_errors_doc)]
 pub mod append;
 pub mod backlinks;
+pub mod create_index;
+pub mod drop_index;
 pub mod find;
 pub mod init;
 pub mod mv;

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -151,34 +151,8 @@ pub fn unwrap_single_file_result(
 // ---------------------------------------------------------------------------
 
 /// Format Unix timestamp (seconds since epoch) as ISO 8601 UTC.
-/// Output: `YYYY-MM-DDTHH:MM:SSZ`
-///
-/// Manual implementation to avoid adding a time/chrono dependency.
-/// Uses Howard Hinnant's civil_from_days algorithm.
-pub(crate) fn format_iso8601(secs: u64) -> String {
-    const SECS_PER_MIN: u64 = 60;
-    const SECS_PER_HOUR: u64 = 3600;
-    const SECS_PER_DAY: u64 = 86400;
-
-    let days = secs / SECS_PER_DAY;
-    let rem = secs % SECS_PER_DAY;
-    let hh = rem / SECS_PER_HOUR;
-    let mm = (rem % SECS_PER_HOUR) / SECS_PER_MIN;
-    let ss = rem % SECS_PER_MIN;
-
-    let z = days as i64 + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = (z - era * 146_097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-
-    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
-}
+/// Delegates to the canonical implementation in `hyalo_core::index`.
+pub(crate) use hyalo_core::index::format_iso8601;
 
 /// Convert a `FileResolveError` into a user-facing `CommandOutcome`.
 #[must_use]

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use crate::commands::{FilesOrOutcome, collect_files};
 use crate::output::{CommandOutcome, Format, format_output};
 use hyalo_core::frontmatter;
+use hyalo_core::index::VaultIndex;
 use hyalo_core::types::PropertySummaryEntry;
 use serde::Serialize;
 
@@ -37,6 +38,49 @@ pub fn properties_summary(
             Err(e) => return Err(e),
         };
         for (key, value) in props.iter().filter(|(k, _)| k.as_str() != "tags") {
+            let prop_type = frontmatter::infer_type(value).to_owned();
+            *agg.entry((key.clone(), prop_type)).or_insert(0) += 1;
+        }
+    }
+
+    let mut result: Vec<PropertySummaryEntry> = agg
+        .into_iter()
+        .map(|((name, prop_type), count)| PropertySummaryEntry {
+            name,
+            prop_type,
+            count,
+        })
+        .collect();
+    result.sort_by(|a, b| a.name.cmp(&b.name).then(a.prop_type.cmp(&b.prop_type)));
+
+    Ok(CommandOutcome::Success(format_output(format, &result)))
+}
+
+/// Aggregate property summary using pre-scanned index data.
+///
+/// `file_filter` is an optional list of vault-relative paths to include.
+/// When `None` (or an empty slice), all index entries are used.
+pub fn properties_summary_from_index(
+    index: &dyn VaultIndex,
+    file_filter: Option<&[String]>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let mut agg: std::collections::BTreeMap<(String, String), usize> =
+        std::collections::BTreeMap::new();
+
+    for entry in index.entries() {
+        // Apply optional file-level filter
+        if let Some(filter) = file_filter
+            && !filter.is_empty()
+            && !filter.iter().any(|f| f == &entry.rel_path)
+        {
+            continue;
+        }
+        for (key, value) in entry
+            .properties
+            .iter()
+            .filter(|(k, _)| k.as_str() != "tags")
+        {
             let prop_type = frontmatter::infer_type(value).to_owned();
             *agg.entry((key.clone(), prop_type)).or_insert(0) += 1;
         }

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -433,8 +433,7 @@ pub fn summary_from_index(
         recent_files,
     };
 
-    let json_value =
-        serde_json::to_value(&vault_summary).expect("derived Serialize impl should not fail");
+    let json_value = serde_json::to_value(&vault_summary).context("failed to serialize summary")?;
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
         &json_value,

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -8,6 +8,7 @@ use crate::commands::{FilesOrOutcome, collect_files};
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::filter::extract_tags;
 use hyalo_core::frontmatter::{infer_type, yaml_to_json};
+use hyalo_core::index::VaultIndex;
 use hyalo_core::link_graph::{FileLinks, LinkGraph, LinkGraphVisitor};
 use hyalo_core::scanner::{FrontmatterCollector, scan_file_multi};
 use hyalo_core::tasks::TaskCounter;
@@ -254,6 +255,191 @@ pub fn summary(
 }
 
 use super::format_iso8601;
+
+/// Show a high-level vault summary using pre-scanned index data.
+///
+/// All aggregation (file counts, properties, tags, status groups, tasks, recent
+/// files, orphans) is derived from `IndexEntry` values rather than scanning
+/// files from disk.
+pub fn summary_from_index(
+    index: &dyn VaultIndex,
+    recent: usize,
+    depth: Option<usize>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let entries = index.entries();
+
+    let mut total_files: usize = 0;
+    let mut dir_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut property_counts: BTreeMap<(String, String), usize> = BTreeMap::new();
+    let mut tag_counts: BTreeMap<String, (String, usize)> = BTreeMap::new();
+    let mut status_groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut total_tasks: usize = 0;
+    let mut done_tasks: usize = 0;
+    let mut recent_entries: Vec<(String, String)> = Vec::new();
+
+    for entry in entries {
+        total_files += 1;
+
+        let dir_key = {
+            let rel = std::path::Path::new(&entry.rel_path);
+            match rel.parent() {
+                Some(p) if !p.as_os_str().is_empty() => p.to_string_lossy().replace('\\', "/"),
+                _ => ".".to_owned(),
+            }
+        };
+        *dir_counts.entry(dir_key).or_insert(0) += 1;
+
+        // Properties aggregation (skip "tags")
+        for (name, value) in entry
+            .properties
+            .iter()
+            .filter(|(n, _)| n.as_str() != "tags")
+        {
+            let prop_type = infer_type(value).to_owned();
+            *property_counts
+                .entry((name.clone(), prop_type))
+                .or_insert(0) += 1;
+        }
+
+        // Tags aggregation (case-insensitive, preserve first-seen casing)
+        for tag in &entry.tags {
+            let key = tag.to_ascii_lowercase();
+            tag_counts
+                .entry(key)
+                .and_modify(|e| e.1 += 1)
+                .or_insert_with(|| (tag.clone(), 1));
+        }
+
+        // Status grouping
+        if let Some(status_val) = entry.properties.get("status") {
+            let status_str = match yaml_to_json(status_val) {
+                serde_json::Value::String(s) => s,
+                other => other.to_string(),
+            };
+            status_groups
+                .entry(status_str)
+                .or_default()
+                .push(entry.rel_path.clone());
+        }
+
+        // Task counts from pre-indexed tasks
+        for task in &entry.tasks {
+            total_tasks += 1;
+            if task.done {
+                done_tasks += 1;
+            }
+        }
+
+        // Recent files: use the pre-indexed ISO 8601 modified timestamp.
+        // Store as (modified_desc_sort_key, rel_path) for descending sort.
+        // Since the timestamp is ISO 8601, lexicographic desc == chronological desc.
+        recent_entries.push((entry.modified.clone(), entry.rel_path.clone()));
+    }
+
+    // Apply depth limit
+    if let Some(max_depth) = depth {
+        let original: Vec<(String, usize)> = dir_counts.into_iter().collect();
+        dir_counts = BTreeMap::new();
+        for (dir_key, count) in original {
+            let target = truncate_to_depth(&dir_key, max_depth);
+            *dir_counts.entry(target).or_insert(0) += count;
+        }
+    }
+
+    // Build FileCounts
+    let mut by_directory: Vec<DirectoryCount> = dir_counts
+        .into_iter()
+        .map(|(directory, count)| DirectoryCount { directory, count })
+        .collect();
+    by_directory.sort_by(|a, b| a.directory.cmp(&b.directory));
+
+    let file_counts = FileCounts {
+        total: total_files,
+        by_directory,
+    };
+
+    // Build properties summary
+    let mut properties: Vec<PropertySummaryEntry> = property_counts
+        .into_iter()
+        .map(|((name, prop_type), count)| PropertySummaryEntry {
+            name,
+            prop_type,
+            count,
+        })
+        .collect();
+    properties.sort_by(|a, b| a.name.cmp(&b.name).then(a.prop_type.cmp(&b.prop_type)));
+
+    // Build tag summary
+    let mut tags_vec: Vec<TagSummaryEntry> = tag_counts
+        .into_iter()
+        .map(|(_, (name, count))| TagSummaryEntry { name, count })
+        .collect();
+    tags_vec.sort_by(|a, b| b.count.cmp(&a.count).then(a.name.cmp(&b.name)));
+    let tags_total = tags_vec.len();
+    let tags = TagSummary {
+        tags: tags_vec,
+        total: tags_total,
+    };
+
+    // Build status groups
+    let status: Vec<StatusGroup> = status_groups
+        .into_iter()
+        .map(|(value, files)| StatusGroup { value, files })
+        .collect();
+
+    let tasks = TaskCount {
+        total: total_tasks,
+        done: done_tasks,
+    };
+
+    // Build recent files (sort most-recent first by ISO 8601 timestamp desc, take top N)
+    recent_entries.sort_by(|a, b| b.0.cmp(&a.0));
+    let recent_files: Vec<RecentFile> = recent_entries
+        .into_iter()
+        .take(recent)
+        .map(|(modified, path)| RecentFile { path, modified })
+        .collect();
+
+    // Build orphan list using the pre-built link graph from the index.
+    let graph = index.link_graph();
+    let targets = graph.all_targets();
+    let sources = graph.all_sources();
+    let mut orphan_files: Vec<String> = index
+        .entries()
+        .iter()
+        .filter(|entry| {
+            let rel_str: &str = &entry.rel_path;
+            let without_md = rel_str.strip_suffix(".md").unwrap_or(rel_str);
+            let has_inbound = targets.contains(rel_str) || targets.contains(without_md);
+            let has_outbound = sources.contains(rel_str);
+            !has_inbound && !has_outbound
+        })
+        .map(|entry| entry.rel_path.clone())
+        .collect();
+    orphan_files.sort();
+    let orphans = OrphanSummary {
+        total: orphan_files.len(),
+        files: orphan_files,
+    };
+
+    let vault_summary = VaultSummary {
+        files: file_counts,
+        orphans,
+        properties,
+        tags,
+        status,
+        tasks,
+        recent_files,
+    };
+
+    let json_value =
+        serde_json::to_value(&vault_summary).expect("derived Serialize impl should not fail");
+    Ok(CommandOutcome::Success(crate::output::format_success(
+        format,
+        &json_value,
+    )))
+}
 
 /// Truncate a directory path to at most `max_depth` components.
 ///

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -261,13 +261,20 @@ use super::format_iso8601;
 /// All aggregation (file counts, properties, tags, status groups, tasks, recent
 /// files, orphans) is derived from `IndexEntry` values rather than scanning
 /// files from disk.
+///
+/// `globs` optionally narrows which entries are included (same semantics as the
+/// `--glob` flag on the `summary` command).
 pub fn summary_from_index(
     index: &dyn VaultIndex,
+    globs: &[String],
     recent: usize,
     depth: Option<usize>,
     format: Format,
 ) -> Result<CommandOutcome> {
-    let entries = index.entries();
+    use crate::commands::find::filter_index_entries;
+    let scoped: Vec<_> = filter_index_entries(index.entries(), &[], globs)?;
+    // Work with a slice of &IndexEntry references.
+    let entries: Vec<_> = scoped;
 
     let mut total_files: usize = 0;
     let mut dir_counts: BTreeMap<String, usize> = BTreeMap::new();
@@ -278,7 +285,7 @@ pub fn summary_from_index(
     let mut done_tasks: usize = 0;
     let mut recent_entries: Vec<(String, String)> = Vec::new();
 
-    for entry in entries {
+    for entry in &entries {
         total_files += 1;
 
         let dir_key = {
@@ -402,11 +409,11 @@ pub fn summary_from_index(
         .collect();
 
     // Build orphan list using the pre-built link graph from the index.
+    // The link graph is vault-wide so links from outside the scoped set still count.
     let graph = index.link_graph();
     let targets = graph.all_targets();
     let sources = graph.all_sources();
-    let mut orphan_files: Vec<String> = index
-        .entries()
+    let mut orphan_files: Vec<String> = entries
         .iter()
         .filter(|entry| {
             let rel_str: &str = &entry.rel_path;

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -7,6 +7,7 @@ use crate::commands::{FilesOrOutcome, collect_files};
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::filter::extract_tags;
 use hyalo_core::frontmatter;
+use hyalo_core::index::VaultIndex;
 use hyalo_core::types::{TagSummary, TagSummaryEntry};
 use serde::Serialize;
 use serde_yaml_ng::Value;
@@ -81,6 +82,48 @@ pub fn tags_summary(
                 .entry(key)
                 .and_modify(|entry| entry.1 += 1)
                 .or_insert((tag, 1));
+        }
+    }
+
+    let tags: Vec<TagSummaryEntry> = counts
+        .into_iter()
+        .map(|(_, (name, count))| TagSummaryEntry { name, count })
+        .collect();
+
+    let total = tags.len();
+    let result = TagSummary { tags, total };
+
+    Ok(CommandOutcome::Success(crate::output::format_output(
+        format, &result,
+    )))
+}
+
+/// Aggregate tag summary using pre-scanned index data.
+///
+/// `file_filter` is an optional list of vault-relative paths to include.
+/// When `None` (or an empty slice), all index entries are used.
+pub fn tags_summary_from_index(
+    index: &dyn VaultIndex,
+    file_filter: Option<&[String]>,
+    format: Format,
+) -> Result<CommandOutcome> {
+    // Aggregate case-insensitively: use lowercase key, preserve first-seen casing for display
+    let mut counts: BTreeMap<String, (String, usize)> = BTreeMap::new();
+
+    for entry in index.entries() {
+        // Apply optional file-level filter
+        if let Some(filter) = file_filter
+            && !filter.is_empty()
+            && !filter.iter().any(|f| f == &entry.rel_path)
+        {
+            continue;
+        }
+        for tag in &entry.tags {
+            let key = tag.to_ascii_lowercase();
+            counts
+                .entry(key)
+                .and_modify(|e| e.1 += 1)
+                .or_insert_with(|| (tag.clone(), 1));
         }
     }
 

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -15,7 +15,7 @@ use hyalo_cli::output::{
     CommandOutcome, Format, apply_jq_filter_result, format_success, format_with_hints,
 };
 use hyalo_core::filter;
-use hyalo_core::index::SnapshotIndex;
+use hyalo_core::index::{SnapshotIndex, VaultIndex};
 
 #[derive(Parser)]
 #[command(
@@ -957,16 +957,49 @@ fn main() {
         eprintln!("warning: --hints has no effect on mutation commands");
     }
 
-    // Load snapshot index if --index is provided (read-only commands only).
-    // Mutation commands never use the index; they always scan from disk.
-    let snapshot_index: Option<SnapshotIndex> = if let Some(ref index_path) = cli.index {
-        match SnapshotIndex::load(index_path) {
-            Ok(Some(idx)) => Some(idx),
-            Ok(None) => None, // incompatible schema — already warned; fall back to disk scan
-            Err(e) => {
-                eprintln!("warning: failed to load index: {e}; falling back to disk scan");
-                None
+    // Load snapshot index if --index is provided, but only for read-only commands.
+    // Mutation commands (set, remove, append, task, mv, tags rename, properties rename)
+    // always scan from disk and never consult the index.
+    let uses_index = matches!(
+        &cli.command,
+        Commands::Find { .. }
+            | Commands::Summary { .. }
+            | Commands::Tags {
+                action: None | Some(TagsAction::Summary { .. })
             }
+            | Commands::Properties {
+                action: None | Some(PropertiesAction::Summary { .. })
+            }
+            | Commands::Backlinks { .. }
+    );
+    let snapshot_index: Option<SnapshotIndex> = if uses_index {
+        if let Some(ref index_path) = cli.index {
+            match SnapshotIndex::load(index_path) {
+                Ok(Some(idx)) => {
+                    // Warn when the snapshot was built for a different vault or
+                    // site-prefix — the index data may not match the current run.
+                    let canonical_dir = std::fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+                    let vault_dir_str = canonical_dir.to_string_lossy();
+                    if !idx.validate(&vault_dir_str, site_prefix) {
+                        let (hdr_vault, hdr_prefix, _, _) = idx.header_info();
+                        eprintln!(
+                            "warning: index was built for vault '{}' (prefix {:?}) but current \
+                             vault is '{}' (prefix {:?}); falling back to disk scan",
+                            hdr_vault, hdr_prefix, vault_dir_str, site_prefix,
+                        );
+                        None
+                    } else {
+                        Some(idx)
+                    }
+                }
+                Ok(None) => None, // incompatible schema — already warned; fall back to disk scan
+                Err(e) => {
+                    eprintln!("warning: failed to load index: {e}; falling back to disk scan");
+                    None
+                }
+            }
+        } else {
+            None
         }
     } else {
         None
@@ -1092,7 +1125,25 @@ fn main() {
             match action {
                 PropertiesAction::Summary { ref glob } => {
                     if let Some(ref idx) = snapshot_index {
-                        properties::properties_summary_from_index(idx, None, effective_format)
+                        let filtered =
+                            find_commands::filter_index_entries(idx.entries(), &[], glob);
+                        match filtered {
+                            Err(e) => Err(e),
+                            Ok(filtered) => {
+                                let paths: Vec<String> =
+                                    filtered.iter().map(|e| e.rel_path.clone()).collect();
+                                let file_filter = if glob.is_empty() {
+                                    None
+                                } else {
+                                    Some(paths.as_slice())
+                                };
+                                properties::properties_summary_from_index(
+                                    idx,
+                                    file_filter,
+                                    effective_format,
+                                )
+                            }
+                        }
                     } else {
                         properties::properties_summary(&dir, None, glob, effective_format)
                     }
@@ -1109,7 +1160,25 @@ fn main() {
             match action {
                 TagsAction::Summary { ref glob } => {
                     if let Some(ref idx) = snapshot_index {
-                        tag_commands::tags_summary_from_index(idx, None, effective_format)
+                        let filtered =
+                            find_commands::filter_index_entries(idx.entries(), &[], glob);
+                        match filtered {
+                            Err(e) => Err(e),
+                            Ok(filtered) => {
+                                let paths: Vec<String> =
+                                    filtered.iter().map(|e| e.rel_path.clone()).collect();
+                                let file_filter = if glob.is_empty() {
+                                    None
+                                } else {
+                                    Some(paths.as_slice())
+                                };
+                                tag_commands::tags_summary_from_index(
+                                    idx,
+                                    file_filter,
+                                    effective_format,
+                                )
+                            }
+                        }
                     } else {
                         tag_commands::tags_summary(&dir, None, glob, effective_format)
                     }
@@ -1159,7 +1228,7 @@ fn main() {
             depth,
         } => {
             if let Some(ref idx) = snapshot_index {
-                summary_commands::summary_from_index(idx, recent, depth, effective_format)
+                summary_commands::summary_from_index(idx, glob, recent, depth, effective_format)
             } else {
                 summary_commands::summary(&dir, glob, recent, depth, effective_format)
             }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -4,16 +4,18 @@ use std::process;
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 
 use hyalo_cli::commands::{
-    append as append_commands, backlinks as backlinks_commands, find as find_commands,
-    init as init_commands, mv as mv_commands, properties, read as read_commands,
-    remove as remove_commands, set as set_commands, summary as summary_commands,
-    tags as tag_commands, tasks as task_commands,
+    append as append_commands, backlinks as backlinks_commands,
+    create_index as create_index_commands, drop_index as drop_index_commands,
+    find as find_commands, init as init_commands, mv as mv_commands, properties,
+    read as read_commands, remove as remove_commands, set as set_commands,
+    summary as summary_commands, tags as tag_commands, tasks as task_commands,
 };
 use hyalo_cli::hints::{HintContext, HintSource, generate_hints};
 use hyalo_cli::output::{
     CommandOutcome, Format, apply_jq_filter_result, format_success, format_with_hints,
 };
 use hyalo_core::filter;
+use hyalo_core::index::SnapshotIndex;
 
 #[derive(Parser)]
 #[command(
@@ -236,6 +238,21 @@ struct Cli {
     /// Precedence: --site-prefix flag > .hyalo.toml > auto-derived from --dir.
     #[arg(long, global = true, value_name = "PREFIX")]
     site_prefix: Option<String>,
+
+    /// Use a pre-built snapshot index instead of scanning files from disk.
+    ///
+    /// The index is a frozen point-in-time snapshot — it becomes stale as
+    /// soon as any file in the vault is modified. Best used as a bracketed
+    /// session: create-index, run read-only queries, drop-index.
+    ///
+    /// Read-only commands (find, summary, tags summary, properties summary,
+    /// backlinks) use the index; mutation commands (set, remove, append, task,
+    /// mv, tags rename, properties rename) always scan from disk and ignore it.
+    ///
+    /// If the index file is incompatible (e.g. after a hyalo upgrade) hyalo
+    /// falls back to a full disk scan automatically.
+    #[arg(long, global = true, value_name = "PATH")]
+    index: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Commands,
@@ -508,6 +525,41 @@ Repeatable (AND).\n\
         /// Set up Claude Code integration (skill + CLAUDE.md hint)
         #[arg(long)]
         claude: bool,
+    },
+    /// Build a snapshot index for faster repeated read-only queries
+    #[command(
+        name = "create-index",
+        long_about = "Scan the vault and write a binary snapshot index to disk.\n\n\
+            The index captures a point-in-time snapshot of all vault metadata.\n\
+            It is short-lived — it becomes stale when any vault file changes.\n\
+            Delete it after use via `hyalo drop-index`.\n\n\
+            The index file can then be passed to subsequent read-only commands via\n\
+            `--index <PATH>` to skip the disk scan entirely.  Mutation commands\n\
+            (set, remove, append, task, mv, tags rename, properties rename) always\n\
+            scan from disk and ignore --index.\n\n\
+            OUTPUT: JSON object with `path`, `files_indexed`, and `warnings`.\n\
+            SIDE EFFECTS: Writes a binary file (default: .hyalo-index in --dir)."
+    )]
+    CreateIndex {
+        /// Output path for the index file (default: .hyalo-index in --dir)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+    /// Delete a snapshot index file created with create-index
+    #[command(
+        name = "drop-index",
+        long_about = "Delete a snapshot index file.\n\n\
+            Always drop the index before running mutation commands if you\n\
+            created one, since mutations need fresh disk data. The index is\n\
+            a frozen snapshot and should not outlive its session.\n\n\
+            If --path is omitted, deletes .hyalo-index in --dir.\n\n\
+            OUTPUT: JSON object with `deleted` path.\n\
+            SIDE EFFECTS: Deletes the index file from disk."
+    )]
+    DropIndex {
+        /// Path to the index file to delete (default: .hyalo-index in --dir)
+        #[arg(short, long)]
+        path: Option<PathBuf>,
     },
     /// Append values to list properties in file(s) frontmatter, promoting scalars to lists
     #[command(
@@ -905,6 +957,21 @@ fn main() {
         eprintln!("warning: --hints has no effect on mutation commands");
     }
 
+    // Load snapshot index if --index is provided (read-only commands only).
+    // Mutation commands never use the index; they always scan from disk.
+    let snapshot_index: Option<SnapshotIndex> = if let Some(ref index_path) = cli.index {
+        match SnapshotIndex::load(index_path) {
+            Ok(Some(idx)) => Some(idx),
+            Ok(None) => None, // incompatible schema — already warned; fall back to disk scan
+            Err(e) => {
+                eprintln!("warning: failed to load index: {e}; falling back to disk scan");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let result = match cli.command {
         Commands::Find {
             ref pattern,
@@ -970,22 +1037,42 @@ fn main() {
                 }
             };
 
-            find_commands::find(
-                &dir,
-                site_prefix,
-                pattern.as_deref(),
-                regexp.as_deref(),
-                &prop_filters,
-                tag,
-                task_filter.as_ref(),
-                &section_filters,
-                file,
-                glob,
-                &parsed_fields,
-                sort_field.as_ref(),
-                limit,
-                effective_format,
-            )
+            if let Some(ref idx) = snapshot_index {
+                find_commands::find_from_index(
+                    idx,
+                    &dir,
+                    site_prefix,
+                    pattern.as_deref(),
+                    regexp.as_deref(),
+                    &prop_filters,
+                    tag,
+                    task_filter.as_ref(),
+                    &section_filters,
+                    file,
+                    glob,
+                    &parsed_fields,
+                    sort_field.as_ref(),
+                    limit,
+                    effective_format,
+                )
+            } else {
+                find_commands::find(
+                    &dir,
+                    site_prefix,
+                    pattern.as_deref(),
+                    regexp.as_deref(),
+                    &prop_filters,
+                    tag,
+                    task_filter.as_ref(),
+                    &section_filters,
+                    file,
+                    glob,
+                    &parsed_fields,
+                    sort_field.as_ref(),
+                    limit,
+                    effective_format,
+                )
+            }
         }
         Commands::Read {
             ref file,
@@ -1004,7 +1091,11 @@ fn main() {
             let action = action.unwrap_or(PropertiesAction::Summary { glob: vec![] });
             match action {
                 PropertiesAction::Summary { ref glob } => {
-                    properties::properties_summary(&dir, None, glob, effective_format)
+                    if let Some(ref idx) = snapshot_index {
+                        properties::properties_summary_from_index(idx, None, effective_format)
+                    } else {
+                        properties::properties_summary(&dir, None, glob, effective_format)
+                    }
                 }
                 PropertiesAction::Rename {
                     ref from,
@@ -1017,7 +1108,11 @@ fn main() {
             let action = action.unwrap_or(TagsAction::Summary { glob: vec![] });
             match action {
                 TagsAction::Summary { ref glob } => {
-                    tag_commands::tags_summary(&dir, None, glob, effective_format)
+                    if let Some(ref idx) = snapshot_index {
+                        tag_commands::tags_summary_from_index(idx, None, effective_format)
+                    } else {
+                        tag_commands::tags_summary(&dir, None, glob, effective_format)
+                    }
                 }
                 TagsAction::Rename {
                     ref from,
@@ -1062,7 +1157,13 @@ fn main() {
             ref glob,
             recent,
             depth,
-        } => summary_commands::summary(&dir, glob, recent, depth, effective_format),
+        } => {
+            if let Some(ref idx) = snapshot_index {
+                summary_commands::summary_from_index(idx, recent, depth, effective_format)
+            } else {
+                summary_commands::summary(&dir, glob, recent, depth, effective_format)
+            }
+        }
         Commands::Set {
             ref properties,
             ref tag,
@@ -1122,13 +1223,26 @@ fn main() {
             )
         }
         Commands::Backlinks { ref file } => {
-            backlinks_commands::backlinks(&dir, site_prefix, file, effective_format)
+            if let Some(ref idx) = snapshot_index {
+                backlinks_commands::backlinks_from_index(idx, file, &dir, effective_format)
+            } else {
+                backlinks_commands::backlinks(&dir, site_prefix, file, effective_format)
+            }
         }
         Commands::Mv {
             ref file,
             ref to,
             dry_run,
         } => mv_commands::mv(&dir, file, to, dry_run, effective_format, site_prefix),
+        Commands::CreateIndex { ref output } => create_index_commands::create_index(
+            &dir,
+            site_prefix,
+            output.as_deref(),
+            effective_format,
+        ),
+        Commands::DropIndex { ref path } => {
+            drop_index_commands::drop_index(&dir, path.as_deref(), effective_format)
+        }
         // `Init` is handled as an early return before this match is reached.
         Commands::Init { .. } => unreachable!("Init is dispatched before this match reached"),
     };

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -1,0 +1,695 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Vault fixture
+// ---------------------------------------------------------------------------
+
+fn setup_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+
+    // alpha.md — status=draft, rust+cli tags, has tasks, links to beta
+    write_md(
+        tmp.path(),
+        "alpha.md",
+        md!(r"
+---
+title: Alpha
+status: draft
+priority: 1
+tags:
+  - rust
+  - cli
+---
+# Alpha
+
+See [[beta]] for context.
+
+- [ ] Write tests
+- [x] Write code
+"),
+    );
+
+    // beta.md — status=published, rust tag, body has unique keyword
+    write_md(
+        tmp.path(),
+        "beta.md",
+        md!(r"
+---
+title: Beta
+status: published
+tags:
+  - rust
+---
+# Beta Content
+
+Rust programming is fascinating.
+"),
+    );
+
+    // gamma.md — status=draft, no tags, links to alpha
+    write_md(
+        tmp.path(),
+        "gamma.md",
+        md!(r"
+---
+title: Gamma
+status: draft
+---
+# Gamma
+
+See also [[alpha]].
+
+- [ ] Pending task
+"),
+    );
+
+    // sub/nested.md — status=published, nested tag
+    write_md(
+        tmp.path(),
+        "sub/nested.md",
+        md!(r"
+---
+title: Nested
+status: published
+tags:
+  - project/backend
+---
+# Nested Content
+
+Some nested content here.
+"),
+    );
+
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Run `hyalo create-index --dir <dir>` and assert success.
+/// Returns the default index path: `<dir>/.hyalo-index`.
+fn create_default_index(tmp: &TempDir) -> std::path::PathBuf {
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "create-index failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    tmp.path().join(".hyalo-index")
+}
+
+/// Run `hyalo find` with extra args and return parsed JSON.
+fn run_find(tmp: &TempDir, extra_args: &[&str]) -> serde_json::Value {
+    let mut cmd = hyalo();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.arg("find");
+    cmd.args(extra_args);
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "find failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        panic!("invalid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    })
+}
+
+/// Extract and sort file paths from a find JSON array.
+fn sorted_files(json: &serde_json::Value) -> Vec<String> {
+    let mut files: Vec<String> = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["file"].as_str().unwrap().to_owned())
+        .collect();
+    files.sort();
+    files
+}
+
+// ---------------------------------------------------------------------------
+// create-index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_index_produces_file() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let index_path = tmp.path().join(".hyalo-index");
+    assert!(
+        index_path.exists(),
+        ".hyalo-index should exist after create-index"
+    );
+
+    // Output should be JSON with path and files_indexed
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["path"].is_string());
+    assert_eq!(json["files_indexed"].as_u64().unwrap(), 4);
+}
+
+#[test]
+fn create_index_custom_output_path() {
+    let tmp = setup_vault();
+    let custom_path = tmp.path().join("my-custom.idx");
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["create-index", "--output", custom_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        custom_path.exists(),
+        "custom index path should exist after create-index --output"
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["path"].as_str().unwrap(),
+        custom_path.to_str().unwrap()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// drop-index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn drop_index_deletes_file() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+    assert!(index_path.exists());
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("drop-index")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !index_path.exists(),
+        ".hyalo-index should be gone after drop-index"
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["deleted"].is_string());
+}
+
+#[test]
+fn drop_index_nonexistent_returns_error() {
+    let tmp = setup_vault();
+    // No index created — drop-index should fail.
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("drop-index")
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "drop-index should fail when index does not exist"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// find --index parity with disk scan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_with_index_returns_same_files_as_disk_scan() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let disk_json = run_find(&tmp, &[]);
+    let index_json = run_find(&tmp, &["--index", index_path.to_str().unwrap()]);
+
+    let mut disk_files = sorted_files(&disk_json);
+    let mut index_files = sorted_files(&index_json);
+    disk_files.sort();
+    index_files.sort();
+
+    assert_eq!(
+        disk_files, index_files,
+        "find --index should return the same file set as a disk scan"
+    );
+}
+
+#[test]
+fn find_with_index_preserves_properties() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let disk_json = run_find(&tmp, &[]);
+    let index_json = run_find(&tmp, &["--index", index_path.to_str().unwrap()]);
+
+    // For each file returned by disk scan, check that index scan has matching properties.
+    for disk_entry in disk_json.as_array().unwrap() {
+        let file = disk_entry["file"].as_str().unwrap();
+        let index_entry = index_json
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|v| v["file"].as_str().unwrap() == file)
+            .unwrap_or_else(|| panic!("file {file} missing from index scan"));
+
+        assert_eq!(
+            disk_entry["properties"], index_entry["properties"],
+            "properties mismatch for {file}"
+        );
+        assert_eq!(
+            disk_entry["tags"], index_entry["tags"],
+            "tags mismatch for {file}"
+        );
+    }
+}
+
+#[test]
+fn find_with_index_property_filter() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let json = run_find(
+        &tmp,
+        &[
+            "--property",
+            "status=draft",
+            "--index",
+            index_path.to_str().unwrap(),
+        ],
+    );
+
+    let files = sorted_files(&json);
+    assert_eq!(files, vec!["alpha.md", "gamma.md"]);
+
+    // Verify properties show status=draft for each result.
+    for entry in json.as_array().unwrap() {
+        assert_eq!(
+            entry["properties"]["status"].as_str().unwrap(),
+            "draft",
+            "non-draft file returned: {}",
+            entry["file"]
+        );
+    }
+}
+
+#[test]
+fn find_with_index_tag_filter() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let json = run_find(
+        &tmp,
+        &["--tag", "rust", "--index", index_path.to_str().unwrap()],
+    );
+
+    let mut files = sorted_files(&json);
+    files.sort();
+    assert_eq!(files, vec!["alpha.md", "beta.md"]);
+}
+
+#[test]
+fn find_with_index_content_search_falls_back_to_disk() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    // "fascinating" only appears in beta.md body.
+    let json = run_find(
+        &tmp,
+        &["fascinating", "--index", index_path.to_str().unwrap()],
+    );
+
+    let files = sorted_files(&json);
+    assert_eq!(files, vec!["beta.md"]);
+}
+
+#[test]
+fn find_with_index_content_search_no_match() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let json = run_find(
+        &tmp,
+        &[
+            "this-string-does-not-exist-anywhere",
+            "--index",
+            index_path.to_str().unwrap(),
+        ],
+    );
+
+    assert!(json.as_array().unwrap().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// summary --index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_with_index_matches_disk_scan() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let disk_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(disk_output.status.success());
+    let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
+
+    let index_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "--index",
+            index_path.to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        index_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&index_output.stderr)
+    );
+    let index_json: serde_json::Value = serde_json::from_slice(&index_output.stdout).unwrap();
+
+    assert_eq!(
+        disk_json["files"]["total"], index_json["files"]["total"],
+        "file count mismatch between disk scan and index"
+    );
+    assert_eq!(
+        disk_json["tasks"]["total"], index_json["tasks"]["total"],
+        "task total mismatch between disk scan and index"
+    );
+    assert_eq!(
+        disk_json["tasks"]["done"], index_json["tasks"]["done"],
+        "tasks done mismatch between disk scan and index"
+    );
+}
+
+#[test]
+fn summary_with_index_file_count() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "--index",
+            index_path.to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(json["files"]["total"].as_u64().unwrap(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// tags summary --index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_summary_with_index_matches_disk_scan() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let disk_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "summary"])
+        .output()
+        .unwrap();
+    assert!(disk_output.status.success());
+    let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
+
+    let index_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--index", index_path.to_str().unwrap(), "tags", "summary"])
+        .output()
+        .unwrap();
+    assert!(
+        index_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&index_output.stderr)
+    );
+    let index_json: serde_json::Value = serde_json::from_slice(&index_output.stdout).unwrap();
+
+    assert_eq!(
+        disk_json["total"], index_json["total"],
+        "tags total mismatch"
+    );
+
+    // Both should have the same set of tags.
+    let mut disk_tags: Vec<&str> = disk_json["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    let mut index_tags: Vec<&str> = index_json["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    disk_tags.sort();
+    index_tags.sort();
+    assert_eq!(
+        disk_tags, index_tags,
+        "tag sets differ between disk and index"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// properties summary --index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn properties_summary_with_index_matches_disk_scan() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let disk_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "summary"])
+        .output()
+        .unwrap();
+    assert!(disk_output.status.success());
+    let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
+
+    let index_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "--index",
+            index_path.to_str().unwrap(),
+            "properties",
+            "summary",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        index_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&index_output.stderr)
+    );
+    let index_json: serde_json::Value = serde_json::from_slice(&index_output.stdout).unwrap();
+
+    // Both should return arrays with the same property names.
+    let mut disk_props: Vec<&str> = disk_json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    let mut index_props: Vec<&str> = index_json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    disk_props.sort();
+    index_props.sort();
+    assert_eq!(
+        disk_props, index_props,
+        "property sets differ between disk and index"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// backlinks --index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backlinks_with_index_finds_wikilinks() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    // gamma.md links to alpha.md via [[alpha]]
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "--index",
+            index_path.to_str().unwrap(),
+            "backlinks",
+            "--file",
+            "alpha.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["file"], "alpha.md");
+    assert!(json["total"].as_u64().unwrap() >= 1);
+
+    let backlinks = json["backlinks"].as_array().unwrap();
+    let sources: Vec<&str> = backlinks
+        .iter()
+        .map(|b| b["source"].as_str().unwrap())
+        .collect();
+    assert!(
+        sources.contains(&"gamma.md"),
+        "gamma.md should be a backlink source for alpha.md; got: {sources:?}"
+    );
+}
+
+#[test]
+fn backlinks_with_index_matches_disk_scan() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    let disk_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["backlinks", "--file", "beta.md"])
+        .output()
+        .unwrap();
+    assert!(disk_output.status.success());
+    let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
+
+    let index_output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "--index",
+            index_path.to_str().unwrap(),
+            "backlinks",
+            "--file",
+            "beta.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(index_output.status.success());
+    let index_json: serde_json::Value = serde_json::from_slice(&index_output.stdout).unwrap();
+
+    assert_eq!(
+        disk_json["total"], index_json["total"],
+        "backlinks total mismatch between disk and index"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Incompatible / garbage index falls back gracefully
+// ---------------------------------------------------------------------------
+
+#[test]
+fn incompatible_index_falls_back_to_disk_scan() {
+    let tmp = setup_vault();
+
+    // Write garbage bytes as the "index" file.
+    let garbage_path = tmp.path().join("garbage.idx");
+    std::fs::write(&garbage_path, b"this is not a valid msgpack snapshot").unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--index", garbage_path.to_str().unwrap(), "find"])
+        .output()
+        .unwrap();
+
+    // Should succeed by falling back to disk scan.
+    assert!(
+        output.status.success(),
+        "find with a garbage index should succeed (fall back to disk); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Stderr should contain a warning about the incompatible index.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning"),
+        "expected a 'warning' on stderr when index is incompatible; got: {stderr}"
+    );
+
+    // Results should still contain all 4 vault files.
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json.as_array().unwrap().len(),
+        4,
+        "expected 4 files from disk fallback"
+    );
+}
+
+#[test]
+fn incompatible_index_falls_back_for_summary() {
+    let tmp = setup_vault();
+
+    let garbage_path = tmp.path().join("bad.idx");
+    std::fs::write(&garbage_path, b"NOTBINCODE").unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "--index",
+            garbage_path.to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "summary with garbage index should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["files"]["total"].as_u64().unwrap(), 4);
+}

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = { workspace = true }
 dunce = { workspace = true }
 globset = { workspace = true }
 ignore = { workspace = true }
+libc = { workspace = true }
 regex = { workspace = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -11,6 +11,7 @@ dunce = { workspace = true }
 globset = { workspace = true }
 ignore = { workspace = true }
 regex = { workspace = true }
+rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -124,10 +124,15 @@ impl ScannedIndex {
             }
         }
 
+        // Sort entries by vault-relative path so VaultIndex::entries() guarantees
+        // a stable, deterministic order (as documented on the trait).
+        entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+
         let graph_build = LinkGraph::from_file_links(file_links_vec, site_prefix);
         // from_file_links never produces warnings (callers handle parse errors
         // before collecting FileLinks), but we could extend this if needed.
 
+        // Build path_index AFTER sorting so indices remain valid.
         let path_index: HashMap<String, usize> = entries
             .iter()
             .enumerate()
@@ -197,40 +202,72 @@ pub struct SnapshotIndex {
 }
 
 impl SnapshotIndex {
+    /// Deserialize snapshot bytes into a `SnapshotIndex`, optionally printing a
+    /// warning when the schema is incompatible.
+    ///
+    /// Returns `Ok(Some(index))` on success, `Ok(None)` on schema mismatch.
+    fn load_inner(bytes: &[u8], warn: bool) -> Option<Self> {
+        match rmp_serde::from_slice::<SnapshotData>(bytes) {
+            Ok(data) => {
+                // Entries are stored in sorted order (ScannedIndex::build sorts
+                // before saving).  Re-sort here to guarantee the invariant even
+                // if an older snapshot was created without sorting.
+                let mut entries = data.entries;
+                entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+
+                let path_index: HashMap<String, usize> = entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, e)| (e.rel_path.clone(), i))
+                    .collect();
+                Some(Self {
+                    entries,
+                    path_index,
+                    graph: data.graph,
+                    header: data.header,
+                })
+            }
+            Err(e) => {
+                if warn {
+                    eprintln!(
+                        "warning: index file is incompatible ({}); falling back to disk scan",
+                        e
+                    );
+                }
+                None
+            }
+        }
+    }
+
     /// Load a snapshot from a MessagePack file.
     ///
     /// Returns `Ok(Some(index))` on success.
     /// Returns `Ok(None)` when the file is present but cannot be deserialized
     /// (e.g. after a hyalo upgrade that changed the schema) — callers should
-    /// fall back to a disk scan.
+    /// fall back to a disk scan. A warning is printed to stderr in this case.
     /// Returns `Err` only for hard I/O failures.
     pub fn load(path: &Path) -> Result<Option<Self>> {
         let bytes = std::fs::read(path)
             .with_context(|| format!("failed to read index file: {}", path.display()))?;
+        Ok(Self::load_inner(&bytes, true))
+    }
 
-        match rmp_serde::from_slice::<SnapshotData>(&bytes) {
-            Ok(data) => {
-                let path_index: HashMap<String, usize> = data
-                    .entries
-                    .iter()
-                    .enumerate()
-                    .map(|(i, e)| (e.rel_path.clone(), i))
-                    .collect();
-                Ok(Some(Self {
-                    entries: data.entries,
-                    path_index,
-                    graph: data.graph,
-                    header: data.header,
-                }))
-            }
-            Err(e) => {
-                eprintln!(
-                    "warning: index file is incompatible ({}); falling back to disk scan",
-                    e
-                );
-                Ok(None)
-            }
-        }
+    /// Load a snapshot silently — identical to [`load`] but suppresses the
+    /// incompatibility warning.  Used by `find_stale_indexes` which expects to
+    /// silently skip files that cannot be deserialized.
+    fn load_silent(path: &Path) -> Result<Option<Self>> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("failed to read index file: {}", path.display()))?;
+        Ok(Self::load_inner(&bytes, false))
+    }
+
+    /// Check whether this snapshot's header matches the expected vault settings.
+    ///
+    /// Returns `true` when both `vault_dir` and `site_prefix` match the stored
+    /// header values.  Callers can use this to detect stale snapshots that were
+    /// built for a different vault or with a different site prefix.
+    pub fn validate(&self, vault_dir: &str, site_prefix: Option<&str>) -> bool {
+        self.header.vault_dir == vault_dir && self.header.site_prefix.as_deref() == site_prefix
     }
 
     /// Save a snapshot of `index` to a MessagePack file at `path`.
@@ -299,9 +336,19 @@ impl VaultIndex for SnapshotIndex {
 fn is_pid_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
-        // SAFETY: kill(pid, 0) is a pure existence check — no signal is sent.
-        // Returns 0 if the process exists (and we have permission), -1 otherwise.
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+        // SAFETY: kill(pid, 0) sends signal 0, which is a pure existence check —
+        // no signal is actually delivered. The only side effect is updating errno.
+        let res = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if res == 0 {
+            // Process exists and we have permission to signal it.
+            true
+        } else {
+            // ESRCH means "no such process" — definitively dead.
+            // EPERM means "process exists but we lack permission" — still alive.
+            // Any other errno is treated as alive (conservative default).
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            errno != libc::ESRCH
+        }
     }
     #[cfg(not(unix))]
     {
@@ -331,7 +378,7 @@ pub fn find_stale_indexes(dir: &Path) -> Result<Vec<(PathBuf, String, u64)>> {
         if !name.ends_with(".hyalo-index") {
             continue;
         }
-        if let Ok(Some(idx)) = SnapshotIndex::load(&path) {
+        if let Ok(Some(idx)) = SnapshotIndex::load_silent(&path) {
             let (vault_dir, _, created_at, pid) = idx.header_info();
             if !is_pid_alive(pid) {
                 stale.push((path, vault_dir.to_owned(), created_at));

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -70,6 +70,8 @@ pub trait VaultIndex {
 /// scanning patterns.
 pub struct ScannedIndex {
     entries: Vec<IndexEntry>,
+    /// Fast path → index lookup built at construction time.
+    path_index: HashMap<String, usize>,
     graph: LinkGraph,
 }
 
@@ -126,9 +128,16 @@ impl ScannedIndex {
         // from_file_links never produces warnings (callers handle parse errors
         // before collecting FileLinks), but we could extend this if needed.
 
+        let path_index: HashMap<String, usize> = entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.rel_path.clone(), i))
+            .collect();
+
         Ok(ScannedIndexBuild {
             index: ScannedIndex {
                 entries,
+                path_index,
                 graph: graph_build.graph,
             },
             warnings,
@@ -142,7 +151,7 @@ impl VaultIndex for ScannedIndex {
     }
 
     fn get(&self, rel_path: &str) -> Option<&IndexEntry> {
-        self.entries.iter().find(|e| e.rel_path == rel_path)
+        self.path_index.get(rel_path).map(|&i| &self.entries[i])
     }
 
     fn link_graph(&self) -> &LinkGraph {
@@ -181,6 +190,8 @@ struct SnapshotData {
 /// Implements [`VaultIndex`] so commands can use it transparently.
 pub struct SnapshotIndex {
     entries: Vec<IndexEntry>,
+    /// Fast path → index lookup built after deserialization.
+    path_index: HashMap<String, usize>,
     graph: LinkGraph,
     header: SnapshotHeader,
 }
@@ -198,11 +209,20 @@ impl SnapshotIndex {
             .with_context(|| format!("failed to read index file: {}", path.display()))?;
 
         match rmp_serde::from_slice::<SnapshotData>(&bytes) {
-            Ok(data) => Ok(Some(Self {
-                entries: data.entries,
-                graph: data.graph,
-                header: data.header,
-            })),
+            Ok(data) => {
+                let path_index: HashMap<String, usize> = data
+                    .entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, e)| (e.rel_path.clone(), i))
+                    .collect();
+                Ok(Some(Self {
+                    entries: data.entries,
+                    path_index,
+                    graph: data.graph,
+                    header: data.header,
+                }))
+            }
             Err(e) => {
                 eprintln!(
                     "warning: index file is incompatible ({}); falling back to disk scan",
@@ -238,8 +258,11 @@ impl SnapshotIndex {
             graph: index.link_graph().clone(),
         };
         let bytes = rmp_serde::to_vec_named(&data).context("failed to serialize index")?;
-        std::fs::write(path, bytes)
-            .with_context(|| format!("failed to write index file: {}", path.display()))?;
+        let tmp_path = path.with_extension("hyalo-index.tmp");
+        std::fs::write(&tmp_path, &bytes)
+            .with_context(|| format!("failed to write temp index: {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, path)
+            .with_context(|| format!("failed to rename index into place: {}", path.display()))?;
         Ok(())
     }
 
@@ -260,7 +283,7 @@ impl VaultIndex for SnapshotIndex {
     }
 
     fn get(&self, rel_path: &str) -> Option<&IndexEntry> {
-        self.entries.iter().find(|e| e.rel_path == rel_path)
+        self.path_index.get(rel_path).map(|&i| &self.entries[i])
     }
 
     fn link_graph(&self) -> &LinkGraph {
@@ -276,19 +299,13 @@ impl VaultIndex for SnapshotIndex {
 fn is_pid_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
-        use std::process::Command;
-        Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(true)
+        // SAFETY: kill(pid, 0) is a pure existence check — no signal is sent.
+        // Returns 0 if the process exists (and we have permission), -1 otherwise.
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
     }
     #[cfg(not(unix))]
     {
         let _ = pid;
-        // Can't cheaply check on non-Unix; assume alive to avoid false positives.
         true
     }
 }
@@ -307,7 +324,11 @@ pub fn find_stale_indexes(dir: &Path) -> Result<Vec<(PathBuf, String, u64)>> {
     for entry in read_dir {
         let entry = entry?;
         let path = entry.path();
-        if path.file_name().and_then(|n| n.to_str()) != Some(".hyalo-index") {
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !name.ends_with(".hyalo-index") {
             continue;
         }
         if let Ok(Some(idx)) = SnapshotIndex::load(&path) {
@@ -386,7 +407,7 @@ fn format_modified(path: &Path) -> Result<String> {
 }
 
 /// Format Unix timestamp as ISO 8601 UTC (`YYYY-MM-DDTHH:MM:SSZ`).
-fn format_iso8601(secs: u64) -> String {
+pub fn format_iso8601(secs: u64) -> String {
     const SECS_PER_MIN: u64 = 60;
     const SECS_PER_HOUR: u64 = 3600;
     const SECS_PER_DAY: u64 = 86400;

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -1,0 +1,748 @@
+//! Vault index abstraction — decouples commands from their data source.
+//!
+//! The [`VaultIndex`] trait provides a uniform interface over pre-scanned vault
+//! data. Commands program against this trait and don't know whether data came
+//! from a live filesystem scan ([`ScannedIndex`]) or a serialized snapshot.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use crate::filter::extract_tags;
+use crate::frontmatter;
+use crate::link_graph::{FileLinks, LinkGraph, LinkGraphVisitor};
+use crate::links::Link;
+use crate::scanner::{self, FileVisitor, FrontmatterCollector, ScanAction};
+use crate::tasks::TaskExtractor;
+use crate::types::{FindTaskInfo, OutlineSection, TaskCount};
+
+// ---------------------------------------------------------------------------
+// IndexEntry
+// ---------------------------------------------------------------------------
+
+/// Per-file pre-scanned data stored in the index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexEntry {
+    /// Vault-relative path (forward slashes).
+    pub rel_path: String,
+    /// ISO 8601 mtime string.
+    pub modified: String,
+    /// Raw frontmatter properties.
+    pub properties: BTreeMap<String, serde_yaml_ng::Value>,
+    /// Extracted tags (from properties).
+    pub tags: Vec<String>,
+    /// Document outline sections.
+    pub sections: Vec<OutlineSection>,
+    /// Task checkboxes with section context.
+    pub tasks: Vec<FindTaskInfo>,
+    /// Outbound links with 1-based line numbers.
+    pub links: Vec<(usize, Link)>,
+}
+
+// ---------------------------------------------------------------------------
+// VaultIndex trait
+// ---------------------------------------------------------------------------
+
+/// Abstraction over how vault data is obtained.
+/// Commands program against this trait, not a concrete data source.
+pub trait VaultIndex {
+    /// All entries in the index, in vault-relative path order.
+    fn entries(&self) -> &[IndexEntry];
+
+    /// Look up a single file by vault-relative path.
+    fn get(&self, rel_path: &str) -> Option<&IndexEntry>;
+
+    /// The pre-built link graph for backlink lookups.
+    fn link_graph(&self) -> &LinkGraph;
+}
+
+// ---------------------------------------------------------------------------
+// ScannedIndex — live filesystem scan
+// ---------------------------------------------------------------------------
+
+/// A vault index built by scanning files from disk.
+///
+/// This extracts the per-file scan logic that was previously inlined in each
+/// command (`find`, `summary`, etc.) into a reusable builder behind the
+/// [`VaultIndex`] trait. No new functionality — it's a refactor of existing
+/// scanning patterns.
+pub struct ScannedIndex {
+    entries: Vec<IndexEntry>,
+    graph: LinkGraph,
+}
+
+/// Warning produced during index build (e.g. malformed YAML frontmatter).
+pub struct IndexWarning {
+    /// Vault-relative path of the file that was skipped.
+    pub rel_path: String,
+    /// Human-readable error message.
+    pub message: String,
+}
+
+/// Result of building a [`ScannedIndex`].
+pub struct ScannedIndexBuild {
+    /// The built index.
+    pub index: ScannedIndex,
+    /// Files that were skipped (e.g. malformed frontmatter).
+    pub warnings: Vec<IndexWarning>,
+}
+
+impl ScannedIndex {
+    /// Build an index by scanning a list of files from disk.
+    ///
+    /// `files` is a slice of `(full_path, rel_path)` pairs, as returned by
+    /// `collect_files` or `discover_files`. Each file is scanned in a single
+    /// pass with multiple visitors.
+    ///
+    /// `site_prefix` is passed through to the link graph builder for resolving
+    /// absolute links.
+    pub fn build(
+        files: &[(PathBuf, String)],
+        site_prefix: Option<&str>,
+    ) -> Result<ScannedIndexBuild> {
+        let mut entries = Vec::with_capacity(files.len());
+        let mut file_links_vec: Vec<FileLinks> = Vec::with_capacity(files.len());
+        let mut warnings: Vec<IndexWarning> = Vec::new();
+
+        for (full_path, rel_path) in files {
+            match scan_one_file(full_path, rel_path) {
+                Ok((entry, file_links)) => {
+                    entries.push(entry);
+                    file_links_vec.push(file_links);
+                }
+                Err(e) if frontmatter::is_parse_error(&e) => {
+                    warnings.push(IndexWarning {
+                        rel_path: rel_path.clone(),
+                        message: e.to_string(),
+                    });
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let graph_build = LinkGraph::from_file_links(file_links_vec, site_prefix);
+        // from_file_links never produces warnings (callers handle parse errors
+        // before collecting FileLinks), but we could extend this if needed.
+
+        Ok(ScannedIndexBuild {
+            index: ScannedIndex {
+                entries,
+                graph: graph_build.graph,
+            },
+            warnings,
+        })
+    }
+}
+
+impl VaultIndex for ScannedIndex {
+    fn entries(&self) -> &[IndexEntry] {
+        &self.entries
+    }
+
+    fn get(&self, rel_path: &str) -> Option<&IndexEntry> {
+        self.entries.iter().find(|e| e.rel_path == rel_path)
+    }
+
+    fn link_graph(&self) -> &LinkGraph {
+        &self.graph
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotIndex — MessagePack-serialized snapshot
+// ---------------------------------------------------------------------------
+
+/// Metadata header embedded in every snapshot file.
+#[derive(Debug, Serialize, Deserialize)]
+struct SnapshotHeader {
+    /// Canonical vault directory path (informational; not re-validated on load).
+    vault_dir: String,
+    /// Site prefix used when building the index (informational).
+    site_prefix: Option<String>,
+    /// Unix timestamp (seconds) when the snapshot was created.
+    created_at: u64,
+    /// PID of the process that created this snapshot.
+    pid: u32,
+}
+
+/// Internal serialization envelope — header + entries + graph.
+#[derive(Serialize, Deserialize)]
+struct SnapshotData {
+    header: SnapshotHeader,
+    entries: Vec<IndexEntry>,
+    graph: LinkGraph,
+}
+
+/// A vault index loaded from a MessagePack snapshot file.
+///
+/// Created by [`SnapshotIndex::save`] and loaded by [`SnapshotIndex::load`].
+/// Implements [`VaultIndex`] so commands can use it transparently.
+pub struct SnapshotIndex {
+    entries: Vec<IndexEntry>,
+    graph: LinkGraph,
+    header: SnapshotHeader,
+}
+
+impl SnapshotIndex {
+    /// Load a snapshot from a MessagePack file.
+    ///
+    /// Returns `Ok(Some(index))` on success.
+    /// Returns `Ok(None)` when the file is present but cannot be deserialized
+    /// (e.g. after a hyalo upgrade that changed the schema) — callers should
+    /// fall back to a disk scan.
+    /// Returns `Err` only for hard I/O failures.
+    pub fn load(path: &Path) -> Result<Option<Self>> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("failed to read index file: {}", path.display()))?;
+
+        match rmp_serde::from_slice::<SnapshotData>(&bytes) {
+            Ok(data) => Ok(Some(Self {
+                entries: data.entries,
+                graph: data.graph,
+                header: data.header,
+            })),
+            Err(e) => {
+                eprintln!(
+                    "warning: index file is incompatible ({}); falling back to disk scan",
+                    e
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Save a snapshot of `index` to a MessagePack file at `path`.
+    ///
+    /// `vault_dir` and `site_prefix` are stored in the header for informational
+    /// purposes (shown by `create-index` on load; not validated on subsequent loads).
+    pub fn save(
+        index: &dyn VaultIndex,
+        path: &Path,
+        vault_dir: &str,
+        site_prefix: Option<&str>,
+    ) -> Result<()> {
+        let header = SnapshotHeader {
+            vault_dir: vault_dir.to_owned(),
+            site_prefix: site_prefix.map(str::to_owned),
+            created_at: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            pid: std::process::id(),
+        };
+        let data = SnapshotData {
+            header,
+            entries: index.entries().to_vec(),
+            graph: index.link_graph().clone(),
+        };
+        let bytes = rmp_serde::to_vec_named(&data).context("failed to serialize index")?;
+        std::fs::write(path, bytes)
+            .with_context(|| format!("failed to write index file: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Return header metadata: `(vault_dir, site_prefix, created_at_secs, pid)`.
+    pub fn header_info(&self) -> (&str, Option<&str>, u64, u32) {
+        (
+            &self.header.vault_dir,
+            self.header.site_prefix.as_deref(),
+            self.header.created_at,
+            self.header.pid,
+        )
+    }
+}
+
+impl VaultIndex for SnapshotIndex {
+    fn entries(&self) -> &[IndexEntry] {
+        &self.entries
+    }
+
+    fn get(&self, rel_path: &str) -> Option<&IndexEntry> {
+        self.entries.iter().find(|e| e.rel_path == rel_path)
+    }
+
+    fn link_graph(&self) -> &LinkGraph {
+        &self.graph
+    }
+}
+
+/// Check whether a PID corresponds to a running process.
+///
+/// On Unix this uses `kill(pid, 0)` (signal 0 is a no-op that only tests
+/// existence). On all other platforms we conservatively assume the PID is
+/// alive so that we never falsely claim a running process is stale.
+fn is_pid_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        use std::process::Command;
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(true)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        // Can't cheaply check on non-Unix; assume alive to avoid false positives.
+        true
+    }
+}
+
+/// Scan `dir` for `.hyalo-index` files whose creator PID is no longer running.
+///
+/// Returns a list of `(path, vault_dir, created_at)` tuples for stale files.
+/// Files that cannot be loaded (incompatible schema, I/O error) are silently
+/// skipped — they are already unreachable by the normal load path.
+pub fn find_stale_indexes(dir: &Path) -> Result<Vec<(PathBuf, String, u64)>> {
+    let mut stale = Vec::new();
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return Ok(stale),
+    };
+    for entry in read_dir {
+        let entry = entry?;
+        let path = entry.path();
+        if path.file_name().and_then(|n| n.to_str()) != Some(".hyalo-index") {
+            continue;
+        }
+        if let Ok(Some(idx)) = SnapshotIndex::load(&path) {
+            let (vault_dir, _, created_at, pid) = idx.header_info();
+            if !is_pid_alive(pid) {
+                stale.push((path, vault_dir.to_owned(), created_at));
+            }
+        }
+    }
+    Ok(stale)
+}
+
+// ---------------------------------------------------------------------------
+// Per-file scan — single pass with multiple visitors
+// ---------------------------------------------------------------------------
+
+/// Scan a single file and return its `IndexEntry` plus `FileLinks` for the
+/// link graph. Mirrors the multi-visitor pattern used by the `find` command.
+fn scan_one_file(full_path: &Path, rel_path: &str) -> Result<(IndexEntry, FileLinks)> {
+    let mut fm = FrontmatterCollector::new(true);
+    let mut section_scanner = SectionScanner::new();
+    let mut task_extractor = TaskExtractor::new();
+    let mut link_visitor = LinkGraphVisitor::new(PathBuf::from(rel_path));
+
+    scanner::scan_file_multi(
+        full_path,
+        &mut [
+            &mut fm,
+            &mut section_scanner,
+            &mut task_extractor,
+            &mut link_visitor,
+        ],
+    )?;
+
+    let props = fm.into_props();
+    let tags = extract_tags(&props);
+    let sections = section_scanner.into_sections();
+    let tasks = task_extractor.into_tasks();
+    let file_links = link_visitor.into_file_links();
+
+    // Clone link data before it's moved into the FileLinks (we need both
+    // the raw links for IndexEntry and the FileLinks for the graph builder).
+    let links_clone: Vec<(usize, Link)> = file_links
+        .links
+        .iter()
+        .map(|(line, link)| (*line, link.clone()))
+        .collect();
+
+    let modified = format_modified(full_path)?;
+
+    let entry = IndexEntry {
+        rel_path: rel_path.to_owned(),
+        modified,
+        properties: props,
+        tags,
+        sections,
+        tasks,
+        links: links_clone,
+    };
+
+    Ok((entry, file_links))
+}
+
+/// Format a file's last-modified time as ISO 8601 UTC.
+fn format_modified(path: &Path) -> Result<String> {
+    let meta = std::fs::metadata(path)
+        .with_context(|| format!("failed to read metadata for {}", path.display()))?;
+    let mtime = meta
+        .modified()
+        .with_context(|| format!("mtime not available for {}", path.display()))?;
+    let secs = mtime
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    Ok(format_iso8601(secs))
+}
+
+/// Format Unix timestamp as ISO 8601 UTC (`YYYY-MM-DDTHH:MM:SSZ`).
+fn format_iso8601(secs: u64) -> String {
+    const SECS_PER_MIN: u64 = 60;
+    const SECS_PER_HOUR: u64 = 3600;
+    const SECS_PER_DAY: u64 = 86400;
+
+    let days = secs / SECS_PER_DAY;
+    let rem = secs % SECS_PER_DAY;
+    let hh = rem / SECS_PER_HOUR;
+    let mm = (rem % SECS_PER_HOUR) / SECS_PER_MIN;
+    let ss = rem % SECS_PER_MIN;
+
+    let z = days as i64 + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
+}
+
+// ---------------------------------------------------------------------------
+// SectionScanner — inline visitor (mirrors hyalo-cli's SectionScanner)
+// ---------------------------------------------------------------------------
+
+// We need a section scanner here in hyalo-core for the index builder.
+// This is equivalent to the one in hyalo-cli/src/commands/section_scanner.rs
+// but lives in core so it can be used without depending on the CLI crate.
+
+use crate::heading::parse_atx_heading;
+use crate::links;
+
+/// State accumulated for the current section being built.
+struct SectionBuilder {
+    level: u8,
+    heading: Option<String>,
+    line: usize,
+    links: Vec<String>,
+    task_total: usize,
+    task_done: usize,
+    code_blocks: Vec<String>,
+}
+
+impl SectionBuilder {
+    fn new(level: u8, heading: Option<String>, line: usize) -> Self {
+        Self {
+            level,
+            heading,
+            line,
+            links: Vec::new(),
+            task_total: 0,
+            task_done: 0,
+            code_blocks: Vec::new(),
+        }
+    }
+
+    fn finish(self) -> OutlineSection {
+        let tasks = if self.task_total > 0 {
+            Some(TaskCount {
+                total: self.task_total,
+                done: self.task_done,
+            })
+        } else {
+            None
+        };
+        OutlineSection {
+            level: self.level,
+            heading: self.heading,
+            line: self.line,
+            links: self.links,
+            tasks,
+            code_blocks: self.code_blocks,
+        }
+    }
+}
+
+/// Visitor that builds outline sections from body events.
+struct SectionScanner {
+    current: SectionBuilder,
+    sections: Vec<OutlineSection>,
+}
+
+impl SectionScanner {
+    fn new() -> Self {
+        Self {
+            current: SectionBuilder::new(0, None, 1),
+            sections: Vec::new(),
+        }
+    }
+
+    fn into_sections(mut self) -> Vec<OutlineSection> {
+        let last = std::mem::replace(&mut self.current, SectionBuilder::new(0, None, 0));
+        let finished = last.finish();
+        let should_emit = finished.level > 0
+            || !finished.links.is_empty()
+            || finished.tasks.is_some()
+            || !finished.code_blocks.is_empty();
+        if should_emit {
+            self.sections.push(finished);
+        }
+        self.sections
+    }
+}
+
+impl FileVisitor for SectionScanner {
+    fn on_body_line(&mut self, raw: &str, cleaned: &str, line_num: usize) -> ScanAction {
+        if let Some((level, heading_text)) = parse_atx_heading(raw) {
+            let finished = std::mem::replace(
+                &mut self.current,
+                SectionBuilder::new(level, Some(heading_text.to_owned()), line_num),
+            );
+            let should_emit = finished.level > 0
+                || !finished.links.is_empty()
+                || finished.task_total > 0
+                || !finished.code_blocks.is_empty();
+            if should_emit {
+                self.sections.push(finished.finish());
+            }
+            return ScanAction::Continue;
+        }
+
+        let mut line_links: Vec<links::Link> = Vec::new();
+        links::extract_links_from_text(cleaned, &mut line_links);
+        for link in line_links {
+            self.current.links.push(format_link_string(&link));
+        }
+
+        if let Some((_status, done)) = crate::tasks::detect_task_checkbox(raw) {
+            self.current.task_total += 1;
+            if done {
+                self.current.task_done += 1;
+            }
+        }
+
+        ScanAction::Continue
+    }
+
+    fn on_code_fence_open(&mut self, _raw: &str, language: &str, _line_num: usize) -> ScanAction {
+        if !language.is_empty() {
+            self.current.code_blocks.push(language.to_owned());
+        }
+        ScanAction::Continue
+    }
+}
+
+/// Format a `Link` into a human-readable string for storage in the outline.
+fn format_link_string(link: &links::Link) -> String {
+    match link.kind {
+        links::LinkKind::Wikilink => match &link.label {
+            Some(label) if !label.is_empty() => format!("[[{}|{}]]", link.target, label),
+            _ => format!("[[{}]]", link.target),
+        },
+        links::LinkKind::Markdown => match &link.label {
+            Some(label) if !label.is_empty() => format!("[{}]({})", label, link.target),
+            _ => format!("[]({})", link.target),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    macro_rules! md {
+        ($s:expr) => {
+            $s.strip_prefix('\n').unwrap_or($s)
+        };
+    }
+
+    fn setup_vault() -> (tempfile::TempDir, Vec<(PathBuf, String)>) {
+        let tmp = tempfile::tempdir().unwrap();
+
+        fs::write(
+            tmp.path().join("a.md"),
+            md!(r"
+---
+title: Alpha
+status: draft
+tags:
+  - rust
+  - cli
+---
+# Introduction
+
+See [[b]] for context.
+
+## Tasks
+
+- [ ] Write tests
+- [x] Write code
+"),
+        )
+        .unwrap();
+
+        fs::write(
+            tmp.path().join("b.md"),
+            md!(r"
+---
+title: Beta
+status: done
+tags:
+  - rust
+---
+# Content
+
+See [[a]] for details.
+"),
+        )
+        .unwrap();
+
+        let files = vec![
+            (tmp.path().join("a.md"), "a.md".to_owned()),
+            (tmp.path().join("b.md"), "b.md".to_owned()),
+        ];
+        (tmp, files)
+    }
+
+    #[test]
+    fn scanned_index_builds_entries() {
+        let (_tmp, files) = setup_vault();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        assert!(build.warnings.is_empty());
+        assert_eq!(build.index.entries().len(), 2);
+    }
+
+    #[test]
+    fn scanned_index_get_by_path() {
+        let (_tmp, files) = setup_vault();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        let idx = &build.index;
+
+        let a = idx.get("a.md").unwrap();
+        assert_eq!(a.tags, vec!["rust", "cli"]);
+        assert_eq!(a.properties.get("status").unwrap(), "draft");
+
+        let b = idx.get("b.md").unwrap();
+        assert_eq!(b.tags, vec!["rust"]);
+
+        assert!(idx.get("c.md").is_none());
+    }
+
+    #[test]
+    fn scanned_index_sections_and_tasks() {
+        let (_tmp, files) = setup_vault();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        let a = build.index.get("a.md").unwrap();
+
+        // a.md has 2 sections: Introduction and Tasks
+        assert_eq!(a.sections.len(), 2);
+        assert_eq!(a.sections[0].heading.as_deref(), Some("Introduction"));
+        assert_eq!(a.sections[1].heading.as_deref(), Some("Tasks"));
+
+        // a.md has 2 tasks
+        assert_eq!(a.tasks.len(), 2);
+        assert!(!a.tasks[0].done);
+        assert!(a.tasks[1].done);
+    }
+
+    #[test]
+    fn scanned_index_link_graph() {
+        let (_tmp, files) = setup_vault();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        let graph = build.index.link_graph();
+
+        // a.md links to b, b.md links to a
+        let a_backlinks = graph.backlinks("a");
+        assert!(!a_backlinks.is_empty());
+        let b_backlinks = graph.backlinks("b");
+        assert!(!b_backlinks.is_empty());
+    }
+
+    #[test]
+    fn scanned_index_outbound_links() {
+        let (_tmp, files) = setup_vault();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        let a = build.index.get("a.md").unwrap();
+
+        // a.md has one outbound link: [[b]]
+        assert_eq!(a.links.len(), 1);
+        assert_eq!(a.links[0].1.target, "b");
+    }
+
+    #[test]
+    fn scanned_index_skips_broken_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("good.md"),
+            md!(r"
+---
+title: Good
+---
+Content.
+"),
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("bad.md"),
+            "---\n: invalid yaml [[[{\n---\nContent.\n",
+        )
+        .unwrap();
+
+        let files = vec![
+            (tmp.path().join("good.md"), "good.md".to_owned()),
+            (tmp.path().join("bad.md"), "bad.md".to_owned()),
+        ];
+        let build = ScannedIndex::build(&files, None).unwrap();
+        assert_eq!(build.index.entries().len(), 1);
+        assert_eq!(build.warnings.len(), 1);
+        assert_eq!(build.warnings[0].rel_path, "bad.md");
+    }
+
+    #[test]
+    fn scanned_index_modified_is_iso8601() {
+        let (_tmp, files) = setup_vault();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        let a = build.index.get("a.md").unwrap();
+        assert!(
+            a.modified.contains('T') && a.modified.ends_with('Z'),
+            "unexpected timestamp: {}",
+            a.modified
+        );
+    }
+
+    #[test]
+    fn snapshot_roundtrip() {
+        let (_tmp, files) = setup_vault();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        let index = &build.index;
+
+        let snap_dir = tempfile::tempdir().unwrap();
+        let snap_path = snap_dir.path().join(".hyalo-index");
+
+        SnapshotIndex::save(index, &snap_path, "/tmp/vault", None).unwrap();
+        let loaded = SnapshotIndex::load(&snap_path)
+            .unwrap()
+            .expect("snapshot should deserialize");
+
+        assert_eq!(loaded.entries().len(), index.entries().len());
+        let a = loaded.get("a.md").unwrap();
+        assert_eq!(a.tags, vec!["rust", "cli"]);
+        assert_eq!(a.properties.get("status").unwrap(), "draft");
+        assert_eq!(a.sections.len(), 2);
+        assert_eq!(a.tasks.len(), 2);
+        assert_eq!(a.links.len(), 1);
+        assert_eq!(a.links[0].1.target, "b");
+
+        // Link graph survives roundtrip
+        let bl = loaded.link_graph().backlinks("a");
+        assert!(!bl.is_empty());
+    }
+}

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod filter;
 pub mod frontmatter;
 pub mod fs_util;
 pub mod heading;
+pub mod index;
 pub mod link_graph;
 pub mod link_rewrite;
 pub mod links;

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 
@@ -9,7 +10,7 @@ use crate::links::{Link, LinkKind, extract_links_from_text_with_original};
 use crate::scanner::{self, FileVisitor, ScanAction};
 
 /// A single backlink: a file that links to some target.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BacklinkEntry {
     /// The file containing the link (relative to vault root).
     pub source: PathBuf,
@@ -32,6 +33,7 @@ pub struct LinkGraphBuild {
 /// Keys are normalized target strings (as they appear in `[[target]]` or
 /// `[text](target)`, without fragment). Values are all files that link to
 /// that target.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct LinkGraph {
     index: HashMap<String, Vec<BacklinkEntry>>,
 }

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -1,11 +1,12 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::scanner::{self, ScanAction};
 
 /// A parsed link extracted from a markdown file.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Link {
     /// Raw target: note name or relative path (without fragment)
     pub target: String,
@@ -16,7 +17,7 @@ pub struct Link {
 }
 
 /// The kind of link syntax used in the source text.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LinkKind {
     Wikilink,
     Markdown,

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -4,7 +4,7 @@
 //! `FileObject`). Some commands also define result structs in their own
 //! modules (e.g. `SetPropertyResult`, `RemoveTagResult`).
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
 // Property types
@@ -77,7 +77,7 @@ pub struct BacklinkInfo {
 // ---------------------------------------------------------------------------
 
 /// Task checkbox counts within a section.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskCount {
     pub total: usize,
     pub done: usize,
@@ -85,7 +85,7 @@ pub struct TaskCount {
 
 /// A single section in the document outline.
 /// Used by `find` (sections field).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutlineSection {
     pub level: u8,
     pub heading: Option<String>,
@@ -179,7 +179,7 @@ pub struct RecentFile {
 
 /// A single task with section context, used by the `find` command.
 /// Extends `TaskInfo` with section heading information.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FindTaskInfo {
     pub line: usize,
     pub section: String,

--- a/hyalo-knowledgebase/backlog/index-server-raii.md
+++ b/hyalo-knowledgebase/backlog/index-server-raii.md
@@ -1,0 +1,28 @@
+---
+title: "RAII index server with file watcher"
+type: backlog
+date: 2026-03-26
+tags:
+  - performance
+  - index
+  - daemon
+---
+
+# RAII Index Server with File Watcher
+
+Long-running `hyalo index-server` process that:
+- Creates and holds a `.hyalo-index` file
+- Watches the vault directory for changes via `notify` crate
+- Atomically updates the index on file changes (write temp → rename)
+- Cleans up the index file on exit (SIGINT/SIGTERM via `ctrlc` crate)
+
+Useful when a skill session both reads and mutates files, so subsequent queries see
+updated state without a full rescan.
+
+Depends on: [[iteration-47-snapshot-index]] (snapshot index infrastructure).
+
+## Alternative: stdin/stdout protocol
+
+Instead of or alongside the file-based approach, serve queries directly over pipes.
+Avoids temp file management entirely — parent dies → pipe closes → child exits.
+Trade-off: only usable by a single client process.

--- a/hyalo-knowledgebase/iterations/iteration-47-snapshot-index.md
+++ b/hyalo-knowledgebase/iterations/iteration-47-snapshot-index.md
@@ -1,0 +1,125 @@
+---
+branch: iter-47/snapshot-index
+date: 2026-03-26
+status: in-progress
+tags:
+- performance
+- index
+- cli
+- architecture
+title: Iteration 47 — Snapshot Index for Repeated Queries
+type: iteration
+---
+
+# Iteration 47 — Snapshot Index for Repeated Queries
+
+## Motivation
+
+Skills like `hyalo-dream` run many sequential queries against the same vault. Each invocation
+rescans all files to build the in-memory index. On a 3,500-file vault this is ~500ms per call,
+compounding to 15+ seconds over 30 queries. A snapshot index lets the vault be scanned once
+and reused across all subsequent queries in a session.
+
+## Design Decisions
+
+- **Core abstraction**: `VaultIndex` trait decouples commands from their data source.
+  Commands receive `&dyn VaultIndex` and don't know whether data came from a filesystem
+  scan or a serialized file. This enables future backends (SQLite, etc.) without changing
+  command code.
+- **First backend**: bincode snapshot file (`.hyalo-index`) — binary, opaque, not an API
+- **Scope**: read-only commands only (`find`, `summary`, `tags`, `properties`, `backlinks`);
+  mutation commands (`set`, `remove`, `append`, `mv`) always scan from disk
+- **Content search**: always scans disk regardless of `--index` — it's query-dependent
+  and can't be pre-indexed. No warning needed, no special handling
+- **No partial indexes**: full vault snapshot every time (rebuild is <500ms)
+- **No backwards compatibility**: if bincode deserialization fails (e.g. after a hyalo upgrade),
+  warn and fall back to normal scanning
+- **No daemon / file watcher**: deferred to a future iteration if needed
+- **Stale detection**: PID in index header; `create-index` checks for existing `.hyalo-index`
+  files with dead PIDs and warns
+
+## Architecture
+
+### The VaultIndex Trait
+
+```rust
+/// Abstraction over how vault data is obtained.
+/// Commands program against this trait, not a concrete data source.
+trait VaultIndex {
+    fn entries(&self) -> &[IndexEntry];
+    fn get(&self, rel_path: &str) -> Option<&IndexEntry>;
+    fn link_graph(&self) -> &LinkGraph;
+}
+```
+
+### IndexEntry — Per-File Data
+
+The intermediate data between scan and filter/format:
+
+- `rel_path: String` — relative path within vault
+- `modified: String` — ISO 8601 mtime
+- `properties: BTreeMap<String, serde_yaml_ng::Value>` — raw frontmatter (for filtering)
+- `tags: Vec<String>` — extracted from properties
+- `sections: Vec<OutlineSection>` — heading outline
+- `tasks: Vec<FindTaskInfo>` — checkbox items
+- `links: Vec<(usize, Link)>` — outbound links with line numbers
+
+### Implementations
+
+**`ScannedIndex`** — extracts the current inline scan logic from commands into a reusable
+builder. This is not new functionality — it's a refactor of what each command does today
+into a shared struct behind the `VaultIndex` trait.
+
+**`SnapshotIndex`** — deserializes a `.hyalo-index` file (bincode). Contains the same
+`IndexEntry` data plus a header with metadata:
+
+- `vault_dir: String` — canonical vault path (validated on load)
+- `site_prefix: Option<String>` — how links were resolved (must match current config)
+- `created_at: u64` — unix timestamp
+- `pid: u32` — creator PID (for orphan detection)
+
+### Flow
+
+```
+main() decides based on --index flag:
+  ├─ --index given  → SnapshotIndex::load(path)?  → &dyn VaultIndex
+  └─ no --index     → ScannedIndex::build(dir)?    → &dyn VaultIndex
+                                                         │
+                              ┌───────────────────────────┘
+                              ▼
+                    command(index: &dyn VaultIndex, ...)
+                       │
+                       ├─ index.entries() / index.get() for per-file data
+                       ├─ index.link_graph() for backlinks
+                       └─ disk scan only for content search (query-dependent)
+```
+
+## Tasks
+
+### Phase 1: Abstraction (the main deliverable)
+- [ ] Define `IndexEntry` struct in `hyalo-core` (new module `index.rs`)
+- [ ] Define `VaultIndex` trait with `entries()`, `get()`, `link_graph()`
+- [ ] Implement `ScannedIndex` — extract current per-file scan logic from `find`/`summary`/etc. into a shared builder behind the trait
+- [ ] Add `Serialize`/`Deserialize` derives to: `IndexEntry`, `BacklinkEntry`, `Link`, `LinkKind`, `LinkGraph`, `OutlineSection`, `FindTaskInfo`
+- [ ] Refactor `find` command to use `&dyn VaultIndex` instead of inline scanning; content search stays as disk I/O
+- [ ] Refactor `summary`, `tags summary`, `properties summary`, `backlinks` to use `&dyn VaultIndex`
+
+### Phase 2: Snapshot Backend
+- [ ] Add `bincode` dependency to `hyalo-core/Cargo.toml`
+- [ ] Implement `SnapshotIndex` — `load(path)` deserializes bincode, validates header, returns `impl VaultIndex`; graceful fallback to `ScannedIndex` on deserialization error
+- [ ] Implement `SnapshotIndex::save(index: &dyn VaultIndex, path)` — serializes to bincode with header
+- [ ] Add `create-index` subcommand: builds `ScannedIndex`, saves as snapshot, detects stale orphan `.hyalo-index` files
+- [ ] Add `drop-index` subcommand: deletes index file, warns about other stale `.hyalo-index` files
+- [ ] Add `--index <PATH>` global CLI flag (clap `global = true`)
+- [ ] Wire up in `main()`: `--index` → `SnapshotIndex::load()`, else `ScannedIndex::build()`
+
+### Phase 3: Tests & Validation
+- [ ] Add e2e tests: create-index → find --index, drop-index, stale detection, incompatible index fallback, content search with --index
+- [ ] Add benchmark: repeated `find --index` vs repeated `find` (measure cumulative savings)
+
+## Future (deferred)
+
+- RAII long-running `index-server` mode with file watcher and atomic rename
+- stdin/stdout query protocol for tighter skill integration
+- `--index=auto` with env var for transparent session-scoped caching
+- SQLite backend behind `VaultIndex` trait

--- a/hyalo-knowledgebase/iterations/iteration-47-snapshot-index.md
+++ b/hyalo-knowledgebase/iterations/iteration-47-snapshot-index.md
@@ -26,13 +26,15 @@ and reused across all subsequent queries in a session.
   Commands receive `&dyn VaultIndex` and don't know whether data came from a filesystem
   scan or a serialized file. This enables future backends (SQLite, etc.) without changing
   command code.
-- **First backend**: bincode snapshot file (`.hyalo-index`) — binary, opaque, not an API
+- **First backend**: MessagePack snapshot file (`.hyalo-index`) via `rmp-serde` — binary, opaque, not an API.
+  Initially attempted bincode, but it doesn't support `deserialize_any` (needed by `serde_yaml_ng::Value`)
+  or `skip_serializing_if` (used by `OutlineSection`). MessagePack in named-map mode handles both natively.
 - **Scope**: read-only commands only (`find`, `summary`, `tags`, `properties`, `backlinks`);
   mutation commands (`set`, `remove`, `append`, `mv`) always scan from disk
 - **Content search**: always scans disk regardless of `--index` — it's query-dependent
   and can't be pre-indexed. No warning needed, no special handling
 - **No partial indexes**: full vault snapshot every time (rebuild is <500ms)
-- **No backwards compatibility**: if bincode deserialization fails (e.g. after a hyalo upgrade),
+- **No backwards compatibility**: if MessagePack deserialization fails (e.g. after a hyalo upgrade),
   warn and fall back to normal scanning
 - **No daemon / file watcher**: deferred to a future iteration if needed
 - **Stale detection**: PID in index header; `create-index` checks for existing `.hyalo-index`
@@ -70,7 +72,7 @@ The intermediate data between scan and filter/format:
 builder. This is not new functionality — it's a refactor of what each command does today
 into a shared struct behind the `VaultIndex` trait.
 
-**`SnapshotIndex`** — deserializes a `.hyalo-index` file (bincode). Contains the same
+**`SnapshotIndex`** — deserializes a `.hyalo-index` file (MessagePack). Contains the same
 `IndexEntry` data plus a header with metadata:
 
 - `vault_dir: String` — canonical vault path (validated on load)
@@ -97,25 +99,25 @@ main() decides based on --index flag:
 ## Tasks
 
 ### Phase 1: Abstraction (the main deliverable)
-- [ ] Define `IndexEntry` struct in `hyalo-core` (new module `index.rs`)
-- [ ] Define `VaultIndex` trait with `entries()`, `get()`, `link_graph()`
-- [ ] Implement `ScannedIndex` — extract current per-file scan logic from `find`/`summary`/etc. into a shared builder behind the trait
-- [ ] Add `Serialize`/`Deserialize` derives to: `IndexEntry`, `BacklinkEntry`, `Link`, `LinkKind`, `LinkGraph`, `OutlineSection`, `FindTaskInfo`
-- [ ] Refactor `find` command to use `&dyn VaultIndex` instead of inline scanning; content search stays as disk I/O
-- [ ] Refactor `summary`, `tags summary`, `properties summary`, `backlinks` to use `&dyn VaultIndex`
+- [x] Define `IndexEntry` struct in `hyalo-core` (new module `index.rs`)
+- [x] Define `VaultIndex` trait with `entries()`, `get()`, `link_graph()`
+- [x] Implement `ScannedIndex` — extract current per-file scan logic from `find`/`summary`/etc. into a shared builder behind the trait
+- [x] Add `Serialize`/`Deserialize` derives to: `IndexEntry`, `BacklinkEntry`, `Link`, `LinkKind`, `LinkGraph`, `OutlineSection`, `FindTaskInfo`
+- [x] Refactor `find` command to use `&dyn VaultIndex` instead of inline scanning; content search stays as disk I/O
+- [x] Refactor `summary`, `tags summary`, `properties summary`, `backlinks` to use `&dyn VaultIndex`
 
 ### Phase 2: Snapshot Backend
-- [ ] Add `bincode` dependency to `hyalo-core/Cargo.toml`
-- [ ] Implement `SnapshotIndex` — `load(path)` deserializes bincode, validates header, returns `impl VaultIndex`; graceful fallback to `ScannedIndex` on deserialization error
-- [ ] Implement `SnapshotIndex::save(index: &dyn VaultIndex, path)` — serializes to bincode with header
-- [ ] Add `create-index` subcommand: builds `ScannedIndex`, saves as snapshot, detects stale orphan `.hyalo-index` files
-- [ ] Add `drop-index` subcommand: deletes index file, warns about other stale `.hyalo-index` files
-- [ ] Add `--index <PATH>` global CLI flag (clap `global = true`)
-- [ ] Wire up in `main()`: `--index` → `SnapshotIndex::load()`, else `ScannedIndex::build()`
+- [x] Add `rmp-serde` dependency to `hyalo-core/Cargo.toml`
+- [x] Implement `SnapshotIndex` — `load(path)` deserializes MessagePack, validates header, returns `impl VaultIndex`; graceful fallback to `ScannedIndex` on deserialization error
+- [x] Implement `SnapshotIndex::save(index: &dyn VaultIndex, path)` — serializes to MessagePack with header
+- [x] Add `create-index` subcommand: builds `ScannedIndex`, saves as snapshot, detects stale orphan `.hyalo-index` files
+- [x] Add `drop-index` subcommand: deletes index file, warns about other stale `.hyalo-index` files
+- [x] Add `--index <PATH>` global CLI flag (clap `global = true`)
+- [x] Wire up in `main()`: `--index` → `SnapshotIndex::load()`, else `ScannedIndex::build()`
 
 ### Phase 3: Tests & Validation
-- [ ] Add e2e tests: create-index → find --index, drop-index, stale detection, incompatible index fallback, content search with --index
-- [ ] Add benchmark: repeated `find --index` vs repeated `find` (measure cumulative savings)
+- [x] Add e2e tests: create-index → find --index, drop-index, stale detection, incompatible index fallback, content search with --index
+- [x] Add benchmark: repeated `find --index` vs repeated `find` (measure cumulative savings)
 
 ## Future (deferred)
 


### PR DESCRIPTION
## Summary

- Introduces `VaultIndex` trait decoupling read-only commands from their data source, with `ScannedIndex` (live scan) and `SnapshotIndex` (MessagePack snapshot) implementations
- New `create-index` / `drop-index` subcommands and `--index <PATH>` global flag — read-only commands (find, summary, tags, properties, backlinks) use the snapshot; mutation commands always scan from disk
- Index is designed as ephemeral: create before a batch of queries, drop when done. Becomes stale the moment files change.
- Benchmarked on 3,500-file vault: 2.1x faster than the previous dump-to-JSON + jq approach, 2.8x faster than repeated disk scans
- Updated hyalo-dream skill to use `--index` instead of temp-file + jq pattern
- Updated README, hyalo skill, and CLI help text with staleness/lifecycle guidance

## Test plan

- [x] 8 unit tests for ScannedIndex build, get, sections, tasks, links, graph, broken frontmatter, snapshot roundtrip
- [x] 18 e2e tests covering create-index, drop-index, find/summary/tags/properties/backlinks with --index, content search fallback, incompatible index fallback
- [x] `cargo fmt` / `cargo clippy` / `cargo test --workspace` — 432 tests passing
- [x] Dogfooded on 120-file knowledgebase: create-index, find --index, summary --index all work correctly
- [x] Benchmarked on vscode-docs (339 files), docs/content (3,521 files), obsidian-hub (6,540 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)