### PR TITLE
Improve hyalo init: overwrite on re-run, install rule, smart dir detection

### DIFF
--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -17,6 +17,9 @@ const RULE_TEMPLATE: &str = include_str!("../../../../.claude/rules/knowledgebas
 
 const CLAUDE_MD_HINT: &str = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.";
 
+const SECTION_START: &str = "<!-- hyalo:start -->";
+const SECTION_END: &str = "<!-- hyalo:end -->";
+
 /// Common documentation directory names to scan for when no `--dir` is given.
 const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "content", "pages"];
 
@@ -161,20 +164,17 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
     }
 
     // ------------------------------------------------------------------
-    // Step 5: append hyalo hint to .claude/CLAUDE.md (no duplicates)
+    // Step 5: upsert the hyalo managed section in .claude/CLAUDE.md
     // ------------------------------------------------------------------
     let claude_md_path = cwd.join(".claude").join("CLAUDE.md");
+    let managed_section = format!("{SECTION_START}\n{CLAUDE_MD_HINT}\n{SECTION_END}");
     if claude_md_path.exists() {
         let existing = fs::read_to_string(&claude_md_path)
             .with_context(|| format!("failed to read {}", claude_md_path.display()))?;
-        if existing.contains(CLAUDE_MD_HINT) {
-            writeln!(summary, "skipped  .claude/CLAUDE.md (hint already present)").unwrap();
-        } else {
-            let appended = append_line_to_file_content(&existing, CLAUDE_MD_HINT);
-            fs::write(&claude_md_path, appended)
-                .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
-            writeln!(summary, "updated  .claude/CLAUDE.md (appended hyalo hint)").unwrap();
-        }
+        let (new_content, action) = upsert_managed_section(&existing, &managed_section);
+        fs::write(&claude_md_path, &new_content)
+            .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
+        writeln!(summary, "updated  .claude/CLAUDE.md ({action})").unwrap();
     } else {
         // Create the file and any parent directories.
         let claude_dir = claude_md_path
@@ -182,10 +182,10 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
             .context("CLAUDE.md path has no parent directory")?;
         fs::create_dir_all(claude_dir)
             .with_context(|| format!("failed to create directory {}", claude_dir.display()))?;
-        let content = format!("{CLAUDE_MD_HINT}\n");
+        let content = format!("{managed_section}\n");
         fs::write(&claude_md_path, content)
             .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
-        writeln!(summary, "created  .claude/CLAUDE.md (with hyalo hint)").unwrap();
+        writeln!(summary, "created  .claude/CLAUDE.md (with managed section)").unwrap();
     }
 
     Ok(CommandOutcome::Success(summary.trim_end().to_owned()))
@@ -312,6 +312,63 @@ fn append_line_to_file_content(content: &str, line: &str) -> String {
     result.push_str(line);
     result.push('\n');
     result
+}
+
+/// Replace the hyalo managed section in `content`, or append it if absent.
+///
+/// Returns `(updated_content, action_description)` where `action_description` is a
+/// short human-readable string describing what was done.
+///
+/// The replacement logic (in priority order):
+/// 1. If both `<!-- hyalo:start -->` and `<!-- hyalo:end -->` markers are present,
+///    replace everything between them (inclusive) with `section`.
+/// 2. If only the start marker is present (no matching end marker), treat as absent.
+/// 3. If the bare `CLAUDE_MD_HINT` text appears without markers, replace that line
+///    with `section` (migration path from old format).
+/// 4. Otherwise, append `section` separated by a blank line.
+fn upsert_managed_section(content: &str, section: &str) -> (String, &'static str) {
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Find line indices of the start and end markers.
+    let start_idx = lines.iter().position(|l| l.contains(SECTION_START));
+    let end_idx = lines.iter().position(|l| l.contains(SECTION_END));
+
+    if let (Some(s), Some(e)) = (start_idx, end_idx) {
+        // Both markers present — replace from start to end (inclusive).
+        let mut result = String::new();
+        for line in &lines[..s] {
+            result.push_str(line);
+            result.push('\n');
+        }
+        result.push_str(section);
+        result.push('\n');
+        for line in &lines[e + 1..] {
+            result.push_str(line);
+            result.push('\n');
+        }
+        return (result, "replaced managed section");
+    }
+
+    // Only start marker without end: treat as absent (fall through).
+    // Check for old bare hint line and migrate it.
+    if let Some(hint_idx) = lines.iter().position(|l| *l == CLAUDE_MD_HINT) {
+        let mut result = String::new();
+        for line in &lines[..hint_idx] {
+            result.push_str(line);
+            result.push('\n');
+        }
+        result.push_str(section);
+        result.push('\n');
+        for line in &lines[hint_idx + 1..] {
+            result.push_str(line);
+            result.push('\n');
+        }
+        return (result, "migrated to managed section");
+    }
+
+    // No markers and no old hint — append.
+    let appended = append_line_to_file_content(content, section);
+    (appended, "appended managed section")
 }
 
 // ---------------------------------------------------------------------------
