### PR TITLE
Add crates.io publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ github.event.release.tag_name }}" artifacts/*
 
+  crates-io:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Publish hyalo-core to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: cargo publish --package hyalo-core
+
+      - name: Wait for crates.io index update
+        run: sleep 30
+
+      - name: Publish hyalo-cli to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        run: cargo publish --package hyalo-cli
+
   homebrew:
     needs: release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,18 +152,51 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Verify CARGO_TOKEN is set
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "${CARGO_TOKEN}" ]; then
+            echo "ERROR: CARGO_TOKEN secret is not set"
+            exit 1
+          fi
+
       - name: Publish hyalo-core to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-        run: cargo publish --package hyalo-core
-
-      - name: Wait for crates.io index update
-        run: sleep 30
+        run: cargo publish --package hyalo-core --locked
 
       - name: Publish hyalo-cli to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-        run: cargo publish --package hyalo-cli
+        run: |
+          set -euo pipefail
+          max_attempts=10
+          delay=15
+          for attempt in $(seq 1 "$max_attempts"); do
+            echo "Publishing hyalo-cli (attempt $attempt/$max_attempts)..."
+            if output=$(cargo publish --package hyalo-cli --locked 2>&1); then
+              echo "$output"
+              echo "hyalo-cli published successfully."
+              exit 0
+            fi
+            echo "$output"
+            if echo "$output" | grep -qiE 'failed to select a version|no matching package named|depends on'; then
+              if [ "$attempt" -eq "$max_attempts" ]; then
+                echo "ERROR: giving up after $max_attempts attempts" >&2
+                exit 1
+              fi
+              echo "Index not yet updated, waiting ${delay}s..."
+              sleep "$delay"
+              delay=$((delay * 2))
+            else
+              echo "ERROR: cargo publish failed with a non-index error" >&2
+              exit 1
+            fi
+          done
 
   homebrew:
     needs: release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ default-members = ["crates/hyalo-cli"]
 version = "0.4.1"
 edition = "2024"
 license = "MIT"
-publish = false
+repository = "https://github.com/ractive/hyalo"
 
 [workspace.dependencies]
 # Internal crates
-hyalo-core = { path = "crates/hyalo-core" }
+hyalo-core = { path = "crates/hyalo-core", version = "0.4.1" }
 
 # External dependencies
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ scoop install hyalo
 winget install ractive.hyalo
 ```
 
-### Cargo (Intel Mac & other platforms)
+### Cargo (from crates.io)
 
 ```sh
-cargo install --git https://github.com/ractive/hyalo.git --locked
+cargo install hyalo-cli
 ```
 
 > **Intel Mac users:** Homebrew bottles and pre-built binaries are only provided for Apple Silicon. If you're on an Intel Mac, use `cargo install` above.

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "hyalo-cli"
+description = "CLI for exploring and managing Markdown knowledge bases with YAML frontmatter"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-publish.workspace = true
+repository.workspace = true
+readme = "../../README.md"
+keywords = ["cli", "yaml", "frontmatter", "markdown", "obsidian"]
+categories = ["command-line-utilities"]
 
 [[bin]]
 name = "hyalo"

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
 keywords = ["yaml", "frontmatter", "markdown", "parsing"]
 categories = ["parser-implementations"]
 

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "hyalo-core"
+description = "Core library for hyalo — frontmatter parsing, querying, and mutation for Markdown files"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-publish.workspace = true
+repository.workspace = true
+keywords = ["yaml", "frontmatter", "markdown", "parsing"]
+categories = ["parser-implementations"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/hyalo-knowledgebase/iterations/iteration-54-crates-io.md
+++ b/hyalo-knowledgebase/iterations/iteration-54-crates-io.md
@@ -1,0 +1,36 @@
+---
+title: "Iteration 54 — Publish to crates.io"
+type: iteration
+date: 2026-03-27
+tags:
+  - iteration
+  - distribution
+  - crates-io
+status: in-progress
+branch: iter-54/crates-io
+---
+
+# Iteration 54 — Publish to crates.io
+
+## Goal
+
+Add crates.io as a distribution channel so Rust developers can install hyalo via `cargo install hyalo-cli`.
+
+## Motivation
+
+Hyalo already ships pre-built binaries via GitHub Releases, Homebrew, Scoop, and winget. Publishing to crates.io covers the Rust developer audience who naturally discover and install tools with `cargo install`. It's zero-cost to maintain once set up.
+
+## Tasks
+
+- [ ] Remove `publish = false` from workspace Cargo.toml
+- [ ] Add `version` field to workspace `hyalo-core` dependency for crates.io resolution
+- [ ] Add crates.io metadata to `hyalo-core` (description, repository, keywords, categories)
+- [ ] Add crates.io metadata to `hyalo-cli` (description, repository, readme, keywords, categories)
+- [ ] Add `crates-io` job to release workflow (publish hyalo-core then hyalo-cli)
+- [ ] Verify with `cargo publish --dry-run`
+- [ ] Pass all quality gates (fmt, clippy, test)
+
+## References
+
+- [[iteration-53-windows-package-managers]] — prior distribution work
+- [[iteration-31-homebrew-distribution]] — initial Homebrew setup


### PR DESCRIPTION
## Summary
- Enable `cargo install hyalo-cli` by publishing both `hyalo-core` and `hyalo-cli` to crates.io
- Add crate metadata (description, repository, keywords, categories) to both crates
- Add `crates-io` job to release workflow that publishes hyalo-core first, waits for index propagation, then publishes hyalo-cli
- Update README install docs to use `cargo install hyalo-cli` instead of `--git`

## Setup required
- Create a `CARGO_TOKEN` repository secret with a crates.io API token (scopes: publish-new + publish-update)

## Test plan
- [x] `cargo publish --package hyalo-core --dry-run --allow-dirty` succeeds
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] After merging: create a GitHub release and verify both crates appear on crates.io
- [ ] Verify `cargo install hyalo-cli` works from a clean environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)