### PR TITLE
Improve --file error hints: directories, fuzzy match, traversal

### DIFF
--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -76,7 +76,7 @@ pub fn collect_files(
                         format!("path is a directory, not a file: {path} (try {hint})")
                     }
                     FileResolveError::OutsideVault { .. } => {
-                        format!("file resolves outside vault: {path}")
+                        format!("file resolves outside vault boundary: {path}")
                     }
                     FileResolveError::InvalidPath { reason, .. } => {
                         format!("invalid path ({reason}): {path}")

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -66,8 +66,14 @@ pub fn collect_files(
             for (path, err) in &errors {
                 let msg = match err {
                     FileResolveError::NotFound { .. } => format!("file not found: {path}"),
+                    FileResolveError::NotFoundSuggestion { suggestion, .. } => {
+                        format!("file not found: {path} (did you mean {suggestion}?)")
+                    }
                     FileResolveError::MissingExtension { hint, .. } => {
                         format!("file not found: {path} (did you mean {hint}?)")
+                    }
+                    FileResolveError::IsDirectory { hint, .. } => {
+                        format!("path is a directory, not a file: {path} (try {hint})")
                     }
                     FileResolveError::OutsideVault { .. } => {
                         format!("file resolves outside vault: {path}")
@@ -314,6 +320,24 @@ pub fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> Comman
         FileResolveError::NotFound { path } => CommandOutcome::UserError(
             crate::output::format_error(format, "file not found", Some(&path), None, None),
         ),
+        FileResolveError::NotFoundSuggestion { path, suggestion } => {
+            CommandOutcome::UserError(crate::output::format_error(
+                format,
+                "file not found",
+                Some(&path),
+                Some(&format!("did you mean {suggestion}?")),
+                None,
+            ))
+        }
+        FileResolveError::IsDirectory { path, hint } => {
+            CommandOutcome::UserError(crate::output::format_error(
+                format,
+                "path is a directory, not a file",
+                Some(&path),
+                Some(&hint),
+                None,
+            ))
+        }
         FileResolveError::OutsideVault { path } => {
             CommandOutcome::UserError(crate::output::format_error(
                 format,

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -3,6 +3,8 @@ use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use hyalo_core::util::levenshtein;
+
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::frontmatter::infer_type;
 use hyalo_core::index::VaultIndex;
@@ -16,38 +18,6 @@ use hyalo_core::types::{
 // ---------------------------------------------------------------------------
 // Rare-value inconsistency detection
 // ---------------------------------------------------------------------------
-
-/// Compute the Levenshtein edit distance between two strings.
-///
-/// Uses the standard iterative two-row DP algorithm.
-/// Runs in O(|a| * |b|) time and O(min(|a|, |b|)) space.
-fn levenshtein(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-
-    // Ensure the shorter string is in the column dimension for minimal allocation.
-    let (a, b) = if a.len() < b.len() { (b, a) } else { (a, b) };
-
-    let m = a.len();
-    let n = b.len();
-
-    // prev[j] = edit distance between a[..i-1] and b[..j]
-    let mut prev: Vec<usize> = (0..=n).collect();
-    let mut curr: Vec<usize> = vec![0; n + 1];
-
-    for i in 1..=m {
-        curr[0] = i;
-        for j in 1..=n {
-            let cost = usize::from(a[i - 1] != b[j - 1]);
-            curr[j] = (curr[j - 1] + 1) // insertion
-                .min(prev[j] + 1) // deletion
-                .min(prev[j - 1] + cost); // substitution
-        }
-        std::mem::swap(&mut prev, &mut curr);
-    }
-
-    prev[n]
-}
 
 /// Emit warnings for property values that appear in very few files and closely
 /// resemble a much more common value (likely typos or inconsistencies).

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -5,6 +5,7 @@ use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
 use crate::link_graph::strip_site_prefix;
+use crate::util::levenshtein;
 
 /// Collect all `.md` files under the given directory, respecting `.gitignore` and skipping hidden dirs.
 pub fn discover_files(dir: &Path) -> Result<Vec<PathBuf>> {
@@ -81,18 +82,30 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
 
     let normalized = normalize_path(path_arg);
 
-    // Reject path traversal attempts
+    // Reject path traversal attempts — use `OutsideVault` so the user
+    // understands the path was rejected because it escapes the vault, not
+    // because the file doesn't exist.
     if normalized.starts_with('/')
         || has_parent_traversal(&normalized)
         || Path::new(&normalized).is_absolute()
     {
-        return Err(FileResolveError::NotFound { path: normalized });
+        return Err(FileResolveError::OutsideVault { path: normalized });
     }
 
     if !std::path::Path::new(&normalized)
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
     {
+        // If the path refers to a directory inside the vault, suggest --glob
+        // instead of the misleading "{name}.md" hint.
+        if dir.join(&normalized).is_dir() {
+            let glob_hint = format!("--glob '{normalized}/*'");
+            return Err(FileResolveError::IsDirectory {
+                path: normalized,
+                hint: glob_hint,
+            });
+        }
+
         let hint = format!("{normalized}.md");
         return Err(FileResolveError::MissingExtension {
             path: normalized,
@@ -102,6 +115,13 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
 
     let full = dir.join(&normalized);
     if !full.is_file() {
+        // Try fuzzy-matching against .md siblings in the same parent directory.
+        if let Some(suggestion) = fuzzy_match_sibling(&full) {
+            return Err(FileResolveError::NotFoundSuggestion {
+                path: normalized,
+                suggestion,
+            });
+        }
         return Err(FileResolveError::NotFound { path: normalized });
     }
 
@@ -125,6 +145,35 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
     }
 
     Ok((full, normalized))
+}
+
+/// Find the closest `.md` sibling by Levenshtein distance.
+///
+/// Returns the file-name of the best match when the distance is at most 3,
+/// or `None` when nothing is close enough.
+fn fuzzy_match_sibling(full: &Path) -> Option<String> {
+    let parent = full.parent()?;
+    let stem = full.file_name()?.to_str()?;
+
+    let entries = std::fs::read_dir(parent).ok()?;
+    let mut best: Option<(usize, String)> = None;
+
+    for entry in entries.filter_map(Result::ok) {
+        let name = entry.file_name();
+        let name_str = name.to_str()?;
+        let is_md = std::path::Path::new(name_str)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+        if !is_md || name_str == stem {
+            continue;
+        }
+        let dist = levenshtein(stem, name_str);
+        if dist <= 3 && best.as_ref().is_none_or(|(d, _)| dist < *d) {
+            best = Some((dist, name_str.to_owned()));
+        }
+    }
+
+    best.map(|(_, name)| name)
 }
 
 /// Return true if the path contains any `..` (parent directory) component.
@@ -356,7 +405,9 @@ pub fn relative_path(dir: &Path, file: &Path) -> String {
 #[derive(Debug)]
 pub enum FileResolveError {
     NotFound { path: String },
+    NotFoundSuggestion { path: String, suggestion: String },
     MissingExtension { path: String, hint: String },
+    IsDirectory { path: String, hint: String },
     OutsideVault { path: String },
     InvalidPath { path: String, reason: &'static str },
 }
@@ -365,8 +416,14 @@ impl std::fmt::Display for FileResolveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NotFound { path } => write!(f, "file not found: {path}"),
+            Self::NotFoundSuggestion { path, suggestion } => {
+                write!(f, "file not found: {path} (did you mean {suggestion}?)")
+            }
             Self::MissingExtension { path, hint } => {
                 write!(f, "file not found: {path} (did you mean {hint}?)")
+            }
+            Self::IsDirectory { path, hint } => {
+                write!(f, "path is a directory, not a file: {path} (try {hint})")
             }
             Self::OutsideVault { path } => {
                 write!(f, "file resolves outside vault boundary: {path}")
@@ -571,19 +628,19 @@ mod tests {
         // Absolute path
         assert!(matches!(
             resolve_file(tmp.path(), "/etc/passwd.md"),
-            Err(FileResolveError::NotFound { .. })
+            Err(FileResolveError::OutsideVault { .. })
         ));
 
         // Parent directory traversal
         assert!(matches!(
             resolve_file(tmp.path(), "../secret.md"),
-            Err(FileResolveError::NotFound { .. })
+            Err(FileResolveError::OutsideVault { .. })
         ));
 
         // Embedded traversal
         assert!(matches!(
             resolve_file(tmp.path(), "sub/../../../etc/passwd.md"),
-            Err(FileResolveError::NotFound { .. })
+            Err(FileResolveError::OutsideVault { .. })
         ));
     }
 
@@ -865,12 +922,12 @@ mod tests {
 
         assert!(matches!(
             resolve_file(tmp.path(), "../secret.md"),
-            Err(FileResolveError::NotFound { .. })
+            Err(FileResolveError::OutsideVault { .. })
         ));
 
         assert!(matches!(
             resolve_file(tmp.path(), "sub/../../etc/passwd.md"),
-            Err(FileResolveError::NotFound { .. })
+            Err(FileResolveError::OutsideVault { .. })
         ));
     }
 
@@ -1088,5 +1145,88 @@ mod tests {
             }
         ));
         assert!(err.to_string().contains("contains null byte"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Iteration 76 — directory detection hint
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_file_directory_suggests_glob() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("notes")).unwrap();
+
+        let err = resolve_file(tmp.path(), "notes").unwrap_err();
+        match err {
+            FileResolveError::IsDirectory { ref path, ref hint } => {
+                assert_eq!(path, "notes");
+                assert!(hint.contains("--glob"));
+                assert!(hint.contains("notes/*"));
+            }
+            other => panic!("expected IsDirectory, got {other:?}"),
+        }
+        assert!(err.to_string().contains("directory"));
+    }
+
+    #[test]
+    fn resolve_file_non_directory_without_ext_still_hints_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        // "notes" doesn't exist as a dir or file — should get MissingExtension
+        let err = resolve_file(tmp.path(), "notes").unwrap_err();
+        assert!(matches!(err, FileResolveError::MissingExtension { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Iteration 76 — fuzzy file name suggestion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_file_fuzzy_suggests_close_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("readme.md"), "").unwrap();
+
+        // "readem.md" is 1 edit away from "readme.md"
+        let err = resolve_file(tmp.path(), "readem.md").unwrap_err();
+        match err {
+            FileResolveError::NotFoundSuggestion { ref suggestion, .. } => {
+                assert_eq!(suggestion, "readme.md");
+            }
+            other => panic!("expected NotFoundSuggestion, got {other:?}"),
+        }
+        assert!(err.to_string().contains("did you mean"));
+    }
+
+    #[test]
+    fn resolve_file_no_fuzzy_for_distant_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("readme.md"), "").unwrap();
+
+        // "zzzzz.md" is far from "readme.md" — should get plain NotFound
+        let err = resolve_file(tmp.path(), "zzzzz.md").unwrap_err();
+        assert!(matches!(err, FileResolveError::NotFound { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Iteration 78 — path traversal returns OutsideVault
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_file_traversal_says_outside_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let err = resolve_file(tmp.path(), "../Cargo.toml").unwrap_err();
+        assert!(matches!(err, FileResolveError::OutsideVault { .. }));
+        assert!(
+            err.to_string().contains("outside vault"),
+            "message should mention 'outside vault', got: {err}",
+        );
+    }
+
+    #[test]
+    fn resolve_file_absolute_path_says_outside_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let err = resolve_file(tmp.path(), "/etc/passwd.md").unwrap_err();
+        assert!(matches!(err, FileResolveError::OutsideVault { .. }));
     }
 }

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -116,7 +116,15 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
     let full = dir.join(&normalized);
     if !full.is_file() {
         // Try fuzzy-matching against .md siblings in the same parent directory.
-        if let Some(suggestion) = fuzzy_match_sibling(&full) {
+        if let Some(sibling_name) = fuzzy_match_sibling(&full) {
+            // Reconstruct the suggestion as a vault-relative path so nested
+            // directories produce e.g. "sub/readme.md", not just "readme.md".
+            let suggestion = match Path::new(&normalized).parent() {
+                Some(p) if p != Path::new("") => {
+                    format!("{}/{sibling_name}", p.display())
+                }
+                _ => sibling_name,
+            };
             return Err(FileResolveError::NotFoundSuggestion {
                 path: normalized,
                 suggestion,
@@ -153,21 +161,23 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
 /// or `None` when nothing is close enough.
 fn fuzzy_match_sibling(full: &Path) -> Option<String> {
     let parent = full.parent()?;
-    let stem = full.file_name()?.to_str()?;
+    let target_name = full.file_name()?.to_str()?;
 
     let entries = std::fs::read_dir(parent).ok()?;
     let mut best: Option<(usize, String)> = None;
 
     for entry in entries.filter_map(Result::ok) {
         let name = entry.file_name();
-        let name_str = name.to_str()?;
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
         let is_md = std::path::Path::new(name_str)
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
-        if !is_md || name_str == stem {
+        if !is_md || name_str == target_name {
             continue;
         }
-        let dist = levenshtein(stem, name_str);
+        let dist = levenshtein(target_name, name_str);
         if dist <= 3 && best.as_ref().is_none_or(|(d, _)| dist < *d) {
             best = Some((dist, name_str.to_owned()));
         }
@@ -1194,6 +1204,22 @@ mod tests {
             other => panic!("expected NotFoundSuggestion, got {other:?}"),
         }
         assert!(err.to_string().contains("did you mean"));
+    }
+
+    #[test]
+    fn resolve_file_fuzzy_suggests_with_relative_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("sub")).unwrap();
+        fs::write(tmp.path().join("sub/readme.md"), "").unwrap();
+
+        // "sub/readem.md" should suggest "sub/readme.md", not just "readme.md"
+        let err = resolve_file(tmp.path(), "sub/readem.md").unwrap_err();
+        match err {
+            FileResolveError::NotFoundSuggestion { ref suggestion, .. } => {
+                assert_eq!(suggestion, "sub/readme.md");
+            }
+            other => panic!("expected NotFoundSuggestion, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -12,3 +12,4 @@ pub mod links;
 pub mod scanner;
 pub mod tasks;
 pub mod types;
+pub mod util;

--- a/crates/hyalo-core/src/util.rs
+++ b/crates/hyalo-core/src/util.rs
@@ -1,0 +1,63 @@
+/// Compute the Levenshtein edit distance between two strings.
+///
+/// Uses the standard iterative two-row DP algorithm.
+/// Runs in O(|a| * |b|) time and O(min(|a|, |b|)) space.
+pub fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+
+    // Ensure the shorter string is in the column dimension for minimal allocation.
+    let (a, b) = if a.len() < b.len() { (b, a) } else { (a, b) };
+
+    let m = a.len();
+    let n = b.len();
+
+    // prev[j] = edit distance between a[..i-1] and b[..j]
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr: Vec<usize> = vec![0; n + 1];
+
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            curr[j] = (curr[j - 1] + 1) // insertion
+                .min(prev[j] + 1) // deletion
+                .min(prev[j - 1] + cost); // substitution
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[n]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_strings() {
+        assert_eq!(levenshtein("hello", "hello"), 0);
+    }
+
+    #[test]
+    fn single_insertion() {
+        assert_eq!(levenshtein("cat", "cats"), 1);
+    }
+
+    #[test]
+    fn single_deletion() {
+        assert_eq!(levenshtein("cats", "cat"), 1);
+    }
+
+    #[test]
+    fn single_substitution() {
+        assert_eq!(levenshtein("cat", "bat"), 1);
+    }
+
+    #[test]
+    fn empty_strings() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("", "abc"), 3);
+    }
+}

--- a/crates/hyalo-core/src/util.rs
+++ b/crates/hyalo-core/src/util.rs
@@ -1,7 +1,7 @@
 /// Compute the Levenshtein edit distance between two strings.
 ///
 /// Uses the standard iterative two-row DP algorithm.
-/// Runs in O(|a| * |b|) time and O(min(|a|, |b|)) space.
+/// Runs in O(|a| * |b|) time and O(|a| + |b|) additional space.
 pub fn levenshtein(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();

--- a/hyalo-knowledgebase/iterations/iteration-76-file-resolve-suggestions.md
+++ b/hyalo-knowledgebase/iterations/iteration-76-file-resolve-suggestions.md
@@ -5,7 +5,7 @@ date: 2026-03-30
 tags:
   - ux
   - dogfood
-status: planned
+status: in-progress
 priority: 3
 branch: iter-76/file-resolve-suggestions
 ---
@@ -22,13 +22,13 @@ A `levenshtein()` function already exists in `hyalo-cli/src/commands/summary.rs`
 
 ## Tasks
 
-- [ ] Move `levenshtein()` from `summary.rs` to a shared utility in `hyalo-core` (e.g. `hyalo-core::util::levenshtein`)
-- [ ] In `resolve_file`, detect when the path is a directory and suggest `--glob 'dir/*'` instead of appending `.md`
-- [ ] When the file is not found and not a directory, fuzzy-match against existing `.md` files in the same parent directory using Levenshtein distance
-- [ ] Suggest the closest match(es) if distance is below a reasonable threshold
-- [ ] Update `FileResolveError` variants as needed for the new hint types
-- [ ] Add tests for directory detection hint
-- [ ] Add tests for fuzzy file name suggestion
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x]Move `levenshtein()` from `summary.rs` to a shared utility in `hyalo-core` (e.g. `hyalo-core::util::levenshtein`)
+- [x]In `resolve_file`, detect when the path is a directory and suggest `--glob 'dir/*'` instead of appending `.md`
+- [x]When the file is not found and not a directory, fuzzy-match against existing `.md` files in the same parent directory using Levenshtein distance
+- [x]Suggest the closest match(es) if distance is below a reasonable threshold
+- [x]Update `FileResolveError` variants as needed for the new hint types
+- [x]Add tests for directory detection hint
+- [x]Add tests for fuzzy file name suggestion
+- [x]`cargo fmt`
+- [x]`cargo clippy --workspace --all-targets -- -D warnings`
+- [x]`cargo test --workspace`

--- a/hyalo-knowledgebase/iterations/iteration-76-file-resolve-suggestions.md
+++ b/hyalo-knowledgebase/iterations/iteration-76-file-resolve-suggestions.md
@@ -22,13 +22,13 @@ A `levenshtein()` function already exists in `hyalo-cli/src/commands/summary.rs`
 
 ## Tasks
 
-- [x]Move `levenshtein()` from `summary.rs` to a shared utility in `hyalo-core` (e.g. `hyalo-core::util::levenshtein`)
-- [x]In `resolve_file`, detect when the path is a directory and suggest `--glob 'dir/*'` instead of appending `.md`
-- [x]When the file is not found and not a directory, fuzzy-match against existing `.md` files in the same parent directory using Levenshtein distance
-- [x]Suggest the closest match(es) if distance is below a reasonable threshold
-- [x]Update `FileResolveError` variants as needed for the new hint types
-- [x]Add tests for directory detection hint
-- [x]Add tests for fuzzy file name suggestion
-- [x]`cargo fmt`
-- [x]`cargo clippy --workspace --all-targets -- -D warnings`
-- [x]`cargo test --workspace`
+- [x] Move `levenshtein()` from `summary.rs` to a shared utility in `hyalo-core` (e.g. `hyalo-core::util::levenshtein`)
+- [x] In `resolve_file`, detect when the path is a directory and suggest `--glob 'dir/*'` instead of appending `.md`
+- [x] When the file is not found and not a directory, fuzzy-match against existing `.md` files in the same parent directory using Levenshtein distance
+- [x] Suggest the closest match(es) if distance is below a reasonable threshold
+- [x] Update `FileResolveError` variants as needed for the new hint types
+- [x] Add tests for directory detection hint
+- [x] Add tests for fuzzy file name suggestion
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`

--- a/hyalo-knowledgebase/iterations/iteration-78-path-traversal-error-message.md
+++ b/hyalo-knowledgebase/iterations/iteration-78-path-traversal-error-message.md
@@ -1,5 +1,5 @@
 ---
-title: Improve error message for path traversal rejection
+title: "Improve error message for path traversal rejection"
 type: iteration
 date: 2026-03-30
 tags:
@@ -20,9 +20,9 @@ Found during v0.6.0 dogfooding (iteration 74). `--file ../Cargo.toml` returns `E
 
 ## Tasks
 
-- [x]In `resolve_file`, return `OutsideVault` (or a new variant) when `..` segments are detected, instead of falling through to `NotFound`
-- [x]Update error message to clearly state the path resolves outside the vault
-- [x]Add/update test for `..` traversal error variant
-- [x]`cargo fmt`
-- [x]`cargo clippy --workspace --all-targets -- -D warnings`
-- [x]`cargo test --workspace`
+- [x] In `resolve_file`, return `OutsideVault` (or a new variant) when `..` segments are detected, instead of falling through to `NotFound`
+- [x] Update error message to clearly state the path resolves outside the vault
+- [x] Add/update test for `..` traversal error variant
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`

--- a/hyalo-knowledgebase/iterations/iteration-78-path-traversal-error-message.md
+++ b/hyalo-knowledgebase/iterations/iteration-78-path-traversal-error-message.md
@@ -1,13 +1,13 @@
 ---
-title: "Improve error message for path traversal rejection"
+title: Improve error message for path traversal rejection
 type: iteration
 date: 2026-03-30
 tags:
   - ux
   - dogfood
-status: planned
+status: in-progress
 priority: 4
-branch: iter-78/path-traversal-error-msg
+branch: iter-76/file-resolve-suggestions
 ---
 
 ## Goal
@@ -20,9 +20,9 @@ Found during v0.6.0 dogfooding (iteration 74). `--file ../Cargo.toml` returns `E
 
 ## Tasks
 
-- [ ] In `resolve_file`, return `OutsideVault` (or a new variant) when `..` segments are detected, instead of falling through to `NotFound`
-- [ ] Update error message to clearly state the path resolves outside the vault
-- [ ] Add/update test for `..` traversal error variant
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x]In `resolve_file`, return `OutsideVault` (or a new variant) when `..` segments are detected, instead of falling through to `NotFound`
+- [x]Update error message to clearly state the path resolves outside the vault
+- [x]Add/update test for `..` traversal error variant
+- [x]`cargo fmt`
+- [x]`cargo clippy --workspace --all-targets -- -D warnings`
+- [x]`cargo test --workspace`


### PR DESCRIPTION
## Summary
- **Directory detection** (iter-76): `--file iterations` now returns "path is a directory" with a `--glob 'iterations/*'` hint instead of the misleading "did you mean iterations.md?"
- **Fuzzy matching** (iter-76): `--file readem.md` suggests the closest `.md` sibling by Levenshtein distance (threshold ≤ 3)
- **Path traversal message** (iter-78): `--file ../Cargo.toml` now returns "file resolves outside vault boundary" instead of the generic "file not found"
- **Shared utility**: Moved `levenshtein()` from `hyalo-cli` to `hyalo-core::util` for reuse

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all 510+ tests pass
- [x] New unit tests for directory detection hint (2 tests)
- [x] New unit tests for fuzzy file name suggestion (2 tests)
- [x] New unit tests for path traversal returning `OutsideVault` (2 tests)
- [x] Existing traversal tests updated to expect `OutsideVault`
- [x] Levenshtein unit tests in `hyalo-core::util` (5 tests)
- [x] Dogfood: verified all three error messages with release binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)