@@ -476,6 +533,107 @@ mod tests {
         let count = count_md_root_only(tmp.path());
         // readme.md (1) + other/note.md (1) = 2; .claude/*.md are excluded
         assert_eq!(count, 2);
+    }
+
+    // ---------------------------------------------------------------------------
+    // upsert_managed_section tests
+    // ---------------------------------------------------------------------------
+
+    fn make_section() -> String {
+        format!("{SECTION_START}\n{CLAUDE_MD_HINT}\n{SECTION_END}")
+    }
+
+    #[test]
+    fn upsert_managed_section_appends_when_absent() {
+        let content = "# Existing\n\nSome content.\n";
+        let section = make_section();
+        let (result, action) = upsert_managed_section(content, &section);
+        assert_eq!(action, "appended managed section");
+        assert!(
+            result.contains("Some content."),
+            "original content preserved"
+        );
+        assert!(result.contains(SECTION_START), "start marker present");
+        assert!(result.contains(SECTION_END), "end marker present");
+        assert!(result.contains(CLAUDE_MD_HINT), "hint content present");
+        // Verify the section appears after the original content.
+        let orig_pos = result.find("Some content.").unwrap();
+        let section_pos = result.find(SECTION_START).unwrap();
+        assert!(
+            section_pos > orig_pos,
+            "section appended after original content"
+        );
+    }
+
+    #[test]
+    fn upsert_managed_section_replaces_existing_markers() {
+        let section = make_section();
+        let old_content =
+            format!("# Before\n\n{SECTION_START}\nold hint text\n{SECTION_END}\n\n# After\n");
+        let (result, action) = upsert_managed_section(&old_content, &section);
+        assert_eq!(action, "replaced managed section");
+        assert!(
+            result.contains("# Before"),
+            "content before markers preserved"
+        );
+        assert!(
+            result.contains("# After"),
+            "content after markers preserved"
+        );
+        assert!(result.contains(CLAUDE_MD_HINT), "new hint content present");
+        assert!(!result.contains("old hint text"), "old hint text replaced");
+        // Verify only one copy of start/end markers.
+        assert_eq!(result.matches(SECTION_START).count(), 1);
+        assert_eq!(result.matches(SECTION_END).count(), 1);
+    }
+
+    #[test]
+    fn upsert_managed_section_migrates_old_hint() {
+        let section = make_section();
+        let old_content = format!("# Header\n\n{CLAUDE_MD_HINT}\n\n# Footer\n");
+        let (result, action) = upsert_managed_section(&old_content, &section);
+        assert_eq!(action, "migrated to managed section");
+        assert!(result.contains("# Header"), "header preserved");
+        assert!(result.contains("# Footer"), "footer preserved");
+        assert!(result.contains(SECTION_START), "start marker added");
+        assert!(result.contains(SECTION_END), "end marker added");
+        assert!(result.contains(CLAUDE_MD_HINT), "hint content present");
+        // Should still appear exactly once.
+        assert_eq!(result.matches(CLAUDE_MD_HINT).count(), 1);
+    }
+
+    #[test]
+    fn upsert_managed_section_preserves_surrounding_content() {
+        let section = make_section();
+        let before = "# Top\n\nFirst paragraph.\n\n";
+        let after = "\n\n# Bottom\n\nLast paragraph.\n";
+        let old_content = format!("{before}{SECTION_START}\nstale\n{SECTION_END}{after}");
+        let (result, _action) = upsert_managed_section(&old_content, &section);
+        assert!(
+            result.starts_with("# Top\n"),
+            "leading content preserved exactly"
+        );
+        assert!(
+            result.contains("First paragraph."),
+            "first paragraph preserved"
+        );
+        assert!(
+            result.contains("Last paragraph."),
+            "last paragraph preserved"
+        );
+        assert!(!result.contains("stale"), "stale content replaced");
+    }
+
+    #[test]
+    fn upsert_managed_section_handles_missing_end_marker() {
+        // Only the start marker, no end — treat as absent and append.
+        let section = make_section();
+        let content = format!("# Existing\n\n{SECTION_START}\norphaned start\n");
+        let (result, action) = upsert_managed_section(&content, &section);
+        assert_eq!(action, "appended managed section");
+        // The fresh section is appended at the end.
+        assert!(result.contains(SECTION_END), "end marker now present");
+        assert!(result.contains(CLAUDE_MD_HINT), "hint content present");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
+use toml::Value as TomlValue;
 
 use crate::output::CommandOutcome;
 
@@ -53,8 +54,36 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
     if toml_existed && !dir_explicit {
         writeln!(summary, "skipped  .hyalo.toml (already exists)").unwrap();
     } else {
-        let escaped = dir_value.replace('\\', "\\\\").replace('"', "\\\"");
-        let toml_content = format!("dir = \"{escaped}\"\n");
+        let toml_content = if toml_existed {
+            // Read and parse the existing file; update only the `dir` key so
+            // that other user config (format, hints, site_prefix …) is preserved.
+            // If the file is malformed, fall back to overwriting with just `dir`.
+            let existing_raw = fs::read_to_string(&toml_path)
+                .with_context(|| format!("failed to read {}", toml_path.display()))?;
+            match existing_raw.parse::<TomlValue>() {
+                Ok(mut table) => {
+                    if let Some(map) = table.as_table_mut() {
+                        map.insert("dir".to_owned(), TomlValue::String(dir_value.clone()));
+                    }
+                    // Serialise back; toml::to_string always produces valid TOML.
+                    match toml::to_string(&table) {
+                        Ok(s) => s,
+                        Err(_) => format!("dir = {:?}\n", dir_value),
+                    }
+                }
+                Err(_) => {
+                    // Malformed existing file — overwrite with just dir and note it.
+                    writeln!(
+                        summary,
+                        "warning  .hyalo.toml was malformed; existing content replaced"
+                    )
+                    .unwrap();
+                    format!("dir = {:?}\n", dir_value)
+                }
+            }
+        } else {
+            format!("dir = {:?}\n", dir_value)
+        };
         fs::write(&toml_path, &toml_content)
             .with_context(|| format!("failed to write {}", toml_path.display()))?;
         if toml_existed {
@@ -218,6 +247,9 @@ fn auto_detect_dir(cwd: &Path) -> String {
 
 /// Count `.md` files directly in `dir` and in non-candidate subdirectories (recursive).
 /// Excludes candidate directories so root doesn't double-count their contents.
+/// Also excludes hidden directories (names starting with `.`) such as `.claude/`
+/// and `.git/` so that files installed there by `init --claude` don't skew
+/// the auto-detection heuristic toward `"."`.
 fn count_md_root_only(dir: &Path) -> usize {
     let Ok(entries) = fs::read_dir(dir) else {
         return 0;
@@ -226,12 +258,12 @@ fn count_md_root_only(dir: &Path) -> usize {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            // Skip candidate directories — they're counted separately.
-            let is_candidate = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|name| CANDIDATE_DIRS.contains(&name));
-            if !is_candidate {
+            let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            // Skip hidden directories (e.g. .git, .claude) and candidate
+            // directories (counted separately in auto_detect_dir).
+            let is_hidden = dir_name.starts_with('.');
+            let is_candidate = CANDIDATE_DIRS.contains(&dir_name);
+            if !is_hidden && !is_candidate {
                 count += count_md_files_recursive(&path);
             }
         } else if path
@@ -245,10 +277,30 @@ fn count_md_root_only(dir: &Path) -> usize {
     count
 }
 
+/// The sentinel path glob in the rule template that gets replaced with the
+/// user's actual vault directory.
+const RULE_SENTINEL: &str = "hyalo-knowledgebase/**";
+
 /// Replace the `hyalo-knowledgebase/**` path glob in the rule template with
 /// `{dir}/**` so the rule targets the actual vault directory.
+///
+/// `dir` is YAML-escaped so that backslashes (Windows paths) and double-quotes
+/// do not corrupt the generated YAML. Path separators are normalised to `/`.
 fn parameterize_rule(template: &str, dir: &str) -> String {
-    template.replace("hyalo-knowledgebase/**", &format!("{dir}/**"))
+    // The sentinel must be present; its absence means the template was changed
+    // without updating this function — a programming error.
+    debug_assert!(
+        template.contains(RULE_SENTINEL),
+        "rule template does not contain the expected sentinel {RULE_SENTINEL:?}"
+    );
+
+    // Normalise Windows backslash separators and escape YAML double-quote
+    // special characters so the substituted value is valid inside a YAML
+    // double-quoted scalar (e.g. `"docs/**"`).
+    let normalised = dir.replace('\\', "/");
+    let yaml_escaped = normalised.replace('"', "\\\"");
+
+    template.replace(RULE_SENTINEL, &format!("{yaml_escaped}/**"))
 }
 
 /// Append `line` to `content`, separated by a blank line. Strips trailing newlines from
@@ -387,6 +439,67 @@ mod tests {
     }
 
     #[test]
+    fn parameterize_rule_normalises_windows_backslashes() {
+        let template = "---\npaths:\n  - \"hyalo-knowledgebase/**\"\n---\n";
+        let result = parameterize_rule(template, "my\\notes");
+        // Backslashes must become forward slashes.
+        assert!(result.contains("my/notes/**"));
+        assert!(!result.contains('\\'));
+    }
+
+    #[test]
+    fn parameterize_rule_escapes_double_quotes_in_dir() {
+        let template = "---\npaths:\n  - \"hyalo-knowledgebase/**\"\n---\n";
+        // A dir name containing a double-quote (unusual but must not corrupt YAML).
+        let result = parameterize_rule(template, "my\"notes");
+        assert!(result.contains("my\\\"notes/**"));
+    }
+
+    #[test]
+    fn count_md_root_only_skips_hidden_dirs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // .claude/ with md files — should be skipped
+        let claude_dir = tmp.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("CLAUDE.md"), "# Hidden").unwrap();
+        fs::write(claude_dir.join("SKILL.md"), "# Skill").unwrap();
+
+        // Visible non-candidate dir with md files — should be counted
+        let other_dir = tmp.path().join("other");
+        fs::create_dir_all(&other_dir).unwrap();
+        fs::write(other_dir.join("note.md"), "# Note").unwrap();
+
+        // Root-level md file — should be counted
+        fs::write(tmp.path().join("readme.md"), "# Root").unwrap();
+
+        let count = count_md_root_only(tmp.path());
+        // readme.md (1) + other/note.md (1) = 2; .claude/*.md are excluded
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn auto_detect_dir_ignores_hidden_dirs_in_root_count() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // docs: 1 md file
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::write(tmp.path().join("docs").join("a.md"), "# A").unwrap();
+
+        // .claude: 3 md files — must NOT make root win
+        let claude_dir = tmp.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("CLAUDE.md"), "#").unwrap();
+        fs::write(claude_dir.join("SKILL.md"), "#").unwrap();
+        fs::write(claude_dir.join("RULE.md"), "#").unwrap();
+
+        // Without the fix, root count would be 3 (from .claude) > 1 (docs) → "."
+        // With the fix, root count is 0 → docs wins.
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, "docs");
+    }
+
+    #[test]
     fn run_init_overwrites_skills_on_rerun() {
         let tmp = tempfile::TempDir::new().unwrap();
 
@@ -423,7 +536,29 @@ mod tests {
         assert!(out.contains(".hyalo.toml"));
 
         let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
-        assert_eq!(content, "dir = \"newdir\"\n");
+        // toml::to_string serialises the value; just verify the key is updated.
+        assert!(content.contains("dir = \"newdir\""));
+    }
+
+    #[test]
+    fn run_init_preserves_other_toml_keys_when_updating_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Existing config with extra keys beyond `dir`.
+        fs::write(
+            tmp.path().join(".hyalo.toml"),
+            "dir = \"old\"\nformat = \"text\"\nhints = true\n",
+        )
+        .unwrap();
+
+        let outcome = run_init_in(Some("newdir"), false, tmp.path()).unwrap();
+        assert!(matches!(outcome, CommandOutcome::Success(_)));
+
+        let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+        // dir updated, other keys preserved.
+        assert!(content.contains("dir = \"newdir\""));
+        assert!(content.contains("format = \"text\""));
+        assert!(content.contains("hints = true"));
     }
 
     #[test]

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -12,6 +12,7 @@ use crate::output::CommandOutcome;
 
 const SKILL_CONTENT: &str = include_str!("../../../../.claude/skills/hyalo/SKILL.md");
 const DREAM_SKILL_CONTENT: &str = include_str!("../../../../.claude/skills/hyalo-dream/SKILL.md");
+const RULE_TEMPLATE: &str = include_str!("../../../../.claude/rules/knowledgebase.md");
 
 const CLAUDE_MD_HINT: &str = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.";
 
@@ -30,24 +31,37 @@ const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "con
 ///   appends a hint line to `.claude/CLAUDE.md`.
 pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
     let cwd = std::env::current_dir().context("failed to determine current working directory")?;
+    run_init_in(dir, claude, &cwd)
+}
+
+fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOutcome> {
     let mut summary = String::new();
 
+    // Resolve the directory value once, so we can use it both for .hyalo.toml
+    // and for the rules file path substitution.
+    let dir_explicit = dir.is_some();
+    let dir_value = match dir {
+        Some(d) => d.to_owned(),
+        None => auto_detect_dir(cwd),
+    };
+
     // ------------------------------------------------------------------
-    // Step 1: create .hyalo.toml
+    // Step 1: create or update .hyalo.toml
     // ------------------------------------------------------------------
     let toml_path = cwd.join(".hyalo.toml");
-    if toml_path.exists() {
+    let toml_existed = toml_path.exists();
+    if toml_existed && !dir_explicit {
         writeln!(summary, "skipped  .hyalo.toml (already exists)").unwrap();
     } else {
-        let dir_value = match dir {
-            Some(d) => d.to_owned(),
-            None => auto_detect_dir(&cwd),
-        };
         let escaped = dir_value.replace('\\', "\\\\").replace('"', "\\\"");
         let toml_content = format!("dir = \"{escaped}\"\n");
         fs::write(&toml_path, &toml_content)
             .with_context(|| format!("failed to write {}", toml_path.display()))?;
-        writeln!(summary, "created  .hyalo.toml  (dir = \"{dir_value}\")").unwrap();
+        if toml_existed {
+            writeln!(summary, "updated  .hyalo.toml  (dir = \"{dir_value}\")").unwrap();
+        } else {
+            writeln!(summary, "created  .hyalo.toml  (dir = \"{dir_value}\")").unwrap();
+        }
     }
 
     if !claude {
@@ -55,57 +69,70 @@ pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
     }
 
     // ------------------------------------------------------------------
-    // Step 2: create .claude/skills/hyalo/SKILL.md
+    // Step 2: write (overwrite) .claude/skills/hyalo/SKILL.md
     // ------------------------------------------------------------------
     let skill_path = cwd
         .join(".claude")
         .join("skills")
         .join("hyalo")
         .join("SKILL.md");
-    if skill_path.exists() {
-        writeln!(
-            summary,
-            "skipped  .claude/skills/hyalo/SKILL.md (already exists)"
-        )
-        .unwrap();
+    let skill_existed = skill_path.exists();
+    let skill_dir = skill_path
+        .parent()
+        .context("skill path has no parent directory")?;
+    fs::create_dir_all(skill_dir)
+        .with_context(|| format!("failed to create directory {}", skill_dir.display()))?;
+    fs::write(&skill_path, SKILL_CONTENT)
+        .with_context(|| format!("failed to write {}", skill_path.display()))?;
+    if skill_existed {
+        writeln!(summary, "updated  .claude/skills/hyalo/SKILL.md").unwrap();
     } else {
-        let skill_dir = skill_path
-            .parent()
-            .context("skill path has no parent directory")?;
-        fs::create_dir_all(skill_dir)
-            .with_context(|| format!("failed to create directory {}", skill_dir.display()))?;
-        fs::write(&skill_path, SKILL_CONTENT)
-            .with_context(|| format!("failed to write {}", skill_path.display()))?;
         writeln!(summary, "created  .claude/skills/hyalo/SKILL.md").unwrap();
     }
 
     // ------------------------------------------------------------------
-    // Step 3: create .claude/skills/hyalo-dream/SKILL.md
+    // Step 3: write (overwrite) .claude/skills/hyalo-dream/SKILL.md
     // ------------------------------------------------------------------
     let dream_skill_path = cwd
         .join(".claude")
         .join("skills")
         .join("hyalo-dream")
         .join("SKILL.md");
-    if dream_skill_path.exists() {
-        writeln!(
-            summary,
-            "skipped  .claude/skills/hyalo-dream/SKILL.md (already exists)"
-        )
-        .unwrap();
+    let dream_skill_existed = dream_skill_path.exists();
+    let dream_skill_dir = dream_skill_path
+        .parent()
+        .context("dream skill path has no parent directory")?;
+    fs::create_dir_all(dream_skill_dir)
+        .with_context(|| format!("failed to create directory {}", dream_skill_dir.display()))?;
+    fs::write(&dream_skill_path, DREAM_SKILL_CONTENT)
+        .with_context(|| format!("failed to write {}", dream_skill_path.display()))?;
+    if dream_skill_existed {
+        writeln!(summary, "updated  .claude/skills/hyalo-dream/SKILL.md").unwrap();
     } else {
-        let dream_skill_dir = dream_skill_path
-            .parent()
-            .context("dream skill path has no parent directory")?;
-        fs::create_dir_all(dream_skill_dir)
-            .with_context(|| format!("failed to create directory {}", dream_skill_dir.display()))?;
-        fs::write(&dream_skill_path, DREAM_SKILL_CONTENT)
-            .with_context(|| format!("failed to write {}", dream_skill_path.display()))?;
         writeln!(summary, "created  .claude/skills/hyalo-dream/SKILL.md").unwrap();
     }
 
     // ------------------------------------------------------------------
-    // Step 4: append hyalo hint to .claude/CLAUDE.md (no duplicates)
+    // Step 4: write (overwrite) .claude/rules/knowledgebase.md
+    // ------------------------------------------------------------------
+    let rules_path = cwd.join(".claude").join("rules").join("knowledgebase.md");
+    let rules_existed = rules_path.exists();
+    let rules_dir = rules_path
+        .parent()
+        .context("rules path has no parent directory")?;
+    fs::create_dir_all(rules_dir)
+        .with_context(|| format!("failed to create directory {}", rules_dir.display()))?;
+    let rule_content = parameterize_rule(RULE_TEMPLATE, &dir_value);
+    fs::write(&rules_path, &rule_content)
+        .with_context(|| format!("failed to write {}", rules_path.display()))?;
+    if rules_existed {
+        writeln!(summary, "updated  .claude/rules/knowledgebase.md").unwrap();
+    } else {
+        writeln!(summary, "created  .claude/rules/knowledgebase.md").unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Step 5: append hyalo hint to .claude/CLAUDE.md (no duplicates)
     // ------------------------------------------------------------------
     let claude_md_path = cwd.join(".claude").join("CLAUDE.md");
     if claude_md_path.exists() {
@@ -139,30 +166,89 @@ pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Scan CWD for the first common doc directory that exists and contains `.md` files.
-/// Falls back to `"."` if none found.
-fn auto_detect_dir(cwd: &Path) -> String {
-    for candidate in CANDIDATE_DIRS {
-        let candidate_path = cwd.join(candidate);
-        if candidate_path.is_dir() && dir_contains_md(&candidate_path) {
-            return (*candidate).to_owned();
-        }
-    }
-    ".".to_owned()
-}
-
-/// Returns `true` if `dir` contains at least one `.md` file (non-recursive).
-fn dir_contains_md(dir: &Path) -> bool {
+/// Recursively count `.md` files under `dir`.
+fn count_md_files_recursive(dir: &Path) -> usize {
     let Ok(entries) = fs::read_dir(dir) else {
-        return false;
+        return 0;
     };
-    entries.flatten().any(|entry| {
-        entry
-            .path()
+    let mut count = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            count += count_md_files_recursive(&path);
+        } else if path
             .extension()
             .and_then(|e| e.to_str())
             .is_some_and(|e| e.eq_ignore_ascii_case("md"))
-    })
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Scan CWD for the candidate or root dir that has the most `.md` files (recursive).
+/// Falls back to `"."` if none found.
+fn auto_detect_dir(cwd: &Path) -> String {
+    let mut best_dir: Option<&str> = None;
+    let mut best_count = 0usize;
+
+    for candidate in CANDIDATE_DIRS {
+        let candidate_path = cwd.join(candidate);
+        if candidate_path.is_dir() {
+            let count = count_md_files_recursive(&candidate_path);
+            if count > best_count {
+                best_count = count;
+                best_dir = Some(candidate);
+            }
+        }
+    }
+
+    // Also consider root "." — but only count .md files that are NOT inside a
+    // candidate directory, so we compare apples to apples.
+    let root_count = count_md_root_only(cwd);
+    if root_count > best_count {
+        return ".".to_owned();
+    }
+
+    best_dir
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| ".".to_owned())
+}
+
+/// Count `.md` files directly in `dir` and in non-candidate subdirectories (recursive).
+/// Excludes candidate directories so root doesn't double-count their contents.
+fn count_md_root_only(dir: &Path) -> usize {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut count = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip candidate directories — they're counted separately.
+            let is_candidate = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|name| CANDIDATE_DIRS.contains(&name));
+            if !is_candidate {
+                count += count_md_files_recursive(&path);
+            }
+        } else if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("md"))
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Replace the `hyalo-knowledgebase/**` path glob in the rule template with
+/// `{dir}/**` so the rule targets the actual vault directory.
+fn parameterize_rule(template: &str, dir: &str) -> String {
+    template.replace("hyalo-knowledgebase/**", &format!("{dir}/**"))
 }
 
 /// Append `line` to `content`, separated by a blank line. Strips trailing newlines from
@@ -206,11 +292,17 @@ mod tests {
     }
 
     #[test]
-    fn dir_contains_md_detects_md_files() {
+    fn count_md_files_recursive_counts_nested() {
         let tmp = tempfile::TempDir::new().unwrap();
-        assert!(!dir_contains_md(tmp.path()));
-        fs::write(tmp.path().join("note.md"), "# Hello").unwrap();
-        assert!(dir_contains_md(tmp.path()));
+        assert_eq!(count_md_files_recursive(tmp.path()), 0);
+
+        fs::write(tmp.path().join("top.md"), "# Top").unwrap();
+        let sub = tmp.path().join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(sub.join("nested.md"), "# Nested").unwrap();
+        fs::write(sub.join("not.txt"), "text").unwrap();
+
+        assert_eq!(count_md_files_recursive(tmp.path()), 2);
     }
 
     #[test]
@@ -218,6 +310,32 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let result = auto_detect_dir(tmp.path());
         assert_eq!(result, ".");
+    }
+
+    #[test]
+    fn auto_detect_dir_picks_most_md_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // docs: 1 md file
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::write(tmp.path().join("docs").join("a.md"), "# A").unwrap();
+
+        // knowledgebase: 3 md files (2 nested)
+        fs::create_dir_all(tmp.path().join("knowledgebase").join("sub")).unwrap();
+        fs::write(tmp.path().join("knowledgebase").join("b.md"), "# B").unwrap();
+        fs::write(
+            tmp.path().join("knowledgebase").join("sub").join("c.md"),
+            "# C",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("knowledgebase").join("sub").join("d.md"),
+            "# D",
+        )
+        .unwrap();
+
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, "knowledgebase");
     }
 
     #[test]
@@ -238,5 +356,108 @@ mod tests {
         fs::write(tmp.path().join("knowledgebase").join("note.md"), "# Hello").unwrap();
         let result = auto_detect_dir(tmp.path());
         assert_eq!(result, "knowledgebase");
+    }
+
+    #[test]
+    fn auto_detect_dir_falls_back_to_dot_when_root_has_most() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // docs: 1 md file
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::write(tmp.path().join("docs").join("a.md"), "# A").unwrap();
+        // root (excluding candidate dirs): 2 md files → root wins
+        fs::write(tmp.path().join("x.md"), "# X").unwrap();
+        fs::write(tmp.path().join("y.md"), "# Y").unwrap();
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, ".");
+    }
+
+    #[test]
+    fn parameterize_rule_replaces_path() {
+        let template = "---\npaths:\n  - \"hyalo-knowledgebase/**\"\n---\nContent here.\n";
+        let result = parameterize_rule(template, "docs");
+        assert!(result.contains("\"docs/**\""));
+        assert!(!result.contains("hyalo-knowledgebase/**"));
+    }
+
+    #[test]
+    fn parameterize_rule_with_dot_dir() {
+        let template = "---\npaths:\n  - \"hyalo-knowledgebase/**\"\n---\n";
+        let result = parameterize_rule(template, ".");
+        assert!(result.contains("\"./**\""));
+    }
+
+    #[test]
+    fn run_init_overwrites_skills_on_rerun() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // First run
+        let outcome1 = run_init_in(Some("docs"), true, tmp.path()).unwrap();
+        let CommandOutcome::Success(out1) = outcome1 else {
+            panic!("expected success");
+        };
+        assert!(out1.contains("created  .claude/skills/hyalo/SKILL.md"));
+        assert!(out1.contains("created  .claude/skills/hyalo-dream/SKILL.md"));
+        assert!(out1.contains("created  .claude/rules/knowledgebase.md"));
+
+        // Second run — should say "updated", not "created"
+        let outcome2 = run_init_in(Some("docs"), true, tmp.path()).unwrap();
+        let CommandOutcome::Success(out2) = outcome2 else {
+            panic!("expected success");
+        };
+        assert!(out2.contains("updated  .claude/skills/hyalo/SKILL.md"));
+        assert!(out2.contains("updated  .claude/skills/hyalo-dream/SKILL.md"));
+        assert!(out2.contains("updated  .claude/rules/knowledgebase.md"));
+    }
+
+    #[test]
+    fn run_init_updates_toml_when_dir_explicit() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Create initial .hyalo.toml
+        fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
+
+        let outcome = run_init_in(Some("newdir"), false, tmp.path()).unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success");
+        };
+        assert!(out.contains(".hyalo.toml"));
+
+        let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+        assert_eq!(content, "dir = \"newdir\"\n");
+    }
+
+    #[test]
+    fn run_init_skips_toml_when_exists_and_no_explicit_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
+
+        let outcome = run_init_in(None, false, tmp.path()).unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success");
+        };
+        assert!(out.contains("skipped  .hyalo.toml"));
+
+        // Content unchanged
+        let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+        assert_eq!(content, "dir = \"old\"\n");
+    }
+
+    #[test]
+    fn run_init_rule_uses_detected_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let outcome = run_init_in(Some("my-notes"), true, tmp.path()).unwrap();
+        assert!(matches!(outcome, CommandOutcome::Success(_)));
+
+        let rule_content = fs::read_to_string(
+            tmp.path()
+                .join(".claude")
+                .join("rules")
+                .join("knowledgebase.md"),
+        )
+        .unwrap();
+        assert!(rule_content.contains("my-notes/**"));
+        assert!(!rule_content.contains("hyalo-knowledgebase/**"));
     }
 }

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -32,7 +32,7 @@ const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "con
 /// - `dir`: explicit value for the `dir` key in `.hyalo.toml`; when `None` the
 ///   function auto-detects a common doc directory.
 /// - `claude`: when `true`, also installs the hyalo and hyalo-dream skills and
