### PR TITLE
Parameterize skill templates and add fuzzy dir auto-detection

### DIFF
--- a/.claude/agents/rust-developer.md
+++ b/.claude/agents/rust-developer.md
@@ -110,7 +110,7 @@ Persist:
 - common pitfalls and patterns
 
 Keep memory concise and practical.
-Use ./hyalo-knowledgebase for long-term memory.
+Use the knowledgebase directory configured in `.hyalo.toml` (`dir`) for long-term memory.
 
 # Persistent Agent Memory
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
 
 [[package]]
 name = "hyalo-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -373,7 +373,12 @@ const DIR_SENTINEL: &str = "hyalo-knowledgebase";
 /// YAML double-quoted scalars and shell strings.
 fn parameterize_template(template: &str, dir: &str) -> String {
     let normalised = dir.replace('\\', "/");
-    let escaped = normalised.replace('"', "\\\"");
+    // Strip trailing slashes to avoid double-slash artifacts like `vault//**`
+    // when the sentinel appears before `/` in templates.
+    let trimmed = normalised.trim_end_matches('/');
+    // Preserve "." for root-dir configs; an empty string would break paths.
+    let clean = if trimmed.is_empty() { "." } else { trimmed };
+    let escaped = clean.replace('"', "\\\"");
     template.replace(DIR_SENTINEL, &escaped)
 }
 
