### PR TITLE
Add --sort by frontmatter property value

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ hyalo find --fields properties,backlinks           # combine with other fields
 
 # Sort and limit
 hyalo find --sort modified --limit 10
-hyalo find --sort title                             # sort by frontmatter title
+hyalo find --sort title                             # sort by title (frontmatter or first H1)
 hyalo find --sort date                              # sort by frontmatter date
 hyalo find --sort property:priority                 # sort by any frontmatter property
 ```

--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ hyalo find --fields properties,backlinks           # combine with other fields
 
 # Sort and limit
 hyalo find --sort modified --limit 10
+hyalo find --sort title                             # sort by frontmatter title
+hyalo find --sort date                              # sort by frontmatter date
+hyalo find --sort property:priority                 # sort by any frontmatter property
 ```
 
 ### read

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -69,6 +69,7 @@ pub fn find(
 
     let sort_needs_backlinks = matches!(sort, Some(SortField::BacklinksCount));
     let sort_needs_links = matches!(sort, Some(SortField::LinksCount));
+    let sort_needs_properties = matches!(sort, Some(SortField::Property(_)));
 
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
@@ -135,7 +136,22 @@ pub fn find(
         && matches!(sort.unwrap_or(&SortField::File), SortField::File)
         && !fields.backlinks
         && !sort_needs_backlinks
-        && !sort_needs_links;
+        && !sort_needs_links
+        && !sort_needs_properties;
+
+    // When sorting by a frontmatter property, we need properties populated in
+    // the FileObject even if the user didn't request --fields properties.
+    let original_fields = fields;
+    let effective_fields;
+    let fields = if sort_needs_properties && !fields.properties {
+        effective_fields = Fields {
+            properties: true,
+            ..fields.clone()
+        };
+        &effective_fields
+    } else {
+        fields
+    };
 
     let mut results: Vec<FileObject> = Vec::new();
 
@@ -289,46 +305,18 @@ pub fn find(
     }
 
     // --- Sort ---
-    match sort.unwrap_or(&SortField::File) {
-        SortField::File => results.sort_by(|a, b| a.file.cmp(&b.file)),
-        SortField::Modified => results.sort_by(|a, b| a.modified.cmp(&b.modified)),
-        SortField::BacklinksCount => {
-            // Sort descending by backlink count (most-linked first).
-            results.sort_by(|a, b| {
-                let a_count = a.backlinks.as_ref().map_or_else(
-                    || {
-                        link_graph
-                            .as_ref()
-                            .map_or(0, |g| g.backlinks(&a.file).len())
-                    },
-                    Vec::len,
-                );
-                let b_count = b.backlinks.as_ref().map_or_else(
-                    || {
-                        link_graph
-                            .as_ref()
-                            .map_or(0, |g| g.backlinks(&b.file).len())
-                    },
-                    Vec::len,
-                );
-                b_count.cmp(&a_count)
-            });
-        }
-        SortField::LinksCount => {
-            // Sort descending by outbound link count.
-            results.sort_by(|a, b| {
-                let a_count = a.links.as_ref().map_or(0, Vec::len);
-                let b_count = b.links.as_ref().map_or(0, Vec::len);
-                b_count.cmp(&a_count)
-            });
-        }
-    }
+    apply_sort(&mut results, sort, link_graph.as_ref());
 
     // Strip internally-computed fields that the user didn't request in --fields.
-    // These were populated only to support sorting by count.
-    if sort_needs_links && !fields.links {
+    // These were populated only to support sorting by count or property.
+    if sort_needs_links && !original_fields.links {
         for obj in &mut results {
             obj.links = None;
+        }
+    }
+    if sort_needs_properties && !original_fields.properties {
+        for obj in &mut results {
+            obj.properties = None;
         }
     }
     // Note: no strip needed for BacklinksCount — build_file_object only populates
@@ -513,6 +501,7 @@ pub fn find_from_index(
 
     let sort_needs_backlinks = matches!(sort, Some(SortField::BacklinksCount));
     let sort_needs_links = matches!(sort, Some(SortField::LinksCount));
+    let sort_needs_properties = matches!(sort, Some(SortField::Property(_)));
 
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
@@ -555,7 +544,21 @@ pub fn find_from_index(
         && matches!(sort.unwrap_or(&SortField::File), SortField::File)
         && !fields.backlinks
         && !sort_needs_backlinks
-        && !sort_needs_links;
+        && !sort_needs_links
+        && !sort_needs_properties;
+
+    // When sorting by a frontmatter property, ensure properties are populated.
+    let original_fields = fields;
+    let effective_fields;
+    let fields = if sort_needs_properties && !fields.properties {
+        effective_fields = Fields {
+            properties: true,
+            ..fields.clone()
+        };
+        &effective_fields
+    } else {
+        fields
+    };
 
     let mut results: Vec<FileObject> = Vec::new();
 
@@ -763,35 +766,17 @@ pub fn find_from_index(
     }
 
     // --- Sort ---
-    match sort.unwrap_or(&SortField::File) {
-        SortField::File => results.sort_by(|a, b| a.file.cmp(&b.file)),
-        SortField::Modified => results.sort_by(|a, b| a.modified.cmp(&b.modified)),
-        SortField::BacklinksCount => {
-            results.sort_by(|a, b| {
-                let a_count = a.backlinks.as_ref().map_or_else(
-                    || link_graph_ref.map_or(0, |g| g.backlinks(&a.file).len()),
-                    Vec::len,
-                );
-                let b_count = b.backlinks.as_ref().map_or_else(
-                    || link_graph_ref.map_or(0, |g| g.backlinks(&b.file).len()),
-                    Vec::len,
-                );
-                b_count.cmp(&a_count)
-            });
-        }
-        SortField::LinksCount => {
-            results.sort_by(|a, b| {
-                let a_count = a.links.as_ref().map_or(0, Vec::len);
-                let b_count = b.links.as_ref().map_or(0, Vec::len);
-                b_count.cmp(&a_count)
-            });
-        }
-    }
+    apply_sort(&mut results, sort, link_graph_ref);
 
-    // Strip internally-computed links field if user didn't request it
-    if sort_needs_links && !fields.links {
+    // Strip internally-computed fields that the user didn't request in --fields.
+    if sort_needs_links && !original_fields.links {
         for obj in &mut results {
             obj.links = None;
+        }
+    }
+    if sort_needs_properties && !original_fields.properties {
+        for obj in &mut results {
+            obj.properties = None;
         }
     }
 
@@ -887,6 +872,45 @@ fn format_modified(path: &Path) -> Result<String> {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     Ok(format_iso8601(secs))
+}
+
+/// Apply the requested sort order to the results.
+fn apply_sort(
+    results: &mut [FileObject],
+    sort: Option<&SortField>,
+    link_graph: Option<&LinkGraph>,
+) {
+    match sort.unwrap_or(&SortField::File) {
+        SortField::File => results.sort_by(|a, b| a.file.cmp(&b.file)),
+        SortField::Modified => results.sort_by(|a, b| a.modified.cmp(&b.modified)),
+        SortField::BacklinksCount => {
+            results.sort_by(|a, b| {
+                let a_count = a.backlinks.as_ref().map_or_else(
+                    || link_graph.map_or(0, |g| g.backlinks(&a.file).len()),
+                    Vec::len,
+                );
+                let b_count = b.backlinks.as_ref().map_or_else(
+                    || link_graph.map_or(0, |g| g.backlinks(&b.file).len()),
+                    Vec::len,
+                );
+                b_count.cmp(&a_count)
+            });
+        }
+        SortField::LinksCount => {
+            results.sort_by(|a, b| {
+                let a_count = a.links.as_ref().map_or(0, Vec::len);
+                let b_count = b.links.as_ref().map_or(0, Vec::len);
+                b_count.cmp(&a_count)
+            });
+        }
+        SortField::Property(key) => {
+            results.sort_by(|a, b| {
+                let a_val = a.properties.as_ref().and_then(|p| p.get(key));
+                let b_val = b.properties.as_ref().and_then(|p| p.get(key));
+                filter::compare_property_values(a_val, b_val)
+            });
+        }
+    }
 }
 
 use super::format_iso8601;

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -70,6 +70,7 @@ pub fn find(
     let sort_needs_backlinks = matches!(sort, Some(SortField::BacklinksCount));
     let sort_needs_links = matches!(sort, Some(SortField::LinksCount));
     let sort_needs_properties = matches!(sort, Some(SortField::Property(_)));
+    let sort_needs_title = matches!(sort, Some(SortField::Title));
 
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
@@ -79,7 +80,8 @@ pub fn find(
         has_content_search,
         has_task_filter,
         has_section_filter,
-    ) || sort_needs_links;
+    ) || sort_needs_links
+        || sort_needs_title;
 
     // Compile the regex once (if any), then clone cheaply per file.
     // Invalid regex is a user error (exit 1), not an internal error (exit 2).
@@ -137,21 +139,24 @@ pub fn find(
         && !fields.backlinks
         && !sort_needs_backlinks
         && !sort_needs_links
-        && !sort_needs_properties;
+        && !sort_needs_properties
+        && !sort_needs_title;
 
-    // When sorting by a frontmatter property, we need properties populated in
-    // the FileObject even if the user didn't request --fields properties.
+    // When sorting by a frontmatter property or title, force the relevant
+    // field on even if the user didn't request it via --fields.
     let original_fields = fields;
     let effective_fields;
-    let fields = if sort_needs_properties && !fields.properties {
-        effective_fields = Fields {
-            properties: true,
-            ..fields.clone()
+    let fields =
+        if (sort_needs_properties && !fields.properties) || (sort_needs_title && !fields.title) {
+            effective_fields = Fields {
+                properties: fields.properties || sort_needs_properties,
+                title: fields.title || sort_needs_title,
+                ..fields.clone()
+            };
+            &effective_fields
+        } else {
+            fields
         };
-        &effective_fields
-    } else {
-        fields
-    };
 
     let mut results: Vec<FileObject> = Vec::new();
 
@@ -317,6 +322,11 @@ pub fn find(
     if sort_needs_properties && !original_fields.properties {
         for obj in &mut results {
             obj.properties = None;
+        }
+    }
+    if sort_needs_title && !original_fields.title {
+        for obj in &mut results {
+            obj.title = None;
         }
     }
     // Note: no strip needed for BacklinksCount — build_file_object only populates
@@ -502,6 +512,7 @@ pub fn find_from_index(
     let sort_needs_backlinks = matches!(sort, Some(SortField::BacklinksCount));
     let sort_needs_links = matches!(sort, Some(SortField::LinksCount));
     let sort_needs_properties = matches!(sort, Some(SortField::Property(_)));
+    let sort_needs_title = matches!(sort, Some(SortField::Title));
 
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
@@ -545,20 +556,24 @@ pub fn find_from_index(
         && !fields.backlinks
         && !sort_needs_backlinks
         && !sort_needs_links
-        && !sort_needs_properties;
+        && !sort_needs_properties
+        && !sort_needs_title;
 
-    // When sorting by a frontmatter property, ensure properties are populated.
+    // When sorting by a frontmatter property or title, force the relevant
+    // field on even if the user didn't request it via --fields.
     let original_fields = fields;
     let effective_fields;
-    let fields = if sort_needs_properties && !fields.properties {
-        effective_fields = Fields {
-            properties: true,
-            ..fields.clone()
+    let fields =
+        if (sort_needs_properties && !fields.properties) || (sort_needs_title && !fields.title) {
+            effective_fields = Fields {
+                properties: fields.properties || sort_needs_properties,
+                title: fields.title || sort_needs_title,
+                ..fields.clone()
+            };
+            &effective_fields
+        } else {
+            fields
         };
-        &effective_fields
-    } else {
-        fields
-    };
 
     let mut results: Vec<FileObject> = Vec::new();
 
@@ -779,6 +794,11 @@ pub fn find_from_index(
             obj.properties = None;
         }
     }
+    if sort_needs_title && !original_fields.title {
+        for obj in &mut results {
+            obj.title = None;
+        }
+    }
 
     // --- Limit ---
     if let Some(n) = limit {
@@ -903,11 +923,18 @@ fn apply_sort(
                 b_count.cmp(&a_count)
             });
         }
+        SortField::Title => {
+            results.sort_by(|a, b| {
+                let a_val = a.title.as_ref();
+                let b_val = b.title.as_ref();
+                filter::compare_property_values(a_val, b_val).then_with(|| a.file.cmp(&b.file))
+            });
+        }
         SortField::Property(key) => {
             results.sort_by(|a, b| {
                 let a_val = a.properties.as_ref().and_then(|p| p.get(key));
                 let b_val = b.properties.as_ref().and_then(|p| p.get(key));
-                filter::compare_property_values(a_val, b_val)
+                filter::compare_property_values(a_val, b_val).then_with(|| a.file.cmp(&b.file))
             });
         }
     }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -319,7 +319,7 @@ enum Commands {
         /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections, tasks, links, backlinks, title (default: all standard fields except properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
         #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
         fields: Vec<String>,
-        /// Sort order: 'file' (default), 'modified', 'backlinks_count', or 'links_count'
+        /// Sort order: 'file' (default), 'modified', 'backlinks_count', 'links_count', 'title', 'date', or 'property:<KEY>' for any frontmatter property
         #[arg(long)]
         sort: Option<String>,
         /// Maximum number of results to return (must be at least 1)

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -2468,6 +2468,111 @@ fn find_sort_links_count_without_fields_links() {
 }
 
 // ---------------------------------------------------------------------------
+// Sort by frontmatter property
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_sort_title() {
+    let tmp = setup_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--sort", "title"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    // Alpha, Beta, Nested sort first (alphabetically), gamma.md (no title) sorts last
+    assert_eq!(files[0], "alpha.md");
+    assert_eq!(files[1], "beta.md");
+    assert_eq!(files[2], "sub/nested.md");
+    assert_eq!(files[3], "gamma.md", "file without title should sort last");
+}
+
+#[test]
+fn find_sort_property_generic() {
+    let tmp = setup_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--sort", "property:status"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    // completed < planned (alphabetically), gamma.md (no status) sorts last
+    assert_eq!(files[0], "beta.md", "completed should sort first");
+    assert_eq!(
+        files.last().unwrap(),
+        &"gamma.md",
+        "missing status sorts last"
+    );
+}
+
+#[test]
+fn find_sort_property_without_fields_properties() {
+    // Sort by property should work even when --fields excludes properties
+    let tmp = setup_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--sort", "title", "--fields", "tags"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files[0], "alpha.md");
+    // Verify properties field is NOT in output (user excluded it via --fields)
+    assert!(
+        arr[0].get("properties").is_none(),
+        "properties should not appear in output when not in --fields"
+    );
+}
+
+#[test]
+fn find_sort_date() {
+    // Create a vault with dates to test --sort date
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "newer.md",
+        md!(r"
+---
+title: Newer
+date: 2026-03-28
+---
+Content.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "older.md",
+        md!(r"
+---
+title: Older
+date: 2024-01-15
+---
+Content.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "no-date.md",
+        md!(r"
+---
+title: No Date
+---
+Content.
+"),
+    );
+    let (status, json, stderr) = find_json(&tmp, &["--sort", "date"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files[0], "older.md", "2024 should sort before 2026");
+    assert_eq!(files[1], "newer.md");
+    assert_eq!(files[2], "no-date.md", "missing date should sort last");
+}
+
+#[test]
+fn find_sort_property_empty_key_errors() {
+    let tmp = setup_vault();
+    let mut cmd = hyalo();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["find", "--sort", "property:"]);
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success(), "empty property key should fail");
+}
+
+// ---------------------------------------------------------------------------
 // Empty body pattern error
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -2477,12 +2477,44 @@ fn find_sort_title() {
     let (status, json, stderr) = find_json(&tmp, &["--sort", "title"]);
     assert!(status.success(), "stderr: {stderr}");
     let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 4);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
-    // Alpha, Beta, Nested sort first (alphabetically), gamma.md (no title) sorts last
+    // Title uses extract_title: frontmatter title first, then first H1.
+    // gamma.md has no frontmatter title but has "# Gamma" → resolves to "Gamma".
+    // All four: Alpha, Beta, Gamma, Nested (alphabetical).
     assert_eq!(files[0], "alpha.md");
     assert_eq!(files[1], "beta.md");
-    assert_eq!(files[2], "sub/nested.md");
-    assert_eq!(files[3], "gamma.md", "file without title should sort last");
+    assert_eq!(files[2], "gamma.md");
+    assert_eq!(files[3], "sub/nested.md");
+}
+
+#[test]
+fn find_sort_title_missing_sorts_last() {
+    // File with neither frontmatter title nor H1 heading sorts last.
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: Alpha
+---
+Content.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+No frontmatter, no heading.
+"),
+    );
+    let (status, json, stderr) = find_json(&tmp, &["--sort", "title"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files[0], "a.md");
+    assert_eq!(files[1], "b.md", "file without any title should sort last");
 }
 
 #[test]
@@ -2502,14 +2534,31 @@ fn find_sort_property_generic() {
 }
 
 #[test]
-fn find_sort_property_without_fields_properties() {
-    // Sort by property should work even when --fields excludes properties
+fn find_sort_title_without_fields_title() {
+    // Sort by title should work even when --fields excludes title
     let tmp = setup_vault();
     let (status, json, stderr) = find_json(&tmp, &["--sort", "title", "--fields", "tags"]);
     assert!(status.success(), "stderr: {stderr}");
     let arr = json.as_array().unwrap();
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files[0], "alpha.md");
+    // Verify title field is NOT in output (user excluded it via --fields)
+    assert!(
+        arr[0].get("title").is_none(),
+        "title should not appear in output when not in --fields"
+    );
+}
+
+#[test]
+fn find_sort_property_without_fields_properties() {
+    // Sort by property should work even when --fields excludes properties
+    let tmp = setup_vault();
+    let (status, json, stderr) =
+        find_json(&tmp, &["--sort", "property:status", "--fields", "tags"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let arr = json.as_array().unwrap();
+    let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
+    assert_eq!(files[0], "beta.md", "completed should sort first");
     // Verify properties field is NOT in output (user excluded it via --fields)
     assert!(
         arr[0].get("properties").is_none(),

--- a/crates/hyalo-core/src/filter.rs
+++ b/crates/hyalo-core/src/filter.rs
@@ -607,19 +607,72 @@ pub enum SortField {
     Modified,
     BacklinksCount,
     LinksCount,
+    /// Sort by a frontmatter property value (e.g. `title`, `date`, or any key).
+    Property(String),
 }
 
 /// Parse a sort field from a string.
+///
+/// Accepts built-in fields (`file`, `modified`, `backlinks_count`, `links_count`)
+/// and frontmatter property names via the `property:<KEY>` syntax.
+/// `title` and `date` are convenient aliases for `property:title` and `property:date`.
 pub fn parse_sort(input: &str) -> Result<SortField> {
     match input {
         "file" => Ok(SortField::File),
         "modified" => Ok(SortField::Modified),
         "backlinks_count" => Ok(SortField::BacklinksCount),
         "links_count" => Ok(SortField::LinksCount),
-        other => bail!(
-            "unknown sort field {:?}: valid values are 'file', 'modified', 'backlinks_count', 'links_count'",
-            other
-        ),
+        "title" => Ok(SortField::Property("title".to_owned())),
+        "date" => Ok(SortField::Property("date".to_owned())),
+        other => {
+            if let Some(key) = other.strip_prefix("property:") {
+                if key.is_empty() {
+                    bail!("property sort key must not be empty: use 'property:<KEY>'");
+                }
+                Ok(SortField::Property(key.to_owned()))
+            } else {
+                bail!(
+                    "unknown sort field {:?}: valid values are 'file', 'modified', \
+                     'backlinks_count', 'links_count', 'title', 'date', or 'property:<KEY>'",
+                    other
+                )
+            }
+        }
+    }
+}
+
+/// Compare two `serde_json::Value`s for sorting purposes.
+///
+/// Ordering rules:
+/// - `Null` / missing sorts **last** (greater than any non-null value).
+/// - Strings are compared lexicographically (case-sensitive).
+/// - Numbers are compared as f64.
+/// - Booleans: `false` < `true`.
+/// - Arrays/objects are compared by their JSON string representation (fallback).
+pub fn compare_property_values(
+    a: Option<&serde_json::Value>,
+    b: Option<&serde_json::Value>,
+) -> std::cmp::Ordering {
+    use serde_json::Value;
+    use std::cmp::Ordering;
+
+    match (a, b) {
+        (None | Some(Value::Null), None | Some(Value::Null)) => Ordering::Equal,
+        (None | Some(Value::Null), _) => Ordering::Greater, // missing sorts last
+        (_, None | Some(Value::Null)) => Ordering::Less,
+        (Some(Value::String(sa)), Some(Value::String(sb))) => sa.cmp(sb),
+        (Some(Value::Number(na)), Some(Value::Number(nb))) => {
+            let fa = na.as_f64().unwrap_or(f64::NAN);
+            let fb = nb.as_f64().unwrap_or(f64::NAN);
+            fa.partial_cmp(&fb).unwrap_or(Ordering::Equal)
+        }
+        (Some(Value::Bool(ba)), Some(Value::Bool(bb))) => ba.cmp(bb),
+        (Some(va), Some(vb)) => {
+            // Fallback: compare JSON representations.
+            let sa = va.to_string();
+            let sb = vb.to_string();
+            sa.cmp(&sb)
+        }
     }
 }
 
@@ -1220,9 +1273,85 @@ mod tests {
     }
 
     #[test]
+    fn sort_title_alias() {
+        assert_eq!(
+            parse_sort("title").unwrap(),
+            SortField::Property("title".to_owned())
+        );
+    }
+
+    #[test]
+    fn sort_date_alias() {
+        assert_eq!(
+            parse_sort("date").unwrap(),
+            SortField::Property("date".to_owned())
+        );
+    }
+
+    #[test]
+    fn sort_property_generic() {
+        assert_eq!(
+            parse_sort("property:priority").unwrap(),
+            SortField::Property("priority".to_owned())
+        );
+    }
+
+    #[test]
+    fn sort_property_empty_key_errors() {
+        assert!(parse_sort("property:").is_err());
+    }
+
+    #[test]
     fn sort_unknown_errors() {
         assert!(parse_sort("name").is_err());
         assert!(parse_sort("").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // compare_property_values
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compare_null_sorts_last() {
+        use std::cmp::Ordering;
+        let s = Value::String("alpha".into());
+        // non-null < null (null sorts last)
+        assert_eq!(compare_property_values(Some(&s), None), Ordering::Less);
+        assert_eq!(compare_property_values(None, Some(&s)), Ordering::Greater);
+        assert_eq!(compare_property_values(None, None), Ordering::Equal);
+        assert_eq!(
+            compare_property_values(Some(&Value::Null), None),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn compare_strings() {
+        use std::cmp::Ordering;
+        let a = Value::String("alpha".into());
+        let b = Value::String("beta".into());
+        assert_eq!(compare_property_values(Some(&a), Some(&b)), Ordering::Less);
+        assert_eq!(
+            compare_property_values(Some(&b), Some(&a)),
+            Ordering::Greater
+        );
+        assert_eq!(compare_property_values(Some(&a), Some(&a)), Ordering::Equal);
+    }
+
+    #[test]
+    fn compare_numbers() {
+        use std::cmp::Ordering;
+        let a = json!(1);
+        let b = json!(2);
+        assert_eq!(compare_property_values(Some(&a), Some(&b)), Ordering::Less);
+    }
+
+    #[test]
+    fn compare_booleans() {
+        use std::cmp::Ordering;
+        let f = json!(false);
+        let t = json!(true);
+        assert_eq!(compare_property_values(Some(&f), Some(&t)), Ordering::Less);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/hyalo-core/src/filter.rs
+++ b/crates/hyalo-core/src/filter.rs
@@ -607,7 +607,9 @@ pub enum SortField {
     Modified,
     BacklinksCount,
     LinksCount,
-    /// Sort by a frontmatter property value (e.g. `title`, `date`, or any key).
+    /// Sort by the resolved title (frontmatter `title` property, then first H1).
+    Title,
+    /// Sort by a frontmatter property value (e.g. `date`, or any key via `property:KEY`).
     Property(String),
 }
 
@@ -622,7 +624,7 @@ pub fn parse_sort(input: &str) -> Result<SortField> {
         "modified" => Ok(SortField::Modified),
         "backlinks_count" => Ok(SortField::BacklinksCount),
         "links_count" => Ok(SortField::LinksCount),
-        "title" => Ok(SortField::Property("title".to_owned())),
+        "title" => Ok(SortField::Title),
         "date" => Ok(SortField::Property("date".to_owned())),
         other => {
             if let Some(key) = other.strip_prefix("property:") {
@@ -646,9 +648,11 @@ pub fn parse_sort(input: &str) -> Result<SortField> {
 /// Ordering rules:
 /// - `Null` / missing sorts **last** (greater than any non-null value).
 /// - Strings are compared lexicographically (case-sensitive).
-/// - Numbers are compared as f64.
+/// - Numbers are compared as f64 (may lose precision for very large integers).
 /// - Booleans: `false` < `true`.
-/// - Arrays/objects are compared by their JSON string representation (fallback).
+/// - All other cases (including mixed primitive types like string vs number,
+///   arrays, and objects) fall back to comparing their JSON string
+///   representations, ensuring a total ordering across all JSON value types.
 pub fn compare_property_values(
     a: Option<&serde_json::Value>,
     b: Option<&serde_json::Value>,
@@ -1273,11 +1277,8 @@ mod tests {
     }
 
     #[test]
-    fn sort_title_alias() {
-        assert_eq!(
-            parse_sort("title").unwrap(),
-            SortField::Property("title".to_owned())
-        );
+    fn sort_title() {
+        assert_eq!(parse_sort("title").unwrap(), SortField::Title);
     }
 
     #[test]

--- a/hyalo-knowledgebase/backlog/repeatable-glob-flag.md
+++ b/hyalo-knowledgebase/backlog/repeatable-glob-flag.md
@@ -1,10 +1,10 @@
 ---
-title: "Repeatable --glob flag for combining include and exclude patterns"
+title: Repeatable --glob flag for combining include and exclude patterns
 type: backlog
 date: 2026-03-26
 origin: dogfooding v0.4.0 (ISSUE-7) and v0.4.1 confirmed
 priority: medium
-status: planned
+status: completed
 ---
 
 `--glob` cannot be passed multiple times. Users want `--glob 'rest/**' --glob '!rest/**/index.md'` to include + exclude in one call. Currently errors with "cannot be used multiple times".

--- a/hyalo-knowledgebase/backlog/sort-by-backlinks-count.md
+++ b/hyalo-knowledgebase/backlog/sort-by-backlinks-count.md
@@ -1,10 +1,10 @@
 ---
-title: "Add backlinks_count and links_count as sort fields"
+title: Add backlinks_count and links_count as sort fields
 type: backlog
 date: 2026-03-26
 origin: dogfooding v0.4.1 on GitHub Docs and VS Code Docs
 priority: medium
-status: planned
+status: completed
 ---
 
 `find --sort backlinks_count` errors with "unknown sort field". Only `file` and `modified` are valid. This makes it impossible to natively find the most-linked-to files — users must pipe through jq.

--- a/hyalo-knowledgebase/backlog/sort-by-property-value.md
+++ b/hyalo-knowledgebase/backlog/sort-by-property-value.md
@@ -1,8 +1,8 @@
 ---
-title: "Support --sort by frontmatter property value (title, date, custom)"
+title: Support --sort by frontmatter property value (title, date, custom)
 type: backlog
 date: 2026-03-28
-status: planned
+status: completed
 priority: medium
 origin: dogfooding v0.4.2 on docs/content and vscode-docs/docs
 ---

--- a/hyalo-knowledgebase/backlog/sort-by-property-value.md
+++ b/hyalo-knowledgebase/backlog/sort-by-property-value.md
@@ -11,10 +11,11 @@ Currently `--sort` only accepts `file`, `modified`, `backlinks_count`, `links_co
 
 `--sort modified` is also useless on git-cloned repos where all files share the same mtime.
 
-**Proposed behavior:**
-- `--sort title` — alias for sorting by the `title` frontmatter property (string sort)
+**Implemented behavior:**
+- `--sort title` — sorts by resolved title (frontmatter `title` property, then first H1 heading)
 - `--sort date` — alias for sorting by the `date` frontmatter property
 - `--sort property:KEY` — generic syntax to sort by any frontmatter property value
-- Files missing the sort property sort last (or first with reverse sort)
+- Files missing the sort property/title sort last
+- Equal values use file path as deterministic tie-breaker
 
 This pairs well with [[backlog/sort-reverse.md]] (if it existed) for `--reverse` support.

--- a/hyalo-knowledgebase/backlog/text-search-skips-code-blocks-undocumented.md
+++ b/hyalo-knowledgebase/backlog/text-search-skips-code-blocks-undocumented.md
@@ -1,11 +1,15 @@
 ---
-title: "Content search should include lines inside code blocks"
+title: Content search should include lines inside code blocks
 type: backlog
 date: 2026-03-25
 origin: dogfooding v0.3.1 against vscode-docs/docs
 priority: medium
-status: planned
-tags: [backlog, bug, search, scanner]
+status: completed
+tags:
+  - backlog
+  - bug
+  - search
+  - scanner
 ---
 
 # Content search should include lines inside code blocks

--- a/hyalo-knowledgebase/iterations/iteration-59-sort-and-filter-enhancements.md
+++ b/hyalo-knowledgebase/iterations/iteration-59-sort-and-filter-enhancements.md
@@ -1,8 +1,8 @@
 ---
-title: "Iteration 59 — Sort & filter enhancements"
+title: Iteration 59 — Sort & filter enhancements
 type: iteration
 date: 2026-03-28
-status: planned
+status: in-progress
 branch: iter-59/sort-filter
 tags:
   - find
@@ -16,10 +16,10 @@ Extend the `find` command's sorting and filtering capabilities. These touch over
 
 ## Tasks
 
-- [ ] Support `--sort` by frontmatter property value ([[backlog/sort-by-property-value.md]])
+- [x] Support `--sort` by frontmatter property value ([[backlog/sort-by-property-value.md]])
   - `--sort title`, `--sort date` as built-in aliases
   - `--sort property:KEY` for arbitrary property sorting
   - Files missing the sort property sort last
-- [ ] Add `backlinks_count` and `links_count` as sort fields ([[backlog/sort-by-backlinks-count.md]])
-- [ ] Support repeatable `--glob` flag for combining include/exclude patterns ([[backlog/repeatable-glob-flag.md]])
-- [ ] Content search should include lines inside code blocks ([[backlog/text-search-skips-code-blocks-undocumented.md]])
+- [x] Add `backlinks_count` and `links_count` as sort fields ([[backlog/sort-by-backlinks-count.md]])
+- [x] Support repeatable `--glob` flag for combining include/exclude patterns ([[backlog/repeatable-glob-flag.md]])
+- [x] Content search should include lines inside code blocks ([[backlog/text-search-skips-code-blocks-undocumented.md]])

--- a/hyalo-knowledgebase/iterations/iteration-59-sort-and-filter-enhancements.md
+++ b/hyalo-knowledgebase/iterations/iteration-59-sort-and-filter-enhancements.md
@@ -17,9 +17,10 @@ Extend the `find` command's sorting and filtering capabilities. These touch over
 ## Tasks
 
 - [x] Support `--sort` by frontmatter property value ([[backlog/sort-by-property-value.md]])
-  - `--sort title`, `--sort date` as built-in aliases
+  - `--sort title` sorts by resolved title (frontmatter title → first H1)
+  - `--sort date` as alias for `property:date`
   - `--sort property:KEY` for arbitrary property sorting
-  - Files missing the sort property sort last
+  - Files missing the sort property sort last; file-path tie-breaker
 - [x] Add `backlinks_count` and `links_count` as sort fields ([[backlog/sort-by-backlinks-count.md]])
 - [x] Support repeatable `--glob` flag for combining include/exclude patterns ([[backlog/repeatable-glob-flag.md]])
 - [x] Content search should include lines inside code blocks ([[backlog/text-search-skips-code-blocks-undocumented.md]])


### PR DESCRIPTION
## Summary
- Add `--sort property:KEY` for sorting find results by any frontmatter property value, with `--sort date` as a convenient alias
- Add `--sort title` that sorts by resolved title (frontmatter title → first H1 heading → null), matching `--fields title` semantics
- Missing/null values sort last; deterministic tie-breaking by file path
- Refactor duplicate sort logic into shared `apply_sort()` helper used by both scan paths
- Properties/title temporarily populated for sorting then stripped if not in `--fields`

## Test plan
- [x] Unit tests for `parse_sort` with title/date/property: aliases and empty-key error
- [x] Unit tests for `compare_property_values` ordering (null-last, strings, numbers, booleans)
- [x] E2e: `--sort title` orders by resolved title (incl. H1 fallback)
- [x] E2e: `--sort title` with no title/H1 sorts last
- [x] E2e: `--sort property:status` orders by arbitrary property
- [x] E2e: `--sort title --fields tags` strips title from output
- [x] E2e: `--sort property:status --fields tags` strips properties from output
- [x] E2e: `--sort date` with date values
- [x] E2e: `--sort property:` (empty key) returns error
- [x] All existing tests pass (468 e2e + 337 unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)