-///   appends a hint line to `.claude/CLAUDE.md`.
+///   writes a managed section to `.claude/CLAUDE.md`.
 pub fn run_init(dir: Option<&str>, claude: bool) -> Result<CommandOutcome> {
     let cwd = std::env::current_dir().context("failed to determine current working directory")?;
     run_init_in(dir, claude, &cwd)
@@ -67,11 +67,26 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
                 Ok(mut table) => {
                     if let Some(map) = table.as_table_mut() {
                         map.insert("dir".to_owned(), TomlValue::String(dir_value.clone()));
-                    }
-                    // Serialise back; toml::to_string always produces valid TOML.
-                    match toml::to_string(&table) {
-                        Ok(s) => s,
-                        Err(_) => format!("dir = {:?}\n", dir_value),
+                        // Serialise back; toml::to_string always produces valid TOML.
+                        match toml::to_string(&table) {
+                            Ok(s) => s,
+                            Err(_) => {
+                                writeln!(
+                                    summary,
+                                    "warning  .hyalo.toml was malformed; existing content replaced"
+                                )
+                                .unwrap();
+                                minimal_toml_dir(&dir_value)
+                            }
+                        }
+                    } else {
+                        // Valid TOML but not a table (e.g. bare string) — overwrite.
+                        writeln!(
+                            summary,
+                            "warning  .hyalo.toml was malformed; existing content replaced"
+                        )
+                        .unwrap();
+                        minimal_toml_dir(&dir_value)
                     }
                 }
                 Err(_) => {
@@ -81,11 +96,11 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
                         "warning  .hyalo.toml was malformed; existing content replaced"
                     )
                     .unwrap();
-                    format!("dir = {:?}\n", dir_value)
+                    minimal_toml_dir(&dir_value)
                 }
             }
         } else {
-            format!("dir = {:?}\n", dir_value)
+            minimal_toml_dir(&dir_value)
         };
         fs::write(&toml_path, &toml_content)
             .with_context(|| format!("failed to write {}", toml_path.display()))?;
