### PR TITLE
Add --dry-run to set, remove, and append commands

### DIFF
--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -337,7 +337,7 @@ shell redirection (e.g. --where-property 'priority>=3'). If the property is a li
 element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
-            SIDE EFFECTS: Modifies matched files on disk.\n\
+            SIDE EFFECTS: Modifies matched files on disk (unless --dry-run is passed).\n\
             USE WHEN: You need to create or overwrite frontmatter properties or add tags, \
             possibly across many files at once."
     )]
@@ -360,6 +360,9 @@ Repeatable (AND).\n\
         /// Filter: only mutate files with this tag (repeatable, AND). Same syntax as find --tag
         #[arg(long = "where-tag", value_name = "TAG")]
         where_tags: Vec<String>,
+        /// Preview changes without modifying any files
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Remove frontmatter properties and/or tags from file(s)
     #[command(
@@ -382,7 +385,7 @@ shell redirection (e.g. --where-property 'priority>=3'). If the property is a li
 element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
-            SIDE EFFECTS: Modifies matched files on disk.\n\
+            SIDE EFFECTS: Modifies matched files on disk (unless --dry-run is passed).\n\
             USE WHEN: You need to delete properties or remove tags from one or more files."
     )]
     Remove {
@@ -404,6 +407,9 @@ Repeatable (AND).\n\
         /// Filter: only mutate files with this tag (repeatable, AND). Same syntax as find --tag
         #[arg(long = "where-tag", value_name = "TAG")]
         where_tags: Vec<String>,
+        /// Preview changes without modifying any files
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Initialize hyalo configuration and optional tool integrations
     #[command(
@@ -479,7 +485,7 @@ shell redirection (e.g. --where-property 'priority>=3'). If the property is a li
 element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
-            SIDE EFFECTS: Modifies matched files on disk.\n\
+            SIDE EFFECTS: Modifies matched files on disk (unless --dry-run is passed).\n\
             USE WHEN: You need to append items to list-type properties such as 'aliases' or 'authors' \
             without overwriting the existing list."
     )]
@@ -499,6 +505,9 @@ Repeatable (AND).\n\
         /// Filter: only mutate files with this tag (repeatable, AND). Same syntax as find --tag
         #[arg(long = "where-tag", value_name = "TAG")]
         where_tags: Vec<String>,
