### PR TITLE
Iteration 58: Find command UX polish

### DIFF
--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -177,7 +177,7 @@ pub fn append(
         let mut props = match frontmatter::read_frontmatter(full_path) {
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel_path}: {e}");
+                crate::warn::warn(format!("skipping {rel_path}: {e}"));
                 continue;
             }
             Err(e) => return Err(e),

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -42,7 +42,7 @@ pub fn backlinks(
     // Build the in-memory link graph
     let build = LinkGraph::build(dir, site_prefix)?;
     for (path, msg) in &build.warnings {
-        eprintln!("warning: skipping {}: {msg}", path.display());
+        crate::warn::warn(format!("skipping {}: {msg}", path.display()));
     }
 
     // Look up backlinks, then exclude self-links at the display boundary.

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -32,7 +32,7 @@ pub fn create_index(
 
     // Warn about skipped files
     for w in &build.warnings {
-        eprintln!("warning: skipped {}: {}", w.rel_path, w.message);
+        crate::warn::warn(format!("skipped {}: {}", w.rel_path, w.message));
     }
 
     // Determine output path
@@ -57,12 +57,12 @@ pub fn create_index(
             if stale_path == index_path {
                 continue;
             }
-            eprintln!(
-                "warning: stale index at {} (vault: {}, created: {})",
+            crate::warn::warn(format!(
+                "stale index at {} (vault: {}, created: {})",
                 stale_path.display(),
                 stale_vault,
                 stale_ts,
-            );
+            ));
         }
     }
 

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -114,7 +114,7 @@ pub fn find(
     let link_graph = if fields.backlinks || sort_needs_backlinks {
         let build = LinkGraph::build(dir, site_prefix)?;
         for (path, msg) in &build.warnings {
-            eprintln!("warning: skipping {}: {msg}", path.display());
+            crate::warn::warn(format!("skipping {}: {msg}", path.display()));
             link_graph_warned.insert(path.to_string_lossy().replace('\\', "/"));
         }
         Some(build.graph)
@@ -143,7 +143,11 @@ pub fn find(
         // --- Single-pass scan ---
         let mut fm = FrontmatterCollector::new(body_needed);
         let mut section_scanner = if body_needed
-            && (fields.sections || fields.links || sort_needs_links || has_section_filter)
+            && (fields.sections
+                || fields.links
+                || fields.title
+                || sort_needs_links
+                || has_section_filter)
         {
             Some(SectionScanner::new())
         } else {
@@ -189,7 +193,7 @@ pub fn find(
                 // Only warn if the link graph build hasn't already warned for this path.
                 // Both are forward-slash-normalized relative strings.
                 if !link_graph_warned.contains(rel_path.as_str()) {
-                    eprintln!("warning: skipping {rel_path}: {e}");
+                    crate::warn::warn(format!("skipping {rel_path}: {e}"));
                 }
                 continue;
             }
@@ -347,7 +351,7 @@ pub fn find(
     // explicit notice on stderr so the caller knows the query succeeded but
     // matched nothing.  JSON mode keeps the empty array on stdout unchanged.
     if format == crate::output::Format::Text && json_array.is_empty() {
-        eprintln!("warning: No files matched.");
+        crate::warn::warn("No files matched.");
     }
 
     let json_output = serde_json::Value::Array(json_array);
@@ -611,7 +615,7 @@ pub fn find_from_index(
             match scan_result {
                 Ok(()) => {}
                 Err(e) if hyalo_core::frontmatter::is_parse_error(&e) => {
-                    eprintln!("warning: skipping {}: {e}", entry.rel_path);
+                    crate::warn::warn(format!("skipping {}: {e}", entry.rel_path));
                     continue;
                 }
                 Err(e) => return Err(e),
@@ -728,9 +732,19 @@ pub fn find_from_index(
             None
         };
 
+        // --- Title field (index path) ---
+        // entry.sections is always available in the index, so we can look up
+        // the first H1 even when fields.sections is false.
+        let title = if fields.title {
+            Some(extract_title(&entry.properties, Some(&entry.sections)))
+        } else {
+            None
+        };
+
         let obj = FileObject {
             file: entry.rel_path.clone(),
             modified: entry.modified.clone(),
+            title,
             properties,
             properties_typed,
             tags: tags_field,
@@ -793,7 +807,7 @@ pub fn find_from_index(
         .collect::<Result<_>>()?;
 
     if format == crate::output::Format::Text && json_array.is_empty() {
-        eprintln!("warning: No files matched.");
+        crate::warn::warn("No files matched.");
     }
 
     let json_output = serde_json::Value::Array(json_array);
@@ -818,9 +832,37 @@ fn needs_body(
     fields.sections
         || fields.tasks
         || fields.links
+        || fields.title
         || has_content_search
         || has_task_filter
         || has_section_filter
+}
+
+/// Extract the title value for `--fields title`.
+///
+/// Priority:
+/// 1. `title` frontmatter property (if it is a string)
+/// 2. First H1 heading in the document outline
+/// 3. `serde_json::Value::Null` if neither found
+fn extract_title(
+    props: &indexmap::IndexMap<String, serde_json::Value>,
+    outline_sections: Option<&Vec<OutlineSection>>,
+) -> serde_json::Value {
+    // 1. Frontmatter title property
+    if let Some(serde_json::Value::String(s)) = props.get("title") {
+        return serde_json::Value::String(s.clone());
+    }
+    // 2. First H1 heading from outline
+    if let Some(sections) = outline_sections {
+        for sec in sections {
+            if sec.level == 1
+                && let Some(ref heading) = sec.heading
+            {
+                return serde_json::Value::String(heading.clone());
+            }
+        }
+    }
+    serde_json::Value::Null
 }
 
 /// Return true if `tasks` satisfy `filter`.
@@ -902,6 +944,13 @@ fn build_file_object(
         None
     };
 
+    // Extract title before outline_sections is consumed into sections.
+    let title = if fields.title {
+        Some(extract_title(props, outline_sections.as_ref()))
+    } else {
+        None
+    };
+
     let sections = if fields.sections {
         outline_sections.map(|mut secs| {
             if !scope_ranges.is_empty() {
@@ -962,6 +1011,7 @@ fn build_file_object(
     FileObject {
         file: rel_path.to_owned(),
         modified: modified.to_owned(),
+        title,
         properties,
         properties_typed,
         tags: tags_field,
@@ -1789,6 +1839,7 @@ title: Empty Body
             tasks: false,
             links: false,
             backlinks: false,
+            title: false,
         };
         assert!(!needs_body(&fields, false, false, false));
     }
@@ -1803,6 +1854,7 @@ title: Empty Body
             tasks: false,
             links: false,
             backlinks: false,
+            title: false,
         };
         assert!(needs_body(&fields, true, false, false));
     }
@@ -1817,6 +1869,7 @@ title: Empty Body
             tasks: false,
             links: false,
             backlinks: false,
+            title: false,
         };
         assert!(needs_body(&fields, false, false, false));
     }
@@ -2096,6 +2149,7 @@ Just intro, no tasks section.
             tasks: false,
             links: false,
             backlinks: false,
+            title: false,
         };
         assert!(needs_body(&fields, false, false, true));
         assert!(!needs_body(&fields, false, false, false));

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -846,7 +846,7 @@ fn needs_body(
 /// 3. `serde_json::Value::Null` if neither found
 fn extract_title(
     props: &indexmap::IndexMap<String, serde_json::Value>,
-    outline_sections: Option<&Vec<OutlineSection>>,
+    outline_sections: Option<&[OutlineSection]>,
 ) -> serde_json::Value {
     // 1. Frontmatter title property
     if let Some(serde_json::Value::String(s)) = props.get("title") {
@@ -946,7 +946,7 @@ fn build_file_object(
 
     // Extract title before outline_sections is consumed into sections.
     let title = if fields.title {
-        Some(extract_title(props, outline_sections.as_ref()))
+        Some(extract_title(props, outline_sections.as_deref()))
     } else {
         None
     };

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -73,7 +73,7 @@ pub fn collect_files(
                         format!("invalid path ({reason}): {path}")
                     }
                 };
-                eprintln!("warning: {msg}");
+                crate::warn::warn(&msg);
             }
             Ok(FilesOrOutcome::Files(resolved))
         }

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -33,7 +33,7 @@ pub fn properties_summary(
         let props = match frontmatter::read_frontmatter(fp) {
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel}: {e}");
+                crate::warn::warn(format!("skipping {rel}: {e}"));
                 continue;
             }
             Err(e) => return Err(e),
@@ -153,7 +153,7 @@ pub fn properties_rename(
         let mut props = match frontmatter::read_frontmatter(full_path) {
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel_path}: {e}");
+                crate::warn::warn(format!("skipping {rel_path}: {e}"));
                 continue;
             }
             Err(e) => return Err(e),

--- a/crates/hyalo-cli/src/commands/remove.rs
+++ b/crates/hyalo-cli/src/commands/remove.rs
@@ -241,7 +241,7 @@ pub fn remove(
         let mut props = match frontmatter::read_frontmatter(full_path) {
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel_path}: {e}");
+                crate::warn::warn(format!("skipping {rel_path}: {e}"));
                 continue;
             }
             Err(e) => return Err(e),

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -232,7 +232,7 @@ pub fn set(
         let mut props = match frontmatter::read_frontmatter(full_path) {
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel_path}: {e}");
+                crate::warn::warn(format!("skipping {rel_path}: {e}"));
                 continue;
             }
             Err(e) => return Err(e),

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -79,7 +79,7 @@ pub fn summary(
         match scan_result {
             Ok(()) => {}
             Err(e) if hyalo_core::frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel_path}: {e}");
+                crate::warn::warn(format!("skipping {rel_path}: {e}"));
                 total_files -= 1;
                 continue;
             }

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -71,7 +71,7 @@ pub fn tags_summary(
         let props = match frontmatter::read_frontmatter(full_path) {
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel}: {e}");
+                crate::warn::warn(format!("skipping {rel}: {e}"));
                 continue;
             }
             Err(e) => return Err(e),
@@ -204,7 +204,7 @@ pub fn tags_rename(
         let mut props = match frontmatter::read_frontmatter(full_path) {
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
-                eprintln!("warning: skipping {rel_path}: {e}");
+                crate::warn::warn(format!("skipping {rel_path}: {e}"));
                 continue;
             }
             Err(e) => return Err(e),

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -50,7 +50,9 @@ pub fn load_config() -> ResolvedDefaults {
     match std::env::current_dir() {
         Ok(cwd) => load_config_from(&cwd),
         Err(e) => {
-            eprintln!("warning: could not determine current directory to locate .hyalo.toml: {e}");
+            crate::warn::warn(format!(
+                "could not determine current directory to locate .hyalo.toml: {e}"
+            ));
             ResolvedDefaults::hardcoded()
         }
     }
@@ -69,7 +71,7 @@ pub fn load_config_from(dir: &Path) -> ResolvedDefaults {
             return ResolvedDefaults::hardcoded();
         }
         Err(e) => {
-            eprintln!("warning: could not read .hyalo.toml: {e}");
+            crate::warn::warn(format!("could not read .hyalo.toml: {e}"));
             return ResolvedDefaults::hardcoded();
         }
     };
@@ -77,7 +79,7 @@ pub fn load_config_from(dir: &Path) -> ResolvedDefaults {
     let cfg: ConfigFile = match toml::from_str(&contents) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("warning: malformed .hyalo.toml: {e}");
+            crate::warn::warn(format!("malformed .hyalo.toml: {e}"));
             return ResolvedDefaults::hardcoded();
         }
     };

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -223,13 +223,60 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
         ));
     }
 
-    // When there are many results, suggest narrowing filters.
+    // When there are many results, suggest data-driven narrowing filters.
     if results.len() > 5 {
-        hints.push(build_command_with_glob(
-            ctx,
-            &["find", "--property", "status=draft"],
-        ));
-        hints.push(build_command_with_glob(ctx, &["find", "--tag", "draft"]));
+        // Collect tag frequencies across all results.
+        let mut tag_counts: std::collections::HashMap<&str, usize> =
+            std::collections::HashMap::new();
+        for item in results.iter() {
+            if let Some(tags) = item.get("tags").and_then(|t| t.as_array()) {
+                for tag in tags {
+                    if let Some(name) = tag.as_str() {
+                        *tag_counts.entry(name).or_insert(0) += 1;
+                    }
+                }
+            }
+        }
+
+        // Collect status property frequencies — status is the most useful drill-down.
+        let mut status_counts: std::collections::HashMap<&str, usize> =
+            std::collections::HashMap::new();
+        for item in results.iter() {
+            if let Some(status) = item
+                .get("properties")
+                .and_then(|p| p.get("status"))
+                .and_then(|s| s.as_str())
+            {
+                *status_counts.entry(status).or_insert(0) += 1;
+            }
+        }
+
+        // Pick the most common tag (if any results have tags).
+        if let Some((top_tag, _)) = tag_counts.iter().max_by_key(|(_, c)| *c) {
+            let remaining = MAX_HINTS.saturating_sub(hints.len());
+            if remaining > 0 {
+                hints.push(build_command_with_glob(ctx, &["find", "--tag", top_tag]));
+            }
+        }
+
+        // Pick the most interesting status value (prefer active/planned over completed).
+        let mut status_vec: Vec<(&str, usize, u8)> = status_counts
+            .iter()
+            .map(|(v, c)| (*v, *c, status_priority(v)))
+            .collect();
+        // Sort by priority (ascending), then by count (descending) as tiebreaker.
+        status_vec.sort_by(|a, b| a.2.cmp(&b.2).then(b.1.cmp(&a.1)));
+
+        if let Some((top_status, _, _)) = status_vec.first() {
+            let remaining = MAX_HINTS.saturating_sub(hints.len());
+            if remaining > 0 {
+                let filter = format!("status={top_status}");
+                hints.push(build_command_with_glob(
+                    ctx,
+                    &["find", "--property", &filter],
+                ));
+            }
+        }
     }
 
     hints
@@ -505,6 +552,130 @@ mod tests {
         let hints = generate_hints(&c, &data);
         assert!(hints[0].contains("--glob"));
         assert!(hints[0].contains("notes/*.md"));
+    }
+
+    // --- hints_for_find ---
+
+    fn make_find_item(file: &str, status: Option<&str>, tags: &[&str]) -> serde_json::Value {
+        let mut props = serde_json::Map::new();
+        if let Some(s) = status {
+            props.insert("status".to_owned(), serde_json::Value::String(s.to_owned()));
+        }
+        json!({
+            "file": file,
+            "properties": props,
+            "tags": tags,
+            "sections": [],
+            "tasks": [],
+            "links": [],
+            "modified": "2026-01-01T00:00:00Z"
+        })
+    }
+
+    #[test]
+    fn find_empty_results_no_hints() {
+        let c = ctx(HintSource::Find);
+        let hints = generate_hints(&c, &json!([]));
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn find_single_result_suggests_read_and_backlinks() {
+        let c = ctx(HintSource::Find);
+        let data = json!([make_find_item("notes/alpha.md", None, &[])]);
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("read") && h.contains("alpha.md")),
+            "should suggest read: {hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("backlinks") && h.contains("alpha.md")),
+            "should suggest backlinks: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn find_many_results_suggests_top_tag() {
+        let c = ctx(HintSource::Find);
+        // 6 results; rust appears 4 times, cli 2 times — rust should be suggested.
+        let data = json!([
+            make_find_item("a.md", Some("planned"), &["rust", "cli"]),
+            make_find_item("b.md", Some("planned"), &["rust"]),
+            make_find_item("c.md", Some("in-progress"), &["rust"]),
+            make_find_item("d.md", Some("completed"), &["rust"]),
+            make_find_item("e.md", Some("completed"), &["cli"]),
+            make_find_item("f.md", Some("completed"), &[]),
+        ]);
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("--tag") && h.contains("rust")),
+            "should suggest --tag rust (most common): {hints:?}"
+        );
+    }
+
+    #[test]
+    fn find_many_results_suggests_interesting_status() {
+        let c = ctx(HintSource::Find);
+        // 6 results; in-progress is more interesting than completed.
+        let data = json!([
+            make_find_item("a.md", Some("in-progress"), &[]),
+            make_find_item("b.md", Some("completed"), &[]),
+            make_find_item("c.md", Some("completed"), &[]),
+            make_find_item("d.md", Some("completed"), &[]),
+            make_find_item("e.md", Some("completed"), &[]),
+            make_find_item("f.md", Some("completed"), &[]),
+        ]);
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("--property") && h.contains("status=in-progress")),
+            "should prefer in-progress status: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn find_many_results_no_tags_falls_back_to_status() {
+        let c = ctx(HintSource::Find);
+        // 6 results, none with tags; should still suggest status narrowing.
+        let data = json!([
+            make_find_item("a.md", Some("planned"), &[]),
+            make_find_item("b.md", Some("planned"), &[]),
+            make_find_item("c.md", Some("planned"), &[]),
+            make_find_item("d.md", Some("planned"), &[]),
+            make_find_item("e.md", Some("planned"), &[]),
+            make_find_item("f.md", Some("planned"), &[]),
+        ]);
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.contains("--property") && h.contains("status=planned")),
+            "should suggest status filter: {hints:?}"
+        );
+        // No --tag hints when no tags exist.
+        assert!(
+            !hints.iter().any(|h| h.contains("--tag")),
+            "should not suggest --tag when no tags: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn find_hints_never_exceed_max() {
+        let c = ctx(HintSource::Find);
+        // 10 results with varied tags and statuses.
+        let items: Vec<serde_json::Value> = (0..10)
+            .map(|i| make_find_item(&format!("{i}.md"), Some("planned"), &["rust", "cli"]))
+            .collect();
+        let data = serde_json::Value::Array(items);
+        let hints = generate_hints(&c, &data);
+        assert!(hints.len() <= MAX_HINTS);
     }
 
     // --- flag propagation ---

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -252,7 +252,11 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
         }
 
         // Pick the most common tag (if any results have tags).
-        if let Some((top_tag, _)) = tag_counts.iter().max_by_key(|(_, c)| *c) {
+        // Break ties alphabetically for deterministic output.
+        if let Some((top_tag, _)) = tag_counts
+            .iter()
+            .max_by(|(a_tag, a_cnt), (b_tag, b_cnt)| a_cnt.cmp(b_cnt).then(b_tag.cmp(a_tag)))
+        {
             let remaining = MAX_HINTS.saturating_sub(hints.len());
             if remaining > 0 {
                 hints.push(build_command_with_glob(ctx, &["find", "--tag", top_tag]));
@@ -264,8 +268,8 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
             .iter()
             .map(|(v, c)| (*v, *c, status_priority(v)))
             .collect();
-        // Sort by priority (ascending), then by count (descending) as tiebreaker.
-        status_vec.sort_by(|a, b| a.2.cmp(&b.2).then(b.1.cmp(&a.1)));
+        // Sort by priority (ascending), then count (descending), then name (ascending).
+        status_vec.sort_by(|a, b| a.2.cmp(&b.2).then(b.1.cmp(&a.1)).then(a.0.cmp(b.0)));
 
         if let Some((top_status, _, _)) = status_vec.first() {
             let remaining = MAX_HINTS.saturating_sub(hints.len());

--- a/crates/hyalo-cli/src/lib.rs
+++ b/crates/hyalo-cli/src/lib.rs
@@ -3,3 +3,4 @@ pub mod config;
 pub mod hints;
 pub mod output;
 pub mod suggest;
+pub mod warn;

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -806,7 +806,7 @@ fn main() {
                      tip: did you mean '--property'?\n\n\
                      Example: hyalo find --property status=planned\n"
                 );
-                process::exit(2);
+                die(2);
             }
 
             // Only attempt subcommand suggestions when clap couldn't recognise a
@@ -818,7 +818,7 @@ fn main() {
                 hyalo_cli::suggest::suggest_subcommand_correction(&raw_args, &Cli::command())
             {
                 eprintln!("{e}\n  tip: did you mean:\n\n    {suggestion}\n");
-                process::exit(2);
+                die(2);
             }
             e.exit();
         }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -769,6 +769,10 @@ fn die(code: i32) -> ! {
 
 #[allow(clippy::too_many_lines)]
 fn main() {
+    // Pre-scan for --quiet / -q so config-loading warnings are also suppressed.
+    let early_quiet = std::env::args().any(|a| a == "--quiet" || a == "-q");
+    hyalo_cli::warn::init(early_quiet);
+
     // Load per-project config from .hyalo.toml in CWD before parsing args.
     // This lets us hide flags that already have config-provided defaults,
     // keeping `--help` output focused on what the user actually needs to set.
@@ -828,9 +832,8 @@ fn main() {
         Err(e) => e.exit(),
     };
 
-    // Initialise the warning system as early as possible after CLI parsing.
-    // Warnings emitted before this point (e.g. from config loading) are always
-    // printed since quiet mode was not yet known.
+    // Re-apply quiet flag from the fully-parsed CLI (the early pre-scan
+    // covers the common case but this ensures correctness after full parsing).
     hyalo_cli::warn::init(cli.quiet);
 
     // `init` operates on CWD directly and needs no config or format resolution.
@@ -1491,4 +1494,7 @@ fn main() {
             die(2);
         }
     }
+
+    // Flush any dedup summary on the success path (die() handles error paths).
+    hyalo_cli::warn::flush_summary();
 }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -257,6 +257,14 @@ struct Cli {
     #[arg(long, global = true, value_name = "PATH")]
     index: Option<PathBuf>,
 
+    /// Suppress all warnings printed to stderr.
+    ///
+    /// Useful in scripts or CI pipelines where warning noise is undesirable.
+    /// Identical warnings are always deduplicated regardless of this flag;
+    /// use `--quiet` to suppress them entirely.
+    #[arg(short = 'q', long, global = true)]
+    quiet: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -308,7 +316,7 @@ enum Commands {
         /// Glob pattern(s) to select files (repeatable); prefix '!' to negate (e.g. '!**/draft-*')
         #[arg(short, long, conflicts_with = "file")]
         glob: Vec<String>,
-        /// Comma-separated list of optional fields to include: properties, properties-typed, tags, sections, tasks, links, backlinks (default: all except properties-typed and backlinks). 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files. Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
+        /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections, tasks, links, backlinks, title (default: all standard fields except properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
         #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
         fields: Vec<String>,
         /// Sort order: 'file' (default), 'modified', 'backlinks_count', or 'links_count'
@@ -738,16 +746,25 @@ fn parse_where_filters(
         Ok(f) => f,
         Err(e) => {
             eprintln!("Error: {e}");
-            process::exit(1);
+            die(1);
         }
     };
     for tag in where_tags {
         if let Err(msg) = hyalo_cli::commands::tags::validate_tag(tag) {
             eprintln!("Error: {msg}");
-            process::exit(1);
+            die(1);
         }
     }
     filters
+}
+
+/// Exit the process, flushing any pending warning summary first.
+///
+/// Use this in place of `process::exit` after `warn::init` has been called so
+/// that duplicate-warning counts are always reported before the process ends.
+fn die(code: i32) -> ! {
+    hyalo_cli::warn::flush_summary();
+    process::exit(code)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -778,6 +795,20 @@ fn main() {
     let matches = match cmd.try_get_matches_from(raw_args.iter().map(String::as_str)) {
         Ok(m) => m,
         Err(e) => {
+            // Intercept `--filter` before falling through to clap's built-in
+            // suggestion, which picks `--file` (closest by Levenshtein distance).
+            // Users almost always mean `--property` here.
+            if e.kind() == clap::error::ErrorKind::UnknownArgument
+                && hyalo_cli::suggest::unknown_arg_is(&e, "--filter")
+            {
+                eprintln!(
+                    "error: unexpected argument '--filter' found\n\n\
+                     tip: did you mean '--property'?\n\n\
+                     Example: hyalo find --property status=planned\n"
+                );
+                process::exit(2);
+            }
+
             // Only attempt subcommand suggestions when clap couldn't recognise a
             // flag or subcommand — this avoids misleading tips for other error kinds.
             if matches!(
@@ -796,6 +827,11 @@ fn main() {
         Ok(c) => c,
         Err(e) => e.exit(),
     };
+
+    // Initialise the warning system as early as possible after CLI parsing.
+    // Warnings emitted before this point (e.g. from config loading) are always
+    // printed since quiet mode was not yet known.
+    hyalo_cli::warn::init(cli.quiet);
 
     // `init` operates on CWD directly and needs no config or format resolution.
     // Dispatch it before the rest of the setup.
@@ -816,7 +852,7 @@ fn main() {
                 2
             }
         };
-        process::exit(code);
+        die(code);
     }
 
     // Merge: CLI args override config, config overrides hardcoded defaults.
@@ -833,7 +869,7 @@ fn main() {
             "Error: --dir path '{}' is a file, not a directory. Use --file to target a single file.",
             dir.display()
         );
-        process::exit(1);
+        die(1);
     }
 
     // Derive site_prefix with tri-state precedence:
@@ -879,7 +915,7 @@ fn main() {
                     "Invalid output format '{}' in .hyalo.toml; supported formats are: json, text",
                     config.format
                 );
-                process::exit(2);
+                die(2);
             }
         }
     };
@@ -907,7 +943,7 @@ fn main() {
     if jq_filter.is_some() && format != Format::Json {
         eprintln!("Error: --jq cannot be combined with --format {}", format);
         eprintln!("  --jq always operates on JSON output; drop --format or use --format json");
-        process::exit(2);
+        die(2);
     }
     // When --jq or --hints is active, force JSON internally so we can re-parse the output.
     // The user-requested format is applied afterwards.
@@ -979,7 +1015,7 @@ fn main() {
             Commands::Set { .. } | Commands::Remove { .. } | Commands::Append { .. }
         )
     {
-        eprintln!("warning: --hints has no effect on mutation commands");
+        hyalo_cli::warn::warn("--hints has no effect on mutation commands");
     }
 
     // Load snapshot index if --index is provided.
@@ -1003,11 +1039,11 @@ fn main() {
                     let vault_dir_str = canonical_dir.to_string_lossy();
                     if !idx.validate(&vault_dir_str, site_prefix) {
                         let (hdr_vault, hdr_prefix, _, _) = idx.header_info();
-                        eprintln!(
-                            "warning: index was built for vault '{}' (prefix {:?}) but current \
+                        hyalo_cli::warn::warn(format!(
+                            "index was built for vault '{}' (prefix {:?}) but current \
                              vault is '{}' (prefix {:?}); falling back to disk scan",
                             hdr_vault, hdr_prefix, vault_dir_str, site_prefix,
-                        );
+                        ));
                         None
                     } else {
                         Some(idx)
@@ -1015,7 +1051,9 @@ fn main() {
                 }
                 Ok(None) => None, // incompatible schema — already warned; fall back to disk scan
                 Err(e) => {
-                    eprintln!("warning: failed to load index: {e}; falling back to disk scan");
+                    hyalo_cli::warn::warn(format!(
+                        "failed to load index: {e}; falling back to disk scan"
+                    ));
                     None
                 }
             }
@@ -1049,7 +1087,7 @@ fn main() {
                 Ok(f) => f,
                 Err(e) => {
                     eprintln!("Error: {e}");
-                    process::exit(1);
+                    die(1);
                 }
             };
             // Parse task filter
@@ -1057,7 +1095,7 @@ fn main() {
                 Some(Ok(f)) => Some(f),
                 Some(Err(e)) => {
                     eprintln!("Error: {e}");
-                    process::exit(1);
+                    die(1);
                 }
                 None => None,
             };
@@ -1066,7 +1104,7 @@ fn main() {
                 Ok(f) => f,
                 Err(e) => {
                     eprintln!("Error: {e}");
-                    process::exit(1);
+                    die(1);
                 }
             };
             // Parse sort
@@ -1074,7 +1112,7 @@ fn main() {
                 Some(Ok(f)) => Some(f),
                 Some(Err(e)) => {
                     eprintln!("Error: {e}");
-                    process::exit(1);
+                    die(1);
                 }
                 None => None,
             };
@@ -1087,7 +1125,7 @@ fn main() {
                 Ok(f) => f,
                 Err(e) => {
                     eprintln!("Error: {e}");
-                    process::exit(1);
+                    die(1);
                 }
             };
 
@@ -1253,7 +1291,7 @@ fn main() {
                         None,
                     );
                     eprintln!("{out}");
-                    process::exit(1);
+                    die(1);
                 }
                 task_commands::task_set_status(
                     &dir,
@@ -1390,7 +1428,7 @@ fn main() {
                             Some(&e.to_string()),
                         );
                         eprintln!("{msg}");
-                        process::exit(2);
+                        die(2);
                     }
                 };
                 match apply_jq_filter_result(filter, &value) {
@@ -1404,7 +1442,7 @@ fn main() {
                             Some(&e),
                         );
                         eprintln!("{msg}");
-                        process::exit(1);
+                        die(1);
                     }
                 }
             } else if let Some(ctx) = &hint_ctx {
@@ -1415,7 +1453,7 @@ fn main() {
                         // Should not happen since effective_format is forced to JSON,
                         // but fall through to plain output if it does.
                         println!("{output}");
-                        process::exit(0);
+                        die(0);
                     }
                 };
                 let hints = generate_hints(ctx, &value);
@@ -1436,7 +1474,7 @@ fn main() {
         }
         Ok(CommandOutcome::UserError(output)) => {
             eprintln!("{output}");
-            process::exit(1);
+            die(1);
         }
         Err(e) => {
             let msg = hyalo_cli::output::format_error(
@@ -1450,7 +1488,7 @@ fn main() {
                     .as_deref(),
             );
             eprintln!("{msg}");
-            process::exit(2);
+            die(2);
         }
     }
 }

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -445,6 +445,11 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
     // Header: file path and modified timestamp — always present.
     let mut parts = vec![r#""\"\(.file)\"  (\(.modified))""#.to_owned()];
 
+    // Title: "  title: <value>" or "  title: (none)"
+    if map.contains_key("title") {
+        parts.push(r#""  title: \(if .title then .title else "(none)" end)""#.to_owned());
+    }
+
     // Properties: header then each as "    key: value"
     if map.contains_key("properties") {
         parts.push(

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -447,7 +447,7 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
 
     // Title: "  title: <value>" or "  title: (none)"
     if map.contains_key("title") {
-        parts.push(r#""  title: \(if .title then .title else "(none)" end)""#.to_owned());
+        parts.push(r#""  title: \(if .title != null then .title else "(none)" end)""#.to_owned());
     }
 
     // Properties: header then each as "    key: value"

--- a/crates/hyalo-cli/src/suggest.rs
+++ b/crates/hyalo-cli/src/suggest.rs
@@ -1,3 +1,14 @@
+/// Returns `true` when a clap `UnknownArgument` error was triggered by `flag`.
+///
+/// Inspects `ContextKind::InvalidArg` in the error's context chain.
+/// The `flag` parameter must include the leading `--` (e.g. `"--filter"`).
+pub fn unknown_arg_is(err: &clap::Error, flag: &str) -> bool {
+    use clap::error::{ContextKind, ContextValue};
+    err.context().any(|(kind, value)| {
+        kind == ContextKind::InvalidArg && matches!(value, ContextValue::String(s) if s == flag)
+    })
+}
+
 /// Given the raw CLI args and the clap Command tree, detect when an unknown
 /// `--flag` matches a known subcommand name and return a corrected command suggestion.
 ///

--- a/crates/hyalo-cli/src/warn.rs
+++ b/crates/hyalo-cli/src/warn.rs
@@ -143,7 +143,7 @@ pub fn flush_summary() {
         Err(_) => return,
     };
 
-    if total_suppressed > 0 {
+    if !QUIET.load(Ordering::Relaxed) && total_suppressed > 0 {
         eprintln!("warning: {total_suppressed} additional identical warning(s) suppressed");
     }
 }

--- a/crates/hyalo-cli/src/warn.rs
+++ b/crates/hyalo-cli/src/warn.rs
@@ -1,0 +1,230 @@
+//! Lightweight warning system for hyalo CLI.
+//!
+//! Provides:
+//! - Quiet mode: suppress all warnings when `-q` / `--quiet` is set.
+//! - Dedup tracking: identical warning messages are counted but only
+//!   printed once; `flush_summary()` reports how many were suppressed.
+//!
+//! # Initialisation
+//!
+//! Call `init(quiet)` as early as possible after CLI flags are parsed.
+//! Until `init` is called the system defaults to non-quiet mode, so any
+//! warnings emitted before initialisation (e.g. from config loading) are
+//! still printed.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! warn::init(cli.quiet);
+//! // ...
+//! warn::warn("skipping foo.md: invalid frontmatter");
+//! // ...
+//! warn::flush_summary();
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static QUIET: AtomicBool = AtomicBool::new(false);
+
+/// Per-message suppression counters.
+/// Key: warning message string.
+/// Value: number of times the message was suppressed (i.e. seen after the first).
+static SUPPRESSED: Mutex<Option<HashMap<String, usize>>> = Mutex::new(None);
+
+/// Initialise the warning system.
+///
+/// Must be called once, early in `main`, after CLI flags are parsed.
+/// Calling it more than once is safe but redundant.
+pub fn init(quiet: bool) {
+    QUIET.store(quiet, Ordering::Relaxed);
+    // Initialise the dedup map (replacing None with an empty map).
+    if let Ok(mut guard) = SUPPRESSED.lock()
+        && guard.is_none()
+    {
+        *guard = Some(HashMap::new());
+    }
+}
+
+/// Emit a warning message to stderr.
+///
+/// - If quiet mode is active the message is silently discarded.
+/// - If the identical message has already been printed once, it is counted
+///   as suppressed rather than re-printed.
+/// - If `init` has not been called yet the message is always printed and
+///   dedup tracking is skipped (the dedup map is not yet initialised).
+pub fn warn(msg: impl AsRef<str>) {
+    if QUIET.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let msg = msg.as_ref();
+
+    // Try dedup tracking.
+    if let Ok(mut guard) = SUPPRESSED.lock()
+        && let Some(ref mut map) = *guard
+    {
+        let count = map.entry(msg.to_owned()).or_insert(0);
+        if *count > 0 {
+            // Already printed once — suppress and increment counter.
+            *count += 1;
+            return;
+        }
+        // First occurrence: mark as seen (count = 1) and fall through to print.
+        *count = 1;
+        // guard.is_none() means init() hasn't been called yet — fall through to print.
+    }
+
+    eprintln!("warning: {msg}");
+}
+
+/// Reset the warning system to its initial state.
+///
+/// **For use in tests only.**  Clears the dedup map and resets the quiet flag
+/// so that each test starts from a clean slate.  This is necessary because the
+/// static globals persist across tests within the same process.
+#[cfg(test)]
+pub fn reset_for_test() {
+    QUIET.store(false, Ordering::Relaxed);
+    if let Ok(mut guard) = SUPPRESSED.lock() {
+        *guard = None;
+    }
+}
+
+/// Return the number of times the given message was suppressed (seen after the
+/// first print).
+///
+/// **For use in tests only.**
+#[cfg(test)]
+pub fn suppressed_count_for(msg: &str) -> usize {
+    SUPPRESSED
+        .lock()
+        .ok()
+        .and_then(|g| g.as_ref().and_then(|m| m.get(msg).copied()))
+        .map(|seen| seen.saturating_sub(1))
+        .unwrap_or(0)
+}
+
+/// Return the total number of suppressed (duplicate) warning occurrences.
+///
+/// **For use in tests only.**
+#[cfg(test)]
+pub fn total_suppressed() -> usize {
+    SUPPRESSED
+        .lock()
+        .ok()
+        .and_then(|g| {
+            g.as_ref().map(|m| {
+                m.values()
+                    .map(|&seen| seen.saturating_sub(1))
+                    .sum::<usize>()
+            })
+        })
+        .unwrap_or(0)
+}
+
+/// Print a summary of suppressed duplicate warnings, if any.
+///
+/// Should be called just before the process exits. Prints to stderr.
+/// If no warnings were suppressed (or `init` was never called) this is a no-op.
+pub fn flush_summary() {
+    let total_suppressed: usize = match SUPPRESSED.lock() {
+        Ok(guard) => guard
+            .as_ref()
+            .map(|map| {
+                map.values()
+                    // Each entry counts: first print is not suppressed, so suppress count
+                    // is (total_seen - 1). We stored total_seen in the map entry.
+                    .map(|&seen| seen.saturating_sub(1))
+                    .sum()
+            })
+            .unwrap_or(0),
+        Err(_) => return,
+    };
+
+    if total_suppressed > 0 {
+        eprintln!("warning: {total_suppressed} additional identical warning(s) suppressed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    // Unit tests use a coarse test-level mutex to serialise execution.
+    // The global SUPPRESSED and QUIET statics are shared across all tests in the
+    // same process, so parallel execution would cause interference.
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    #[test]
+    fn dedup_first_occurrence_not_suppressed() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        warn("msg-dedup-first");
+        assert_eq!(suppressed_count_for("msg-dedup-first"), 0);
+    }
+
+    #[test]
+    fn dedup_second_occurrence_counted() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        warn("msg-dedup-second");
+        warn("msg-dedup-second");
+        assert_eq!(suppressed_count_for("msg-dedup-second"), 1);
+    }
+
+    #[test]
+    fn dedup_many_occurrences_all_counted() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        for _ in 0..5 {
+            warn("msg-dedup-many");
+        }
+        // First one is printed; remaining 4 are suppressed.
+        assert_eq!(suppressed_count_for("msg-dedup-many"), 4);
+        assert_eq!(total_suppressed(), 4);
+    }
+
+    #[test]
+    fn quiet_mode_suppresses_all() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(true);
+        warn("msg-quiet-a");
+        warn("msg-quiet-a");
+        // In quiet mode nothing is tracked or printed.
+        assert_eq!(suppressed_count_for("msg-quiet-a"), 0);
+    }
+
+    #[test]
+    fn different_messages_not_deduped() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        warn("msg-diff-a");
+        warn("msg-diff-b");
+        assert_eq!(suppressed_count_for("msg-diff-a"), 0);
+        assert_eq!(suppressed_count_for("msg-diff-b"), 0);
+        assert_eq!(total_suppressed(), 0);
+    }
+
+    #[test]
+    fn total_suppressed_across_multiple_messages() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        // "x" fires 3 times → 2 suppressed; "y" fires 2 times → 1 suppressed
+        for _ in 0..3 {
+            warn("msg-total-x");
+        }
+        for _ in 0..2 {
+            warn("msg-total-y");
+        }
+        assert_eq!(total_suppressed(), 3);
+    }
+}

--- a/crates/hyalo-cli/src/warn.rs
+++ b/crates/hyalo-cli/src/warn.rs
@@ -65,14 +65,13 @@ pub fn warn(msg: impl AsRef<str>) {
     if let Ok(mut guard) = SUPPRESSED.lock()
         && let Some(ref mut map) = *guard
     {
-        let count = map.entry(msg.to_owned()).or_insert(0);
-        if *count > 0 {
+        if let Some(count) = map.get_mut(msg) {
             // Already printed once — suppress and increment counter.
             *count += 1;
             return;
         }
-        // First occurrence: mark as seen (count = 1) and fall through to print.
-        *count = 1;
+        // First occurrence: insert and fall through to print.
+        map.insert(msg.to_owned(), 1);
         // guard.is_none() means init() hasn't been called yet — fall through to print.
     }
 

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -590,6 +590,48 @@ fn find_fields_backlinks_not_included_by_default() {
     }
 }
 
+#[test]
+fn find_fields_all_includes_every_category() {
+    let tmp = setup_vault();
+    // Use --file alpha.md so backlinks scanning covers a single file with known content
+    let (status, json, stderr) = find_json(&tmp, &["--fields", "all", "--file", "alpha.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let entry = &arr[0];
+
+    assert!(
+        entry["properties"].is_object(),
+        "properties should be present with --fields all"
+    );
+    assert!(
+        entry["properties_typed"].is_array(),
+        "properties_typed should be present with --fields all"
+    );
+    assert!(
+        entry["tags"].is_array(),
+        "tags should be present with --fields all"
+    );
+    assert!(
+        entry["sections"].is_array(),
+        "sections should be present with --fields all"
+    );
+    assert!(
+        entry["tasks"].is_array(),
+        "tasks should be present with --fields all"
+    );
+    assert!(
+        entry["links"].is_array(),
+        "links should be present with --fields all"
+    );
+    // backlinks is always an array (may be empty) when explicitly requested
+    assert!(
+        entry["backlinks"].is_array(),
+        "backlinks should be present with --fields all"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Sort
 // ---------------------------------------------------------------------------
@@ -2462,5 +2504,150 @@ fn find_whitespace_only_body_pattern_errors() {
     assert!(
         stderr.contains("body pattern must not be empty"),
         "stderr should contain error about empty pattern, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --fields title
+// ---------------------------------------------------------------------------
+
+fn setup_title_vault() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // File with title in frontmatter
+    write_md(
+        tmp.path(),
+        "with_fm_title.md",
+        md!(r"
+---
+title: Frontmatter Title
+status: active
+---
+# H1 Heading That Should Not Be Used
+
+Some body text.
+"),
+    );
+
+    // File with no title frontmatter property but an H1 heading
+    write_md(
+        tmp.path(),
+        "with_h1_title.md",
+        md!(r"
+---
+status: active
+---
+# H1 Heading Title
+
+Some body text.
+"),
+    );
+
+    // File with neither title property nor H1
+    write_md(
+        tmp.path(),
+        "no_title.md",
+        md!(r"
+---
+status: active
+---
+## Only an H2
+
+Some body text.
+"),
+    );
+
+    tmp
+}
+
+#[test]
+fn find_title_from_frontmatter() {
+    let tmp = setup_title_vault();
+    let (status, json, stderr) =
+        find_json(&tmp, &["--file", "with_fm_title.md", "--fields", "title"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let obj = &arr[0];
+    assert_eq!(
+        obj["title"].as_str(),
+        Some("Frontmatter Title"),
+        "title should come from frontmatter: {obj}"
+    );
+    // Other fields should not be present when --fields title is used alone
+    assert!(
+        obj.get("properties").is_none(),
+        "properties should not appear"
+    );
+    assert!(obj.get("tags").is_none(), "tags should not appear");
+    assert!(obj.get("sections").is_none(), "sections should not appear");
+}
+
+#[test]
+fn find_title_from_h1_when_no_frontmatter_property() {
+    let tmp = setup_title_vault();
+    let (status, json, stderr) =
+        find_json(&tmp, &["--file", "with_h1_title.md", "--fields", "title"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let obj = &arr[0];
+    assert_eq!(
+        obj["title"].as_str(),
+        Some("H1 Heading Title"),
+        "title should fall back to H1 heading: {obj}"
+    );
+}
+
+#[test]
+fn find_title_null_when_neither_found() {
+    let tmp = setup_title_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--file", "no_title.md", "--fields", "title"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let obj = &arr[0];
+    assert!(
+        obj["title"].is_null(),
+        "title should be null when neither frontmatter nor H1 found: {obj}"
+    );
+}
+
+#[test]
+fn find_title_not_present_by_default() {
+    let tmp = setup_title_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--file", "with_fm_title.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let obj = &arr[0];
+    assert!(
+        obj.get("title").is_none(),
+        "title should not appear in default output: {obj}"
+    );
+}
+
+#[test]
+fn find_fields_all_includes_title() {
+    let tmp = setup_title_vault();
+    let (status, json, stderr) =
+        find_json(&tmp, &["--file", "with_fm_title.md", "--fields", "all"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let obj = &arr[0];
+    assert!(
+        obj.get("title").is_some(),
+        "--fields all should include title: {obj}"
+    );
+    assert_eq!(obj["title"].as_str(), Some("Frontmatter Title"));
+    // Other standard fields should also be present
+    assert!(
+        obj.get("properties").is_some(),
+        "properties should appear with --fields all"
+    );
+    assert!(
+        obj.get("tags").is_some(),
+        "tags should appear with --fields all"
     );
 }

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -7,6 +7,7 @@ use tempfile::TempDir;
 // Fixture helpers
 // ---------------------------------------------------------------------------
 
+/// A 3-file vault sufficient for basic hints tests.
 fn setup_vault() -> TempDir {
     let tmp = TempDir::new().unwrap();
 
@@ -662,4 +663,221 @@ fn append_with_hints_warns() {
         stderr.contains("warning: --hints has no effect on mutation commands"),
         "should warn when --hints is passed to append: {stderr}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Larger vault fixture for data-driven find --hints tests
+// ---------------------------------------------------------------------------
+
+/// A 6-file vault where:
+///   - "rust" appears on 4 files (top tag)
+///   - status "planned" appears on 4 files (most interesting non-completed status)
+///   - status "completed" appears on 2 files
+fn setup_large_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+
+    for (name, status, tags) in &[
+        ("a", "planned", vec!["rust", "cli"]),
+        ("b", "planned", vec!["rust"]),
+        ("c", "planned", vec!["rust"]),
+        ("d", "planned", vec!["rust"]),
+        ("e", "completed", vec!["cli"]),
+        ("f", "completed", vec!["docs"]),
+    ] {
+        let tags_yaml: String = tags
+            .iter()
+            .map(|t| format!("  - {t}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        write_md(
+            tmp.path(),
+            &format!("{name}.md"),
+            md!(&format!(
+                "---\ntitle: {name}\nstatus: {status}\ntags:\n{tags_yaml}\n---\n# {name}\n"
+            )),
+        );
+    }
+
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// find --hints: data-driven narrowing suggestions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_hints_suggests_top_tag_from_results() {
+    let tmp = setup_large_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--hints", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // "rust" is the most common tag — hints should suggest it.
+    assert!(
+        stdout.contains("find --tag rust"),
+        "should suggest --tag rust (most common tag): {stdout}"
+    );
+}
+
+#[test]
+fn find_hints_suggests_interesting_status_from_results() {
+    let tmp = setup_large_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--hints", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // "planned" should be preferred over "completed" even though counts are close.
+    assert!(
+        stdout.contains("status=planned"),
+        "should suggest status=planned (interesting status): {stdout}"
+    );
+    // "completed" should NOT be suggested when "planned" is available.
+    assert!(
+        !stdout.contains("status=completed"),
+        "should not suggest completed when planned is available: {stdout}"
+    );
+}
+
+#[test]
+fn find_hints_no_hardcoded_draft() {
+    let tmp = setup_large_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--hints", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // The vault has no "draft" items — hints should not hardcode it.
+    assert!(
+        !stdout.contains("status=draft"),
+        "should not suggest hardcoded status=draft: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--tag draft"),
+        "should not suggest hardcoded tag draft: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// properties summary --hints: verify data-driven suggestions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn properties_summary_hints_json_envelope() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "summary", "--hints", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert!(parsed.get("data").is_some(), "should have 'data' key");
+    let hints = parsed["hints"].as_array().unwrap();
+    assert!(!hints.is_empty(), "should have hints");
+    for hint in hints {
+        assert!(hint.as_str().unwrap().starts_with("hyalo"));
+    }
+}
+
+#[test]
+fn properties_summary_hints_suggest_top_properties() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["properties", "summary", "--hints", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // The vault has "title" and "status" properties on all 3 files.
+    assert!(
+        stdout.contains("find --property title") || stdout.contains("find --property status"),
+        "should suggest find --property for common properties: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tags summary --hints: verify data-driven suggestions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_summary_hints_json_envelope() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "summary", "--hints", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert!(parsed.get("data").is_some(), "should have 'data' key");
+    let hints = parsed["hints"].as_array().unwrap();
+    assert!(!hints.is_empty(), "should have hints");
+    for hint in hints {
+        assert!(hint.as_str().unwrap().starts_with("hyalo"));
+    }
+}
+
+#[test]
+fn tags_summary_hints_suggest_top_tag_by_count() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "summary", "--hints", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // "rust" tag appears on 2 files (alpha and beta), "docs" on 1 — rust should be top.
+    assert!(
+        stdout.contains("find --tag rust"),
+        "should suggest find --tag for top tag (rust): {stdout}"
+    );
+}
+
+#[test]
+fn tags_summary_hints_empty_vault_no_crash() {
+    let tmp = TempDir::new().unwrap();
+    // Empty vault — no tags at all.
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["tags", "summary", "--hints", "--format", "json"])
+        .output()
+        .unwrap();
+    // Should succeed without crashing.
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    // Either no envelope (no hints) or empty hints array.
+    if let Some(hints) = parsed.get("hints") {
+        assert!(
+            hints.as_array().map(|a| a.is_empty()).unwrap_or(false),
+            "empty vault should produce no hints: {parsed}"
+        );
+    }
 }

--- a/crates/hyalo-cli/tests/e2e_quiet.rs
+++ b/crates/hyalo-cli/tests/e2e_quiet.rs
@@ -1,0 +1,267 @@
+mod common;
+
+use common::{hyalo, write_md};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write a markdown file with invalid YAML frontmatter (triggers a parse-error
+/// warning when hyalo tries to read it).
+fn write_invalid_frontmatter(dir: &std::path::Path, name: &str) {
+    write_md(dir, name, "---\nbad: [unclosed bracket\n---\n# Body\n");
+}
+
+/// Write a valid markdown file with a known tag so scans produce results.
+fn write_valid(dir: &std::path::Path, name: &str) {
+    write_md(
+        dir,
+        name,
+        "---\ntitle: Valid\ntags:\n  - test\n---\n# Body\n",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --quiet / -q: suppress warnings
+// ---------------------------------------------------------------------------
+
+/// Without `--quiet`, a parse-error warning is printed to stderr.
+#[test]
+fn warning_appears_without_quiet() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "good.md");
+    write_invalid_frontmatter(tmp.path(), "bad.md");
+
+    let output = hyalo()
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("tags")
+        .arg("summary")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning:"),
+        "expected warning on stderr without --quiet, got: {stderr:?}"
+    );
+}
+
+/// With `--quiet`, no warnings are printed to stderr.
+#[test]
+fn warning_suppressed_with_quiet_long() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "good.md");
+    write_invalid_frontmatter(tmp.path(), "bad.md");
+
+    let output = hyalo()
+        .arg("--quiet")
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("tags")
+        .arg("summary")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "expected no stderr with --quiet, got: {stderr:?}"
+    );
+    // stdout should still contain valid JSON
+    assert!(output.status.success(), "expected exit 0 with --quiet");
+}
+
+/// The short flag `-q` also suppresses warnings.
+#[test]
+fn warning_suppressed_with_quiet_short() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "good.md");
+    write_invalid_frontmatter(tmp.path(), "bad.md");
+
+    let output = hyalo()
+        .arg("-q")
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("tags")
+        .arg("summary")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "expected no stderr with -q, got: {stderr:?}"
+    );
+}
+
+/// The `--quiet` flag suppresses warnings on `find` too.
+#[test]
+fn warning_suppressed_on_find_with_quiet() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "good.md");
+    write_invalid_frontmatter(tmp.path(), "bad.md");
+
+    let output = hyalo()
+        .arg("-q")
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("find")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "expected no stderr from find with -q, got: {stderr:?}"
+    );
+}
+
+/// The `--quiet` flag suppresses warnings on `properties summary` too.
+#[test]
+fn warning_suppressed_on_properties_with_quiet() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "good.md");
+    write_invalid_frontmatter(tmp.path(), "bad.md");
+
+    let output = hyalo()
+        .arg("-q")
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("properties")
+        .arg("summary")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "expected no stderr from properties summary with -q, got: {stderr:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Warning dedup — verified via e2e + unit tests in warn.rs
+// ---------------------------------------------------------------------------
+
+// NOTE: Exact-string dedup of "skipping <file>: <reason>" warnings is not
+// trivially triggerable via the CLI because each file produces a unique
+// message (the filename is part of the message).  The dedup logic is
+// tested exhaustively at the unit level in crates/hyalo-cli/src/warn.rs.
+//
+// The e2e tests below verify:
+//  - Multiple unique warnings appear (no false dedup).
+//  - No spurious suppression summary when all messages are distinct.
+//  - The `--hints has no effect...` warning (a static message) is not
+//    duplicated when --hints is combined with a mutation command.
+
+/// Multiple files with different names each emit a unique warning.
+/// The suppression summary must NOT appear when no messages are identical.
+#[test]
+fn no_dedup_summary_for_unique_warnings() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "good.md");
+    for i in 0..3 {
+        write_invalid_frontmatter(tmp.path(), &format!("bad{i}.md"));
+    }
+
+    let output = hyalo()
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("tags")
+        .arg("summary")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Each bad file emits a unique warning (different filename in message).
+    assert_eq!(
+        stderr.matches("warning: skipping").count(),
+        3,
+        "expected 3 distinct warnings, got:\n{stderr}"
+    );
+    // No suppression summary for distinct messages.
+    assert!(
+        !stderr.contains("suppressed"),
+        "unexpected suppression summary for distinct warnings:\n{stderr}"
+    );
+}
+
+/// When a static warning message fires and no duplicates occur, no summary appears.
+#[test]
+fn no_dedup_summary_when_no_warnings_at_all() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "only.md");
+
+    let output = hyalo()
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("tags")
+        .arg("summary")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "expected empty stderr for clean vault, got:\n{stderr}"
+    );
+}
+
+/// The `--hints has no effect` warning is a static string (no per-file info).
+/// It fires exactly once — verify it appears exactly once and is not
+/// duplicated or suppressed.
+#[test]
+fn hints_warning_appears_exactly_once() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "note.md");
+
+    let output = hyalo()
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("--hints")
+        .arg("set")
+        .arg("--property")
+        .arg("status=done")
+        .arg("--file")
+        .arg("note.md")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("warning:").count(),
+        1,
+        "expected exactly 1 warning line, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--hints has no effect"),
+        "expected --hints warning, got:\n{stderr}"
+    );
+}
+
+/// With `--quiet`, no dedup summary appears even when multiple warnings would
+/// otherwise be present.
+#[test]
+fn quiet_suppresses_all_output_including_summary() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_valid(tmp.path(), "good.md");
+    for i in 0..3 {
+        write_invalid_frontmatter(tmp.path(), &format!("bad{i}.md"));
+    }
+
+    let output = hyalo()
+        .arg("--quiet")
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("tags")
+        .arg("summary")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "expected empty stderr with --quiet (all warnings suppressed), got:\n{stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_suggest.rs
+++ b/crates/hyalo-cli/tests/e2e_suggest.rs
@@ -119,3 +119,30 @@ fn no_suggestion_for_valid_task_toggle() {
         "exit code 2 indicates a clap error was hit; stderr: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --filter typo → suggest --property (not --file)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn suggest_property_when_filter_used() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--filter", "status=draft"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--property"),
+        "expected '--property' suggestion in stderr; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("--file"),
+        "unexpected '--file' suggestion in stderr; got: {stderr}"
+    );
+}

