### PR TITLE
Add vault-wide broken link detection and auto-repair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "strsim",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ regex = "1"
 rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }
 serde-saphyr = "0.0.22"
+strsim = "0.11"
 serde_json = "1.0.149"
 tempfile = "3"
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Search and filter files. Returns an array of file objects, each containing front
 # All files
 hyalo find
 
+# Files with broken links (unresolved wikilinks or markdown links)
+hyalo find --broken-links
+
 # Content search (case-insensitive substring)
 hyalo find "retry backoff"
 hyalo find "retry" --tag research
@@ -245,7 +248,7 @@ hyalo tags rename --from old-tag --to new-tag --glob "notes/*.md"
 
 ### summary
 
-High-level vault overview: file counts, property and tag aggregates, status groups, tasks, orphan files (fully isolated — no links in or out), and recently modified files.
+High-level vault overview: file counts, property and tag aggregates, status groups, tasks, link health (total and broken links with source locations), orphan files (fully isolated — no links in or out), and recently modified files.
 
 ```sh
 hyalo summary
@@ -401,6 +404,31 @@ Updated 1 link in 1 file:
 Use `--dry-run` to preview which files and links would change without modifying anything.
 
 Root-absolute links (e.g. `/docs/guides/setup.md`) are also rewritten during a move. Hyalo uses the site prefix to map these to vault-relative paths. If `mv` reports 0 links updated but you expect absolute links to be rewritten, check your `--site-prefix` setting (see [Absolute link resolution](#absolute-link-resolution-site-prefix)).
+
+### links
+
+Subcommand group for link operations.
+
+```sh
+# Preview broken link fixes (dry-run, default)
+hyalo links fix
+
+# Apply fixes to disk
+hyalo links fix --apply
+
+# Adjust fuzzy matching threshold (0.0–1.0, default: 0.8)
+hyalo links fix --threshold 0.9
+
+# Scope to specific files
+hyalo links fix --glob "notes/*.md"
+
+# Text output
+hyalo links fix --format text
+```
+
+`links fix` detects broken `[[wikilinks]]` and `[markdown](links)` across the vault and attempts auto-repair using four strategies (in priority order): case-insensitive exact match, extension mismatch (`.md` present/absent), unique stem match anywhere in the vault (shortest-path resolution), and Jaro-Winkler fuzzy match above `--threshold`.
+
+Default is `--dry-run` (preview only). Pass `--apply` to write fixes to disk.
 
 ### Hints
 

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -82,7 +82,10 @@ pub fn find(
         has_task_filter,
         has_section_filter,
     ) || sort_needs_links
-        || sort_needs_title;
+        || sort_needs_title
+        // --broken-links forces fields.links on (applied later in effective_fields),
+        // so we must also force body scanning here before effective_fields is built.
+        || broken_links;
 
     // Compile the regex once (if any), then clone cheaply per file.
     // Invalid regex is a user error (exit 1), not an internal error (exit 2).

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -53,6 +53,7 @@ pub fn find(
     fields: &Fields,
     sort: Option<&SortField>,
     limit: Option<usize>,
+    broken_links: bool,
     format: Format,
 ) -> Result<CommandOutcome> {
     let files = collect_files(dir, files_arg, globs, format)?;
@@ -142,21 +143,24 @@ pub fn find(
         && !sort_needs_properties
         && !sort_needs_title;
 
-    // When sorting by a frontmatter property or title, force the relevant
-    // field on even if the user didn't request it via --fields.
+    // When sorting by a frontmatter property or title, or when --broken-links
+    // is active, force the relevant fields on even if not requested via --fields.
     let original_fields = fields;
     let effective_fields;
-    let fields =
-        if (sort_needs_properties && !fields.properties) || (sort_needs_title && !fields.title) {
-            effective_fields = Fields {
-                properties: fields.properties || sort_needs_properties,
-                title: fields.title || sort_needs_title,
-                ..fields.clone()
-            };
-            &effective_fields
-        } else {
-            fields
+    let fields = if (sort_needs_properties && !fields.properties)
+        || (sort_needs_title && !fields.title)
+        || (broken_links && !fields.links)
+    {
+        effective_fields = Fields {
+            properties: fields.properties || sort_needs_properties,
+            title: fields.title || sort_needs_title,
+            links: fields.links || broken_links,
+            ..fields.clone()
         };
+        &effective_fields
+    } else {
+        fields
+    };
 
     let mut results: Vec<FileObject> = Vec::new();
 
@@ -300,6 +304,19 @@ pub fn find(
             link_graph.as_ref(),
             site_prefix,
         );
+
+        // --- Apply broken-links filter ---
+        if broken_links {
+            let has_broken = obj
+                .links
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .any(|l| l.path.is_none());
+            if !has_broken {
+                continue;
+            }
+        }
 
         results.push(obj);
 
@@ -501,6 +518,7 @@ pub fn find_from_index(
     fields: &Fields,
     sort: Option<&SortField>,
     limit: Option<usize>,
+    broken_links: bool,
     format: Format,
 ) -> Result<CommandOutcome> {
     if pattern.is_some_and(|p| p.trim().is_empty()) {
@@ -559,21 +577,24 @@ pub fn find_from_index(
         && !sort_needs_properties
         && !sort_needs_title;
 
-    // When sorting by a frontmatter property or title, force the relevant
-    // field on even if the user didn't request it via --fields.
+    // When sorting by a frontmatter property or title, or when --broken-links
+    // is active, force the relevant fields on even if not requested via --fields.
     let original_fields = fields;
     let effective_fields;
-    let fields =
-        if (sort_needs_properties && !fields.properties) || (sort_needs_title && !fields.title) {
-            effective_fields = Fields {
-                properties: fields.properties || sort_needs_properties,
-                title: fields.title || sort_needs_title,
-                ..fields.clone()
-            };
-            &effective_fields
-        } else {
-            fields
+    let fields = if (sort_needs_properties && !fields.properties)
+        || (sort_needs_title && !fields.title)
+        || (broken_links && !fields.links)
+    {
+        effective_fields = Fields {
+            properties: fields.properties || sort_needs_properties,
+            title: fields.title || sort_needs_title,
+            links: fields.links || broken_links,
+            ..fields.clone()
         };
+        &effective_fields
+    } else {
+        fields
+    };
 
     let mut results: Vec<FileObject> = Vec::new();
 
@@ -772,6 +793,19 @@ pub fn find_from_index(
             backlinks,
             matches: content_matches,
         };
+
+        // --- Apply broken-links filter ---
+        if broken_links {
+            let has_broken = obj
+                .links
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .any(|l| l.path.is_none());
+            if !has_broken {
+                continue;
+            }
+        }
 
         results.push(obj);
 
@@ -1200,6 +1234,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1228,6 +1263,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1259,6 +1295,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1296,6 +1333,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1326,6 +1364,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1357,6 +1396,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1386,6 +1426,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1416,6 +1457,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1445,6 +1487,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1477,6 +1520,7 @@ Just some text here.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1538,6 +1582,7 @@ title: Empty Body
             &fields,
             None,
             None,
+            false,
             Format::Json,
         )
         .unwrap();
@@ -1573,6 +1618,7 @@ title: Empty Body
             &fields,
             None,
             None,
+            false,
             Format::Json,
         )
         .unwrap();
@@ -1609,6 +1655,7 @@ title: Empty Body
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1639,6 +1686,7 @@ title: Empty Body
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1670,6 +1718,7 @@ title: Empty Body
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1704,6 +1753,7 @@ title: Empty Body
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1742,6 +1792,7 @@ title: Empty Body
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1777,6 +1828,7 @@ title: Empty Body
                 &fields,
                 None,
                 Some(1),
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1807,6 +1859,7 @@ title: Empty Body
                 &fields,
                 Some(&SortField::Modified),
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1844,6 +1897,7 @@ title: Empty Body
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -1872,6 +1926,7 @@ title: Empty Body
             &fields,
             None,
             None,
+            false,
             Format::Json,
         )
         .unwrap();
@@ -2039,6 +2094,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2071,6 +2127,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2105,6 +2162,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2138,6 +2196,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2177,6 +2236,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2230,6 +2290,7 @@ Just intro, no tasks section.
             &fields,
             None,
             None,
+            false,
             Format::Json,
         )
         .unwrap();
@@ -2265,6 +2326,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2323,6 +2385,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2361,6 +2424,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2400,6 +2464,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2432,6 +2497,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),
@@ -2466,6 +2532,7 @@ Just intro, no tasks section.
                 &fields,
                 None,
                 None,
+                false,
                 Format::Json,
             )
             .unwrap(),

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -1,0 +1,158 @@
+#![allow(clippy::missing_errors_doc)]
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::output::{CommandOutcome, Format};
+use hyalo_core::discovery;
+use hyalo_core::index::{ScannedIndex, VaultIndex};
+use hyalo_core::link_fix::{LinkMatcher, apply_fixes, detect_broken_links_from_index, plan_fixes};
+
+// ---------------------------------------------------------------------------
+// Command entry points
+// ---------------------------------------------------------------------------
+
+/// Run `hyalo links fix` using a pre-built index.
+///
+/// `dry_run = true`  → preview only (default)
+/// `dry_run = false` → write fixes to disk (`--apply`)
+pub fn links_fix_from_index(
+    index: &dyn VaultIndex,
+    dir: &Path,
+    site_prefix: Option<&str>,
+    globs: &[String],
+    dry_run: bool,
+    threshold: f64,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let report = detect_broken_links_from_index(dir, index, site_prefix);
+
+    // Filter broken links by glob, if any were provided.
+    let broken = if globs.is_empty() {
+        report.broken
+    } else {
+        let all_files: Vec<std::path::PathBuf> = index
+            .entries()
+            .iter()
+            .map(|e| dir.join(&e.rel_path))
+            .collect();
+        let matched = discovery::match_globs(dir, &all_files, globs)?;
+        let matched_set: std::collections::HashSet<&str> =
+            matched.iter().map(|(_, rel)| rel.as_str()).collect();
+        report
+            .broken
+            .into_iter()
+            .filter(|b| matched_set.contains(b.source.as_str()))
+            .collect()
+    };
+
+    let matcher = LinkMatcher::from_index(index, threshold);
+    let fix_report = plan_fixes(&broken, &matcher);
+
+    if !dry_run {
+        apply_fixes(dir, &fix_report.fixes, site_prefix)?;
+    }
+
+    let output = serde_json::json!({
+        "broken": broken.len(),
+        "fixable": fix_report.fixes.len(),
+        "unfixable": fix_report.unfixable.len(),
+        "fixes": fix_report.fixes,
+        "unfixable_links": fix_report.unfixable,
+        "applied": !dry_run,
+    });
+
+    let formatted = match format {
+        Format::Json => serde_json::to_string_pretty(&output)?,
+        Format::Text => format_text_output(&output),
+    };
+
+    Ok(CommandOutcome::Success(formatted))
+}
+
+/// Run `hyalo links fix` with a full disk scan (no pre-built index).
+///
+/// Discovers all files, builds an ephemeral `ScannedIndex`, then delegates to
+/// [`links_fix_from_index`].
+pub fn links_fix(
+    dir: &Path,
+    site_prefix: Option<&str>,
+    globs: &[String],
+    dry_run: bool,
+    threshold: f64,
+    format: Format,
+) -> Result<CommandOutcome> {
+    let files = discovery::discover_files(dir)?;
+    let file_pairs: Vec<(std::path::PathBuf, String)> = files
+        .into_iter()
+        .map(|p| {
+            let rel = discovery::relative_path(dir, &p);
+            (p, rel)
+        })
+        .collect();
+    let build = ScannedIndex::build(&file_pairs, site_prefix)?;
+    for w in &build.warnings {
+        crate::warn::warn(format!("skipping {}: {}", w.rel_path, w.message));
+    }
+    links_fix_from_index(
+        &build.index,
+        dir,
+        site_prefix,
+        globs,
+        dry_run,
+        threshold,
+        format,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Text formatter
+// ---------------------------------------------------------------------------
+
+/// Format the links-fix output shape for `--format text`.
+///
+/// Key signature: `applied,broken,fixable,fixes,unfixable,unfixable_links`
+fn format_text_output(value: &serde_json::Value) -> String {
+    use std::fmt::Write as _;
+
+    let broken = value["broken"].as_u64().unwrap_or(0);
+    let fixable = value["fixable"].as_u64().unwrap_or(0);
+    let unfixable = value["unfixable"].as_u64().unwrap_or(0);
+    let applied = value["applied"].as_bool().unwrap_or(false);
+
+    let mut out = String::new();
+
+    let _ = writeln!(out, "Broken links: {broken}");
+    let _ = writeln!(out, "Fixable: {fixable} ({unfixable} unfixable)");
+
+    if let Some(fixes) = value["fixes"].as_array() {
+        for fix in fixes {
+            let source = fix["source"].as_str().unwrap_or("");
+            let line = fix["line"].as_u64().unwrap_or(0);
+            let old_target = fix["old_target"].as_str().unwrap_or("");
+            let new_target = fix["new_target"].as_str().unwrap_or("");
+            let strategy = fix["strategy"].as_str().unwrap_or("");
+            let confidence = fix["confidence"].as_f64().unwrap_or(0.0);
+            let _ = writeln!(
+                out,
+                "  \"{source}\":{line} [[{old_target}]] \u{2192} {new_target} ({strategy}, {confidence:.2})"
+            );
+        }
+    }
+
+    if unfixable > 0 {
+        let _ = writeln!(out, "Unfixable:");
+        if let Some(unfixable_links) = value["unfixable_links"].as_array() {
+            for item in unfixable_links {
+                let source = item["source"].as_str().unwrap_or("");
+                let line = item["line"].as_u64().unwrap_or(0);
+                let target = item["target"].as_str().unwrap_or("");
+                let _ = writeln!(out, "  \"{source}\":{line} [[{target}]]");
+            }
+        }
+    }
+
+    let _ = write!(out, "Applied: {}", if applied { "yes" } else { "no" });
+
+    out
+}

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod create_index;
 pub mod drop_index;
 pub mod find;
 pub mod init;
+pub mod links;
 pub mod mv;
 pub mod properties;
 pub mod read;

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -9,12 +9,14 @@ use crate::output::{CommandOutcome, Format};
 use hyalo_core::filter::extract_tags;
 use hyalo_core::frontmatter::infer_type;
 use hyalo_core::index::VaultIndex;
+use hyalo_core::link_fix::detect_broken_links;
+use hyalo_core::link_fix::detect_broken_links_from_index;
 use hyalo_core::link_graph::{FileLinks, LinkGraph, LinkGraphVisitor};
 use hyalo_core::scanner::{FrontmatterCollector, scan_file_multi};
 use hyalo_core::tasks::TaskCounter;
 use hyalo_core::types::{
-    DirectoryCount, FileCounts, OrphanSummary, PropertySummaryEntry, RecentFile, StatusGroup,
-    TagSummary, TagSummaryEntry, TaskCount, VaultSummary,
+    DirectoryCount, FileCounts, LinkHealthSummary, OrphanSummary, PropertySummaryEntry, RecentFile,
+    StatusGroup, TagSummary, TagSummaryEntry, TaskCount, VaultSummary,
 };
 
 /// Show a high-level vault summary.
@@ -220,6 +222,16 @@ pub fn summary(
         })
         .collect();
 
+    // Detect broken links from collected link data (only available when no glob).
+    let link_health = {
+        let report = detect_broken_links(dir, &collected_links, site_prefix);
+        LinkHealthSummary {
+            total: report.total_links,
+            broken: report.broken.len(),
+            broken_links: report.broken,
+        }
+    };
+
     // Build orphan list: files with no inbound AND no outbound links (fully isolated).
     // When no glob: use pre-collected link data (single pass, no re-read).
     // When glob: build vault-wide link graph so links from outside the glob count.
@@ -258,6 +270,7 @@ pub fn summary(
     let vault_summary = VaultSummary {
         files: file_counts,
         orphans,
+        links: link_health,
         properties,
         tags,
         status,
@@ -393,10 +406,12 @@ fn warn_inconsistent_properties(string_prop_values: &BTreeMap<String, BTreeMap<S
 /// `globs` optionally narrows which entries are included (same semantics as the
 /// `--glob` flag on the `summary` command).
 pub fn summary_from_index(
+    dir: &Path,
     index: &dyn VaultIndex,
     globs: &[String],
     recent: usize,
     depth: Option<usize>,
+    site_prefix: Option<&str>,
     format: Format,
 ) -> Result<CommandOutcome> {
     use crate::commands::find::filter_index_entries;
@@ -574,9 +589,20 @@ pub fn summary_from_index(
     // Emit warnings for any property value that looks like a typo of a dominant value.
     warn_inconsistent_properties(&string_prop_values);
 
+    // Link health is intentionally vault-wide regardless of any --glob scope.
+    let link_health = {
+        let report = detect_broken_links_from_index(dir, index, site_prefix);
+        LinkHealthSummary {
+            total: report.total_links,
+            broken: report.broken.len(),
+            broken_links: report.broken,
+        }
+    };
+
     let vault_summary = VaultSummary {
         files: file_counts,
         orphans,
+        links: link_health,
         properties,
         tags,
         status,
@@ -1027,8 +1053,9 @@ No tasks here.
         )
         .unwrap();
         let loaded = SnapshotIndex::load(&index_path).unwrap().unwrap();
-        let index_val =
-            unwrap_success(summary_from_index(&loaded, &[], 10, None, Format::Json).unwrap());
+        let index_val = unwrap_success(
+            summary_from_index(dir, &loaded, &[], 10, None, prefix, Format::Json).unwrap(),
+        );
         let index_orphans: Vec<&str> = index_val["orphans"]["files"]
             .as_array()
             .unwrap()

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -222,9 +222,34 @@ pub fn summary(
         })
         .collect();
 
-    // Detect broken links from collected link data (only available when no glob).
+    // Link health is intentionally vault-wide regardless of any --glob scope:
+    // a broken link is a broken link whether or not the referencing file matches
+    // the glob filter, and scoped results (0/0 when globs are active) would be
+    // misleading.  When no glob is active, `collected_links` already covers the
+    // whole vault so we reuse it; otherwise we do a separate vault-wide scan.
     let link_health = {
-        let report = detect_broken_links(dir, &collected_links, site_prefix);
+        let report = if collect_links {
+            detect_broken_links(dir, &collected_links, site_prefix)
+        } else {
+            let all_files = hyalo_core::discovery::discover_files(dir)
+                .context("failed to discover files for link health")?;
+            let mut all_links: Vec<FileLinks> = Vec::with_capacity(all_files.len());
+            for full_path in &all_files {
+                let rel = full_path
+                    .strip_prefix(dir)
+                    .unwrap_or(full_path)
+                    .to_path_buf();
+                let mut lv = LinkGraphVisitor::new(rel);
+                match scan_file_multi(full_path, &mut [&mut lv]) {
+                    Ok(()) => {
+                        all_links.push(lv.into_file_links());
+                    }
+                    Err(e) if hyalo_core::frontmatter::is_parse_error(&e) => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+            detect_broken_links(dir, &all_links, site_prefix)
+        };
         LinkHealthSummary {
             total: report.total_links,
             broken: report.broken.len(),
@@ -589,7 +614,10 @@ pub fn summary_from_index(
     // Emit warnings for any property value that looks like a typo of a dominant value.
     warn_inconsistent_properties(&string_prop_values);
 
-    // Link health is intentionally vault-wide regardless of any --glob scope.
+    // Link health is intentionally vault-wide: detect_broken_links_from_index
+    // scans all entries in the index regardless of any --glob scope.  This is
+    // consistent with the disk-scan path and ensures the report is meaningful
+    // (scoped results would produce misleadingly low counts).
     let link_health = {
         let report = detect_broken_links_from_index(dir, index, site_prefix);
         LinkHealthSummary {

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -88,6 +88,9 @@ const HELP_LONG: &str = "COMMAND REFERENCE:
   Backlinks (reverse link lookup, read-only):
     hyalo backlinks -f/--file F
 
+  Links (link operations):
+    hyalo links fix [--apply] [--threshold T] [-g/--glob G]   Detect and fix broken links (default: dry-run)
+
   Mv (move/rename file, updates links, mutates files):
     hyalo mv -f/--file F --to NEW [--dry-run]
 
@@ -596,7 +599,8 @@ enum Commands {
             OUTPUT: A single 'VaultSummary' object with file counts (total + by directory), \
             property summary (unique names/types/counts), tag summary (unique tags/counts), \
             status grouping (files grouped by frontmatter 'status' value), \
-            task counts (total/done), and recently modified files.\n\
+            task counts (total/done), link health (total/broken links with source locations), \
+            orphan files, and recently modified files.\n\
             SCOPE: Scans all .md files under --dir unless narrowed with --glob.\n\
             SIDE EFFECTS: None (read-only).\n\
             USE WHEN: You need a quick overview of a vault's metadata landscape.")]

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -855,7 +855,7 @@ enum LinksAction {
         #[arg(long, conflicts_with = "dry_run")]
         apply: bool,
         /// Minimum similarity threshold for fuzzy matching (0.0–1.0)
-        #[arg(long, default_value = "0.8")]
+        #[arg(long, default_value = "0.8", value_parser = parse_threshold)]
         threshold: f64,
         /// Glob pattern(s) to filter which files to check (repeatable); prefix '!' to negate
         #[arg(short, long)]
@@ -979,6 +979,20 @@ enum TagsAction {
         #[arg(short, long)]
         glob: Vec<String>,
     },
+}
+
+/// Value parser for `--threshold`: accepts a `f64` in `[0.0, 1.0]`.
+fn parse_threshold(s: &str) -> Result<f64, String> {
+    let v: f64 = s
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid floating-point number"))?;
+    if (0.0..=1.0).contains(&v) {
+        Ok(v)
+    } else {
+        Err(format!(
+            "threshold must be between 0.0 and 1.0 (inclusive), got {v}"
+        ))
+    }
 }
 
 /// Parse `--where-property` filters and validate `--where-tag` names.

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -6,8 +6,8 @@ use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use hyalo_cli::commands::{
     append as append_commands, backlinks as backlinks_commands,
     create_index as create_index_commands, drop_index as drop_index_commands,
-    find as find_commands, init as init_commands, mv as mv_commands, properties,
-    read as read_commands, remove as remove_commands, set as set_commands,
+    find as find_commands, init as init_commands, links as links_commands, mv as mv_commands,
+    properties, read as read_commands, remove as remove_commands, set as set_commands,
     summary as summary_commands, tags as tag_commands, tasks as task_commands,
 };
 use hyalo_cli::hints::{HintContext, HintSource, generate_hints};
@@ -526,6 +526,9 @@ enum Commands {
         /// Maximum number of results to return (must be at least 1)
         #[arg(short = 'n', long, value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..))]
         limit: Option<usize>,
+        /// Only return files with at least one unresolved link (auto-includes links field)
+        #[arg(long)]
+        broken_links: bool,
     },
     /// Read file body content, optionally filtered by section or line range (read-only)
     #[command(long_about = "Read the body content of a markdown file.\n\n\
@@ -815,6 +818,48 @@ Repeatable (AND).\n\
         /// Filter: only mutate files with this tag (repeatable, AND). Same syntax as find --tag
         #[arg(long = "where-tag", value_name = "TAG")]
         where_tags: Vec<String>,
+    },
+    /// Detect and repair broken links across the vault
+    #[command(
+        long_about = "Detect and repair broken wikilinks and markdown links.\n\n\
+            Scans the vault for links that cannot be resolved to an existing file, \
+            then uses fuzzy matching (case-insensitive, extension mismatch, shortest-path, \
+            Jaro-Winkler) to find the best candidate replacement.\n\n\
+            Default behaviour is a dry run — no files are modified. Pass --apply to write fixes.\n\n\
+            OUTPUT: JSON object with broken/fixable/unfixable counts, per-fix details \
+            (source, line, old_target, new_target, strategy, confidence), and \
+            the list of links that could not be matched.\n\
+            SIDE EFFECTS: None unless --apply is passed."
+    )]
+    Links {
+        #[command(subcommand)]
+        action: LinksAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum LinksAction {
+    /// Auto-repair broken links using fuzzy matching
+    #[command(long_about = "Find broken links and propose (or apply) fixes.\n\n\
+            Matching strategies (in priority order):\n\
+            1. Case-insensitive exact match\n\
+            2. Extension mismatch (.md present/absent)\n\
+            3. Unique stem match anywhere in the vault (shortest-path)\n\
+            4. Jaro-Winkler fuzzy match above --threshold\n\n\
+            Use --apply to write fixes to disk. Without --apply, only a dry-run report is printed.")]
+    Fix {
+        /// Preview changes without modifying files (default when --apply is omitted)
+        #[arg(long)]
+        dry_run: bool,
+        /// Apply fixes to files on disk
+        #[arg(long, conflicts_with = "dry_run")]
+        apply: bool,
+        /// Minimum similarity threshold for fuzzy matching (0.0–1.0)
+        #[arg(long, default_value = "0.8")]
+        threshold: f64,
+        /// Glob pattern(s) to filter which files to check (repeatable); prefix '!' to negate
+        #[arg(short, long)]
+        glob: Vec<String>,
     },
 }
 
@@ -1297,6 +1342,7 @@ fn main() {
             ref fields,
             ref sort,
             limit,
+            broken_links,
         } => {
             // Parse property filters
             let prop_filters: Vec<filter::PropertyFilter> = match properties
@@ -1365,6 +1411,7 @@ fn main() {
                     &parsed_fields,
                     sort_field.as_ref(),
                     limit,
+                    broken_links,
                     effective_format,
                 )
             } else {
@@ -1382,6 +1429,7 @@ fn main() {
                     &parsed_fields,
                     sort_field.as_ref(),
                     limit,
+                    broken_links,
                     effective_format,
                 )
             }
@@ -1530,7 +1578,15 @@ fn main() {
             depth,
         } => {
             if let Some(ref idx) = snapshot_index {
-                summary_commands::summary_from_index(idx, glob, recent, depth, effective_format)
+                summary_commands::summary_from_index(
+                    &dir,
+                    idx,
+                    glob,
+                    recent,
+                    depth,
+                    site_prefix,
+                    effective_format,
+                )
             } else {
                 summary_commands::summary(&dir, glob, recent, depth, site_prefix, effective_format)
             }
@@ -1629,6 +1685,35 @@ fn main() {
         Commands::DropIndex { ref path } => {
             drop_index_commands::drop_index(&dir, path.as_deref(), effective_format)
         }
+        Commands::Links { action } => match action {
+            LinksAction::Fix {
+                dry_run: _,
+                apply,
+                threshold,
+                ref glob,
+            } => {
+                if let Some(ref idx) = snapshot_index {
+                    links_commands::links_fix_from_index(
+                        idx,
+                        &dir,
+                        site_prefix,
+                        glob,
+                        !apply,
+                        threshold,
+                        effective_format,
+                    )
+                } else {
+                    links_commands::links_fix(
+                        &dir,
+                        site_prefix,
+                        glob,
+                        !apply,
+                        threshold,
+                        effective_format,
+                    )
+                }
+            }
+        },
         // `Init` is handled as an early return before this match is reached.
         Commands::Init { .. } => unreachable!("Init is dispatched before this match reached"),
     };

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -201,8 +201,8 @@ const TASK_INFO_FILTER: &str =
 const TASK_READ_RESULT_FILTER: &str =
     r#""\"\(.file)\":\(.line) [\(.status)] \(.text)\(if .done then " (done)" else "" end)""#;
 
-/// `VaultSummary`: `{files, orphans, properties, recent_files, status, tags, tasks}`
-const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nOrphans: \(.orphans.total)\(if (.orphans.files | length) > 0 then "\n\(.orphans.files | map("  \"\(.)\"") | join("\n"))" else "" end)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
+/// `VaultSummary`: `{files, links, orphans, properties, recent_files, status, tags, tasks}`
+const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nLinks: \(.links.total) total, \(.links.broken) broken\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nOrphans: \(.orphans.total)\(if (.orphans.files | length) > 0 then "\n\(.orphans.files | map("  \"\(.)\"") | join("\n"))" else "" end)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
 
 /// `FindTaskInfo`: `{done, line, section, status, text}`
 /// Format: `  [x] text (line N, section)` or `  [ ] text (line N, section)`
@@ -277,7 +277,9 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         // TaskReadResult
         "done,file,line,status,text" => Some(TASK_READ_RESULT_FILTER),
         // VaultSummary
-        "files,orphans,properties,recent_files,status,tags,tasks" => Some(VAULT_SUMMARY_FILTER),
+        "files,links,orphans,properties,recent_files,status,tags,tasks" => {
+            Some(VAULT_SUMMARY_FILTER)
+        }
         // Mutation results with property + value (SetPropertyResult, AppendPropertyResult,
         // RemovePropertyResult with value)
         "modified,property,scanned,skipped,total,value" => Some(PROPERTY_VALUE_MUTATION_FILTER),

--- a/crates/hyalo-cli/tests/e2e_links.rs
+++ b/crates/hyalo-cli/tests/e2e_links.rs
@@ -1,0 +1,711 @@
+mod common;
+
+use common::{hyalo, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Vault fixture
+// ---------------------------------------------------------------------------
+
+fn setup_vault() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    // File with all links working — a links to b which exists at vault root
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+See [[b]] for details.
+"),
+    );
+
+    // File with a broken link and a working link
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+See [[nonexistent]] here.
+And also [[a]].
+"),
+    );
+
+    // File with no links (will be excluded by --broken-links)
+    write_md(
+        tmp.path(),
+        "c.md",
+        md!(r"
+---
+title: C
+---
+No links here.
+"),
+    );
+
+    // File with a broken link that can be fuzzy-matched to authentication.md
+    write_md(
+        tmp.path(),
+        "d.md",
+        md!(r"
+---
+title: D
+---
+See [[Authnticaton]] for auth details.
+"),
+    );
+
+    // The file that the fuzzy match should find
+    write_md(
+        tmp.path(),
+        "authentication.md",
+        md!(r"
+---
+title: Authentication
+---
+Auth docs.
+"),
+    );
+
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// summary: link health section
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_includes_link_health() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo summary should run");
+    assert!(
+        output.status.success(),
+        "summary exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    // links.total counts all links across the vault
+    let total = json["links"]["total"]
+        .as_u64()
+        .expect("links.total should be a number");
+    assert!(total > 0, "expected at least one link, got {total}");
+
+    // links.broken >= 1 because b.md has [[nonexistent]] and d.md has [[Authnticaton]]
+    let broken = json["links"]["broken"]
+        .as_u64()
+        .expect("links.broken should be a number");
+    assert!(broken >= 1, "expected at least 1 broken link, got {broken}");
+
+    // links.broken_links is an array of broken link entries
+    let broken_links = json["links"]["broken_links"]
+        .as_array()
+        .expect("links.broken_links should be an array");
+    assert!(
+        !broken_links.is_empty(),
+        "broken_links array should not be empty"
+    );
+
+    // Each entry must have source, line, and target fields
+    let first = &broken_links[0];
+    assert!(
+        first["source"].is_string(),
+        "broken link entry must have 'source' string field"
+    );
+    assert!(
+        first["line"].is_number(),
+        "broken link entry must have 'line' number field"
+    );
+    assert!(
+        first["target"].is_string(),
+        "broken link entry must have 'target' string field"
+    );
+}
+
+#[test]
+fn summary_broken_links_includes_nonexistent_target() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo summary should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    let broken_links = json["links"]["broken_links"]
+        .as_array()
+        .expect("links.broken_links should be an array");
+
+    // b.md has [[nonexistent]] — that broken link must appear
+    let has_nonexistent = broken_links.iter().any(|entry| {
+        entry["source"].as_str().unwrap_or("") == "b.md"
+            && entry["target"].as_str().unwrap_or("") == "nonexistent"
+    });
+    assert!(
+        has_nonexistent,
+        "expected broken link {{source: 'b.md', target: 'nonexistent'}} in: {broken_links:?}"
+    );
+}
+
+#[test]
+fn summary_text_includes_links_line() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "summary",
+            "--format",
+            "text",
+        ])
+        .output()
+        .expect("hyalo summary --format text should run");
+    assert!(
+        output.status.success(),
+        "summary exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let text = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+
+    // The text output should contain "Links: N total, M broken"
+    assert!(
+        text.contains("Links:"),
+        "expected 'Links:' in summary text output, got:\n{text}"
+    );
+    assert!(
+        text.contains("total"),
+        "expected 'total' in Links line, got:\n{text}"
+    );
+    assert!(
+        text.contains("broken"),
+        "expected 'broken' in Links line, got:\n{text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// find --broken-links
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_broken_links_filter() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "find",
+            "--broken-links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find --broken-links should run");
+    assert!(
+        output.status.success(),
+        "find --broken-links exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    let results = json.as_array().expect("find output should be a JSON array");
+
+    // b.md and d.md have broken links; they must appear
+    let files: Vec<&str> = results
+        .iter()
+        .map(|r| r["file"].as_str().unwrap_or(""))
+        .collect();
+
+    assert!(
+        files.contains(&"b.md"),
+        "b.md (has broken [[nonexistent]]) should appear in --broken-links results: {files:?}"
+    );
+    assert!(
+        files.contains(&"d.md"),
+        "d.md (has broken [[Authnticaton]]) should appear in --broken-links results: {files:?}"
+    );
+
+    // Files without broken links must NOT appear
+    assert!(
+        !files.contains(&"a.md"),
+        "a.md (no broken links) should NOT appear in --broken-links results: {files:?}"
+    );
+    assert!(
+        !files.contains(&"c.md"),
+        "c.md (no links at all) should NOT appear in --broken-links results: {files:?}"
+    );
+    assert!(
+        !files.contains(&"authentication.md"),
+        "authentication.md (no broken links) should NOT appear: {files:?}"
+    );
+}
+
+#[test]
+fn find_broken_links_entries_have_null_path() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "find",
+            "--broken-links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find --broken-links should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    let results = json.as_array().expect("find output should be a JSON array");
+
+    // Each returned file should have at least one link entry with path = null
+    for result in results {
+        let file = result["file"].as_str().unwrap_or("?");
+        let links = result["links"]
+            .as_array()
+            .unwrap_or_else(|| panic!("file {file} should have a 'links' array"));
+
+        let has_null_path = links.iter().any(|l| l["path"].is_null());
+        assert!(
+            has_null_path,
+            "file {file} returned by --broken-links should have at least one link with path=null"
+        );
+    }
+}
+
+#[test]
+fn find_broken_links_combined_with_glob_filter() {
+    let tmp = setup_vault();
+    // Restrict to b.md only via glob — should return just that file
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "find",
+            "--broken-links",
+            "--glob",
+            "b.md",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find --broken-links --glob should run");
+    assert!(
+        output.status.success(),
+        "find --broken-links --glob exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    let results = json.as_array().expect("find output should be a JSON array");
+    let files: Vec<&str> = results
+        .iter()
+        .map(|r| r["file"].as_str().unwrap_or(""))
+        .collect();
+
+    // Only b.md matches the glob AND has broken links
+    assert_eq!(
+        files,
+        vec!["b.md"],
+        "--broken-links AND --glob=b.md should yield only b.md"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// links fix: dry run
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_dry_run_reports_broken_and_fixable() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix should run");
+    assert!(
+        output.status.success(),
+        "links fix exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    // broken >= 1 (at minimum [[nonexistent]] and [[Authnticaton]])
+    let broken_count = json["broken"]
+        .as_u64()
+        .expect("'broken' should be a number");
+    assert!(
+        broken_count >= 1,
+        "expected at least 1 broken link, got {broken_count}"
+    );
+
+    // fixable >= 1 because [[Authnticaton]] fuzzy-matches authentication.md
+    let fixable_count = json["fixable"]
+        .as_u64()
+        .expect("'fixable' should be a number");
+    assert!(
+        fixable_count >= 1,
+        "expected at least 1 fixable link, got {fixable_count}"
+    );
+
+    // By default (no --apply), applied must be false
+    assert!(
+        !json["applied"]
+            .as_bool()
+            .expect("'applied' should be a bool"),
+        "dry-run should report applied=false"
+    );
+
+    // fixes is an array with entries having source, line, old_target, new_target
+    let fixes = json["fixes"]
+        .as_array()
+        .expect("'fixes' should be an array");
+    assert!(
+        !fixes.is_empty(),
+        "fixes array should not be empty when fixable > 0"
+    );
+
+    let first_fix = &fixes[0];
+    assert!(
+        first_fix["source"].is_string(),
+        "fix entry must have 'source'"
+    );
+    assert!(first_fix["line"].is_number(), "fix entry must have 'line'");
+    assert!(
+        first_fix["old_target"].is_string(),
+        "fix entry must have 'old_target'"
+    );
+    assert!(
+        first_fix["new_target"].is_string(),
+        "fix entry must have 'new_target'"
+    );
+}
+
+#[test]
+fn links_fix_dry_run_detects_fuzzy_match() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    let fixes = json["fixes"]
+        .as_array()
+        .expect("'fixes' should be an array");
+
+    // [[Authnticaton]] in d.md should be proposed as a fix to authentication.md
+    let has_auth_fix = fixes.iter().any(|fix| {
+        fix["source"].as_str().unwrap_or("") == "d.md"
+            && fix["old_target"]
+                .as_str()
+                .unwrap_or("")
+                .eq_ignore_ascii_case("Authnticaton")
+            && fix["new_target"]
+                .as_str()
+                .unwrap_or("")
+                .contains("authentication")
+    });
+    assert!(
+        has_auth_fix,
+        "expected a fix for [[Authnticaton]] → authentication.md in d.md, fixes: {fixes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// links fix: apply
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_apply_reduces_broken_links() {
+    let tmp = setup_vault();
+
+    // Apply fixes
+    let apply_output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--apply",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix --apply should run");
+    assert!(
+        apply_output.status.success(),
+        "links fix --apply exited non-zero: {}",
+        String::from_utf8_lossy(&apply_output.stderr)
+    );
+
+    let apply_json: serde_json::Value =
+        serde_json::from_slice(&apply_output.stdout).expect("apply stdout should be valid JSON");
+
+    // applied must be true
+    assert!(
+        apply_json["applied"]
+            .as_bool()
+            .expect("'applied' should be a bool"),
+        "links fix --apply should report applied=true"
+    );
+
+    let fixed_count = apply_json["fixable"]
+        .as_u64()
+        .expect("'fixable' should be a number");
+    assert!(fixed_count >= 1, "should have applied at least 1 fix");
+
+    // After applying, run find --broken-links; the count should be lower
+    let before_broken = apply_json["broken"]
+        .as_u64()
+        .expect("'broken' should be a number");
+
+    let after_output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "find",
+            "--broken-links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find --broken-links should run after fix");
+    assert!(after_output.status.success());
+
+    let after_json: serde_json::Value =
+        serde_json::from_slice(&after_output.stdout).expect("after stdout should be valid JSON");
+
+    let after_files = after_json
+        .as_array()
+        .expect("find output should be an array");
+    let after_broken = after_files.len() as u64;
+
+    // After applying fixes, the count of files with broken links must be lower
+    // (or equal if all were unfixable, but we know at least one is fixable).
+    assert!(
+        after_broken < before_broken,
+        "after applying fixes, broken link file count should decrease: before={before_broken}, after={after_broken}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// links fix: text format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_text_format() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--format",
+            "text",
+        ])
+        .output()
+        .expect("hyalo links fix --format text should run");
+    assert!(
+        output.status.success(),
+        "links fix --format text exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let text = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+
+    assert!(
+        text.contains("Broken links:"),
+        "text output should contain 'Broken links:' — got:\n{text}"
+    );
+    assert!(
+        text.contains("Fixable:"),
+        "text output should contain 'Fixable:' — got:\n{text}"
+    );
+    assert!(
+        text.contains("Applied:"),
+        "text output should contain 'Applied:' — got:\n{text}"
+    );
+    // Dry-run default should say "Applied: no"
+    assert!(
+        text.contains("Applied: no"),
+        "default (dry-run) should say 'Applied: no' — got:\n{text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// links fix: threshold controls fuzzy matching
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_high_threshold_suppresses_fuzzy_fixes() {
+    let tmp = setup_vault();
+    // With threshold=0.99 the typo "Authnticaton" should not match authentication.md
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--threshold",
+            "0.99",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix --threshold should run");
+    assert!(
+        output.status.success(),
+        "links fix --threshold exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    let fixes = json["fixes"]
+        .as_array()
+        .expect("'fixes' should be an array");
+
+    // At threshold=0.99, the fuzzy match for "Authnticaton" → authentication.md
+    // should not fire (score is well below 0.99).
+    let has_auth_fix = fixes.iter().any(|fix| {
+        fix["source"].as_str().unwrap_or("") == "d.md"
+            && fix["old_target"]
+                .as_str()
+                .unwrap_or("")
+                .eq_ignore_ascii_case("Authnticaton")
+    });
+    assert!(
+        !has_auth_fix,
+        "at threshold=0.99, [[Authnticaton]] should NOT produce a fix: {fixes:?}"
+    );
+}
+
+#[test]
+fn links_fix_default_threshold_finds_fuzzy_match() {
+    let tmp = setup_vault();
+    // With the default threshold, "Authnticaton" should fuzzy-match authentication.md
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    let fixable = json["fixable"]
+        .as_u64()
+        .expect("'fixable' should be a number");
+    let high_threshold_output = hyalo()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--threshold",
+            "0.99",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix --threshold=0.99 should run");
+    assert!(high_threshold_output.status.success());
+
+    let high_json: serde_json::Value = serde_json::from_slice(&high_threshold_output.stdout)
+        .expect("high threshold stdout should be valid JSON");
+    let high_fixable = high_json["fixable"]
+        .as_u64()
+        .expect("'fixable' should be a number");
+
+    // Default threshold should yield more (or equal) fixes than 0.99 threshold
+    assert!(
+        fixable >= high_fixable,
+        "default threshold should yield >= fixes than threshold=0.99: default={fixable}, high={high_fixable}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_links.rs
+++ b/crates/hyalo-cli/tests/e2e_links.rs
@@ -521,39 +521,44 @@ fn links_fix_apply_reduces_broken_links() {
         .expect("'fixable' should be a number");
     assert!(fixed_count >= 1, "should have applied at least 1 fix");
 
-    // After applying, run find --broken-links; the count should be lower
+    // Capture the broken link count reported by the apply run (before fixes were written).
     let before_broken = apply_json["broken"]
         .as_u64()
         .expect("'broken' should be a number");
 
+    // Re-run links fix in dry-run mode to measure the remaining broken link count
+    // (same unit: number of broken links, not files).
     let after_output = hyalo()
         .args([
             "--dir",
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
-            "find",
-            "--broken-links",
+            "links",
+            "fix",
             "--format",
             "json",
         ])
         .output()
-        .expect("hyalo find --broken-links should run after fix");
-    assert!(after_output.status.success());
+        .expect("hyalo links fix (dry-run) should run after apply");
+    assert!(
+        after_output.status.success(),
+        "links fix dry-run after apply exited non-zero: {}",
+        String::from_utf8_lossy(&after_output.stderr)
+    );
 
-    let after_json: serde_json::Value =
-        serde_json::from_slice(&after_output.stdout).expect("after stdout should be valid JSON");
+    let after_json: serde_json::Value = serde_json::from_slice(&after_output.stdout)
+        .expect("after dry-run stdout should be valid JSON");
 
-    let after_files = after_json
-        .as_array()
-        .expect("find output should be an array");
-    let after_broken = after_files.len() as u64;
+    let after_broken = after_json["broken"]
+        .as_u64()
+        .expect("'broken' should be a number in after dry-run output");
 
-    // After applying fixes, the count of files with broken links must be lower
-    // (or equal if all were unfixable, but we know at least one is fixable).
+    // After applying fixes, the broken link count must be lower — both values
+    // are broken-link counts reported by `links fix`, so the comparison is like-for-like.
     assert!(
         after_broken < before_broken,
-        "after applying fixes, broken link file count should decrease: before={before_broken}, after={after_broken}"
+        "after applying fixes, broken link count should decrease: before={before_broken}, after={after_broken}"
     );
 }
 

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -21,6 +21,7 @@ rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-saphyr = { workspace = true }
 serde_json = { workspace = true }
+strsim = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod frontmatter;
 pub mod fs_util;
 pub mod heading;
 pub mod index;
+pub mod link_fix;
 pub mod link_graph;
 pub mod link_rewrite;
 pub mod links;

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -1,0 +1,820 @@
+//! Broken link detection and auto-repair with fuzzy matching.
+//!
+//! # Overview
+//!
+//! 1. [`detect_broken_links`] / [`detect_broken_links_from_index`] — scan a
+//!    vault for links that cannot be resolved to an existing file and return a
+//!    [`BrokenLinkReport`].
+//!
+//! 2. [`plan_fixes`] — for each broken link, find the best candidate file using
+//!    a priority-ordered strategy (case-insensitive → extension mismatch →
+//!    shortest-path → fuzzy Jaro-Winkler) and produce a [`FixReport`].
+//!
+//! 3. [`apply_fixes`] — convert [`FixPlan`]s to [`RewritePlan`]s and write
+//!    the corrected link text back to disk.
+
+#![allow(clippy::missing_errors_doc)]
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::discovery::canonicalize_vault_dir;
+use crate::discovery::resolve_target;
+use crate::index::VaultIndex;
+use crate::link_graph::{FileLinks, normalize_target};
+use crate::link_rewrite::{Replacement, RewritePlan, apply_replacements, execute_plans};
+use crate::links::{LinkKind, extract_link_spans_with_original};
+use crate::scanner::{FenceTracker, is_comment_fence, strip_inline_code, strip_inline_comments};
+use crate::types::BrokenLinkInfo;
+
+// ---------------------------------------------------------------------------
+// Report types
+// ---------------------------------------------------------------------------
+
+/// Summary of broken link detection across the vault.
+#[derive(Debug, Clone, Serialize)]
+pub struct BrokenLinkReport {
+    pub total_links: usize,
+    pub broken: Vec<BrokenLinkInfo>,
+}
+
+/// A single actionable fix: rewrite `old_target` → `new_target` in `source`.
+#[derive(Debug, Clone, Serialize)]
+pub struct FixPlan {
+    /// Vault-relative path of the file containing the broken link.
+    pub source: String,
+    /// 1-based line number where the broken link appears.
+    pub line: usize,
+    /// The original (broken) link target as written in the source file.
+    pub old_target: String,
+    /// The corrected link target.
+    pub new_target: String,
+    /// How the match was found.
+    pub strategy: FixStrategy,
+    /// Similarity confidence in `[0.0, 1.0]`.
+    pub confidence: f64,
+}
+
+/// How a candidate file was matched to a broken link target.
+#[derive(Debug, Clone, Serialize)]
+pub enum FixStrategy {
+    /// The target matched an existing file path case-insensitively.
+    CaseInsensitive,
+    /// The target was written with or without `.md` and the other form matched.
+    ExtensionMismatch,
+    /// The bare stem matched exactly one file anywhere in the vault.
+    ShortestPath,
+    /// Jaro-Winkler similarity above the configured threshold.
+    FuzzyMatch,
+}
+
+/// Result of planning fixes for a set of broken links.
+#[derive(Debug, Clone, Serialize)]
+pub struct FixReport {
+    /// Broken links for which a candidate fix was found.
+    pub fixes: Vec<FixPlan>,
+    /// Broken links for which no suitable candidate could be found.
+    pub unfixable: Vec<BrokenLinkInfo>,
+}
+
+// ---------------------------------------------------------------------------
+// Broken link detection
+// ---------------------------------------------------------------------------
+
+/// Detect broken links from pre-collected file links data.
+///
+/// `file_links` is a slice of [`FileLinks`] (from `link_graph.rs`).
+/// Uses [`resolve_target`] to check if each link target exists.
+pub fn detect_broken_links(
+    dir: &Path,
+    file_links: &[FileLinks],
+    site_prefix: Option<&str>,
+) -> BrokenLinkReport {
+    let canonical = match canonicalize_vault_dir(dir) {
+        Ok(p) => p,
+        Err(_) => {
+            return BrokenLinkReport {
+                total_links: 0,
+                broken: Vec::new(),
+            };
+        }
+    };
+
+    let mut total_links = 0usize;
+    let mut broken: Vec<BrokenLinkInfo> = Vec::new();
+
+    for fl in file_links {
+        let source_str = fl.source.to_string_lossy().replace('\\', "/");
+
+        for (line, link) in &fl.links {
+            total_links += 1;
+
+            // Normalize the target before resolution.
+            // Wikilinks are vault-relative; markdown links may be relative to
+            // the source file's directory.
+            let resolved_target = match link.kind {
+                LinkKind::Wikilink => link.target.clone(),
+                LinkKind::Markdown => {
+                    if link.target.starts_with('/') {
+                        link.target.clone()
+                    } else if link.target.contains('/') || link.target.contains('\\') {
+                        normalize_target(Path::new(&source_str), &link.target)
+                    } else {
+                        link.target.clone()
+                    }
+                }
+            };
+
+            if resolve_target(&canonical, &resolved_target, site_prefix).is_none() {
+                broken.push(BrokenLinkInfo {
+                    source: source_str.clone(),
+                    line: *line,
+                    target: link.target.clone(),
+                });
+            }
+        }
+    }
+
+    broken.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
+
+    BrokenLinkReport {
+        total_links,
+        broken,
+    }
+}
+
+/// Detect broken links from index entries.
+///
+/// Each [`IndexEntry`](crate::index::IndexEntry) has
+/// `links: Vec<(usize, Link)>` and `rel_path: String`.
+pub fn detect_broken_links_from_index(
+    dir: &Path,
+    index: &dyn VaultIndex,
+    site_prefix: Option<&str>,
+) -> BrokenLinkReport {
+    let canonical = match canonicalize_vault_dir(dir) {
+        Ok(p) => p,
+        Err(_) => {
+            return BrokenLinkReport {
+                total_links: 0,
+                broken: Vec::new(),
+            };
+        }
+    };
+
+    let mut total_links = 0usize;
+    let mut broken: Vec<BrokenLinkInfo> = Vec::new();
+
+    for entry in index.entries() {
+        for (line, link) in &entry.links {
+            total_links += 1;
+
+            let resolved_target = match link.kind {
+                LinkKind::Wikilink => link.target.clone(),
+                LinkKind::Markdown => {
+                    if link.target.starts_with('/') {
+                        link.target.clone()
+                    } else if link.target.contains('/') || link.target.contains('\\') {
+                        normalize_target(Path::new(&entry.rel_path), &link.target)
+                    } else {
+                        link.target.clone()
+                    }
+                }
+            };
+
+            if resolve_target(&canonical, &resolved_target, site_prefix).is_none() {
+                broken.push(BrokenLinkInfo {
+                    source: entry.rel_path.clone(),
+                    line: *line,
+                    target: link.target.clone(),
+                });
+            }
+        }
+    }
+
+    broken.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
+
+    BrokenLinkReport {
+        total_links,
+        broken,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fix planning — candidate matching
+// ---------------------------------------------------------------------------
+
+/// Pre-indexed file list for efficient broken link matching.
+///
+/// Encapsulates the four-strategy matching pipeline:
+/// 1. Case-insensitive exact match
+/// 2. Extension mismatch (`.md` present/absent)
+/// 3. Shortest-path (unique stem match anywhere in vault)
+/// 4. Jaro-Winkler fuzzy match
+///
+/// Build once, then call [`find_match`] for each broken link target.
+pub struct LinkMatcher {
+    /// All vault-relative file paths (canonical form).
+    files: Vec<String>,
+    /// Lowercased path → original index into `files`.
+    lower_to_idx: HashMap<String, usize>,
+    /// Lowercased stem (filename without .md and path) → list of indices.
+    /// Used for shortest-path: unique means unambiguous.
+    stem_to_indices: HashMap<String, Vec<usize>>,
+    /// Minimum Jaro-Winkler score for fuzzy matching.
+    threshold: f64,
+}
+
+/// Result of a single match attempt.
+pub struct MatchResult {
+    /// Vault-relative path of the matched file.
+    pub matched_file: String,
+    pub strategy: FixStrategy,
+    pub confidence: f64,
+}
+
+impl LinkMatcher {
+    /// Build a matcher from a list of vault-relative file paths.
+    pub fn new(files: Vec<String>, threshold: f64) -> Self {
+        let mut lower_to_idx = HashMap::with_capacity(files.len());
+        let mut stem_to_indices: HashMap<String, Vec<usize>> = HashMap::new();
+
+        for (i, f) in files.iter().enumerate() {
+            // Index by lowercased full path (with and without .md).
+            let lower = f.to_ascii_lowercase();
+            lower_to_idx.entry(lower.clone()).or_insert(i);
+            if let Some(stem) = lower.strip_suffix(".md") {
+                lower_to_idx.entry(stem.to_string()).or_insert(i);
+            }
+
+            // Index by lowercased filename stem for shortest-path.
+            let fname = f.rsplit('/').next().unwrap_or(f.as_str());
+            let fstem = fname.strip_suffix(".md").unwrap_or(fname);
+            stem_to_indices
+                .entry(fstem.to_ascii_lowercase())
+                .or_default()
+                .push(i);
+        }
+
+        Self {
+            files,
+            lower_to_idx,
+            stem_to_indices,
+            threshold,
+        }
+    }
+
+    /// Build a matcher from an index (avoids rescanning the directory).
+    pub fn from_index(index: &dyn VaultIndex, threshold: f64) -> Self {
+        let files: Vec<String> = index.entries().iter().map(|e| e.rel_path.clone()).collect();
+        Self::new(files, threshold)
+    }
+
+    /// Try to find a matching file for a broken link target.
+    ///
+    /// Returns `None` if no match is found above the configured threshold.
+    pub fn find_match(&self, raw_target: &str) -> Option<MatchResult> {
+        let target_filename = raw_target.rsplit('/').next().unwrap_or(raw_target);
+        let target_stem = target_filename
+            .strip_suffix(".md")
+            .unwrap_or(target_filename);
+
+        // --- Strategy 1: Case-insensitive exact match ---
+        let target_lower = raw_target.to_ascii_lowercase();
+
+        // Precompute the exact-case alt form so strategy 1 doesn't steal strategy 2 hits.
+        let exact_alt = if raw_target.ends_with(".md") {
+            raw_target
+                .strip_suffix(".md")
+                .unwrap_or(raw_target)
+                .to_string()
+        } else {
+            format!("{raw_target}.md")
+        };
+
+        if let Some(&idx) = self.lower_to_idx.get(&target_lower) {
+            let candidate = &self.files[idx];
+            // Only report as case-insensitive if it's not an exact-case extension mismatch.
+            if *candidate != exact_alt {
+                return Some(MatchResult {
+                    matched_file: candidate.clone(),
+                    strategy: FixStrategy::CaseInsensitive,
+                    confidence: 1.0,
+                });
+            }
+        }
+
+        // --- Strategy 2: Extension mismatch (exact case, only extension differs) ---
+        for candidate in &self.files {
+            if *candidate == exact_alt {
+                return Some(MatchResult {
+                    matched_file: candidate.clone(),
+                    strategy: FixStrategy::ExtensionMismatch,
+                    confidence: 1.0,
+                });
+            }
+        }
+
+        // --- Strategy 3: Shortest-path (unique stem match) ---
+        let target_stem_lower = target_stem.to_ascii_lowercase();
+        if let Some(indices) = self.stem_to_indices.get(&target_stem_lower)
+            && indices.len() == 1
+        {
+            return Some(MatchResult {
+                matched_file: self.files[indices[0]].clone(),
+                strategy: FixStrategy::ShortestPath,
+                confidence: 0.95,
+            });
+        }
+
+        // --- Strategy 4: Fuzzy match (Jaro-Winkler on filename stem) ---
+        let mut best_score = self.threshold;
+        let mut best_idx: Option<usize> = None;
+
+        for (i, candidate) in self.files.iter().enumerate() {
+            let fname = candidate.rsplit('/').next().unwrap_or(candidate.as_str());
+            let fstem = fname.strip_suffix(".md").unwrap_or(fname);
+            let score = strsim::jaro_winkler(target_stem, fstem);
+            if score > best_score {
+                best_score = score;
+                best_idx = Some(i);
+            }
+        }
+
+        best_idx.map(|idx| MatchResult {
+            matched_file: self.files[idx].clone(),
+            strategy: FixStrategy::FuzzyMatch,
+            confidence: best_score,
+        })
+    }
+}
+
+/// Plan fixes for broken links.
+///
+/// For each broken link, attempts to find the best matching file using
+/// the [`LinkMatcher`] priority-ordered strategy.
+///
+/// `threshold` is the minimum Jaro-Winkler score (0.0–1.0) for fuzzy matching.
+pub fn plan_fixes(broken: &[BrokenLinkInfo], matcher: &LinkMatcher) -> FixReport {
+    let mut fixes = Vec::new();
+    let mut unfixable = Vec::new();
+
+    for info in broken {
+        if let Some(result) = matcher.find_match(&info.target) {
+            fixes.push(FixPlan {
+                source: info.source.clone(),
+                line: info.line,
+                old_target: info.target.clone(),
+                new_target: result.matched_file,
+                strategy: result.strategy,
+                confidence: result.confidence,
+            });
+        } else {
+            unfixable.push(info.clone());
+        }
+    }
+
+    FixReport { fixes, unfixable }
+}
+
+// ---------------------------------------------------------------------------
+// Fix application
+// ---------------------------------------------------------------------------
+
+/// Convert fix plans to [`RewritePlan`]s and apply them to disk.
+///
+/// Groups fixes by source file, reads each file once, builds [`Replacement`]s
+/// for every fix in that file, applies them via [`apply_replacements`], and
+/// writes back via [`execute_plans`].
+///
+/// Returns the list of [`RewritePlan`]s for reporting.
+pub fn apply_fixes(
+    dir: &Path,
+    fixes: &[FixPlan],
+    site_prefix: Option<&str>,
+) -> Result<Vec<RewritePlan>> {
+    // Group fixes by source file.
+    let mut by_source: HashMap<&str, Vec<&FixPlan>> = HashMap::new();
+    for fix in fixes {
+        by_source.entry(fix.source.as_str()).or_default().push(fix);
+    }
+
+    let mut plans: Vec<RewritePlan> = Vec::new();
+
+    for (source_rel, file_fixes) in &by_source {
+        let abs_path = dir.join(source_rel.replace('\\', "/"));
+        let content = std::fs::read_to_string(&abs_path)
+            .with_context(|| format!("reading {}", abs_path.display()))?;
+
+        let replacements =
+            build_replacements_for_file(&content, source_rel, file_fixes, site_prefix);
+
+        if !replacements.is_empty() {
+            let rewritten_content = apply_replacements(&content, &replacements);
+            plans.push(RewritePlan {
+                path: abs_path,
+                rel_path: source_rel.to_string(),
+                replacements,
+                rewritten_content,
+            });
+        }
+    }
+
+    execute_plans(dir, &plans)?;
+
+    Ok(plans)
+}
+
+/// Walk `content` line by line (skipping frontmatter, code fences, comment
+/// fences) and build [`Replacement`]s for all link fixes that apply to this
+/// file.
+fn build_replacements_for_file(
+    content: &str,
+    source_rel: &str,
+    fixes: &[&FixPlan],
+    _site_prefix: Option<&str>,
+) -> Vec<Replacement> {
+    // Index fixes by line number for O(1) lookup during the scan.
+    let mut fixes_by_line: HashMap<usize, Vec<&FixPlan>> = HashMap::new();
+    for fix in fixes {
+        fixes_by_line.entry(fix.line).or_default().push(fix);
+    }
+
+    let mut replacements = Vec::new();
+    let mut fence = FenceTracker::new();
+    let mut in_comment_fence = false;
+    let mut in_frontmatter = false;
+    let mut frontmatter_done = false;
+    let mut line_num = 0usize;
+
+    for line in content.split('\n') {
+        line_num += 1;
+
+        // --- Frontmatter ---
+        if !frontmatter_done {
+            if line_num == 1 && line.trim() == "---" {
+                in_frontmatter = true;
+                continue;
+            }
+            if in_frontmatter {
+                if line.trim() == "---" {
+                    in_frontmatter = false;
+                    frontmatter_done = true;
+                }
+                continue;
+            }
+            frontmatter_done = true;
+        }
+
+        // --- Comment fence (Obsidian %% blocks) ---
+        if is_comment_fence(line) {
+            in_comment_fence = !in_comment_fence;
+            continue;
+        }
+        if in_comment_fence {
+            continue;
+        }
+
+        // --- Fenced code block ---
+        if fence.process_line(line) {
+            continue;
+        }
+
+        // If there are no fixes on this line, skip expensive span extraction.
+        let Some(line_fixes) = fixes_by_line.get(&line_num) else {
+            continue;
+        };
+
+        // Extract link spans (skipping inline code and comments).
+        let stripped_code = strip_inline_code(line);
+        let cleaned = strip_inline_comments(stripped_code.as_ref());
+        let spans = extract_link_spans_with_original(&cleaned, line);
+
+        for span in &spans {
+            // Normalize the span's target the same way detection does, so we
+            // can match it against each fix's old_target.
+            let normalized_span_target = match span.kind {
+                LinkKind::Wikilink => span.link.target.clone(),
+                LinkKind::Markdown => {
+                    if span.link.target.starts_with('/') {
+                        span.link.target.clone()
+                    } else if span.link.target.contains('/') || span.link.target.contains('\\') {
+                        normalize_target(Path::new(source_rel), &span.link.target)
+                    } else {
+                        span.link.target.clone()
+                    }
+                }
+            };
+
+            // Find the fix for this particular span.
+            let Some(fix) = line_fixes.iter().find(|f| {
+                f.old_target == normalized_span_target || f.old_target == span.link.target
+            }) else {
+                continue;
+            };
+
+            // Compute new target text based on link kind.
+            let new_target_text = match span.kind {
+                LinkKind::Wikilink => {
+                    // Use stem (without .md) for wikilinks.
+                    fix.new_target
+                        .strip_suffix(".md")
+                        .unwrap_or(&fix.new_target)
+                        .to_string()
+                }
+                LinkKind::Markdown => fix.new_target.clone(),
+            };
+
+            // Build old_text / new_text from the ORIGINAL line bytes.
+            let old_text = line[span.full_start..span.full_end].to_string();
+            let new_text = format!(
+                "{}{}{}",
+                &line[span.full_start..span.target_start],
+                new_target_text,
+                &line[span.target_end..span.full_end],
+            );
+
+            if old_text != new_text {
+                replacements.push(Replacement {
+                    line: line_num,
+                    byte_offset: span.full_start,
+                    old_text,
+                    new_text,
+                });
+            }
+        }
+    }
+
+    replacements
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    // --- Fuzzy matching helpers ---
+
+    fn make_files(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn broken(source: &str, line: usize, target: &str) -> BrokenLinkInfo {
+        BrokenLinkInfo {
+            source: source.to_string(),
+            line,
+            target: target.to_string(),
+        }
+    }
+
+    fn vault_with_files(files: &[(&str, &str)]) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        for (rel, content) in files {
+            let path = dir
+                .path()
+                .join(rel.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&path, content).unwrap();
+        }
+        dir
+    }
+
+    // --- LinkMatcher unit tests ---
+
+    #[test]
+    fn matcher_case_insensitive() {
+        let matcher = LinkMatcher::new(make_files(&["Auth.md"]), 0.8);
+        let result = matcher.find_match("auth").unwrap();
+        assert_eq!(result.matched_file, "Auth.md");
+        assert!(matches!(result.strategy, FixStrategy::CaseInsensitive));
+        assert_eq!(result.confidence, 1.0);
+    }
+
+    #[test]
+    fn matcher_extension_mismatch_add_md() {
+        let matcher = LinkMatcher::new(make_files(&["notes/foo.md"]), 0.8);
+        let result = matcher.find_match("notes/foo").unwrap();
+        assert_eq!(result.matched_file, "notes/foo.md");
+        assert!(matches!(result.strategy, FixStrategy::ExtensionMismatch));
+    }
+
+    #[test]
+    fn matcher_extension_mismatch_strip_md() {
+        let matcher = LinkMatcher::new(make_files(&["foo"]), 0.8);
+        let result = matcher.find_match("foo.md").unwrap();
+        assert_eq!(result.matched_file, "foo");
+        assert!(matches!(result.strategy, FixStrategy::ExtensionMismatch));
+    }
+
+    #[test]
+    fn matcher_shortest_path_unique_stem() {
+        let matcher = LinkMatcher::new(make_files(&["sub/deep/bar.md"]), 0.8);
+        let result = matcher.find_match("bar").unwrap();
+        assert_eq!(result.matched_file, "sub/deep/bar.md");
+        assert!(matches!(result.strategy, FixStrategy::ShortestPath));
+        assert_eq!(result.confidence, 0.95);
+    }
+
+    #[test]
+    fn matcher_shortest_path_ambiguous_skipped() {
+        let matcher = LinkMatcher::new(make_files(&["a/bar.md", "b/bar.md"]), 0.99);
+        let result = matcher.find_match("bar");
+        // Both stem-match so shortest-path doesn't fire; fuzzy threshold is
+        // very high (0.99) but "bar" vs "bar" scores 1.0, so fuzzy wins.
+        if let Some(r) = result {
+            assert!(!matches!(r.strategy, FixStrategy::ShortestPath));
+        }
+    }
+
+    #[test]
+    fn matcher_fuzzy_match() {
+        let matcher = LinkMatcher::new(make_files(&["authentication.md"]), 0.7);
+        // "authentcation" is a typo of "authentication"
+        let result = matcher.find_match("authentcation").unwrap();
+        assert_eq!(result.matched_file, "authentication.md");
+        assert!(matches!(result.strategy, FixStrategy::FuzzyMatch));
+        assert!(result.confidence >= 0.7);
+    }
+
+    #[test]
+    fn matcher_no_match() {
+        let matcher = LinkMatcher::new(make_files(&["completely-unrelated.md"]), 0.95);
+        assert!(matcher.find_match("xyz-abc-notexist").is_none());
+    }
+
+    // --- plan_fixes integration ---
+
+    #[test]
+    fn plan_fixes_produces_fix_and_unfixable() {
+        let matcher = LinkMatcher::new(make_files(&["Auth.md"]), 0.95);
+        let broken_links = vec![
+            broken("index.md", 1, "auth"),
+            broken("index.md", 5, "totally-nonexistent"),
+        ];
+        let report = plan_fixes(&broken_links, &matcher);
+        assert_eq!(report.fixes.len(), 1);
+        assert_eq!(report.fixes[0].new_target, "Auth.md");
+        assert_eq!(report.unfixable.len(), 1);
+    }
+
+    // --- detect_broken_links: basic ---
+
+    #[test]
+    fn detect_broken_links_finds_missing() {
+        use crate::link_graph::FileLinks;
+        use crate::links::{Link, LinkKind};
+
+        let tmp = vault_with_files(&[("index.md", "[[existing]]"), ("existing.md", "")]);
+
+        let file_links = vec![FileLinks {
+            source: PathBuf::from("index.md"),
+            links: vec![
+                (
+                    1,
+                    Link {
+                        target: "existing".to_string(),
+                        label: None,
+                        kind: LinkKind::Wikilink,
+                    },
+                ),
+                (
+                    2,
+                    Link {
+                        target: "missing".to_string(),
+                        label: None,
+                        kind: LinkKind::Wikilink,
+                    },
+                ),
+            ],
+        }];
+
+        let report = detect_broken_links(tmp.path(), &file_links, None);
+
+        assert_eq!(report.total_links, 2);
+        assert_eq!(report.broken.len(), 1);
+        assert_eq!(report.broken[0].target, "missing");
+    }
+
+    // --- detect_broken_links: sorted output ---
+
+    #[test]
+    fn detect_broken_links_sorted() {
+        use crate::link_graph::FileLinks;
+        use crate::links::{Link, LinkKind};
+
+        let tmp = vault_with_files(&[("a.md", ""), ("b.md", "")]);
+
+        let file_links = vec![
+            FileLinks {
+                source: PathBuf::from("b.md"),
+                links: vec![(
+                    3,
+                    Link {
+                        target: "gone".to_string(),
+                        label: None,
+                        kind: LinkKind::Wikilink,
+                    },
+                )],
+            },
+            FileLinks {
+                source: PathBuf::from("a.md"),
+                links: vec![
+                    (
+                        5,
+                        Link {
+                            target: "also-gone".to_string(),
+                            label: None,
+                            kind: LinkKind::Wikilink,
+                        },
+                    ),
+                    (
+                        1,
+                        Link {
+                            target: "nope".to_string(),
+                            label: None,
+                            kind: LinkKind::Wikilink,
+                        },
+                    ),
+                ],
+            },
+        ];
+
+        let report = detect_broken_links(tmp.path(), &file_links, None);
+
+        assert_eq!(report.broken.len(), 3);
+        // Sorted by (source, line)
+        assert_eq!(report.broken[0].source, "a.md");
+        assert_eq!(report.broken[0].line, 1);
+        assert_eq!(report.broken[1].source, "a.md");
+        assert_eq!(report.broken[1].line, 5);
+        assert_eq!(report.broken[2].source, "b.md");
+        assert_eq!(report.broken[2].line, 3);
+    }
+
+    // --- apply_fixes: wikilink rewrite ---
+
+    #[test]
+    fn apply_fixes_rewrites_wikilink() {
+        let tmp = vault_with_files(&[
+            ("index.md", "See [[wrongname]] for details.\n"),
+            ("correct-name.md", ""),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "index.md".to_string(),
+            line: 1,
+            old_target: "wrongname".to_string(),
+            new_target: "correct-name.md".to_string(),
+            strategy: FixStrategy::FuzzyMatch,
+            confidence: 0.9,
+        }];
+
+        let plans = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        let written = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+        assert!(
+            written.contains("[[correct-name]]"),
+            "expected wikilink stem, got: {written}"
+        );
+    }
+
+    // --- apply_fixes: markdown link rewrite ---
+
+    #[test]
+    fn apply_fixes_rewrites_markdown_link() {
+        let tmp = vault_with_files(&[
+            ("index.md", "See [text](wrong.md) for details.\n"),
+            ("correct.md", ""),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "index.md".to_string(),
+            line: 1,
+            old_target: "wrong.md".to_string(),
+            new_target: "correct.md".to_string(),
+            strategy: FixStrategy::CaseInsensitive,
+            confidence: 1.0,
+        }];
+
+        let plans = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        let written = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+        assert!(
+            written.contains("[text](correct.md)"),
+            "expected rewritten link, got: {written}"
+        );
+    }
+}

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -221,6 +221,8 @@ pub struct LinkMatcher {
     files: Vec<String>,
     /// Lowercased path → original index into `files`.
     lower_to_idx: HashMap<String, usize>,
+    /// Exact-case path → index into `files` (used for O(1) strategy-2 lookup).
+    exact_to_idx: HashMap<String, usize>,
     /// Lowercased stem (filename without .md and path) → list of indices.
     /// Used for shortest-path: unique means unambiguous.
     stem_to_indices: HashMap<String, Vec<usize>>,
@@ -240,9 +242,23 @@ impl LinkMatcher {
     /// Build a matcher from a list of vault-relative file paths.
     pub fn new(files: Vec<String>, threshold: f64) -> Self {
         let mut lower_to_idx = HashMap::with_capacity(files.len());
+        let mut exact_to_idx = HashMap::with_capacity(files.len());
         let mut stem_to_indices: HashMap<String, Vec<usize>> = HashMap::new();
 
         for (i, f) in files.iter().enumerate() {
+            // Index by exact path, plus the extension-toggled form.
+            exact_to_idx.entry(f.clone()).or_insert(i);
+            let alt = if f.to_ascii_lowercase().ends_with(".md") {
+                f.strip_suffix(".md")
+                    .or_else(|| f.strip_suffix(".MD"))
+                    .map(|s| s.to_string())
+            } else {
+                Some(format!("{f}.md"))
+            };
+            if let Some(a) = alt {
+                exact_to_idx.entry(a).or_insert(i);
+            }
+
             // Index by lowercased full path (with and without .md).
             let lower = f.to_ascii_lowercase();
             lower_to_idx.entry(lower.clone()).or_insert(i);
@@ -262,6 +278,7 @@ impl LinkMatcher {
         Self {
             files,
             lower_to_idx,
+            exact_to_idx,
             stem_to_indices,
             threshold,
         }
@@ -283,14 +300,14 @@ impl LinkMatcher {
             .unwrap_or(target_filename);
 
         // --- Strategy 1: Case-insensitive exact match ---
+        // `target_lower` is also used for the exact-case alt computation below.
         let target_lower = raw_target.to_ascii_lowercase();
 
         // Precompute the exact-case alt form so strategy 1 doesn't steal strategy 2 hits.
-        let exact_alt = if raw_target.ends_with(".md") {
-            raw_target
-                .strip_suffix(".md")
-                .unwrap_or(raw_target)
-                .to_string()
+        // Check the .md suffix on the lowercased form to avoid a case-sensitive comparison.
+        let exact_alt = if target_lower.ends_with(".md") {
+            // Strip the original suffix (preserving the non-suffix casing).
+            raw_target[..raw_target.len() - 3].to_string()
         } else {
             format!("{raw_target}.md")
         };
@@ -308,14 +325,13 @@ impl LinkMatcher {
         }
 
         // --- Strategy 2: Extension mismatch (exact case, only extension differs) ---
-        for candidate in &self.files {
-            if *candidate == exact_alt {
-                return Some(MatchResult {
-                    matched_file: candidate.clone(),
-                    strategy: FixStrategy::ExtensionMismatch,
-                    confidence: 1.0,
-                });
-            }
+        // Use the pre-built exact_to_idx for O(1) lookup instead of a linear scan.
+        if let Some(&idx) = self.exact_to_idx.get(&exact_alt) {
+            return Some(MatchResult {
+                matched_file: self.files[idx].clone(),
+                strategy: FixStrategy::ExtensionMismatch,
+                confidence: 1.0,
+            });
         }
 
         // --- Strategy 3: Shortest-path (unique stem match) ---
@@ -331,7 +347,12 @@ impl LinkMatcher {
         }
 
         // --- Strategy 4: Fuzzy match (Jaro-Winkler on filename stem) ---
+        // Track the top-two scores to detect ties: if two candidates score within
+        // 0.01 of each other the match is ambiguous and we return None rather than
+        // silently picking the first.
+        const TIE_DELTA: f64 = 0.01;
         let mut best_score = self.threshold;
+        let mut second_score = 0.0_f64;
         let mut best_idx: Option<usize> = None;
 
         for (i, candidate) in self.files.iter().enumerate() {
@@ -339,9 +360,18 @@ impl LinkMatcher {
             let fstem = fname.strip_suffix(".md").unwrap_or(fname);
             let score = strsim::jaro_winkler(target_stem, fstem);
             if score > best_score {
+                second_score = best_score;
                 best_score = score;
                 best_idx = Some(i);
+            } else if score > second_score {
+                second_score = score;
             }
+        }
+
+        // If the runner-up is within TIE_DELTA of the winner the match is
+        // ambiguous — decline rather than guessing.
+        if best_score - second_score <= TIE_DELTA {
+            return None;
         }
 
         best_idx.map(|idx| MatchResult {
@@ -525,7 +555,20 @@ fn build_replacements_for_file(
                         .unwrap_or(&fix.new_target)
                         .to_string()
                 }
-                LinkKind::Markdown => fix.new_target.clone(),
+                LinkKind::Markdown => {
+                    // Preserve the original `.md` presence/absence in the link.
+                    // If the original target had no `.md` suffix, strip it from
+                    // the new target too so the style is unchanged.
+                    let orig_had_md = fix.old_target.to_ascii_lowercase().ends_with(".md");
+                    if orig_had_md {
+                        fix.new_target.clone()
+                    } else {
+                        fix.new_target
+                            .strip_suffix(".md")
+                            .unwrap_or(&fix.new_target)
+                            .to_string()
+                    }
+                }
             };
 
             // Build old_text / new_text from the ORIGINAL line bytes.

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -437,7 +437,7 @@ fn plan_outbound_rewrites(content: &str, old_rel: &str, new_rel: &str) -> Vec<Re
 /// Replacements are matched against lines by their `old_text`.  Multiple
 /// replacements on the same line are applied right-to-left (by first
 /// occurrence of `old_text`) to avoid offset shifts.
-fn apply_replacements(content: &str, replacements: &[Replacement]) -> String {
+pub(crate) fn apply_replacements(content: &str, replacements: &[Replacement]) -> String {
     // Group replacements by 1-based line number.
     let mut by_line: HashMap<usize, Vec<&Replacement>> = HashMap::new();
     for r in replacements {

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -130,11 +130,28 @@ pub struct TaskReadResult {
 pub struct VaultSummary {
     pub files: FileCounts,
     pub orphans: OrphanSummary,
+    pub links: LinkHealthSummary,
     pub properties: Vec<PropertySummaryEntry>,
     pub tags: TagSummary,
     pub status: Vec<StatusGroup>,
     pub tasks: TaskCount,
     pub recent_files: Vec<RecentFile>,
+}
+
+/// Vault-wide link health: total links, broken count, and broken link details.
+#[derive(Debug, Clone, Serialize)]
+pub struct LinkHealthSummary {
+    pub total: usize,
+    pub broken: usize,
+    pub broken_links: Vec<BrokenLinkInfo>,
+}
+
+/// A single broken link with source file, line number, and raw target.
+#[derive(Debug, Clone, Serialize)]
+pub struct BrokenLinkInfo {
+    pub source: String,
+    pub line: usize,
+    pub target: String,
 }
 
 /// Fully isolated files: no inbound links (nothing links to them) and no

--- a/hyalo-knowledgebase/backlog/shortest-path-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/shortest-path-link-resolution.md
@@ -1,8 +1,8 @@
 ---
-title: "Obsidian-style shortest-path link resolution"
+title: Obsidian-style shortest-path link resolution
 type: backlog
 date: 2026-03-21
-status: deferred
+status: completed
 priority: medium
 origin: DEC-014, iteration-plan
 blocked-by: indexing

--- a/hyalo-knowledgebase/iterations/iteration-61-link-health.md
+++ b/hyalo-knowledgebase/iterations/iteration-61-link-health.md
@@ -7,7 +7,7 @@ tags:
   - links
   - summary
   - find
-status: in-progress
+status: completed
 branch: iter-61/link-health
 ---
 

--- a/hyalo-knowledgebase/iterations/iteration-61-link-health.md
+++ b/hyalo-knowledgebase/iterations/iteration-61-link-health.md
@@ -1,0 +1,95 @@
+---
+title: "Iteration 61: Link Health"
+type: iteration
+date: 2026-03-28
+tags:
+  - iteration
+  - links
+  - summary
+  - find
+status: in-progress
+branch: iter-61/link-health
+---
+
+## Goal
+
+Add vault-wide broken link detection and auto-repair. Surface link health in `summary`, add `find --broken-links` filter, and provide `links fix` to auto-repair them.
+
+## Motivation
+
+Broken links silently accumulate as files are renamed, moved, or deleted outside hyalo. There is currently no way to detect them vault-wide. The `mv` command prevents breakage during renames, but nothing catches pre-existing or externally-introduced broken links.
+
+## Design Decisions
+
+### Broken links in `summary` — not a new command
+
+`summary` already reports orphans, tasks, and tag/property health. Adding a `broken_links` section keeps the health dashboard in one place rather than creating a separate `links check` command.
+
+**New `links` section in VaultSummary:**
+```json
+{
+  "links": {
+    "total": 142,
+    "broken": 3,
+    "broken_links": [
+      { "source": "notes/auth.md", "line": 12, "target": "[[old-middleware]]" },
+      ...
+    ]
+  }
+}
+```
+
+### `find --broken-links` — convenience filter
+
+`find --fields links` already shows links per file with `path: None` for broken ones, but that's an implementation detail users shouldn't need to know. `--broken-links` is a dedicated boolean filter: returns only files that have at least one unresolved link, auto-includes the links field in output.
+
+### `links fix` — new command with fuzzy matching
+
+Auto-repair broken links by finding the best-matching existing file. Reuses `Replacement` + `apply_replacements()` from `link_rewrite.rs`.
+
+**Match strategy (in priority order):**
+1. Case-insensitive exact match (`[[Auth]]` → `auth.md`)
+2. With/without `.md` extension
+3. Shortest-path resolution (`[[foo]]` → `sub/deep/foo.md` if unique) — closes the deferred backlog item `shortest-path-link-resolution`
+4. Edit distance (Levenshtein/Jaro-Winkler) above a configurable threshold
+
+**New dependency:** `strsim` crate (~lightweight) for string similarity.
+
+**CLI:**
+```
+hyalo links fix [--dry-run] [--apply] [--threshold 0.7] [-g/--glob PATTERN]
+```
+Default is `--dry-run` (preview only). Must pass `--apply` to write changes. This is a mutation command — safe defaults matter.
+
+**Risk:** Low. New isolated module `link_fix.rs` in hyalo-core + new command file. No changes to existing link_rewrite, link_graph, or links modules.
+
+## Risks & Concerns
+
+1. **Index path for broken link detection.** The index already has the full file list, so broken link detection is just a set lookup — no extra stat calls needed. The disk-scan path already reads every file, so resolving links there is nearly free too. No performance concern.
+
+2. **Fuzzy matching false positives.** `links fix --apply` could rewrite a link to the wrong target. Mitigation: `--dry-run` default, clear diff-style preview, configurable threshold.
+
+3. **VaultSummary serialization contract.** Adding a new `links` field to VaultSummary is additive — existing JSON consumers just get an extra key. No breaking change.
+
+## Tasks
+
+- [x] Add `BrokenLinkSummary` and `LinkHealthSummary` types to `hyalo-core/src/types.rs`
+- [x] Implement broken link detection in summary disk-scan path
+- [x] Implement broken link detection in summary index path
+- [x] Update summary text formatter for new links section
+- [x] Add `strsim` dependency to hyalo-core
+- [x] Implement `link_fix.rs` in hyalo-core (fuzzy matching + fix planning)
+- [x] Implement `links fix` CLI command with `--dry-run`/`--apply`
+- [x] Implement shortest-path resolution as part of fix match strategy
+- [x] Add unit tests for broken link detection and fuzzy matching
+- [x] Add `--broken-links` filter flag to `find` command
+- [x] Add e2e tests for summary link health, find --broken-links, and links fix
+- [x] Close backlog item `shortest-path-link-resolution` (subsumed by links fix)
+
+## Out of Scope
+
+- `links suggest` (unlinked title mentions in prose) — future iteration
+- `links convert` (wikilink ↔ markdown normalization) — future iteration
+- `links graph` (DOT/Mermaid export) — future iteration
+- `summary --fields` selective output — separate iteration
+- Caching resolution status in the snapshot index — future optimization


### PR DESCRIPTION
## Summary
- Add vault-wide broken link detection to `hyalo summary` (new `links` section with total/broken counts and source locations)
- Add `hyalo find --broken-links` filter to return only files with unresolved links
- Add `hyalo links fix` command with fuzzy matching auto-repair (case-insensitive, extension mismatch, shortest-path, Jaro-Winkler) and `--dry-run`/`--apply` workflow
- Add `strsim` dependency for string similarity, new `link_fix.rs` module in hyalo-core

## Test plan
- [x] 12 new e2e tests covering summary link health, find --broken-links, and links fix (dry-run, apply, text format, threshold tuning)
- [x] 8 new unit tests for LinkMatcher strategies, plan_fixes, detect_broken_links, and apply_fixes
- [x] All 478 unit + integration tests pass
- [x] cargo fmt / clippy / test gates green
- [x] Dogfooded against hyalo-knowledgebase (35 broken links detected, all fixable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)