+        /// Preview changes without modifying any files
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Detect and repair broken links across the vault
     #[command(

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -24,6 +24,7 @@ pub struct AppendPropertyResult {
     pub skipped: Vec<String>,
     pub total: usize,
     pub scanned: usize,
+    pub dry_run: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +124,7 @@ pub fn append(
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
+    dry_run: bool,
 ) -> Result<CommandOutcome> {
     if property_args.is_empty() {
         let out = crate::output::format_error(
@@ -211,7 +213,7 @@ pub fn append(
             }
         }
 
-        if file_changed {
+        if file_changed && !dry_run {
             frontmatter::write_frontmatter(full_path, &props)?;
             mutation::update_index_entry(
                 snapshot_index,
@@ -223,7 +225,9 @@ pub fn append(
         }
     }
 
-    mutation::save_index_if_dirty(snapshot_index, index_path, index_dirty)?;
+    if !dry_run {
+        mutation::save_index_if_dirty(snapshot_index, index_path, index_dirty)?;
+    }
 
     let mut results: Vec<serde_json::Value> = Vec::new();
 
@@ -238,6 +242,7 @@ pub fn append(
             skipped,
             total,
             scanned,
+            dry_run,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -290,6 +295,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -330,6 +336,7 @@ aliases:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
 
@@ -362,6 +369,7 @@ aliases:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -397,6 +405,7 @@ author: Alice
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
 
@@ -430,6 +439,7 @@ author: Alice
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -464,6 +474,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -489,6 +500,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -507,6 +519,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -526,6 +539,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -545,6 +559,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -570,6 +585,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
 
@@ -601,6 +617,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -637,6 +654,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -671,6 +689,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -704,6 +723,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         match outcome {
@@ -728,6 +748,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -747,6 +768,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));

--- a/crates/hyalo-cli/src/commands/remove.rs
+++ b/crates/hyalo-cli/src/commands/remove.rs
@@ -26,6 +26,7 @@ pub struct RemovePropertyResult {
     pub skipped: Vec<String>,
     pub total: usize,
     pub scanned: usize,
+    pub dry_run: bool,
 }
 
 /// Result of a `remove --tag T` operation across files.
@@ -36,6 +37,7 @@ pub struct RemoveTagResult {
     pub skipped: Vec<String>,
     pub total: usize,
     pub scanned: usize,
+    pub dry_run: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -171,6 +173,7 @@ pub fn remove(
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
+    dry_run: bool,
 ) -> Result<CommandOutcome> {
     if property_args.is_empty() && tag_args.is_empty() {
         let out = crate::output::format_error(
@@ -284,7 +287,7 @@ pub fn remove(
             }
         }
 
-        if file_changed {
+        if file_changed && !dry_run {
             frontmatter::write_frontmatter(full_path, &props)?;
             mutation::update_index_entry(
                 snapshot_index,
@@ -296,7 +299,9 @@ pub fn remove(
         }
     }
 
-    mutation::save_index_if_dirty(snapshot_index, index_path, index_dirty)?;
+    if !dry_run {
+        mutation::save_index_if_dirty(snapshot_index, index_path, index_dirty)?;
+    }
 
     let mut results: Vec<serde_json::Value> = Vec::new();
 
@@ -312,6 +317,7 @@ pub fn remove(
             skipped,
             total,
             scanned,
+            dry_run,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -326,6 +332,7 @@ pub fn remove(
             skipped,
             total,
             scanned,
+            dry_run,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -412,6 +419,7 @@ status: draft
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -451,6 +459,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -487,6 +496,7 @@ status: draft
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -523,6 +533,7 @@ status: published
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -563,6 +574,7 @@ aliases:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -604,6 +616,7 @@ tags:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -643,6 +656,7 @@ tags:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -666,6 +680,7 @@ tags:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -685,6 +700,7 @@ tags:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -716,6 +732,7 @@ tags:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -747,6 +764,7 @@ tags:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
 
@@ -781,6 +799,7 @@ priority: low
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -826,6 +845,7 @@ priority: low
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -865,6 +885,7 @@ priority: low
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -899,6 +920,7 @@ priority: low
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         match outcome {
@@ -924,6 +946,7 @@ priority: low
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -944,6 +967,7 @@ priority: low
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -23,6 +23,7 @@ pub struct SetPropertyResult {
     pub skipped: Vec<String>,
     pub total: usize,
     pub scanned: usize,
+    pub dry_run: bool,
 }
 
 /// Result of a `set --tag T` operation across files.
@@ -33,6 +34,7 @@ pub struct SetTagResult {
     pub skipped: Vec<String>,
     pub total: usize,
     pub scanned: usize,
+    pub dry_run: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +147,7 @@ pub fn set(
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
+    dry_run: bool,
 ) -> Result<CommandOutcome> {
     // At least one mutation target required
     if property_args.is_empty() && tag_args.is_empty() {
@@ -279,7 +282,7 @@ pub fn set(
             }
         }
 
-        if file_changed {
+        if file_changed && !dry_run {
             frontmatter::write_frontmatter(full_path, &props)?;
             mutation::update_index_entry(
                 snapshot_index,
@@ -291,7 +294,9 @@ pub fn set(
         }
     }
 
-    mutation::save_index_if_dirty(snapshot_index, index_path, index_dirty)?;
+    if !dry_run {
+        mutation::save_index_if_dirty(snapshot_index, index_path, index_dirty)?;
+    }
 
     let mut results: Vec<serde_json::Value> = Vec::new();
 
@@ -306,6 +311,7 @@ pub fn set(
             skipped,
             total,
             scanned,
+            dry_run,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -319,6 +325,7 @@ pub fn set(
             skipped,
             total,
             scanned,
+            dry_run,
         };
         results
             .push(serde_json::to_value(&result).expect("derived Serialize impl should not fail"));
@@ -405,6 +412,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let out = match outcome {
@@ -446,6 +454,7 @@ status: draft
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
 
@@ -478,6 +487,7 @@ status: done
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -513,6 +523,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -551,6 +562,7 @@ tags:
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -584,6 +596,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -608,6 +621,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -627,6 +641,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -647,6 +662,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -667,6 +683,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -693,6 +710,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
 
@@ -726,6 +744,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -769,6 +788,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -806,6 +826,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -842,6 +863,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         let CommandOutcome::Success(out) = outcome else {
@@ -876,6 +898,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         match outcome {
@@ -901,6 +924,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -921,6 +945,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -941,6 +966,7 @@ title: Note
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -351,6 +351,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             glob,
             where_properties,
             where_tags,
+            dry_run,
         } => {
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
@@ -369,6 +370,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 effective_format,
                 snapshot_index,
                 index_path,
+                dry_run,
             )
         }
         Commands::Remove {
@@ -378,6 +380,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             glob,
             where_properties,
             where_tags,
+            dry_run,
         } => {
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
@@ -396,6 +399,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 effective_format,
                 snapshot_index,
                 index_path,
+                dry_run,
             )
         }
         Commands::Append {
@@ -404,6 +408,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             glob,
             where_properties,
             where_tags,
+            dry_run,
         } => {
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
@@ -421,6 +426,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 effective_format,
                 snapshot_index,
                 index_path,
+                dry_run,
             )
         }
         Commands::Backlinks { file } => match resolve_index(

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -215,24 +215,24 @@ const CONTENT_MATCH_FILTER: &str = r#""  line \(.line) (\(.section)): \(.text)""
 
 /// Mutation result with `property` + `value` fields:
 /// covers `SetPropertyResult`, `AppendPropertyResult`, and `RemovePropertyResult` (with value).
-/// Key signature: `modified,property,scanned,skipped,total,value`
-/// Format: `property=value: N/T modified (S scanned)` when not all scanned files were
-/// processed (e.g. where-filters or parse errors), or `property=value: N/T modified` otherwise.
-const PROPERTY_VALUE_MUTATION_FILTER: &str = r#""\(.property)=\(.value): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
+/// Key signature: `dry_run,modified,property,scanned,skipped,total,value`
+/// Format: `[dry-run] property=value: N/T modified (S scanned)` when dry-run; omits prefix otherwise.
+/// Appends `(S scanned)` when not all scanned files were processed (e.g. where-filters).
+const PROPERTY_VALUE_MUTATION_FILTER: &str = r#""\(if .dry_run then "[dry-run] " else "" end)\(.property)=\(.value): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `property` only (no value field):
 /// covers `RemovePropertyResult` (without value).
-/// Key signature: `modified,property,scanned,skipped,total`
-/// Format: `property: N/T modified (S scanned)` when not all scanned files were
-/// processed (e.g. where-filters or parse errors), or `property: N/T modified` otherwise.
-const PROPERTY_MUTATION_FILTER: &str = r#""\(.property): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
+/// Key signature: `dry_run,modified,property,scanned,skipped,total`
+/// Format: `[dry-run] property: N/T modified (S scanned)` when dry-run; omits prefix otherwise.
+/// Appends `(S scanned)` when not all scanned files were processed (e.g. where-filters).
+const PROPERTY_MUTATION_FILTER: &str = r#""\(if .dry_run then "[dry-run] " else "" end)\(.property): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 /// Mutation result with `tag` field:
 /// covers `SetTagResult` and `RemoveTagResult`.
-/// Key signature: `modified,scanned,skipped,tag,total`
-/// Format: `tag: N/T modified (S scanned)` when not all scanned files were
-/// processed (e.g. where-filters or parse errors), or `tag: N/T modified` otherwise.
-const TAG_MUTATION_FILTER: &str = r#""\(.tag): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
+/// Key signature: `dry_run,modified,scanned,skipped,tag,total`
+/// Format: `[dry-run] tag: N/T modified (S scanned)` when dry-run; omits prefix otherwise.
+/// Appends `(S scanned)` when not all scanned files were processed (e.g. where-filters).
+const TAG_MUTATION_FILTER: &str = r#""\(if .dry_run then "[dry-run] " else "" end)\(.tag): \(.modified | length)/\(.total) modified\(if .scanned != .total then " (\(.scanned) scanned)" else "" end)\(if (.modified | length) > 0 then "\n\(.modified | map("  \"\(.)\"") | join("\n"))" else "" end)""#;
 
 // ---------------------------------------------------------------------------
 // Shape-based filter lookup
@@ -943,6 +943,7 @@ mod tests {
     fn property_mutation_filter_no_value() {
         // RemovePropertyResult without value; scanned == total
         let val = json!({
+            "dry_run": false,
             "modified": ["note.md"],
             "property": "draft",
             "scanned": 1,
@@ -963,6 +964,7 @@ mod tests {
     fn property_mutation_filter_no_value_with_where_filter() {
         // RemovePropertyResult without value; scanned > total
         let val = json!({
+            "dry_run": false,
             "modified": ["note.md"],
             "property": "draft",
             "scanned": 7,
@@ -979,6 +981,7 @@ mod tests {
     fn tag_mutation_filter_with_modified() {
         // SetTagResult / RemoveTagResult; scanned == total
         let val = json!({
+            "dry_run": false,
             "modified": ["a.md", "b.md"],
             "scanned": 3,
             "skipped": ["c.md"],
@@ -1001,6 +1004,7 @@ mod tests {
     fn tag_mutation_filter_with_where_filter() {
         // scanned > total: "(N scanned)" suffix
         let val = json!({
+            "dry_run": false,
             "modified": ["a.md"],
             "scanned": 10,
             "skipped": [],
@@ -1026,6 +1030,61 @@ mod tests {
         let out = fmt(&val);
         assert!(out.contains("cli"));
         assert!(!out.contains("tag: cli"), "should not use generic fallback");
+    }
+
+    // --- dry-run prefix in text output ---
+
+    #[test]
+    fn property_value_mutation_dry_run_prefix() {
+        let val = json!({
+            "dry_run": true,
+            "modified": ["note.md"],
+            "property": "status",
+            "scanned": 1,
+            "skipped": [],
+            "total": 1,
+            "value": "done"
+        });
+        let out = fmt(&val);
+        assert!(
+            out.contains("[dry-run] status=done"),
+            "dry-run prefix missing: {out}"
+        );
+    }
+
+    #[test]
+    fn tag_mutation_dry_run_prefix() {
+        let val = json!({
+            "dry_run": true,
+            "modified": ["note.md"],
+            "scanned": 1,
+            "skipped": [],
+            "tag": "rust",
+            "total": 1
+        });
+        let out = fmt(&val);
+        assert!(
+            out.contains("[dry-run] rust"),
+            "dry-run prefix missing: {out}"
+        );
+    }
+
+    #[test]
+    fn property_value_mutation_no_dry_run_prefix() {
+        let val = json!({
+            "dry_run": false,
+            "modified": ["note.md"],
+            "property": "status",
+            "scanned": 1,
+            "skipped": [],
+            "total": 1,
+            "value": "done"
+        });
+        let out = fmt(&val);
+        assert!(
+            !out.contains("[dry-run]"),
+            "should not have dry-run prefix: {out}"
+        );
     }
 
     // --- build_file_object_filter ---

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -282,11 +282,13 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         }
         // Mutation results with property + value (SetPropertyResult, AppendPropertyResult,
         // RemovePropertyResult with value)
-        "modified,property,scanned,skipped,total,value" => Some(PROPERTY_VALUE_MUTATION_FILTER),
+        "dry_run,modified,property,scanned,skipped,total,value" => {
+            Some(PROPERTY_VALUE_MUTATION_FILTER)
+        }
         // Mutation results with property only (RemovePropertyResult without value)
-        "modified,property,scanned,skipped,total" => Some(PROPERTY_MUTATION_FILTER),
+        "dry_run,modified,property,scanned,skipped,total" => Some(PROPERTY_MUTATION_FILTER),
         // Mutation results with tag (SetTagResult, RemoveTagResult)
-        "modified,scanned,skipped,tag,total" => Some(TAG_MUTATION_FILTER),
+        "dry_run,modified,scanned,skipped,tag,total" => Some(TAG_MUTATION_FILTER),
         _ => None,
     }
 }
@@ -921,6 +923,7 @@ mod tests {
     #[test]
     fn property_value_mutation_via_format_value_as_text() {
         let val = json!({
+            "dry_run": false,
             "modified": ["notes/a.md"],
             "property": "status",
             "scanned": 1,
@@ -1013,6 +1016,7 @@ mod tests {
     #[test]
     fn tag_mutation_via_format_value_as_text() {
         let val = json!({
+            "dry_run": false,
             "modified": [],
             "scanned": 1,
             "skipped": ["note.md"],

--- a/crates/hyalo-cli/tests/e2e_append.rs
+++ b/crates/hyalo-cli/tests/e2e_append.rs
@@ -632,4 +632,11 @@ fn append_without_dry_run_has_dry_run_false() {
     );
     assert!(status.success(), "stderr: {stderr}");
     assert_eq!(json["dry_run"], false);
+
+    // File should actually be modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("my-note"),
+        "file was not written:\n{content}"
+    );
 }

--- a/crates/hyalo-cli/tests/e2e_append.rs
+++ b/crates/hyalo-cli/tests/e2e_append.rs
@@ -581,3 +581,55 @@ fn append_accepts_list_property() {
     assert!(status.success(), "stderr: {stderr}");
     assert_eq!(json["property"], "tags");
 }
+
+// ---------------------------------------------------------------------------
+// --dry-run: preview without modifying
+// ---------------------------------------------------------------------------
+
+#[test]
+fn append_dry_run_does_not_modify() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+---
+"),
+    );
+
+    let (status, json, stderr) = append_json(
+        &tmp,
+        &[
+            "--property",
+            "aliases=my-note",
+            "--file",
+            "note.md",
+            "--dry-run",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    // File must NOT have been modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        !content.contains("aliases"),
+        "file was modified despite --dry-run:\n{content}"
+    );
+}
+
+#[test]
+fn append_without_dry_run_has_dry_run_false() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
+
+    let (status, json, stderr) = append_json(
+        &tmp,
+        &["--property", "aliases=my-note", "--file", "note.md"],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], false);
+}

--- a/crates/hyalo-cli/tests/e2e_remove.rs
+++ b/crates/hyalo-cli/tests/e2e_remove.rs
@@ -586,3 +586,47 @@ fn remove_accepts_kv_property() {
     assert!(status.success(), "stderr: {stderr}");
     assert_eq!(json["property"], "status");
 }
+
+// ---------------------------------------------------------------------------
+// --dry-run: preview without modifying
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_dry_run_does_not_modify() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+status: draft
+---
+"),
+    );
+
+    let (status, json, stderr) = remove_json(
+        &tmp,
+        &["--property", "status", "--file", "note.md", "--dry-run"],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    // File must NOT have been modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("status"),
+        "file was modified despite --dry-run:\n{content}"
+    );
+}
+
+#[test]
+fn remove_without_dry_run_has_dry_run_false() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\nstatus: draft\n---\n");
+
+    let (status, json, stderr) = remove_json(&tmp, &["--property", "status", "--file", "note.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], false);
+}

--- a/crates/hyalo-cli/tests/e2e_remove.rs
+++ b/crates/hyalo-cli/tests/e2e_remove.rs
@@ -622,6 +622,29 @@ status: draft
 }
 
 #[test]
+fn remove_dry_run_tag_does_not_modify() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntags:\n  - rust\n  - cli\n---\n",
+    );
+
+    let (status, json, stderr) =
+        remove_json(&tmp, &["--tag", "rust", "--file", "note.md", "--dry-run"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    // File must NOT have been modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("rust"),
+        "tag was removed despite --dry-run:\n{content}"
+    );
+}
+
+#[test]
 fn remove_without_dry_run_has_dry_run_false() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\nstatus: draft\n---\n");
@@ -629,4 +652,11 @@ fn remove_without_dry_run_has_dry_run_false() {
     let (status, json, stderr) = remove_json(&tmp, &["--property", "status", "--file", "note.md"]);
     assert!(status.success(), "stderr: {stderr}");
     assert_eq!(json["dry_run"], false);
+
+    // File should actually be modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        !content.contains("status"),
+        "file was not written:\n{content}"
+    );
 }

--- a/crates/hyalo-cli/tests/e2e_set.rs
+++ b/crates/hyalo-cli/tests/e2e_set.rs
@@ -1042,3 +1042,53 @@ fn set_accepts_list_property() {
     assert!(status.success(), "stderr: {stderr}");
     assert_eq!(json["property"], "tags");
 }
+
+// ---------------------------------------------------------------------------
+// --dry-run: preview without modifying
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_dry_run_does_not_modify() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+---
+"),
+    );
+
+    let (status, json, stderr) = set_json(
+        &tmp,
+        &[
+            "--property",
+            "status=done",
+            "--file",
+            "note.md",
+            "--dry-run",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    // File must NOT have been modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        !content.contains("status"),
+        "file was modified despite --dry-run:\n{content}"
+    );
+}
+
+#[test]
+fn set_without_dry_run_has_dry_run_false() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
+
+    let (status, json, stderr) =
+        set_json(&tmp, &["--property", "status=done", "--file", "note.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], false);
+}

--- a/crates/hyalo-cli/tests/e2e_set.rs
+++ b/crates/hyalo-cli/tests/e2e_set.rs
@@ -1083,6 +1083,25 @@ title: Note
 }
 
 #[test]
+fn set_dry_run_tag_does_not_modify() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n");
+
+    let (status, json, stderr) =
+        set_json(&tmp, &["--tag", "rust", "--file", "note.md", "--dry-run"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    // File must NOT have been modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        !content.contains("rust"),
+        "file was modified despite --dry-run:\n{content}"
+    );
+}
+
+#[test]
 fn set_without_dry_run_has_dry_run_false() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
@@ -1091,4 +1110,11 @@ fn set_without_dry_run_has_dry_run_false() {
         set_json(&tmp, &["--property", "status=done", "--file", "note.md"]);
     assert!(status.success(), "stderr: {stderr}");
     assert_eq!(json["dry_run"], false);
+
+    // File should actually be modified
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("status: done"),
+        "file was not written:\n{content}"
+    );
 }

--- a/hyalo-knowledgebase/iterations/iteration-75-dry-run-mutations.md
+++ b/hyalo-knowledgebase/iterations/iteration-75-dry-run-mutations.md
@@ -1,12 +1,12 @@
 ---
-title: "Add --dry-run to set, remove, and append commands"
+title: Add --dry-run to set, remove, and append commands
 type: iteration
 date: 2026-03-30
 tags:
   - feature
   - ux
   - dogfood
-status: planned
+status: completed
 priority: 3
 branch: iter-75/dry-run-mutations
 ---
@@ -21,11 +21,11 @@ Found during v0.6.0 dogfooding (iteration 74). The `mv` command already supports
 
 ## Tasks
 
-- [ ] Add `--dry-run` flag to `set` subcommand
-- [ ] Add `--dry-run` flag to `remove` subcommand
-- [ ] Add `--dry-run` flag to `append` subcommand
-- [ ] When `--dry-run` is active, compute and display changes without writing to disk
-- [ ] Add e2e tests for `--dry-run` on each mutation command
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x] Add `--dry-run` flag to `set` subcommand
+- [x] Add `--dry-run` flag to `remove` subcommand
+- [x] Add `--dry-run` flag to `append` subcommand
+- [x] When `--dry-run` is active, compute and display changes without writing to disk
+- [x] Add e2e tests for `--dry-run` on each mutation command
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`

--- a/hyalo-knowledgebase/iterations/iteration-75-dry-run-mutations.md
+++ b/hyalo-knowledgebase/iterations/iteration-75-dry-run-mutations.md
@@ -1,5 +1,5 @@
 ---
-title: Add --dry-run to set, remove, and append commands
+title: "Add --dry-run to set, remove, and append commands"
 type: iteration
 date: 2026-03-30
 tags:


### PR DESCRIPTION
## Summary
- Adds `--dry-run` flag to `set`, `remove`, and `append` mutation commands, matching the existing `--dry-run` on `mv`
- When active, mutations are computed and reported in output but **no files are written to disk** and the snapshot index is not updated
- JSON output includes a `dry_run` boolean field so callers can distinguish preview from real runs
- Text output shows `[dry-run]` prefix (e.g. `[dry-run] status=done: 3/5 modified`) for clear visual distinction

## Test plan
- [x] Unit tests: all existing tests updated to pass `dry_run: false`; structs include `dry_run` field
- [x] Unit tests: `[dry-run]` prefix in text format output verified
- [x] E2e tests: `set_dry_run_does_not_modify`, `remove_dry_run_does_not_modify`, `append_dry_run_does_not_modify`
- [x] E2e tests: `set_dry_run_tag_does_not_modify`, `remove_dry_run_tag_does_not_modify` (tag code path)
- [x] E2e tests: `*_without_dry_run_has_dry_run_false` verifies flag is `false` and file is actually written
- [x] Manual dogfood: `hyalo set --property status=archived --glob '*.md' --dry-run` reports modifications without changing files
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)