### PR TITLE
Fix derived title matching and add backlinks text rendering

### DIFF
--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -137,13 +137,39 @@ pub fn find(
         presort_index_entries(&mut scoped_entries, sort, index.link_graph());
     }
 
+    // Pre-check: does any property filter target the "title" key?
+    // If so, we may need to inject the derived title (from H1) into the
+    // properties map for entries that lack a frontmatter `title`.
+    let has_title_property_filter = property_filters.iter().any(|f| f.key() == Some("title"));
+
     let mut results: Vec<FileObject> = Vec::new();
     let mut total_matching: usize = 0;
 
     for entry in &scoped_entries {
         // --- Metadata filters using pre-indexed data ---
+        // When a property filter targets "title" and the entry has no
+        // frontmatter title, inject the derived title (from H1 heading)
+        // so that `--property 'title~=...'` matches derived titles too.
+        let props_with_derived_title;
+        let effective_props =
+            if has_title_property_filter && !entry.properties.contains_key("title") {
+                let derived = extract_title(&entry.properties, Some(&entry.sections));
+                if derived.is_null() {
+                    &entry.properties
+                } else {
+                    props_with_derived_title = {
+                        let mut p = entry.properties.clone();
+                        p.insert("title".to_owned(), derived);
+                        p
+                    };
+                    &props_with_derived_title
+                }
+            } else {
+                &entry.properties
+            };
+
         if !filter::matches_filters_with_tags(
-            &entry.properties,
+            effective_props,
             property_filters,
             &entry.tags,
             tag_filters,
@@ -750,8 +776,9 @@ Just some text here.
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         let arr = parsed["results"].as_array().unwrap();
-        // alpha and beta have title; gamma does not
-        assert_eq!(arr.len(), 2);
+        // alpha and beta have frontmatter title; gamma has a derived title
+        // from its H1 heading — all three should match the existence filter.
+        assert_eq!(arr.len(), 3);
     }
 
     // --- find: tag filter ---

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -148,25 +148,31 @@ pub fn find(
     for entry in &scoped_entries {
         // --- Metadata filters using pre-indexed data ---
         // When a property filter targets "title" and the entry has no
-        // frontmatter title, inject the derived title (from H1 heading)
-        // so that `--property 'title~=...'` matches derived titles too.
+        // frontmatter title (or a non-string title), inject the derived
+        // title (from H1 heading) so that `--property 'title~=...'`
+        // matches derived titles too.  The gate mirrors `extract_title()`
+        // which only treats a frontmatter title as authoritative when it
+        // is a String.
         let props_with_derived_title;
-        let effective_props =
-            if has_title_property_filter && !entry.properties.contains_key("title") {
-                let derived = extract_title(&entry.properties, Some(&entry.sections));
-                if derived.is_null() {
-                    &entry.properties
-                } else {
-                    props_with_derived_title = {
-                        let mut p = entry.properties.clone();
-                        p.insert("title".to_owned(), derived);
-                        p
-                    };
-                    &props_with_derived_title
-                }
-            } else {
+        let effective_props = if has_title_property_filter
+            && !matches!(
+                entry.properties.get("title"),
+                Some(serde_json::Value::String(_))
+            ) {
+            let derived = extract_title(&entry.properties, Some(&entry.sections));
+            if derived.is_null() {
                 &entry.properties
-            };
+            } else {
+                props_with_derived_title = {
+                    let mut p = entry.properties.clone();
+                    p.insert("title".to_owned(), derived);
+                    p
+                };
+                &props_with_derived_title
+            }
+        } else {
+            &entry.properties
+        };
 
         if !filter::matches_filters_with_tags(
             effective_props,

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -503,6 +503,13 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
         );
     }
 
+    // Backlinks: header then each as "    \"source\" line N" or "    \"source\" line N: label"
+    if map.contains_key("backlinks") {
+        parts.push(
+            r#"if (.backlinks | length) > 0 then "  backlinks:\n\(.backlinks | map("    \"\(.source)\" line \(.line)\(if .label then ": \(.label)" else "" end)") | join("\n"))" else empty end"#.to_owned(),
+        );
+    }
+
     parts.join(", ")
 }
 

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -1112,6 +1112,34 @@ fn find_text_format_fields_properties_only() {
     );
 }
 
