### PR TITLE
Replace serde_yaml_ng with serde-saphyr (safe Rust YAML parser)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +38,17 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
 
 [[package]]
 name = "anstream"
@@ -81,6 +105,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "assert_cmd"
@@ -336,6 +366,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,13 +428,27 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -463,8 +525,8 @@ dependencies = [
  "predicates",
  "regex",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml_ng",
  "tempfile",
  "toml",
 ]
@@ -482,8 +544,8 @@ dependencies = [
  "regex",
  "rmp-serde",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml_ng",
  "tempfile",
 ]
 
@@ -665,6 +727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +853,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -883,18 +957,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saphyr-parser-bw"
+version = "0.0.610"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d643f5e972f17219245b82f038c22cd3c74320bb17c6e8f7e8537de268b1bc6"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -911,6 +990,26 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546b4da4f679832602a8f8ab8ddc10b6b1d2e1a13b4f9dddcaee499436fa06ad"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "nohash-hasher",
+ "num-traits",
+ "regex",
+ "saphyr-parser-bw",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -956,23 +1055,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -998,7 +1090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1009,6 +1101,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinytemplate"
@@ -1074,16 +1186,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "urlencoding"
@@ -1096,6 +1208,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ predicates = "3"
 regex = "1"
 rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }
+serde-saphyr = "0.0.22"
 serde_json = "1.0.149"
-serde_yaml_ng = "0.10"
 tempfile = "3"
 toml = "0.8"
 

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -19,8 +19,8 @@ jaq-std = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde-saphyr = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml_ng = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
 use serde::Serialize;
-use serde_yaml_ng::Value;
+use serde_json::Value;
 use std::path::Path;
 
 use crate::commands::set::parse_kv;