@@ -645,6 +650,23 @@ mod tests {
         let template = "path: hyalo-knowledgebase\n";
         let result = parameterize_template(template, "my\"notes");
         assert!(result.contains("my\\\"notes"));
+    }
+
+    #[test]
+    fn parameterize_template_strips_trailing_slash() {
+        let template = "git log -- \"hyalo-knowledgebase/\" | head\n";
+        let result = parameterize_template(template, "vault/");
+        // Should produce "vault/" not "vault//"
+        assert!(result.contains("\"vault/\""));
+        assert!(!result.contains("//"));
+    }
+
+    #[test]
+    fn parameterize_template_trailing_slash_only_becomes_dot() {
+        let template = "hyalo-knowledgebase/**";
+        let result = parameterize_template(template, "/");
+        // "/" trimmed to "" → falls back to "."
+        assert_eq!(result, "./**");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -129,8 +129,11 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
         .context("skill path has no parent directory")?;
     fs::create_dir_all(skill_dir)
         .with_context(|| format!("failed to create directory {}", skill_dir.display()))?;
-    fs::write(&skill_path, SKILL_CONTENT)
-        .with_context(|| format!("failed to write {}", skill_path.display()))?;
+    fs::write(
+        &skill_path,
+        parameterize_template(SKILL_CONTENT, &dir_value),
+    )
+    .with_context(|| format!("failed to write {}", skill_path.display()))?;
     if skill_existed {
         writeln!(summary, "updated  .claude/skills/hyalo/SKILL.md").unwrap();
     } else {
@@ -151,8 +154,11 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
         .context("dream skill path has no parent directory")?;
     fs::create_dir_all(dream_skill_dir)
         .with_context(|| format!("failed to create directory {}", dream_skill_dir.display()))?;
-    fs::write(&dream_skill_path, DREAM_SKILL_CONTENT)
-        .with_context(|| format!("failed to write {}", dream_skill_path.display()))?;
+    fs::write(
+        &dream_skill_path,
+        parameterize_template(DREAM_SKILL_CONTENT, &dir_value),
+    )
+    .with_context(|| format!("failed to write {}", dream_skill_path.display()))?;
     if dream_skill_existed {
         writeln!(summary, "updated  .claude/skills/hyalo-dream/SKILL.md").unwrap();
     } else {
@@ -254,40 +260,79 @@ fn count_md_files_recursive(dir: &Path) -> usize {
     count
 }
 
+/// Returns `true` if the directory name is an exact candidate match or
+/// contains a candidate substring (case-insensitive).
+fn is_fuzzy_candidate(dir_name: &str) -> bool {
+    let lower = dir_name.to_ascii_lowercase();
+    CANDIDATE_DIRS.iter().any(|c| lower.contains(*c))
+}
+
 /// Scan CWD for the candidate or root dir that has the most `.md` files (recursive).
 /// Falls back to `"."` if none found.
+///
+/// Exact candidate names (e.g. `docs`) are tried first. Then all non-hidden
+/// subdirectories whose names *contain* a candidate substring (e.g.
+/// `my-knowledgebase`) are also considered, so common naming variants are
+/// auto-detected without an explicit `--dir` flag.
 fn auto_detect_dir(cwd: &Path) -> String {
-    let mut best_dir: Option<&str> = None;
+    let mut best_dir: Option<String> = None;
     let mut best_count = 0usize;
 
+    // 1. Exact candidate matches.
     for candidate in CANDIDATE_DIRS {
         let candidate_path = cwd.join(candidate);
         if candidate_path.is_dir() {
             let count = count_md_files_recursive(&candidate_path);
             if count > best_count {
                 best_count = count;
-                best_dir = Some(candidate);
+                best_dir = Some((*candidate).to_owned());
             }
         }
     }
 
-    // Also consider root "." — but only count .md files that are NOT inside a
-    // candidate directory, so we compare apples to apples.
+    // 2. Fuzzy matches: non-hidden subdirectories whose names contain a
+    //    candidate substring but are not themselves exact candidates.
+    if let Ok(entries) = fs::read_dir(cwd) {
+        for entry in entries.flatten() {
+            let Ok(ft) = entry.file_type() else { continue };
+            if !ft.is_dir() || ft.is_symlink() {
+                continue;
+            }
+            let path = entry.path();
+            let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            // Skip hidden dirs and exact candidates (already handled above).
+            if dir_name.starts_with('.') || CANDIDATE_DIRS.contains(&dir_name) {
+                continue;
+            }
+            if is_fuzzy_candidate(dir_name) {
+                let count = count_md_files_recursive(&path);
+                if count > best_count {
+                    best_count = count;
+                    best_dir = Some(dir_name.to_owned());
+                }
+            }
+        }
+    }
+
+    // 3. Also consider root "." — but only count .md files that are NOT inside
+    //    a candidate directory, so we compare apples to apples.
     let root_count = count_md_root_only(cwd);
     if root_count > best_count {
         return ".".to_owned();
     }
 
-    best_dir
-        .map(|s| s.to_owned())
-        .unwrap_or_else(|| ".".to_owned())
+    best_dir.unwrap_or_else(|| ".".to_owned())
 }
 
 /// Count `.md` files directly in `dir` and in non-candidate subdirectories (recursive).
-/// Excludes candidate directories so root doesn't double-count their contents.
-/// Also excludes hidden directories (names starting with `.`) such as `.claude/`
-/// and `.git/` so that files installed there by `init --claude` don't skew
-/// the auto-detection heuristic toward `"."`.
+///
+/// Excludes:
+/// - Exact candidate directories (e.g. `docs`, `wiki`) — counted separately.
+/// - Fuzzy-matched directories (e.g. `my-knowledgebase`) — also counted separately.
+/// - Hidden directories (names starting with `.`, e.g. `.git`, `.claude`).
+///
+/// This keeps root-level `.md` count independent so the comparison in
+/// `auto_detect_dir` is apples-to-apples.
 fn count_md_root_only(dir: &Path) -> usize {
     let Ok(entries) = fs::read_dir(dir) else {
         return 0;
@@ -300,11 +345,9 @@ fn count_md_root_only(dir: &Path) -> usize {
         if is_real_dir {
             let path = entry.path();
             let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            // Skip hidden directories (e.g. .git, .claude) and candidate
-            // directories (counted separately in auto_detect_dir).
-            let is_hidden = dir_name.starts_with('.');
-            let is_candidate = CANDIDATE_DIRS.contains(&dir_name);
-            if !is_hidden && !is_candidate {
+            // Skip hidden directories and any directory that auto_detect_dir
+            // would consider as a candidate (exact or fuzzy).
+            if !dir_name.starts_with('.') && !is_fuzzy_candidate(dir_name) {
                 count += count_md_files_recursive(&path);
             }
         } else if entry
@@ -319,30 +362,36 @@ fn count_md_root_only(dir: &Path) -> usize {
     count
 }
 
-/// The sentinel path glob in the rule template that gets replaced with the
-/// user's actual vault directory.
-const RULE_SENTINEL: &str = "hyalo-knowledgebase/**";
+/// The sentinel string used in all templates to represent the docs directory.
+/// Occurrences are replaced at install time with the user's actual vault directory.
+const DIR_SENTINEL: &str = "hyalo-knowledgebase";
+
+/// Replace all occurrences of `hyalo-knowledgebase` in `template` with `dir`.
+///
+/// Path separators in `dir` are normalised to `/` (Windows compatibility).
+/// Double-quotes in `dir` are escaped so substituted values remain valid inside
+/// YAML double-quoted scalars and shell strings.
+fn parameterize_template(template: &str, dir: &str) -> String {
+    let normalised = dir.replace('\\', "/");
+    let escaped = normalised.replace('"', "\\\"");
+    template.replace(DIR_SENTINEL, &escaped)
+}
 
 /// Replace the `hyalo-knowledgebase/**` path glob in the rule template with
 /// `{dir}/**` so the rule targets the actual vault directory.
 ///
-/// `dir` is YAML-escaped so that backslashes (Windows paths) and double-quotes
-/// do not corrupt the generated YAML. Path separators are normalised to `/`.
+/// Asserts that the sentinel glob is present so template drift is caught early.
 fn parameterize_rule(template: &str, dir: &str) -> String {
+    let sentinel_glob = format!("{DIR_SENTINEL}/**");
     // The sentinel must be present; its absence means the template was changed
     // without updating this function — a programming error.
     assert!(
-        template.contains(RULE_SENTINEL),
-        "rule template does not contain the expected sentinel {RULE_SENTINEL:?}"
+        template.contains(&sentinel_glob),
+        "rule template does not contain the expected sentinel {sentinel_glob:?}"
     );
-
-    // Normalise Windows backslash separators and escape YAML double-quote
-    // special characters so the substituted value is valid inside a YAML
-    // double-quoted scalar (e.g. `"docs/**"`).
-    let normalised = dir.replace('\\', "/");
-    let yaml_escaped = normalised.replace('"', "\\\"");
-
-    template.replace(RULE_SENTINEL, &format!("{yaml_escaped}/**"))
+    // parameterize_template replaces `hyalo-knowledgebase` with `dir`, leaving
+    // the `/**` suffix intact — so the glob path is correctly rewritten.
+    parameterize_template(template, dir)
 }
 
 /// Append `line` to `content`, separated by a blank line. Strips trailing newlines from
@@ -525,11 +574,85 @@ mod tests {
     }
 
     #[test]
+    fn auto_detect_dir_fuzzy_matches_containing_candidate_substring() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // "my-knowledgebase" contains "knowledgebase" → should be auto-detected
+        fs::create_dir_all(tmp.path().join("my-knowledgebase")).unwrap();
+        fs::write(tmp.path().join("my-knowledgebase").join("a.md"), "# A").unwrap();
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, "my-knowledgebase");
+    }
+
+    #[test]
+    fn auto_detect_dir_fuzzy_matches_project_wiki() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("project-wiki")).unwrap();
+        fs::write(
+            tmp.path().join("project-wiki").join("readme.md"),
+            "# Readme",
+        )
+        .unwrap();
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, "project-wiki");
+    }
+
+    #[test]
+    fn auto_detect_dir_fuzzy_does_not_double_count_in_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // "my-knowledgebase" contains "knowledgebase" — 2 md files
+        fs::create_dir_all(tmp.path().join("my-knowledgebase")).unwrap();
+        fs::write(tmp.path().join("my-knowledgebase").join("a.md"), "# A").unwrap();
+        fs::write(tmp.path().join("my-knowledgebase").join("b.md"), "# B").unwrap();
+        // root-level md files (should NOT include the fuzzy dir's files)
+        fs::write(tmp.path().join("readme.md"), "# Root").unwrap();
+        let result = auto_detect_dir(tmp.path());
+        // fuzzy dir has 2, root-only has 1 → fuzzy dir wins
+        assert_eq!(result, "my-knowledgebase");
+    }
+
+    #[test]
+    fn auto_detect_dir_exact_candidate_beats_fuzzy_with_fewer_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // exact "docs" with 2 md files
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::write(tmp.path().join("docs").join("a.md"), "# A").unwrap();
+        fs::write(tmp.path().join("docs").join("b.md"), "# B").unwrap();
+        // fuzzy "my-docs" with 1 md file
+        fs::create_dir_all(tmp.path().join("my-docs")).unwrap();
+        fs::write(tmp.path().join("my-docs").join("c.md"), "# C").unwrap();
+        let result = auto_detect_dir(tmp.path());
+        assert_eq!(result, "docs");
+    }
+
+    #[test]
+    fn parameterize_template_replaces_sentinel() {
+        let template = "Use hyalo-knowledgebase for all docs in hyalo-knowledgebase/\n";
+        let result = parameterize_template(template, "my-docs");
+        assert_eq!(result, "Use my-docs for all docs in my-docs/\n");
+        assert!(!result.contains("hyalo-knowledgebase"));
+    }
+
+    #[test]
+    fn parameterize_template_normalises_windows_backslashes() {
+        let template = "git log -- \"hyalo-knowledgebase/\"\n";
+        let result = parameterize_template(template, "my\\notes");
+        assert!(result.contains("my/notes"));
+        assert!(!result.contains('\\'));
+    }
+
+    #[test]
+    fn parameterize_template_escapes_double_quotes() {
+        let template = "path: hyalo-knowledgebase\n";
+        let result = parameterize_template(template, "my\"notes");
+        assert!(result.contains("my\\\"notes"));
+    }
+
+    #[test]
     fn parameterize_rule_replaces_path() {
         let template = "---\npaths:\n  - \"hyalo-knowledgebase/**\"\n---\nContent here.\n";
         let result = parameterize_rule(template, "docs");
         assert!(result.contains("\"docs/**\""));
-        assert!(!result.contains("hyalo-knowledgebase/**"));
+        assert!(!result.contains("hyalo-knowledgebase"));
     }
 
     #[test]

