### PR TITLE
Harden vault boundaries, symlink checks, and unsafe block safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "dunce",
  "globset",
  "hyalo-core",
  "indexmap",

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -18,6 +18,7 @@ hyalo-core = { workspace = true }
 anyhow = { workspace = true }
 indexmap = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+dunce = { workspace = true }
 jaq-core = { workspace = true }
 jaq-json = { workspace = true }
 jaq-std = { workspace = true }

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -158,7 +158,8 @@ pub fn append(
     let parsed_args: Vec<(&str, &str, Value)> = {
         let mut v = Vec::with_capacity(property_args.len());
         for arg in property_args {
-            let (name, raw_value) = parse_kv(arg).expect("already validated");
+            let (name, raw_value) =
+                parse_kv(arg).map_err(|e| anyhow::anyhow!("invalid property argument: {e}"))?;
             let parsed = frontmatter::parse_value(raw_value, None)
                 .map_err(|e| anyhow::anyhow!("failed to parse value for property '{name}': {e}"))?;
             v.push((name, raw_value, parsed));

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::missing_errors_doc)]
-use anyhow::Result;
+use anyhow::{Context, Result};
 use hyalo_core::discovery;
 use hyalo_core::index::{ScannedIndex, SnapshotIndex, VaultIndex, find_stale_indexes};
 use std::path::{Path, PathBuf};
@@ -16,6 +16,7 @@ pub fn create_index(
     site_prefix: Option<&str>,
     output: Option<&Path>,
     format: Format,
+    allow_outside_vault: bool,
 ) -> Result<CommandOutcome> {
     // Discover all markdown files
     let all = discovery::discover_files(dir)?;
@@ -40,6 +41,30 @@ pub fn create_index(
         Some(p) => p.to_path_buf(),
         None => dir.join(".hyalo-index"),
     };
+
+    // Vault boundary check: only applies when the caller specified a custom path
+    if output.is_some() && !allow_outside_vault {
+        let canonical_dir = discovery::canonicalize_vault_dir(dir)?;
+        let parent = index_path
+            .parent()
+            .context("output path has no parent directory")?;
+        let canonical_parent = std::fs::canonicalize(parent).with_context(|| {
+            format!(
+                "failed to canonicalize parent of output path: {}",
+                parent.display()
+            )
+        })?;
+        if !canonical_parent.starts_with(&canonical_dir) {
+            let out = crate::output::format_error(
+                format,
+                "output path is outside the vault boundary",
+                Some(&index_path.display().to_string()),
+                Some("use --allow-outside-vault to override"),
+                None,
+            );
+            return Ok(CommandOutcome::UserError(out));
+        }
+    }
 
     // Serialize vault_dir as a canonical string (fall back to raw display)
     let vault_dir_str = std::fs::canonicalize(dir)

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -18,6 +18,37 @@ pub fn create_index(
     format: Format,
     allow_outside_vault: bool,
 ) -> Result<CommandOutcome> {
+    // Determine output path
+    let index_path = match output {
+        Some(p) => p.to_path_buf(),
+        None => dir.join(".hyalo-index"),
+    };
+
+    // Vault boundary check: run early (before the expensive scan) when the
+    // caller specified a custom output path.
+    if output.is_some() && !allow_outside_vault {
+        let canonical_dir = discovery::canonicalize_vault_dir(dir)?;
+        let parent = index_path
+            .parent()
+            .context("output path has no parent directory")?;
+        let canonical_parent = dunce::canonicalize(parent).with_context(|| {
+            format!(
+                "failed to canonicalize parent of output path: {}",
+                parent.display()
+            )
+        })?;
+        if !canonical_parent.starts_with(&canonical_dir) {
+            let out = crate::output::format_error(
+                format,
+                "output path is outside the vault boundary",
+                Some(&index_path.display().to_string()),
+                Some("use --allow-outside-vault to override"),
+                None,
+            );
+            return Ok(CommandOutcome::UserError(out));
+        }
+    }
+
     // Discover all markdown files
     let all = discovery::discover_files(dir)?;
     let files: Vec<(PathBuf, String)> = all
@@ -34,36 +65,6 @@ pub fn create_index(
     // Warn about skipped files
     for w in &build.warnings {
         crate::warn::warn(format!("skipped {}: {}", w.rel_path, w.message));
-    }
-
-    // Determine output path
-    let index_path = match output {
-        Some(p) => p.to_path_buf(),
-        None => dir.join(".hyalo-index"),
-    };
-
-    // Vault boundary check: only applies when the caller specified a custom path
-    if output.is_some() && !allow_outside_vault {
-        let canonical_dir = discovery::canonicalize_vault_dir(dir)?;
-        let parent = index_path
-            .parent()
-            .context("output path has no parent directory")?;
-        let canonical_parent = std::fs::canonicalize(parent).with_context(|| {
-            format!(
-                "failed to canonicalize parent of output path: {}",
-                parent.display()
-            )
-        })?;
-        if !canonical_parent.starts_with(&canonical_dir) {
-            let out = crate::output::format_error(
-                format,
-                "output path is outside the vault boundary",
-                Some(&index_path.display().to_string()),
-                Some("use --allow-outside-vault to override"),
-                None,
-            );
-            return Ok(CommandOutcome::UserError(out));
-        }
     }
 
     // Serialize vault_dir as a canonical string (fall back to raw display)

--- a/crates/hyalo-cli/src/commands/drop_index.rs
+++ b/crates/hyalo-cli/src/commands/drop_index.rs
@@ -19,22 +19,37 @@ pub fn drop_index(
         None => dir.join(".hyalo-index"),
     };
 
-    // Vault boundary check: only applies when the caller specified a custom path
+    // Vault boundary check: only applies when the caller specified a custom path.
+    // Fail closed — if canonicalization fails we refuse the operation rather than
+    // allowing a potentially out-of-vault deletion.
     if path.is_some() && !allow_outside_vault {
         let canonical_dir = hyalo_core::discovery::canonicalize_vault_dir(dir)?;
-        // The file should exist at this point; canonicalize it directly.
-        // If it doesn't exist the remove_file below will return a NotFound error.
-        if let Ok(canonical_path) = std::fs::canonicalize(&index_path)
-            && !canonical_path.starts_with(&canonical_dir)
-        {
-            let out = crate::output::format_error(
-                format,
-                "index path is outside the vault boundary",
-                Some(&index_path.display().to_string()),
-                Some("use --allow-outside-vault to override"),
-                None,
-            );
-            return Ok(CommandOutcome::UserError(out));
+        match dunce::canonicalize(&index_path) {
+            Ok(canonical_path) => {
+                if !canonical_path.starts_with(&canonical_dir) {
+                    let out = crate::output::format_error(
+                        format,
+                        "index path is outside the vault boundary",
+                        Some(&index_path.display().to_string()),
+                        Some("use --allow-outside-vault to override"),
+                        None,
+                    );
+                    return Ok(CommandOutcome::UserError(out));
+                }
+            }
+            Err(e) => {
+                let details = format!("failed to resolve index path for boundary check: {e}");
+                let out = crate::output::format_error(
+                    format,
+                    "could not verify that index path is inside the vault",
+                    Some(&index_path.display().to_string()),
+                    Some(
+                        "ensure the path is accessible and inside the vault, or use --allow-outside-vault",
+                    ),
+                    Some(&details),
+                );
+                return Ok(CommandOutcome::UserError(out));
+            }
         }
     }
 

--- a/crates/hyalo-cli/src/commands/drop_index.rs
+++ b/crates/hyalo-cli/src/commands/drop_index.rs
@@ -8,11 +8,35 @@ use crate::output::{CommandOutcome, Format, format_success};
 ///
 /// If `path` is `None`, defaults to `<dir>/.hyalo-index`.
 /// Returns a user error if the file does not exist.
-pub fn drop_index(dir: &Path, path: Option<&Path>, format: Format) -> Result<CommandOutcome> {
+pub fn drop_index(
+    dir: &Path,
+    path: Option<&Path>,
+    format: Format,
+    allow_outside_vault: bool,
+) -> Result<CommandOutcome> {
     let index_path: PathBuf = match path {
         Some(p) => p.to_path_buf(),
         None => dir.join(".hyalo-index"),
     };
+
+    // Vault boundary check: only applies when the caller specified a custom path
+    if path.is_some() && !allow_outside_vault {
+        let canonical_dir = hyalo_core::discovery::canonicalize_vault_dir(dir)?;
+        // The file should exist at this point; canonicalize it directly.
+        // If it doesn't exist the remove_file below will return a NotFound error.
+        if let Ok(canonical_path) = std::fs::canonicalize(&index_path)
+            && !canonical_path.starts_with(&canonical_dir)
+        {
+            let out = crate::output::format_error(
+                format,
+                "index path is outside the vault boundary",
+                Some(&index_path.display().to_string()),
+                Some("use --allow-outside-vault to override"),
+                None,
+            );
+            return Ok(CommandOutcome::UserError(out));
+        }
+    }
 
     match std::fs::remove_file(&index_path) {
         Ok(()) => {}

--- a/crates/hyalo-cli/src/commands/remove.rs
+++ b/crates/hyalo-cli/src/commands/remove.rs
@@ -224,8 +224,10 @@ pub fn remove(
     // Pre-parse property args: (name, opt_value)
     let parsed_props: Vec<(&str, Option<&str>)> = property_args
         .iter()
-        .map(|arg| parse_kv_optional(arg).expect("already validated"))
-        .collect();
+        .map(|arg| {
+            parse_kv_optional(arg).map_err(|e| anyhow::anyhow!("invalid property argument: {e}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     let files = collect_files(dir, files, globs, format)?;
     let files = match files {

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -199,7 +199,8 @@ pub fn set(
     let parsed_props: Vec<(&str, &str, Value)> = {
         let mut v = Vec::with_capacity(property_args.len());
         for arg in property_args {
-            let (name, raw_value) = parse_kv(arg).expect("already validated");
+            let (name, raw_value) =
+                parse_kv(arg).map_err(|e| anyhow::anyhow!("invalid property argument: {e}"))?;
             let value = match frontmatter::parse_value(raw_value, None) {
                 Ok(val) => val,
                 Err(e) => {

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -771,6 +771,9 @@ Repeatable (AND).\n\
         /// Output path for the index file (default: .hyalo-index in --dir)
         #[arg(short, long)]
         output: Option<PathBuf>,
+        /// Allow writing the index file outside the vault directory
+        #[arg(long)]
+        allow_outside_vault: bool,
     },
     /// Delete a snapshot index file created with create-index
     #[command(
@@ -786,6 +789,9 @@ Repeatable (AND).\n\
         /// Path to the index file to delete (default: .hyalo-index in --dir)
         #[arg(short, long)]
         path: Option<PathBuf>,
+        /// Allow deleting an index file outside the vault directory
+        #[arg(long)]
+        allow_outside_vault: bool,
     },
     /// Append values to list properties in file(s) frontmatter, promoting scalars to lists
     #[command(
@@ -1700,15 +1706,25 @@ fn main() {
             &mut snapshot_index,
             cli.index.as_deref(),
         ),
-        Commands::CreateIndex { ref output } => create_index_commands::create_index(
+        Commands::CreateIndex {
+            ref output,
+            allow_outside_vault,
+        } => create_index_commands::create_index(
             &dir,
             site_prefix,
             output.as_deref(),
             effective_format,
+            allow_outside_vault,
         ),
-        Commands::DropIndex { ref path } => {
-            drop_index_commands::drop_index(&dir, path.as_deref(), effective_format)
-        }
+        Commands::DropIndex {
+            ref path,
+            allow_outside_vault,
+        } => drop_index_commands::drop_index(
+            &dir,
+            path.as_deref(),
+            effective_format,
+            allow_outside_vault,
+        ),
         Commands::Links { action } => match action {
             LinksAction::Fix {
                 dry_run: _,

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -3,6 +3,9 @@ mod common;
 use common::{hyalo, md, write_md};
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use std::os::unix::fs as unix_fs;
+
 // ---------------------------------------------------------------------------
 // Vault fixture
 // ---------------------------------------------------------------------------
@@ -1086,5 +1089,297 @@ fn chained_mutations_with_index_keep_index_consistent() {
     assert_eq!(
         tags, disk_tags,
         "index and disk scan should agree after chained mutations"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Vault boundary checks — create-index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_index_rejects_output_outside_vault() {
+    let vault = setup_vault();
+    let outside = TempDir::new().unwrap();
+    let outside_path = outside.path().join("evil.idx");
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["create-index", "--output", outside_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "create-index should fail for paths outside vault"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{stderr}{stdout}");
+    assert!(
+        combined.contains("outside the vault boundary")
+            || combined.contains("--allow-outside-vault"),
+        "should mention vault boundary or escape hatch, got: {combined}"
+    );
+    assert!(
+        !outside_path.exists(),
+        "index file should not have been written outside vault"
+    );
+}
+
+#[test]
+fn create_index_allow_outside_vault_flag() {
+    let vault = setup_vault();
+    let outside = TempDir::new().unwrap();
+    let outside_path = outside.path().join("allowed.idx");
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "create-index",
+            "--output",
+            outside_path.to_str().unwrap(),
+            "--allow-outside-vault",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "create-index with --allow-outside-vault should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        outside_path.exists(),
+        "index file should have been written with escape hatch"
+    );
+}
+
+#[test]
+fn create_index_normal_in_vault_path_works() {
+    let vault = setup_vault();
+    let in_vault_path = vault.path().join("subdir");
+    std::fs::create_dir_all(&in_vault_path).unwrap();
+    let index_path = in_vault_path.join("my.idx");
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["create-index", "--output", index_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "create-index with in-vault path should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(index_path.exists(), "index file should exist inside vault");
+}
+
+// ---------------------------------------------------------------------------
+// Vault boundary checks — drop-index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn drop_index_rejects_path_outside_vault() {
+    let vault = setup_vault();
+    // Create a real file outside the vault to try to delete
+    let outside = TempDir::new().unwrap();
+    let outside_file = outside.path().join("victim.idx");
+    std::fs::write(&outside_file, b"fake index").unwrap();
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["drop-index", "--path", outside_file.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "drop-index should fail for paths outside vault"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{stderr}{stdout}");
+    assert!(
+        combined.contains("outside the vault boundary")
+            || combined.contains("--allow-outside-vault"),
+        "should mention vault boundary or escape hatch, got: {combined}"
+    );
+    assert!(
+        outside_file.exists(),
+        "file outside vault should NOT have been deleted"
+    );
+}
+
+#[test]
+fn drop_index_allow_outside_vault_flag() {
+    let vault = setup_vault();
+    let outside = TempDir::new().unwrap();
+    let outside_file = outside.path().join("allowed.idx");
+    std::fs::write(&outside_file, b"fake index").unwrap();
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "drop-index",
+            "--path",
+            outside_file.to_str().unwrap(),
+            "--allow-outside-vault",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "drop-index with --allow-outside-vault should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !outside_file.exists(),
+        "file should have been deleted with escape hatch"
+    );
+}
+
+#[test]
+fn drop_index_normal_in_vault_path_works() {
+    let vault = setup_vault();
+    let index_path = create_default_index(&vault);
+    assert!(index_path.exists());
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["drop-index", "--path", index_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "drop-index with in-vault path should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!index_path.exists(), "index should have been deleted");
+}
+
+// ---------------------------------------------------------------------------
+// Symlink boundary checks — discover_files (via find)
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn find_skips_symlinked_md_outside_vault() {
+    let vault = TempDir::new().unwrap();
+    write_md(
+        vault.path(),
+        "real.md",
+        md!(r"
+---
+title: Real
+---
+Content
+"),
+    );
+
+    // Create a file outside the vault and symlink to it
+    let outside = TempDir::new().unwrap();
+    let outside_file = outside.path().join("secret.md");
+    std::fs::write(&outside_file, "---\ntitle: Secret\n---\nSecret content\n").unwrap();
+    unix_fs::symlink(&outside_file, vault.path().join("evil.md")).unwrap();
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .arg("find")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "find should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let files: Vec<&str> = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["file"].as_str().unwrap())
+        .collect();
+    assert!(
+        files.contains(&"real.md"),
+        "real.md should be found: {files:?}"
+    );
+    assert!(
+        !files.iter().any(|f| f.contains("evil")),
+        "symlinked file outside vault should be skipped: {files:?}"
+    );
+
+    // Should emit a warning on stderr
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning") && stderr.contains("outside vault"),
+        "should warn about skipped symlink: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn find_includes_symlinked_md_inside_vault() {
+    let vault = TempDir::new().unwrap();
+    write_md(
+        vault.path(),
+        "real.md",
+        md!(r"
+---
+title: Real
+---
+Content
+"),
+    );
+
+    // Create a subdirectory with a file, then symlink within the vault
+    std::fs::create_dir_all(vault.path().join("sub")).unwrap();
+    write_md(
+        vault.path(),
+        "sub/target.md",
+        md!(r"
+---
+title: Target
+---
+Target content
+"),
+    );
+    unix_fs::symlink(
+        vault.path().join("sub/target.md"),
+        vault.path().join("link.md"),
+    )
+    .unwrap();
+
+    let output = hyalo()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .arg("find")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "find should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let files: Vec<&str> = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["file"].as_str().unwrap())
+        .collect();
+    assert!(
+        files.contains(&"real.md"),
+        "real.md should be found: {files:?}"
+    );
+    // The symlink resolves inside the vault, so it should be included
+    assert!(
+        files.iter().any(|f| f.contains("link")),
+        "symlinked file inside vault should be included: {files:?}"
     );
 }

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -26,27 +26,38 @@ pub fn discover_files(dir: &Path) -> Result<Vec<PathBuf>> {
         }
     }
 
-    // Filter out symlinks that resolve outside the vault boundary
+    // Filter out symlinks whose target resolves outside the vault boundary.
+    // Only canonicalize paths that are actually symlinks to avoid unnecessary
+    // syscalls on the common (non-symlink) path.
     let canonical_dir = canonicalize_vault_dir(dir)?;
-    files.retain(|path| match dunce::canonicalize(path) {
-        Ok(canonical) => {
-            if canonical.starts_with(&canonical_dir) {
-                true
-            } else {
+    files.retain(|path| {
+        let is_symlink = path
+            .symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false);
+        if !is_symlink {
+            return true;
+        }
+        match dunce::canonicalize(path) {
+            Ok(canonical) => {
+                if canonical.starts_with(&canonical_dir) {
+                    true
+                } else {
+                    eprintln!(
+                        "warning: skipping {}: symlink target resolves outside vault",
+                        path.display()
+                    );
+                    false
+                }
+            }
+            Err(e) => {
                 eprintln!(
-                    "warning: skipping {}: symlink target resolves outside vault",
-                    path.display()
+                    "warning: skipping {}: failed to resolve path: {}",
+                    path.display(),
+                    e
                 );
                 false
             }
-        }
-        Err(e) => {
-            eprintln!(
-                "warning: skipping {}: failed to resolve path: {}",
-                path.display(),
-                e
-            );
-            false
         }
     });
 

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -26,6 +26,30 @@ pub fn discover_files(dir: &Path) -> Result<Vec<PathBuf>> {
         }
     }
 
+    // Filter out symlinks that resolve outside the vault boundary
+    let canonical_dir = canonicalize_vault_dir(dir)?;
+    files.retain(|path| match dunce::canonicalize(path) {
+        Ok(canonical) => {
+            if canonical.starts_with(&canonical_dir) {
+                true
+            } else {
+                eprintln!(
+                    "warning: skipping {}: symlink target resolves outside vault",
+                    path.display()
+                );
+                false
+            }
+        }
+        Err(e) => {
+            eprintln!(
+                "warning: skipping {}: failed to resolve path: {}",
+                path.display(),
+                e
+            );
+            false
+        }
+    });
+
     files.sort();
     Ok(files)
 }
@@ -121,7 +145,7 @@ pub fn canonicalize_vault_dir(dir: &Path) -> Result<PathBuf> {
 /// - `Ok(true)`  — `full` is within the vault
 /// - `Ok(false)` — `full` resolves outside the vault boundary
 /// - `Err(_)`    — `full` could not be canonicalized (permission error, symlink loop, etc.)
-pub(crate) fn ensure_within_vault(canonical_dir: &Path, full: &Path) -> Result<bool> {
+pub fn ensure_within_vault(canonical_dir: &Path, full: &Path) -> Result<bool> {
     let canonical_full = dunce::canonicalize(full)
         .with_context(|| format!("failed to canonicalize path: {}", full.display()))?;
     Ok(canonical_full.starts_with(canonical_dir))

--- a/crates/hyalo-core/src/scanner.rs
+++ b/crates/hyalo-core/src/scanner.rs
@@ -125,6 +125,13 @@ pub(crate) fn is_closing_fence(line: &str, fence_char: char, min_count: usize) -
 /// Strip inline code spans from a line, replacing their content with spaces
 /// to preserve byte positions for link parsing.
 /// Returns a borrowed reference when no backticks are present (zero allocation).
+///
+/// # Safety constraint
+///
+/// The `unsafe` block at the end of this function relies on the fact that
+/// backtick (0x60) and space (0x20) are both single-byte ASCII characters.
+/// Any future change to the delimiter or replacement byte must preserve this
+/// single-byte-ASCII invariant to keep the UTF-8 validity proof sound.
 pub fn strip_inline_code(line: &str) -> Cow<'_, str> {
     if !line.contains('`') {
         return Cow::Borrowed(line);
@@ -204,6 +211,13 @@ pub(crate) fn is_comment_fence(line: &str) -> bool {
 ///
 /// Returns a borrowed reference when no `%%` is present (zero allocation).
 /// Unmatched opening `%%` is treated as literal text.
+///
+/// # Safety constraint
+///
+/// The `unsafe` block at the end of this function relies on the fact that
+/// percent (0x25) and space (0x20) are both single-byte ASCII characters.
+/// Any future change to the delimiter or replacement byte must preserve this
+/// single-byte-ASCII invariant to keep the UTF-8 validity proof sound.
 pub fn strip_inline_comments(line: &str) -> Cow<'_, str> {
     if !line.contains("%%") {
         return Cow::Borrowed(line);

--- a/hyalo-knowledgebase/iterations/iteration-64-security-hardening.md
+++ b/hyalo-knowledgebase/iterations/iteration-64-security-hardening.md
@@ -1,11 +1,11 @@
 ---
-title: "Security hardening for open-source release"
+title: Security hardening for open-source release
 type: iteration
 date: 2026-03-28
 tags:
   - iteration
   - security
-status: planned
+status: completed
 branch: iter-64/security-hardening
 ---
 
@@ -17,30 +17,30 @@ Addresses findings from the security audit (2026-03-28). Hardens vault boundary 
 
 `create-index --output` and `drop-index --path` accept arbitrary filesystem paths with no vault boundary validation. In automated pipelines where these args could come from untrusted input, an attacker could write or delete arbitrary files.
 
-- [ ] Add `ensure_within_vault` check to `create-index --output` resolved path
-- [ ] Add `ensure_within_vault` check to `drop-index --path` resolved path
-- [ ] Add `--allow-outside-vault` escape hatch for intentional use outside the vault
-- [ ] Add e2e tests: reject paths outside vault (both commands)
-- [ ] Add e2e tests: `--allow-outside-vault` allows paths outside vault
-- [ ] Add e2e tests: normal in-vault paths still work
+- [x] Add `ensure_within_vault` check to `create-index --output` resolved path
+- [x] Add `ensure_within_vault` check to `drop-index --path` resolved path
+- [x] Add `--allow-outside-vault` escape hatch for intentional use outside the vault
+- [x] Add e2e tests: reject paths outside vault (both commands)
+- [x] Add e2e tests: `--allow-outside-vault` allows paths outside vault
+- [x] Add e2e tests: normal in-vault paths still work
 
 ## Symlink boundary check in discover_files
 
 `discover_files` (used by `--glob` and bulk scan) collects symlinked `.md` files without checking if their target is inside the vault. An attacker with write access to the vault dir could plant `evil.md -> /etc/shadow` and cause hyalo to read arbitrary files.
 
-- [ ] After `discover_files` collects paths, canonicalize and check against vault boundary
-- [ ] Skip files that resolve outside the vault (with a warning)
-- [ ] Add e2e test: symlinked `.md` file pointing outside vault is skipped
-- [ ] Add e2e test: symlinked `.md` file pointing inside vault is included
+- [x] After `discover_files` collects paths, canonicalize and check against vault boundary
+- [x] Skip files that resolve outside the vault (with a warning)
+- [x] Add e2e test: symlinked `.md` file pointing outside vault is skipped
+- [x] Add e2e test: symlinked `.md` file pointing inside vault is included
 
 ## Harden unsafe blocks (maintenance safety)
 
-- [ ] Add top-of-function comment in `strip_inline_code` noting single-byte-ASCII constraint for the `unsafe` block
-- [ ] Add top-of-function comment in `strip_inline_comments` noting single-byte-ASCII constraint
-- [ ] Replace `.expect("already validated")` with `?` in `append.rs`, `set.rs`, `remove.rs`
+- [x] Add top-of-function comment in `strip_inline_code` noting single-byte-ASCII constraint for the `unsafe` block
+- [x] Add top-of-function comment in `strip_inline_comments` noting single-byte-ASCII constraint
+- [x] Replace `.expect("already validated")` with `?` in `append.rs`, `set.rs`, `remove.rs`
 
 ## Verify
 
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`


### PR DESCRIPTION
## Summary
- **Vault boundary enforcement on index commands**: `create-index --output` and `drop-index --path` now reject paths outside the vault directory, preventing arbitrary file write/delete in automated pipelines. Added `--allow-outside-vault` escape hatch for intentional use.
- **Symlink boundary check in `discover_files`**: Symlinked `.md` files whose target resolves outside the vault are skipped with a stderr warning, closing a path traversal vector. Only symlinks are canonicalized (regular files skip the syscall).
- **Harden unsafe blocks**: Added `# Safety constraint` doc comments to `strip_inline_code` and `strip_inline_comments` documenting the single-byte-ASCII invariant.
- **Replace `.expect("already validated")`**: Converted panicking `.expect()` calls in `append.rs`, `set.rs`, and `remove.rs` to fallible `?` with proper error messages.
- **Review fixes**: Fail-closed boundary check in `drop_index` (canonicalization errors now block deletion), consistent `dunce::canonicalize` usage across both commands (fixes Windows `\\?\` prefix mismatch), early boundary validation in `create_index` (before expensive vault scan).

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 485 tests pass
- [x] e2e: `create-index --output` outside vault is rejected
- [x] e2e: `create-index --output --allow-outside-vault` succeeds
- [x] e2e: `create-index --output` with in-vault path succeeds
- [x] e2e: `drop-index --path` outside vault is rejected
- [x] e2e: `drop-index --path --allow-outside-vault` succeeds
- [x] e2e: `drop-index --path` with in-vault path succeeds
- [x] e2e: symlinked `.md` pointing outside vault is skipped by `find`
- [x] e2e: symlinked `.md` pointing inside vault is included by `find`

🤖 Generated with [Claude Code](https://claude.com/claude-code)