--- a/crates/hyalo-core/src/filter.rs
+++ b/crates/hyalo-core/src/filter.rs
@@ -520,6 +520,8 @@ pub struct Fields {
     pub links: bool,
     /// Backlinks are opt-in only: building the link graph requires scanning all files.
     pub backlinks: bool,
+    /// Title extracted from frontmatter `title` property or first H1 heading.
+    pub title: bool,
 }
 
 impl Default for Fields {
@@ -532,6 +534,7 @@ impl Default for Fields {
             tasks: true,
             links: true,
             backlinks: false,
+            title: false,
         }
     }
 }
@@ -555,6 +558,7 @@ impl Fields {
             tasks: false,
             links: false,
             backlinks: false,
+            title: false,
         };
 
         for item in input {
@@ -564,6 +568,16 @@ impl Fields {
                     continue;
                 }
                 match part {
+                    "all" => {
+                        fields.properties = true;
+                        fields.properties_typed = true;
+                        fields.tags = true;
+                        fields.sections = true;
+                        fields.tasks = true;
+                        fields.links = true;
+                        fields.backlinks = true;
+                        fields.title = true;
+                    }
                     "properties" => fields.properties = true,
                     "properties-typed" => fields.properties_typed = true,
                     "tags" => fields.tags = true,
@@ -571,8 +585,9 @@ impl Fields {
                     "tasks" => fields.tasks = true,
                     "links" => fields.links = true,
                     "backlinks" => fields.backlinks = true,
+                    "title" => fields.title = true,
                     unknown => bail!(
-                        "unknown field {:?}: valid fields are properties, properties-typed, tags, sections, tasks, links, backlinks",
+                        "unknown field {:?}: valid fields are all, properties, properties-typed, tags, sections, tasks, links, backlinks, title",
                         unknown
                     ),
                 }
@@ -1155,6 +1170,33 @@ mod tests {
         let f = Fields::parse(&input).unwrap();
         assert!(f.properties);
         assert!(f.properties_typed);
+    }
+
+    #[test]
+    fn fields_all_keyword_enables_everything() {
+        let input = vec!["all".to_owned()];
+        let f = Fields::parse(&input).unwrap();
+        assert!(f.properties, "properties should be set");
+        assert!(f.properties_typed, "properties_typed should be set");
+        assert!(f.tags, "tags should be set");
+        assert!(f.sections, "sections should be set");
+        assert!(f.tasks, "tasks should be set");
+        assert!(f.links, "links should be set");
+        assert!(f.backlinks, "backlinks should be set");
+        assert!(f.title, "title should be set");
+    }
+
+    #[test]
+    fn fields_title_only() {
+        let input = vec!["title".to_owned()];
+        let f = Fields::parse(&input).unwrap();
+        assert!(f.title, "title should be set");
+        assert!(!f.properties, "properties should not be set");
+        assert!(!f.tags, "tags should not be set");
+        assert!(!f.sections, "sections should not be set");
+        assert!(!f.tasks, "tasks should not be set");
+        assert!(!f.links, "links should not be set");
+        assert!(!f.backlinks, "backlinks should not be set");
     }
 
     #[test]

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -202,6 +202,12 @@ pub struct ContentMatch {
 pub struct FileObject {
     pub file: String,
     pub modified: String,
+    /// Title extracted from frontmatter `title` property or first H1 heading.
+    /// - `None`: field not requested (omitted from JSON output)
+    /// - `Some(Value::String(...))`: title found
+    /// - `Some(Value::Null)`: title requested but not found
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<serde_json::Map<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/hyalo-knowledgebase/backlog/fields-title-skip-body-scan.md
+++ b/hyalo-knowledgebase/backlog/fields-title-skip-body-scan.md
@@ -1,0 +1,19 @@
+---
+title: "Skip body scan for --fields title when frontmatter has title"
+type: backlog
+date: 2026-03-28
+status: planned
+priority: low
+origin: Copilot review on PR #68 (iter-58)
+tags:
+  - performance
+  - find
+---
+
+When `--fields title` is set, `needs_body()` returns `true` unconditionally, triggering the full `SectionScanner` on every file. But if the frontmatter already contains a `title` property (the common case), the body scan is unnecessary — the title is resolved from frontmatter without needing the H1 heading.
+
+**Fix:** Parse frontmatter first, check for a string `title` property, and only fall back to body scanning for the H1 when it's absent. This avoids the `SectionScanner` overhead on files that already have a frontmatter title.
+
+**Note:** The index path (`--index`) already resolves titles from `entry.properties` and `entry.sections` without any body scan, so this issue only affects the disk-scan path. Using `--index` is the recommended workaround for large vaults.
+
+**Impact:** Proportional to vault size and how many files have frontmatter titles. Negligible on small vaults; potentially noticeable on large ones where most files already declare `title` in frontmatter.

--- a/hyalo-knowledgebase/backlog/filter-typo-suggestion.md
+++ b/hyalo-knowledgebase/backlog/filter-typo-suggestion.md
@@ -9,7 +9,4 @@ origin: dogfooding v0.4.2 on docs/content
 
 When a user types `--filter` (which doesn't exist), clap suggests `--file` as the closest match. Since the user almost certainly meant `--property`, the error message is misleading.
 
-**Fix options:**
-1. Add `--filter` as a hidden alias for `--property` (most user-friendly)
-2. Customize the clap error to suggest `--property` explicitly
-3. Add `visible_alias("filter")` to the property arg in clap
+**Fix:** Customize clap's error handling so that unknown flags like `--filter` suggest `--property` instead of the misleading `--file` suggestion based on string similarity alone.

--- a/hyalo-knowledgebase/iterations/iteration-58-find-ux-polish.md
+++ b/hyalo-knowledgebase/iterations/iteration-58-find-ux-polish.md
@@ -1,8 +1,8 @@
 ---
-title: "Iteration 58 — Find command UX polish"
+title: Iteration 58 — Find command UX polish
 type: iteration
 date: 2026-03-28
-status: planned
+status: in-progress
 branch: iter-58/find-ux-polish
 tags:
   - ux
@@ -16,9 +16,9 @@ Small, independent improvements to the `find` command that improve discoverabili
 
 ## Tasks
 
-- [ ] Support `--fields all` keyword ([[backlog/fields-all-keyword.md]])
-- [ ] Support `--fields title` shorthand ([[backlog/fields-title-shorthand.md]])
-- [ ] Add `--filter` as hidden alias for `--property` ([[backlog/filter-typo-suggestion.md]])
-- [ ] Add `--quiet` / `-q` flag to suppress warnings ([[backlog/quiet-flag-warning-dedup.md]])
-- [ ] Deduplicate identical warnings within a single invocation (show summary count)
-- [ ] Fix `--hints` flag silently accepted but no-op for find/properties/tags ([[backlog/hints-flag-no-op-for-most-commands.md]])
+- [x] Support `--fields all` keyword ([[backlog/fields-all-keyword.md]])
+- [x] Support `--fields title` shorthand ([[backlog/fields-title-shorthand.md]])
+- [x] Improve clap suggestion when user types `--filter` to suggest `--property` instead of `--file` ([[backlog/filter-typo-suggestion.md]])
+- [x] Add `--quiet` / `-q` flag to suppress warnings ([[backlog/quiet-flag-warning-dedup.md]])
+- [x] Deduplicate identical warnings within a single invocation (show summary count)
+- [x] Fix `--hints` flag silently accepted but no-op for find/properties/tags ([[backlog/hints-flag-no-op-for-most-commands.md]])


### PR DESCRIPTION
## Summary

- **`--fields all`**: New keyword that includes every field category in find results
- **`--fields title`**: Convenience shorthand extracting title from frontmatter property → first H1 heading → null; works in both disk-scan and index-backed paths, renders in JSON and text output
- **`--filter` suggestion**: Intercepts clap's `UnknownArgument` error to suggest `--property` instead of the misleading `--file`
- **`--quiet` / `-q`**: New global flag with centralized `warn.rs` module replacing ~20 scattered `eprintln!("warning: ...")` calls; identical warnings are deduplicated with a summary count at exit
- **`--hints` for find**: Now generates data-driven suggestions from actual result data (top tags, interesting statuses) instead of hardcoded `status=draft` / `tag draft`

## Test plan

- [x] `--fields all` — unit test + e2e test verifying all 7 field categories present
- [x] `--fields title` — 5 e2e tests: frontmatter source, H1 fallback, null when absent, excluded by default, included in `--fields all`
- [x] `--filter` suggestion — e2e test asserting stderr contains `--property`, not `--file`
- [x] `--quiet` / `-q` — 9 e2e tests covering suppression for find, properties, summary; long/short flag forms
- [x] Warning dedup — unit tests in `warn.rs` + e2e coverage in `e2e_quiet.rs`
- [x] Hints — 7 unit tests + 8 e2e tests for find/properties/tags hints with data-driven assertions
- [x] All quality gates pass: `cargo fmt`, `cargo clippy -D warnings`, `cargo test` (458 tests)