### PR TITLE
Add Scoop and winget distribution for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,7 @@ jobs:
             --pattern "SHA256SUMS" --dir .
 
       - name: Update Scoop manifest
+        shell: bash
         env:
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
         run: |
@@ -284,39 +285,51 @@ jobs:
             fi
           done
 
-          cat > hyalo.json <<MANIFEST
-          {
-              "version": "${VERSION}",
-              "description": "CLI for exploring and managing Markdown knowledge bases",
-              "homepage": "https://github.com/ractive/hyalo",
-              "license": "MIT",
-              "architecture": {
-                  "64bit": {
-                      "url": "https://github.com/ractive/hyalo/releases/download/v${VERSION}/hyalo-x86_64-pc-windows-msvc.zip",
-                      "hash": "${SHA_WIN_X64}"
-                  },
-                  "arm64": {
-                      "url": "https://github.com/ractive/hyalo/releases/download/v${VERSION}/hyalo-aarch64-pc-windows-msvc.zip",
-                      "hash": "${SHA_WIN_ARM64}"
-                  }
-              },
-              "bin": "hyalo.exe",
-              "checkver": "github",
-              "autoupdate": {
-                  "architecture": {
-                      "64bit": {
-                          "url": "https://github.com/ractive/hyalo/releases/download/v\$version/hyalo-x86_64-pc-windows-msvc.zip"
-                      },
-                      "arm64": {
-                          "url": "https://github.com/ractive/hyalo/releases/download/v\$version/hyalo-aarch64-pc-windows-msvc.zip"
-                      }
-                  }
-              }
-          }
-          MANIFEST
+          RELEASE_URL="https://github.com/ractive/hyalo/releases/download"
 
-          # Remove leading whitespace from heredoc
-          sed -i 's/^          //' hyalo.json
+          jq -n \
+            --arg version "$VERSION" \
+            --arg sha_x64 "$SHA_WIN_X64" \
+            --arg sha_arm64 "$SHA_WIN_ARM64" \
+            --arg release_url "$RELEASE_URL" \
+            '{
+              version: $version,
+              description: "CLI for exploring and managing Markdown knowledge bases",
+              homepage: "https://github.com/ractive/hyalo",
+              license: "MIT",
+              architecture: {
+                "64bit": {
+                  url: "\($release_url)/v\($version)/hyalo-x86_64-pc-windows-msvc.zip",
+                  hash: $sha_x64
+                },
+                arm64: {
+                  url: "\($release_url)/v\($version)/hyalo-aarch64-pc-windows-msvc.zip",
+                  hash: $sha_arm64
+                }
+              },
+              bin: "hyalo.exe",
+              checkver: "github",
+              autoupdate: {
+                architecture: {
+                  "64bit": {
+                    url: "\($release_url)/v$version/hyalo-x86_64-pc-windows-msvc.zip",
+                    hash: {
+                      url: "\($release_url)/v$version/SHA256SUMS",
+                      regex: "([a-fA-F0-9]+)\\s+hyalo-x86_64-pc-windows-msvc.zip"
+                    }
+                  },
+                  arm64: {
+                    url: "\($release_url)/v$version/hyalo-aarch64-pc-windows-msvc.zip",
+                    hash: {
+                      url: "\($release_url)/v$version/SHA256SUMS",
+                      regex: "([a-fA-F0-9]+)\\s+hyalo-aarch64-pc-windows-msvc.zip"
+                    }
+                  }
+                }
+              }
+            }' > hyalo.json
+
+          cat hyalo.json
 
           git clone "https://x-access-token:${SCOOP_BUCKET_TOKEN}@github.com/ractive/scoop-hyalo.git" bucket
           cp hyalo.json bucket/bucket/hyalo.json
@@ -335,6 +348,16 @@ jobs:
     needs: release
     runs-on: windows-latest
     steps:
+      - name: Verify WINGET_TOKEN is set
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "${WINGET_TOKEN}" ]; then
+            echo "ERROR: WINGET_TOKEN secret is not set"
+            exit 1
+          fi
+
       - name: Submit to winget-pkgs
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            cross_compile: true
 
     runs-on: ${{ matrix.os }}
 
@@ -91,10 +94,11 @@ jobs:
         run: ${{ matrix.cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }}
 
       - name: Run tests
+        if: "!matrix.cross_compile"
         run: ${{ matrix.cross && 'cross' || 'cargo' }} test --workspace --target ${{ matrix.target }}
 
       - name: Verify CLI runs
-        if: "!matrix.cross"
+        if: "!matrix.cross && !matrix.cross_compile"
         run: cargo run --release --target ${{ matrix.target }} -p hyalo-cli -- --help
 
       - name: Package (Unix)
@@ -238,3 +242,102 @@ jobs:
             git commit -m "Update hyalo to ${VERSION}"
             git push
           fi
+
+  scoop:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download SHA256SUMS from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ github.event.release.tag_name }}" \
+            --pattern "SHA256SUMS" --dir .
+
+      - name: Update Scoop manifest
+        env:
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SCOOP_BUCKET_TOKEN}" ]; then
+            echo "ERROR: SCOOP_BUCKET_TOKEN secret is not set"
+            exit 1
+          fi
+
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+
+          get_sha() {
+            awk -v file="$1" '$2 == file {print $1}' SHA256SUMS
+          }
+
+          SHA_WIN_X64=$(get_sha "hyalo-x86_64-pc-windows-msvc.zip")
+          SHA_WIN_ARM64=$(get_sha "hyalo-aarch64-pc-windows-msvc.zip")
+
+          for var in SHA_WIN_X64 SHA_WIN_ARM64; do
+            if [ -z "${!var}" ]; then
+              echo "ERROR: missing SHA256 checksum for $var"
+              exit 1
+            fi
+          done
+
+          cat > hyalo.json <<MANIFEST
+          {
+              "version": "${VERSION}",
+              "description": "CLI for exploring and managing Markdown knowledge bases",
+              "homepage": "https://github.com/ractive/hyalo",
+              "license": "MIT",
+              "architecture": {
+                  "64bit": {
+                      "url": "https://github.com/ractive/hyalo/releases/download/v${VERSION}/hyalo-x86_64-pc-windows-msvc.zip",
+                      "hash": "${SHA_WIN_X64}"
+                  },
+                  "arm64": {
+                      "url": "https://github.com/ractive/hyalo/releases/download/v${VERSION}/hyalo-aarch64-pc-windows-msvc.zip",
+                      "hash": "${SHA_WIN_ARM64}"
+                  }
+              },
+              "bin": "hyalo.exe",
+              "checkver": "github",
+              "autoupdate": {
+                  "architecture": {
+                      "64bit": {
+                          "url": "https://github.com/ractive/hyalo/releases/download/v\$version/hyalo-x86_64-pc-windows-msvc.zip"
+                      },
+                      "arm64": {
+                          "url": "https://github.com/ractive/hyalo/releases/download/v\$version/hyalo-aarch64-pc-windows-msvc.zip"
+                      }
+                  }
+              }
+          }
+          MANIFEST
+
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' hyalo.json
+
+          git clone "https://x-access-token:${SCOOP_BUCKET_TOKEN}@github.com/ractive/scoop-hyalo.git" bucket
+          cp hyalo.json bucket/bucket/hyalo.json
+          cd bucket
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/hyalo.json
+          if git diff --cached --quiet; then
+            echo "Manifest unchanged, skipping commit"
+          else
+            git commit -m "Update hyalo to ${VERSION}"
+            git push
+          fi
+
+  winget:
+    needs: release
+    runs-on: windows-latest
+    steps:
+      - name: Submit to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: ractive.hyalo
+          installers-regex: 'hyalo-.*-pc-windows-msvc\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
             os: windows-latest
           - target: aarch64-pc-windows-msvc
             os: windows-latest