--- a/crates/hyalo-cli/tests/e2e_init.rs
+++ b/crates/hyalo-cli/tests/e2e_init.rs
@@ -759,3 +759,124 @@ fn init_summary_mentions_rule() {
         "summary should mention .claude/rules/knowledgebase.md; got: {stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Skill parameterization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_claude_dream_skill_parameterized_with_dir() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude", "--dir", "my-kb"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let dream_skill_path = tmp
+        .path()
+        .join(".claude")
+        .join("skills")
+        .join("hyalo-dream")
+        .join("SKILL.md");
+    let content = fs::read_to_string(&dream_skill_path).unwrap();
+
+    // Sentinel must have been replaced
+    assert!(
+        !content.contains("hyalo-knowledgebase"),
+        "dream SKILL.md should not contain sentinel after parameterization; got: {content}"
+    );
+    // Actual dir name must be present
+    assert!(
+        content.contains("my-kb"),
+        "dream SKILL.md should contain the configured dir 'my-kb'; got: {content}"
+    );
+}
+
+#[test]
+fn init_claude_hyalo_skill_has_no_sentinel() {
+    // The hyalo SKILL.md template doesn't currently use the sentinel — verify
+    // that parameterization is a safe no-op (no hyalo-knowledgebase leaks).
+    let tmp = TempDir::new().unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init", "--claude", "--dir", "custom-docs"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let skill_path = tmp
+        .path()
+        .join(".claude")
+        .join("skills")
+        .join("hyalo")
+        .join("SKILL.md");
+    let content = fs::read_to_string(&skill_path).unwrap();
+    assert!(
+        !content.contains("hyalo-knowledgebase"),
+        "hyalo SKILL.md should not contain sentinel; got: {content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fuzzy directory auto-detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_auto_detects_fuzzy_knowledgebase_dir() {
+    let tmp = TempDir::new().unwrap();
+
+    // "my-knowledgebase" contains "knowledgebase" → should be auto-detected
+    fs::create_dir_all(tmp.path().join("my-knowledgebase")).unwrap();
+    fs::write(
+        tmp.path().join("my-knowledgebase").join("index.md"),
+        "# Index",
+    )
+    .unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        content.contains("my-knowledgebase"),
+        "should auto-detect 'my-knowledgebase'; stdout: {stdout}, toml: {content}"
+    );
+}
+
+#[test]
+fn init_auto_detects_fuzzy_wiki_dir() {
+    let tmp = TempDir::new().unwrap();
+
+    fs::create_dir_all(tmp.path().join("project-wiki")).unwrap();
+    fs::write(tmp.path().join("project-wiki").join("home.md"), "# Home").unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        content.contains("project-wiki"),
+        "should auto-detect 'project-wiki'; toml: {content}"
+    );
+}