@@ -48,10 +48,10 @@ fn append_value_in_memory(
 ) -> Result<bool> {
     match props.get(name).cloned() {
         None | Some(Value::Null) => {
-            props.insert(name.to_owned(), Value::Sequence(vec![new_val.clone()]));
+            props.insert(name.to_owned(), Value::Array(vec![new_val.clone()]));
             Ok(true)
         }
-        Some(Value::Sequence(mut seq)) => {
+        Some(Value::Array(mut seq)) => {
             let already_present = seq.iter().any(|v| match v {
                 Value::String(s) => s.eq_ignore_ascii_case(raw_value),
                 Value::Number(n) => n.to_string().eq_ignore_ascii_case(raw_value),
@@ -62,7 +62,7 @@ fn append_value_in_memory(
                 Ok(false)
             } else {
                 seq.push(new_val.clone());
-                props.insert(name.to_owned(), Value::Sequence(seq));
+                props.insert(name.to_owned(), Value::Array(seq));
                 Ok(true)
             }
         }
@@ -70,7 +70,7 @@ fn append_value_in_memory(
             if existing.eq_ignore_ascii_case(raw_value) {
                 Ok(false)
             } else {
-                let list = Value::Sequence(vec![Value::String(existing), new_val.clone()]);
+                let list = Value::Array(vec![Value::String(existing), new_val.clone()]);
                 props.insert(name.to_owned(), list);
                 Ok(true)
             }
@@ -79,7 +79,7 @@ fn append_value_in_memory(
             if n.to_string().eq_ignore_ascii_case(raw_value) {
                 Ok(false)
             } else {
-                let list = Value::Sequence(vec![Value::Number(n), new_val.clone()]);
+                let list = Value::Array(vec![Value::Number(n), new_val.clone()]);
                 props.insert(name.to_owned(), list);
                 Ok(true)
             }
@@ -88,15 +88,14 @@ fn append_value_in_memory(
             if b.to_string().eq_ignore_ascii_case(raw_value) {
                 Ok(false)
             } else {
-                let list = Value::Sequence(vec![Value::Bool(b), new_val.clone()]);
+                let list = Value::Array(vec![Value::Bool(b), new_val.clone()]);
                 props.insert(name.to_owned(), list);
                 Ok(true)
             }
         }
         Some(other) => {
             let kind = match &other {
-                Value::Mapping(_) => "mapping",
-                Value::Tagged(_) => "tagged",
+                Value::Object(_) => "mapping",
                 _ => "unknown",
             };
             anyhow::bail!("property '{name}' is a {kind} value — cannot append to it");

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -875,7 +875,7 @@ use super::format_iso8601;
 fn build_file_object(
     rel_path: &str,
     modified: &str,
-    props: &BTreeMap<String, serde_yaml_ng::Value>,
+    props: &BTreeMap<String, serde_json::Value>,
     tags: &[String],
     fields: &Fields,
     outline_sections: Option<Vec<OutlineSection>>,

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -692,7 +692,7 @@ pub fn find_from_index(
                 .iter()
                 .filter(|(n, _)| n.as_str() != "tags")
             {
-                map.insert(name.clone(), hyalo_core::frontmatter::yaml_to_json(value));
+                map.insert(name.clone(), value.clone());
             }
             Some(map)
         } else {
@@ -708,7 +708,7 @@ pub fn find_from_index(
                     .map(|(name, value)| PropertyInfo {
                         name: name.clone(),
                         prop_type: hyalo_core::frontmatter::infer_type(value).to_owned(),
-                        value: hyalo_core::frontmatter::yaml_to_json(value),
+                        value: value.clone(),
                     })
                     .collect(),
             )
@@ -890,7 +890,7 @@ fn build_file_object(
     let properties = if fields.properties {
         let mut map = serde_json::Map::new();
         for (name, value) in props.iter().filter(|(n, _)| n.as_str() != "tags") {
-            map.insert(name.clone(), frontmatter::yaml_to_json(value));
+            map.insert(name.clone(), value.clone());
         }
         Some(map)
     } else {
@@ -905,7 +905,7 @@ fn build_file_object(
                 .map(|(name, value)| PropertyInfo {
                     name: name.clone(),
                     prop_type: frontmatter::infer_type(value).to_owned(),
-                    value: frontmatter::yaml_to_json(value),
+                    value: value.clone(),
                 })
                 .collect(),
         )

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -406,7 +406,7 @@ title: Good Note
 "),
         )
         .unwrap();
-        // Malformed YAML: a bare colon key is rejected by serde_yaml_ng.
+        // Malformed YAML: a bare colon key is rejected by serde_saphyr.
         fs::write(
             tmp.path().join("bad.md"),
             "---\n: invalid yaml [[[{\n---\n# Bad\n",

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -310,7 +310,7 @@ pub fn run(
                 // Render frontmatter as YAML
                 out.push_str("---\n");
                 if !props.is_empty() {
-                    let yaml = serde_yaml_ng::to_string(props)
+                    let yaml = serde_saphyr::to_string(props)
                         .context("failed to serialize frontmatter as YAML")?;
                     out.push_str(&yaml);
                 }

--- a/crates/hyalo-cli/src/commands/remove.rs
+++ b/crates/hyalo-cli/src/commands/remove.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
 use serde::Serialize;
-use serde_yaml_ng::Value;
+use serde_json::Value;
 use std::path::Path;
 
 use crate::commands::tags::validate_tag;
@@ -87,11 +87,11 @@ fn remove_value_in_memory(
     target: &str,
 ) -> bool {
     // Check what kind of value we have without cloning.
-    let is_sequence = matches!(props.get(name), Some(Value::Sequence(_)));
+    let is_sequence = matches!(props.get(name), Some(Value::Array(_)));
 
     if is_sequence {
         // Sequence arm: mutate in place, no clone needed.
-        let Some(Value::Sequence(seq)) = props.get_mut(name) else {
+        let Some(Value::Array(seq)) = props.get_mut(name) else {
             unreachable!()
         };
         let before = seq.len();

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::Result;
 use serde::Serialize;
-use serde_yaml_ng::Value;
+use serde_json::Value;
 use std::path::Path;
 
 use crate::commands::{FilesOrOutcome, collect_files, require_file_or_glob};
@@ -78,12 +78,12 @@ fn add_tag_in_memory(
 
     // Guard: reject non-list scalar types that are neither string nor sequence.
     match props.get(KEY) {
-        None | Some(Value::Null | Value::String(_) | Value::Sequence(_)) => {}
+        None | Some(Value::Null | Value::String(_) | Value::Array(_)) => {}
         Some(existing) => {
             let kind = match existing {
                 Value::Bool(_) => "boolean",
                 Value::Number(_) => "number",
-                Value::Mapping(_) => "mapping",
+                Value::Object(_) => "mapping",
                 _ => "unknown",
             };
             anyhow::bail!(
@@ -93,7 +93,7 @@ fn add_tag_in_memory(
         }
     }
 
-    if let Some(Value::Sequence(seq)) = props.get_mut(KEY) {
+    if let Some(Value::Array(seq)) = props.get_mut(KEY) {
         let already = seq.iter().any(|v| match v {
             Value::String(s) => s.eq_ignore_ascii_case(tag),
             Value::Number(n) => n.to_string().eq_ignore_ascii_case(tag),
@@ -121,7 +121,7 @@ fn add_tag_in_memory(
 
         let mut list: Vec<Value> = existing_str.map(Value::String).into_iter().collect();
         list.push(Value::String(tag.to_owned()));
-        props.insert(KEY.to_owned(), Value::Sequence(list));
+        props.insert(KEY.to_owned(), Value::Array(list));
         Ok(true)
     }
 }

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 use crate::commands::{FilesOrOutcome, collect_files};
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::filter::extract_tags;
-use hyalo_core::frontmatter::{infer_type, yaml_to_json};
+use hyalo_core::frontmatter::infer_type;
 use hyalo_core::index::VaultIndex;
 use hyalo_core::link_graph::{FileLinks, LinkGraph, LinkGraphVisitor};
 use hyalo_core::scanner::{FrontmatterCollector, scan_file_multi};
@@ -114,7 +114,7 @@ pub fn summary(
 
         // Status grouping
         if let Some(status_val) = props.get("status") {
-            let status_str = match yaml_to_json(status_val) {
+            let status_str = match status_val.clone() {
                 serde_json::Value::String(s) => s,
                 other => other.to_string(),
             };
@@ -320,7 +320,7 @@ pub fn summary_from_index(
 
         // Status grouping
         if let Some(status_val) = entry.properties.get("status") {
-            let status_str = match yaml_to_json(status_val) {
+            let status_str = match status_val.clone() {
                 serde_json::Value::String(s) => s,
                 other => other.to_string(),
             };

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -10,7 +10,7 @@ use hyalo_core::frontmatter;
 use hyalo_core::index::{SnapshotIndex, VaultIndex, format_modified};
 use hyalo_core::types::{TagSummary, TagSummaryEntry};
 use serde::Serialize;
-use serde_yaml_ng::Value;
+use serde_json::Value;
 
 // ---------------------------------------------------------------------------
 // Tag format validation
@@ -222,7 +222,7 @@ pub fn tags_rename(
         // Remove old tag and add new tag, handling both sequence and scalar forms
         let mut remove_tags_key = false;
         match props.get_mut("tags") {
-            Some(Value::Sequence(seq)) => {
+            Some(Value::Array(seq)) => {
                 seq.retain(|v| match v {
                     Value::String(s) => !s.eq_ignore_ascii_case(from),
                     _ => true,
@@ -286,7 +286,7 @@ pub fn tags_rename(
 mod tests {
     use super::*;
     use hyalo_core::filter::tag_matches;
-    use serde_yaml_ng::Value;
+    use serde_json::Value;
     use std::fs;
 
     macro_rules! md {
@@ -371,7 +371,7 @@ mod tests {
     // --- Tag extraction ---
 
     fn make_props(yaml: &str) -> BTreeMap<String, Value> {
-        serde_yaml_ng::from_str(yaml).unwrap()
+        serde_saphyr::from_str(yaml).unwrap()
     }
 
     #[test]
@@ -630,7 +630,7 @@ tags:
 "),
         )
         .unwrap();
-        // Malformed YAML: a bare colon key is rejected by serde_yaml_ng.
+        // Malformed YAML: a bare colon key is rejected by serde_saphyr.
         fs::write(
             tmp.path().join("bad.md"),
             "---\n: invalid yaml [[[{\n---\n# Bad\n",

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -14,8 +14,8 @@ libc = { workspace = true }
 regex = { workspace = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde-saphyr = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml_ng = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hyalo-core/src/filter.rs
+++ b/crates/hyalo-core/src/filter.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use regex::Regex;
-use serde_yaml_ng::Value;
+use serde_json::Value;
 use std::collections::BTreeMap;
 
 // ---------------------------------------------------------------------------
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 #[must_use]
 pub fn extract_tags(props: &BTreeMap<String, Value>) -> Vec<String> {
     match props.get("tags") {
-        Some(Value::Sequence(seq)) => seq
+        Some(Value::Array(seq)) => seq
             .iter()
             .filter_map(|v| match v {
                 Value::String(s) => Some(s.clone()),
@@ -389,17 +389,13 @@ fn yaml_value_regex_match(yaml: &Value, pattern: &Regex) -> bool {
         Value::String(s) => pattern.is_match(s),
         Value::Number(n) => pattern.is_match(&n.to_string()),
         Value::Bool(b) => pattern.is_match(if *b { "true" } else { "false" }),
-        Value::Sequence(seq) => seq.iter().any(|item| yaml_value_regex_match(item, pattern)),
+        Value::Array(seq) => seq.iter().any(|item| yaml_value_regex_match(item, pattern)),
         // For mappings, match against keys and recurse into values.
         // This allows `versions~=ghes` to match `{fpt: "*", ghes: "*"}`.
-        Value::Mapping(map) => map.iter().any(|(k, v)| {
-            let key_matches = match k {
-                Value::String(s) => pattern.is_match(s),
-                _ => false,
-            };
-            key_matches || yaml_value_regex_match(v, pattern)
-        }),
-        _ => false,
+        Value::Object(map) => map
+            .iter()
+            .any(|(k, v)| pattern.is_match(k) || yaml_value_regex_match(v, pattern)),
+        Value::Null => false,
     }
 }
 
@@ -425,7 +421,7 @@ fn yaml_value_eq(yaml: &Value, filter: &str) -> bool {
         Value::Bool(b) => parse_bool_filter(filter)
             .map(|fv| fv == *b)
             .unwrap_or(false),
-        Value::Sequence(seq) => seq.iter().any(|item| yaml_value_eq(item, filter)),
+        Value::Array(seq) => seq.iter().any(|item| yaml_value_eq(item, filter)),
         _ => yaml
             .as_str()
             .map(|s| str_eq_ignore_case(s, filter))
@@ -617,7 +613,7 @@ pub fn parse_sort(input: &str) -> Result<SortField> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_yaml_ng::Value;
+    use serde_json::{Value, json};
     use std::collections::BTreeMap;
 
     // -----------------------------------------------------------------------
@@ -924,7 +920,7 @@ mod tests {
     fn match_regex_list_any_element() {
         let p = props(&[(
             "tags",
-            Value::Sequence(vec![
+            Value::Array(vec![
                 Value::String("rust".into()),
                 Value::String("cli-tool".into()),
             ]),
@@ -964,11 +960,7 @@ mod tests {
     #[test]
     fn match_regex_mapping_key() {
         // versions: {fpt: "*", ghes: "*", ghec: "*"}
-        let mut map = serde_yaml_ng::Mapping::new();
-        map.insert(Value::String("fpt".into()), Value::String("*".into()));
-        map.insert(Value::String("ghes".into()), Value::String("*".into()));
-        map.insert(Value::String("ghec".into()), Value::String("*".into()));
-        let p = props(&[("versions", Value::Mapping(map))]);
+        let p = props(&[("versions", json!({"fpt": "*", "ghes": "*", "ghec": "*"}))]);
         let f = parse_property_filter("versions~=ghes").unwrap();
         assert!(f.matches(&p));
         let f2 = parse_property_filter("versions~=nonexistent").unwrap();
@@ -977,9 +969,7 @@ mod tests {
 
     #[test]
     fn match_regex_mapping_value() {
-        let mut map = serde_yaml_ng::Mapping::new();
-        map.insert(Value::String("ghes".into()), Value::String(">=3.10".into()));
-        let p = props(&[("versions", Value::Mapping(map))]);
+        let p = props(&[("versions", json!({"ghes": ">=3.10"}))]);
         // Match on the value, not the key
         let f = parse_property_filter("versions~=3\\.10").unwrap();
         assert!(f.matches(&p));
@@ -1046,7 +1036,7 @@ mod tests {
     fn match_list_eq_any_element() {
         let p = props(&[(
             "tags",
-            Value::Sequence(vec![
+            Value::Array(vec![
                 Value::String("rust".into()),
                 Value::String("cli".into()),
             ]),
@@ -1060,7 +1050,7 @@ mod tests {
     fn match_list_neq_none_match() {
         let p = props(&[(
             "tags",
-            Value::Sequence(vec![
+            Value::Array(vec![
                 Value::String("rust".into()),
                 Value::String("cli".into()),
             ]),
@@ -1220,10 +1210,10 @@ mod tests {
 
     #[test]
     fn matches_frontmatter_filters_list_property() {
-        // Value is a YAML sequence — filter matches any element.
+        // Value is a YAML array — filter matches any element.
         let p = props(&[(
             "tags",
-            Value::Sequence(vec![
+            Value::Array(vec![
                 Value::String("rust".into()),
                 Value::String("cli".into()),
             ]),
@@ -1243,7 +1233,7 @@ mod tests {
         // Nested tag: query "inbox" matches tag "inbox/processing".
         let p = props(&[(
             "tags",
-            Value::Sequence(vec![Value::String("inbox/processing".into())]),
+            Value::Array(vec![Value::String("inbox/processing".into())]),
         )]);
         let tag_filters = vec!["inbox".to_owned()];
         assert!(matches_frontmatter_filters(&p, &[], &tag_filters));
@@ -1262,7 +1252,7 @@ mod tests {
         // Both property and tag filters must pass.
         let p = props(&[
             ("status", Value::String("done".into())),
-            ("tags", Value::Sequence(vec![Value::String("rust".into())])),
+            ("tags", Value::Array(vec![Value::String("rust".into())])),
         ]);
         let prop_filters = [parse_property_filter("status=done").unwrap()];
         let tag_filters = vec!["rust".to_owned()];

--- a/crates/hyalo-core/src/frontmatter.rs
+++ b/crates/hyalo-core/src/frontmatter.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
-use serde_yaml_ng::Value;
+use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
@@ -32,7 +32,7 @@ impl Document {
 
         let properties: BTreeMap<String, Value> = match yaml_str {
             Some(yaml) if !yaml.trim().is_empty() => {
-                serde_yaml_ng::from_str(yaml).context("failed to parse YAML frontmatter")?
+                serde_saphyr::from_str(yaml).context("failed to parse YAML frontmatter")?
             }
             _ => BTreeMap::new(),
         };
@@ -50,7 +50,7 @@ impl Document {
         if !self.properties.is_empty() {
             out.push_str("---\n");
             let yaml =
-                serde_yaml_ng::to_string(&self.properties).context("failed to serialize YAML")?;
+                serde_saphyr::to_string(&self.properties).context("failed to serialize YAML")?;
             out.push_str(&yaml);
             // serde_yaml adds a trailing newline, but let's ensure
             if !yaml.ends_with('\n') {
@@ -124,7 +124,7 @@ pub fn write_frontmatter(path: &Path, props: &BTreeMap<String, Value>) -> Result
     let mut out: Vec<u8> = Vec::new();
     if !props.is_empty() {
         out.extend_from_slice(b"---\n");
-        let yaml = serde_yaml_ng::to_string(props).context("failed to serialize YAML")?;
+        let yaml = serde_saphyr::to_string(props).context("failed to serialize YAML")?;
         out.extend_from_slice(yaml.as_bytes());
         if !yaml.ends_with('\n') {
             out.push(b'\n');
@@ -282,7 +282,7 @@ fn read_frontmatter_from_reader<R: BufRead>(reader: R) -> Result<BTreeMap<String
         return Ok(BTreeMap::new());
     }
 
-    serde_yaml_ng::from_str(&yaml).context("failed to parse YAML frontmatter")
+    serde_saphyr::from_str(&yaml).context("failed to parse YAML frontmatter")
 }
 
 /// Extract frontmatter YAML string and the body from a markdown document.
@@ -371,9 +371,9 @@ pub fn infer_type(value: &Value) -> &'static str {
     match value {
         Value::Bool(_) => "checkbox",
         Value::Number(_) => "number",
-        Value::Sequence(_) => "list",
+        Value::Array(_) => "list",
         Value::String(s) => infer_string_type(s),
-        Value::Null | Value::Mapping(_) | Value::Tagged(_) => "text",
+        Value::Null | Value::Object(_) => "text",
     }
 }
 
@@ -430,7 +430,9 @@ pub fn parse_value(raw: &str, forced_type: Option<&str>) -> Result<Value> {
             } else {
                 let f: f64 = raw.parse().context("value is not a valid number")?;
                 anyhow::ensure!(f.is_finite(), "value is not a finite number");
-                Ok(Value::Number(serde_yaml_ng::Number::from(f)))
+                Ok(Value::Number(
+                    serde_json::Number::from_f64(f).unwrap_or_else(|| serde_json::Number::from(0)),
+                ))
             }
         }
         Some("checkbox") => {
@@ -458,7 +460,7 @@ pub fn parse_value(raw: &str, forced_type: Option<&str>) -> Result<Value> {
                 .split(',')
                 .map(|s| Value::String(s.trim().to_owned()))
                 .collect();
-            Ok(Value::Sequence(items))
+            Ok(Value::Array(items))
         }
         Some(other) => anyhow::bail!("unknown type: {other}"),
         None => Ok(infer_value(raw)),
@@ -475,7 +477,9 @@ fn infer_value(raw: &str) -> Value {
     if let Ok(f) = raw.parse::<f64>()
         && f.is_finite()
     {
-        return Value::Number(serde_yaml_ng::Number::from(f));
+        return Value::Number(
+            serde_json::Number::from_f64(f).unwrap_or_else(|| serde_json::Number::from(0)),
+        );
     }
     // Try bool
     match raw {
@@ -488,49 +492,24 @@ fn infer_value(raw: &str) -> Value {
         let inner = &raw[1..raw.len() - 1];
         // Empty brackets = empty list
         if inner.trim().is_empty() {
-            return Value::Sequence(Vec::new());
+            return Value::Array(Vec::new());
         }
         // Split by comma, trim each item, keep as strings
         let items: Vec<Value> = inner
             .split(',')
             .map(|s| Value::String(s.trim().to_owned()))
             .collect();
-        return Value::Sequence(items);
+        return Value::Array(items);
     }
     Value::String(raw.to_owned())
 }
 
 /// Convert a YAML value to a `serde_json::Value` for output.
+///
+/// Since `Value` is already `serde_json::Value`, this is an identity clone.
+/// Kept as a public API for callers that previously needed type conversion.
 pub fn yaml_to_json(value: &Value) -> serde_json::Value {
-    match value {
-        Value::Null => serde_json::Value::Null,
-        Value::Bool(b) => serde_json::Value::Bool(*b),
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                serde_json::Value::Number(i.into())
-            } else if let Some(f) = n.as_f64() {
-                serde_json::json!(f)
-            } else {
-                serde_json::Value::Null
-            }
-        }
-        Value::String(s) => serde_json::Value::String(s.clone()),
-        Value::Sequence(seq) => serde_json::Value::Array(seq.iter().map(yaml_to_json).collect()),
-        Value::Mapping(map) => {
-            let obj: serde_json::Map<String, serde_json::Value> = map
-                .iter()
-                .map(|(k, v)| {
-                    let key = match k {
-                        Value::String(s) => s.clone(),
-                        _ => format!("{k:?}"),
-                    };
-                    (key, yaml_to_json(v))
-                })
-                .collect();
-            serde_json::Value::Object(obj)
-        }
-        Value::Tagged(tagged) => yaml_to_json(&tagged.value),
-    }
+    value.clone()
 }
 
 #[cfg(test)]
@@ -624,7 +603,7 @@ No closing delimiter.
     #[test]
     fn infer_type_list() {
         assert_eq!(
-            infer_type(&Value::Sequence(vec![Value::String("a".into())])),
+            infer_type(&Value::Array(vec![Value::String("a".into())])),
             "list"
         );
     }
@@ -699,8 +678,8 @@ Body
         }
         // Force list
         match parse_value("a, b, c", Some("list")).unwrap() {
-            Value::Sequence(items) => assert_eq!(items.len(), 3),
-            other => panic!("expected sequence, got {other:?}"),
+            Value::Array(items) => assert_eq!(items.len(), 3),
+            other => panic!("expected array, got {other:?}"),
         }
     }
 
@@ -941,20 +920,20 @@ Body.
     #[test]
     fn infer_value_list_basic() {
         match parse_value("[a, b, c]", None).unwrap() {
-            Value::Sequence(items) => {
+            Value::Array(items) => {
                 assert_eq!(items.len(), 3);
                 assert_eq!(items[0], Value::String("a".to_owned()));
                 assert_eq!(items[1], Value::String("b".to_owned()));
                 assert_eq!(items[2], Value::String("c".to_owned()));
             }
-            other => panic!("expected sequence, got {other:?}"),
+            other => panic!("expected array, got {other:?}"),
         }
     }
 
     #[test]
     fn infer_value_list_empty() {
         match parse_value("[]", None).unwrap() {
-            Value::Sequence(items) => assert!(items.is_empty()),
+            Value::Array(items) => assert!(items.is_empty()),
             other => panic!("expected empty sequence, got {other:?}"),
         }
     }
@@ -962,11 +941,11 @@ Body.
     #[test]
     fn infer_value_list_single_item() {
         match parse_value("[single]", None).unwrap() {
-            Value::Sequence(items) => {
+            Value::Array(items) => {
                 assert_eq!(items.len(), 1);
                 assert_eq!(items[0], Value::String("single".to_owned()));
             }
-            other => panic!("expected sequence, got {other:?}"),
+            other => panic!("expected array, got {other:?}"),
         }
     }
 
@@ -982,12 +961,12 @@ Body.
     #[test]
     fn infer_value_list_whitespace_trimmed() {
         match parse_value("[  a , b ,  c  ]", None).unwrap() {
-            Value::Sequence(items) => {
+            Value::Array(items) => {
                 assert_eq!(items[0], Value::String("a".to_owned()));
                 assert_eq!(items[1], Value::String("b".to_owned()));
                 assert_eq!(items[2], Value::String("c".to_owned()));
             }
-            other => panic!("expected sequence, got {other:?}"),
+            other => panic!("expected array, got {other:?}"),
         }
     }
 }

--- a/crates/hyalo-core/src/frontmatter.rs
+++ b/crates/hyalo-core/src/frontmatter.rs
@@ -52,7 +52,7 @@ impl Document {
             let yaml =
                 serde_saphyr::to_string(&self.properties).context("failed to serialize YAML")?;
             out.push_str(&yaml);
-            // serde_yaml adds a trailing newline, but let's ensure
+            // The YAML serializer adds a trailing newline, but let's ensure
             if !yaml.ends_with('\n') {
                 out.push('\n');
             }
@@ -431,7 +431,8 @@ pub fn parse_value(raw: &str, forced_type: Option<&str>) -> Result<Value> {
                 let f: f64 = raw.parse().context("value is not a valid number")?;
                 anyhow::ensure!(f.is_finite(), "value is not a finite number");
                 Ok(Value::Number(
-                    serde_json::Number::from_f64(f).unwrap_or_else(|| serde_json::Number::from(0)),
+                    serde_json::Number::from_f64(f)
+                        .expect("finite f64 must produce a valid JSON number"),
                 ))
             }
         }
@@ -478,7 +479,7 @@ fn infer_value(raw: &str) -> Value {
         && f.is_finite()
     {
         return Value::Number(
-            serde_json::Number::from_f64(f).unwrap_or_else(|| serde_json::Number::from(0)),
+            serde_json::Number::from_f64(f).expect("finite f64 must produce a valid JSON number"),
         );
     }
     // Try bool
@@ -502,14 +503,6 @@ fn infer_value(raw: &str) -> Value {
         return Value::Array(items);
     }
     Value::String(raw.to_owned())
-}
-
-/// Convert a YAML value to a `serde_json::Value` for output.
-///
-/// Since `Value` is already `serde_json::Value`, this is an identity clone.
-/// Kept as a public API for callers that previously needed type conversion.
-pub fn yaml_to_json(value: &Value) -> serde_json::Value {
-    value.clone()
 }
 
 #[cfg(test)]

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -31,7 +31,7 @@ pub struct IndexEntry {
     /// ISO 8601 mtime string.
     pub modified: String,
     /// Raw frontmatter properties.
-    pub properties: BTreeMap<String, serde_yaml_ng::Value>,
+    pub properties: BTreeMap<String, serde_json::Value>,
     /// Extracted tags (from properties).
     pub tags: Vec<String>,
     /// Document outline sections.

--- a/crates/hyalo-core/src/scanner.rs
+++ b/crates/hyalo-core/src/scanner.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
-use serde_yaml_ng::Value;
+use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fs::File;
@@ -316,7 +316,7 @@ pub trait FileVisitor {
 
     /// Whether this visitor needs parsed frontmatter properties.
     /// If **no** visitor needs frontmatter, the scanner skips YAML accumulation
-    /// and `serde_yaml_ng` parsing (but still reads past the `---` delimiters).
+    /// and `serde_saphyr` parsing (but still reads past the `---` delimiters).
     /// Default: `true`.
     fn needs_frontmatter(&self) -> bool {
         true
@@ -424,7 +424,7 @@ pub fn scan_reader_multi<R: BufRead>(
         }
         let props: BTreeMap<String, Value> = match yaml {
             Some(ref y) if !y.trim().is_empty() => {
-                serde_yaml_ng::from_str(y).context("failed to parse YAML frontmatter")?
+                serde_saphyr::from_str(y).context("failed to parse YAML frontmatter")?
             }
             _ => BTreeMap::new(),
         };
@@ -1246,7 +1246,7 @@ Line 2
 
     #[test]
     fn needs_frontmatter_false_skips_yaml_parse() {
-        // Malformed YAML that would fail serde_yaml_ng if parsed,
+        // Malformed YAML that would fail serde_saphyr if parsed,
         // but a body-only visitor with needs_frontmatter=false should succeed.
         struct BodyOnly {
             lines: Vec<(String, usize)>,

--- a/hyalo-knowledgebase/iterations/iteration-51-safe-yaml-parser.md
+++ b/hyalo-knowledgebase/iterations/iteration-51-safe-yaml-parser.md
@@ -1,0 +1,63 @@
+---
+branch: iter-51/safe-yaml-parser
+date: 2026-03-27
+status: in-progress
+tags:
+- security
+- dependencies
+- parser
+title: Replace serde_yaml_ng with serde-saphyr (safe Rust YAML parser)
+type: iteration
+---
+
+# Replace serde_yaml_ng with serde-saphyr
+
+## Motivation
+
+Pre-release security audit (iteration 50) identified `unsafe-libyaml` — the backend of
+`serde_yaml_ng` — as the largest unsafe surface in hyalo's dependency tree: **14,491 unsafe
+expressions** (a mechanical C-to-Rust transpilation of libyaml). While mitigated by the 8 KB
+frontmatter cap, eliminating this dependency removes the entire attack surface.
+
+`serde-saphyr` is a pure safe Rust YAML parser with `#![forbid(unsafe_code)]`, YAML 1.2
+compliance, native serde support, and active maintenance (last release Mar 2026). It is built
+on the saphyr parser (300 stars, 1M+ downloads).
+
+## Research summary
+
+There is no formal standard for YAML frontmatter in markdown — it is a de facto convention
+from Jekyll (2008). All tools simply parse "valid YAML between `---` lines." Obsidian restricts
+its Properties UI to flat maps with scalar values and simple lists, but the underlying files
+can contain any YAML. Since hyalo processes arbitrary user vaults, we need a proper YAML parser
+— not a restricted subset parser.
+
+See: [[iteration-50-security-hardening]] for full audit findings.
+
+## Migration plan
+
+- [x] Add `serde-saphyr` to workspace dependencies
+- [x] Audit API differences between `serde_yaml_ng` and `serde-saphyr` (`Value` type, `from_str`, `to_string`, error types)
+- [x] Replace `serde_yaml_ng` with `serde-saphyr` in `hyalo-core/Cargo.toml`
+- [x] Update `frontmatter.rs`: swap `serde_yaml_ng::Value` → `serde_json::Value` (serde-saphyr has no own Value type)
+- [x] Update `filter.rs`: adapt property matching for new `Value` variants (`Array`/`Object` instead of `Sequence`/`Mapping`)
+- [x] Update `scanner.rs`: swap YAML parsing calls
+- [x] Update CLI commands (`set.rs`, `append.rs`, `remove.rs`, `tags.rs`, `read.rs`, `find.rs`) referencing `serde_yaml_ng::Value`
+- [x] Simplify `yaml_to_json()` — now identity since internal representation is already `serde_json::Value`
+- [x] Remove `serde_yaml_ng` and `unsafe-libyaml` from dependency tree
+- [x] Verify roundtrip fidelity: parse → serialize → parse produces identical frontmatter
+- [x] Test with real-world vaults (own knowledgebase — 125 files, all commands work)
+- [x] Run benchmarks to confirm no performance regression
+
+## Risk
+
+- serde-saphyr is at version 0.0.22 with 271K downloads (vs serde_yaml_ng's 2.6M). The underlying saphyr parser is more mature.
+- YAML 1.2 vs 1.1 behavioral differences: `yes`/`no`/`on`/`off` are no longer booleans in 1.2. This is actually a *fix* (fewer surprising type coercions), but could change behavior for users whose frontmatter relied on YAML 1.1 quirks.
+- The `Value` type may have different variant names or serialization defaults — needs careful API audit.
+
+## Quality gates
+
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace` (437 tests pass)
+- [x] `unsafe-libyaml` confirmed gone from `Cargo.lock`
+- [x] `cargo deny check` still passes (advisories ok, bans ok, licenses ok, sources ok)


### PR DESCRIPTION
## Summary

- Replace `serde_yaml_ng` (backed by `unsafe-libyaml`, 14,491 unsafe expressions) with `serde-saphyr`, a pure safe Rust YAML 1.2 parser (`#![forbid(unsafe_code)]`)
- Internal dynamic value type changed from `serde_yaml_ng::Value` to `serde_json::Value`, simplifying `yaml_to_json()` to an identity operation
- `unsafe-libyaml` completely removed from dependency tree — `cargo deny check` passes clean

## Test plan

- [x] All 437 existing tests pass (no new tests needed — this is a dependency swap)
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all clean
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] Roundtrip fidelity verified: parse → set property → serialize → re-parse preserves all types (strings, numbers, booleans, lists)
- [x] Dogfooded against own knowledgebase (125 files) — `summary`, `find`, `set` all work correctly
- [x] Micro benchmarks show no regression
- [x] `Cargo.lock` confirms zero `unsafe-libyaml` / `serde_yaml_ng` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)