### PR TITLE
Implement 4 dogfood UX improvements (iteration 66)

### DIFF
--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -80,7 +80,14 @@ pub fn find(
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
     let has_section_filter = !section_filters.is_empty();
-    let has_title_filter = title_filter.is_some();
+    // Compile --title filter once before the loop to avoid per-file regex
+    // compilation and repeated to_lowercase() allocation.
+    let title_matcher = match title_filter.map(TitleMatcher::parse) {
+        Some(Ok(m)) => Some(m),
+        Some(Err(outcome)) => return Ok(outcome),
+        None => None,
+    };
+    let has_title_filter = title_matcher.is_some();
     let body_needed = needs_body(
         fields,
         has_content_search,
@@ -252,9 +259,9 @@ pub fn find(
             section_scanner.map(SectionScanner::into_sections);
 
         // --- Apply title filter ---
-        if let Some(title_pat) = title_filter {
+        if let Some(ref matcher) = title_matcher {
             let title_val = extract_title(&props, outline_sections.as_deref());
-            if !matches_title(&title_val, title_pat) {
+            if !matcher.matches(&title_val) {
                 continue;
             }
         }
@@ -578,6 +585,13 @@ pub fn find_from_index(
     let has_task_filter = task_filter.is_some();
     let has_section_filter = !section_filters.is_empty();
 
+    // Compile --title filter once before the loop.
+    let title_matcher = match title_filter.map(TitleMatcher::parse) {
+        Some(Ok(m)) => Some(m),
+        Some(Err(outcome)) => return Ok(outcome),
+        None => None,
+    };
+
     // Compile regex once (if any)
     let compiled_regex = match regexp {
         Some(re) => {
@@ -654,9 +668,9 @@ pub fn find_from_index(
         }
 
         // --- Apply title filter (index path: sections are pre-indexed, no I/O needed) ---
-        if let Some(title_pat) = title_filter {
+        if let Some(ref matcher) = title_matcher {
             let title_val = extract_title(&entry.properties, Some(&entry.sections));
-            if !matches_title(&title_val, title_pat) {
+            if !matcher.matches(&title_val) {
                 continue;
             }
         }
@@ -975,23 +989,46 @@ fn extract_title(
     serde_json::Value::Null
 }
 
-/// Check if a title value matches the given pattern.
-///
-/// - `~=REGEX` prefix: case-insensitive regex match
-/// - Otherwise: case-insensitive substring match
-/// - `Null` titles never match any pattern
-fn matches_title(title: &serde_json::Value, pattern: &str) -> bool {
-    let title_str = match title {
-        serde_json::Value::String(s) => s.as_str(),
-        _ => return false,
-    };
-    if let Some(regex_pat) = pattern.strip_prefix("~=") {
-        let effective = format!("(?i){regex_pat}");
-        regex::Regex::new(&effective)
-            .map(|re| re.is_match(title_str))
-            .unwrap_or(false)
-    } else {
-        title_str.to_lowercase().contains(&pattern.to_lowercase())
+/// Pre-compiled title filter — avoids per-file regex compilation and repeated
+/// `to_lowercase()` allocation.
+enum TitleMatcher {
+    /// Case-insensitive substring: stores the lowered pattern.
+    Substring(String),
+    /// Pre-compiled case-insensitive regex.
+    Regex(regex::Regex),
+}
+
+impl TitleMatcher {
+    /// Parse a `--title` value into a compiled matcher.
+    ///
+    /// Returns `Err(CommandOutcome::UserError(...))` on invalid regex.
+    fn parse(pattern: &str) -> Result<Self, CommandOutcome> {
+        if let Some(regex_pat) = pattern.strip_prefix("~=") {
+            let effective = format!("(?i){regex_pat}");
+            match regex::RegexBuilder::new(&effective)
+                .size_limit(1 << 20)
+                .build()
+            {
+                Ok(re) => Ok(Self::Regex(re)),
+                Err(e) => Err(CommandOutcome::UserError(format!(
+                    "invalid --title regex: {regex_pat}\n{e}"
+                ))),
+            }
+        } else {
+            Ok(Self::Substring(pattern.to_lowercase()))
+        }
+    }
+
+    /// Returns true if the title value matches. `Null` titles never match.
+    fn matches(&self, title: &serde_json::Value) -> bool {
+        let title_str = match title {
+            serde_json::Value::String(s) => s.as_str(),
+            _ => return false,
+        };
+        match self {
+            Self::Substring(lowered) => title_str.to_lowercase().contains(lowered.as_str()),
+            Self::Regex(re) => re.is_match(title_str),
+        }
     }
 }
 

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -37,7 +37,9 @@ use hyalo_core::types::{
 /// - `file` / `glob`      — scope limiting
 /// - `fields`             — controls which fields appear in each `FileObject`
 /// - `sort`               — sort order; defaults to ascending by file path
+/// - `reverse`            — reverse the final sort order
 /// - `limit`              — maximum number of results
+/// - `title_filter`       — case-insensitive substring or `~=regex` match against title
 #[allow(clippy::too_many_arguments)]
 pub fn find(
     dir: &Path,
@@ -52,8 +54,10 @@ pub fn find(
     globs: &[String],
     fields: &Fields,
     sort: Option<&SortField>,
+    reverse: bool,
     limit: Option<usize>,
     broken_links: bool,
+    title_filter: Option<&str>,
     format: Format,
 ) -> Result<CommandOutcome> {
     let files = collect_files(dir, files_arg, globs, format)?;
@@ -76,6 +80,7 @@ pub fn find(
     let has_content_search = pattern.is_some() || regexp.is_some();
     let has_task_filter = task_filter.is_some();
     let has_section_filter = !section_filters.is_empty();
+    let has_title_filter = title_filter.is_some();
     let body_needed = needs_body(
         fields,
         has_content_search,
@@ -85,7 +90,9 @@ pub fn find(
         || sort_needs_title
         // --broken-links forces fields.links on (applied later in effective_fields),
         // so we must also force body scanning here before effective_fields is built.
-        || broken_links;
+        || broken_links
+        // --title filter needs body scanning for H1 fallback when frontmatter title absent.
+        || has_title_filter;
 
     // Compile the regex once (if any), then clone cheaply per file.
     // Invalid regex is a user error (exit 1), not an internal error (exit 2).
@@ -144,7 +151,9 @@ pub fn find(
         && !sort_needs_backlinks
         && !sort_needs_links
         && !sort_needs_properties
-        && !sort_needs_title;
+        && !sort_needs_title
+        // Reverse requires all results before we can reverse+limit correctly.
+        && !reverse;
 
     // When sorting by a frontmatter property or title, or when --broken-links
     // is active, force the relevant fields on even if not requested via --fields.
@@ -175,7 +184,8 @@ pub fn find(
                 || fields.links
                 || fields.title
                 || sort_needs_links
-                || has_section_filter)
+                || has_section_filter
+                || has_title_filter)
         {
             Some(SectionScanner::new())
         } else {
@@ -240,6 +250,14 @@ pub fn find(
         // Must happen before scope building and before build_file_object.
         let outline_sections: Option<Vec<OutlineSection>> =
             section_scanner.map(SectionScanner::into_sections);
+
+        // --- Apply title filter ---
+        if let Some(title_pat) = title_filter {
+            let title_val = extract_title(&props, outline_sections.as_deref());
+            if !matches_title(&title_val, title_pat) {
+                continue;
+            }
+        }
 
         // --- Build section scope ranges (if section filter is active) ---
         let scope_ranges: Vec<SectionRange> = if has_section_filter {
@@ -366,6 +384,11 @@ pub fn find(
     // Note: no strip needed for BacklinksCount — build_file_object only populates
     // obj.backlinks when fields.backlinks is true. The sort closure queries
     // link_graph directly when obj.backlinks is None.
+
+    // --- Reverse ---
+    if reverse {
+        results.reverse();
+    }
 
     // --- Limit ---
     if let Some(n) = limit {
@@ -534,8 +557,10 @@ pub fn find_from_index(
     globs: &[String],
     fields: &Fields,
     sort: Option<&SortField>,
+    reverse: bool,
     limit: Option<usize>,
     broken_links: bool,
+    title_filter: Option<&str>,
     format: Format,
 ) -> Result<CommandOutcome> {
     if pattern.is_some_and(|p| p.trim().is_empty()) {
@@ -592,7 +617,9 @@ pub fn find_from_index(
         && !sort_needs_backlinks
         && !sort_needs_links
         && !sort_needs_properties
-        && !sort_needs_title;
+        && !sort_needs_title
+        // Reverse requires all results before we can reverse+limit correctly.
+        && !reverse;
 
     // When sorting by a frontmatter property or title, or when --broken-links
     // is active, force the relevant fields on even if not requested via --fields.
@@ -624,6 +651,14 @@ pub fn find_from_index(
             tag_filters,
         ) {
             continue;
+        }
+
+        // --- Apply title filter (index path: sections are pre-indexed, no I/O needed) ---
+        if let Some(title_pat) = title_filter {
+            let title_val = extract_title(&entry.properties, Some(&entry.sections));
+            if !matches_title(&title_val, title_pat) {
+                continue;
+            }
         }
 
         // --- Build section scopes from pre-indexed sections ---
@@ -865,6 +900,11 @@ pub fn find_from_index(
         }
     }
 
+    // --- Reverse ---
+    if reverse {
+        results.reverse();
+    }
+
     // --- Limit ---
     if let Some(n) = limit {
         results.truncate(n);
@@ -933,6 +973,26 @@ fn extract_title(
         }
     }
     serde_json::Value::Null
+}
+
+/// Check if a title value matches the given pattern.
+///
+/// - `~=REGEX` prefix: case-insensitive regex match
+/// - Otherwise: case-insensitive substring match
+/// - `Null` titles never match any pattern
+fn matches_title(title: &serde_json::Value, pattern: &str) -> bool {
+    let title_str = match title {
+        serde_json::Value::String(s) => s.as_str(),
+        _ => return false,
+    };
+    if let Some(regex_pat) = pattern.strip_prefix("~=") {
+        let effective = format!("(?i){regex_pat}");
+        regex::Regex::new(&effective)
+            .map(|re| re.is_match(title_str))
+            .unwrap_or(false)
+    } else {
+        title_str.to_lowercase().contains(&pattern.to_lowercase())
+    }
 }
 
 /// Return true if `tasks` satisfy `filter`.
@@ -1264,8 +1324,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1293,8 +1355,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1325,8 +1389,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1363,8 +1429,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1394,8 +1462,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1426,8 +1496,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1456,8 +1528,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1487,8 +1561,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1517,8 +1593,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1550,8 +1628,10 @@ Just some text here.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1612,8 +1692,10 @@ title: Empty Body
             &[],
             &fields,
             None,
+            false,
             None,
             false,
+            None,
             Format::Json,
         )
         .unwrap();
@@ -1648,8 +1730,10 @@ title: Empty Body
             &[],
             &fields,
             None,
+            false,
             None,
             false,
+            None,
             Format::Json,
         )
         .unwrap();
@@ -1685,8 +1769,10 @@ title: Empty Body
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1716,8 +1802,10 @@ title: Empty Body
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1748,8 +1836,10 @@ title: Empty Body
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1783,8 +1873,10 @@ title: Empty Body
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1822,8 +1914,10 @@ title: Empty Body
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1858,8 +1952,10 @@ title: Empty Body
                 &[],
                 &fields,
                 None,
+                false,
                 Some(1),
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1889,8 +1985,10 @@ title: Empty Body
                 &[],
                 &fields,
                 Some(&SortField::Modified),
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1927,8 +2025,10 @@ title: Empty Body
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -1956,8 +2056,10 @@ title: Empty Body
             &[],
             &fields,
             None,
+            false,
             None,
             false,
+            None,
             Format::Json,
         )
         .unwrap();
@@ -2124,8 +2226,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2157,8 +2261,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2192,8 +2298,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2226,8 +2334,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2266,8 +2376,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2320,8 +2432,10 @@ Just intro, no tasks section.
             &[],
             &fields,
             None,
+            false,
             None,
             false,
+            None,
             Format::Json,
         )
         .unwrap();
@@ -2356,8 +2470,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2415,8 +2531,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2454,8 +2572,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2494,8 +2614,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2527,8 +2649,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),
@@ -2562,8 +2686,10 @@ Just intro, no tasks section.
                 &[],
                 &fields,
                 None,
+                false,
                 None,
                 false,
+                None,
                 Format::Json,
             )
             .unwrap(),

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -16,6 +16,7 @@ use hyalo_core::link_fix::{LinkMatcher, apply_fixes, detect_broken_links_from_in
 ///
 /// `dry_run = true`  → preview only (default)
 /// `dry_run = false` → write fixes to disk (`--apply`)
+#[allow(clippy::too_many_arguments)]
 pub fn links_fix_from_index(
     index: &dyn VaultIndex,
     dir: &Path,
@@ -23,6 +24,7 @@ pub fn links_fix_from_index(
     globs: &[String],
     dry_run: bool,
     threshold: f64,
+    ignore_target: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     let report = detect_broken_links_from_index(dir, index, site_prefix);
@@ -46,6 +48,23 @@ pub fn links_fix_from_index(
             .collect()
     };
 
+    // Filter out ignored targets (--ignore-target substrings).
+    let (broken, ignored_count) = if ignore_target.is_empty() {
+        (broken, 0usize)
+    } else {
+        let before = broken.len();
+        let filtered: Vec<_> = broken
+            .into_iter()
+            .filter(|b| {
+                !ignore_target
+                    .iter()
+                    .any(|pat| b.target.contains(pat.as_str()))
+            })
+            .collect();
+        let ignored = before - filtered.len();
+        (filtered, ignored)
+    };
+
     let matcher = LinkMatcher::from_index(index, threshold);
     let fix_report = plan_fixes(&broken, &matcher);
 
@@ -57,6 +76,7 @@ pub fn links_fix_from_index(
         "broken": broken.len(),
         "fixable": fix_report.fixes.len(),
         "unfixable": fix_report.unfixable.len(),
+        "ignored": ignored_count,
         "fixes": fix_report.fixes,
         "unfixable_links": fix_report.unfixable,
         "applied": !dry_run,
@@ -80,6 +100,7 @@ pub fn links_fix(
     globs: &[String],
     dry_run: bool,
     threshold: f64,
+    ignore_target: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     let files = discovery::discover_files(dir)?;
@@ -101,6 +122,7 @@ pub fn links_fix(
         globs,
         dry_run,
         threshold,
+        ignore_target,
         format,
     )
 }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -536,12 +536,19 @@ enum Commands {
         /// Sort order: 'file' (default), 'modified', 'backlinks_count', 'links_count', 'title', 'date', or 'property:<KEY>' for any frontmatter property
         #[arg(long)]
         sort: Option<String>,
+        /// Reverse the sort order (ascending becomes descending and vice versa)
+        #[arg(long)]
+        reverse: bool,
         /// Maximum number of results to return (must be at least 1)
         #[arg(short = 'n', long, value_parser = parse_limit)]
         limit: Option<usize>,
         /// Only return files with at least one unresolved link (auto-includes links field)
         #[arg(long)]
         broken_links: bool,
+        /// Filter by title: case-insensitive substring match against the displayed title
+        /// (frontmatter 'title' property or first H1 heading). Prefix with '~=' for regex
+        #[arg(long)]
+        title: Option<String>,
     },
     /// Read file body content, optionally filtered by section or line range (read-only)
     #[command(long_about = "Read the body content of a markdown file.\n\n\
@@ -855,7 +862,9 @@ Repeatable (AND).\n\
             OUTPUT: JSON object with broken/fixable/unfixable counts, per-fix details \
             (source, line, old_target, new_target, strategy, confidence), and \
             the list of links that could not be matched.\n\
-            SIDE EFFECTS: None unless --apply is passed."
+            SIDE EFFECTS: None unless --apply is passed.\n\n\
+            TIP: For read-only auditing, use 'hyalo summary' (link health overview)\n\
+            or 'hyalo find --broken-links' (list files with unresolved links)."
     )]
     Links {
         #[command(subcommand)]
@@ -886,6 +895,10 @@ enum LinksAction {
         /// Glob pattern(s) to filter which files to check (repeatable); prefix '!' to negate
         #[arg(short, long)]
         glob: Vec<String>,
+        /// Ignore broken links whose target contains any of these substrings (repeatable).
+        /// Useful for skipping Hugo template links, external paths, etc.
+        #[arg(long)]
+        ignore_target: Vec<String>,
     },
 }
 
@@ -1406,8 +1419,10 @@ fn main() {
             ref glob,
             ref fields,
             ref sort,
+            reverse,
             limit,
             broken_links,
+            ref title,
         } => {
             // Parse property filters
             let prop_filters: Vec<filter::PropertyFilter> = match properties
@@ -1482,8 +1497,10 @@ fn main() {
                     glob,
                     &parsed_fields,
                     sort_field.as_ref(),
+                    reverse,
                     limit,
                     broken_links,
+                    title.as_deref(),
                     effective_format,
                 )
             } else {
@@ -1500,8 +1517,10 @@ fn main() {
                     glob,
                     &parsed_fields,
                     sort_field.as_ref(),
+                    reverse,
                     limit,
                     broken_links,
+                    title.as_deref(),
                     effective_format,
                 )
             }
@@ -1773,6 +1792,7 @@ fn main() {
                 apply,
                 threshold,
                 ref glob,
+                ref ignore_target,
             } => {
                 if let Some(ref idx) = snapshot_index {
                     links_commands::links_fix_from_index(
@@ -1782,6 +1802,7 @@ fn main() {
                         glob,
                         !apply,
                         threshold,
+                        ignore_target,
                         effective_format,
                     )
                 } else {
@@ -1791,6 +1812,7 @@ fn main() {
                         glob,
                         !apply,
                         threshold,
+                        ignore_target,
                         effective_format,
                     )
                 }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -546,7 +546,7 @@ enum Commands {
         #[arg(long)]
         broken_links: bool,
         /// Filter by title: case-insensitive substring match against the displayed title
-        /// (frontmatter 'title' property or first H1 heading). Prefix with '~=' for regex
+        /// (frontmatter 'title' property or first H1 heading). Prefix with '~=' for regex.
         #[arg(long)]
         title: Option<String>,
     },

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -2952,8 +2952,13 @@ fn find_sort_title_reverse() {
         .arg(tmp.path())
         .output()
         .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
-    // Titles should be in reverse alphabetical order (null titles last when reversed)
+    // Titles should be in reverse alphabetical order
     let titles: Vec<&str> = json.iter().filter_map(|v| v["title"].as_str()).collect();
     let mut sorted = titles.clone();
     sorted.sort();
@@ -3115,5 +3120,25 @@ fn find_title_frontmatter_match() {
     assert!(
         json.iter().any(|v| v["file"] == "alpha.md"),
         "should match frontmatter title 'Alpha' for pattern 'alph': {json:?}"
+    );
+}
+
+#[test]
+fn find_title_invalid_regex_returns_error() {
+    let tmp = setup_vault();
+    let out = hyalo()
+        .args(["find", "--title", "~=[unclosed", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "invalid regex should exit with error"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("invalid --title regex"),
+        "stderr should mention invalid regex: {stderr}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -2929,3 +2929,191 @@ title: A
         "expected 'limit must be at least 1' in stderr; got: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// UX-2: --reverse flag for sort
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_sort_title_reverse() {
+    let tmp = setup_vault();
+    let out = hyalo()
+        .args([
+            "find",
+            "--sort",
+            "title",
+            "--reverse",
+            "--fields",
+            "title",
+            "--format",
+            "json",
+        ])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    // Titles should be in reverse alphabetical order (null titles last when reversed)
+    let titles: Vec<&str> = json.iter().filter_map(|v| v["title"].as_str()).collect();
+    let mut sorted = titles.clone();
+    sorted.sort();
+    sorted.reverse();
+    assert_eq!(
+        titles, sorted,
+        "titles should be reverse-sorted: {titles:?}"
+    );
+}
+
+#[test]
+fn find_reverse_with_limit() {
+    let tmp = setup_vault();
+    let out = hyalo()
+        .args([
+            "find",
+            "--sort",
+            "file",
+            "--reverse",
+            "--limit",
+            "2",
+            "--format",
+            "json",
+        ])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json.len(), 2, "expected exactly 2 results");
+    // Should be last 2 files alphabetically (reversed then limited)
+    let files: Vec<&str> = json.iter().filter_map(|v| v["file"].as_str()).collect();
+    assert!(
+        files[0] > files[1],
+        "files should be in reverse order: {files:?}"
+    );
+}
+
+#[test]
+fn find_reverse_alone() {
+    let tmp = setup_vault();
+    // --reverse without --sort should reverse the default file-path sort
+    let out = hyalo()
+        .args(["find", "--reverse", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    let files: Vec<&str> = json.iter().filter_map(|v| v["file"].as_str()).collect();
+    let mut expected = files.clone();
+    expected.sort();
+    expected.reverse();
+    assert_eq!(
+        files, expected,
+        "files should be in reverse alphabetical order"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// UX-1: --title filter flag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_title_h1_match() {
+    let tmp = setup_vault();
+    // gamma.md has no frontmatter title but has H1 "# Gamma"
+    let out = hyalo()
+        .args(["find", "--title", "gamma", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        json.len(),
+        1,
+        "expected exactly 1 match for 'gamma': {json:?}"
+    );
+    assert_eq!(json[0]["file"], "gamma.md");
+}
+
+#[test]
+fn find_title_case_insensitive() {
+    let tmp = setup_vault();
+    let out = hyalo()
+        .args(["find", "--title", "ALPHA", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        json.len(),
+        1,
+        "expected exactly 1 match for 'ALPHA': {json:?}"
+    );
+    assert_eq!(json[0]["file"], "alpha.md");
+}
+
+#[test]
+fn find_title_regex_mode() {
+    let tmp = setup_vault();
+    let out = hyalo()
+        .args(["find", "--title", "~=^(Alpha|Beta)$", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        json.len(),
+        2,
+        "expected exactly 2 matches for regex: {json:?}"
+    );
+}
+
+#[test]
+fn find_title_frontmatter_match() {
+    let tmp = setup_vault();
+    // alpha.md has frontmatter title "Alpha"
+    let out = hyalo()
+        .args(["find", "--title", "alph", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(
+        json.iter().any(|v| v["file"] == "alpha.md"),
+        "should match frontmatter title 'Alpha' for pattern 'alph': {json:?}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_links.rs
+++ b/crates/hyalo-cli/tests/e2e_links.rs
@@ -843,8 +843,18 @@ See [[missing]] and [hugo]({{ .RelPermalink }}) and [hugo2]({{ .Site.BaseURL }})
 "),
     );
 
+    // Two distinct --ignore-target patterns: one matches RelPermalink, the other BaseURL
     let out = common::hyalo()
-        .args(["links", "fix", "--ignore-target", "{{", "--format", "json"])
+        .args([
+            "links",
+            "fix",
+            "--ignore-target",
+            "RelPermalink",
+            "--ignore-target",
+            "BaseURL",
+            "--format",
+            "json",
+        ])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -855,9 +865,10 @@ See [[missing]] and [hugo]({{ .RelPermalink }}) and [hugo2]({{ .Site.BaseURL }})
         String::from_utf8_lossy(&out.stderr)
     );
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
-    assert!(
-        json["ignored"].as_u64().unwrap_or(0) >= 1,
-        "expected at least 1 ignored link: {json}"
+    assert_eq!(
+        json["ignored"].as_u64().unwrap_or(0),
+        2,
+        "expected 2 ignored links (one per pattern): {json}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_links.rs
+++ b/crates/hyalo-cli/tests/e2e_links.rs
@@ -771,3 +771,124 @@ See [[sort-reverse]] for reverse sorting.
         "broken self-link should be counted as unfixable"
     );
 }
+
+// ---------------------------------------------------------------------------
+// UX-3: --ignore-target
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_ignore_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    // page.md has two broken links: one normal missing link, one Hugo template target
+    write_md(
+        tmp.path(),
+        "page.md",
+        md!(r"
+---
+title: Page
+---
+# Page
+
+See [[missing-note]] and [template]({{ .RelPermalink }}).
+"),
+    );
+    write_md(
+        tmp.path(),
+        "other.md",
+        md!(r"
+---
+title: Other
+---
+# Other
+
+Some text.
+"),
+    );
+
+    let out = common::hyalo()
+        .args(["links", "fix", "--ignore-target", "{{", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    // The Hugo template link should be ignored
+    assert_eq!(
+        json["ignored"]
+            .as_u64()
+            .expect("'ignored' should be a number"),
+        1,
+        "expected 1 ignored link: {json}"
+    );
+}
+
+#[test]
+fn links_fix_ignore_target_multiple() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "page.md",
+        md!(r"
+---
+title: Page
+---
+# Page
+
+See [[missing]] and [hugo]({{ .RelPermalink }}) and [hugo2]({{ .Site.BaseURL }}).
+"),
+    );
+
+    let out = common::hyalo()
+        .args(["links", "fix", "--ignore-target", "{{", "--format", "json"])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(
+        json["ignored"].as_u64().unwrap_or(0) >= 1,
+        "expected at least 1 ignored link: {json}"
+    );
+}
+
+#[test]
+fn links_fix_ignore_target_absent() {
+    // With no matching ignore_target, count should be 0
+    let tmp = setup_vault();
+    let out = common::hyalo()
+        .args([
+            "links",
+            "fix",
+            "--ignore-target",
+            "this-will-not-match-anything",
+            "--format",
+            "json",
+        ])
+        .arg("--dir")
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        json["ignored"]
+            .as_u64()
+            .expect("'ignored' should be a number"),
+        0,
+        "expected 0 ignored links when pattern doesn't match: {json}"
+    );
+}


### PR DESCRIPTION
## Summary
- **UX-4**: Add tip to `links` help text pointing to `summary` and `find --broken-links` for read-only auditing
- **UX-2**: Add `--reverse` flag to `find` to reverse sort order (disables short-circuit optimization when active)
- **UX-1**: Add `--title` filter flag for case-insensitive substring matching against display title (frontmatter or H1 fallback); supports `~=REGEX` prefix for regex mode. Perf-safe: uses same single-pass scan, no extra I/O
- **UX-3**: Add `--ignore-target` flag to `links fix` to skip broken links whose target contains given substrings (useful for Hugo templates, external paths)

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test --workspace` — 497 tests pass
- [x] E2E: `--reverse` with `--sort title`, `--limit`, and standalone (3 tests)
- [x] E2E: `--title` with H1 match, case-insensitive, regex mode, frontmatter match (4 tests)
- [x] E2E: `--ignore-target` single and multiple patterns (2 tests)
- [x] Help text verified for all new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)