### PR TITLE
Add dead-end detection, find results envelope, --limit total count

### DIFF
--- a/.claude/skills/hyalo-tidy/SKILL.md
+++ b/.claude/skills/hyalo-tidy/SKILL.md
@@ -71,7 +71,7 @@ git log --oneline --since="4 weeks ago" -- "*.rs" | head -30
 
 Extract non-completed iterations and their branches from the index:
 ```bash
-hyalo find --property type=iteration --index .hyalo-index --jq 'map(select(.properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})'
+hyalo find --property type=iteration --index .hyalo-index --jq '.results | map(select(.properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})'
 ```
 
 For each non-completed iteration that has a branch, check if that branch was merged:
@@ -113,7 +113,7 @@ All queries below use `--index .hyalo-index` — no additional disk scans needed
 
 ### Broken links
 ```bash
-hyalo find --fields links --index .hyalo-index --jq '[.[] | {file: .file, broken: [.links[] | select(.path == null)] | map(.target)} | select(.broken | length > 0)]'
+hyalo find --fields links --index .hyalo-index --jq '[.results[] | {file: .file, broken: [.links[] | select(.path == null)] | map(.target)} | select(.broken | length > 0)]'
 ```
 For each broken link, try to find the intended target:
 - Search for the filename in `done/` subdirectories (common after archiving)
@@ -125,7 +125,7 @@ exist at all).
 
 ### Orphan files
 ```bash
-hyalo find --fields backlinks --index .hyalo-index --jq 'map(select(.backlinks | length == 0)) | map(.file)'
+hyalo find --fields backlinks --index .hyalo-index --jq '.results | map(select(.backlinks | length == 0)) | map(.file)'
 ```
 Not all orphans are problems. Expect these to be legitimately orphaned:
 - Top-level files (SEED.md, project-pitch.md, decision-log.md)
@@ -137,19 +137,19 @@ Focus on **actionable orphans**: active/planned items that should be cross-refer
 ### Stale statuses
 ```bash
 # In-progress items — should any be completed?
-hyalo find --property status=in-progress --index .hyalo-index --jq 'map({file, date: .properties.date, branch: .properties.branch})'
+hyalo find --property status=in-progress --index .hyalo-index --jq '.results | map({file, date: .properties.date, branch: .properties.branch})'
 
 # Planned items where all tasks are done
-hyalo find --property status=planned --index .hyalo-index --jq 'map(select((.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)'
+hyalo find --property status=planned --index .hyalo-index --jq '.results | map(select((.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)'
 
 # In-progress items sorted by date (oldest first — possibly stale)
-hyalo find --property status=in-progress --index .hyalo-index --jq 'map(select(.properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})'
+hyalo find --property status=in-progress --index .hyalo-index --jq '.results | map(select(.properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})'
 ```
 Cross-reference with git merges from Phase 2. If the branch was merged, update status.
 
 ### Stale backlog items
 ```bash
-hyalo find --property status=planned --property type=backlog --index .hyalo-index --jq 'map({file, title: .properties.title})'
+hyalo find --property status=planned --property type=backlog --index .hyalo-index --jq '.results | map({file, title: .properties.title})'
 ```
 Compare each planned backlog item against merged iterations and recent git history.
 If the feature clearly shipped (in a different iteration or under a different name),

--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -54,7 +54,7 @@ scanning all files to build the link graph. Each backlink entry contains `source
 
 ```bash
 hyalo find --fields backlinks --file my-note.md       # see who links to this note
-hyalo find --fields backlinks --jq 'map(select(.backlinks | length == 0))' # find orphan notes
+hyalo find --fields backlinks --jq '.results | map(select(.backlinks | length == 0))' # find orphan notes
 hyalo find --fields properties,backlinks              # combine with other fields
 ```
 
@@ -63,7 +63,7 @@ Pipe through `--jq` to reshape output into anything — dashboards, burndowns, r
 
 ```bash
 hyalo find --property status=in-progress --fields tasks \