-            cross_compile: true
+            skip_tests: true
 
     runs-on: ${{ matrix.os }}
 
@@ -94,11 +94,11 @@ jobs:
         run: ${{ matrix.cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }}
 
       - name: Run tests
-        if: "!matrix.cross_compile"
+        if: "!matrix.skip_tests"
         run: ${{ matrix.cross && 'cross' || 'cargo' }} test --workspace --target ${{ matrix.target }}
 
       - name: Verify CLI runs
-        if: "!matrix.cross && !matrix.cross_compile"
+        if: "!matrix.cross && !matrix.skip_tests"
         run: cargo run --release --target ${{ matrix.target }} -p hyalo-cli -- --help
 
       - name: Package (Unix)
@@ -247,8 +247,6 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
       - name: Download SHA256SUMS from release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -275,8 +273,8 @@ jobs:
             awk -v file="$1" '$2 == file {print $1}' SHA256SUMS
           }
 
-          SHA_WIN_X64=$(get_sha "hyalo-x86_64-pc-windows-msvc.zip")
-          SHA_WIN_ARM64=$(get_sha "hyalo-aarch64-pc-windows-msvc.zip")
+          SHA_WIN_X64=$(get_sha "hyalo-x86_64-pc-windows-msvc\\.zip")
+          SHA_WIN_ARM64=$(get_sha "hyalo-aarch64-pc-windows-msvc\\.zip")
 
           for var in SHA_WIN_X64 SHA_WIN_ARM64; do
             if [ -z "${!var}" ]; then
@@ -299,11 +297,11 @@ jobs:
               license: "MIT",
               architecture: {
                 "64bit": {
-                  url: "\($release_url)/v\($version)/hyalo-x86_64-pc-windows-msvc.zip",
+                  url: "\($release_url)/v\($version)/hyalo-x86_64-pc-windows-msvc\\.zip",
                   hash: $sha_x64
                 },
                 arm64: {
-                  url: "\($release_url)/v\($version)/hyalo-aarch64-pc-windows-msvc.zip",
+                  url: "\($release_url)/v\($version)/hyalo-aarch64-pc-windows-msvc\\.zip",
                   hash: $sha_arm64
                 }
               },