+// Text format: find with --fields backlinks renders backlinks
+#[test]
+fn find_text_format_fields_backlinks_renders() {
+    let tmp = setup_vault();
+    // alpha.md links to [[beta]], so beta should have backlinks in text format
+    let mut cmd = hyalo();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--format", "text"]);
+    cmd.args(["find", "--file", "beta.md", "--fields", "backlinks"]);
+    let output = cmd.output().unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(
+        stdout.contains("backlinks:"),
+        "backlinks group label should appear: {stdout}"
+    );
+    assert!(
+        stdout.contains("alpha.md"),
+        "backlink source should appear: {stdout}"
+    );
+    assert!(
+        stdout.contains("line"),
+        "backlink line number should appear: {stdout}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Regexp search (--regexp / -e)
 // ---------------------------------------------------------------------------
@@ -1943,6 +1971,35 @@ fn find_property_eq_tilde_delimited_case_insensitive() {
     let tmp = setup_vault();
     // =~ delimited with /i flag: title=~/ALPHA/i should match alpha.md
     let (status, json, stderr) = find_json(&tmp, &["--property", "title=~/ALPHA/i"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    let arr = unwrap_results(&json);
+    assert_eq!(arr.len(), 1, "expected alpha.md: {arr:?}");
+    assert_eq!(arr[0]["file"], "alpha.md");
+}
+
+// ---------------------------------------------------------------------------
+// Derived title: --property 'title~=...' falls back to H1 heading
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_property_regex_matches_derived_title_from_h1() {
+    let tmp = setup_vault();
+    // gamma.md has no frontmatter title but has "# Gamma" as H1.
+    // `title~=Gamma` should match it via the derived title fallback.
+    let (status, json, stderr) = find_json(&tmp, &["--property", "title~=Gamma"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    let arr = unwrap_results(&json);
+    assert_eq!(arr.len(), 1, "expected gamma.md: {arr:?}");
+    assert_eq!(arr[0]["file"], "gamma.md");
+}
+
+#[test]
+fn find_property_regex_derived_title_does_not_shadow_frontmatter() {
+    let tmp = setup_vault();
+    // alpha.md has frontmatter title "Alpha" — should match that, not H1 text.
+    let (status, json, stderr) = find_json(&tmp, &["--property", "title~=Alpha"]);
     assert!(status.success(), "stderr: {stderr}");
 
     let arr = unwrap_results(&json);

--- a/crates/hyalo-core/src/filter/parse.rs
+++ b/crates/hyalo-core/src/filter/parse.rs
@@ -41,6 +41,17 @@ pub enum PropertyFilter {
     RegexMatch { key: String, pattern: Regex },
 }
 
+impl PropertyFilter {
+    /// Return the property key this filter targets, if any.
+    #[must_use]
+    pub fn key(&self) -> Option<&str> {
+        match self {
+            PropertyFilter::Scalar { name, .. } => Some(name),
+            PropertyFilter::Absent { key } | PropertyFilter::RegexMatch { key, .. } => Some(key),
+        }
+    }
+}
+
 /// Parse a property filter expression.
 ///
 /// Supported formats:

--- a/hyalo-knowledgebase/iterations/iteration-74-dogfood-bugfixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-74-dogfood-bugfixes.md
@@ -1,0 +1,60 @@
+---
+title: "Dogfood bugfixes: derived title regex, text backlinks rendering"
+type: iteration
+date: 2026-03-30
+tags:
+  - bugfix
+  - dogfood
+status: in-progress
+branch: iter-74/dogfood-bugfixes
+---
+
+## Goal
+
+Fix the two bugs found during v0.6.0 post-refactor dogfooding on `docs/content` (3520 files) and `vscode-docs/docs` (339 files).
+
+## Context
+
+After iterations 70–73 (structural refactors), a thorough dogfood session confirmed zero regressions from the refactoring but uncovered two bugs in existing functionality.
+
+## Bugs
+
+### BUG 1: `--property 'title~=...'` doesn't match derived titles
+
+**Repro:**
+```
+cd vscode-docs/docs
+hyalo find --property 'title~=Settings' --format text   # → "No files matched"
+hyalo find --fields title --limit 3 --format json        # → titles are present (derived from H1)
+```
+
+**Expected:** Files with derived title matching the regex should be returned.
+
+**Root cause:** The property filter for `title` with regex operator `~=` only checks frontmatter properties, not the derived title (extracted from `# H1` heading). The `--sort title` and `--fields title` paths do consider derived titles, but the filter path does not.
+
+**Fix:** In the property matching code, when the filter key is `title` and the file has no frontmatter `title` property, fall back to checking the derived title.
+
+### BUG 2: Text format silently drops backlinks from `--fields backlinks`
+
+**Repro:**
+```
+cd vscode-docs/docs
+hyalo find --file configure/settings.md --fields backlinks --format text   # → shows only file path
+hyalo find --file configure/settings.md --fields backlinks --format json   # → 116 backlinks
+```
+
+**Expected:** Text format should render backlinks similarly to how it renders `links` (source file, line number, label).
+
+**Root cause:** The text formatter has rendering code for `links`, `sections`, `tasks`, `properties`, `tags`, and `matches` — but no code path for `backlinks`.
+
+**Fix:** Add a backlinks rendering block to the text formatter, showing each backlink's source file, line, and label.
+
+## Tasks
+
+- [x] Fix derived title matching in property regex filter
+- [x] Add backlinks rendering to text formatter
+- [x] Add test: `--property 'title~=...'` matches derived title when no frontmatter title
+- [x] Add test: `--format text` renders backlinks field
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`


### PR DESCRIPTION
## Summary
- **Bug 1:** `--property 'title~=...'` now falls back to the derived title (from H1 heading) when no frontmatter `title` exists. Previously only `--sort title` and `--fields title` considered derived titles — the property filter path did not.
- **Bug 2:** `--format text` with `--fields backlinks` now renders backlinks (source file, line number, label) instead of silently dropping them. The text formatter had rendering code for links, sections, tasks, etc. but was missing a backlinks handler.
- Added `PropertyFilter::key()` accessor method for inspecting which property a filter targets.

## Test plan
- [x] New e2e test: `--property 'title~=Gamma'` matches file with H1-derived title and no frontmatter
- [x] New e2e test: frontmatter title is still preferred over H1 when both exist
- [x] New e2e test: `--format text --fields backlinks` renders backlink source and line info
- [x] Updated unit test: `find_property_filter_exists` now expects derived titles to count
- [x] `cargo fmt` / `cargo clippy` / `cargo test --workspace` — all green (498 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)