--- a/hyalo-knowledgebase/iterations/iteration-55-init-dir-detection.md
+++ b/hyalo-knowledgebase/iterations/iteration-55-init-dir-detection.md
@@ -1,0 +1,30 @@
+---
+title: "Replace hardcoded hyalo-knowledgebase in init --claude and add fuzzy dir detection"
+type: iteration
+date: 2026-03-27
+tags:
+  - init
+  - cli
+  - developer-experience
+status: in-progress
+branch: iter-55/init-dir-detection
+---
+
+## Problem
+
+`hyalo init --claude` installs skill templates that contain hardcoded references to
+`hyalo-knowledgebase/`. When users have a different docs directory (e.g. `docs/`,
+`my-knowledgebase/`), the installed skills reference a non-existent path.
+
+Additionally, auto-detection only checks exact directory names from a fixed list
+(`docs`, `knowledgebase`, `wiki`, etc.), missing common variants like `my-docs` or
+`project-knowledgebase`.
+
+## Tasks
+
+- [x] Parameterize skill templates with actual dir value (like rule template already does)
+- [x] Add fuzzy directory detection (substring matching on candidate names)
+- [x] Update agent template to not hardcode hyalo-knowledgebase
+- [x] Add unit tests for fuzzy detection and template parameterization
+- [x] Add e2e tests verifying skills are parameterized
+- [ ] Create PR and review