@@ -312,17 +310,17 @@ jobs:
               autoupdate: {
                 architecture: {
                   "64bit": {
-                    url: "\($release_url)/v$version/hyalo-x86_64-pc-windows-msvc.zip",
+                    url: "\($release_url)/v$version/hyalo-x86_64-pc-windows-msvc\\.zip",
                     hash: {
                       url: "\($release_url)/v$version/SHA256SUMS",
-                      regex: "([a-fA-F0-9]+)\\s+hyalo-x86_64-pc-windows-msvc.zip"
+                      regex: "([a-fA-F0-9]+)\\s+hyalo-x86_64-pc-windows-msvc\\.zip"
                     }
                   },
                   arm64: {
-                    url: "\($release_url)/v$version/hyalo-aarch64-pc-windows-msvc.zip",
+                    url: "\($release_url)/v$version/hyalo-aarch64-pc-windows-msvc\\.zip",
                     hash: {
                       url: "\($release_url)/v$version/SHA256SUMS",
-                      regex: "([a-fA-F0-9]+)\\s+hyalo-aarch64-pc-windows-msvc.zip"
+                      regex: "([a-fA-F0-9]+)\\s+hyalo-aarch64-pc-windows-msvc\\.zip"
                     }
                   }
                 }
@@ -331,9 +329,9 @@ jobs:
 
           cat hyalo.json
 
-          git clone "https://x-access-token:${SCOOP_BUCKET_TOKEN}@github.com/ractive/scoop-hyalo.git" bucket
-          cp hyalo.json bucket/bucket/hyalo.json
-          cd bucket
+          git clone "https://x-access-token:${SCOOP_BUCKET_TOKEN}@github.com/ractive/scoop-hyalo.git" scoop-repo
+          cp hyalo.json scoop-repo/bucket/hyalo.json
+          cd scoop-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add bucket/hyalo.json
@@ -346,7 +344,7 @@ jobs:
 
   winget:
     needs: release
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Verify WINGET_TOKEN is set
         env:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ brew tap ractive/tap
 brew install ractive/tap/hyalo
 ```
 
+### Scoop (Windows)
+
+```powershell
+scoop bucket add hyalo https://github.com/ractive/scoop-hyalo
+scoop install hyalo
+```
+
+### winget (Windows)
+
+```powershell
+winget install ractive.hyalo
+```
+
 ### Cargo (Intel Mac & other platforms)
 
 ```sh
@@ -21,7 +34,7 @@ cargo install --git https://github.com/ractive/hyalo.git --locked
 
 ### Manual download
 
-Download pre-built binaries from the [GitHub Releases](https://github.com/ractive/hyalo/releases) page.
+Download pre-built binaries from the [GitHub Releases](https://github.com/ractive/hyalo/releases) page. Binaries are available for Linux (x86_64, ARM64, glibc and musl), macOS (Apple Silicon), and Windows (x86_64, ARM64).
 
 ## Build
 

--- a/hyalo-knowledgebase/iterations/iteration-53-windows-package-managers.md
+++ b/hyalo-knowledgebase/iterations/iteration-53-windows-package-managers.md
@@ -1,0 +1,23 @@
+---
+title: "Windows Package Managers (Scoop & winget)"
+type: iteration
+date: 2026-03-27
+tags:
+  - distribution
+  - windows
+  - ci
+status: in-progress
+branch: iter-53/windows-package-managers
+---
+
+# Iteration 53 — Windows Package Managers (Scoop & winget)
+
+Add Scoop and winget distribution for hyalo on Windows, plus ARM64 Windows build target.
+
+## Tasks
+
+- [ ] Add `aarch64-pc-windows-msvc` to the release build matrix (skip tests — can't run ARM on x86 runner)
+- [ ] Add `scoop` job to release workflow that generates manifest and pushes to `ractive/scoop-hyalo`
+- [ ] Add `winget` job to release workflow using winget-releaser action
+- [ ] Document required secrets: `SCOOP_BUCKET_TOKEN`, `WINGET_TOKEN`
+- [ ] Run CI validation (fmt, clippy, test)


### PR DESCRIPTION
## Summary
- Add `aarch64-pc-windows-msvc` (ARM64 Windows) to the release build matrix, with tests skipped since ARM binaries can't run on the x86 GitHub runner
- Add **Scoop** job: uses `jq` to generate a manifest with x64 + arm64 architectures (including autoupdate with hash verification via SHA256SUMS) and pushes to `ractive/scoop-hyalo` bucket repo
- Add **winget** job: uses `vedantmgoyal9/winget-releaser` to auto-submit PRs to `microsoft/winget-pkgs`, with `WINGET_TOKEN` pre-check for consistent error handling
- Update **README** with Scoop, winget, and updated manual download instructions (now lists ARM64 Windows)

### Setup required before first release
1. Create repo `ractive/scoop-hyalo` with a `bucket/` directory
2. Add secrets to `ractive/hyalo`: `SCOOP_BUCKET_TOKEN` (PAT → push to scoop-hyalo) and `WINGET_TOKEN` (PAT → `public_repo` scope for winget-pkgs PRs)

## Test plan
- [ ] Verify YAML is valid (validated locally with yaml-lint)
- [ ] Verify ARM64 Windows build compiles on `windows-latest` runner
- [ ] Verify Scoop manifest JSON is well-formed (validated locally with jq)
- [ ] First release: confirm winget-releaser creates a PR to winget-pkgs
- [ ] First release: confirm Scoop manifest is pushed to scoop-hyalo bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)