### PR TITLE
Add --regexp and --jq .total examples to help and cookbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Then use target/release/hyalo to work with the documentation in `./hyalo-knowled
 
 **Always use hyalo for knowledgebase interactions — never use Edit/Read/Grep directly:**
 - **Search/filter**: `hyalo find --property status=planned --tag iteration --format text`
-- **Body search**: `hyalo find "broken links" --format text`
+- **Body search**: `hyalo find "broken links" --format text` or regex: `hyalo find -e 'TODO|FIXME' --format text`
 - **Title regex**: `hyalo find --property 'title~=link' --format text`
 - **Overview**: `hyalo summary`, `hyalo properties`, `hyalo tags`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append` (e.g., `hyalo set --property status=completed --file iterations/iteration-16-robustness.md`)

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -4,6 +4,7 @@ pub(crate) const HELP_EXAMPLES: &str = "EXAMPLES:
   Filter by tag:                hyalo find --tag project
   Filter by task status:        hyalo find --task todo
   Full-text search:             hyalo find 'meeting notes'
+  Regex body search:            hyalo find -e 'perf(ormance)?'
   Filter by section:            hyalo find --section 'Tasks' --task todo
   Read file content:            hyalo read --file notes/todo.md
   Read a section:               hyalo read --file notes/todo.md --section Proposal
@@ -115,6 +116,15 @@ COOKBOOK:
 
   # Find files tagged 'project' (matches project/backend, project/frontend, etc.)
   hyalo find --tag project
+
+  # Regex body search (standalone)
+  hyalo find -e 'TODO|FIXME'
+
+  # Regex body search combined with filters
+  hyalo find -e 'perf(ormance)?' --tag iteration --property status=completed
+
+  # Count matching files
+  hyalo find --property status=draft --jq '.total'
 
   # Find files with open tasks
   hyalo find --task todo

--- a/hyalo-knowledgebase/iterations/iteration-77-regexp-help-visibility.md
+++ b/hyalo-knowledgebase/iterations/iteration-77-regexp-help-visibility.md
@@ -27,5 +27,5 @@ Found during v0.6.0 dogfooding (iteration 74). Several powerful features are har
 - [x] Add a regex body search example to the short help in `HELP_EXAMPLES` (e.g. `Regex body search: hyalo find -e 'perf(ormance)?'`)
 - [x] Add 1–2 `--regexp` examples to the cookbook in `HELP_LONG` (standalone + combined with other filters)
 - [x] Add a `--jq '.total'` counting example to the cookbook (e.g. `# Count matching files` / `hyalo find --property status=draft --jq '.total'`)
-- [x] Add a `(?i)` case-insensitive property regex example to the cookbook — already present as `/pattern/i` syntax at line 113-114
+- [x] Add a `(?i)` case-insensitive property regex example to the cookbook — already present as `/pattern/i` syntax in the cookbook
 - [x] Mention `-e`/`--regexp` in `CLAUDE.md` body search bullet

--- a/hyalo-knowledgebase/iterations/iteration-77-regexp-help-visibility.md
+++ b/hyalo-knowledgebase/iterations/iteration-77-regexp-help-visibility.md
@@ -6,7 +6,7 @@ tags:
   - ux
   - docs
   - dogfood
-status: planned
+status: completed
 priority: 3
 branch: iter-77/regexp-help-visibility
 ---
@@ -24,8 +24,8 @@ Found during v0.6.0 dogfooding (iteration 74). Several powerful features are har
 
 ## Tasks
 
-- [ ] Add a regex body search example to the short help in `HELP_EXAMPLES` (e.g. `Regex body search: hyalo find -e 'perf(ormance)?'`)
-- [ ] Add 1–2 `--regexp` examples to the cookbook in `HELP_LONG` (standalone + combined with other filters)
-- [ ] Add a `--jq '.total'` counting example to the cookbook (e.g. `# Count matching files` / `hyalo find --property status=draft --jq '.total'`)
-- [ ] Add a `(?i)` case-insensitive property regex example to the cookbook
-- [ ] Mention `-e`/`--regexp` in `CLAUDE.md` body search bullet
+- [x] Add a regex body search example to the short help in `HELP_EXAMPLES` (e.g. `Regex body search: hyalo find -e 'perf(ormance)?'`)
+- [x] Add 1–2 `--regexp` examples to the cookbook in `HELP_LONG` (standalone + combined with other filters)
+- [x] Add a `--jq '.total'` counting example to the cookbook (e.g. `# Count matching files` / `hyalo find --property status=draft --jq '.total'`)
+- [x] Add a `(?i)` case-insensitive property regex example to the cookbook — already present as `/pattern/i` syntax at line 113-114
+- [x] Mention `-e`/`--regexp` in `CLAUDE.md` body search bullet


### PR DESCRIPTION
## Summary
- Add `Regex body search: hyalo find -e 'perf(ormance)?'` to short help (`-h`)
- Add two `--regexp` cookbook recipes (standalone + combined with filters) and a `--jq '.total'` counting recipe to long help (`--help`)
- Mention `-e`/`--regexp` in `CLAUDE.md` body search bullet for agent discoverability
- Mark iteration 77 as completed

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass (docs-only change, no new code paths)
- [ ] Verify `hyalo -h` shows the new regex body search line
- [ ] Verify `hyalo --help` shows the three new cookbook recipes
- [ ] Verify CLAUDE.md body search bullet includes `-e` example

🤖 Generated with [Claude Code](https://claude.com/claude-code)