### PR TITLE
Slim defaults: enable hints, drop tasks from default fields

### DIFF
--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -46,7 +46,7 @@ hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
 `--glob` supports negation with `!` prefix to exclude files: `--glob '!**/draft-*'`.
 
 The `--fields` flag controls which data is returned. Available fields: `properties`,
-`properties-typed`, `tags`, `sections`, `tasks`, `links`, `backlinks`. Default fields are
+`properties-typed`, `tags`, `sections`, `tasks`, `links`, `backlinks`, `title`. Default fields are
 `properties`, `tags`, `sections`, `links`. Opt-in fields: `tasks`, `properties-typed`,
 `backlinks`, `title`. Use `--fields all` or `--fields tasks` to include them. `properties-typed`
 returns a `[{name, type, value}]` array instead of a `{key: value}` map; `backlinks` requires

--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -46,8 +46,9 @@ hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
 `--glob` supports negation with `!` prefix to exclude files: `--glob '!**/draft-*'`.
 
 The `--fields` flag controls which data is returned. Available fields: `properties`,
-`properties-typed`, `tags`, `sections`, `tasks`, `links`, `backlinks`. All fields except
-`properties-typed` and `backlinks` are included by default. Both are opt-in: `properties-typed`
+`properties-typed`, `tags`, `sections`, `tasks`, `links`, `backlinks`. Default fields are
+`properties`, `tags`, `sections`, `links`. Opt-in fields: `tasks`, `properties-typed`,
+`backlinks`, `title`. Use `--fields all` or `--fields tasks` to include them. `properties-typed`
 returns a `[{name, type, value}]` array instead of a `{key: value}` map; `backlinks` requires
 scanning all files to build the link graph. Each backlink entry contains `source` (file path),
 `line` (line number), and an optional `label`.