-  --jq 'map({file, done: ([.tasks[] | select(.status == "x")] | length), total: (.tasks | length)})'
+  --jq '.results | map({file, done: ([.tasks[] | select(.status == "x")] | length), total: (.tasks | length)})'
 ```
 
 **Run `hyalo --help` and `hyalo <command> --help` to learn the full API.**

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -382,8 +382,8 @@ pub fn find(
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
         .into_iter()
-        .map(|obj| serde_json::to_value(obj).expect("derived Serialize impl should not fail"))
-        .collect();
+        .map(|obj| serde_json::to_value(obj).context("failed to serialize find result"))
+        .collect::<Result<_>>()?;
 
     // In text mode, an empty result set produces no stdout output, which an
     // LLM (or script) cannot distinguish from a silent failure.  Emit an

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -143,12 +143,6 @@ pub fn find(
         None
     };
 
-    // Short-circuit is disabled: when --limit is active we need to count all
-    // matching results to report the accurate total in the output envelope.
-    // Previously this optimisation stopped scanning after N matches, which
-    // made it impossible to know the true total without a second full pass.
-    let can_short_circuit = false;
-
     // When sorting by a frontmatter property or title, or when --broken-links
     // is active, force the relevant fields on even if not requested via --fields.
     let original_fields = fields;
@@ -334,11 +328,6 @@ pub fn find(
         }
 
         results.push(obj);
-
-        // Early exit when we have enough results and a full scan is not needed.
-        if can_short_circuit && results.len() >= limit.unwrap() {
-            break;
-        }
     }
 
     // --- Sort ---
@@ -624,10 +613,6 @@ pub fn find_from_index(
         None
     };
 
-    // Short-circuit is disabled: when --limit is active we need to count all
-    // matching results to report the accurate total in the output envelope.
-    let can_short_circuit = false;
-
     // When sorting by a frontmatter property or title, or when --broken-links
     // is active, force the relevant fields on even if not requested via --fields.
     let original_fields = fields;
@@ -867,10 +852,6 @@ pub fn find_from_index(
         }
 
         results.push(obj);
-
-        if can_short_circuit && results.len() >= limit.unwrap() {
-            break;
-        }
     }
 
     // --- Sort ---

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -162,7 +162,18 @@ pub fn find(
         fields
     };
 
+    // Pre-sort the file list when we can determine the final order upfront.
+    // Currently only --sort file (explicit) qualifies for the scan path,
+    // since other sort keys require scanning the file first.
+    let presorted = matches!(sort, Some(SortField::File)) && !reverse && !fields.backlinks;
+
+    let mut files = files;
+    if presorted {
+        files.sort_by(|a, b| a.1.cmp(&b.1));
+    }
+
     let mut results: Vec<FileObject> = Vec::new();
+    let mut total_matching: usize = 0;
 
     for (full_path, rel_path) in &files {
         // --- Single-pass scan ---
@@ -294,6 +305,13 @@ pub fn find(
             continue;
         }
 
+        // When pre-sorted with a limit, skip expensive construction once full.
+        // (broken_links needs the built object, so it must fall through.)
+        if presorted && limit.is_some_and(|n| results.len() >= n) && !broken_links {
+            total_matching += 1;
+            continue;
+        }
+
         // --- Get modified time ---
         let modified = format_modified(full_path)?;
 
@@ -327,11 +345,20 @@ pub fn find(
             }
         }
 
-        results.push(obj);
+        if presorted {
+            total_matching += 1;
+        }
+        if !presorted || limit.is_none_or(|n| results.len() < n) {
+            results.push(obj);
+        }
     }
 
     // --- Sort ---
-    apply_sort(&mut results, sort, link_graph.as_ref());
+    // When presorted, files were pre-sorted and results already collected in
+    // order — skip the redundant sort.
+    if !presorted {
+        apply_sort(&mut results, sort, link_graph.as_ref());
+    }
 
     if let Some(SortField::Property(key)) = sort
         && !results.is_empty()
@@ -374,10 +401,17 @@ pub fn find(
     }
 
     // --- Limit ---
-    let total = results.len();
-    if let Some(n) = limit {
-        results.truncate(n);
-    }
+    // When presorted, total_matching already holds the accurate count and
+    // results are already capped — skip truncation.
+    let total = if presorted {
+        total_matching
+    } else {
+        let t = results.len();
+        if let Some(n) = limit {
+            results.truncate(n);
+        }
+        t
+    };
 
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
@@ -623,7 +657,19 @@ pub fn find_from_index(
         fields
     };
 
+    // The index has all metadata, so we can pre-sort by any sort key
+    // except BacklinksCount (which needs the link graph per result).
+    // presorted=true even without --limit — pre-sorting is no more expensive
+    // than post-sorting, and it simplifies the limit/total logic below.
+    let presorted = !reverse && !matches!(sort, Some(SortField::BacklinksCount));
+
+    let mut scoped_entries = scoped_entries;
+    if presorted {
+        presort_index_entries(&mut scoped_entries, sort, index.link_graph());
+    }
+
     let mut results: Vec<FileObject> = Vec::new();
+    let mut total_matching: usize = 0;
 
     for entry in &scoped_entries {
         // --- Metadata filters using pre-indexed data ---
@@ -710,6 +756,13 @@ pub fn find_from_index(
 
         // Filter: content search must have at least one match
         if has_content_search && content_matches.as_ref().is_some_and(|m| m.is_empty()) {
+            continue;
+        }
+
+        // When pre-sorted with a limit, skip expensive construction once full.
+        // (broken_links needs the resolved links, so fall through.)
+        if presorted && limit.is_some_and(|n| results.len() >= n) && !broken_links {
+            total_matching += 1;
             continue;
         }
 
@@ -842,11 +895,18 @@ pub fn find_from_index(
             }
         }
 
-        results.push(obj);
+        if presorted {
+            total_matching += 1;
+        }
+        if !presorted || limit.is_none_or(|n| results.len() < n) {
+            results.push(obj);
+        }
     }
 
     // --- Sort ---
-    apply_sort(&mut results, sort, link_graph_ref);
+    if !presorted {
+        apply_sort(&mut results, sort, link_graph_ref);
+    }
 
     if let Some(SortField::Property(key)) = sort
         && !results.is_empty()
@@ -885,10 +945,17 @@ pub fn find_from_index(
     }
 
     // --- Limit ---
-    let total = results.len();
-    if let Some(n) = limit {
-        results.truncate(n);
-    }
+    // When presorted, total_matching already holds the accurate count and
+    // results are already capped — skip truncation.
+    let total = if presorted {
+        total_matching
+    } else {
+        let t = results.len();
+        if let Some(n) = limit {
+            results.truncate(n);
+        }
+        t
+    };
 
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
@@ -1066,6 +1133,53 @@ fn apply_sort(
                 let a_val = a.properties.as_ref().and_then(|p| p.get(key));
                 let b_val = b.properties.as_ref().and_then(|p| p.get(key));
                 filter::compare_property_values(a_val, b_val).then_with(|| a.file.cmp(&b.file))
+            });
+        }
+    }
+}
+
+/// Pre-sort index entries by the requested sort key so that the early-exit
+/// optimisation can collect the first N matches in final order.
+///
+/// This mirrors `apply_sort` but operates on `&IndexEntry` references
+/// instead of `FileObject` values, avoiding construction of the full object.
+fn presort_index_entries(
+    entries: &mut [&IndexEntry],
+    sort: Option<&SortField>,
+    link_graph: &LinkGraph,
+) {
+    match sort.unwrap_or(&SortField::File) {
+        SortField::File => entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path)),
+        SortField::Modified => entries.sort_by(|a, b| a.modified.cmp(&b.modified)),
+        SortField::BacklinksCount => {
+            // Descending by backlink count — matches apply_sort.
+            entries.sort_by(|a, b| {
+                let a_count = link_graph.backlinks(&a.rel_path).len();
+                let b_count = link_graph.backlinks(&b.rel_path).len();
+                b_count.cmp(&a_count)
+            });
+        }
+        SortField::LinksCount => {
+            entries.sort_by(|a, b| {
+                let a_count = a.links.len();
+                let b_count = b.links.len();
+                b_count.cmp(&a_count)
+            });
+        }
+        SortField::Title => {
+            entries.sort_by(|a, b| {
+                let a_val = extract_title(&a.properties, Some(&a.sections));
+                let b_val = extract_title(&b.properties, Some(&b.sections));
+                filter::compare_property_values(Some(&a_val), Some(&b_val))
+                    .then_with(|| a.rel_path.cmp(&b.rel_path))
+            });
+        }
+        SortField::Property(key) => {
+            entries.sort_by(|a, b| {
+                let a_val = a.properties.get(key.as_str());
+                let b_val = b.properties.get(key.as_str());
+                filter::compare_property_values(a_val, b_val)
+                    .then_with(|| a.rel_path.cmp(&b.rel_path))
             });
         }
     }

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -143,24 +143,11 @@ pub fn find(
         None
     };
 
-    // Short-circuit: when sort order is by file path (the same order
-    // `discover_files` already returns) and backlinks are not requested
-    // (which would need a full-vault scan regardless), we can stop as soon
-    // as we have accumulated `limit` matching results instead of scanning
-    // every file and truncating afterwards.
-    //
-    // Disabled when `--file` args are given: explicit file lists preserve CLI
-    // order (not alphabetical), so stopping early could return the wrong N files.
-    let can_short_circuit = limit.is_some()
-        && files_arg.is_empty()
-        && matches!(sort.unwrap_or(&SortField::File), SortField::File)
-        && !fields.backlinks
-        && !sort_needs_backlinks
-        && !sort_needs_links
-        && !sort_needs_properties
-        && !sort_needs_title
-        // Reverse requires all results before we can reverse+limit correctly.
-        && !reverse;
+    // Short-circuit is disabled: when --limit is active we need to count all
+    // matching results to report the accurate total in the output envelope.
+    // Previously this optimisation stopped scanning after N matches, which
+    // made it impossible to know the true total without a second full pass.
+    let can_short_circuit = false;
 
     // When sorting by a frontmatter property or title, or when --broken-links
     // is active, force the relevant fields on even if not requested via --fields.
@@ -398,9 +385,14 @@ pub fn find(
     }
 
     // --- Limit ---
-    if let Some(n) = limit {
+    let total_before_limit = results.len();
+    let was_truncated = if let Some(n) = limit {
+        let truncated = total_before_limit > n;
         results.truncate(n);
-    }
+        truncated
+    } else {
+        false
+    };
 
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
@@ -416,7 +408,15 @@ pub fn find(
         crate::warn::warn("No files matched.");
     }
 
-    let json_output = serde_json::Value::Array(json_array);
+    let json_output = if was_truncated {
+        // Wrap in an envelope so callers can see "showing N of M".
+        serde_json::json!({
+            "total": total_before_limit,
+            "results": json_array,
+        })
+    } else {
+        serde_json::Value::Array(json_array)
+    };
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
@@ -624,16 +624,9 @@ pub fn find_from_index(
         None
     };
 
-    let can_short_circuit = limit.is_some()
-        && files_arg.is_empty()
-        && matches!(sort.unwrap_or(&SortField::File), SortField::File)
-        && !fields.backlinks
-        && !sort_needs_backlinks
-        && !sort_needs_links
-        && !sort_needs_properties
-        && !sort_needs_title
-        // Reverse requires all results before we can reverse+limit correctly.
-        && !reverse;
+    // Short-circuit is disabled: when --limit is active we need to count all
+    // matching results to report the accurate total in the output envelope.
+    let can_short_circuit = false;
 
     // When sorting by a frontmatter property or title, or when --broken-links
     // is active, force the relevant fields on even if not requested via --fields.
@@ -920,9 +913,14 @@ pub fn find_from_index(
     }
 
     // --- Limit ---
-    if let Some(n) = limit {
+    let total_before_limit = results.len();
+    let was_truncated = if let Some(n) = limit {
+        let truncated = total_before_limit > n;
         results.truncate(n);
-    }
+        truncated
+    } else {
+        false
+    };
 
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
@@ -934,7 +932,15 @@ pub fn find_from_index(
         crate::warn::warn("No files matched.");
     }
 
-    let json_output = serde_json::Value::Array(json_array);
+    let json_output = if was_truncated {
+        // Wrap in an envelope so callers can see "showing N of M".
+        serde_json::json!({
+            "total": total_before_limit,
+            "results": json_array,
+        })
+    } else {
+        serde_json::Value::Array(json_array)
+    };
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
@@ -1998,8 +2004,15 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
-        assert_eq!(arr.len(), 1);
+        // When limit truncates results, output is an envelope {total, results}.
+        assert!(parsed.is_object(), "expected envelope, got: {parsed}");
+        let results = parsed["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        // total reflects the full vault size (3 files in unit test vault).
+        assert!(
+            parsed["total"].as_u64().unwrap() > 1,
+            "total should exceed the limit"
+        );
     }
 
     // --- find: sort ---

--- a/crates/hyalo-cli/src/commands/find.rs
+++ b/crates/hyalo-cli/src/commands/find.rs
@@ -374,14 +374,10 @@ pub fn find(
     }
 
     // --- Limit ---
-    let total_before_limit = results.len();
-    let was_truncated = if let Some(n) = limit {
-        let truncated = total_before_limit > n;
+    let total = results.len();
+    if let Some(n) = limit {
         results.truncate(n);
-        truncated
-    } else {
-        false
-    };
+    }
 
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
@@ -397,15 +393,10 @@ pub fn find(
         crate::warn::warn("No files matched.");
     }
 
-    let json_output = if was_truncated {
-        // Wrap in an envelope so callers can see "showing N of M".
-        serde_json::json!({
-            "total": total_before_limit,
-            "results": json_array,
-        })
-    } else {
-        serde_json::Value::Array(json_array)
-    };
+    let json_output = serde_json::json!({
+        "total": total,
+        "results": json_array,
+    });
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
@@ -894,14 +885,10 @@ pub fn find_from_index(
     }
 
     // --- Limit ---
-    let total_before_limit = results.len();
-    let was_truncated = if let Some(n) = limit {
-        let truncated = total_before_limit > n;
+    let total = results.len();
+    if let Some(n) = limit {
         results.truncate(n);
-        truncated
-    } else {
-        false
-    };
+    }
 
     // --- Serialize ---
     let json_array: Vec<serde_json::Value> = results
@@ -913,15 +900,10 @@ pub fn find_from_index(
         crate::warn::warn("No files matched.");
     }
 
-    let json_output = if was_truncated {
-        // Wrap in an envelope so callers can see "showing N of M".
-        serde_json::json!({
-            "total": total_before_limit,
-            "results": json_array,
-        })
-    } else {
-        serde_json::Value::Array(json_array)
-    };
+    let json_output = serde_json::json!({
+        "total": total,
+        "results": json_array,
+    });
 
     Ok(CommandOutcome::Success(crate::output::format_success(
         format,
@@ -1357,7 +1339,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert_eq!(arr.len(), 3);
     }
 
@@ -1388,7 +1370,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
         let mut sorted = files.clone();
         sorted.sort();
@@ -1422,7 +1404,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         for entry in arr {
             assert!(entry["file"].as_str().is_some());
             let modified = entry["modified"].as_str().unwrap();
@@ -1462,7 +1444,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert!(arr[0]["file"].as_str().unwrap().contains("alpha"));
     }
@@ -1495,7 +1477,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         // alpha and beta have title; gamma does not
         assert_eq!(arr.len(), 2);
     }
@@ -1529,7 +1511,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert!(arr[0]["file"].as_str().unwrap().contains("alpha"));
     }
@@ -1561,7 +1543,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert!(arr.is_empty());
     }
 
@@ -1594,7 +1576,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert!(arr[0]["file"].as_str().unwrap().contains("beta"));
     }
@@ -1626,7 +1608,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         // beta has "Rust programming" in body; alpha has no Rust in body
         // (tags are in frontmatter which is not scanned for content)
         for entry in arr {
@@ -1661,7 +1643,7 @@ Just some text here.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         for entry in arr {
             assert!(entry["matches"].is_null(), "matches should be absent");
         }
@@ -1802,7 +1784,7 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         // only alpha.md has an open task
         assert_eq!(arr.len(), 1);
         assert!(arr[0]["file"].as_str().unwrap().contains("alpha"));
@@ -1835,7 +1817,7 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert!(arr[0]["file"].as_str().unwrap().contains("alpha"));
     }
@@ -1869,7 +1851,7 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         for entry in arr {
             assert!(entry["properties"].is_object());
             assert!(entry["tags"].is_null());
@@ -1906,7 +1888,7 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let alpha = arr
             .iter()
             .find(|e| e["file"].as_str().unwrap().contains("alpha"))
@@ -1947,7 +1929,7 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let alpha = &arr[0];
         let links = alpha["links"].as_array().unwrap();
         assert!(!links.is_empty());
@@ -2025,7 +2007,7 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let times: Vec<&str> = arr
             .iter()
             .map(|v| v["modified"].as_str().unwrap())
@@ -2065,7 +2047,7 @@ title: Empty Body
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert!(parsed.as_array().unwrap().is_empty());
+        assert!(parsed["results"].as_array().unwrap().is_empty());
     }
 
     // --- find: file not found ---
@@ -2266,7 +2248,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         let tasks = arr[0]["tasks"].as_array().unwrap();
         assert_eq!(tasks.len(), 2, "should have 2 tasks in Tasks section");
@@ -2301,7 +2283,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         // File has no matching section — it is excluded entirely
         assert!(
             arr.is_empty(),
@@ -2338,7 +2320,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         // "background" only appears in ## Background section, not in ## Tasks, so no match
         assert!(
             arr.is_empty(),
@@ -2374,7 +2356,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         let sections = arr[0]["sections"].as_array().unwrap();
         // Only the "Tasks" section (and its heading line) should be included
@@ -2416,7 +2398,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         // empty.md has no Tasks section — it is excluded entirely
         assert!(
             arr.is_empty(),
@@ -2472,7 +2454,7 @@ Just intro, no tasks section.
         .unwrap();
         let out = unwrap_success(result);
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         // Should return the 3 good files, skipping the broken one
         assert_eq!(arr.len(), 3);
         assert!(
@@ -2510,7 +2492,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let entry = &arr[0];
 
         // properties_typed must be an array of {name, type, value} objects
@@ -2571,7 +2553,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let entry = &arr[0];
 
         // Both fields present simultaneously
@@ -2612,7 +2594,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let typed = arr[0]["properties_typed"].as_array().unwrap();
 
         // alpha.md has status: planned (text) and title: Alpha Note (text)
@@ -2654,7 +2636,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let beta = &arr[0];
         let backlinks = beta["backlinks"].as_array().unwrap();
         assert_eq!(backlinks.len(), 1);
@@ -2689,7 +2671,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         for entry in arr {
             assert!(
                 !entry.as_object().unwrap().contains_key("backlinks"),
@@ -2726,7 +2708,7 @@ Just intro, no tasks section.
             .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let arr = parsed.as_array().unwrap();
+        let arr = parsed["results"].as_array().unwrap();
         let gamma = &arr[0];
         let backlinks = gamma["backlinks"].as_array().unwrap();
         assert!(backlinks.is_empty());

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -15,8 +15,9 @@ use hyalo_core::link_graph::{FileLinks, LinkGraph, LinkGraphVisitor};
 use hyalo_core::scanner::{FrontmatterCollector, scan_file_multi};
 use hyalo_core::tasks::TaskCounter;
 use hyalo_core::types::{
-    DirectoryCount, FileCounts, LinkHealthSummary, OrphanSummary, PropertySummaryEntry, RecentFile,
-    StatusGroup, TagSummary, TagSummaryEntry, TaskCount, VaultSummary,
+    DeadEndSummary, DirectoryCount, FileCounts, LinkHealthSummary, OrphanSummary,
+    PropertySummaryEntry, RecentFile, StatusGroup, TagSummary, TagSummaryEntry, TaskCount,
+    VaultSummary,
 };
 
 /// Show a high-level vault summary.
@@ -257,10 +258,10 @@ pub fn summary(
         }
     };
 
-    // Build orphan list: files with no inbound AND no outbound links (fully isolated).
+    // Build orphan and dead-end lists using the vault-wide link graph.
     // When no glob: use pre-collected link data (single pass, no re-read).
     // When glob: build vault-wide link graph so links from outside the glob count.
-    let orphans = {
+    let (orphans, dead_ends) = {
         let build = if collect_links {
             LinkGraph::from_file_links(collected_links, site_prefix)
         } else {
@@ -269,6 +270,8 @@ pub fn summary(
         };
         let targets = build.graph.all_targets();
         let sources = build.graph.all_sources();
+
+        // Orphans: no inbound AND no outbound (fully isolated)
         let mut orphan_files: Vec<String> = good_files
             .iter()
             .map(|(_, rel)| rel.to_string_lossy())
@@ -282,11 +285,32 @@ pub fn summary(
             .map(|rel| rel.into_owned())
             .collect();
         orphan_files.sort();
-        let total = orphan_files.len();
-        OrphanSummary {
-            total,
-            files: orphan_files,
-        }
+
+        // Dead-ends: has inbound links but no outbound links
+        let mut dead_end_files: Vec<String> = good_files
+            .iter()
+            .map(|(_, rel)| rel.to_string_lossy())
+            .filter(|rel| {
+                let rel_str: &str = rel.as_ref();
+                let without_md = rel_str.strip_suffix(".md").unwrap_or(rel_str);
+                let has_inbound = targets.contains(rel_str) || targets.contains(without_md);
+                let has_outbound = sources.contains(rel_str);
+                has_inbound && !has_outbound
+            })
+            .map(|rel| rel.into_owned())
+            .collect();
+        dead_end_files.sort();
+
+        (
+            OrphanSummary {
+                total: orphan_files.len(),
+                files: orphan_files,
+            },
+            DeadEndSummary {
+                total: dead_end_files.len(),
+                files: dead_end_files,
+            },
+        )
     };
 
     // Emit warnings for any property value that looks like a typo of a dominant value.
@@ -295,6 +319,7 @@ pub fn summary(
     let vault_summary = VaultSummary {
         files: file_counts,
         orphans,
+        dead_ends,
         links: link_health,
         properties,
         tags,
@@ -589,26 +614,51 @@ pub fn summary_from_index(
         .map(|(modified, path)| RecentFile { path, modified })
         .collect();
 
-    // Build orphan list using the pre-built link graph from the index.
+    // Build orphan and dead-end lists using the pre-built link graph from the index.
     // The link graph is vault-wide so links from outside the scoped set still count.
-    let graph = index.link_graph();
-    let targets = graph.all_targets();
-    let sources = graph.all_sources();
-    let mut orphan_files: Vec<String> = entries
-        .iter()
-        .filter(|entry| {
-            let rel_str: &str = &entry.rel_path;
-            let without_md = rel_str.strip_suffix(".md").unwrap_or(rel_str);
-            let has_inbound = targets.contains(rel_str) || targets.contains(without_md);
-            let has_outbound = sources.contains(rel_str);
-            !has_inbound && !has_outbound
-        })
-        .map(|entry| entry.rel_path.clone())
-        .collect();
-    orphan_files.sort();
-    let orphans = OrphanSummary {
-        total: orphan_files.len(),
-        files: orphan_files,
+    let (orphans, dead_ends) = {
+        let graph = index.link_graph();
+        let targets = graph.all_targets();
+        let sources = graph.all_sources();
+
+        // Orphans: no inbound AND no outbound (fully isolated)
+        let mut orphan_files: Vec<String> = entries
+            .iter()
+            .filter(|entry| {
+                let rel_str: &str = &entry.rel_path;
+                let without_md = rel_str.strip_suffix(".md").unwrap_or(rel_str);
+                let has_inbound = targets.contains(rel_str) || targets.contains(without_md);
+                let has_outbound = sources.contains(rel_str);
+                !has_inbound && !has_outbound
+            })
+            .map(|entry| entry.rel_path.clone())
+            .collect();
+        orphan_files.sort();
+
+        // Dead-ends: has inbound links but no outbound links
+        let mut dead_end_files: Vec<String> = entries
+            .iter()
+            .filter(|entry| {
+                let rel_str: &str = &entry.rel_path;
+                let without_md = rel_str.strip_suffix(".md").unwrap_or(rel_str);
+                let has_inbound = targets.contains(rel_str) || targets.contains(without_md);
+                let has_outbound = sources.contains(rel_str);
+                has_inbound && !has_outbound
+            })
+            .map(|entry| entry.rel_path.clone())
+            .collect();
+        dead_end_files.sort();
+
+        (
+            OrphanSummary {
+                total: orphan_files.len(),
+                files: orphan_files,
+            },
+            DeadEndSummary {
+                total: dead_end_files.len(),
+                files: dead_end_files,
+            },
+        )
     };
 
     // Emit warnings for any property value that looks like a typo of a dominant value.
@@ -630,6 +680,7 @@ pub fn summary_from_index(
     let vault_summary = VaultSummary {
         files: file_counts,
         orphans,
+        dead_ends,
         links: link_health,
         properties,
         tags,
@@ -1102,6 +1153,50 @@ No tasks here.
         );
         // orphan.md should be the only orphan
         assert_eq!(disk_orphans, vec!["orphan.md"]);
+    }
+
+    /// Dead-end detection:
+    /// - a.md links to b.md and c.md (has outbound, no inbound → not a dead-end, not an orphan)
+    /// - b.md links to c.md (has inbound from a, has outbound to c → not a dead-end)
+    /// - c.md has no links (has inbound from a and b, no outbound → dead-end)
+    /// - d.md has no links and nothing links to it → orphan
+    #[test]
+    fn summary_dead_end_detection() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("a.md"),
+            "---\ntitle: A\n---\n[[b]]\n[[c]]\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("b.md"), "---\ntitle: B\n---\n[[c]]\n").unwrap();
+        fs::write(tmp.path().join("c.md"), "---\ntitle: C\n---\nNo links.\n").unwrap();
+        fs::write(tmp.path().join("d.md"), "---\ntitle: D\n---\nNo links.\n").unwrap();
+
+        let val = unwrap_success(summary(tmp.path(), &[], 10, None, None, Format::Json).unwrap());
+
+        // c.md is the only dead-end
+        assert_eq!(val["dead_ends"]["total"], 1, "expected 1 dead-end");
+        let dead_end_files: Vec<&str> = val["dead_ends"]["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            dead_end_files,
+            vec!["c.md"],
+            "dead-ends: {dead_end_files:?}"
+        );
+
+        // d.md is the only orphan
+        assert_eq!(val["orphans"]["total"], 1, "expected 1 orphan");
+        let orphan_files: Vec<&str> = val["orphans"]["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(orphan_files, vec!["d.md"], "orphans: {orphan_files:?}");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -1199,6 +1199,62 @@ No tasks here.
         assert_eq!(orphan_files, vec!["d.md"], "orphans: {orphan_files:?}");
     }
 
+    /// Dead-end parity: disk scan and index path must agree on dead-end lists.
+    #[test]
+    fn summary_dead_end_parity_disk_vs_index() {
+        use hyalo_core::index::{ScannedIndex, SnapshotIndex};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        // a.md links to b and c
+        fs::write(dir.join("a.md"), "---\ntitle: A\n---\n[[b]]\n[[c]]\n").unwrap();
+        // b.md links to c
+        fs::write(dir.join("b.md"), "---\ntitle: B\n---\n[[c]]\n").unwrap();
+        // c.md is a dead-end (inbound from a and b, no outbound)
+        fs::write(dir.join("c.md"), "---\ntitle: C\n---\nNo links.\n").unwrap();
+        // d.md is an orphan (no links in or out)
+        fs::write(dir.join("d.md"), "---\ntitle: D\n---\nNo links.\n").unwrap();
+
+        // Disk-scan path
+        let disk_val = unwrap_success(summary(dir, &[], 10, None, None, Format::Json).unwrap());
+        let disk_dead_ends: Vec<&str> = disk_val["dead_ends"]["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+
+        // Index path
+        let all = hyalo_core::discovery::discover_files(dir).unwrap();
+        let files: Vec<(std::path::PathBuf, String)> = all
+            .into_iter()
+            .map(|p| {
+                let rel = hyalo_core::discovery::relative_path(dir, &p);
+                (p, rel)
+            })
+            .collect();
+        let build = ScannedIndex::build(&files, None).unwrap();
+        let index_path = dir.join(".hyalo-index");
+        SnapshotIndex::save(&build.index, &index_path, &dir.display().to_string(), None).unwrap();
+        let loaded = SnapshotIndex::load(&index_path).unwrap().unwrap();
+        let index_val = unwrap_success(
+            summary_from_index(dir, &loaded, &[], 10, None, None, Format::Json).unwrap(),
+        );
+        let index_dead_ends: Vec<&str> = index_val["dead_ends"]["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+
+        assert_eq!(
+            disk_dead_ends, index_dead_ends,
+            "disk scan and index must produce identical dead-end lists"
+        );
+        assert_eq!(disk_dead_ends, vec!["c.md"]);
+    }
+
     #[test]
     fn summary_skips_broken_frontmatter_file() {
         let tmp = setup_vault();

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -203,9 +203,13 @@ fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> 
 }
 
 fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
-    let results = match data.as_array() {
-        Some(arr) => arr,
-        None => return vec![],
+    // find always returns a {total, results} envelope; fall back to bare array for compatibility.
+    let results = if let Some(arr) = data["results"].as_array() {
+        arr
+    } else if let Some(arr) = data.as_array() {
+        arr
+    } else {
+        return vec![];
     };
 
     if results.is_empty() {

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -203,10 +203,8 @@ fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> 
 }
 
 fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
-    // find always returns a {total, results} envelope; fall back to bare array for compatibility.
+    // find always returns a {total, results} envelope.
     let results = if let Some(arr) = data["results"].as_array() {
-        arr
-    } else if let Some(arr) = data.as_array() {
         arr
     } else {
         return vec![];
@@ -590,7 +588,8 @@ mod tests {
     #[test]
     fn find_single_result_suggests_read_and_backlinks() {
         let c = ctx(HintSource::Find);
-        let data = json!([make_find_item("notes/alpha.md", None, &[])]);
+        let items = vec![make_find_item("notes/alpha.md", None, &[])];
+        let data = json!({"total": items.len(), "results": items});
         let hints = generate_hints(&c, &data);
         assert!(
             hints
@@ -610,14 +609,15 @@ mod tests {
     fn find_many_results_suggests_top_tag() {
         let c = ctx(HintSource::Find);
         // 6 results; rust appears 4 times, cli 2 times — rust should be suggested.
-        let data = json!([
+        let items = vec![
             make_find_item("a.md", Some("planned"), &["rust", "cli"]),
             make_find_item("b.md", Some("planned"), &["rust"]),
             make_find_item("c.md", Some("in-progress"), &["rust"]),
             make_find_item("d.md", Some("completed"), &["rust"]),
             make_find_item("e.md", Some("completed"), &["cli"]),
             make_find_item("f.md", Some("completed"), &[]),
-        ]);
+        ];
+        let data = json!({"total": items.len(), "results": items});
         let hints = generate_hints(&c, &data);
         assert!(
             hints
@@ -631,14 +631,15 @@ mod tests {
     fn find_many_results_suggests_interesting_status() {
         let c = ctx(HintSource::Find);
         // 6 results; in-progress is more interesting than completed.
-        let data = json!([
+        let items = vec![
             make_find_item("a.md", Some("in-progress"), &[]),
             make_find_item("b.md", Some("completed"), &[]),
             make_find_item("c.md", Some("completed"), &[]),
             make_find_item("d.md", Some("completed"), &[]),
             make_find_item("e.md", Some("completed"), &[]),
             make_find_item("f.md", Some("completed"), &[]),
-        ]);
+        ];
+        let data = json!({"total": items.len(), "results": items});
         let hints = generate_hints(&c, &data);
         assert!(
             hints
@@ -652,14 +653,15 @@ mod tests {
     fn find_many_results_no_tags_falls_back_to_status() {
         let c = ctx(HintSource::Find);
         // 6 results, none with tags; should still suggest status narrowing.
-        let data = json!([
+        let items = vec![
             make_find_item("a.md", Some("planned"), &[]),
             make_find_item("b.md", Some("planned"), &[]),
             make_find_item("c.md", Some("planned"), &[]),
             make_find_item("d.md", Some("planned"), &[]),
             make_find_item("e.md", Some("planned"), &[]),
             make_find_item("f.md", Some("planned"), &[]),
-        ]);
+        ];
+        let data = json!({"total": items.len(), "results": items});
         let hints = generate_hints(&c, &data);
         assert!(
             hints
@@ -681,7 +683,7 @@ mod tests {
         let items: Vec<serde_json::Value> = (0..10)
             .map(|i| make_find_item(&format!("{i}.md"), Some("planned"), &["rust", "cli"]))
             .collect();
-        let data = serde_json::Value::Array(items);
+        let data = json!({"total": items.len(), "results": items});
         let hints = generate_hints(&c, &data);
         assert!(hints.len() <= MAX_HINTS);
     }

--- a/crates/hyalo-cli/src/main.rs
+++ b/crates/hyalo-cli/src/main.rs
@@ -160,7 +160,7 @@ COOKBOOK:
   hyalo find --section '## Sprint' --task todo
 
   # Find broken [[wikilinks]] (fields=links, then filter in jq)
-  hyalo find --fields links --jq '[.[] | select(.links | map(select(.path == null)) | length > 0)]'
+  hyalo find --fields links --jq '[.results[] | select(.links | map(select(.path == null)) | length > 0)]'
 
   # Exclude draft files with glob negation
   hyalo find --glob '!**/draft-*'
@@ -187,10 +187,10 @@ COOKBOOK:
   hyalo properties summary --jq '[.[].name] | join(\", \")'
 
   # Get just file paths (no metadata)
-  hyalo find --property status=draft --jq '[.[].file]'
+  hyalo find --property status=draft --jq '[.results[].file]'
 
   # Pipe file paths for scripting (Unix)
-  hyalo find --tag research --jq '.[].file' | xargs -I{} hyalo set --property reviewed=true --file {}
+  hyalo find --tag research --jq '.results[].file' | xargs -I{} hyalo set --property reviewed=true --file {}
 
   # Find all files that link to a given note
   hyalo backlinks --file decision-log.md
@@ -236,9 +236,9 @@ COOKBOOK:
 
 OUTPUT SHAPES (JSON, default):
   # find
-  [{\"file\": \"notes/todo.md\", \"modified\": \"2026-03-21T...\",
+  {\"total\": N, \"results\": [{\"file\": \"notes/todo.md\", \"modified\": \"2026-03-21T...\",
    \"properties\": {\"status\": \"draft\", \"title\": \"My Note\"},
-   \"tags\": [...], \"sections\": [...], \"tasks\": [...], \"links\": [...]}]
+   \"tags\": [...], \"sections\": [...], \"tasks\": [...], \"links\": [...]}]}
 
   # read
   {\"file\": \"notes/todo.md\", \"content\": \"...body text...\"}
@@ -265,7 +265,7 @@ OUTPUT SHAPES (JSON, default):
   # summary
   {\"files\": {\"total\": 31, \"by_directory\": [...]}, \"properties\": [...], \"tags\": {...},
   \"status\": [{\"value\": \"draft\", \"files\": [...]}], \"tasks\": {\"total\": 50, \"done\": 30},
-  \"orphans\": [\"orphan.md\", ...],
+  \"orphans\": {\"total\": N, \"files\": [...]}, \"dead_ends\": {\"total\": N, \"files\": [...]},
   \"recent_files\": [{\"path\": \"note.md\", \"modified\": \"2026-03-21T...\"}]}
 
   # backlinks

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -526,8 +526,9 @@ fn format_value_as_text(value: &serde_json::Value, cache: &mut JaqFilterCache) -
                 .join(sep)
         }
         serde_json::Value::Object(map) => {
-            // Detect the --limit truncation envelope: {"total": N, "results": [...]}
-            // Format each result element normally, then append "showing N of M matches".
+            // Detect the find results envelope: {"total": N, "results": [...]}
+            // Format each result element normally; append "showing N of M matches"
+            // only when limit actually truncated results.
             if map.len() == 2
                 && map.contains_key("total")
                 && map.contains_key("results")
@@ -539,7 +540,9 @@ fn format_value_as_text(value: &serde_json::Value, cache: &mut JaqFilterCache) -
                     .iter()
                     .map(|v| format_value_as_text(v, cache))
                     .collect();
-                parts.push(format!("showing {shown} of {total} matches"));
+                if (shown as u64) < total {
+                    parts.push(format!("showing {shown} of {total} matches"));
+                }
                 // Preserve blank-line separation when results are FileObjects.
                 let is_file_objects = results
                     .first()

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -529,11 +529,8 @@ fn format_value_as_text(value: &serde_json::Value, cache: &mut JaqFilterCache) -
             // Detect the find results envelope: {"total": N, "results": [...]}
             // Format each result element normally; append "showing N of M matches"
             // only when limit actually truncated results.
-            if map.len() == 2
-                && map.contains_key("total")
-                && map.contains_key("results")
-                && let (Some(total), Some(results)) =
-                    (map["total"].as_u64(), map["results"].as_array())
+            if let (Some(total_val), Some(results_val)) = (map.get("total"), map.get("results"))
+                && let (Some(total), Some(results)) = (total_val.as_u64(), results_val.as_array())
             {
                 let shown = results.len();
                 let mut parts: Vec<String> = results

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -527,6 +527,9 @@ fn format_value_as_text(value: &serde_json::Value, cache: &mut JaqFilterCache) -
         }
         serde_json::Value::Object(map) => {
             // Detect the find results envelope: {"total": N, "results": [...]}
+            // This is duck-typed — any object with both keys triggers this path.
+            // Currently only `find` produces this shape; if another command does
+            // in the future, add an explicit tag or dedicated serialisation path.
             // Format each result element normally; append "showing N of M matches"
             // only when limit actually truncated results.
             if let (Some(total_val), Some(results_val)) = (map.get("total"), map.get("results"))

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -201,8 +201,8 @@ const TASK_INFO_FILTER: &str =
 const TASK_READ_RESULT_FILTER: &str =
     r#""\"\(.file)\":\(.line) [\(.status)] \(.text)\(if .done then " (done)" else "" end)""#;
 
-/// `VaultSummary`: `{files, links, orphans, properties, recent_files, status, tags, tasks}`
-const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nLinks: \(.links.total) total, \(.links.broken) broken\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nOrphans: \(.orphans.total)\(if (.orphans.files | length) > 0 then "\n\(.orphans.files | map("  \"\(.)\"") | join("\n"))" else "" end)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
+/// `VaultSummary`: `{dead_ends, files, links, orphans, properties, recent_files, status, tags, tasks}`
+const VAULT_SUMMARY_FILTER: &str = r#""Files: \(.files.total) total\(if (.files.by_directory | length) > 0 then "\n\(.files.by_directory | map("  \"\(.directory)\": \(.count)") | join("\n"))" else "" end)\nLinks: \(.links.total) total, \(.links.broken) broken\nProperties: \(.properties | length) unique\nTags: \(.tags.total) unique\nStatus: \(if (.status | length) > 0 then (.status | map("\(.value) (\(.files | length))") | join(", ")) else "(none)" end)\nTasks: \(.tasks.done)/\(.tasks.total)\nOrphans: \(.orphans.total)\(if (.orphans.files | length) > 0 then "\n\(.orphans.files | map("  \"\(.)\"") | join("\n"))" else "" end)\nDead-ends: \(.dead_ends.total)\(if (.dead_ends.files | length) > 0 then "\n\(.dead_ends.files | map("  \"\(.)\"") | join("\n"))" else "" end)\nRecent:\(if (.recent_files | length) > 0 then "\n\(.recent_files | map("  \"\(.path)\"") | join("\n"))" else " (none)" end)""#;
 
 /// `FindTaskInfo`: `{done, line, section, status, text}`
 /// Format: `  [x] text (line N, section)` or `  [ ] text (line N, section)`
@@ -277,7 +277,7 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         // TaskReadResult
         "done,file,line,status,text" => Some(TASK_READ_RESULT_FILTER),
         // VaultSummary
-        "files,links,orphans,properties,recent_files,status,tags,tasks" => {
+        "dead_ends,files,links,orphans,properties,recent_files,status,tags,tasks" => {
             Some(VAULT_SUMMARY_FILTER)
         }
         // Mutation results with property + value (SetPropertyResult, AppendPropertyResult,
@@ -526,6 +526,29 @@ fn format_value_as_text(value: &serde_json::Value, cache: &mut JaqFilterCache) -
                 .join(sep)
         }
         serde_json::Value::Object(map) => {
+            // Detect the --limit truncation envelope: {"total": N, "results": [...]}
+            // Format each result element normally, then append "showing N of M matches".
+            if map.len() == 2
+                && map.contains_key("total")
+                && map.contains_key("results")
+                && let (Some(total), Some(results)) =
+                    (map["total"].as_u64(), map["results"].as_array())
+            {
+                let shown = results.len();
+                let mut parts: Vec<String> = results
+                    .iter()
+                    .map(|v| format_value_as_text(v, cache))
+                    .collect();
+                parts.push(format!("showing {shown} of {total} matches"));
+                // Preserve blank-line separation when results are FileObjects.
+                let is_file_objects = results
+                    .first()
+                    .and_then(|v| v.as_object())
+                    .is_some_and(|m| m.contains_key("file") && m.contains_key("modified"));
+                let sep = if is_file_objects { "\n\n" } else { "\n" };
+                return parts.join(sep);
+            }
+
             let sig = key_signature(map);
             if let Some(filter) = lookup_filter(&sig)
                 && let Some(output) = apply_jq_filter(filter, value, cache)

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -727,7 +727,7 @@ fn find_limit_truncated_json_envelope() {
 
 /// When --limit equals or exceeds the match count, output is an envelope where total == results.len().
 #[test]
-fn find_limit_no_truncation_plain_array() {
+fn find_limit_no_truncation_returns_envelope() {
     let tmp = setup_vault();
     let (status, json, stderr) = find_json(&tmp, &["--limit", "10"]);
     assert!(status.success(), "stderr: {stderr}");

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -678,13 +678,23 @@ fn find_sort_file_default() {
 // Limit
 // ---------------------------------------------------------------------------
 
+/// Helper: extract the results array from either a plain array or a `{total, results}` envelope.
+fn unwrap_results(json: &serde_json::Value) -> &Vec<serde_json::Value> {
+    if let Some(arr) = json.as_array() {
+        return arr;
+    }
+    json["results"]
+        .as_array()
+        .expect("expected either a JSON array or {total, results} envelope")
+}
+
 #[test]
 fn find_limit_2_returns_2_results() {
     let tmp = setup_vault();
     let (status, json, stderr) = find_json(&tmp, &["--limit", "2"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 2, "expected exactly 2 results with --limit 2");
 }
 
@@ -694,15 +704,76 @@ fn find_limit_larger_than_results() {
     let (status, json, stderr) = find_json(&tmp, &["--limit", "100"]);
     assert!(status.success(), "stderr: {stderr}");
 
+    // Limit exceeds file count: plain array, no envelope.
     let arr = json.as_array().unwrap();
-    // All 4 files returned; limit is a ceiling not a floor
     assert_eq!(arr.len(), 4);
 }
 
-/// Short-circuit path: --limit with default sort (file) must return the same
-/// first N results as a full scan with explicit --sort file and truncation.
+/// When --limit truncates results, the JSON output is an envelope `{total, results}`.
 #[test]
-fn find_limit_short_circuit_matches_full_scan() {
+fn find_limit_truncated_json_envelope() {
+    let tmp = setup_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--limit", "2"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    // Must be an object, not a plain array.
+    assert!(json.is_object(), "expected envelope object, got: {json}");
+    assert_eq!(
+        json["total"].as_u64().unwrap(),
+        4,
+        "total should be 4 (all vault files)"
+    );
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(results.len(), 2, "results should contain 2 entries");
+}
+
+/// When --limit equals or exceeds the match count, output is a plain array (no envelope).
+#[test]
+fn find_limit_no_truncation_plain_array() {
+    let tmp = setup_vault();
+    let (status, json, stderr) = find_json(&tmp, &["--limit", "10"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    assert!(
+        json.is_array(),
+        "expected plain array when limit >= total, got: {json}"
+    );
+    assert_eq!(json.as_array().unwrap().len(), 4);
+}
+
+/// Text output when --limit truncates ends with "showing N of M matches".
+#[test]
+fn find_limit_truncated_text_shows_summary() {
+    let tmp = setup_vault();
+    let mut cmd = common::hyalo();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--format", "text"]);
+    cmd.args(["find", "--limit", "2"]);
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("showing 2 of 4 matches"),
+        "expected 'showing 2 of 4 matches' in output, got:\n{stdout}"
+    );
+}
+
+/// --limit with --jq can drill into the envelope.
+#[test]
+fn find_limit_jq_total() {
+    let tmp = setup_vault();
+    let mut cmd = common::hyalo();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["find", "--limit", "2", "--jq", ".total"]);
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    assert_eq!(stdout, "4", "expected .total == 4, got: {stdout}");
+}
+
+/// --limit with default sort (file) must return the same first N results as a full scan.
+#[test]
+fn find_limit_matches_full_scan_order() {
     let tmp = setup_vault();
 
     // Full scan, explicit file sort — reference result set.
@@ -710,15 +781,14 @@ fn find_limit_short_circuit_matches_full_scan() {
     assert!(status.success(), "full scan stderr: {stderr}");
     let full_arr = full_json.as_array().unwrap();
 
-    // Short-circuit path: limit=2, default sort (file).
+    // Limit=2, default sort (file) — should return an envelope.
     let (status, limited_json, stderr) = find_json(&tmp, &["--limit", "2"]);
     assert!(status.success(), "limited scan stderr: {stderr}");
-    let limited_arr = limited_json.as_array().unwrap();
+    let limited_arr = unwrap_results(&limited_json);
 
     assert_eq!(limited_arr.len(), 2);
 
-    // The first 2 files from the short-circuit path must match the first 2
-    // from the full sorted scan — same files, same order.
+    // The first 2 files must match the first 2 from the full sorted scan.
     let full_files: Vec<&str> = full_arr[..2]
         .iter()
         .map(|v| v["file"].as_str().unwrap())
@@ -729,12 +799,11 @@ fn find_limit_short_circuit_matches_full_scan() {
         .collect();
     assert_eq!(
         limited_files, full_files,
-        "short-circuit result order differs from full-scan order"
+        "limited result order differs from full-scan order"
     );
 }
 
-/// When --sort modified is used with --limit, short-circuit must NOT
-/// activate: all files must be scanned so the sort is correct.
+/// When --sort modified is used with --limit, all files must be scanned so the sort is correct.
 #[test]
 fn find_limit_with_sort_modified_returns_correct_results() {
     let tmp = setup_vault();
@@ -748,7 +817,7 @@ fn find_limit_with_sort_modified_returns_correct_results() {
     // files from the full sorted result, not the first 2 by file path.
     let (status, limited_json, stderr) = find_json(&tmp, &["--sort", "modified", "--limit", "2"]);
     assert!(status.success(), "limited stderr: {stderr}");
-    let limited_arr = limited_json.as_array().unwrap();
+    let limited_arr = unwrap_results(&limited_json);
 
     assert_eq!(limited_arr.len(), 2);
 
@@ -762,14 +831,13 @@ fn find_limit_with_sort_modified_returns_correct_results() {
         .collect();
     assert_eq!(
         actual_files, expected_files,
-        "--sort-by modified + --limit must sort first then truncate"
+        "--sort modified + --limit must sort first then truncate"
     );
 }
 
 /// With --file args in reverse alphabetical order and --limit 1, the result
 /// must be the alphabetically-first file (matching --sort file behaviour),
-/// not the first file in CLI arg order.  Short-circuit is disabled for
-/// explicit --file lists because they preserve CLI order, not sort order.
+/// not the first file in CLI arg order.
 #[test]
 fn find_limit_with_explicit_files_uses_sort_order() {
     let tmp = setup_vault();
@@ -781,7 +849,7 @@ fn find_limit_with_explicit_files_uses_sort_order() {
         &["--file", "gamma.md", "--file", "alpha.md", "--limit", "1"],
     );
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     assert_eq!(
         arr[0]["file"].as_str().unwrap(),
@@ -2992,10 +3060,11 @@ fn find_reverse_with_limit() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
-    assert_eq!(json.len(), 2, "expected exactly 2 results");
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
+    assert_eq!(results.len(), 2, "expected exactly 2 results");
     // Should be last 2 files alphabetically (reversed then limited)
-    let files: Vec<&str> = json.iter().filter_map(|v| v["file"].as_str()).collect();
+    let files: Vec<&str> = results.iter().filter_map(|v| v["file"].as_str()).collect();
     assert!(
         files[0] > files[1],
         "files should be in reverse order: {files:?}"

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -862,6 +862,93 @@ fn find_limit_with_explicit_files_uses_sort_order() {
     );
 }
 
+/// --sort file --limit N triggers the early-exit memory optimisation.
+/// The results must be identical to a full scan sorted by file path and
+/// truncated to N, proving that the pre-sorted-iteration shortcut is correct.
+#[test]
+fn find_sort_file_limit_deterministic() {
+    let tmp = setup_vault();
+
+    // Full scan with explicit file sort — reference result set.
+    let (status, full_json, stderr) = find_json(&tmp, &["--sort", "file"]);
+    assert!(status.success(), "full scan stderr: {stderr}");
+    let full_arr = unwrap_results(&full_json);
+
+    // --sort file --limit 2 should return the first 2 from full_arr,
+    // exercising the early-exit path (pre-sorted files, capped collection).
+    let (status, limited_json, stderr) = find_json(&tmp, &["--sort", "file", "--limit", "2"]);
+    assert!(status.success(), "limited scan stderr: {stderr}");
+
+    // Envelope must report the total before truncation.
+    let total = limited_json["total"].as_u64().unwrap();
+    assert_eq!(
+        total,
+        full_arr.len() as u64,
+        "total in envelope must equal full match count"
+    );
+
+    let limited_arr = unwrap_results(&limited_json);
+    assert_eq!(limited_arr.len(), 2);
+
+    let expected_files: Vec<&str> = full_arr[..2]
+        .iter()
+        .map(|v| v["file"].as_str().unwrap())
+        .collect();
+    let actual_files: Vec<&str> = limited_arr
+        .iter()
+        .map(|v| v["file"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        actual_files, expected_files,
+        "--sort file --limit must return the first N files in alphabetical order"
+    );
+}
+
+/// --sort file --limit with property filter: the total must reflect only
+/// files that pass the filter, not all vault files.
+#[test]
+fn find_sort_file_limit_with_filter_reports_accurate_total() {
+    let tmp = setup_vault();
+
+    // Full filtered scan — only status=planned files.
+    let (status, full_json, stderr) =
+        find_json(&tmp, &["--property", "status=planned", "--sort", "file"]);
+    assert!(status.success(), "full scan stderr: {stderr}");
+    let full_arr = unwrap_results(&full_json);
+    assert!(
+        full_arr.len() >= 2,
+        "test fixture must have ≥2 planned files"
+    );
+
+    // Limited to 1 result.
+    let (status, limited_json, stderr) = find_json(
+        &tmp,
+        &[
+            "--property",
+            "status=planned",
+            "--sort",
+            "file",
+            "--limit",
+            "1",
+        ],
+    );
+    assert!(status.success(), "limited stderr: {stderr}");
+
+    let total = limited_json["total"].as_u64().unwrap();
+    assert_eq!(
+        total,
+        full_arr.len() as u64,
+        "total must equal the count of matching files, not total vault files"
+    );
+
+    let limited_arr = unwrap_results(&limited_json);
+    assert_eq!(limited_arr.len(), 1);
+    assert_eq!(
+        limited_arr[0]["file"].as_str().unwrap(),
+        full_arr[0]["file"].as_str().unwrap(),
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Text format
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -117,7 +117,7 @@ fn find_all_files_returns_sorted_array() {
     let (status, json, stderr) = find_json(&tmp, &[]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 4, "expected 4 files, got: {arr:?}");
 
     // Verify sorted by file path
@@ -136,7 +136,7 @@ fn find_all_files_have_required_fields() {
     let (status, json, stderr) = find_json(&tmp, &[]);
     assert!(status.success(), "stderr: {stderr}");
 
-    for entry in json.as_array().unwrap() {
+    for entry in unwrap_results(&json) {
         assert!(entry["file"].is_string(), "missing file field in {entry}");
         let modified = entry["modified"]
             .as_str()
@@ -157,9 +157,9 @@ fn find_single_file_returns_array_not_object() {
     let (status, json, stderr) = find_json(&tmp, &["--file", "alpha.md"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    // Must be an array, not a bare object
-    assert!(json.is_array(), "expected array, got: {json}");
-    let arr = json.as_array().unwrap();
+    // Must be an envelope {total, results}, not a bare array
+    assert!(json.is_object(), "expected envelope, got: {json}");
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -174,7 +174,7 @@ fn find_glob_sub_only() {
     let (status, json, stderr) = find_json(&tmp, &["--glob", "sub/*.md"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     assert_eq!(arr[0]["file"], "sub/nested.md");
 }
@@ -205,7 +205,7 @@ fn find_property_eq_status_planned() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "status=planned"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // alpha (planned) + nested (planned) = 2
     assert_eq!(
         arr.len(),
@@ -226,7 +226,7 @@ fn find_property_neq_status_completed() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "status!=completed"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // gamma has no status → filter returns false for !=; alpha+nested have status!=completed → 2 files
     assert_eq!(arr.len(), 2, "expected 2 files (alpha, nested): {arr:?}");
     let files: Vec<&str> = arr
@@ -243,7 +243,7 @@ fn find_property_existence_status() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "status"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // alpha, beta, nested have status; gamma does not
     assert_eq!(arr.len(), 3, "expected 3 files with status: {arr:?}");
     let files: Vec<&str> = arr
@@ -261,7 +261,7 @@ fn find_property_gte_priority() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "priority>=3"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Only alpha has priority: 3
     assert_eq!(arr.len(), 1, "expected 1 file with priority>=3: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
@@ -276,7 +276,7 @@ fn find_property_and_semantics() {
     );
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Only alpha satisfies both: status=planned AND priority>=3
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
@@ -292,7 +292,7 @@ fn find_tag_rust_matches_three_files() {
     let (status, json, stderr) = find_json(&tmp, &["--tag", "rust"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // alpha, beta, nested all have rust tag
     assert_eq!(arr.len(), 3, "expected 3 files with rust tag: {arr:?}");
 }
@@ -303,7 +303,7 @@ fn find_tag_cli_matches_only_alpha() {
     let (status, json, stderr) = find_json(&tmp, &["--tag", "cli"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file with cli tag: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -315,7 +315,7 @@ fn find_tag_project_matches_nested_tag() {
     let (status, json, stderr) = find_json(&tmp, &["--tag", "project"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(
         arr.len(),
         1,
@@ -331,7 +331,7 @@ fn find_tag_and_semantics() {
     let (status, json, stderr) = find_json(&tmp, &["--tag", "rust", "--tag", "cli"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file with rust+cli tags: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -346,7 +346,7 @@ fn find_pattern_rust_programming_matches_beta() {
     let (status, json, stderr) = find_json(&tmp, &["Rust programming"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "beta.md");
 }
@@ -358,7 +358,7 @@ fn find_pattern_write_matches_alpha() {
     let (status, json, stderr) = find_json(&tmp, &["Write"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -369,7 +369,7 @@ fn find_pattern_no_match_returns_empty_array() {
     let (status, json, stderr) = find_json(&tmp, &["nonexistent_phrase_xyz"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert!(arr.is_empty(), "expected empty array: {arr:?}");
 }
 
@@ -379,7 +379,7 @@ fn find_pattern_includes_matches_field() {
     let (status, json, stderr) = find_json(&tmp, &["Rust programming"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     assert!(
         arr[0]["matches"].is_array(),
@@ -393,7 +393,7 @@ fn find_no_pattern_no_matches_field() {
     let (status, json, stderr) = find_json(&tmp, &[]);
     assert!(status.success(), "stderr: {stderr}");
 
-    for entry in json.as_array().unwrap() {
+    for entry in unwrap_results(&json) {
         assert!(
             entry["matches"].is_null(),
             "matches field should be absent without pattern, got: {}",
@@ -412,7 +412,7 @@ fn find_task_todo_matches_alpha() {
     let (status, json, stderr) = find_json(&tmp, &["--task", "todo"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Only alpha has an open task
     assert_eq!(arr.len(), 1, "expected 1 file with todo task: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
@@ -424,7 +424,7 @@ fn find_task_done_matches_alpha() {
     let (status, json, stderr) = find_json(&tmp, &["--task", "done"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Only alpha has a completed task
     assert_eq!(arr.len(), 1, "expected 1 file with done task: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
@@ -436,7 +436,7 @@ fn find_task_any_matches_only_files_with_tasks() {
     let (status, json, stderr) = find_json(&tmp, &["--task", "any"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Only alpha has tasks
     assert_eq!(arr.len(), 1, "expected 1 file with any tasks: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
@@ -454,7 +454,7 @@ fn find_tag_and_property_combined() {
         find_json(&tmp, &["--tag", "rust", "--property", "status=planned"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 2, "expected 2 files: {arr:?}");
     let files: Vec<&str> = arr
         .iter()
@@ -471,7 +471,7 @@ fn find_pattern_and_tag_combined() {
     let (status, json, stderr) = find_json(&tmp, &["Write", "--tag", "rust"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -500,7 +500,7 @@ fn find_all_four_filters_combined() {
     );
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(
         arr.len(),
         1,
@@ -519,7 +519,7 @@ fn find_fields_properties_and_tags_only() {
     let (status, json, stderr) = find_json(&tmp, &["--fields", "properties,tags"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    for entry in json.as_array().unwrap() {
+    for entry in unwrap_results(&json) {
         assert!(
             entry["properties"].is_object(),
             "properties should be present"
@@ -538,7 +538,7 @@ fn find_fields_tasks_only() {
     let (status, json, stderr) = find_json(&tmp, &["--fields", "tasks"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    for entry in json.as_array().unwrap() {
+    for entry in unwrap_results(&json) {
         // tasks field present (may be null for files without tasks, but the key exists)
         assert!(entry["properties"].is_null(), "properties should be absent");
         assert!(entry["tags"].is_null(), "tags should be absent");
@@ -547,7 +547,7 @@ fn find_fields_tasks_only() {
     }
 
     // alpha specifically should have tasks populated
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let alpha = arr
         .iter()
         .find(|e| e["file"].as_str().expect("field 'file' should be a string") == "alpha.md")
@@ -565,7 +565,7 @@ fn find_fields_backlinks_shows_incoming_links() {
     let (status, json, stderr) = find_json(&tmp, &["--fields", "backlinks", "--file", "beta.md"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let beta = &arr[0];
     let backlinks = beta["backlinks"]
@@ -582,7 +582,7 @@ fn find_fields_backlinks_not_included_by_default() {
     let (status, json, stderr) = find_json(&tmp, &[]);
     assert!(status.success(), "stderr: {stderr}");
 
-    for entry in json.as_array().unwrap() {
+    for entry in unwrap_results(&json) {
         assert!(
             !entry.as_object().unwrap().contains_key("backlinks"),
             "backlinks key should be absent by default, not just null"
@@ -597,7 +597,7 @@ fn find_fields_all_includes_every_category() {
     let (status, json, stderr) = find_json(&tmp, &["--fields", "all", "--file", "alpha.md"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let entry = &arr[0];
 
@@ -642,7 +642,7 @@ fn find_sort_modified() {
     let (status, json, stderr) = find_json(&tmp, &["--sort", "modified"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 4);
 
     let times: Vec<&str> = arr
@@ -664,7 +664,7 @@ fn find_sort_file_default() {
     let (status, json, stderr) = find_json(&tmp, &["--sort", "file"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr
         .iter()
         .map(|v| v["file"].as_str().expect("field 'file' should be a string"))
@@ -678,14 +678,11 @@ fn find_sort_file_default() {
 // Limit
 // ---------------------------------------------------------------------------
 
-/// Helper: extract the results array from either a plain array or a `{total, results}` envelope.
+/// Helper: extract the results array from a `{total, results}` envelope.
 fn unwrap_results(json: &serde_json::Value) -> &Vec<serde_json::Value> {
-    if let Some(arr) = json.as_array() {
-        return arr;
-    }
     json["results"]
         .as_array()
-        .expect("expected either a JSON array or {total, results} envelope")
+        .expect("expected {total, results} envelope")
 }
 
 #[test]
@@ -704,9 +701,10 @@ fn find_limit_larger_than_results() {
     let (status, json, stderr) = find_json(&tmp, &["--limit", "100"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    // Limit exceeds file count: plain array, no envelope.
-    let arr = json.as_array().unwrap();
+    // Limit exceeds file count: still returns envelope with total == results.len().
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 4);
+    assert_eq!(json["total"].as_u64().unwrap(), 4);
 }
 
 /// When --limit truncates results, the JSON output is an envelope `{total, results}`.
@@ -727,7 +725,7 @@ fn find_limit_truncated_json_envelope() {
     assert_eq!(results.len(), 2, "results should contain 2 entries");
 }
 
-/// When --limit equals or exceeds the match count, output is a plain array (no envelope).
+/// When --limit equals or exceeds the match count, output is an envelope where total == results.len().
 #[test]
 fn find_limit_no_truncation_plain_array() {
     let tmp = setup_vault();
@@ -735,10 +733,16 @@ fn find_limit_no_truncation_plain_array() {
     assert!(status.success(), "stderr: {stderr}");
 
     assert!(
-        json.is_array(),
-        "expected plain array when limit >= total, got: {json}"
+        json.is_object(),
+        "expected envelope when limit >= total, got: {json}"
     );
-    assert_eq!(json.as_array().unwrap().len(), 4);
+    let results = unwrap_results(&json);
+    assert_eq!(results.len(), 4);
+    assert_eq!(
+        json["total"].as_u64().unwrap(),
+        results.len() as u64,
+        "total should equal results.len() when limit is not truncating"
+    );
 }
 
 /// Text output when --limit truncates ends with "showing N of M matches".
@@ -779,7 +783,7 @@ fn find_limit_matches_full_scan_order() {
     // Full scan, explicit file sort — reference result set.
     let (status, full_json, stderr) = find_json(&tmp, &["--sort", "file"]);
     assert!(status.success(), "full scan stderr: {stderr}");
-    let full_arr = full_json.as_array().unwrap();
+    let full_arr = unwrap_results(&full_json);
 
     // Limit=2, default sort (file) — should return an envelope.
     let (status, limited_json, stderr) = find_json(&tmp, &["--limit", "2"]);
@@ -811,7 +815,7 @@ fn find_limit_with_sort_modified_returns_correct_results() {
     // Full scan sorted by modified — reference.
     let (status, full_json, stderr) = find_json(&tmp, &["--sort", "modified"]);
     assert!(status.success(), "full scan stderr: {stderr}");
-    let full_arr = full_json.as_array().unwrap();
+    let full_arr = unwrap_results(&full_json);
 
     // Limit=2 with sort modified must return the 2 most-recently-modified
     // files from the full sorted result, not the first 2 by file path.
@@ -1032,7 +1036,7 @@ fn find_regexp_alternation_matches_multiple_files() {
     let (status, json, stderr) = find_json(&tmp, &["--regexp", "programming|body"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 2, "expected 2 files: {arr:?}");
     let files: Vec<&str> = arr
         .iter()
@@ -1049,7 +1053,7 @@ fn find_regexp_short_flag_e_works() {
     let (status, json, stderr) = find_json(&tmp, &["-e", "rust.*great"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "beta.md");
 }
@@ -1060,7 +1064,7 @@ fn find_regexp_case_insensitive_by_default() {
     let (status, json, stderr) = find_json(&tmp, &["--regexp", "rust PROGRAMMING"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "beta.md");
 }
@@ -1071,7 +1075,7 @@ fn find_regexp_includes_matches_field() {
     let (status, json, stderr) = find_json(&tmp, &["-e", "programming"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     assert!(
         arr[0]["matches"].is_array(),
@@ -1089,7 +1093,7 @@ fn find_regexp_no_match_returns_empty_array() {
     let (status, json, stderr) = find_json(&tmp, &["--regexp", r"\d{4}-\d{2}-\d{2}"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert!(arr.is_empty(), "expected empty array: {arr:?}");
 }
 
@@ -1100,7 +1104,7 @@ fn find_regexp_combined_with_tag() {
     let (status, json, stderr) = find_json(&tmp, &["-e", "content", "--tag", "rust"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // beta has "Content" in heading + rust tag; nested has "content" in body text + rust tag
     assert_eq!(arr.len(), 2, "expected 2 files: {arr:?}");
 }
@@ -1156,7 +1160,7 @@ title: Dotdot
     let (status, json, stderr) = find_json(&tmp, &["--file", "etc..md"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 result: {arr:?}");
     assert_eq!(arr[0]["file"], "etc..md");
 }
@@ -1210,7 +1214,7 @@ fn find_glob_no_match_returns_empty_array() {
         "non-matching glob should exit 0; stderr: {stderr}"
     );
     assert_eq!(
-        json.as_array().unwrap().len(),
+        unwrap_results(&json).len(),
         0,
         "non-matching glob should return empty array"
     );
@@ -1297,7 +1301,7 @@ fn section_filter_scopes_tasks() {
         &["--section", "Tasks", "--task", "todo", "--fields", "tasks"],
     );
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Both files have ## Tasks sections with open tasks
     assert_eq!(arr.len(), 2);
     for entry in arr {
@@ -1334,7 +1338,7 @@ fn section_filter_includes_nested_children() {
         ],
     );
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let tasks = arr[0]["tasks"]
         .as_array()
@@ -1368,7 +1372,7 @@ fn section_filter_nearest_heading_in_output() {
         ],
     );
     assert!(status.success());
-    let tasks = json.as_array().unwrap()[0]["tasks"]
+    let tasks = unwrap_results(&json)[0]["tasks"]
         .as_array()
         .expect("field 'tasks' should be an array");
     // The nested task should show "### Subtasks" as its section, not "## Tasks"
@@ -1392,7 +1396,7 @@ fn section_filter_case_insensitive() {
         &["--section", "tasks", "--task", "any", "--fields", "tasks"],
     );
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Should still match ## Tasks sections
     assert_eq!(arr.len(), 2);
 }
@@ -1407,7 +1411,7 @@ fn section_filter_level_pinned() {
         &["--section", "# Introduction", "--fields", "sections"],
     );
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // Only doc.md should be returned — other.md's ## Introduction is level 2, not level 1
     assert_eq!(
         arr.len(),
@@ -1441,7 +1445,7 @@ fn section_filter_or_semantics() {
         ],
     );
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let tasks = arr[0]["tasks"]
         .as_array()
@@ -1460,7 +1464,7 @@ fn section_filter_no_match_excludes_file() {
     let tmp = setup_section_vault();
     let (status, json, _) = find_json(&tmp, &["--section", "Nonexistent", "--task", "any"]);
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // No files should match since no section named "Nonexistent" exists
     assert!(arr.is_empty());
 }
@@ -1470,7 +1474,7 @@ fn section_filter_content_search_scoped() {
     let tmp = setup_section_vault();
     let (status, json, _) = find_json(&tmp, &["--section", "Notes", "TODO", "--file", "doc.md"]);
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let matches = arr[0]["matches"]
         .as_array()
@@ -1491,7 +1495,7 @@ fn section_filter_content_search_excludes_other_sections() {
     // "TODO" appears in both Notes and Design, but --section "Notes" should only find it in Notes
     let (status, json, _) = find_json(&tmp, &["--section", "Notes", "TODO", "--file", "other.md"]);
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // other.md has no ## Notes section, so it shouldn't match
     assert!(arr.is_empty());
 }
@@ -1549,7 +1553,10 @@ fn empty_json_result_returns_empty_array_no_stderr() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert_eq!(stdout.trim(), "[]");
+    // find now always returns an envelope; for empty results: {"total":0,"results":[]}
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["total"].as_u64().unwrap(), 0);
+    assert!(json["results"].as_array().unwrap().is_empty());
     assert!(
         !stderr.contains("No files matched"),
         "JSON mode should not print 'No files matched' notice"
@@ -1569,7 +1576,7 @@ fn find_fields_properties_typed_json() {
     );
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let entry = &arr[0];
 
@@ -1608,7 +1615,7 @@ fn find_fields_properties_typed_type_and_value() {
     );
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let typed = arr[0]["properties_typed"].as_array().unwrap();
 
     // alpha.md has: title: Alpha, status: planned, priority: 3
@@ -1641,7 +1648,7 @@ fn find_fields_properties_and_properties_typed_together_e2e() {
     );
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let entry = &arr[0];
 
     // Both fields present
@@ -1706,7 +1713,7 @@ fn find_property_absence_no_priority() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "!priority"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 3, "expected 3 files without priority: {arr:?}");
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert!(
@@ -1725,7 +1732,7 @@ fn find_property_absence_no_status_only_gamma() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "!status"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file without status: {arr:?}");
     assert_eq!(arr[0]["file"], "gamma.md");
 }
@@ -1740,7 +1747,7 @@ fn find_property_absence_combined_with_other_filters() {
     );
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 match: {arr:?}");
     assert_eq!(arr[0]["file"], "sub/nested.md");
 }
@@ -1756,7 +1763,7 @@ fn find_property_regex_bare_substring() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "status~=compl"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "beta.md");
 }
@@ -1768,7 +1775,7 @@ fn find_property_regex_delimited_anchored_exact() {
     let (status, json, stderr) = find_json(&tmp, &["--property", r"status~=/^planned$/"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 2, "expected alpha + nested: {arr:?}");
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert!(files.contains(&"alpha.md"));
@@ -1782,7 +1789,7 @@ fn find_property_regex_case_insensitive_flag() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "title~=/ALPHA/i"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected alpha.md: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -1794,7 +1801,7 @@ fn find_property_regex_list_property_any_element() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "tags~=cli"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected alpha.md only: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -1806,7 +1813,7 @@ fn find_property_regex_list_property_nested_tag() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "tags~=backend"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected sub/nested.md: {arr:?}");
     assert_eq!(arr[0]["file"], "sub/nested.md");
 }
@@ -1839,7 +1846,7 @@ fn find_property_eq_tilde_bare_substring() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "status=~compl"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected 1 file: {arr:?}");
     assert_eq!(arr[0]["file"], "beta.md");
 }
@@ -1851,7 +1858,7 @@ fn find_property_eq_tilde_delimited_case_insensitive() {
     let (status, json, stderr) = find_json(&tmp, &["--property", "title=~/ALPHA/i"]);
     assert!(status.success(), "stderr: {stderr}");
 
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected alpha.md: {arr:?}");
     assert_eq!(arr[0]["file"], "alpha.md");
 }
@@ -1923,7 +1930,7 @@ fn section_filter_substring_matches_heading_with_count_suffix() {
         ],
     );
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected tasks.md to match");
     let sections = arr[0]["sections"].as_array().unwrap();
     let headings: Vec<&str> = sections
@@ -1952,7 +1959,7 @@ fn section_filter_substring_matches_ticket_heading() {
         ],
     );
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected decision.md to match");
     let tasks = arr[0]["tasks"].as_array().unwrap();
     assert!(!tasks.is_empty(), "expected tasks in DEC-031 section");
@@ -1964,7 +1971,7 @@ fn section_filter_substring_exact_heading_still_matches() {
     let tmp = setup_section_vault();
     let (status, json, stderr) = find_json(&tmp, &["--section", "Tasks", "--task", "any"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert!(!arr.is_empty(), "expected files with ## Tasks section");
 }
 
@@ -1984,7 +1991,7 @@ fn section_filter_level_pinned_substring() {
         ],
     );
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(
         arr.len(),
         1,
@@ -2008,7 +2015,7 @@ fn section_filter_regex_matches() {
         ],
     );
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "expected decision.md to match");
     let tasks = arr[0]["tasks"].as_array().unwrap();
     // Both DEC-031 and DEC-032 have tasks, so we should get 2 tasks
@@ -2031,7 +2038,7 @@ fn section_filter_regex_anchored() {
         ],
     );
     assert!(status.success());
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     // tasks.md only has "Tasks [4/4]" — anchored regex should NOT match
     assert!(
         arr.is_empty(),
@@ -2085,7 +2092,7 @@ fn find_glob_negation_excludes_specific_file() {
     let tmp = setup_negation_vault();
     let (status, json, stderr) = find_json(&tmp, &["--glob", "!notes/draft.md"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert!(
         !files.contains(&"notes/draft.md"),
@@ -2106,7 +2113,7 @@ fn find_glob_negation_wildcard_pattern() {
 
     let (status, json, stderr) = find_json(&tmp, &["--glob", "!draft-*"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert!(
         !files.iter().any(|f| f.starts_with("draft-")),
@@ -2123,7 +2130,7 @@ fn find_glob_negation_double_star() {
     let tmp = setup_negation_vault();
     let (status, json, stderr) = find_json(&tmp, &["--glob", "!**/index.md"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert!(
         !files.iter().any(|f| f.ends_with("index.md")),
@@ -2139,7 +2146,7 @@ fn find_glob_positive_still_works() {
     let tmp = setup_negation_vault();
     let (status, json, stderr) = find_json(&tmp, &["--glob", "notes/*.md"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 3, "expected 3 files in notes/");
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert!(files.iter().all(|f| f.starts_with("notes/")));
@@ -2163,8 +2170,8 @@ fn find_multi_file_returns_array() {
     assert!(output.status.success());
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(json.is_array());
-    assert_eq!(json.as_array().unwrap().len(), 2);
+    assert!(json.is_object(), "expected envelope, got: {json}");
+    assert_eq!(unwrap_results(&json).len(), 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -2191,7 +2198,7 @@ let typescript = 42;
 
     let (status, json, stderr) = find_json(&tmp, &["typescript"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "should find match inside code block: {arr:?}");
     assert_eq!(arr[0]["file"], "code.md");
 }
@@ -2217,7 +2224,7 @@ def hello_world():
 
     let (status, json, stderr) = find_json(&tmp, &["-e", "hello.*world"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "should find regex match inside code block");
 }
 
@@ -2242,7 +2249,7 @@ unique_code_term_xyz
 
     let (status, json, stderr) = find_json(&tmp, &["unique_code_term_xyz"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1, "term only inside code block should be found");
 }
 
@@ -2268,7 +2275,7 @@ Some content about versions.
 
     let (status, json, stderr) = find_json(&tmp, &["content about"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let matches = arr[0]["matches"].as_array().unwrap();
     assert_eq!(matches.len(), 1);
@@ -2303,13 +2310,13 @@ TYPESCRIPT is uppercase
     // Default: case-insensitive, all 3 lines match
     let (status, json, stderr) = find_json(&tmp, &["-e", "typescript"]);
     assert!(status.success(), "stderr: {stderr}");
-    let matches = json.as_array().unwrap()[0]["matches"].as_array().unwrap();
+    let matches = unwrap_results(&json)[0]["matches"].as_array().unwrap();
     assert_eq!(matches.len(), 3, "default should be case-insensitive");
 
     // (?-i) override: only exact case matches
     let (status, json, stderr) = find_json(&tmp, &["-e", "(?-i)TypeScript"]);
     assert!(status.success(), "stderr: {stderr}");
-    let matches = json.as_array().unwrap()[0]["matches"].as_array().unwrap();
+    let matches = unwrap_results(&json)[0]["matches"].as_array().unwrap();
     assert_eq!(
         matches.len(),
         1,
@@ -2353,7 +2360,7 @@ fn find_repeatable_glob_union_of_two_dirs() {
     let tmp = setup_multi_glob_vault();
     let (status, json, stderr) = find_json(&tmp, &["--glob", "sub1/**", "--glob", "sub2/**"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(
         arr.len(),
@@ -2377,7 +2384,7 @@ fn find_repeatable_glob_positive_and_negative() {
     let (status, json, stderr) =
         find_json(&tmp, &["--glob", "sub2/**", "--glob", "!sub2/draft.md"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(arr.len(), 1, "expected only c.md, got: {files:?}");
     assert!(files.contains(&"sub2/c.md"));
@@ -2394,7 +2401,7 @@ fn find_repeatable_glob_multiple_negations_only() {
     let (status, json, stderr) =
         find_json(&tmp, &["--glob", "!sub1/**", "--glob", "!sub2/draft.md"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     // root.md + sub2/c.md should remain (sub1/** excluded, sub2/draft.md excluded)
     assert_eq!(arr.len(), 2, "expected root.md + sub2/c.md, got: {files:?}");
@@ -2416,7 +2423,7 @@ fn find_repeatable_glob_one_positive_one_negative() {
     let tmp = setup_multi_glob_vault();
     let (status, json, stderr) = find_json(&tmp, &["--glob", "sub1/**", "--glob", "!sub1/b.md"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(arr.len(), 1, "expected only sub1/a.md, got: {files:?}");
     assert!(files.contains(&"sub1/a.md"));
@@ -2427,7 +2434,7 @@ fn find_single_glob_backward_compat() {
     let tmp = setup_multi_glob_vault();
     let (status, json, stderr) = find_json(&tmp, &["--glob", "sub1/**"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(arr.len(), 2, "expected 2 files in sub1, got: {files:?}");
     assert!(files.contains(&"sub1/a.md"));
@@ -2480,7 +2487,7 @@ fn find_sort_backlinks_count() {
         &["--sort", "backlinks_count", "--fields", "backlinks"],
     );
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files.len(), 3, "expected 3 files, got: {files:?}");
     assert_eq!(files[0], "c.md", "c.md should be first (2 backlinks)");
@@ -2494,7 +2501,7 @@ fn find_sort_links_count() {
     // a has 2 outbound links, b has 1, c has 0
     let (status, json, stderr) = find_json(&tmp, &["--sort", "links_count", "--fields", "links"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files.len(), 3, "expected 3 files, got: {files:?}");
     assert_eq!(files[0], "a.md", "a.md should be first (2 links)");
@@ -2508,7 +2515,7 @@ fn find_sort_backlinks_count_without_fields_backlinks() {
     let tmp = setup_link_vault();
     let (status, json, stderr) = find_json(&tmp, &["--sort", "backlinks_count"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files[0], "c.md", "c.md should be first (most backlinks)");
     // Verify backlinks field is NOT in output (user didn't request it)
@@ -2525,7 +2532,7 @@ fn find_sort_links_count_without_fields_links() {
     let (status, json, stderr) =
         find_json(&tmp, &["--sort", "links_count", "--fields", "properties"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files[0], "a.md", "a.md should be first (most links)");
     // Verify links field is NOT in output (user excluded it via --fields)
@@ -2544,7 +2551,7 @@ fn find_sort_title() {
     let tmp = setup_vault();
     let (status, json, stderr) = find_json(&tmp, &["--sort", "title"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 4);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     // Title uses extract_title: frontmatter title first, then first H1.
@@ -2579,7 +2586,7 @@ No frontmatter, no heading.
     );
     let (status, json, stderr) = find_json(&tmp, &["--sort", "title"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files[0], "a.md");
     assert_eq!(files[1], "b.md", "file without any title should sort last");
@@ -2590,7 +2597,7 @@ fn find_sort_property_generic() {
     let tmp = setup_vault();
     let (status, json, stderr) = find_json(&tmp, &["--sort", "property:status"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     // completed < planned (alphabetically), gamma.md (no status) sorts last
     assert_eq!(files[0], "beta.md", "completed should sort first");
@@ -2607,7 +2614,7 @@ fn find_sort_title_without_fields_title() {
     let tmp = setup_vault();
     let (status, json, stderr) = find_json(&tmp, &["--sort", "title", "--fields", "tags"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files[0], "alpha.md");
     // Verify title field is NOT in output (user excluded it via --fields)
@@ -2624,7 +2631,7 @@ fn find_sort_property_without_fields_properties() {
     let (status, json, stderr) =
         find_json(&tmp, &["--sort", "property:status", "--fields", "tags"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files[0], "beta.md", "completed should sort first");
     // Verify properties field is NOT in output (user excluded it via --fields)
@@ -2672,7 +2679,7 @@ Content.
     );
     let (status, json, stderr) = find_json(&tmp, &["--sort", "date"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files[0], "older.md", "2024 should sort before 2026");
     assert_eq!(files[1], "newer.md");
@@ -2788,7 +2795,7 @@ fn find_title_from_frontmatter() {
     let (status, json, stderr) =
         find_json(&tmp, &["--file", "with_fm_title.md", "--fields", "title"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let obj = &arr[0];
     assert_eq!(
@@ -2811,7 +2818,7 @@ fn find_title_from_h1_when_no_frontmatter_property() {
     let (status, json, stderr) =
         find_json(&tmp, &["--file", "with_h1_title.md", "--fields", "title"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let obj = &arr[0];
     assert_eq!(
@@ -2826,7 +2833,7 @@ fn find_title_null_when_neither_found() {
     let tmp = setup_title_vault();
     let (status, json, stderr) = find_json(&tmp, &["--file", "no_title.md", "--fields", "title"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let obj = &arr[0];
     assert!(
@@ -2840,7 +2847,7 @@ fn find_title_not_present_by_default() {
     let tmp = setup_title_vault();
     let (status, json, stderr) = find_json(&tmp, &["--file", "with_fm_title.md"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let obj = &arr[0];
     assert!(
@@ -2855,7 +2862,7 @@ fn find_fields_all_includes_title() {
     let (status, json, stderr) =
         find_json(&tmp, &["--file", "with_fm_title.md", "--fields", "all"]);
     assert!(status.success(), "stderr: {stderr}");
-    let arr = json.as_array().unwrap();
+    let arr = unwrap_results(&json);
     assert_eq!(arr.len(), 1);
     let obj = &arr[0];
     assert!(
@@ -3025,9 +3032,10 @@ fn find_sort_title_reverse() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
     // Titles should be in reverse alphabetical order
-    let titles: Vec<&str> = json.iter().filter_map(|v| v["title"].as_str()).collect();
+    let titles: Vec<&str> = results.iter().filter_map(|v| v["title"].as_str()).collect();
     let mut sorted = titles.clone();
     sorted.sort();
     sorted.reverse();
@@ -3086,8 +3094,9 @@ fn find_reverse_alone() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
-    let files: Vec<&str> = json.iter().filter_map(|v| v["file"].as_str()).collect();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
+    let files: Vec<&str> = results.iter().filter_map(|v| v["file"].as_str()).collect();
     let mut expected = files.clone();
     expected.sort();
     expected.reverse();
@@ -3116,13 +3125,14 @@ fn find_title_h1_match() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
     assert_eq!(
-        json.len(),
+        results.len(),
         1,
-        "expected exactly 1 match for 'gamma': {json:?}"
+        "expected exactly 1 match for 'gamma': {results:?}"
     );
-    assert_eq!(json[0]["file"], "gamma.md");
+    assert_eq!(results[0]["file"], "gamma.md");
 }
 
 #[test]
@@ -3139,13 +3149,14 @@ fn find_title_case_insensitive() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
     assert_eq!(
-        json.len(),
+        results.len(),
         1,
-        "expected exactly 1 match for 'ALPHA': {json:?}"
+        "expected exactly 1 match for 'ALPHA': {results:?}"
     );
-    assert_eq!(json[0]["file"], "alpha.md");
+    assert_eq!(results[0]["file"], "alpha.md");
 }
 
 #[test]
@@ -3162,11 +3173,12 @@ fn find_title_regex_mode() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
     assert_eq!(
-        json.len(),
+        results.len(),
         2,
-        "expected exactly 2 matches for regex: {json:?}"
+        "expected exactly 2 matches for regex: {results:?}"
     );
 }
 
@@ -3185,10 +3197,11 @@ fn find_title_frontmatter_match() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
     assert!(
-        json.iter().any(|v| v["file"] == "alpha.md"),
-        "should match frontmatter title 'Alpha' for pattern 'alph': {json:?}"
+        results.iter().any(|v| v["file"] == "alpha.md"),
+        "should match frontmatter title 'Alpha' for pattern 'alph': {results:?}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -128,11 +128,16 @@ fn run_find(tmp: &TempDir, extra_args: &[&str]) -> serde_json::Value {
     })
 }
 
-/// Extract and sort file paths from a find JSON array.
-fn sorted_files(json: &serde_json::Value) -> Vec<String> {
-    let mut files: Vec<String> = json
+/// Helper: extract the results array from a `{total, results}` envelope.
+fn unwrap_results(json: &serde_json::Value) -> &Vec<serde_json::Value> {
+    json["results"]
         .as_array()
-        .unwrap()
+        .expect("expected {total, results} envelope")
+}
+
+/// Extract and sort file paths from a find JSON envelope.
+fn sorted_files(json: &serde_json::Value) -> Vec<String> {
+    let mut files: Vec<String> = unwrap_results(json)
         .iter()
         .map(|v| v["file"].as_str().unwrap().to_owned())
         .collect();
@@ -275,11 +280,9 @@ fn find_with_index_preserves_properties() {
     let index_json = run_find(&tmp, &["--index", index_path.to_str().unwrap()]);
 
     // For each file returned by disk scan, check that index scan has matching properties.
-    for disk_entry in disk_json.as_array().unwrap() {
+    for disk_entry in unwrap_results(&disk_json) {
         let file = disk_entry["file"].as_str().unwrap();
-        let index_entry = index_json
-            .as_array()
-            .unwrap()
+        let index_entry = unwrap_results(&index_json)
             .iter()
             .find(|v| v["file"].as_str().unwrap() == file)
             .unwrap_or_else(|| panic!("file {file} missing from index scan"));
@@ -314,7 +317,7 @@ fn find_with_index_property_filter() {
     assert_eq!(files, vec!["alpha.md", "gamma.md"]);
 
     // Verify properties show status=draft for each result.
-    for entry in json.as_array().unwrap() {
+    for entry in unwrap_results(&json) {
         assert_eq!(
             entry["properties"]["status"].as_str().unwrap(),
             "draft",
@@ -368,7 +371,7 @@ fn find_with_index_content_search_no_match() {
         ],
     );
 
-    assert!(json.as_array().unwrap().is_empty());
+    assert!(unwrap_results(&json).is_empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -662,7 +665,7 @@ fn incompatible_index_falls_back_to_disk_scan() {
     // Results should still contain all 4 vault files.
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
-        json.as_array().unwrap().len(),
+        unwrap_results(&json).len(),
         4,
         "expected 4 files from disk fallback"
     );
@@ -746,9 +749,9 @@ fn set_with_index_updates_index_for_subsequent_find() {
     let files = sorted_files(&json);
     assert_eq!(files, vec!["alpha.md"]);
     assert_eq!(
-        json.as_array().unwrap()[0]["properties"]["reviewed"]
+        unwrap_results(&json)[0]["properties"]["reviewed"]
             .as_str()
-            .or_else(|| json.as_array().unwrap()[0]["properties"]["reviewed"]
+            .or_else(|| unwrap_results(&json)[0]["properties"]["reviewed"]
                 .as_bool()
                 .map(|_| "true")),
         Some("true"),
@@ -772,7 +775,7 @@ fn remove_with_index_updates_index_for_subsequent_find() {
             index_path.to_str().unwrap(),
         ],
     );
-    assert_eq!(before.as_array().unwrap().len(), 1);
+    assert_eq!(unwrap_results(&before).len(), 1);
 
     // Remove the status property via --index
     run_with_index(
@@ -850,7 +853,7 @@ fn task_toggle_with_index_updates_index() {
             index_path.to_str().unwrap(),
         ],
     );
-    let todo_tasks: Vec<&serde_json::Value> = before.as_array().unwrap()[0]["tasks"]
+    let todo_tasks: Vec<&serde_json::Value> = unwrap_results(&before)[0]["tasks"]
         .as_array()
         .unwrap()
         .iter()
@@ -888,7 +891,7 @@ fn task_toggle_with_index_updates_index() {
             index_path.to_str().unwrap(),
         ],
     );
-    let tasks = after.as_array().unwrap()[0]["tasks"].as_array().unwrap();
+    let tasks = unwrap_results(&after)[0]["tasks"].as_array().unwrap();
     let toggled = tasks
         .iter()
         .find(|t| t["line"].as_u64().unwrap() == task_line)
@@ -975,7 +978,7 @@ fn tags_rename_with_index_updates_index() {
         &["--tag", "cli", "--index", index_path.to_str().unwrap()],
     );
     assert!(
-        old.as_array().unwrap().is_empty(),
+        unwrap_results(&old).is_empty(),
         "old tag 'cli' should match nothing after rename"
     );
 }
@@ -1022,7 +1025,7 @@ fn properties_rename_with_index_updates_index() {
         ],
     );
     assert!(
-        old.as_array().unwrap().is_empty(),
+        unwrap_results(&old).is_empty(),
         "old property 'priority' should match nothing after rename"
     );
 }
@@ -1059,7 +1062,7 @@ fn chained_mutations_with_index_keep_index_consistent() {
             index_path.to_str().unwrap(),
         ],
     );
-    let entry = &json.as_array().unwrap()[0];
+    let entry = &unwrap_results(&json)[0];
     assert_eq!(entry["properties"]["status"], "archived");
     let tags: Vec<&str> = entry["tags"]
         .as_array()
@@ -1078,7 +1081,7 @@ fn chained_mutations_with_index_keep_index_consistent() {
 
     // Now do a fresh disk scan (no --index) and verify it matches
     let disk_json = run_find(&tmp, &["--file", "alpha.md"]);
-    let disk_entry = &disk_json.as_array().unwrap()[0];
+    let disk_entry = &unwrap_results(&disk_json)[0];
     assert_eq!(disk_entry["properties"]["status"], "archived");
     let disk_tags: Vec<&str> = disk_entry["tags"]
         .as_array()
@@ -1298,9 +1301,7 @@ Content
     );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let files: Vec<&str> = json
-        .as_array()
-        .unwrap()
+    let files: Vec<&str> = unwrap_results(&json)
         .iter()
         .map(|v| v["file"].as_str().unwrap())
         .collect();
@@ -1367,9 +1368,7 @@ Target content
     );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let files: Vec<&str> = json
-        .as_array()
-        .unwrap()
+    let files: Vec<&str> = unwrap_results(&json)
         .iter()
         .map(|v| v["file"].as_str().unwrap())
         .collect();

--- a/crates/hyalo-cli/tests/e2e_jq.rs
+++ b/crates/hyalo-cli/tests/e2e_jq.rs
@@ -90,7 +90,7 @@ fn jq_works_on_find_property_filter() {
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["--jq", ".[].file"])
+        .args(["--jq", ".results[].file"])
         .args(["find", "--property", "status=draft"])
         .output()
         .unwrap();
@@ -117,7 +117,7 @@ fn jq_works_on_find_links() {
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["--jq", ".[0].links | length"])
+        .args(["--jq", ".results[0].links | length"])
         .args(["find", "--file", "source.md", "--fields", "links"])
         .output()
         .unwrap();
@@ -142,7 +142,7 @@ fn jq_works_on_find_sections() {
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["--jq", ".[0].sections | length"])
+        .args(["--jq", ".results[0].sections | length"])
         .args(["find", "--file", "doc.md", "--fields", "sections"])
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e_links.rs
+++ b/crates/hyalo-cli/tests/e2e_links.rs
@@ -241,7 +241,9 @@ fn find_broken_links_filter() {
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
 
-    let results = json.as_array().expect("find output should be a JSON array");
+    let results = json["results"]
+        .as_array()
+        .expect("find output should have a results array");
 
     // b.md and d.md have broken links; they must appear
     let files: Vec<&str> = results
@@ -294,7 +296,9 @@ fn find_broken_links_entries_have_null_path() {
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
 
-    let results = json.as_array().expect("find output should be a JSON array");
+    let results = json["results"]
+        .as_array()
+        .expect("find output should have a results array");
 
     // Each returned file should have at least one link entry with path = null
     for result in results {
@@ -339,7 +343,9 @@ fn find_broken_links_combined_with_glob_filter() {
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
 
-    let results = json.as_array().expect("find output should be a JSON array");
+    let results = json["results"]
+        .as_array()
+        .expect("find output should have a results array");
     let files: Vec<&str> = results
         .iter()
         .map(|r| r["file"].as_str().unwrap_or(""))

--- a/crates/hyalo-cli/tests/e2e_properties.rs
+++ b/crates/hyalo-cli/tests/e2e_properties.rs
@@ -4,6 +4,13 @@ use common::{hyalo, md, sample_frontmatter, write_md};
 use std::fs;
 use tempfile::TempDir;
 
+/// Helper: extract the results array from a `{total, results}` envelope.
+fn unwrap_results(json: &serde_json::Value) -> &Vec<serde_json::Value> {
+    json["results"]
+        .as_array()
+        .expect("expected {total, results} envelope")
+}
+
 // ---------------------------------------------------------------------------
 // `hyalo properties summary` — aggregate property summary
 // ---------------------------------------------------------------------------
@@ -201,9 +208,12 @@ fn find_properties_single_file() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json.len(), 1);
-    let entry = &json[0];
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = json["results"]
+        .as_array()
+        .expect("{total, results} envelope");
+    assert_eq!(results.len(), 1);
+    let entry = &results[0];
     assert_eq!(entry["file"], "file.md");
 
     let props = entry["properties"]
@@ -262,10 +272,11 @@ title: Sub B
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json.len(), 2);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = unwrap_results(&json);
+    assert_eq!(results.len(), 2);
 
-    let paths: Vec<&str> = json
+    let paths: Vec<&str> = results
         .iter()
         .map(|v| v["file"].as_str().expect("field 'file' should be a string"))
         .collect();
@@ -284,10 +295,11 @@ fn find_properties_file_without_frontmatter() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json.len(), 1);
-    assert_eq!(json[0]["file"], "plain.md");
-    let props = json[0]["properties"].as_object().unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = unwrap_results(&json);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["file"], "plain.md");
+    let props = results[0]["properties"].as_object().unwrap();
     assert!(props.is_empty());
 }
 

--- a/crates/hyalo-cli/tests/e2e_short_flags.rs
+++ b/crates/hyalo-cli/tests/e2e_short_flags.rs
@@ -137,7 +137,11 @@ fn find_short_n_for_limit() {
         .unwrap();
     assert!(output.status.success());
     let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(v.as_array().unwrap().len(), 1);
+    // Limit truncates 2 files to 1, so output is an envelope {total, results}.
+    let results = v
+        .as_array()
+        .unwrap_or_else(|| v["results"].as_array().expect("expected array or envelope"));
+    assert_eq!(results.len(), 1);
 }
 
 // -- read: -f, -s, -l ------------------------------------------------------

--- a/crates/hyalo-cli/tests/e2e_site_prefix.rs
+++ b/crates/hyalo-cli/tests/e2e_site_prefix.rs
@@ -50,8 +50,9 @@ fn find_links(dir_arg: &str) -> serde_json::Value {
 }
 
 fn extract_link_paths(json: &serde_json::Value) -> Vec<String> {
-    json.as_array()
-        .unwrap()
+    json["results"]
+        .as_array()
+        .expect("expected {total, results} envelope")
         .iter()
         .flat_map(|entry| {
             entry["links"]

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -1177,3 +1177,72 @@ No links.
     assert!(json["dead_ends"]["files"].as_array().unwrap().is_empty());
     assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 2);
 }
+
+/// Dead-end results must be identical between disk-scan and index-based summary.
+#[test]
+fn summary_dead_end_parity_disk_vs_index() {
+    let tmp = setup_dead_end_vault();
+    let dir_str = tmp.path().to_str().unwrap();
+
+    // Disk scan
+    let disk_out = hyalo()
+        .args(["--dir", dir_str, "summary", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        disk_out.status.success(),
+        "disk summary failed: {}",
+        String::from_utf8_lossy(&disk_out.stderr)
+    );
+    let disk_json: serde_json::Value = serde_json::from_slice(&disk_out.stdout).unwrap();
+    let disk_dead_ends: Vec<&str> = disk_json["dead_ends"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+
+    // Create index
+    let idx_create = hyalo()
+        .args(["--dir", dir_str, "create-index"])
+        .output()
+        .unwrap();
+    assert!(
+        idx_create.status.success(),
+        "create-index failed: {}",
+        String::from_utf8_lossy(&idx_create.stderr)
+    );
+
+    // Index-based summary
+    let index_path = tmp.path().join(".hyalo-index");
+    let idx_out = hyalo()
+        .args([
+            "--dir",
+            dir_str,
+            "--index",
+            index_path.to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        idx_out.status.success(),
+        "index summary failed: {}",
+        String::from_utf8_lossy(&idx_out.stderr)
+    );
+    let idx_json: serde_json::Value = serde_json::from_slice(&idx_out.stdout).unwrap();
+    let idx_dead_ends: Vec<&str> = idx_json["dead_ends"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+
+    assert_eq!(
+        disk_dead_ends, idx_dead_ends,
+        "disk scan and index dead-end lists must match"
+    );
+    assert_eq!(disk_dead_ends, vec!["c.md"]);
+}

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -1000,3 +1000,180 @@ No links.
     );
     assert_eq!(disk_orphans, vec!["orphan.md"]);
 }
+
+// ---------------------------------------------------------------------------
+// Dead-end detection
+// ---------------------------------------------------------------------------
+
+/// Build a vault where:
+/// - a.md links to b and c (has outbound, no inbound → not a dead-end, not an orphan)
+/// - b.md links to c (has inbound from a, has outbound → not a dead-end)
+/// - c.md has no links but is linked to by a and b → dead-end
+/// - d.md has no links and nothing links to it → orphan
+fn setup_dead_end_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+[[b]]
+[[c]]
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+[[c]]
+"),
+    );
+    write_md(
+        tmp.path(),
+        "c.md",
+        md!(r"
+---
+title: C
+---
+No links.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "d.md",
+        md!(r"
+---
+title: D
+---
+No links.
+"),
+    );
+
+    tmp
+}
+
+#[test]
+fn summary_dead_ends_json() {
+    let tmp = setup_dead_end_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert!(
+        json["dead_ends"]["total"].is_number(),
+        "dead_ends.total should be a number"
+    );
+    assert!(
+        json["dead_ends"]["files"].is_array(),
+        "dead_ends.files should be an array"
+    );
+
+    assert_eq!(
+        json["dead_ends"]["total"].as_u64().unwrap(),
+        1,
+        "expected 1 dead-end"
+    );
+    let dead_end_files: Vec<&str> = json["dead_ends"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(dead_end_files, vec!["c.md"]);
+
+    // d.md is the orphan, not a dead-end
+    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 1);
+    let orphan_files: Vec<&str> = json["orphans"]["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(orphan_files, vec!["d.md"]);
+}
+
+#[test]
+fn summary_dead_ends_text_format() {
+    let tmp = setup_dead_end_vault();
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let text = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        text.contains("Dead-ends: 1"),
+        "expected 'Dead-ends: 1' in: {text}"
+    );
+    assert!(
+        text.contains("\"c.md\""),
+        "expected dead-end file listed in: {text}"
+    );
+}
+
+#[test]
+fn summary_dead_ends_empty_when_no_links() {
+    let tmp = TempDir::new().unwrap();
+
+    // Two isolated files: both are orphans, neither is a dead-end
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+No links.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+No links.
+"),
+    );
+
+    let output = hyalo()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["dead_ends"]["total"].as_u64().unwrap(), 0);
+    assert!(json["dead_ends"]["files"].as_array().unwrap().is_empty());
+    assert_eq!(json["orphans"]["total"].as_u64().unwrap(), 2);
+}

--- a/crates/hyalo-cli/tests/e2e_tags.rs
+++ b/crates/hyalo-cli/tests/e2e_tags.rs
@@ -3,6 +3,13 @@ mod common;
 use common::{hyalo, md, write_md, write_tagged};
 use tempfile::TempDir;
 
+/// Helper: extract the results array from a `{total, results}` envelope.
+fn unwrap_results(json: &serde_json::Value) -> &Vec<serde_json::Value> {
+    json["results"]
+        .as_array()
+        .expect("expected {total, results} envelope")
+}
+
 // ---------------------------------------------------------------------------
 // `hyalo tags summary` — aggregate tag summary
 // ---------------------------------------------------------------------------
@@ -192,7 +199,8 @@ fn find_tag_exact_match() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let json = unwrap_results(&json);
     assert_eq!(json.len(), 1);
     assert!(json[0]["file"].as_str().unwrap().contains("a.md"));
 }
@@ -212,7 +220,8 @@ fn find_tag_nested_match() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let json = unwrap_results(&json);
     assert_eq!(json.len(), 3);
     let paths: Vec<&str> = json.iter().map(|e| e["file"].as_str().unwrap()).collect();
     assert!(paths.iter().any(|f| f.contains("a.md")));
@@ -233,7 +242,8 @@ fn find_tag_no_match_returns_empty_array() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let json = unwrap_results(&json);
     assert!(json.is_empty());
 }
 
@@ -251,7 +261,8 @@ fn find_tag_with_glob() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let json = unwrap_results(&json);
     assert_eq!(json.len(), 1);
     let paths: Vec<&str> = json.iter().map(|e| e["file"].as_str().unwrap()).collect();
     assert!(paths.iter().any(|f| f.contains("sub/a.md")));
@@ -270,7 +281,8 @@ fn find_tag_case_insensitive() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let json = unwrap_results(&json);
     assert_eq!(json.len(), 1);
 }
 
@@ -528,7 +540,8 @@ fn find_tag_empty_tags_list() {
         .unwrap();
 
     assert!(output.status.success());
-    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let json = unwrap_results(&json);
     assert!(json.is_empty());
 }
 

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -130,6 +130,7 @@ pub struct TaskReadResult {
 pub struct VaultSummary {
     pub files: FileCounts,
     pub orphans: OrphanSummary,
+    pub dead_ends: DeadEndSummary,
     pub links: LinkHealthSummary,
     pub properties: Vec<PropertySummaryEntry>,
     pub tags: TagSummary,
@@ -158,6 +159,16 @@ pub struct BrokenLinkInfo {
 /// outbound links (they don't link to anything).
 #[derive(Debug, Clone, Serialize)]
 pub struct OrphanSummary {
+    pub total: usize,
+    pub files: Vec<String>,
+}
+
+/// Navigation dead-ends: files that have inbound links (something links to
+/// them) but no outbound links (they don't link to anything else).
+/// Orphans (no inbound AND no outbound) are excluded — they are reported
+/// separately.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeadEndSummary {
     pub total: usize,
     pub files: Vec<String>,
 }

--- a/hyalo-knowledgebase/backlog/find-limit-memory-optimization.md
+++ b/hyalo-knowledgebase/backlog/find-limit-memory-optimization.md
@@ -1,9 +1,9 @@
 ---
-title: "Reduce memory usage when find --limit + --sort file are combined"
+title: Reduce memory usage when find --limit + --sort file are combined
 type: backlog
-status: planned
+status: completed
 date: 2026-03-29
-origin: PR #78 review — Copilot flagged memory cost of accumulating all results
+origin: PR
 priority: low
 tags:
   - find

--- a/hyalo-knowledgebase/backlog/find-limit-memory-optimization.md
+++ b/hyalo-knowledgebase/backlog/find-limit-memory-optimization.md
@@ -1,0 +1,51 @@
+---
+title: "Reduce memory usage when find --limit + --sort file are combined"
+type: backlog
+status: planned
+date: 2026-03-29
+origin: PR #78 review — Copilot flagged memory cost of accumulating all results
+priority: low
+tags:
+  - find
+  - performance
+---
+
+## Problem
+
+When `--limit N` is used, `find` accumulates all matching `FileObject`s in memory before
+truncating to N. This is needed to compute the accurate `total` in the results envelope.
+On large vaults (10k+ files), this causes an unnecessary memory spike when the caller only
+wants a few results.
+
+## Proposal
+
+When `--sort file` is **explicitly** specified and `--limit` is active (and no `--reverse`),
+stop pushing results after N matches but continue scanning to count the total:
+
+```rust
+total_matching += 1;
+if results.len() < limit {
+    results.push(obj);
+}
+// else: obj dropped immediately, only counter advances
+```
+
+This reduces memory from O(all matches) to O(limit) while still reporting an accurate total.
+
+### Conditions for the optimization
+
+- `--limit` is present
+- `--sort file` is explicitly passed (not the implicit default — without explicit sort,
+  filesystem traversal order is non-deterministic)
+- `!reverse`
+- `!fields.backlinks` (backlink sort needs all results)
+
+### Why not the default sort?
+
+Without `--sort`, file order depends on `readdir` which varies across OS/filesystem. The
+first N files encountered would be arbitrary, giving different results each run.
+
+## Scope
+
+- Both `find()` and `find_from_index()` paths
+- Add e2e test confirming deterministic results with `--sort file --limit N`

--- a/hyalo-knowledgebase/backlog/find-limit-total-count.md
+++ b/hyalo-knowledgebase/backlog/find-limit-total-count.md
@@ -1,0 +1,32 @@
+---
+title: Show total match count when --limit truncates results
+type: backlog
+status: completed
+date: 2026-03-29
+origin: dogfood v0.6.0 tidy round
+priority: medium
+tags:
+  - find
+  - ux
+---
+
+## Problem
+
+When using `--limit N`, the output is silently truncated. There's no way to know whether
+there were N+1 or N+10,000 matches without running a second query with `--jq 'length'`.
+
+This came up repeatedly during dogfooding: agents ran the same query twice — once with
+`--limit 5` for examples, once with `--jq 'length'` for the count.
+
+## Proposal
+
+When `--limit` is active, always report the total number of matches:
+
+**Text mode:** append a line like `showing 5 of 342 matches`
+
+**JSON mode:** wrap output in an envelope:
+```json
+{"total": 342, "results": [...5 items...]}
+```
+
+When `--limit` is not used, output stays unchanged (flat array / plain list).

--- a/hyalo-knowledgebase/backlog/summary-dead-ends.md
+++ b/hyalo-knowledgebase/backlog/summary-dead-ends.md
@@ -1,0 +1,49 @@
+---
+title: Add dead-end detection to summary command
+type: backlog
+status: completed
+date: 2026-03-29
+origin: dogfood v0.6.0 tidy round
+priority: medium
+tags:
+  - summary
+  - links
+  - ux
+---
+
+## Context
+
+The `summary` command reports **orphans** (files with no inbound AND no outbound links — fully
+isolated, matching Obsidian/Foam's graph-view definition). This is correct and should stay.
+
+Missing: **dead-ends** — files that have inbound links but no outbound links. These are
+navigation dead-ends: a user can arrive there but has nowhere to go next.
+
+Wikipedia defines these as ["dead-end pages"](https://en.wikipedia.org/wiki/Wikipedia:Dead-end_pages).
+
+## Proposal
+
+Add a `dead_ends` section to `summary` output alongside `orphans`:
+
+```json
+{
+  "orphans": { "total": 25, "files": [...] },
+  "dead_ends": { "total": 42, "files": [...] }
+}
+```
+
+Text format:
+
+```
+Orphans (isolated, no links in/out):  25 files
+Dead-ends (no outbound links):        42 files
+```
+
+## Design consideration
+
+Many dead-ends are not actionable — e.g. top-level files in root or well-known directories
+like `/iterations/` that users navigate to by browsing, not by following links. Consider:
+
+- Not flagging files in root or first-level directories by default
+- A `--strict` flag to include all dead-ends
+- Or just reporting the count and letting `find --fields links --jq ...` drill down

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -369,3 +369,75 @@ Supports `--file`, `--glob`, and vault-wide mode (unlike `links` which is single
 **Consequences:**
 - No output sanitization, escaping, or filtering added to hyalo
 - If hyalo ever adds a server mode (MCP server, HTTP API) serving vault content to remote/untrusted clients, this decision should be revisited — trust boundaries change in that scenario
+
+## DEC-036: Orphan vs Dead-End Terminology (2026-03-29)
+
+**Context:** During v0.6.0 dogfood tidy across 3 external repos, the `summary` command's orphan count (25 in vscode-docs) diverged from a `find --fields backlinks` query filtering for zero backlinks (56 files). Investigation revealed `summary` defines orphans as files with **no inbound AND no outbound links** (fully isolated), matching Obsidian Graph View and Foam. The backlinks-based query finds files with **no inbound links** (unreachable), matching the Wikipedia/SEO definition.
+
+Research across tools:
+- **Wikipedia/SEO** (older, broader): orphan = no inbound links; dead-end = no outbound links
+- **Obsidian Graph View / Foam / Logseq**: orphan = no links in either direction (isolated)
+
+**Decision:** Keep hyalo's orphan definition as-is (no inbound AND no outbound = fully isolated, consistent with Obsidian). Add a new **dead-end** concept: files with no outbound links, regardless of inbound links.
+
+**Why:** Both definitions are useful. Orphans (isolated files) are clearly disconnected. Dead-ends (no outbound links) flag navigation dead-ends where users arrive but have nowhere to go. Note: many dead-ends are not actionable — top-level files in root or well-known directories (e.g. `/iterations/`) are easily accessible by browsing and don't need outbound links.
+
+**Consequences:**
+- `summary` gains a `dead_ends` section alongside `orphans`
+- No change to existing orphan behavior
+- See [[iterations/iteration-67-summary-enhancements]]
+
+## DEC-037: Won't Fix — False-Positive Links from Square Brackets in Body Text (2026-03-29)
+
+**Context:** Dogfood on legalize-es (8,643 files) found 3 broken links that were false positives: markdown reference-style links like `[Opcion][1]` (where `[1]` is a ref label) and math expressions in square brackets like `[0,35 * kms.recorridos]`. This was flagged in v0.5.0 round 2 and again in v0.6.0.
+
+**Decision:** Won't fix.
+
+**Why:**
+
+1. **Negligible rate.** 3 false positives in 8,643 files (0.03%). The other two repos (3,520 and 339 files) had zero false positives of this type.
+
+2. **Reference-style links are real markdown syntax.** `[text][ref]` IS a valid markdown link — the issue is that hyalo doesn't resolve reference-link definitions (`[1]: http://...`). Adding a full reference-link resolver is significant parser work for near-zero practical impact.
+
+3. **Square brackets in prose are ambiguous.** Distinguishing `[math expression]` from `[link text]` in raw markdown is impossible without full rendering context. Any heuristic would be fragile.
+
+**Consequences:**
+- No changes to link parsing
+- Accept occasional false positives on repos with heavy use of reference-style links or mathematical notation
+- If this becomes a real problem for a specific repo, `--quiet` suppresses warnings
+
+## DEC-038: Won't Fix — Template/Liquid Syntax in Links (2026-03-29)
+
+**Context:** Dogfood on docs/content (Hugo, 3,520 files) flagged thousands of "broken" links that contain Liquid template syntax like `{% ifversion ghes %}...{% endif %}`. These links are dynamically expanded at Hugo build time and work correctly on the live site.
+
+**Decision:** Won't fix. Hyalo is a static analysis tool operating on raw markdown files — it cannot and should not evaluate template engines.
+
+**Why:**
+
+1. **Unbounded scope.** Hugo uses Go templates, Jekyll uses Liquid, Docusaurus uses JSX — supporting any template engine means supporting all of them.
+
+2. **Correct behavior.** Reporting these as broken is technically accurate: the raw link target does not resolve to a file. The user knows their build pipeline expands these.
+
+3. **Workaround exists.** Users can filter template-heavy files with `--glob '!**/template-dir/**'` or pipe through `--jq` to exclude links matching template patterns.
+
+**Consequences:**
+- No template-aware link resolution
+- Documentation/SKILL.md could note this as expected behavior for SSG repos
+
+## DEC-039: Won't Fix — `children` Frontmatter as Implicit Links (2026-03-29)
+
+**Context:** Hugo's docs/content repo uses a `children` frontmatter property (list of page paths) to define navigation hierarchy. Since hyalo only counts `[[wikilinks]]` and `[markdown](links)` in the body as links, 52% of files appeared as orphans despite being reachable via the `children` navigation tree.
+
+**Decision:** Won't fix. Frontmatter properties are data, not links.
+
+**Why:**
+
+1. **Convention-specific.** `children` is a Hugo convention. Other SSGs use `sidebar`, `nav`, `menu`, `weight`, or directory structure. There's no universal standard.
+
+2. **Semantic ambiguity.** A frontmatter list of paths could be references, related content, aliases, or data — hyalo can't infer intent from the key name alone.
+
+3. **Workaround exists.** Users can exclude known navigation-structured directories from orphan analysis, or use `--jq` to subtract files listed in `children` properties from the orphan set.
+
+**Consequences:**
+- Orphan counts will be inflated for SSG repos that use frontmatter-based navigation
+- This is expected and documented behavior, not a bug

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -378,9 +378,9 @@ Research across tools:
 - **Wikipedia/SEO** (older, broader): orphan = no inbound links; dead-end = no outbound links
 - **Obsidian Graph View / Foam / Logseq**: orphan = no links in either direction (isolated)
 