@@ -195,17 +210,40 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Produce a minimal valid TOML string containing only `dir = "<value>"`.
+///
+/// Uses the `toml` crate to correctly escape the value (handles Unicode,
+/// backslashes, double-quotes) rather than relying on Rust's `{:?}` debug
+/// format which produces `\u{NNNN}` — invalid TOML escape sequences.
+fn minimal_toml_dir(dir_value: &str) -> String {
+    let table =
+        toml::map::Map::from_iter([("dir".to_owned(), TomlValue::String(dir_value.to_owned()))]);
+    toml::to_string(&table).unwrap_or_else(|_| {
+        // Fallback: manual escaping of backslash and double-quote only.
+        format!(
+            "dir = \"{}\"\n",
+            dir_value.replace('\\', "\\\\").replace('"', "\\\"")
+        )
+    })
+}
+
 /// Recursively count `.md` files under `dir`.
+///
+/// Uses `DirEntry::file_type()` instead of `Path::is_dir()` to avoid following
+/// symlinks, which could cause infinite loops on circular symlink structures.
 fn count_md_files_recursive(dir: &Path) -> usize {
     let Ok(entries) = fs::read_dir(dir) else {
         return 0;
     };
     let mut count = 0;
     for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            count += count_md_files_recursive(&path);
-        } else if path
+        let is_real_dir = entry
+            .file_type()
+            .is_ok_and(|ft| ft.is_dir() && !ft.is_symlink());
+        if is_real_dir {
+            count += count_md_files_recursive(&entry.path());
+        } else if entry
+            .path()
             .extension()
             .and_then(|e| e.to_str())
             .is_some_and(|e| e.eq_ignore_ascii_case("md"))
