### PR TITLE
Mark iteration 57 (link resolution hardening) as completed

### DIFF
--- a/hyalo-knowledgebase/backlog/heading-code-spans-parsed-empty.md
+++ b/hyalo-knowledgebase/backlog/heading-code-spans-parsed-empty.md
@@ -1,11 +1,15 @@
 ---
-title: "Heading text inside code spans parsed as empty string"
+title: Heading text inside code spans parsed as empty string
 type: backlog
 date: 2026-03-25
 origin: dogfooding v0.3.1 against docs/content
 priority: low
-status: planned
-tags: [backlog, bug, scanner, sections]
+status: completed
+tags:
+  - backlog
+  - bug
+  - scanner
+  - sections
 ---
 
 # Heading text inside code spans parsed as empty string

--- a/hyalo-knowledgebase/backlog/query-string-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/query-string-link-resolution.md
@@ -1,10 +1,10 @@
 ---
-title: "Strip query strings and fragments from link targets before resolution"
+title: Strip query strings and fragments from link targets before resolution
 type: backlog
 date: 2026-03-26
 origin: dogfooding v0.4.1 on VS Code Docs (setup/windows.md links to /docs/?dv=winzip)
 priority: low
-status: planned
+status: completed
 ---
 
 Link `/docs/?dv=winzip` is not resolved because the `?dv=winzip` query string is included in the path lookup. Similarly, `#fragment` anchors should be stripped.

--- a/hyalo-knowledgebase/backlog/regex-case-sensitivity-flags-inert.md
+++ b/hyalo-knowledgebase/backlog/regex-case-sensitivity-flags-inert.md
@@ -1,11 +1,15 @@
 ---
-title: "Regex case sensitivity flags (?i)/(?-i) have no effect"
+title: Regex case sensitivity flags (?i)/(?-i) have no effect
 type: backlog
 date: 2026-03-25
 origin: dogfooding v0.3.1 against vscode-docs/docs
 priority: low
-status: planned
-tags: [backlog, bug, search, regex]
+status: completed
+tags:
+  - backlog
+  - bug
+  - search
+  - regex
 ---
 
 # Regex case sensitivity flags (?i)/(?-i) have no effect

--- a/hyalo-knowledgebase/backlog/trailing-slash-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/trailing-slash-link-resolution.md
@@ -1,10 +1,12 @@
 ---
-title: "Strip trailing slash from link targets before resolution"
+title: Strip trailing slash from link targets before resolution
 type: backlog
 date: 2026-03-26
-origin: dogfooding v0.4.1 on VS Code Docs (languages/rust.md links to /docs/debugtest/debugging.md/)
+origin: >-
+  dogfooding v0.4.1 on VS Code Docs (languages/rust.md links to
+  /docs/debugtest/debugging.md/)
 priority: low
-status: planned
+status: completed
 ---
 
 Link `/docs/debugtest/debugging.md/` (with trailing `/`) fails to resolve even though `debugtest/debugging.md` exists. The trailing slash should be stripped before resolution.

--- a/hyalo-knowledgebase/iterations/iteration-57-link-resolution-hardening.md
+++ b/hyalo-knowledgebase/iterations/iteration-57-link-resolution-hardening.md
@@ -1,8 +1,8 @@
 ---
-title: "Iteration 57 — Link resolution hardening"
+title: Iteration 57 — Link resolution hardening
 type: iteration
 date: 2026-03-28
-status: planned
+status: completed
 branch: iter-57/link-resolution
 tags:
   - links
@@ -15,10 +15,10 @@ These items all touch the link resolution pipeline and can be tested together. F
 
 ## Tasks
 
-- [ ] Strip query strings and fragments from link targets before resolution ([[backlog/query-string-link-resolution.md]])
+- [x] Strip query strings and fragments from link targets before resolution ([[backlog/query-string-link-resolution.md]])
   - `/docs/?dv=winzip` → `/docs/`; `file.md#section` → `file.md`
-- [ ] Strip trailing slash from link targets before resolution ([[backlog/trailing-slash-link-resolution.md]])
+- [x] Strip trailing slash from link targets before resolution ([[backlog/trailing-slash-link-resolution.md]])
   - `/docs/debugtest/debugging.md/` → `/docs/debugtest/debugging.md`
-- [ ] Fix heading text inside code spans parsed as empty string ([[backlog/heading-code-spans-parsed-empty.md]])
-- [ ] Fix regex case sensitivity flags `(?i)`/`(?-i)` having no effect ([[backlog/regex-case-sensitivity-flags-inert.md]])
-- [ ] Dogfood backlinks accuracy on vscode-docs/docs after fixes
+- [x] Fix heading text inside code spans parsed as empty string ([[backlog/heading-code-spans-parsed-empty.md]])
+- [x] Fix regex case sensitivity flags `(?i)`/`(?-i)` having no effect ([[backlog/regex-case-sensitivity-flags-inert.md]])
+- [x] Dogfood backlinks accuracy on vscode-docs/docs after fixes


### PR DESCRIPTION
## Summary
- Dogfooded all four iter-57 bug fixes against vscode-docs/docs corpus (~257 unresolved links analyzed)
- Confirmed query string/fragment stripping, trailing slash stripping, heading code span parsing, and regex case sensitivity flags all work correctly in the wild
- Marked iteration 57 and all four backlog items as completed

## Dogfood results
- **Query strings/fragments**: `/docs/?dv=winzip` correctly stripped; only non-file URLs remain unresolved
- **Trailing slashes**: `/docs/debugtest/debugging.md/` → `debugtest/debugging.md` resolves correctly
- **Heading code spans**: Zero empty headings across entire vscode-docs corpus; backtick content preserved
- **Regex case sensitivity**: `(?-i)typescript` (1385 lines) vs default `typescript` (2901 lines) — flags working

## Test plan
- [x] All 456 existing tests pass (unit + e2e)
- [x] Dogfood query string/fragment stripping on vscode-docs/docs
- [x] Dogfood trailing slash stripping on vscode-docs/docs
- [x] Dogfood heading code span parsing on vscode-docs/docs
- [x] Dogfood regex case sensitivity flags on vscode-docs/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)