-**Decision:** Keep hyalo's orphan definition as-is (no inbound AND no outbound = fully isolated, consistent with Obsidian). Add a new **dead-end** concept: files with no outbound links, regardless of inbound links.
+**Decision:** Keep hyalo's orphan definition as-is (no inbound AND no outbound = fully isolated, consistent with Obsidian). Add a new **dead-end** concept: files that have inbound links but no outbound links (orphans are excluded and reported separately).
 
-**Why:** Both definitions are useful. Orphans (isolated files) are clearly disconnected. Dead-ends (no outbound links) flag navigation dead-ends where users arrive but have nowhere to go. Note: many dead-ends are not actionable — top-level files in root or well-known directories (e.g. `/iterations/`) are easily accessible by browsing and don't need outbound links.
+**Why:** Both definitions are useful. Orphans (isolated files) are clearly disconnected. Dead-ends (inbound links but no outbound links, excluding orphans) flag navigation dead-ends where users arrive but have nowhere to go. Note: many dead-ends are not actionable — top-level files in root or well-known directories (e.g. `/iterations/`) are easily accessible by browsing and don't need outbound links.
 
 **Consequences:**
 - `summary` gains a `dead_ends` section alongside `orphans`

--- a/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
+++ b/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
@@ -41,6 +41,17 @@ See [[backlog/summary-dead-ends]]
 
 See [[backlog/find-limit-total-count]]
 