@@ -57,6 +58,11 @@ hyalo find --fields backlinks --file my-note.md       # see who links to this no
 hyalo find --fields backlinks --jq '.results | map(select(.backlinks | length == 0))' # find orphan notes
 hyalo find --fields properties,backlinks              # combine with other fields
 ```
+
+**Hints are enabled by default.** Every query appends drill-down suggestions (`-> hyalo ...`
+lines in text mode, a `"hints"` array in JSON mode). Read and follow these hints — they show
+concrete next commands to explore deeper. Use `--no-hints` to suppress them, or `--jq` which
+suppresses hints automatically.
 
 Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports
 (requires JSON format — do not combine with `--format text`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Then use target/release/hyalo to work with the documentation in `./hyalo-knowled
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append` (e.g., `hyalo set --property status=completed --file iterations/iteration-16-robustness.md`)
 - Only fall back to Edit for body content changes (markdown prose, task checkboxes) that hyalo can't handle
 - **Do NOT pass `--dir hyalo-knowledgebase/`** — `.hyalo.toml` already sets it as the default
+- **Follow hints**: hyalo outputs drill-down hints by default — read and follow them to navigate deeper into the knowledgebase. Use `--no-hints` only when you need raw output.
 
 **Iteration file rules:**
 - Always name `iteration-NN-slug.md` — no standalone plan files

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -48,7 +48,7 @@ pub(crate) fn parse_threshold(s: &str) -> Result<f64, String> {
         CONFIG: Place a .hyalo.toml in the working directory to set defaults:\n\
         \u{00a0} dir = \"vault/\"        # default --dir\n\
         \u{00a0} format = \"text\"       # default --format (CLI default is json)\n\
-        \u{00a0} hints = true           # default --hints on (CLI default is off)\n\
+        \u{00a0} hints = false          # disable hints (CLI default is on)\n\
         \u{00a0} site_prefix = \"docs\"  # override auto-derived site prefix for absolute links\n\
         CLI flags always take precedence.\n\n\
         See COMMAND REFERENCE below for full syntax of each command."
@@ -71,15 +71,15 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "FILTER")]
     pub jq: Option<String>,
 
-    /// Append drill-down command hints to the output.
+    /// Force hints on (already the default).
     /// Text mode: '-> hyalo ...' lines — concrete, copy-pasteable commands.
     /// JSON mode: wraps in {"data": ..., "hints": [...]}.
     /// Suppressed when --jq is active.
-    /// Override via .hyalo.toml
     #[arg(long, global = true)]
     pub hints: bool,
 
-    /// Disable hints even when enabled in .hyalo.toml
+    /// Disable drill-down command hints (enabled by default).
+    /// Override via .hyalo.toml: hints = false
     #[arg(long, global = true, conflicts_with = "hints")]
     pub no_hints: bool,
 
@@ -178,7 +178,7 @@ pub(crate) enum Commands {
         /// Glob pattern(s) to select files (repeatable); prefix '!' to negate (e.g. '!**/draft-*')
         #[arg(short, long, conflicts_with = "file")]
         glob: Vec<String>,
-        /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections, tasks, links, backlinks, title (default: all standard fields except properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
+        /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections, tasks, links, backlinks, title (default: properties, tags, sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
         #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
         fields: Vec<String>,
         /// Sort order: 'file' (default), 'modified', 'backlinks_count', 'links_count', 'title', 'date', or 'property:<KEY>' for any frontmatter property

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -18,7 +18,7 @@ pub(crate) const HELP_EXAMPLES: &str = "EXAMPLES:
   Aggregate tag summary:        hyalo tags summary
   Rename a tag across files:    hyalo tags rename --from old-tag --to new-tag
   Vault overview:               hyalo summary --format text
-  Overview with drill-down:     hyalo summary --format text --hints
+  Overview (hints are default):  hyalo summary --format text
   Toggle a task:                hyalo task toggle --file todo.md --line 5
   Find backlinks:               hyalo backlinks --file decision-log.md
   Move a file (update links):   hyalo mv --file old.md --to new.md
@@ -83,8 +83,8 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
     -d/--dir <DIR>          Root directory (default: ., override via .hyalo.toml)
     --format json|text      Output format (default: json, override via .hyalo.toml)
     --jq <FILTER>           Apply a jq expression to JSON output
-    --hints                 Append drill-down hints (default: off, override via .hyalo.toml)
-    --no-hints              Disable hints (overrides .hyalo.toml)
+    --hints                 Force hints on (already the default; suppressed by --jq)
+    --no-hints              Disable drill-down hints (enabled by default, override via .hyalo.toml)
     --site-prefix <PREFIX>  Override site prefix for absolute link resolution (auto-derived from --dir)
 
 COOKBOOK:
@@ -99,7 +99,7 @@ COOKBOOK:
   hyalo tags rename --from old-tag --to new-tag
 
   # Get a vault overview with drill-down hints
-  hyalo summary --format text --hints
+  hyalo summary --format text
 
   # Find all files with status=draft
   hyalo find --property status=draft

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -151,13 +151,16 @@ site_prefix = "docs"
     #[test]
     fn partial_config_merges_with_defaults() {
         let dir = make_temp();
-        fs::write(dir.path().join(".hyalo.toml"), "hints = true\n").unwrap();
+        fs::write(dir.path().join(".hyalo.toml"), "hints = false\n").unwrap();
 
         let resolved = load_config_from(dir.path());
         // Only hints overridden; dir and format stay at defaults.
         assert_eq!(resolved.dir, PathBuf::from("."));
         assert_eq!(resolved.format, "json");
-        assert!(resolved.hints);
+        assert!(
+            !resolved.hints,
+            "config should override the default (true) to false"
+        );
     }
 
     #[test]

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -34,7 +34,7 @@ impl ResolvedDefaults {
         Self {
             dir: PathBuf::from("."),
             format: "json".to_owned(),
-            hints: false,
+            hints: true,
             site_prefix: None,
         }
     }
@@ -187,6 +187,6 @@ site_prefix = "docs"
         let resolved = load_config_from(dir.path());
         assert_eq!(resolved.format, "xml");
         assert_eq!(resolved.dir, PathBuf::from("."));
-        assert!(!resolved.hints);
+        assert!(resolved.hints);
     }
 }

--- a/crates/hyalo-cli/tests/e2e_backlinks.rs
+++ b/crates/hyalo-cli/tests/e2e_backlinks.rs
@@ -109,7 +109,7 @@ fn backlinks_text_format() {
     write_md(tmp.path(), "source.md", "Link to [[target]]\n");
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["--format", "text"])
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -127,7 +127,7 @@ fn backlinks_text_format_empty() {
     write_md(tmp.path(), "lonely.md", "# Alone\n");
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["--format", "text"])
         .args(["backlinks", "--file", "lonely.md"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_config.rs
+++ b/crates/hyalo-cli/tests/e2e_config.rs
@@ -81,7 +81,7 @@ fn config_sets_default_dir() {
     let output = hyalo()
         .current_dir(tmp.path())
         // No --dir flag: relies on config's dir = "vault"
-        .args(["summary", "--format", "json"])
+        .args(["summary", "--format", "json", "--no-hints"])
         .output()
         .unwrap();
 
@@ -113,6 +113,7 @@ fn cli_dir_overrides_config() {
         .args([
             "--dir",
             vault_path.to_str().unwrap(),
+            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -141,7 +142,7 @@ fn cli_dir_overrides_config() {
 #[test]
 fn missing_config_uses_defaults() {
     let tmp = TempDir::new().unwrap();
-    // No .hyalo.toml written — hardcoded defaults apply (format=json, dir=., hints=false)
+    // No .hyalo.toml written — hardcoded defaults apply (format=json, dir=., hints=true)
     write_note(tmp.path(), "note.md");
 
     let output = hyalo()

--- a/crates/hyalo-cli/tests/e2e_errors.rs
+++ b/crates/hyalo-cli/tests/e2e_errors.rs
@@ -140,7 +140,7 @@ title: OK
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["summary"])
         .output()
         .unwrap();
@@ -371,6 +371,7 @@ fn error_text_format() {
             tmp.path().to_str().unwrap(),
             "--format",
             "text",
+            "--no-hints",
             "find",
             "--file",
             "nope.md",

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -91,7 +91,7 @@ fn find_json(
     extra_args: &[&str],
 ) -> (std::process::ExitStatus, serde_json::Value, String) {
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.arg("find");
     cmd.args(extra_args);
     let output = cmd.output().unwrap();
@@ -993,9 +993,9 @@ fn find_text_format_with_pattern() {
 fn find_text_format_file_object_structure() {
     let tmp = setup_vault();
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["--format", "text"]);
-    cmd.args(["find", "--file", "alpha.md"]);
+    cmd.args(["find", "--file", "alpha.md", "--fields", "all"]);
     let output = cmd.output().unwrap();
 
     assert!(output.status.success());
@@ -1630,7 +1630,7 @@ fn section_filter_invalid_exits_1() {
 fn empty_text_result_prints_notice_on_stderr() {
     let tmp = setup_vault();
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args([
         "find",
         "--property",
@@ -1656,7 +1656,7 @@ fn empty_text_result_prints_notice_on_stderr() {
 fn empty_json_result_returns_empty_array_no_stderr() {
     let tmp = setup_vault();
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args([
         "find",
         "--property",
@@ -2100,6 +2100,8 @@ fn section_filter_substring_matches_ticket_heading() {
             "DEC-031",
             "--task",
             "any",
+            "--fields",
+            "tasks",
         ],
     );
     assert!(status.success(), "stderr: {stderr}");
@@ -2156,6 +2158,8 @@ fn section_filter_regex_matches() {
             "~=/DEC-03[12]/",
             "--task",
             "any",
+            "--fields",
+            "tasks",
         ],
     );
     assert!(status.success(), "stderr: {stderr}");
@@ -2308,7 +2312,7 @@ fn find_multi_file_returns_array() {
     write_md(tmp.path(), "c.md", "---\ntitle: C\n---\n");
 
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["find", "--file", "a.md", "--file", "b.md"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -3158,6 +3162,7 @@ fn find_sort_title_reverse() {
     let tmp = setup_vault();
     let out = hyalo()
         .args([
+            "--no-hints",
             "find",
             "--sort",
             "title",
@@ -3194,6 +3199,7 @@ fn find_reverse_with_limit() {
     let tmp = setup_vault();
     let out = hyalo()
         .args([
+            "--no-hints",
             "find",
             "--sort",
             "file",
@@ -3228,7 +3234,7 @@ fn find_reverse_alone() {
     let tmp = setup_vault();
     // --reverse without --sort should reverse the default file-path sort
     let out = hyalo()
-        .args(["find", "--reverse", "--format", "json"])
+        .args(["--no-hints", "find", "--reverse", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3259,7 +3265,7 @@ fn find_title_h1_match() {
     let tmp = setup_vault();
     // gamma.md has no frontmatter title but has H1 "# Gamma"
     let out = hyalo()
-        .args(["find", "--title", "gamma", "--format", "json"])
+        .args(["--no-hints", "find", "--title", "gamma", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3283,7 +3289,7 @@ fn find_title_h1_match() {
 fn find_title_case_insensitive() {
     let tmp = setup_vault();
     let out = hyalo()
-        .args(["find", "--title", "ALPHA", "--format", "json"])
+        .args(["--no-hints", "find", "--title", "ALPHA", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3307,7 +3313,14 @@ fn find_title_case_insensitive() {
 fn find_title_regex_mode() {
     let tmp = setup_vault();
     let out = hyalo()
-        .args(["find", "--title", "~=^(Alpha|Beta)$", "--format", "json"])
+        .args([
+            "--no-hints",
+            "find",
+            "--title",
+            "~=^(Alpha|Beta)$",
+            "--format",
+            "json",
+        ])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3331,7 +3344,7 @@ fn find_title_frontmatter_match() {
     let tmp = setup_vault();
     // alpha.md has frontmatter title "Alpha"
     let out = hyalo()
-        .args(["find", "--title", "alph", "--format", "json"])
+        .args(["--no-hints", "find", "--title", "alph", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -198,6 +198,45 @@ fn tags_hints_text() {
 }
 
 // ---------------------------------------------------------------------------
+// Hints active by default (no flag needed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_hints_active_by_default_text() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["summary", "--format", "text"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("  -> hyalo"),
+        "hints should appear by default without --hints flag: {stdout}"
+    );
+}
+
+#[test]
+fn find_hints_active_by_default_json() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(
+        parsed.get("data").is_some(),
+        "JSON should have hints envelope by default: {stdout}"
+    );
+    assert!(
+        parsed.get("hints").is_some(),
+        "JSON should have hints array by default: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Without --hints: output unchanged (regression)
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -206,7 +206,7 @@ fn summary_without_hints_no_arrows() {
     let tmp = setup_vault();
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["summary", "--format", "text"])
+        .args(["summary", "--no-hints", "--format", "text"])
         .output()
         .unwrap();
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -219,16 +219,16 @@ fn summary_without_hints_json_no_envelope() {
     let tmp = setup_vault();
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["summary", "--format", "json"])
+        .args(["summary", "--no-hints", "--format", "json"])
         .output()
         .unwrap();
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
 
-    // Without --hints, should NOT have envelope
+    // With --no-hints, should NOT have envelope
     assert!(
         parsed.get("data").is_none(),
-        "should not have 'data' envelope without --hints"
+        "should not have 'data' envelope with --no-hints"
     );
     // Should have direct summary fields
     assert!(parsed.get("files").is_some());

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -112,7 +112,7 @@ fn create_default_index(tmp: &TempDir) -> std::path::PathBuf {
 /// Run `hyalo find` with extra args and return parsed JSON.
 fn run_find(tmp: &TempDir, extra_args: &[&str]) -> serde_json::Value {
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.arg("find");
     cmd.args(extra_args);
     let output = cmd.output().unwrap();
@@ -384,7 +384,7 @@ fn summary_with_index_matches_disk_scan() {
     let index_path = create_default_index(&tmp);
 
     let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["summary", "--format", "json"])
         .output()
         .unwrap();
@@ -396,6 +396,7 @@ fn summary_with_index_matches_disk_scan() {
         .args([
             "--index",
             index_path.to_str().unwrap(),
+            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -433,6 +434,7 @@ fn summary_with_index_file_count() {
         .args([
             "--index",
             index_path.to_str().unwrap(),
+            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -455,7 +457,7 @@ fn tags_summary_with_index_matches_disk_scan() {
     let index_path = create_default_index(&tmp);
 
     let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -463,7 +465,7 @@ fn tags_summary_with_index_matches_disk_scan() {
     let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
 
     let index_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["--index", index_path.to_str().unwrap(), "tags", "summary"])
         .output()
         .unwrap();
@@ -510,7 +512,7 @@ fn properties_summary_with_index_matches_disk_scan() {
     let index_path = create_default_index(&tmp);
 
     let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["properties", "summary"])
         .output()
         .unwrap();
@@ -518,7 +520,7 @@ fn properties_summary_with_index_matches_disk_scan() {
     let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
 
     let index_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args([
             "--index",
             index_path.to_str().unwrap(),
@@ -568,6 +570,7 @@ fn backlinks_with_index_finds_wikilinks() {
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
+            "--no-hints",
             "--index",
             index_path.to_str().unwrap(),
             "backlinks",
@@ -603,7 +606,7 @@ fn backlinks_with_index_matches_disk_scan() {
     let index_path = create_default_index(&tmp);
 
     let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["backlinks", "--file", "beta.md"])
         .output()
         .unwrap();
@@ -613,6 +616,7 @@ fn backlinks_with_index_matches_disk_scan() {
     let index_output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
+            "--no-hints",
             "--index",
             index_path.to_str().unwrap(),
             "backlinks",
@@ -644,7 +648,12 @@ fn incompatible_index_falls_back_to_disk_scan() {
 
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["--index", garbage_path.to_str().unwrap(), "find"])
+        .args([
+            "--no-hints",
+            "--index",
+            garbage_path.to_str().unwrap(),
+            "find",
+        ])
         .output()
         .unwrap();
 
@@ -681,6 +690,7 @@ fn incompatible_index_falls_back_for_summary() {
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
+            "--no-hints",
             "--index",
             garbage_path.to_str().unwrap(),
             "summary",
@@ -849,6 +859,8 @@ fn task_toggle_with_index_updates_index() {
             "todo",
             "--file",
             "alpha.md",
+            "--fields",
+            "tasks",
             "--index",
             index_path.to_str().unwrap(),
         ],
@@ -1289,7 +1301,7 @@ Content
     unix_fs::symlink(&outside_file, vault.path().join("evil.md")).unwrap();
 
     let output = hyalo()
-        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["--dir", vault.path().to_str().unwrap(), "--no-hints"])
         .arg("find")
         .output()
         .unwrap();
@@ -1356,7 +1368,7 @@ Target content
     .unwrap();
 
     let output = hyalo()
-        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["--dir", vault.path().to_str().unwrap(), "--no-hints"])
         .arg("find")
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e_links.rs
+++ b/crates/hyalo-cli/tests/e2e_links.rs
@@ -87,6 +87,7 @@ fn summary_includes_link_health() {
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
+            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -148,6 +149,7 @@ fn summary_broken_links_includes_nonexistent_target() {
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
+            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -225,6 +227,7 @@ fn find_broken_links_filter() {
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
+            "--no-hints",
             "find",
             "--broken-links",
             "--format",
@@ -284,6 +287,7 @@ fn find_broken_links_entries_have_null_path() {
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
+            "--no-hints",
             "find",
             "--broken-links",
             "--format",
@@ -325,6 +329,7 @@ fn find_broken_links_combined_with_glob_filter() {
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
+            "--no-hints",
             "find",
             "--broken-links",
             "--glob",
@@ -581,6 +586,7 @@ fn links_fix_text_format() {
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
+            "--no-hints",
             "links",
             "fix",
             "--format",

--- a/crates/hyalo-cli/tests/e2e_mv.rs
+++ b/crates/hyalo-cli/tests/e2e_mv.rs
@@ -386,7 +386,7 @@ fn mv_text_format() {
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["--format", "text"])
         .args(["mv", "--file", "sub/b.md", "--to", "archive/b.md"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_properties.rs
+++ b/crates/hyalo-cli/tests/e2e_properties.rs
@@ -42,7 +42,7 @@ priority: 1
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["properties", "summary"])
         .output()
         .unwrap();
@@ -74,7 +74,7 @@ fn properties_empty_dir() {
     let tmp = TempDir::new().unwrap();
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["properties", "summary"])
         .output()
         .unwrap();
@@ -108,7 +108,7 @@ only_in_sub: yes
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["properties", "summary", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -171,7 +171,7 @@ fn properties_glob_no_match() {
     write_md(tmp.path(), "note.md", sample_frontmatter());
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["properties", "summary", "--glob", "nonexistent/*.md"])
         .output()
         .unwrap();
@@ -202,7 +202,7 @@ fn find_properties_single_file() {
     write_md(tmp.path(), "file.md", sample_frontmatter());
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--file", "file.md", "--fields", "properties"])
         .output()
         .unwrap();
@@ -266,7 +266,7 @@ title: Sub B
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--glob", "sub/*.md", "--fields", "properties"])
         .output()
         .unwrap();
@@ -289,7 +289,7 @@ fn find_properties_file_without_frontmatter() {
     write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--file", "plain.md", "--fields", "properties"])
         .output()
         .unwrap();
@@ -331,7 +331,7 @@ status: draft
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["properties", "summary"])
         .output()
         .unwrap();
@@ -479,6 +479,7 @@ fn properties_glob_negation_excludes_files() {
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
+            "--no-hints",
             "properties",
             "summary",
             "--glob",

--- a/crates/hyalo-cli/tests/e2e_read.rs
+++ b/crates/hyalo-cli/tests/e2e_read.rs
@@ -317,7 +317,7 @@ fn read_lines_open_end() {
 fn read_lines_open_start() {
     let tmp = setup();
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["read", "--file", "note.md", "--lines", ":2"])
         .output()
         .unwrap();
@@ -348,7 +348,7 @@ fn read_lines_invalid() {
 fn read_frontmatter_only() {
     let tmp = setup();
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["read", "--file", "note.md", "--frontmatter"])
         .output()
         .unwrap();
@@ -501,7 +501,7 @@ fn read_frontmatter_only_file_returns_empty_body() {
 
     // Text output: body should be empty
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["read", "--file", "fm-only.md"])
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e_short_flags.rs
+++ b/crates/hyalo-cli/tests/e2e_short_flags.rs
@@ -132,7 +132,14 @@ fn find_short_g_for_glob() {
 fn find_short_n_for_limit() {
     let dir = setup();
     let output = hyalo()
-        .args(["find", "-n", "1", "-d", dir.path().to_str().unwrap()])
+        .args([
+            "--no-hints",
+            "find",
+            "-n",
+            "1",
+            "-d",
+            dir.path().to_str().unwrap(),
+        ])
         .output()
         .unwrap();
     assert!(output.status.success());

--- a/crates/hyalo-cli/tests/e2e_site_prefix.rs
+++ b/crates/hyalo-cli/tests/e2e_site_prefix.rs
@@ -36,7 +36,7 @@ fn build_vault(root: &std::path::Path) {
 /// Run `hyalo --dir <dir_arg> find --fields links` and return the parsed JSON.
 fn find_links(dir_arg: &str) -> serde_json::Value {
     let output = hyalo()
-        .args(["--dir", dir_arg])
+        .args(["--dir", dir_arg, "--no-hints"])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
         .unwrap();
@@ -88,7 +88,7 @@ fn find_links_absolute_path_with_dotslash_dir() {
     let docs = format!("{}/docs/", tmp.path().to_str().unwrap());
 
     let output = hyalo()
-        .args(["--dir", docs.trim_end_matches('/')])
+        .args(["--dir", docs.trim_end_matches('/'), "--no-hints"])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
         .unwrap();
@@ -113,7 +113,7 @@ fn find_links_site_prefix_cli_flag() {
     let docs = tmp.path().join("docs");
 
     let output = hyalo()
-        .args(["--dir", docs.to_str().unwrap()])
+        .args(["--dir", docs.to_str().unwrap(), "--no-hints"])
         .args(["--site-prefix", "docs"])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
@@ -153,7 +153,11 @@ fn find_links_site_prefix_config_file() {
     .unwrap();
 
     let output = hyalo()
-        .args(["--dir", tmp.path().join("docs").to_str().unwrap()])
+        .args([
+            "--dir",
+            tmp.path().join("docs").to_str().unwrap(),
+            "--no-hints",
+        ])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -124,6 +124,7 @@ fn summary_json_has_all_fields() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -163,6 +164,7 @@ fn summary_file_counts_by_directory() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -196,6 +198,7 @@ fn summary_task_counts() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -218,6 +221,7 @@ fn summary_status_groups() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -255,6 +259,7 @@ fn summary_tag_counts() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -289,6 +294,7 @@ fn summary_property_summary() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -320,6 +326,7 @@ fn summary_recent_files_limited() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--recent",
             "2",
             "--format",
@@ -344,6 +351,7 @@ fn summary_text_format() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "text",
         ])
@@ -369,6 +377,7 @@ fn summary_glob_filter() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--glob",
             "notes/*.md",
             "--format",
@@ -391,6 +400,7 @@ fn summary_jq_filter() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--jq",
             ".tasks.total",
         ])
@@ -409,6 +419,7 @@ fn summary_empty_vault() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -432,6 +443,7 @@ fn summary_depth_zero_collapses_all_dirs() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--depth",
             "0",
             "--format",
@@ -458,6 +470,7 @@ fn summary_depth_one_collapses_sub_into_parent() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--depth",
             "1",
             "--format",
@@ -490,6 +503,7 @@ fn summary_depth_no_flag_shows_all_directories() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -516,6 +530,7 @@ fn summary_recent_zero() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--recent",
             "0",
             "--format",
@@ -539,6 +554,7 @@ fn summary_json_has_orphans_field() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -593,6 +609,7 @@ No links to me
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -650,6 +667,7 @@ See [[a]]
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -691,6 +709,7 @@ No links
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -723,6 +742,7 @@ No links
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "text",
         ])
@@ -749,6 +769,7 @@ fn summary_orphans_empty_vault() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -807,6 +828,7 @@ No links
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--glob",
             "notes/*.md",
             "--format",
@@ -848,6 +870,7 @@ fn summary_glob_negation_excludes_files() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--glob",
             "!notes/**/*.md",
             "--format",
@@ -933,6 +956,7 @@ No links.
             "json",
         ])
         .arg("summary")
+        .arg("--no-hints")
         .output()
         .unwrap();
     assert!(
@@ -974,6 +998,7 @@ No links.
             "json",
         ])
         .arg("summary")
+        .arg("--no-hints")
         .output()
         .unwrap();
     assert!(
@@ -1066,6 +1091,7 @@ fn summary_dead_ends_json() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -1116,6 +1142,7 @@ fn summary_dead_ends_text_format() {
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "text",
         ])
@@ -1165,6 +1192,7 @@ No links.
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])
@@ -1186,7 +1214,14 @@ fn summary_dead_end_parity_disk_vs_index() {
 
     // Disk scan
     let disk_out = hyalo()
-        .args(["--dir", dir_str, "summary", "--format", "json"])
+        .args([
+            "--dir",
+            dir_str,
+            "--no-hints",
+            "summary",
+            "--format",
+            "json",
+        ])
         .output()
         .unwrap();
     assert!(
@@ -1222,6 +1257,7 @@ fn summary_dead_end_parity_disk_vs_index() {
             "--index",
             index_path.to_str().unwrap(),
             "summary",
+            "--no-hints",
             "--format",
             "json",
         ])

--- a/crates/hyalo-cli/tests/e2e_tags.rs
+++ b/crates/hyalo-cli/tests/e2e_tags.rs
@@ -22,7 +22,7 @@ fn tags_summary_returns_counts() {
     write_md(tmp.path(), "c.md", "No frontmatter.\n");
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -42,7 +42,7 @@ fn tags_empty_vault() {
     let tmp = TempDir::new().unwrap();
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -61,7 +61,7 @@ fn tags_with_glob() {
     write_tagged(tmp.path(), "root.md", &["gamma"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["tags", "summary", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -86,7 +86,7 @@ fn tags_glob_no_match() {
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["tags", "summary", "--glob", "nonexistent/*.md"])
         .output()
         .unwrap();
@@ -145,7 +145,7 @@ fn tags_file_without_frontmatter() {
     write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -171,7 +171,7 @@ tags: rust
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -193,7 +193,7 @@ fn find_tag_exact_match() {
     write_tagged(tmp.path(), "b.md", &["links"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--tag", "iteration", "--fields", "tags"])
         .output()
         .unwrap();
@@ -214,7 +214,7 @@ fn find_tag_nested_match() {
     write_tagged(tmp.path(), "d.md", &["inboxes"]); // must NOT match
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--tag", "inbox"])
         .output()
         .unwrap();
@@ -236,7 +236,7 @@ fn find_tag_no_match_returns_empty_array() {
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--tag", "nonexistent"])
         .output()
         .unwrap();
@@ -255,7 +255,7 @@ fn find_tag_with_glob() {
     write_tagged(tmp.path(), "root.md", &["rust"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--tag", "rust", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -275,7 +275,7 @@ fn find_tag_case_insensitive() {
     write_tagged(tmp.path(), "note.md", &["Rust"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--tag", "rust"])
         .output()
         .unwrap();
@@ -304,7 +304,7 @@ title: Note
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["set", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -326,7 +326,7 @@ fn set_tag_glob_pattern() {
     write_tagged(tmp.path(), "sub/b.md", &["existing"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["set", "--tag", "new-tag", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -343,7 +343,7 @@ fn set_tag_idempotent() {
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["set", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -369,7 +369,7 @@ title: Note
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["set", "--tag", "plan", "--file", "note.md"])
         .output()
         .unwrap();
@@ -386,7 +386,7 @@ fn set_tag_file_not_found() {
     let tmp = TempDir::new().unwrap();
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["set", "--tag", "rust", "--file", "nonexistent.md"])
         .output()
         .unwrap();
@@ -407,7 +407,7 @@ No frontmatter here.
     );
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["set", "--tag", "rust", "--file", "plain.md"])
         .output()
         .unwrap();
@@ -432,7 +432,7 @@ fn remove_tag_single_file() {
     write_tagged(tmp.path(), "note.md", &["rust", "cli"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["remove", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -454,7 +454,7 @@ fn remove_tag_glob_pattern() {
     write_tagged(tmp.path(), "sub/b.md", &["rust", "python"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["remove", "--tag", "rust", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -470,7 +470,7 @@ fn remove_tag_absent_tag_idempotent() {
     write_tagged(tmp.path(), "note.md", &["cli"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["remove", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -487,7 +487,7 @@ fn remove_tag_empties_tags_property() {
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["remove", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -503,7 +503,7 @@ fn remove_tag_file_not_found() {
     let tmp = TempDir::new().unwrap();
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["remove", "--tag", "rust", "--file", "nonexistent.md"])
         .output()
         .unwrap();
@@ -517,7 +517,7 @@ fn remove_tag_from_file_with_no_frontmatter() {
     write_md(tmp.path(), "plain.md", "No frontmatter here.\n");
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["remove", "--tag", "rust", "--file", "plain.md"])
         .output()
         .unwrap();
@@ -534,7 +534,7 @@ fn find_tag_empty_tags_list() {
     write_tagged(tmp.path(), "empty.md", &[]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["find", "--tag", "rust"])
         .output()
         .unwrap();
@@ -555,7 +555,7 @@ fn set_tag_without_file_or_glob_is_user_error() {
     write_tagged(tmp.path(), "note.md", &["existing"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["set", "--tag", "new-tag"])
         .output()
         .unwrap();
@@ -576,7 +576,7 @@ fn remove_tag_without_file_or_glob_is_user_error() {
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .args(["remove", "--tag", "rust"])
         .output()
         .unwrap();
@@ -603,7 +603,7 @@ fn tags_rename_basic() {
     write_tagged(tmp.path(), "c.md", &["cli"]); // no "filtering"
 
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["tags", "rename", "--from", "filtering", "--to", "filters"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -623,7 +623,7 @@ fn tags_rename_already_has_new_tag() {
     write_tagged(tmp.path(), "note.md", &["old-name", "new-name"]);
 
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["tags", "rename", "--from", "old-name", "--to", "new-name"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -642,7 +642,7 @@ fn tags_rename_already_has_new_tag() {
 fn tags_rename_same_name_exits_1() {
     let tmp = TempDir::new().unwrap();
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["tags", "rename", "--from", "foo", "--to", "foo"]);
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
@@ -655,7 +655,7 @@ fn tags_rename_with_glob_scope() {
     write_tagged(tmp.path(), "other/b.md", &["old-tag"]);
 
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args([
         "tags",
         "rename",
@@ -682,7 +682,7 @@ fn tags_rename_with_glob_scope() {
 fn tags_rename_invalid_tag_exits_1() {
     let tmp = TempDir::new().unwrap();
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["tags", "rename", "--from", "valid", "--to", "invalid tag!"]);
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
@@ -699,7 +699,7 @@ fn tags_rename_scalar_tag() {
     );
 
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["tags", "rename", "--from", "old-tag", "--to", "new-tag"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -732,7 +732,7 @@ fn tags_rename_scalar_tag_already_has_new() {
     write_md(tmp.path(), "note.md", "---\ntags: alpha\n---\n");
 
     let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
     cmd.args(["tags", "rename", "--from", "alpha", "--to", "beta"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -758,6 +758,7 @@ fn tags_glob_negation_excludes_files() {
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
+            "--no-hints",
             "tags",
             "summary",
             "--glob",
@@ -791,7 +792,7 @@ fn tags_bare_defaults_to_summary() {
     write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
 
     let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
         .arg("tags")
         .output()
         .unwrap();

--- a/crates/hyalo-core/src/filter/fields.rs
+++ b/crates/hyalo-core/src/filter/fields.rs
@@ -22,7 +22,7 @@ impl Default for Fields {
             properties_typed: false,
             tags: true,
             sections: true,
-            tasks: true,
+            tasks: false,
             links: true,
             backlinks: false,
             title: false,
@@ -34,8 +34,8 @@ impl Fields {
     /// Parse a fields selection from a list of `--fields` argument values.
     ///
     /// Each element may be a comma-separated list of field names. An empty
-    /// slice returns the default (all standard fields enabled; `properties-typed` and `backlinks`
-    /// are opt-in).
+    /// slice returns the default (properties, tags, sections, links;
+    /// `tasks`, `properties-typed`, `backlinks`, and `title` are opt-in).
     pub fn parse(input: &[String]) -> Result<Fields> {
         if input.is_empty() {
             return Ok(Fields::default());

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -512,9 +512,13 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn fields_empty_returns_all() {
+    fn fields_empty_returns_default() {
         let f = Fields::parse(&[]).unwrap();
-        assert!(f.properties && f.tags && f.sections && f.tasks && f.links);
+        // Default: properties, tags, sections, links enabled; tasks is opt-in (off by default)
+        assert!(f.properties && f.tags && f.sections && f.links);
+        assert!(!f.tasks, "tasks should be off by default");
+        assert!(!f.backlinks, "backlinks should be off by default");
+        assert!(!f.title, "title should be off by default");
     }
 
     #[test]

--- a/hyalo-knowledgebase/iterations/iteration-79-slim-defaults.md
+++ b/hyalo-knowledgebase/iterations/iteration-79-slim-defaults.md
@@ -1,12 +1,12 @@
 ---
-title: "Slim default fields and make --hints the default"
+title: Slim default fields and make --hints the default
 type: iteration
 date: 2026-03-30
 tags:
   - ux
   - dogfood
   - breaking-change
-status: planned
+status: in-progress
 priority: 2
 branch: iter-79/slim-defaults
 ---
@@ -27,16 +27,16 @@ See also: [[iteration-80-smarter-hints]] for making hints context-aware.
 
 ## Tasks
 
-- [ ] Make `--hints` the default (flip the default in the hints logic)
-- [ ] Keep `--no-hints` as opt-out
-- [ ] Keep `--jq` suppressing hints (already the case)
-- [ ] Remove `tasks` from default `--fields` (require `--fields tasks` or `--fields all` to include)
-- [ ] Update `Fields::default()` in `hyalo-core/src/filter/fields.rs`
-- [ ] Update `.hyalo.toml` schema/docs if hints default is stored there
-- [ ] Update help text in `args.rs` to reflect new defaults
-- [ ] Update `SKILL.md` to instruct LLMs to read and follow hints
-- [ ] Update `CLAUDE.md` to mention hints as a navigation aid
-- [ ] Update e2e tests that depend on default field/hint output
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x] Make `--hints` the default (flip the default in the hints logic)
+- [x] Keep `--no-hints` as opt-out
+- [x] Keep `--jq` suppressing hints (already the case)
+- [x] Remove `tasks` from default `--fields` (require `--fields tasks` or `--fields all` to include)
+- [x] Update `Fields::default()` in `hyalo-core/src/filter/fields.rs`
+- [x] Update `.hyalo.toml` schema/docs if hints default is stored there
+- [x] Update help text in `args.rs` to reflect new defaults
+- [x] Update `SKILL.md` to instruct LLMs to read and follow hints
+- [x] Update `CLAUDE.md` to mention hints as a navigation aid
+- [x] Update e2e tests that depend on default field/hint output
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`


### PR DESCRIPTION
## Summary
- **Hints enabled by default**: every query now appends drill-down suggestions (`-> hyalo ...` in text, `"hints"` array in JSON). Opt out with `--no-hints` or `--jq` (which suppresses hints automatically).
- **Tasks removed from default `--fields`**: default fields are now `properties, tags, sections, links`. Use `--fields tasks` or `--fields all` to include tasks. Reduces output noise for list queries.
- Updated help text (args.rs + help.rs), SKILL.md (LLM guidance to follow hints), and CLAUDE.md (hints as navigation aid).
- All 500 e2e/unit tests passing, including 2 new tests asserting hints are active by default.

Closes iteration-79. Discovered during v0.6.0 dogfooding (iteration 74).

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 500 tests pass
- [x] Dogfood: `hyalo summary --format text` shows hints by default
- [x] Dogfood: `--no-hints` suppresses hints
- [x] Dogfood: `hyalo find --file ...` omits tasks from JSON output
- [x] Dogfood: `--fields tasks` and `--fields all` still include tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)