@@ -256,8 +294,11 @@ fn count_md_root_only(dir: &Path) -> usize {
     };
     let mut count = 0;
     for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
+        let is_real_dir = entry
+            .file_type()
+            .is_ok_and(|ft| ft.is_dir() && !ft.is_symlink());
+        if is_real_dir {
+            let path = entry.path();
             let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
             // Skip hidden directories (e.g. .git, .claude) and candidate
             // directories (counted separately in auto_detect_dir).
@@ -266,7 +307,8 @@ fn count_md_root_only(dir: &Path) -> usize {
             if !is_hidden && !is_candidate {
                 count += count_md_files_recursive(&path);
             }
-        } else if path
+        } else if entry
+            .path()
             .extension()
             .and_then(|e| e.to_str())
             .is_some_and(|e| e.eq_ignore_ascii_case("md"))
@@ -289,7 +331,7 @@ const RULE_SENTINEL: &str = "hyalo-knowledgebase/**";
 fn parameterize_rule(template: &str, dir: &str) -> String {
     // The sentinel must be present; its absence means the template was changed
     // without updating this function — a programming error.
-    debug_assert!(
+    assert!(
         template.contains(RULE_SENTINEL),
         "rule template does not contain the expected sentinel {RULE_SENTINEL:?}"
     );
@@ -333,8 +375,10 @@ fn upsert_managed_section(content: &str, section: &str) -> (String, &'static str
     let start_idx = lines.iter().position(|l| l.contains(SECTION_START));
     let end_idx = lines.iter().position(|l| l.contains(SECTION_END));
 
-    if let (Some(s), Some(e)) = (start_idx, end_idx) {
-        // Both markers present — replace from start to end (inclusive).
+    if let (Some(s), Some(e)) = (start_idx, end_idx)
+        && s < e
+    {
+        // Both markers present in correct order — replace from start to end (inclusive).
         let mut result = String::new();
         for line in &lines[..s] {
             result.push_str(line);
@@ -752,5 +796,101 @@ mod tests {
         .unwrap();
         assert!(rule_content.contains("my-notes/**"));
         assert!(!rule_content.contains("hyalo-knowledgebase/**"));
+    }
+
+    #[test]
+    fn upsert_managed_section_inverted_markers_treated_as_absent() {
+        // End marker appears before start marker (malformed file) — must not
+        // produce garbled output; instead treat as absent and append.
+        let section = make_section();
+        let content = format!("# File\n\n{SECTION_END}\nsome text\n{SECTION_START}\n# After\n");
+        let (result, action) = upsert_managed_section(&content, &section);
+        assert_eq!(
+            action, "appended managed section",
+            "inverted markers fall through to append"
+        );
+        // Original content preserved and new section appended at the end.
+        assert!(result.contains("# File"), "leading content preserved");
+        assert!(result.contains("# After"), "trailing content preserved");
+        assert!(result.contains(CLAUDE_MD_HINT), "hint content present");
+        // The section must appear after the original content.
+        let orig_pos = result.find("# After").unwrap();
+        let section_pos = result.find(CLAUDE_MD_HINT).unwrap();
+        assert!(
+            section_pos > orig_pos,
+            "appended section follows original content"
+        );
+    }
+
+    #[test]
+    fn minimal_toml_dir_produces_valid_toml_for_unicode() {
+        // A directory name with a non-ASCII character.
+        let output = minimal_toml_dir("my\u{1F4C1}notes");
+        // Must parse back as valid TOML with the correct value.
+        let parsed: toml::Value = output.parse().expect("must be valid TOML");
+        assert_eq!(
+            parsed.get("dir").and_then(|v| v.as_str()),
+            Some("my\u{1F4C1}notes"),
+            "unicode round-trips correctly"
+        );
+    }
+
+    #[test]
+    fn minimal_toml_dir_produces_valid_toml_for_backslash() {
+        // Windows-style path — backslashes must be escaped in TOML strings.
+        let output = minimal_toml_dir("C:\\Users\\me\\notes");
+        let parsed: toml::Value = output.parse().expect("must be valid TOML");
+        assert_eq!(
+            parsed.get("dir").and_then(|v| v.as_str()),
+            Some("C:\\Users\\me\\notes"),
+            "backslashes round-trip correctly"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn count_md_files_recursive_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let real_dir = tmp.path().join("real");
+        fs::create_dir_all(&real_dir).unwrap();
+        fs::write(real_dir.join("a.md"), "# A").unwrap();
+
+        // Create a symlink that points back to the parent — a cycle.
+        let link = real_dir.join("loop");
+        symlink(tmp.path(), &link).unwrap();
+
+        // Without the fix this would overflow the stack. With the fix it
+        // completes and counts only the one real file.
+        let count = count_md_files_recursive(tmp.path());
+        assert_eq!(count, 1, "only the real file counted, symlink loop ignored");
+    }
+
+    #[test]
+    fn run_init_overwrites_malformed_toml_non_table() {
+        // .hyalo.toml contains valid TOML that is not a table (bare string).
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::write(tmp.path().join(".hyalo.toml"), "\"just a string\"\n").unwrap();
+
+        let outcome = run_init_in(Some("docs"), false, tmp.path()).unwrap();
+        let CommandOutcome::Success(out) = outcome else {
+            panic!("expected success");
+        };
+        // Warning emitted.
+        assert!(
+            out.contains("warning  .hyalo.toml was malformed"),
+            "malformed warning present"
+        );
+        // File overwritten with a valid table.
+        let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+        let parsed: toml::Value = content
+            .parse()
+            .expect("overwritten content must be valid TOML");
+        assert_eq!(
+            parsed.get("dir").and_then(|v| v.as_str()),
+            Some("docs"),
+            "dir key written correctly"
+        );
     }
 }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -768,6 +768,11 @@ fn main() {
         cmd = cmd.mut_arg("format", |a| a.hide(true));
     }
 
+    // Global args (--format, --jq, etc.) are only defined on the root Command
+    // in clap derive — they aren't propagated to subcommands until parse time.
+    // We can't use mut_subcommand to hide them from `init --help` because
+    // they don't exist on the subcommand Command node yet.  This is a known
+    // clap limitation with `global = true` derive args.
     let matches = cmd.get_matches();
     let cli = match Cli::from_arg_matches(&matches) {
         Ok(c) => c,

--- a/crates/hyalo-cli/tests/e2e_init.rs
+++ b/crates/hyalo-cli/tests/e2e_init.rs
@@ -497,6 +497,14 @@ fn init_claude_creates_claude_md() {
         content.contains("hyalo"),
         ".claude/CLAUDE.md should contain hyalo hint; got: {content}"
     );
+    assert!(
+        content.contains("<!-- hyalo:start -->"),
+        ".claude/CLAUDE.md should contain start marker; got: {content}"
+    );
+    assert!(
+        content.contains("<!-- hyalo:end -->"),
+        ".claude/CLAUDE.md should contain end marker; got: {content}"
+    );
 }
 
 #[test]
@@ -528,10 +536,18 @@ fn init_claude_appends_to_existing_claude_md() {
         content.contains("Some existing content."),
         "original content should be preserved; got: {content}"
     );
-    // Hint must have been appended
+    // Hint must have been appended with markers
     assert!(
         content.contains("hyalo"),
         "hyalo hint should have been appended; got: {content}"
+    );
+    assert!(
+        content.contains("<!-- hyalo:start -->"),
+        "start marker should be present; got: {content}"
+    );
+    assert!(
+        content.contains("<!-- hyalo:end -->"),
+        "end marker should be present; got: {content}"
     );
 }
 
@@ -541,9 +557,10 @@ fn init_claude_no_duplicate_in_claude_md() {
     let claude_dir = tmp.path().join(".claude");
     fs::create_dir_all(&claude_dir).unwrap();
     let claude_md_path = claude_dir.join("CLAUDE.md");
-    // Pre-populate with the exact hint line
-    let original = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.\n";
-    fs::write(&claude_md_path, original).unwrap();
+    // Pre-populate with the marker-wrapped section (as a prior run would have written).
+    let hint = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.";
+    let original = format!("<!-- hyalo:start -->\n{hint}\n<!-- hyalo:end -->\n");
+    fs::write(&claude_md_path, &original).unwrap();
 
     let output = hyalo()
         .current_dir(tmp.path())
@@ -555,16 +572,135 @@ fn init_claude_no_duplicate_in_claude_md() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "stderr: {stderr}");
     assert!(
-        stdout.contains("skipped"),
-        "expected 'skipped' when hint already present; got: {stdout}"
+        stdout.contains("updated"),
+        "expected 'updated' (replaced managed section) in stdout; got: {stdout}"
     );
 
-    // The file should still contain exactly one copy of the hint
+    // The file should contain exactly one copy of the hint and one pair of markers.
     let content = fs::read_to_string(&claude_md_path).unwrap();
     let occurrences = content.matches("hyalo --help").count();
     assert_eq!(
         occurrences, 1,
         "hint should appear exactly once; got {occurrences} times in: {content}"
+    );
+    assert_eq!(
+        content.matches("<!-- hyalo:start -->").count(),
+        1,
+        "start marker should appear exactly once; got: {content}"
+    );
+    assert_eq!(
+        content.matches("<!-- hyalo:end -->").count(),
+        1,
+        "end marker should appear exactly once; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_updates_managed_section_on_rerun() {
+    // Run init twice; verify the section is replaced (not duplicated) and
+    // surrounding content is preserved.
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    let claude_md_path = claude_dir.join("CLAUDE.md");
+    let surrounding = "# Project Rules\n\nKeep these instructions.\n";
+    fs::write(&claude_md_path, surrounding).unwrap();
+
+    // First run — appends section.
+    let out1 = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+    let stderr1 = String::from_utf8_lossy(&out1.stderr);
+    assert!(out1.status.success(), "first run stderr: {stderr1}");
+
+    // Second run — should replace, not duplicate.
+    let out2 = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+    let stdout2 = String::from_utf8_lossy(&out2.stdout);
+    let stderr2 = String::from_utf8_lossy(&out2.stderr);
+    assert!(out2.status.success(), "second run stderr: {stderr2}");
+    assert!(
+        stdout2.contains("updated"),
+        "second run should report 'updated'; got: {stdout2}"
+    );
+
+    let content = fs::read_to_string(&claude_md_path).unwrap();
+    // Surrounding content preserved.
+    assert!(
+        content.contains("Keep these instructions."),
+        "surrounding content should be preserved; got: {content}"
+    );
+    // Exactly one copy of the managed section.
+    assert_eq!(
+        content.matches("<!-- hyalo:start -->").count(),
+        1,
+        "start marker should appear exactly once; got: {content}"
+    );
+    assert_eq!(
+        content.matches("<!-- hyalo:end -->").count(),
+        1,
+        "end marker should appear exactly once; got: {content}"
+    );
+    assert_eq!(
+        content.matches("hyalo --help").count(),
+        1,
+        "hint should appear exactly once; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_migrates_old_hint_to_managed_section() {
+    // Pre-populate with just the old bare hint line (no markers), then run init.
+    // The hint should be wrapped in markers afterwards.
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    let claude_md_path = claude_dir.join("CLAUDE.md");
+    let old_hint = "Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.";
+    let original = format!("# Header\n\n{old_hint}\n\n# Footer\n");
+    fs::write(&claude_md_path, &original).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("updated"),
+        "expected 'updated' in stdout; got: {stdout}"
+    );
+
+    let content = fs::read_to_string(&claude_md_path).unwrap();
+    assert!(
+        content.contains("# Header"),
+        "header preserved; got: {content}"
+    );
+    assert!(
+        content.contains("# Footer"),
+        "footer preserved; got: {content}"
+    );
+    assert!(
+        content.contains("<!-- hyalo:start -->"),
+        "start marker added; got: {content}"
+    );
+    assert!(
+        content.contains("<!-- hyalo:end -->"),
+        "end marker added; got: {content}"
+    );
+    // Hint should appear exactly once (now inside the managed section).
+    assert_eq!(
+        content.matches("hyalo --help").count(),
+        1,
+        "hint should appear exactly once; got: {content}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_init.rs
+++ b/crates/hyalo-cli/tests/e2e_init.rs
@@ -33,6 +33,7 @@ fn init_creates_hyalo_toml() {
 
 #[test]
 fn init_does_not_overwrite_existing_toml() {
+    // Without an explicit --dir flag, .hyalo.toml is skipped if it already exists.
     let tmp = TempDir::new().unwrap();
     let original = "dir = \"my-vault\"\n";
     fs::write(tmp.path().join(".hyalo.toml"), original).unwrap();
@@ -54,7 +55,34 @@ fn init_does_not_overwrite_existing_toml() {
     let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
     assert_eq!(
         content, original,
-        ".hyalo.toml should not have been modified"
+        ".hyalo.toml should not have been modified when no --dir given"
+    );
+}
+
+#[test]
+fn init_dir_flag_updates_existing_toml() {
+    // When --dir is explicitly given, .hyalo.toml is updated even if it already exists.
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--dir", "new-dir"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("updated"),
+        "expected 'updated' in stdout; got: {stdout}"
+    );
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert_eq!(
+        content, "dir = \"new-dir\"\n",
+        ".hyalo.toml should have been updated to new-dir"
     );
 }
 
@@ -121,6 +149,44 @@ fn init_falls_back_to_dot_when_no_doc_dir() {
     );
 }
 
+#[test]
+fn init_smart_detection_picks_dir_with_most_md() {
+    let tmp = TempDir::new().unwrap();
+
+    // docs: 1 md file
+    fs::create_dir_all(tmp.path().join("docs")).unwrap();
+    fs::write(tmp.path().join("docs").join("a.md"), "# A").unwrap();
+
+    // knowledgebase: 3 md files (including nested)
+    fs::create_dir_all(tmp.path().join("knowledgebase").join("sub")).unwrap();
+    fs::write(tmp.path().join("knowledgebase").join("b.md"), "# B").unwrap();
+    fs::write(
+        tmp.path().join("knowledgebase").join("sub").join("c.md"),
+        "# C",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("knowledgebase").join("sub").join("d.md"),
+        "# D",
+    )
+    .unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        content.contains("dir = \"knowledgebase\""),
+        "should have picked knowledgebase (most .md files); got: {content}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // --claude flag: skill creation
 // ---------------------------------------------------------------------------
@@ -158,12 +224,13 @@ fn init_claude_creates_skill() {
 }
 
 #[test]
-fn init_claude_skips_existing_skill() {
+fn init_claude_overwrites_existing_skill() {
+    // Skills are always overwritten on re-run; summary says "updated".
     let tmp = TempDir::new().unwrap();
     let skill_dir = tmp.path().join(".claude").join("skills").join("hyalo");
     fs::create_dir_all(&skill_dir).unwrap();
     let skill_path = skill_dir.join("SKILL.md");
-    let original = "---\nname: custom\n---\n";
+    let original = "---\nname: custom\n---\nstale content\n";
     fs::write(&skill_path, original).unwrap();
 
     let output = hyalo()
@@ -176,13 +243,20 @@ fn init_claude_skips_existing_skill() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "stderr: {stderr}");
     assert!(
-        stdout.contains("skipped"),
-        "expected 'skipped' in stdout for existing SKILL.md; got: {stdout}"
+        stdout.contains("updated"),
+        "expected 'updated' in stdout for overwritten SKILL.md; got: {stdout}"
     );
 
-    // Content should not have been overwritten
+    // Content should have been replaced with the canonical skill content
     let content = fs::read_to_string(&skill_path).unwrap();
-    assert_eq!(content, original);
+    assert_ne!(
+        content, original,
+        "SKILL.md should have been overwritten, not preserved"
+    );
+    assert!(
+        content.contains("name: hyalo"),
+        "overwritten SKILL.md should contain canonical name field; got: {content}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -225,7 +299,8 @@ fn init_claude_creates_dream_skill() {
 }
 
 #[test]
-fn init_claude_skips_existing_dream_skill() {
+fn init_claude_overwrites_existing_dream_skill() {
+    // Dream skill is always overwritten on re-run; summary says "updated".
     let tmp = TempDir::new().unwrap();
     let dream_skill_dir = tmp
         .path()
@@ -234,7 +309,7 @@ fn init_claude_skips_existing_dream_skill() {
         .join("hyalo-dream");
     fs::create_dir_all(&dream_skill_dir).unwrap();
     let dream_skill_path = dream_skill_dir.join("SKILL.md");
-    let original = "---\nname: custom-dream\n---\n";
+    let original = "---\nname: custom-dream\n---\nstale content\n";
     fs::write(&dream_skill_path, original).unwrap();
 
     let output = hyalo()
@@ -247,14 +322,150 @@ fn init_claude_skips_existing_dream_skill() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "stderr: {stderr}");
     assert!(
-        stdout.contains("skipped"),
-        "expected 'skipped' for existing dream SKILL.md; got: {stdout}"
+        stdout.contains("updated"),
+        "expected 'updated' for overwritten dream SKILL.md; got: {stdout}"
     );
 
     let content = fs::read_to_string(&dream_skill_path).unwrap();
-    assert_eq!(
+    assert_ne!(
         content, original,
-        "dream SKILL.md should not be overwritten"
+        "dream SKILL.md should have been overwritten, not preserved"
+    );
+    assert!(
+        content.contains("name: hyalo-dream"),
+        "overwritten dream SKILL.md should contain canonical name field; got: {content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --claude flag: knowledgebase rule creation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_claude_creates_rule() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let rule_path = tmp
+        .path()
+        .join(".claude")
+        .join("rules")
+        .join("knowledgebase.md");
+    assert!(
+        rule_path.exists(),
+        ".claude/rules/knowledgebase.md should have been created"
+    );
+
+    let content = fs::read_to_string(&rule_path).unwrap();
+    assert!(
+        content.contains("paths:"),
+        "rule should contain a paths: key; got: {content}"
+    );
+    // Should not contain the template placeholder
+    assert!(
+        !content.contains("hyalo-knowledgebase/**"),
+        "rule should have the placeholder replaced; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_overwrites_existing_rule() {
+    // Rule is always overwritten on re-run; summary says "updated".
+    let tmp = TempDir::new().unwrap();
+    let rules_dir = tmp.path().join(".claude").join("rules");
+    fs::create_dir_all(&rules_dir).unwrap();
+    let rule_path = rules_dir.join("knowledgebase.md");
+    let original = "---\npaths:\n  - \"old-vault/**\"\n---\nold content\n";
+    fs::write(&rule_path, original).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("updated"),
+        "expected 'updated' for overwritten rule; got: {stdout}"
+    );
+
+    let content = fs::read_to_string(&rule_path).unwrap();
+    assert_ne!(
+        content, original,
+        "rule should have been overwritten, not preserved"
+    );
+}
+
+#[test]
+fn init_claude_rule_uses_detected_dir() {
+    // When a docs/ dir has .md files, the rule paths should reference docs/**.
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("docs")).unwrap();
+    fs::write(tmp.path().join("docs").join("note.md"), "# Hello").unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let rule_path = tmp
+        .path()
+        .join(".claude")
+        .join("rules")
+        .join("knowledgebase.md");
+    let content = fs::read_to_string(&rule_path).unwrap();
+    assert!(
+        content.contains("docs/**"),
+        "rule paths should reference docs/**; got: {content}"
+    );
+    assert!(
+        !content.contains("hyalo-knowledgebase/**"),
+        "rule should not contain the placeholder; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_rule_uses_explicit_dir() {
+    // --dir my-vault should be reflected in the rule paths.
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude", "--dir", "my-vault"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let rule_path = tmp
+        .path()
+        .join(".claude")
+        .join("rules")
+        .join("knowledgebase.md");
+    let content = fs::read_to_string(&rule_path).unwrap();
+    assert!(
+        content.contains("my-vault/**"),
+        "rule paths should reference my-vault/**; got: {content}"
+    );
+    assert!(
+        !content.contains("hyalo-knowledgebase/**"),
+        "rule should not contain the placeholder; got: {content}"
     );
 }
 
@@ -375,7 +586,7 @@ fn init_prints_summary_of_actions() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "stderr: {stderr}");
     assert!(!stdout.is_empty(), "stdout should contain a summary");
-    // Should mention the toml and the skill at minimum
+    // Should mention the toml and the skills at minimum
     assert!(
         stdout.contains(".hyalo.toml"),
         "summary should mention .hyalo.toml; got: {stdout}"
@@ -391,5 +602,24 @@ fn init_prints_summary_of_actions() {
     assert!(
         stdout.contains("CLAUDE.md"),
         "summary should mention CLAUDE.md; got: {stdout}"
+    );
+}
+
+#[test]
+fn init_summary_mentions_rule() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("rules/knowledgebase.md"),
+        "summary should mention .claude/rules/knowledgebase.md; got: {stdout}"
     );
 }

--- a/hyalo-knowledgebase/iterations/iteration-49-init-improvements.md
+++ b/hyalo-knowledgebase/iterations/iteration-49-init-improvements.md
@@ -1,0 +1,28 @@
+---
+title: "Improve `hyalo init` — overwrite, rules, smart dir detection"
+type: iteration
+date: 2026-03-26
+tags:
+  - cli
+  - init
+  - claude-code
+status: in-progress
+branch: iter-49/init-improvements
+---
+
+## Goal
+
+Make `hyalo init --claude` a reliable one-command setup that installs the latest skills,
+rule, and CLAUDE.md hint — parameterized with the detected (or user-specified) knowledgebase
+directory. Re-running it should update everything to the latest version.
+
+## Tasks
+
+- [x] Smart dir detection: pick the directory with the most `.md` files (recursive count), respect `--dir` flag override
+- [x] Change skill/rule installation from skip to overwrite — always write the latest embedded content
+- [x] Install `.claude/rules/knowledgebase.md` as part of `--claude`, with `paths:` using the detected dir
+- [x] Parameterize rule paths with the detected dir
+- [ ] Hide irrelevant global flags (`--jq`, `--format`, `--index`, `--hints`) from `hyalo init --help` — blocked: clap `global = true` args can't be hidden per-subcommand via `mut_subcommand`
+- [x] Keep `.hyalo.toml` skip behavior (don't overwrite user config) but update dir if re-running with explicit `--dir`
+- [x] Update e2e tests for new overwrite behavior, rule installation, smart dir detection
+- [x] Refactor `run_init` to accept `cwd` parameter for testability (no more `set_current_dir` races)


### PR DESCRIPTION
## Summary

- **Overwrite on re-run**: `hyalo init --claude` now always writes the latest embedded skills and rule files instead of silently skipping when they exist. Summary reports "created" vs "updated".
- **Install `.claude/rules/knowledgebase.md`**: New step installs the knowledgebase rule with `paths:` parameterized to the detected/specified vault directory.
- **Smart dir detection**: Replaces first-match heuristic with recursive `.md` file counting — picks the candidate directory with the most markdown files. Root count excludes candidate and hidden dirs to avoid skew.
- **`.hyalo.toml` update with explicit `--dir`**: If `.hyalo.toml` exists but `--dir` is explicitly given, only the `dir` key is updated (other config keys are preserved).
- **Managed CLAUDE.md section**: Uses `<!-- hyalo:start -->` / `<!-- hyalo:end -->` HTML comment markers (following the emerging community convention used by Nx, Mulch, Skilld, etc.). Re-running `init` reliably replaces the managed section. Auto-migrates from the old bare hint line format.
- **Testability**: Refactored `run_init` to accept `cwd` as parameter, eliminating `set_current_dir` race conditions in parallel unit tests.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 293 unit + 432 integration tests pass
- [x] 22 e2e init tests cover: overwrite, rule creation, parameterized paths, smart detection, toml update/skip, managed section upsert, migration from old hint format
- [x] Unit tests cover: recursive md counting, root-only counting (hidden dir exclusion), auto-detect logic, rule parameterization, YAML escaping, TOML key preservation, managed section upsert/replace/migrate