+### Memory optimisation: find --limit with pre-sorted iteration
+
+- [x] Scan path: pre-sort file list when `--sort file` + `--limit` + `!reverse`
+- [x] Index path: pre-sort entries by any sort key (except backlinks_count) when `--limit` + `!reverse`
+- [x] Skip FileObject construction once limit reached (count-only mode)
+- [x] Both `find()` and `find_from_index()` paths
+- [x] E2e test: deterministic results with `--sort file --limit N`
+- [x] E2e test: accurate total with filters + `--sort file --limit`
+
+See [[backlog/find-limit-memory-optimization]]
+
 ### Quality gates
 
 - [x] `cargo fmt`

--- a/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
+++ b/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
@@ -22,7 +22,7 @@ the v0.6.0 tidy round (tested on 3 external repos: docs/content 3520 files, vsco
 
 ### Dead-end detection in summary
 
-- [x] Add dead-end detection: files with no outbound links (regardless of inbound)
+- [x] Add dead-end detection: files that have inbound links and no outbound links (excluding orphans)
 - [x] Add `dead_ends` section to summary JSON output: `{"total": N, "files": [...]}`
 - [x] Add dead-end line to summary text output
 - [x] Add unit tests for dead-end detection

--- a/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
+++ b/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
@@ -33,11 +33,10 @@ See [[backlog/summary-dead-ends]]
 
 ### Show total count when --limit truncates
 
-- [x] When `--limit` is active on `find`, compute total match count before truncating
-- [x] JSON output: wrap in `{"total": N, "results": [...]}` envelope when `--limit` is used
-- [x] Text output: append `showing N of M matches` line when `--limit` is used
-- [x] When `--limit` is not used, output stays unchanged (no envelope)
-- [x] Add e2e tests for `--limit` with total count in both formats
+- [x] Compute total match count; when `--limit` is active, compute before truncating
+- [x] JSON output: always wrap in `{"total": N, "results": [...]}` envelope (stable schema)
+- [x] Text output: append `showing N of M matches` line when `--limit` truncates
+- [x] Add e2e tests for find JSON envelope (both limited and unlimited) and text --limit total count
 - [x] Verify `--limit` + `--jq` interaction works correctly (jq operates on the envelope)
 
 See [[backlog/find-limit-total-count]]

--- a/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
+++ b/hyalo-knowledgebase/iterations/iteration-67-summary-enhancements.md
@@ -1,0 +1,49 @@
+---
+title: "Iteration 67: Summary command enhancements"
+type: iteration
+date: 2026-03-29
+status: in-progress
+branch: iter-67/summary-enhancements
+tags:
+  - iteration
+  - summary
+  - ux
+---
+
+# Iteration 67 — Summary Command Enhancements
+
+## Goal
+
+Improve the `summary` command and `find --limit` output based on dogfood findings from
+the v0.6.0 tidy round (tested on 3 external repos: docs/content 3520 files, vscode-docs
+339 files, legalize-es 8643 files).
+
+## Tasks
+
+### Dead-end detection in summary
+
+- [x] Add dead-end detection: files with no outbound links (regardless of inbound)
+- [x] Add `dead_ends` section to summary JSON output: `{"total": N, "files": [...]}`
+- [x] Add dead-end line to summary text output
+- [x] Add unit tests for dead-end detection
+- [x] Add e2e tests for dead-end output in both JSON and text formats
+- [x] Dogfood on external repos to verify dead-end counts are reasonable
+
+See [[backlog/summary-dead-ends]]
+
+### Show total count when --limit truncates
+
+- [x] When `--limit` is active on `find`, compute total match count before truncating
+- [x] JSON output: wrap in `{"total": N, "results": [...]}` envelope when `--limit` is used
+- [x] Text output: append `showing N of M matches` line when `--limit` is used
+- [x] When `--limit` is not used, output stays unchanged (no envelope)
+- [x] Add e2e tests for `--limit` with total count in both formats
+- [x] Verify `--limit` + `--jq` interaction works correctly (jq operates on the envelope)
+
+See [[backlog/find-limit-total-count]]
+
+### Quality gates
+
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`


### PR DESCRIPTION
## Summary
- **Dead-end detection**: `summary` now reports dead-end files (inbound links but no outbound) alongside orphans, in both JSON and text formats
- **Find results envelope**: `find` always returns `{"total": N, "results": [...]}` — stable schema for all callers
- **--limit total count**: when `--limit` truncates, text appends `showing N of M matches`; JSON envelope naturally exposes `.total`
- Short-circuit optimization removed (needed for accurate total counts)
- Unit + e2e tests for all features; help text, skill files, and knowledgebase updated

## Review findings addressed
- Replaced `.expect()` with `.context()?` in disk-scan serialization
- Removed dead `can_short_circuit` code and bare-array fallback in hints
- Relaxed envelope detection (presence of `total`+`results` keys, not exact key count)
- Added dead-end parity test (disk vs index)
- Updated iteration doc and decision log for accurate dead-end/envelope definitions

## Test plan
- [x] `cargo fmt` / `cargo clippy` / `cargo test` — 497 tests pass
- [x] Dogfood `hyalo summary --format text` — dead-ends section with 52 files
- [x] Dogfood `hyalo find --limit 3 --format text` — "showing 3 of 156 matches"
- [x] Dogfood `hyalo find --limit 3 --jq '.total'` — returns 156
- [x] Dogfood `hyalo find --format json` — envelope with total + results
- [x] Help text `--jq` examples updated to `.results[]` format
- [x] Skill files (hyalo, hyalo-tidy) updated
- [x] Copilot review addressed (2 rounds)
- [x] Local Rust review addressed (2 rounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)