### PR DESCRIPTION
## Summary

- **Skill parameterization**: `hyalo init --claude` now replaces the `hyalo-knowledgebase` sentinel in installed skill templates with the actual configured docs directory, matching the existing behavior for the rule template. Previously the dream skill contained hardcoded `hyalo-knowledgebase/` references.
- **Fuzzy directory detection**: `auto_detect_dir()` now also scans non-hidden subdirectories whose names *contain* a candidate substring (e.g. `my-knowledgebase`, `project-wiki`), not just exact matches from the fixed candidate list.
- **Agent template fix**: Updated `.claude/agents/rust-developer.md` to reference `.hyalo.toml`'s `dir` setting instead of hardcoding `hyalo-knowledgebase`.

## Test plan

- [x] Unit tests for `parameterize_template()` (sentinel replacement, Windows backslash normalization, double-quote escaping)
- [x] Unit tests for fuzzy directory detection (substring matching, no double-counting, exact beats fuzzy)
- [x] E2E test: dream skill is parameterized with configured dir (no sentinel in output)
- [x] E2E test: hyalo skill has no sentinel (safe no-op parameterization)
- [x] E2E test: fuzzy detection of `my-knowledgebase` and `project-wiki` directories
- [x] All 446 existing tests still pass
- [x] `cargo fmt` + `cargo clippy` clean