### PR TITLE
Context-aware hints with descriptions for all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Orphans: 3
   -> hyalo --dir . find --property status=in-progress
 ```
 
-In JSON mode, `--hints` wraps the output in `{"data": ..., "hints": [...]}`. Hints are concrete, copy-pasteable commands — no templates or placeholders. Suppressed when combined with `--jq`.
+In JSON mode, `--hints` wraps the output in `{"data": ..., "hints": [{"description": "...", "cmd": "hyalo ..."}]}`. Each hint has a short description and a concrete, copy-pasteable command. Suppressed when combined with `--jq`.
 
 ## Snapshot Index
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -72,15 +72,16 @@ pub(crate) struct Cli {
     pub jq: Option<String>,
 
     /// Force hints on (already the default).
-    /// Text mode: '-> hyalo ...' lines — concrete, copy-pasteable commands.
-    /// JSON mode: wraps in {"data": ..., "hints": [...]}.
+    /// Text mode: '-> hyalo ...  # description' lines — concrete, copy-pasteable commands with descriptions.
+    /// JSON mode: wraps in {"data": ..., "hints": [{"description": "...", "cmd": "hyalo ..."}]}.
     /// Suppressed when --jq is active.
     #[arg(long, global = true)]
     pub hints: bool,
 
     /// Disable drill-down command hints (enabled by default).
     /// Override via .hyalo.toml: hints = false
-    #[arg(long, global = true, conflicts_with = "hints")]
+    /// When both --hints and --no-hints are present, --hints takes precedence.
+    #[arg(long, global = true)]
     pub no_hints: bool,
 
     /// Site prefix for resolving root-absolute links like `/docs/page.md`.

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -259,7 +259,7 @@ OUTPUT SHAPES (JSON, default):
   {\"deleted\": \".hyalo-index\"}
 
   # --hints wraps JSON output in an envelope with drill-down commands
-  {\"data\": { ... original output ... }, \"hints\": [\"hyalo properties\", ...]}
+  {\"data\": { ... original output ... }, \"hints\": [{\"description\": \"...\", \"cmd\": \"hyalo ...\"}, ...]}
 
   # errors (stderr, exit code 1 for user errors, 2 for internal)
   {\"error\": \"property not found\", \"path\": \"notes/todo.md\"}

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -35,6 +35,7 @@ pub enum HintSource {
     Read,
     Backlinks,
     Mv,
+    TaskRead,
     TaskToggle,
     TaskSetStatus,
     LinksFix,
@@ -97,7 +98,8 @@ impl HintContext {
 
 /// Generate concrete drill-down hints from a command's JSON output.
 ///
-/// Returns at most [`MAX_HINTS`] executable `hyalo` command strings.
+/// Returns at most [`MAX_HINTS`] [`Hint`]s, each with a human-readable description
+/// and an executable `hyalo` command (`cmd`).
 #[must_use]
 pub fn generate_hints(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let hints = match &ctx.source {
@@ -109,6 +111,7 @@ pub fn generate_hints(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> 
         HintSource::Read => hints_for_read(ctx, data),
         HintSource::Backlinks => hints_for_backlinks(ctx, data),
         HintSource::Mv => hints_for_mv(ctx, data),
+        HintSource::TaskRead => hints_for_task_read(ctx, data),
         HintSource::TaskToggle | HintSource::TaskSetStatus => hints_for_task_mutation(ctx, data),
         HintSource::LinksFix => hints_for_links_fix(ctx, data),
         HintSource::CreateIndex => hints_for_create_index(ctx, data),
@@ -646,6 +649,42 @@ fn hints_for_mv(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
                 build_command_no_glob(ctx, &["backlinks", "--file", to_path]),
             ));
         }
+    }
+
+    hints
+}
+
+/// Hints for `task read` — suggest toggling or viewing remaining tasks.
+fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let file = data.get("file").and_then(|f| f.as_str());
+    let line = data.get("line").and_then(serde_json::Value::as_u64);
+    let done = data
+        .get("done")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    if let (Some(file), Some(line)) = (file, line) {
+        let line_str = line.to_string();
+        if !done {
+            hints.push(Hint::new(
+                "Toggle this task to done",
+                build_command_no_glob(
+                    ctx,
+                    &["task", "toggle", "--file", file, "--line", &line_str],
+                ),
+            ));
+        }
+        hints.push(Hint::new(
+            "See all open tasks in this file",
+            build_command_no_glob(
+                ctx,
+                &[
+                    "find", "--file", file, "--task", "todo", "--fields", "tasks",
+                ],
+            ),
+        ));
     }
 
     hints
@@ -1297,6 +1336,34 @@ mod tests {
                 .iter()
                 .any(|h| h.cmd.contains("backlinks") && h.cmd.contains("new.md")),
             "should suggest checking backlinks: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn task_read_undone_suggests_toggle() {
+        let c = ctx(HintSource::TaskRead);
+        let data =
+            json!({"file": "todo.md", "line": 5, "status": " ", "text": "Fix bug", "done": false});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("task toggle")),
+            "should suggest toggling undone task: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn task_read_done_omits_toggle() {
+        let c = ctx(HintSource::TaskRead);
+        let data =
+            json!({"file": "todo.md", "line": 5, "status": "x", "text": "Fix bug", "done": true});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            !hints.iter().any(|h| h.cmd.contains("task toggle")),
+            "should not suggest toggling already-done task: {hints:?}"
+        );
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("--task todo")),
+            "should suggest viewing open tasks: {hints:?}"
         );
     }
 

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -10,8 +10,8 @@ const MAX_HINTS: usize = 5;
 /// A single drill-down hint: a concrete command plus a short human-readable description.
 #[derive(Debug, Clone)]
 pub struct Hint {
-    pub description: String,
-    pub cmd: String,
+    pub(crate) description: String,
+    pub(crate) cmd: String,
 }
 
 impl Hint {
@@ -150,6 +150,38 @@ fn build_command_no_glob(ctx: &HintContext, args: &[&str]) -> String {
 fn build_command_with_glob(ctx: &HintContext, args: &[&str]) -> String {
     let mut parts: Vec<String> = vec!["hyalo".to_owned()];
     for arg in args {
+        parts.push(shell_quote(arg));
+    }
+    push_global_flags(&mut parts, ctx);
+    for glob in &ctx.glob {
+        parts.push("--glob".to_owned());
+        parts.push(shell_quote(glob));
+    }
+    parts.join(" ")
+}
+
+/// Build a `find` command that preserves the caller's existing filters (property,
+/// tag, task, file targets) plus `--glob`, then appends `extra_args`.  Use this for
+/// hints like sort and limit that refine the current query without changing its scope.
+fn build_find_command_preserving_filters(ctx: &HintContext, extra_args: &[&str]) -> String {
+    let mut parts: Vec<String> = vec!["hyalo".to_owned(), "find".to_owned()];
+    for pf in &ctx.property_filters {
+        parts.push("--property".to_owned());
+        parts.push(shell_quote(pf));
+    }
+    for tf in &ctx.tag_filters {
+        parts.push("--tag".to_owned());
+        parts.push(shell_quote(tf));
+    }
+    if let Some(task) = &ctx.task_filter {
+        parts.push("--task".to_owned());
+        parts.push(shell_quote(task));
+    }
+    for ft in &ctx.file_targets {
+        parts.push("--file".to_owned());
+        parts.push(shell_quote(ft));
+    }
+    for arg in extra_args {
         parts.push(shell_quote(arg));
     }
     push_global_flags(&mut parts, ctx);
@@ -453,7 +485,10 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
             if remaining > 0 {
                 hints.push(Hint::new(
                     "Sort by most recently modified",
-                    build_command_with_glob(ctx, &["find", "--sort", "modified", "--reverse"]),
+                    build_find_command_preserving_filters(
+                        ctx,
+                        &["--sort", "modified", "--reverse"],
+                    ),
                 ));
             }
         }
@@ -464,22 +499,15 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
             if remaining > 0 {
                 hints.push(Hint::new(
                     "Limit to 10 results",
-                    build_command_with_glob(ctx, &["find", "--limit", "10"]),
+                    build_find_command_preserving_filters(ctx, &["--limit", "10"]),
                 ));
             }
         }
     }
 
-    // --- Body search → regex suggestion ---
-    if ctx.has_body_search && result_count > 10 {
-        let remaining = MAX_HINTS.saturating_sub(hints.len());
-        if remaining > 0 {
-            hints.push(Hint::new(
-                "Narrow with regex pattern",
-                build_command_with_glob(ctx, &["find", "-e", "'pattern'"]),
-            ));
-        }
-    }
+    // Body search → regex suggestion is intentionally omitted.
+    // We cannot produce a concrete regex without knowing the user's intent,
+    // and a placeholder like `'pattern'` would violate our no-templates contract.
 
     hints
 }
@@ -602,11 +630,12 @@ fn hints_for_mv(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
 
     if let Some(to_path) = to_path {
         if is_dry_run {
-            let from_path = data.get("from").and_then(|f| f.as_str()).unwrap_or("");
-            hints.push(Hint::new(
-                "Apply this move",
-                build_command_no_glob(ctx, &["mv", "--file", from_path, "--to", to_path]),
-            ));
+            if let Some(from_path) = data.get("from").and_then(|f| f.as_str()) {
+                hints.push(Hint::new(
+                    "Apply this move",
+                    build_command_no_glob(ctx, &["mv", "--file", from_path, "--to", to_path]),
+                ));
+            }
         } else {
             hints.push(Hint::new(
                 "Read the moved file",
@@ -1069,6 +1098,51 @@ mod tests {
         assert!(hints.len() <= MAX_HINTS);
     }
 
+    #[test]
+    fn find_sort_hint_preserves_existing_filters() {
+        let mut c = ctx(HintSource::Find);
+        c.property_filters = vec!["status=draft".to_owned()];
+        c.tag_filters = vec!["research".to_owned()];
+        // 6 results to trigger sort/limit hints.
+        let items: Vec<serde_json::Value> = (0..6)
+            .map(|i| make_find_item(&format!("{i}.md"), Some("draft"), &["research"]))
+            .collect();
+        let data = json!({"total": items.len(), "results": items});
+        let hints = generate_hints(&c, &data);
+        let sort_hint = hints.iter().find(|h| h.cmd.contains("--sort"));
+        assert!(sort_hint.is_some(), "should include a sort hint: {hints:?}");
+        let cmd = &sort_hint.unwrap().cmd;
+        assert!(
+            cmd.contains("--property status=draft"),
+            "sort hint should preserve --property filter: {cmd}"
+        );
+        assert!(
+            cmd.contains("--tag research"),
+            "sort hint should preserve --tag filter: {cmd}"
+        );
+    }
+
+    #[test]
+    fn find_limit_hint_preserves_existing_filters() {
+        let mut c = ctx(HintSource::Find);
+        c.tag_filters = vec!["iteration".to_owned()];
+        let items: Vec<serde_json::Value> = (0..6)
+            .map(|i| make_find_item(&format!("{i}.md"), Some("planned"), &["iteration"]))
+            .collect();
+        let data = json!({"total": items.len(), "results": items});
+        let hints = generate_hints(&c, &data);
+        let limit_hint = hints.iter().find(|h| h.cmd.contains("--limit"));
+        assert!(
+            limit_hint.is_some(),
+            "should include a limit hint: {hints:?}"
+        );
+        let cmd = &limit_hint.unwrap().cmd;
+        assert!(
+            cmd.contains("--tag iteration"),
+            "limit hint should preserve --tag filter: {cmd}"
+        );
+    }
+
     // --- flag propagation ---
 
     #[test]
@@ -1300,10 +1374,14 @@ mod tests {
             .collect();
         let data = json!({"total": items.len(), "results": items});
         let hints = generate_hints(&c, &data);
-        // Should NOT suggest --tag rust (already filtered), but should suggest --tag cli
+        // Should NOT suggest narrowing by --tag rust (already filtered).
+        // Sort/limit hints may legitimately include --tag rust as a preserved filter,
+        // so only check narrowing hints (those whose description starts with "Narrow").
         assert!(
-            !hints.iter().any(|h| h.cmd.contains("--tag rust")),
-            "should not suggest already-filtered tag: {hints:?}"
+            !hints
+                .iter()
+                .any(|h| h.description.starts_with("Narrow") && h.cmd.contains("--tag rust")),
+            "should not suggest narrowing by already-filtered tag: {hints:?}"
         );
         assert!(
             hints.iter().any(|h| h.cmd.contains("--tag cli")),

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -7,12 +7,39 @@
 /// Maximum number of hints to return from any generator.
 const MAX_HINTS: usize = 5;
 
+/// A single drill-down hint: a concrete command plus a short human-readable description.
+#[derive(Debug, Clone)]
+pub struct Hint {
+    pub description: String,
+    pub cmd: String,
+}
+
+impl Hint {
+    fn new(description: impl Into<String>, cmd: String) -> Self {
+        Self {
+            description: description.into(),
+            cmd,
+        }
+    }
+}
+
 /// Identifies which command produced the output.
 pub enum HintSource {
     Summary,
     PropertiesSummary,
     TagsSummary,
     Find,
+    Set,
+    Remove,
+    Append,
+    Read,
+    Backlinks,
+    Mv,
+    TaskToggle,
+    TaskSetStatus,
+    LinksFix,
+    CreateIndex,
+    DropIndex,
 }
 
 /// Global flags to propagate into generated hint commands.
@@ -29,18 +56,63 @@ pub struct HintContext {
     pub format: Option<String>,
     /// Explicit `--hints` from CLI (not from config).
     pub hints: bool,
+    // Find context
+    pub fields: Vec<String>,
+    pub sort: Option<String>,
+    pub has_limit: bool,
+    pub has_body_search: bool,
+    pub has_regex_search: bool,
+    pub property_filters: Vec<String>,
+    pub tag_filters: Vec<String>,
+    pub task_filter: Option<String>,
+    pub file_targets: Vec<String>,
+    // Mutation context
+    pub dry_run: bool,
+    // Index context
+    pub index_path: Option<String>,
+}
+
+impl HintContext {
+    pub fn new(source: HintSource) -> Self {
+        Self {
+            source,
+            dir: None,
+            glob: vec![],
+            format: None,
+            hints: false,
+            fields: vec![],
+            sort: None,
+            has_limit: false,
+            has_body_search: false,
+            has_regex_search: false,
+            property_filters: vec![],
+            tag_filters: vec![],
+            task_filter: None,
+            file_targets: vec![],
+            dry_run: false,
+            index_path: None,
+        }
+    }
 }
 
 /// Generate concrete drill-down hints from a command's JSON output.
 ///
 /// Returns at most [`MAX_HINTS`] executable `hyalo` command strings.
 #[must_use]
-pub fn generate_hints(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
+pub fn generate_hints(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let hints = match &ctx.source {
         HintSource::Summary => hints_for_summary(ctx, data),
         HintSource::PropertiesSummary => hints_for_properties_summary(ctx, data),
         HintSource::TagsSummary => hints_for_tags_summary(ctx, data),
         HintSource::Find => hints_for_find(ctx, data),
+        HintSource::Set | HintSource::Remove | HintSource::Append => hints_for_mutation(ctx, data),
+        HintSource::Read => hints_for_read(ctx, data),
+        HintSource::Backlinks => hints_for_backlinks(ctx, data),
+        HintSource::Mv => hints_for_mv(ctx, data),
+        HintSource::TaskToggle | HintSource::TaskSetStatus => hints_for_task_mutation(ctx, data),
+        HintSource::LinksFix => hints_for_links_fix(ctx, data),
+        HintSource::CreateIndex => hints_for_create_index(ctx, data),
+        HintSource::DropIndex => hints_for_drop_index(ctx, data),
     };
     hints.into_iter().take(MAX_HINTS).collect()
 }
@@ -132,15 +204,39 @@ fn status_priority(value: &str) -> u8 {
 }
 
 // ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the first modified file path from mutation output (single object or array).
+fn first_modified_file(data: &serde_json::Value) -> Option<&str> {
+    fn extract(obj: &serde_json::Value) -> Option<&str> {
+        obj.get("modified")
+            .and_then(|m| m.as_array())
+            .and_then(|a| a.first())
+            .and_then(|f| f.as_str())
+    }
+    if let Some(arr) = data.as_array() {
+        arr.iter().find_map(extract)
+    } else {
+        extract(data)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Per-source hint generators
 // ---------------------------------------------------------------------------
 
-fn hints_for_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
+fn hints_for_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let mut hints = Vec::new();
 
-    // Always suggest aggregate views.
-    hints.push(build_command_with_glob(ctx, &["properties"]));
-    hints.push(build_command_with_glob(ctx, &["tags"]));
+    hints.push(Hint::new(
+        "Browse property names and types",
+        build_command_with_glob(ctx, &["properties"]),
+    ));
+    hints.push(Hint::new(
+        "Browse tags and their counts",
+        build_command_with_glob(ctx, &["tags"]),
+    ));
 
     // Suggest find --task todo if there are open tasks.
     let tasks_total = data
@@ -154,7 +250,23 @@ fn hints_for_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<String>
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
     if tasks_total > tasks_done {
-        hints.push(build_command_with_glob(ctx, &["find", "--task", "todo"]));
+        hints.push(Hint::new(
+            "Find files with open tasks",
+            build_command_with_glob(ctx, &["find", "--task", "todo"]),
+        ));
+    }
+
+    // Suggest find --broken-links if there are broken links.
+    let broken_links = data
+        .get("links")
+        .and_then(|l| l.get("broken"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    if broken_links > 0 {
+        hints.push(Hint::new(
+            format!("List {broken_links} files with broken links"),
+            build_command_with_glob(ctx, &["find", "--broken-links"]),
+        ));
     }
 
     // Pick 1-2 most interesting status values.
@@ -171,14 +283,17 @@ fn hints_for_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<String>
         let remaining = MAX_HINTS.saturating_sub(hints.len());
         for (value, _) in groups.into_iter().take(remaining.min(2)) {
             let filter = format!("status={value}");
-            hints.push(build_command_no_glob(ctx, &["find", "--property", &filter]));
+            hints.push(Hint::new(
+                format!("Filter by status: {value}"),
+                build_command_no_glob(ctx, &["find", "--property", &filter]),
+            ));
         }
     }
 
     hints
 }
 
-fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
+fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let Some(arr) = data.as_array() else {
         return vec![];
     };
@@ -200,11 +315,16 @@ fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> 
     entries
         .into_iter()
         .take(3)
-        .map(|(name, _)| build_command_with_glob(ctx, &["find", "--property", name]))
+        .map(|(name, count)| {
+            Hint::new(
+                format!("Find {count} files with property: {name}"),
+                build_command_with_glob(ctx, &["find", "--property", name]),
+            )
+        })
         .collect()
 }
 
-fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
+fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     // find always returns a {total, results} envelope.
     let Some(results) = data["results"].as_array() else {
         return vec![];
@@ -215,32 +335,64 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
     }
 
     let mut hints = Vec::new();
+    let result_count = results.len();
+    let is_single = result_count == 1;
 
-    // Suggest reading the first result.
+    // --- Single-result hints ---
     if let Some(first_file) = results[0].get("file").and_then(|f| f.as_str()) {
-        hints.push(build_command_no_glob(ctx, &["read", "--file", first_file]));
-        hints.push(build_command_no_glob(
-            ctx,
-            &["backlinks", "--file", first_file],
+        hints.push(Hint::new(
+            "Read this file's content",
+            build_command_no_glob(ctx, &["read", "--file", first_file]),
+        ));
+        if is_single {
+            hints.push(Hint::new(
+                "See all metadata for this file",
+                build_command_no_glob(ctx, &["find", "--file", first_file, "--fields", "all"]),
+            ));
+        }
+        hints.push(Hint::new(
+            "See what links to this file",
+            build_command_no_glob(ctx, &["backlinks", "--file", first_file]),
         ));
     }
 
-    // When there are many results, suggest data-driven narrowing filters.
-    if results.len() > 5 {
-        // Collect tag frequencies across all results.
+    // --- Broad query → suggest summary ---
+    let has_no_filters = ctx.property_filters.is_empty()
+        && ctx.tag_filters.is_empty()
+        && ctx.task_filter.is_none()
+        && !ctx.has_body_search
+        && !ctx.has_regex_search
+        && ctx.file_targets.is_empty();
+
+    if has_no_filters && result_count > 10 {
+        hints.push(Hint::new(
+            if ctx.glob.is_empty() {
+                "Get a high-level vault overview"
+            } else {
+                "Get stats for this file set"
+            },
+            build_command_with_glob(ctx, &["summary"]),
+        ));
+    }
+
+    // --- Narrowing for many results (>5) ---
+    if result_count > 5 {
+        // Tag narrowing (skip tags already filtered on).
         let mut tag_counts: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
         for item in results {
             if let Some(tags) = item.get("tags").and_then(|t| t.as_array()) {
                 for tag in tags {
-                    if let Some(name) = tag.as_str() {
+                    if let Some(name) = tag.as_str()
+                        && !ctx.tag_filters.iter().any(|t| t == name)
+                    {
                         *tag_counts.entry(name).or_insert(0) += 1;
                     }
                 }
             }
         }
 
-        // Collect status property frequencies — status is the most useful drill-down.
+        // Collect status property frequencies — skip statuses already filtered on.
         let mut status_counts: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
         for item in results {
@@ -249,19 +401,28 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
                 .and_then(|p| p.get("status"))
                 .and_then(|s| s.as_str())
             {
-                *status_counts.entry(status).or_insert(0) += 1;
+                let already_filtered = ctx
+                    .property_filters
+                    .iter()
+                    .any(|f| f == &format!("status={status}"));
+                if !already_filtered {
+                    *status_counts.entry(status).or_insert(0) += 1;
+                }
             }
         }
 
         // Pick the most common tag (if any results have tags).
         // Break ties alphabetically for deterministic output.
-        if let Some((top_tag, _)) = tag_counts
+        if let Some((top_tag, count)) = tag_counts
             .iter()
             .max_by(|(a_tag, a_cnt), (b_tag, b_cnt)| a_cnt.cmp(b_cnt).then(b_tag.cmp(a_tag)))
         {
             let remaining = MAX_HINTS.saturating_sub(hints.len());
             if remaining > 0 {
-                hints.push(build_command_with_glob(ctx, &["find", "--tag", top_tag]));
+                hints.push(Hint::new(
+                    format!("Narrow by tag: {top_tag} ({count} files)"),
+                    build_command_with_glob(ctx, &["find", "--tag", top_tag]),
+                ));
             }
         }
 
@@ -273,22 +434,57 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
         // Sort by priority (ascending), then count (descending), then name (ascending).
         status_vec.sort_by(|a, b| a.2.cmp(&b.2).then(b.1.cmp(&a.1)).then(a.0.cmp(b.0)));
 
-        if let Some((top_status, _, _)) = status_vec.first() {
+        if let Some((top_status, count, _)) = status_vec.first() {
             let remaining = MAX_HINTS.saturating_sub(hints.len());
             if remaining > 0 {
-                let filter = format!("status={top_status}");
-                hints.push(build_command_with_glob(
-                    ctx,
-                    &["find", "--property", &filter],
+                hints.push(Hint::new(
+                    format!("Filter by status: {top_status} ({count} files)"),
+                    build_command_with_glob(
+                        ctx,
+                        &["find", "--property", &format!("status={top_status}")],
+                    ),
                 ));
             }
+        }
+
+        // Sort suggestion (only if not already sorting).
+        if ctx.sort.is_none() {
+            let remaining = MAX_HINTS.saturating_sub(hints.len());
+            if remaining > 0 {
+                hints.push(Hint::new(
+                    "Sort by most recently modified",
+                    build_command_with_glob(ctx, &["find", "--sort", "modified", "--reverse"]),
+                ));
+            }
+        }
+
+        // Limit suggestion (only if not already limited).
+        if !ctx.has_limit {
+            let remaining = MAX_HINTS.saturating_sub(hints.len());
+            if remaining > 0 {
+                hints.push(Hint::new(
+                    "Limit to 10 results",
+                    build_command_with_glob(ctx, &["find", "--limit", "10"]),
+                ));
+            }
+        }
+    }
+
+    // --- Body search → regex suggestion ---
+    if ctx.has_body_search && result_count > 10 {
+        let remaining = MAX_HINTS.saturating_sub(hints.len());
+        if remaining > 0 {
+            hints.push(Hint::new(
+                "Narrow with regex pattern",
+                build_command_with_glob(ctx, &["find", "-e", "'pattern'"]),
+            ));
         }
     }
 
     hints
 }
 
-fn hints_for_tags_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<String> {
+fn hints_for_tags_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let Some(tags_arr) = data.get("tags").and_then(|t| t.as_array()) else {
         return vec![];
     };
@@ -310,8 +506,205 @@ fn hints_for_tags_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<St
     entries
         .into_iter()
         .take(3)
-        .map(|(name, _)| build_command_with_glob(ctx, &["find", "--tag", name]))
+        .map(|(name, count)| {
+            Hint::new(
+                format!("Find {count} files tagged: {name}"),
+                build_command_with_glob(ctx, &["find", "--tag", name]),
+            )
+        })
         .collect()
+}
+
+fn hints_for_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let first_modified = first_modified_file(data);
+
+    if let Some(file) = first_modified {
+        hints.push(Hint::new(
+            "Verify the updated file",
+            build_command_no_glob(
+                ctx,
+                &["find", "--file", file, "--fields", "properties,tags"],
+            ),
+        ));
+        hints.push(Hint::new(
+            "Read the modified file",
+            build_command_no_glob(ctx, &["read", "--file", file]),
+        ));
+    }
+
+    hints
+}
+
+fn hints_for_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let file = data
+        .get("file")
+        .and_then(|f| f.as_str())
+        .or_else(|| ctx.file_targets.first().map(String::as_str));
+
+    if let Some(file) = file {
+        hints.push(Hint::new(
+            "See metadata for this file",
+            build_command_no_glob(ctx, &["find", "--file", file, "--fields", "all"]),
+        ));
+        hints.push(Hint::new(
+            "See what links to this file",
+            build_command_no_glob(ctx, &["backlinks", "--file", file]),
+        ));
+    }
+
+    hints
+}
+
+fn hints_for_backlinks(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let file = data.get("file").and_then(|f| f.as_str());
+
+    if let Some(file) = file {
+        hints.push(Hint::new(
+            "Read this file's content",
+            build_command_no_glob(ctx, &["read", "--file", file]),
+        ));
+        hints.push(Hint::new(
+            "See this file's outgoing links",
+            build_command_no_glob(ctx, &["find", "--file", file, "--fields", "links"]),
+        ));
+    }
+
+    // Suggest reading the first backlink source.
+    if let Some(backlinks) = data.get("backlinks").and_then(|b| b.as_array())
+        && let Some(first_source) = backlinks
+            .first()
+            .and_then(|b| b.get("source"))
+            .and_then(|s| s.as_str())
+    {
+        hints.push(Hint::new(
+            format!("Read linking file: {first_source}"),
+            build_command_no_glob(ctx, &["read", "--file", first_source]),
+        ));
+    }
+
+    hints
+}
+
+fn hints_for_mv(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let to_path = data.get("to").and_then(|t| t.as_str());
+    let is_dry_run = data
+        .get("dry_run")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    if let Some(to_path) = to_path {
+        if is_dry_run {
+            let from_path = data.get("from").and_then(|f| f.as_str()).unwrap_or("");
+            hints.push(Hint::new(
+                "Apply this move",
+                build_command_no_glob(ctx, &["mv", "--file", from_path, "--to", to_path]),
+            ));
+        } else {
+            hints.push(Hint::new(
+                "Read the moved file",
+                build_command_no_glob(ctx, &["read", "--file", to_path]),
+            ));
+            hints.push(Hint::new(
+                "Verify backlinks updated",
+                build_command_no_glob(ctx, &["backlinks", "--file", to_path]),
+            ));
+        }
+    }
+
+    hints
+}
+
+fn hints_for_task_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let file = data.get("file").and_then(|f| f.as_str());
+
+    if let Some(file) = file {
+        hints.push(Hint::new(
+            "See remaining open tasks",
+            build_command_no_glob(
+                ctx,
+                &[
+                    "find", "--file", file, "--task", "todo", "--fields", "tasks",
+                ],
+            ),
+        ));
+        hints.push(Hint::new(
+            "Read the file",
+            build_command_no_glob(ctx, &["read", "--file", file]),
+        ));
+    }
+
+    hints
+}
+
+fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let is_dry_run = !data
+        .get("applied")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let fixable = data
+        .get("fixable")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let unfixable = data
+        .get("unfixable")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    if is_dry_run && fixable > 0 {
+        hints.push(Hint::new(
+            format!("Apply {fixable} fixes"),
+            build_command_with_glob(ctx, &["links", "fix", "--apply"]),
+        ));
+    }
+
+    if unfixable > 0 {
+        hints.push(Hint::new(
+            "List files with remaining broken links",
+            build_command_with_glob(ctx, &["find", "--broken-links"]),
+        ));
+    }
+
+    hints
+}
+
+fn hints_for_create_index(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let index_path = data
+        .get("path")
+        .and_then(|p| p.as_str())
+        .or(ctx.index_path.as_deref())
+        .unwrap_or(".hyalo-index");
+
+    hints.push(Hint::new(
+        "Query using the index",
+        build_command_no_glob(ctx, &["find", "--index", index_path]),
+    ));
+    hints.push(Hint::new(
+        "Delete the index when done",
+        build_command_no_glob(ctx, &["drop-index"]),
+    ));
+
+    hints
+}
+
+fn hints_for_drop_index(ctx: &HintContext, _data: &serde_json::Value) -> Vec<Hint> {
+    vec![Hint::new(
+        "Rebuild the index",
+        build_command_no_glob(ctx, &["create-index"]),
+    )]
 }
 
 #[cfg(test)]
@@ -320,33 +713,19 @@ mod tests {
     use serde_json::json;
 
     fn ctx(source: HintSource) -> HintContext {
-        HintContext {
-            source,
-            dir: None,
-            glob: vec![],
-            format: None,
-            hints: false,
-        }
+        HintContext::new(source)
     }
 
     fn ctx_with_dir(source: HintSource, dir: &str) -> HintContext {
-        HintContext {
-            source,
-            dir: Some(dir.to_owned()),
-            glob: vec![],
-            format: None,
-            hints: false,
-        }
+        let mut ctx = HintContext::new(source);
+        ctx.dir = Some(dir.to_owned());
+        ctx
     }
 
     fn ctx_with_glob(source: HintSource, glob: &str) -> HintContext {
-        HintContext {
-            source,
-            dir: None,
-            glob: vec![glob.to_owned()],
-            format: None,
-            hints: false,
-        }
+        let mut ctx = HintContext::new(source);
+        ctx.glob = vec![glob.to_owned()];
+        ctx
     }
 
     // --- shell_quote ---
@@ -435,14 +814,14 @@ mod tests {
         });
         let hints = generate_hints(&c, &data);
         assert!(hints.iter().any(|h| {
-            h == "hyalo properties"
-                || (h.starts_with("hyalo properties ") && h.contains("--dir "))
-                || (h.starts_with("hyalo properties ") && h.contains("--glob "))
+            h.cmd == "hyalo properties"
+                || (h.cmd.starts_with("hyalo properties ") && h.cmd.contains("--dir "))
+                || (h.cmd.starts_with("hyalo properties ") && h.cmd.contains("--glob "))
         }));
         assert!(hints.iter().any(|h| {
-            h == "hyalo tags"
-                || (h.starts_with("hyalo tags ") && h.contains("--dir "))
-                || (h.starts_with("hyalo tags ") && h.contains("--glob "))
+            h.cmd == "hyalo tags"
+                || (h.cmd.starts_with("hyalo tags ") && h.cmd.contains("--dir "))
+                || (h.cmd.starts_with("hyalo tags ") && h.cmd.contains("--glob "))
         }));
     }
 
@@ -459,9 +838,9 @@ mod tests {
         });
         let hints = generate_hints(&c, &data);
         assert!(
-            hints
-                .iter()
-                .any(|h| h.contains("find") && h.contains("--task") && h.contains("todo"))
+            hints.iter().any(|h| h.cmd.contains("find")
+                && h.cmd.contains("--task")
+                && h.cmd.contains("todo"))
         );
     }
 
@@ -477,7 +856,7 @@ mod tests {
             "recent_files": []
         });
         let hints = generate_hints(&c, &data);
-        assert!(!hints.iter().any(|h| h.contains("--todo")));
+        assert!(!hints.iter().any(|h| h.cmd.contains("--todo")));
     }
 
     #[test]
@@ -497,8 +876,8 @@ mod tests {
         });
         let hints = generate_hints(&c, &data);
         // in-progress should appear before completed
-        let in_progress_pos = hints.iter().position(|h| h.contains("in-progress"));
-        let completed_pos = hints.iter().position(|h| h.contains("completed"));
+        let in_progress_pos = hints.iter().position(|h| h.cmd.contains("in-progress"));
+        let completed_pos = hints.iter().position(|h| h.cmd.contains("completed"));
         assert!(in_progress_pos.is_some(), "should suggest in-progress");
         // completed may appear (only if limit not reached) or not — but in-progress must come first
         if let Some(cp) = completed_pos {
@@ -539,11 +918,11 @@ mod tests {
         ]);
         let hints = generate_hints(&c, &data);
         assert_eq!(hints.len(), 3);
-        assert!(hints[0].contains("title"));
-        assert!(hints[1].contains("status"));
-        assert!(hints[2].contains("tags"));
+        assert!(hints[0].cmd.contains("title"));
+        assert!(hints[1].cmd.contains("status"));
+        assert!(hints[2].cmd.contains("tags"));
         // author should not appear (rank 4)
-        assert!(!hints.iter().any(|h| h.contains("author")));
+        assert!(!hints.iter().any(|h| h.cmd.contains("author")));
     }
 
     #[test]
@@ -558,8 +937,8 @@ mod tests {
         let c = ctx_with_glob(HintSource::PropertiesSummary, "notes/*.md");
         let data = json!([{"name": "status", "type": "text", "count": 5}]);
         let hints = generate_hints(&c, &data);
-        assert!(hints[0].contains("--glob"));
-        assert!(hints[0].contains("notes/*.md"));
+        assert!(hints[0].cmd.contains("--glob"));
+        assert!(hints[0].cmd.contains("notes/*.md"));
     }
 
     // --- hints_for_find ---
@@ -596,13 +975,13 @@ mod tests {
         assert!(
             hints
                 .iter()
-                .any(|h| h.contains("read") && h.contains("alpha.md")),
+                .any(|h| h.cmd.contains("read") && h.cmd.contains("alpha.md")),
             "should suggest read: {hints:?}"
         );
         assert!(
             hints
                 .iter()
-                .any(|h| h.contains("backlinks") && h.contains("alpha.md")),
+                .any(|h| h.cmd.contains("backlinks") && h.cmd.contains("alpha.md")),
             "should suggest backlinks: {hints:?}"
         );
     }
@@ -624,7 +1003,7 @@ mod tests {
         assert!(
             hints
                 .iter()
-                .any(|h| h.contains("--tag") && h.contains("rust")),
+                .any(|h| h.cmd.contains("--tag") && h.cmd.contains("rust")),
             "should suggest --tag rust (most common): {hints:?}"
         );
     }
@@ -646,7 +1025,7 @@ mod tests {
         assert!(
             hints
                 .iter()
-                .any(|h| h.contains("--property") && h.contains("status=in-progress")),
+                .any(|h| h.cmd.contains("--property") && h.cmd.contains("status=in-progress")),
             "should prefer in-progress status: {hints:?}"
         );
     }
@@ -668,12 +1047,12 @@ mod tests {
         assert!(
             hints
                 .iter()
-                .any(|h| h.contains("--property") && h.contains("status=planned")),
+                .any(|h| h.cmd.contains("--property") && h.cmd.contains("status=planned")),
             "should suggest status filter: {hints:?}"
         );
         // No --tag hints when no tags exist.
         assert!(
-            !hints.iter().any(|h| h.contains("--tag")),
+            !hints.iter().any(|h| h.cmd.contains("--tag")),
             "should not suggest --tag when no tags: {hints:?}"
         );
     }
@@ -700,7 +1079,235 @@ mod tests {
             "total": 1
         });
         let hints = generate_hints(&c, &data);
-        assert!(hints[0].contains("--dir"));
-        assert!(hints[0].contains("/vault"));
+        assert!(hints[0].cmd.contains("--dir"));
+        assert!(hints[0].cmd.contains("/vault"));
+    }
+
+    // --- new generator tests ---
+
+    #[test]
+    fn mutation_hints_suggest_verify_and_read() {
+        let c = ctx(HintSource::Set);
+        let data = json!({
+            "property": "status",
+            "value": "completed",
+            "modified": ["notes/alpha.md"],
+            "skipped": [],
+            "total": 1
+        });
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("find") && h.cmd.contains("alpha.md")),
+            "should suggest verify: {hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("read") && h.cmd.contains("alpha.md")),
+            "should suggest read: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn read_hints_suggest_metadata_and_backlinks() {
+        let c = ctx(HintSource::Read);
+        let data = json!({"file": "notes/alpha.md", "content": "Some content"});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("find") && h.cmd.contains("alpha.md")),
+            "should suggest find: {hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("backlinks") && h.cmd.contains("alpha.md")),
+            "should suggest backlinks: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn backlinks_hints_suggest_read_and_outgoing() {
+        let c = ctx(HintSource::Backlinks);
+        let data = json!({
+            "file": "target.md",
+            "backlinks": [{"source": "a.md", "line": 5, "target": "target"}],
+            "total": 1
+        });
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("read") && h.cmd.contains("target.md")),
+            "should suggest read target: {hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("read") && h.cmd.contains("a.md")),
+            "should suggest read first backlink source: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn create_index_hints_suggest_find_and_drop() {
+        let c = ctx(HintSource::CreateIndex);
+        let data = json!({"path": ".hyalo-index", "files_indexed": 42, "warnings": 0});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("find") && h.cmd.contains("--index")),
+            "should suggest find with index: {hints:?}"
+        );
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("drop-index")),
+            "should suggest drop-index: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn drop_index_hints_suggest_create() {
+        let c = ctx(HintSource::DropIndex);
+        let data = json!({"deleted": ".hyalo-index"});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("create-index")),
+            "should suggest create-index: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn mv_dry_run_hints_suggest_apply() {
+        let c = ctx(HintSource::Mv);
+        let data = json!({
+            "from": "old.md",
+            "to": "new.md",
+            "dry_run": true,
+            "updated_files": [],
+            "total_files_updated": 0,
+            "total_links_updated": 0
+        });
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("mv")
+                && h.cmd.contains("new.md")
+                && !h.cmd.contains("dry-run")),
+            "should suggest applying the move: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn mv_applied_hints_suggest_read_and_backlinks() {
+        let c = ctx(HintSource::Mv);
+        let data = json!({
+            "from": "old.md",
+            "to": "new.md",
+            "dry_run": false,
+            "updated_files": [],
+            "total_files_updated": 0,
+            "total_links_updated": 0
+        });
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("read") && h.cmd.contains("new.md")),
+            "should suggest reading moved file: {hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.contains("backlinks") && h.cmd.contains("new.md")),
+            "should suggest checking backlinks: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn task_mutation_hints_suggest_remaining_tasks() {
+        let c = ctx(HintSource::TaskToggle);
+        let data =
+            json!({"file": "todo.md", "line": 5, "status": "x", "text": "Fix bug", "done": true});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("find")
+                && h.cmd.contains("--task")
+                && h.cmd.contains("todo")),
+            "should suggest finding remaining tasks: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn links_fix_dry_run_hints_suggest_apply() {
+        let c = ctx(HintSource::LinksFix);
+        let data = json!({
+            "broken": 5,
+            "fixable": 3,
+            "unfixable": 2,
+            "applied": false,
+            "fixes": []
+        });
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("links fix --apply")),
+            "should suggest applying fixes: {hints:?}"
+        );
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("--broken-links")),
+            "should suggest finding broken links: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn find_broad_query_suggests_summary() {
+        let c = ctx(HintSource::Find);
+        // 15 results, no filters
+        let items: Vec<serde_json::Value> = (0..15)
+            .map(|i| make_find_item(&format!("{i}.md"), Some("completed"), &[]))
+            .collect();
+        let data = json!({"total": items.len(), "results": items});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("summary")),
+            "broad query should suggest summary: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn find_with_filters_does_not_suggest_summary() {
+        let mut c = ctx(HintSource::Find);
+        c.tag_filters = vec!["rust".to_owned()];
+        let items: Vec<serde_json::Value> = (0..15)
+            .map(|i| make_find_item(&format!("{i}.md"), Some("completed"), &["rust"]))
+            .collect();
+        let data = json!({"total": items.len(), "results": items});
+        let hints = generate_hints(&c, &data);
+        assert!(
+            !hints.iter().any(|h| h.cmd.contains("summary")),
+            "filtered query should not suggest summary: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn find_suppresses_already_filtered_tag() {
+        let mut c = ctx(HintSource::Find);
+        c.tag_filters = vec!["rust".to_owned()];
+        let items: Vec<serde_json::Value> = (0..10)
+            .map(|i| make_find_item(&format!("{i}.md"), Some("planned"), &["rust", "cli"]))
+            .collect();
+        let data = json!({"total": items.len(), "results": items});
+        let hints = generate_hints(&c, &data);
+        // Should NOT suggest --tag rust (already filtered), but should suggest --tag cli
+        assert!(
+            !hints.iter().any(|h| h.cmd.contains("--tag rust")),
+            "should not suggest already-filtered tag: {hints:?}"
+        );
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("--tag cli")),
+            "should suggest non-filtered tag: {hints:?}"
+        );
     }
 }

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -80,20 +80,28 @@ pub fn format_output<T: Serialize>(format: Format, value: &T) -> String {
 
 /// Format output with drill-down hints appended.
 ///
-/// - **JSON**: wraps the original value in `{"data": ..., "hints": [...]}`
-/// - **Text**: appends `  -> <command>` lines after the formatted output
+/// - **JSON**: wraps the original value in `{"data": ..., "hints": [{"description": "...", "cmd": "..."}]}`
+/// - **Text**: appends `  -> <command>  # <description>` lines after the formatted output
 ///
 /// If `hints` is empty, produces the same output as [`format_success`].
 #[must_use]
-pub fn format_with_hints(format: Format, value: &serde_json::Value, hints: &[String]) -> String {
+pub fn format_with_hints(
+    format: Format,
+    value: &serde_json::Value,
+    hints: &[crate::hints::Hint],
+) -> String {
     if hints.is_empty() {
         return format_success(format, value);
     }
     match format {
         Format::Json => {
+            let hints_json: Vec<serde_json::Value> = hints
+                .iter()
+                .map(|h| serde_json::json!({"description": &h.description, "cmd": &h.cmd}))
+                .collect();
             let envelope = serde_json::json!({
                 "data": value,
-                "hints": hints,
+                "hints": hints_json,
             });
             serde_json::to_string_pretty(&envelope).unwrap_or_default()
         }
@@ -103,7 +111,9 @@ pub fn format_with_hints(format: Format, value: &serde_json::Value, hints: &[Str
             text.push('\n');
             for hint in hints {
                 text.push_str("\n  -> ");
-                text.push_str(hint);
+                text.push_str(&hint.cmd);
+                text.push_str("  # ");
+                text.push_str(&hint.description);
             }
             text
         }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -433,7 +433,14 @@ fn run_inner() -> Result<(), AppError> {
                     ctx.file_targets = vec![file.clone()];
                     Some(ctx)
                 }
-                crate::cli::args::TaskAction::Read { .. } => None,
+                crate::cli::args::TaskAction::Read { file, .. } => {
+                    let mut ctx = HintContext::new(HintSource::TaskRead);
+                    ctx.dir = dir_hint;
+                    ctx.format = format_hint;
+                    ctx.hints = hints_from_cli;
+                    ctx.file_targets = vec![file.clone()];
+                    Some(ctx)
+                }
             },
             Commands::Links { action } => match action {
                 crate::cli::args::LinksAction::Fix { apply, glob, .. } => {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -281,53 +281,191 @@ fn run_inner() -> Result<(), AppError> {
         };
 
         match &cli.command {
-            Commands::Summary { glob, .. } => Some(HintContext {
-                source: HintSource::Summary,
-                dir: dir_hint,
-                glob: glob.clone(),
-                format: format_hint,
-                hints: hints_from_cli,
-            }),
+            Commands::Summary { glob, .. } => {
+                let mut ctx = HintContext::new(HintSource::Summary);
+                ctx.dir = dir_hint;
+                ctx.glob.clone_from(glob);
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                Some(ctx)
+            }
             Commands::Properties {
                 action: Some(crate::cli::args::PropertiesAction::Summary { glob }),
-            } => Some(HintContext {
-                source: HintSource::PropertiesSummary,
-                dir: dir_hint,
-                glob: glob.clone(),
-                format: format_hint,
-                hints: hints_from_cli,
-            }),
+            } => {
+                let mut ctx = HintContext::new(HintSource::PropertiesSummary);
+                ctx.dir = dir_hint;
+                ctx.glob.clone_from(glob);
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                Some(ctx)
+            }
             Commands::Tags {
                 action: Some(crate::cli::args::TagsAction::Summary { glob }),
-            } => Some(HintContext {
-                source: HintSource::TagsSummary,
-                dir: dir_hint,
-                glob: glob.clone(),
-                format: format_hint,
-                hints: hints_from_cli,
-            }),
-            Commands::Find { glob, .. } => Some(HintContext {
-                source: HintSource::Find,
-                dir: dir_hint,
-                glob: glob.clone(),
-                format: format_hint,
-                hints: hints_from_cli,
-            }),
-            _ => None,
+            } => {
+                let mut ctx = HintContext::new(HintSource::TagsSummary);
+                ctx.dir = dir_hint;
+                ctx.glob.clone_from(glob);
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                Some(ctx)
+            }
+            Commands::Tags { action: None } => {
+                // Bare `hyalo tags` defaults to summary with no glob.
+                let mut ctx = HintContext::new(HintSource::TagsSummary);
+                ctx.dir = dir_hint;
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                Some(ctx)
+            }
+            Commands::Find {
+                glob,
+                pattern,
+                regexp,
+                properties,
+                tag,
+                task,
+                file,
+                fields,
+                sort,
+                limit,
+                ..
+            } => {
+                let mut ctx = HintContext::new(HintSource::Find);
+                ctx.dir = dir_hint;
+                ctx.glob.clone_from(glob);
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.fields.clone_from(fields);
+                ctx.sort.clone_from(sort);
+                ctx.has_limit = limit.is_some();
+                ctx.has_body_search = pattern.is_some();
+                ctx.has_regex_search = regexp.is_some();
+                ctx.property_filters.clone_from(properties);
+                ctx.tag_filters.clone_from(tag);
+                ctx.task_filter.clone_from(task);
+                ctx.file_targets.clone_from(file);
+                Some(ctx)
+            }
+            Commands::Set {
+                file,
+                glob,
+                dry_run,
+                ..
+            } => {
+                let mut ctx = HintContext::new(HintSource::Set);
+                ctx.dir = dir_hint;
+                ctx.glob.clone_from(glob);
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.file_targets.clone_from(file);
+                ctx.dry_run = *dry_run;
+                Some(ctx)
+            }
+            Commands::Remove {
+                file,
+                glob,
+                dry_run,
+                ..
+            } => {
+                let mut ctx = HintContext::new(HintSource::Remove);
+                ctx.dir = dir_hint;
+                ctx.glob.clone_from(glob);
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.file_targets.clone_from(file);
+                ctx.dry_run = *dry_run;
+                Some(ctx)
+            }
+            Commands::Append {
+                file,
+                glob,
+                dry_run,
+                ..
+            } => {
+                let mut ctx = HintContext::new(HintSource::Append);
+                ctx.dir = dir_hint;
+                ctx.glob.clone_from(glob);
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.file_targets.clone_from(file);
+                ctx.dry_run = *dry_run;
+                Some(ctx)
+            }
+            Commands::Read { file, .. } => {
+                let mut ctx = HintContext::new(HintSource::Read);
+                ctx.dir = dir_hint;
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.file_targets = vec![file.clone()];
+                Some(ctx)
+            }
+            Commands::Backlinks { file } => {
+                let mut ctx = HintContext::new(HintSource::Backlinks);
+                ctx.dir = dir_hint;
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.file_targets = vec![file.clone()];
+                Some(ctx)
+            }
+            Commands::Mv { file, dry_run, .. } => {
+                let mut ctx = HintContext::new(HintSource::Mv);
+                ctx.dir = dir_hint;
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.file_targets = vec![file.clone()];
+                ctx.dry_run = *dry_run;
+                Some(ctx)
+            }
+            Commands::Task { action } => match action {
+                crate::cli::args::TaskAction::Toggle { file, .. } => {
+                    let mut ctx = HintContext::new(HintSource::TaskToggle);
+                    ctx.dir = dir_hint;
+                    ctx.format = format_hint;
+                    ctx.hints = hints_from_cli;
+                    ctx.file_targets = vec![file.clone()];
+                    Some(ctx)
+                }
+                crate::cli::args::TaskAction::SetStatus { file, .. } => {
+                    let mut ctx = HintContext::new(HintSource::TaskSetStatus);
+                    ctx.dir = dir_hint;
+                    ctx.format = format_hint;
+                    ctx.hints = hints_from_cli;
+                    ctx.file_targets = vec![file.clone()];
+                    Some(ctx)
+                }
+                crate::cli::args::TaskAction::Read { .. } => None,
+            },
+            Commands::Links { action } => match action {
+                crate::cli::args::LinksAction::Fix { apply, glob, .. } => {
+                    let mut ctx = HintContext::new(HintSource::LinksFix);
+                    ctx.dir = dir_hint;
+                    ctx.glob.clone_from(glob);
+                    ctx.format = format_hint;
+                    ctx.hints = hints_from_cli;
+                    ctx.dry_run = !apply;
+                    Some(ctx)
+                }
+            },
+            Commands::CreateIndex { output, .. } => {
+                let mut ctx = HintContext::new(HintSource::CreateIndex);
+                ctx.dir = dir_hint;
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                ctx.index_path = output.as_ref().map(|p| p.to_string_lossy().into_owned());
+                Some(ctx)
+            }
+            Commands::DropIndex { .. } => {
+                let mut ctx = HintContext::new(HintSource::DropIndex);
+                ctx.dir = dir_hint;
+                ctx.format = format_hint;
+                ctx.hints = hints_from_cli;
+                Some(ctx)
+            }
+            Commands::Properties { .. } | Commands::Tags { .. } | Commands::Init { .. } => None,
         }
     } else {
         None
     };
-
-    // Warn when --hints is passed to mutation commands, which do not generate hints.
-    if hints_from_cli
-        && matches!(
-            &cli.command,
-            Commands::Set { .. } | Commands::Remove { .. } | Commands::Append { .. }
-        )
-    {
-        crate::warn::warn("--hints has no effect on mutation commands");
-    }
 
     // Load snapshot index if --index is provided.
     // Read-only commands use it to skip disk scans. Mutation commands use it to

--- a/crates/hyalo-cli/tests/common/mod.rs
+++ b/crates/hyalo-cli/tests/common/mod.rs
@@ -12,8 +12,21 @@ macro_rules! md {
 pub(crate) use md;
 
 /// Returns a `Command` pre-configured to run the `hyalo` binary built by Cargo.
+#[allow(dead_code)]
 pub fn hyalo() -> Command {
     Command::cargo_bin("hyalo").unwrap()
+}
+
+/// Returns a `Command` pre-configured to run `hyalo` with `--no-hints`.
+///
+/// Use this in tests that verify plain (non-wrapped) JSON output and do not
+/// test hint behaviour. Hints are on by default in the built-in config, so
+/// without `--no-hints` the output would be wrapped in a hints envelope.
+#[allow(dead_code)]
+pub fn hyalo_no_hints() -> Command {
+    let mut cmd = Command::cargo_bin("hyalo").unwrap();
+    cmd.arg("--no-hints");
+    cmd
 }
 
 /// Writes a file at `relative_path` inside `dir`, creating parent directories as needed.

--- a/crates/hyalo-cli/tests/e2e_append.rs
+++ b/crates/hyalo-cli/tests/e2e_append.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use std::fs;
 use tempfile::TempDir;
 
@@ -12,7 +12,7 @@ fn append_json(
     tmp: &TempDir,
     extra_args: &[&str],
 ) -> (std::process::ExitStatus, serde_json::Value, String) {
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.arg("append");
     cmd.args(extra_args);
@@ -302,7 +302,7 @@ title: Untagged
 #[test]
 fn append_requires_file_or_glob() {
     let tmp = TempDir::new().unwrap();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["append", "--property", "aliases=x"]);
     let output = cmd.output().unwrap();
@@ -320,7 +320,7 @@ fn append_requires_file_or_glob() {
 fn append_requires_at_least_one_property() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["append", "--file", "note.md"]);
     let output = cmd.output().unwrap();
@@ -335,7 +335,7 @@ fn append_requires_at_least_one_property() {
 fn append_invalid_kv_no_equals_returns_error() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "append",
@@ -357,7 +357,7 @@ fn append_invalid_kv_no_equals_returns_error() {
 fn append_empty_property_name_returns_error() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["append", "--property", "=value", "--file", "note.md"]);
     let output = cmd.output().unwrap();
@@ -446,7 +446,7 @@ fn append_multi_file_modifies_all() {
     write_md(tmp.path(), "a.md", "---\ntitle: A\n---\n");
     write_md(tmp.path(), "b.md", "---\ntitle: B\n---\n");
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "append",
@@ -483,7 +483,7 @@ tags:
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["append", "--property", "tags=cli", "--file", "note.md"])

--- a/crates/hyalo-cli/tests/e2e_backlinks.rs
+++ b/crates/hyalo-cli/tests/e2e_backlinks.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -42,7 +42,7 @@ Also links to [[target|the target page]].
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -72,7 +72,7 @@ fn backlinks_finds_markdown_links() {
         "See [my note](notes/target.md) for details.\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "notes/target.md"])
         .output()
@@ -90,7 +90,7 @@ fn backlinks_empty_result() {
     write_md(tmp.path(), "lonely.md", "# No one links here\n");
     write_md(tmp.path(), "other.md", "# Other\nNo links.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "lonely.md"])
         .output()
@@ -108,8 +108,8 @@ fn backlinks_text_format() {
     write_md(tmp.path(), "target.md", "# Target\n");
     write_md(tmp.path(), "source.md", "Link to [[target]]\n");
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -126,8 +126,8 @@ fn backlinks_text_format_empty() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "lonely.md", "# Alone\n");
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["backlinks", "--file", "lonely.md"])
         .output()
@@ -142,7 +142,7 @@ fn backlinks_text_format_empty() {
 fn backlinks_file_not_found() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "nonexistent.md"])
         .output()
@@ -163,7 +163,7 @@ fn backlinks_ignores_links_in_code_blocks() {
         "```\n[[target]]\n```\nReal [[target]] link\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -200,7 +200,7 @@ Link is here: [[target]]
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -228,7 +228,7 @@ fn backlinks_cross_directory_relative_link() {
         "See [the target](../target.md) for more.\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -248,7 +248,7 @@ fn backlinks_wikilink_without_extension_finds_md_file() {
     write_md(tmp.path(), "notes.md", "# Notes\n");
     write_md(tmp.path(), "source.md", "See [[notes]] for details.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "notes.md"])
         .output()
@@ -267,7 +267,7 @@ fn backlinks_with_jq_filter() {
     write_md(tmp.path(), "a.md", "[[target]]\n");
     write_md(tmp.path(), "b.md", "[[target]]\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".total"])
         .args(["backlinks", "--file", "target.md"])
@@ -292,7 +292,7 @@ fn backlinks_wikilink_with_path_separator() {
         "See [[backlog/item]] for context.\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "backlog/item.md"])
         .output()
@@ -318,7 +318,7 @@ fn backlinks_resolves_absolute_links_with_dir_config() {
     write_md(tmp.path(), "docs/target.md", "# Target\n");
     std::fs::write(tmp.path().join(".hyalo.toml"), "dir = \"docs\"\n").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -341,7 +341,7 @@ fn backlinks_excludes_self_links() {
     write_md(tmp.path(), "a.md", "Self-ref: [[a]]\n");
     write_md(tmp.path(), "b.md", "Link to [[a]]\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "a.md"])
         .output()
@@ -365,7 +365,7 @@ fn backlinks_wikilink_with_path_from_subdirectory() {
     write_md(tmp.path(), "other/target.md", "# Target\n");
     write_md(tmp.path(), "sub/source.md", "See [[other/target]] here.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "other/target.md"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_config.rs
+++ b/crates/hyalo-cli/tests/e2e_config.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::fs;
 
-use common::{hyalo, write_md};
+use common::{hyalo, hyalo_no_hints, write_md};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ fn config_sets_default_format() {
     fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
     write_note(tmp.path(), "note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["summary"])
         .output()
@@ -51,7 +51,7 @@ fn cli_format_overrides_config() {
     fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
     write_note(tmp.path(), "note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["summary", "--format", "json"])
         .output()
@@ -78,10 +78,10 @@ fn config_sets_default_dir() {
     fs::write(tmp.path().join(".hyalo.toml"), "dir = \"vault\"\n").unwrap();
     write_note(tmp.path(), "vault/note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         // No --dir flag: relies on config's dir = "vault"
-        .args(["summary", "--format", "json", "--no-hints"])
+        .args(["summary", "--format", "json"])
         .output()
         .unwrap();
 
@@ -108,12 +108,11 @@ fn cli_dir_overrides_config() {
     write_note(tmp.path(), "vault/note.md");
 
     let vault_path = tmp.path().join("vault");
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args([
             "--dir",
             vault_path.to_str().unwrap(),
-            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -145,7 +144,7 @@ fn missing_config_uses_defaults() {
     // No .hyalo.toml written — hardcoded defaults apply (format=json, dir=., hints=true)
     write_note(tmp.path(), "note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["summary"])
         .output()
@@ -172,7 +171,7 @@ fn malformed_config_warns_on_stderr() {
     fs::write(tmp.path().join(".hyalo.toml"), "{{invalid\n").unwrap();
     write_note(tmp.path(), "note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["summary", "--format", "json"])
         .output()
@@ -204,6 +203,7 @@ fn config_sets_hints_true() {
     fs::write(tmp.path().join(".hyalo.toml"), "hints = true\n").unwrap();
     write_note(tmp.path(), "note.md");
 
+    // Use plain hyalo() without --no-hints, so the config's hints = true takes effect
     let output = hyalo()
         .current_dir(tmp.path())
         .args(["summary", "--format", "json"])
@@ -234,9 +234,9 @@ fn cli_hints_false_overrides_config() {
     fs::write(tmp.path().join(".hyalo.toml"), "hints = true\n").unwrap();
     write_note(tmp.path(), "note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
-        .args(["summary", "--format", "json", "--no-hints"])
+        .args(["summary", "--format", "json"])
         .output()
         .unwrap();
 

--- a/crates/hyalo-cli/tests/e2e_errors.rs
+++ b/crates/hyalo-cli/tests/e2e_errors.rs
@@ -1,13 +1,13 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
 #[test]
 fn error_nonexistent_file() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--file", "missing.md"])
         .output()
@@ -25,7 +25,7 @@ fn error_nonexistent_dir() {
     let tmp = TempDir::new().unwrap();
     let nonexistent = tmp.path().join("does_not_exist");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", nonexistent.to_str().unwrap()])
         .args(["properties"])
         .output()
@@ -51,7 +51,7 @@ fn error_invalid_yaml() {
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "summary", "--glob", "bad.md"])
         .output()
@@ -90,7 +90,7 @@ fn error_find_malformed_yaml_graceful_skip() {
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find"])
         .output()
@@ -139,8 +139,8 @@ title: OK
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["summary"])
         .output()
         .unwrap();
@@ -207,7 +207,7 @@ title: Target
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "target.md"])
         .output()
@@ -256,7 +256,7 @@ title: Good
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--fields", "links,backlinks"])
         .output()
@@ -298,7 +298,7 @@ title: Good
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--fields", "backlinks"])
         .output()
@@ -329,7 +329,7 @@ title: Test
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--file", "note"])
         .output()
@@ -346,7 +346,7 @@ title: Test
 fn error_json_structure() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--file", "nope.md"])
         .output()
@@ -365,13 +365,12 @@ fn error_json_structure() {
 fn error_text_format() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "--format",
             "text",
-            "--no-hints",
             "find",
             "--file",
             "nope.md",
@@ -400,7 +399,7 @@ title: Test
     );
     let file_path = tmp.path().join("note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", file_path.to_str().unwrap()])
         .args(["find"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 
 // ---------------------------------------------------------------------------
 // Vault fixture
@@ -90,8 +90,8 @@ fn find_json(
     tmp: &tempfile::TempDir,
     extra_args: &[&str],
 ) -> (std::process::ExitStatus, serde_json::Value, String) {
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.arg("find");
     cmd.args(extra_args);
     let output = cmd.output().unwrap();
@@ -186,7 +186,7 @@ fn find_glob_sub_only() {
 #[test]
 fn find_file_not_found_exits_1() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--file", "does_not_exist.md"]);
     let output = cmd.output().unwrap();
@@ -749,7 +749,7 @@ fn find_limit_no_truncation_returns_envelope() {
 #[test]
 fn find_limit_truncated_text_shows_summary() {
     let tmp = setup_vault();
-    let mut cmd = common::hyalo();
+    let mut cmd = common::hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.args(["find", "--limit", "2"]);
@@ -766,7 +766,7 @@ fn find_limit_truncated_text_shows_summary() {
 #[test]
 fn find_limit_jq_total() {
     let tmp = setup_vault();
-    let mut cmd = common::hyalo();
+    let mut cmd = common::hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--limit", "2", "--jq", ".total"]);
     let output = cmd.output().unwrap();
@@ -956,7 +956,7 @@ fn find_sort_file_limit_with_filter_reports_accurate_total() {
 #[test]
 fn find_text_format_produces_output() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.arg("find");
@@ -974,7 +974,7 @@ fn find_text_format_produces_output() {
 #[test]
 fn find_text_format_with_pattern() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.args(["find", "Rust programming"]);
@@ -992,8 +992,8 @@ fn find_text_format_with_pattern() {
 #[test]
 fn find_text_format_file_object_structure() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.args(["find", "--file", "alpha.md", "--fields", "all"]);
     let output = cmd.output().unwrap();
@@ -1046,7 +1046,7 @@ fn find_text_format_file_object_structure() {
 #[test]
 fn find_text_format_content_matches() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.args(["find", "Rust programming"]);
@@ -1067,7 +1067,7 @@ fn find_text_format_content_matches() {
 #[test]
 fn find_text_format_multi_file_separation() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.arg("find");
@@ -1087,7 +1087,7 @@ fn find_text_format_multi_file_separation() {
 #[test]
 fn find_text_format_fields_properties_only() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.args(["find", "--file", "alpha.md", "--fields", "properties"]);
@@ -1117,7 +1117,7 @@ fn find_text_format_fields_properties_only() {
 fn find_text_format_fields_backlinks_renders() {
     let tmp = setup_vault();
     // alpha.md links to [[beta]], so beta should have backlinks in text format
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--format", "text"]);
     cmd.args(["find", "--file", "beta.md", "--fields", "backlinks"]);
@@ -1227,7 +1227,7 @@ fn find_regexp_combined_with_tag() {
 #[test]
 fn find_regexp_invalid_exits_1() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--regexp", "[invalid"]);
     let output = cmd.output().unwrap();
@@ -1243,7 +1243,7 @@ fn find_regexp_invalid_exits_1() {
 #[test]
 fn find_regexp_conflicts_with_positional_pattern() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "substring", "--regexp", "regex"]);
     let output = cmd.output().unwrap();
@@ -1287,7 +1287,7 @@ title: Dotdot
 #[test]
 fn find_task_invalid_multi_char_exits_1() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--task", "invalid_multi_char"]);
     let output = cmd.output().unwrap();
@@ -1299,7 +1299,7 @@ fn find_task_invalid_multi_char_exits_1() {
 #[test]
 fn find_fields_bogus_exits_1() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--fields", "bogus"]);
     let output = cmd.output().unwrap();
@@ -1311,7 +1311,7 @@ fn find_fields_bogus_exits_1() {
 #[test]
 fn find_sort_bogus_exits_1() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--sort", "bogus"]);
     let output = cmd.output().unwrap();
@@ -1618,7 +1618,7 @@ fn section_filter_content_search_excludes_other_sections() {
 #[test]
 fn section_filter_invalid_exits_1() {
     let tmp = setup_section_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--section", "####### Too deep"]);
     let output = cmd.output().unwrap();
@@ -1629,8 +1629,8 @@ fn section_filter_invalid_exits_1() {
 #[test]
 fn empty_text_result_prints_notice_on_stderr() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "find",
         "--property",
@@ -1655,8 +1655,8 @@ fn empty_text_result_prints_notice_on_stderr() {
 #[test]
 fn empty_json_result_returns_empty_array_no_stderr() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "find",
         "--property",
@@ -1780,7 +1780,7 @@ fn find_fields_properties_and_properties_typed_together_e2e() {
 #[test]
 fn find_fields_properties_typed_text_format() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "find",
@@ -1809,7 +1809,7 @@ fn find_fields_properties_typed_text_format() {
 #[test]
 fn find_fields_properties_typed_unknown_field_error() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--fields", "properties-badtypo"]);
     let output = cmd.output().unwrap();
@@ -1936,7 +1936,7 @@ fn find_property_regex_list_property_nested_tag() {
 #[test]
 fn find_property_regex_invalid_pattern_returns_user_error() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--property", "status~=[invalid"]);
     let output = cmd.output().unwrap();
@@ -2197,7 +2197,7 @@ fn section_filter_regex_anchored() {
 #[test]
 fn section_filter_regex_invalid_exits_1() {
     let tmp = setup_section_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--section", "~=/[invalid/"]);
     let output = cmd.output().unwrap();
@@ -2311,8 +2311,8 @@ fn find_multi_file_returns_array() {
     write_md(tmp.path(), "b.md", "---\ntitle: B\n---\n");
     write_md(tmp.path(), "c.md", "---\ntitle: C\n---\n");
 
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--file", "a.md", "--file", "b.md"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -2837,7 +2837,7 @@ Content.
 #[test]
 fn find_sort_property_empty_key_errors() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "--sort", "property:"]);
     let output = cmd.output().unwrap();
@@ -2851,7 +2851,7 @@ fn find_sort_property_empty_key_errors() {
 #[test]
 fn find_empty_body_pattern_errors() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", ""]);
     let output = cmd.output().unwrap();
@@ -2869,7 +2869,7 @@ fn find_empty_body_pattern_errors() {
 #[test]
 fn find_whitespace_only_body_pattern_errors() {
     let tmp = setup_vault();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["find", "   "]);
     let output = cmd.output().unwrap();
@@ -3047,7 +3047,7 @@ tags: [foo]
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", dir.path().to_str().unwrap(), "find", "--tag", ""])
         .output()
         .unwrap();
@@ -3090,7 +3090,7 @@ title: B
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             dir.path().to_str().unwrap(),
@@ -3130,7 +3130,7 @@ title: A
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             dir.path().to_str().unwrap(),
@@ -3160,9 +3160,8 @@ title: A
 #[test]
 fn find_sort_title_reverse() {
     let tmp = setup_vault();
-    let out = hyalo()
+    let out = hyalo_no_hints()
         .args([
-            "--no-hints",
             "find",
             "--sort",
             "title",
@@ -3197,9 +3196,8 @@ fn find_sort_title_reverse() {
 #[test]
 fn find_reverse_with_limit() {
     let tmp = setup_vault();
-    let out = hyalo()
+    let out = hyalo_no_hints()
         .args([
-            "--no-hints",
             "find",
             "--sort",
             "file",
@@ -3233,8 +3231,8 @@ fn find_reverse_with_limit() {
 fn find_reverse_alone() {
     let tmp = setup_vault();
     // --reverse without --sort should reverse the default file-path sort
-    let out = hyalo()
-        .args(["--no-hints", "find", "--reverse", "--format", "json"])
+    let out = hyalo_no_hints()
+        .args(["find", "--reverse", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3264,8 +3262,8 @@ fn find_reverse_alone() {
 fn find_title_h1_match() {
     let tmp = setup_vault();
     // gamma.md has no frontmatter title but has H1 "# Gamma"
-    let out = hyalo()
-        .args(["--no-hints", "find", "--title", "gamma", "--format", "json"])
+    let out = hyalo_no_hints()
+        .args(["find", "--title", "gamma", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3288,8 +3286,8 @@ fn find_title_h1_match() {
 #[test]
 fn find_title_case_insensitive() {
     let tmp = setup_vault();
-    let out = hyalo()
-        .args(["--no-hints", "find", "--title", "ALPHA", "--format", "json"])
+    let out = hyalo_no_hints()
+        .args(["find", "--title", "ALPHA", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3312,15 +3310,8 @@ fn find_title_case_insensitive() {
 #[test]
 fn find_title_regex_mode() {
     let tmp = setup_vault();
-    let out = hyalo()
-        .args([
-            "--no-hints",
-            "find",
-            "--title",
-            "~=^(Alpha|Beta)$",
-            "--format",
-            "json",
-        ])
+    let out = hyalo_no_hints()
+        .args(["find", "--title", "~=^(Alpha|Beta)$", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3343,8 +3334,8 @@ fn find_title_regex_mode() {
 fn find_title_frontmatter_match() {
     let tmp = setup_vault();
     // alpha.md has frontmatter title "Alpha"
-    let out = hyalo()
-        .args(["--no-hints", "find", "--title", "alph", "--format", "json"])
+    let out = hyalo_no_hints()
+        .args(["find", "--title", "alph", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3365,7 +3356,7 @@ fn find_title_frontmatter_match() {
 #[test]
 fn find_title_invalid_regex_returns_error() {
     let tmp = setup_vault();
-    let out = hyalo()
+    let out = hyalo_no_hints()
         .args(["find", "--title", "~=[unclosed", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())

--- a/crates/hyalo-cli/tests/e2e_help.rs
+++ b/crates/hyalo-cli/tests/e2e_help.rs
@@ -2,12 +2,12 @@ mod common;
 
 use std::fs;
 
-use common::hyalo;
+use common::hyalo_no_hints;
 use tempfile::TempDir;
 
 #[test]
 fn short_help_is_compact() {
-    let output = hyalo().arg("-h").output().unwrap();
+    let output = hyalo_no_hints().arg("-h").output().unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
 
@@ -34,7 +34,7 @@ fn short_help_is_compact() {
 
 #[test]
 fn long_help_contains_enriched_sections() {
-    let output = hyalo().arg("--help").output().unwrap();
+    let output = hyalo_no_hints().arg("--help").output().unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
 
@@ -52,7 +52,7 @@ fn long_help_contains_enriched_sections() {
 
 #[test]
 fn long_help_command_reference_lists_all_commands() {
-    let output = hyalo().arg("--help").output().unwrap();
+    let output = hyalo_no_hints().arg("--help").output().unwrap();
     let stdout = String::from_utf8(output.stdout).unwrap();
 
     // Verify every command/subcommand appears in the COMMAND REFERENCE
@@ -79,7 +79,7 @@ fn long_help_command_reference_lists_all_commands() {
 #[test]
 fn subcommand_help_unchanged_by_enriched_root() {
     // Subcommand --help should NOT contain root-level enriched sections
-    let output = hyalo().args(["task", "--help"]).output().unwrap();
+    let output = hyalo_no_hints().args(["task", "--help"]).output().unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
 
@@ -128,7 +128,7 @@ fn help_hides_dir_when_config_sets_it() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join(".hyalo.toml"), "dir = \"notes\"\n").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--help")
         .current_dir(tmp.path())
         .output()
@@ -149,7 +149,7 @@ fn help_hides_format_when_config_sets_it() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--help")
         .current_dir(tmp.path())
         .output()
@@ -170,7 +170,7 @@ fn help_shows_dir_without_config() {
     let tmp = TempDir::new().unwrap();
     // No .hyalo.toml — dir defaults to "."
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--help")
         .current_dir(tmp.path())
         .output()
@@ -218,7 +218,11 @@ fn examples_omit_format_when_config_sets_it() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
 
-    let output = hyalo().arg("-h").current_dir(tmp.path()).output().unwrap();
+    let output = hyalo_no_hints()
+        .arg("-h")
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -235,7 +239,11 @@ fn examples_show_format_without_config() {
     let tmp = TempDir::new().unwrap();
     // No .hyalo.toml
 
-    let output = hyalo().arg("-h").current_dir(tmp.path()).output().unwrap();
+    let output = hyalo_no_hints()
+        .arg("-h")
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -252,7 +260,7 @@ fn cookbook_omits_format_when_config_sets_it() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--help")
         .current_dir(tmp.path())
         .output()
@@ -273,7 +281,7 @@ fn cookbook_shows_format_without_config() {
     let tmp = TempDir::new().unwrap();
     // No .hyalo.toml
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--help")
         .current_dir(tmp.path())
         .output()
@@ -311,7 +319,7 @@ fn command_reference_omits_dir_flag_when_config_sets_it() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join(".hyalo.toml"), "dir = \"notes\"\n").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--help")
         .current_dir(tmp.path())
         .output()
@@ -333,7 +341,7 @@ fn command_reference_shows_dir_flag_without_config() {
     let tmp = TempDir::new().unwrap();
     // No .hyalo.toml
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--help")
         .current_dir(tmp.path())
         .output()

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -86,11 +86,18 @@ fn summary_hints_json_has_data_and_hints() {
     // Data must be the vault summary
     assert!(parsed["data"]["files"]["total"].as_u64().unwrap() > 0);
 
-    // Hints must be an array of strings
+    // Hints must be an array of {description, cmd} objects
     let hints = parsed["hints"].as_array().unwrap();
     assert!(!hints.is_empty());
     for hint in hints {
-        assert!(hint.as_str().unwrap().starts_with("hyalo"));
+        assert!(
+            hint["cmd"].as_str().unwrap().starts_with("hyalo"),
+            "hint cmd should start with hyalo: {hint}"
+        );
+        assert!(
+            hint.get("description").and_then(|d| d.as_str()).is_some(),
+            "hint should have description: {hint}"
+        );
     }
 }
 
@@ -429,9 +436,9 @@ fn set_format_text_with_hints_outputs_text_not_json() {
 
 // ---------------------------------------------------------------------------
 // Mutation commands with --hints
-// Mutation commands (set, remove, append) accept --hints but do not generate
-// hint suggestions — they produce the same JSON output as without --hints.
-// These tests verify the flag is accepted and output remains valid/correct.
+// Mutation commands (set, remove, append) accept --hints and generate
+// hint suggestions — they produce a hints envelope with verify/read hints.
+// These tests verify the flag is accepted and hints are generated.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -458,15 +465,22 @@ fn set_hints_accepted_produces_valid_json() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("expected valid JSON, got: {stdout}\nerr: {e}"));
-    // Output should be the mutation result, not wrapped in a hints envelope
+    // Output should be wrapped in a hints envelope
     assert!(
-        parsed.get("modified").is_some(),
-        "should have modified field: {parsed}"
+        parsed.get("data").is_some(),
+        "should have data envelope: {parsed}"
     );
-    // Mutation commands do not generate hints, so no envelope
     assert!(
-        parsed.get("hints").is_none(),
-        "mutation commands should not wrap output in hints envelope: {parsed}"
+        parsed["data"].get("modified").is_some(),
+        "data should have modified field: {parsed}"
+    );
+    // Mutation commands generate verify/read hints
+    assert!(
+        parsed
+            .get("hints")
+            .and_then(|h| h.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "mutation commands should generate hints: {parsed}"
     );
 }
 
@@ -490,12 +504,19 @@ fn remove_hints_accepted_produces_valid_json() {
     let parsed: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("expected valid JSON, got: {stdout}\nerr: {e}"));
     assert!(
-        parsed.get("modified").is_some(),
-        "should have modified field: {parsed}"
+        parsed.get("data").is_some(),
+        "should have data envelope: {parsed}"
     );
     assert!(
-        parsed.get("hints").is_none(),
-        "mutation commands should not wrap output in hints envelope: {parsed}"
+        parsed["data"].get("modified").is_some(),
+        "data should have modified field: {parsed}"
+    );
+    assert!(
+        parsed
+            .get("hints")
+            .and_then(|h| h.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "mutation commands should generate hints: {parsed}"
     );
 }
 
@@ -525,12 +546,19 @@ fn append_hints_accepted_produces_valid_json() {
     let parsed: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("expected valid JSON, got: {stdout}\nerr: {e}"));
     assert!(
-        parsed.get("modified").is_some(),
-        "should have modified field: {parsed}"
+        parsed.get("data").is_some(),
+        "should have data envelope: {parsed}"
     );
     assert!(
-        parsed.get("hints").is_none(),
-        "mutation commands should not wrap output in hints envelope: {parsed}"
+        parsed["data"].get("modified").is_some(),
+        "data should have modified field: {parsed}"
+    );
+    assert!(
+        parsed
+            .get("hints")
+            .and_then(|h| h.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "mutation commands should generate hints: {parsed}"
     );
 }
 
@@ -586,7 +614,10 @@ fn find_with_hints_json_envelope() {
     let hints = parsed["hints"].as_array().unwrap();
     assert!(!hints.is_empty(), "should have at least one hint");
     for hint in hints {
-        assert!(hint.as_str().unwrap().starts_with("hyalo"));
+        assert!(
+            hint["cmd"].as_str().unwrap().starts_with("hyalo"),
+            "hint cmd should start with hyalo: {hint}"
+        );
     }
 }
 
@@ -643,10 +674,11 @@ fn mutation_with_hints_warns() {
         "set --hints should succeed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    // Mutation commands now generate hints — no warning expected
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
-        stderr.contains("warning: --hints has no effect on mutation commands"),
-        "should warn when --hints is passed to set: {stderr}"
+        !stderr.contains("--hints has no effect"),
+        "should not warn about --hints on mutation commands: {stderr}"
     );
 }
 
@@ -670,10 +702,11 @@ fn remove_with_hints_warns() {
         "remove --hints should succeed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    // Mutation commands now generate hints — no warning expected
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
-        stderr.contains("warning: --hints has no effect on mutation commands"),
-        "should warn when --hints is passed to remove: {stderr}"
+        !stderr.contains("--hints has no effect"),
+        "should not warn about --hints on mutation commands: {stderr}"
     );
 }
 
@@ -697,10 +730,11 @@ fn append_with_hints_warns() {
         "append --hints should succeed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    // Mutation commands now generate hints — no warning expected
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
-        stderr.contains("warning: --hints has no effect on mutation commands"),
-        "should warn when --hints is passed to append: {stderr}"
+        !stderr.contains("--hints has no effect"),
+        "should not warn about --hints on mutation commands: {stderr}"
     );
 }
 
@@ -835,7 +869,10 @@ fn properties_summary_hints_json_envelope() {
     let hints = parsed["hints"].as_array().unwrap();
     assert!(!hints.is_empty(), "should have hints");
     for hint in hints {
-        assert!(hint.as_str().unwrap().starts_with("hyalo"));
+        assert!(
+            hint["cmd"].as_str().unwrap().starts_with("hyalo"),
+            "hint cmd should start with hyalo: {hint}"
+        );
     }
 }
 
@@ -877,7 +914,10 @@ fn tags_summary_hints_json_envelope() {
     let hints = parsed["hints"].as_array().unwrap();
     assert!(!hints.is_empty(), "should have hints");
     for hint in hints {
-        assert!(hint.as_str().unwrap().starts_with("hyalo"));
+        assert!(
+            hint["cmd"].as_str().unwrap().starts_with("hyalo"),
+            "hint cmd should start with hyalo: {hint}"
+        );
     }
 }
 

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -850,6 +850,406 @@ fn find_hints_no_hardcoded_draft() {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: assert a JSON value has a non-empty hints array where every element
+// has both "description" and "cmd" string fields.
+// ---------------------------------------------------------------------------
+
+fn assert_hints_present(parsed: &serde_json::Value) {
+    let hints = parsed["hints"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected 'hints' array in: {parsed}"));
+    assert!(!hints.is_empty(), "expected at least one hint in: {parsed}");
+    for hint in hints {
+        assert!(
+            hint.get("description").and_then(|d| d.as_str()).is_some(),
+            "hint missing 'description': {hint}"
+        );
+        assert!(
+            hint.get("cmd").and_then(|c| c.as_str()).is_some(),
+            "hint missing 'cmd': {hint}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// read --hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_hints() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+---
+# Note
+
+Body content here.
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(
+        parsed.get("data").is_some(),
+        "expected 'data' key: {parsed}"
+    );
+    assert_hints_present(&parsed);
+}
+
+// ---------------------------------------------------------------------------
+// backlinks --hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backlinks_hints() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "target.md",
+        md!(r"
+---
+title: Target
+---
+# Target
+"),
+    );
+    write_md(
+        tmp.path(),
+        "source.md",
+        md!(r"
+---
+title: Source
+---
+# Source
+
+See [[target]].
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["backlinks", "--file", "target.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(
+        parsed.get("data").is_some(),
+        "expected 'data' key: {parsed}"
+    );
+    assert_hints_present(&parsed);
+}
+
+// ---------------------------------------------------------------------------
+// mv --dry-run --hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mv_dry_run_hints() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "original.md",
+        md!(r"
+---
+title: Original
+---
+# Original
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "mv",
+            "--file",
+            "original.md",
+            "--to",
+            "renamed.md",
+            "--dry-run",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(
+        parsed.get("data").is_some(),
+        "expected 'data' key: {parsed}"
+    );
+    // dry-run hint should suggest applying (without --dry-run)
+    let hints = parsed["hints"].as_array().unwrap();
+    assert!(
+        !hints.is_empty(),
+        "expected hints for mv --dry-run: {parsed}"
+    );
+    let apply_hint = hints.iter().find(|h| {
+        h.get("cmd")
+            .and_then(|c| c.as_str())
+            .is_some_and(|s| s.contains("mv") && !s.contains("--dry-run"))
+    });
+    assert!(
+        apply_hint.is_some(),
+        "expected a hint suggesting mv without --dry-run: {parsed}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// task toggle --hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_toggle_hints() {
+    let tmp = TempDir::new().unwrap();
+    // Task is on line 6: frontmatter(3) + heading(1) + blank(1) + task(1)
+    write_md(
+        tmp.path(),
+        "tasks.md",
+        md!(r"
+---
+title: Tasks
+---
+# Tasks
+
+- [ ] task one
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "task", "toggle", "--file", "tasks.md", "--line", "6", "--format", "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(
+        parsed.get("data").is_some(),
+        "expected 'data' key: {parsed}"
+    );
+    assert_hints_present(&parsed);
+}
+
+// ---------------------------------------------------------------------------
+// links fix --hints (with a fixable broken link)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_hints() {
+    let tmp = TempDir::new().unwrap();
+    // "ActualNote" is a wikilink that can be fuzzy-matched to actual-note.md
+    write_md(
+        tmp.path(),
+        "source.md",
+        md!(r"
+---
+title: Source
+---
+# Source
+
+See [[ActualNote]] for details.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "actual-note.md",
+        md!(r"
+---
+title: ActualNote
+---
+# ActualNote
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["links", "fix", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(
+        parsed.get("data").is_some(),
+        "expected 'data' key: {parsed}"
+    );
+    assert_hints_present(&parsed);
+}
+
+// ---------------------------------------------------------------------------
+// create-index --hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_index_hints() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+---
+# Note
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["create-index", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(
+        parsed.get("data").is_some(),
+        "expected 'data' key: {parsed}"
+    );
+    let hints = parsed["hints"].as_array().unwrap();
+    assert!(
+        !hints.is_empty(),
+        "expected hints after create-index: {parsed}"
+    );
+    // Should suggest using the index and dropping it
+    let cmds: Vec<&str> = hints
+        .iter()
+        .filter_map(|h| h.get("cmd").and_then(|c| c.as_str()))
+        .collect();
+    assert!(
+        cmds.iter().any(|c| c.contains("--index")),
+        "expected a hint suggesting --index flag: {parsed}"
+    );
+    assert!(
+        cmds.iter().any(|c| c.contains("drop-index")),
+        "expected a hint suggesting drop-index: {parsed}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// drop-index --hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn drop_index_hints() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+---
+# Note
+"),
+    );
+
+    // First create the index, then drop it and check the hints.
+    hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["create-index", "--no-hints"])
+        .output()
+        .unwrap();
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["drop-index", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert!(
+        parsed.get("data").is_some(),
+        "expected 'data' key: {parsed}"
+    );
+    let hints = parsed["hints"].as_array().unwrap();
+    assert!(
+        !hints.is_empty(),
+        "expected hints after drop-index: {parsed}"
+    );
+    let cmds: Vec<&str> = hints
+        .iter()
+        .filter_map(|h| h.get("cmd").and_then(|c| c.as_str()))
+        .collect();
+    assert!(
+        cmds.iter().any(|c| c.contains("create-index")),
+        "expected a hint suggesting create-index: {parsed}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // properties summary --hints: verify data-driven suggestions
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
 #[cfg(unix)]
@@ -96,7 +96,7 @@ Some nested content here.
 /// Run `hyalo create-index --dir <dir>` and assert success.
 /// Returns the default index path: `<dir>/.hyalo-index`.
 fn create_default_index(tmp: &TempDir) -> std::path::PathBuf {
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .arg("create-index")
         .output()
@@ -111,8 +111,8 @@ fn create_default_index(tmp: &TempDir) -> std::path::PathBuf {
 
 /// Run `hyalo find` with extra args and return parsed JSON.
 fn run_find(tmp: &TempDir, extra_args: &[&str]) -> serde_json::Value {
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.arg("find");
     cmd.args(extra_args);
     let output = cmd.output().unwrap();
@@ -152,7 +152,7 @@ fn sorted_files(json: &serde_json::Value) -> Vec<String> {
 #[test]
 fn create_index_produces_file() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .arg("create-index")
         .output()
@@ -180,7 +180,7 @@ fn create_index_custom_output_path() {
     let tmp = setup_vault();
     let custom_path = tmp.path().join("my-custom.idx");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["create-index", "--output", custom_path.to_str().unwrap()])
         .output()
@@ -213,7 +213,7 @@ fn drop_index_deletes_file() {
     let index_path = create_default_index(&tmp);
     assert!(index_path.exists());
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .arg("drop-index")
         .output()
@@ -237,7 +237,7 @@ fn drop_index_deletes_file() {
 fn drop_index_nonexistent_returns_error() {
     let tmp = setup_vault();
     // No index created — drop-index should fail.
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .arg("drop-index")
         .output()
@@ -383,20 +383,19 @@ fn summary_with_index_matches_disk_scan() {
     let tmp = setup_vault();
     let index_path = create_default_index(&tmp);
 
-    let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let disk_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["summary", "--format", "json"])
         .output()
         .unwrap();
     assert!(disk_output.status.success());
     let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
 
-    let index_output = hyalo()
+    let index_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "--index",
             index_path.to_str().unwrap(),
-            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -429,12 +428,11 @@ fn summary_with_index_file_count() {
     let tmp = setup_vault();
     let index_path = create_default_index(&tmp);
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "--index",
             index_path.to_str().unwrap(),
-            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -456,16 +454,16 @@ fn tags_summary_with_index_matches_disk_scan() {
     let tmp = setup_vault();
     let index_path = create_default_index(&tmp);
 
-    let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let disk_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "summary"])
         .output()
         .unwrap();
     assert!(disk_output.status.success());
     let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
 
-    let index_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let index_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--index", index_path.to_str().unwrap(), "tags", "summary"])
         .output()
         .unwrap();
@@ -511,16 +509,16 @@ fn properties_summary_with_index_matches_disk_scan() {
     let tmp = setup_vault();
     let index_path = create_default_index(&tmp);
 
-    let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let disk_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "summary"])
         .output()
         .unwrap();
     assert!(disk_output.status.success());
     let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
 
-    let index_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let index_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "--index",
             index_path.to_str().unwrap(),
@@ -567,10 +565,9 @@ fn backlinks_with_index_finds_wikilinks() {
     let index_path = create_default_index(&tmp);
 
     // gamma.md links to alpha.md via [[alpha]]
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
-            "--no-hints",
             "--index",
             index_path.to_str().unwrap(),
             "backlinks",
@@ -605,18 +602,17 @@ fn backlinks_with_index_matches_disk_scan() {
     let tmp = setup_vault();
     let index_path = create_default_index(&tmp);
 
-    let disk_output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let disk_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["backlinks", "--file", "beta.md"])
         .output()
         .unwrap();
     assert!(disk_output.status.success());
     let disk_json: serde_json::Value = serde_json::from_slice(&disk_output.stdout).unwrap();
 
-    let index_output = hyalo()
+    let index_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
-            "--no-hints",
             "--index",
             index_path.to_str().unwrap(),
             "backlinks",
@@ -646,14 +642,9 @@ fn incompatible_index_falls_back_to_disk_scan() {
     let garbage_path = tmp.path().join("garbage.idx");
     std::fs::write(&garbage_path, b"this is not a valid msgpack snapshot").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "--no-hints",
-            "--index",
-            garbage_path.to_str().unwrap(),
-            "find",
-        ])
+        .args(["--index", garbage_path.to_str().unwrap(), "find"])
         .output()
         .unwrap();
 
@@ -687,10 +678,9 @@ fn incompatible_index_falls_back_for_summary() {
     let garbage_path = tmp.path().join("bad.idx");
     std::fs::write(&garbage_path, b"NOTBINCODE").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
-            "--no-hints",
             "--index",
             garbage_path.to_str().unwrap(),
             "summary",
@@ -716,7 +706,7 @@ fn incompatible_index_falls_back_for_summary() {
 
 /// Helper: run a hyalo command with --index and assert success.
 fn run_with_index(tmp: &TempDir, index_path: &std::path::Path, args: &[&str]) -> serde_json::Value {
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["--index", index_path.to_str().unwrap()]);
     cmd.args(args);
@@ -1117,7 +1107,7 @@ fn create_index_rejects_output_outside_vault() {
     let outside = TempDir::new().unwrap();
     let outside_path = outside.path().join("evil.idx");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", vault.path().to_str().unwrap()])
         .args(["create-index", "--output", outside_path.to_str().unwrap()])
         .output()
@@ -1147,7 +1137,7 @@ fn create_index_allow_outside_vault_flag() {
     let outside = TempDir::new().unwrap();
     let outside_path = outside.path().join("allowed.idx");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", vault.path().to_str().unwrap()])
         .args([
             "create-index",
@@ -1176,7 +1166,7 @@ fn create_index_normal_in_vault_path_works() {
     std::fs::create_dir_all(&in_vault_path).unwrap();
     let index_path = in_vault_path.join("my.idx");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", vault.path().to_str().unwrap()])
         .args(["create-index", "--output", index_path.to_str().unwrap()])
         .output()
@@ -1202,7 +1192,7 @@ fn drop_index_rejects_path_outside_vault() {
     let outside_file = outside.path().join("victim.idx");
     std::fs::write(&outside_file, b"fake index").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", vault.path().to_str().unwrap()])
         .args(["drop-index", "--path", outside_file.to_str().unwrap()])
         .output()
@@ -1233,7 +1223,7 @@ fn drop_index_allow_outside_vault_flag() {
     let outside_file = outside.path().join("allowed.idx");
     std::fs::write(&outside_file, b"fake index").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", vault.path().to_str().unwrap()])
         .args([
             "drop-index",
@@ -1261,7 +1251,7 @@ fn drop_index_normal_in_vault_path_works() {
     let index_path = create_default_index(&vault);
     assert!(index_path.exists());
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", vault.path().to_str().unwrap()])
         .args(["drop-index", "--path", index_path.to_str().unwrap()])
         .output()
@@ -1300,8 +1290,8 @@ Content
     std::fs::write(&outside_file, "---\ntitle: Secret\n---\nSecret content\n").unwrap();
     unix_fs::symlink(&outside_file, vault.path().join("evil.md")).unwrap();
 
-    let output = hyalo()
-        .args(["--dir", vault.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
         .arg("find")
         .output()
         .unwrap();
@@ -1367,8 +1357,8 @@ Target content
     )
     .unwrap();
 
-    let output = hyalo()
-        .args(["--dir", vault.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
         .arg("find")
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e_init.rs
+++ b/crates/hyalo-cli/tests/e2e_init.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::hyalo;
+use common::hyalo_no_hints;
 use std::fs;
 use tempfile::TempDir;
 
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 fn init_creates_hyalo_toml() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init"])
         .output()
@@ -38,7 +38,7 @@ fn init_does_not_overwrite_existing_toml() {
     let original = "dir = \"my-vault\"\n";
     fs::write(tmp.path().join(".hyalo.toml"), original).unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init"])
         .output()
@@ -65,7 +65,7 @@ fn init_dir_flag_updates_existing_toml() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--dir", "new-dir"])
         .output()
@@ -90,7 +90,7 @@ fn init_dir_flag_updates_existing_toml() {
 fn init_with_dir_flag() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--dir", "docs"])
         .output()
@@ -113,7 +113,7 @@ fn init_auto_detects_docs_dir() {
     fs::create_dir_all(tmp.path().join("docs")).unwrap();
     fs::write(tmp.path().join("docs").join("note.md"), "# Hello").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init"])
         .output()
@@ -133,7 +133,7 @@ fn init_auto_detects_docs_dir() {
 fn init_falls_back_to_dot_when_no_doc_dir() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init"])
         .output()
@@ -171,7 +171,7 @@ fn init_smart_detection_picks_dir_with_most_md() {
     )
     .unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init"])
         .output()
@@ -195,7 +195,7 @@ fn init_smart_detection_picks_dir_with_most_md() {
 fn init_claude_creates_skill() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -233,7 +233,7 @@ fn init_claude_overwrites_existing_skill() {
     let original = "---\nname: custom\n---\nstale content\n";
     fs::write(&skill_path, original).unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -267,7 +267,7 @@ fn init_claude_overwrites_existing_skill() {
 fn init_claude_creates_tidy_skill() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -308,7 +308,7 @@ fn init_claude_overwrites_existing_tidy_skill() {
     let original = "---\nname: custom-tidy\n---\nstale content\n";
     fs::write(&tidy_skill_path, original).unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -341,7 +341,7 @@ fn init_claude_overwrites_existing_tidy_skill() {
 fn init_claude_creates_rule() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -382,7 +382,7 @@ fn init_claude_overwrites_existing_rule() {
     let original = "---\npaths:\n  - \"old-vault/**\"\n---\nold content\n";
     fs::write(&rule_path, original).unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -410,7 +410,7 @@ fn init_claude_rule_uses_detected_dir() {
     fs::create_dir_all(tmp.path().join("docs")).unwrap();
     fs::write(tmp.path().join("docs").join("note.md"), "# Hello").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -440,7 +440,7 @@ fn init_claude_rule_uses_explicit_dir() {
     // --dir my-vault should be reflected in the rule paths.
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude", "--dir", "my-vault"])
         .output()
@@ -473,7 +473,7 @@ fn init_claude_rule_uses_explicit_dir() {
 fn init_claude_creates_claude_md() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -512,7 +512,7 @@ fn init_claude_appends_to_existing_claude_md() {
     let original = "# Project Instructions\n\nSome existing content.\n";
     fs::write(&claude_md_path, original).unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -558,7 +558,7 @@ fn init_claude_no_duplicate_in_claude_md() {
     let original = format!("<!-- hyalo:start -->\n{hint}\n<!-- hyalo:end -->\n");
     fs::write(&claude_md_path, &original).unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -603,7 +603,7 @@ fn init_claude_updates_managed_section_on_rerun() {
     fs::write(&claude_md_path, surrounding).unwrap();
 
     // First run — appends section.
-    let out1 = hyalo()
+    let out1 = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -612,7 +612,7 @@ fn init_claude_updates_managed_section_on_rerun() {
     assert!(out1.status.success(), "first run stderr: {stderr1}");
 
     // Second run — should replace, not duplicate.
-    let out2 = hyalo()
+    let out2 = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -660,7 +660,7 @@ fn init_claude_appends_section_when_no_markers_exist() {
     let original = "# Header\n\nSome existing instructions.\n\n# Footer\n";
     fs::write(&claude_md_path, original).unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -705,7 +705,7 @@ fn init_claude_appends_section_when_no_markers_exist() {
 fn init_prints_summary_of_actions() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -738,7 +738,7 @@ fn init_prints_summary_of_actions() {
 fn init_summary_mentions_rule() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude"])
         .output()
@@ -761,7 +761,7 @@ fn init_summary_mentions_rule() {
 fn init_claude_tidy_skill_parameterized_with_dir() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude", "--dir", "my-kb"])
         .output()
@@ -796,7 +796,7 @@ fn init_claude_hyalo_skill_has_no_sentinel() {
     // that parameterization is a safe no-op (no hyalo-knowledgebase leaks).
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init", "--claude", "--dir", "custom-docs"])
         .output()
@@ -834,7 +834,7 @@ fn init_auto_detects_fuzzy_knowledgebase_dir() {
     )
     .unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init"])
         .output()
@@ -858,7 +858,7 @@ fn init_auto_detects_fuzzy_wiki_dir() {
     fs::create_dir_all(tmp.path().join("project-wiki")).unwrap();
     fs::write(tmp.path().join("project-wiki").join("home.md"), "# Home").unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["init"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_jq.rs
+++ b/crates/hyalo-cli/tests/e2e_jq.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md, write_tagged};
+use common::{hyalo_no_hints, write_md, write_tagged};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -23,7 +23,7 @@ fn setup_vault() -> TempDir {
 fn jq_extracts_total_from_tags_summary() {
     let tmp = setup_vault();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".total"])
         .args(["tags", "summary"])
@@ -43,7 +43,7 @@ fn jq_extracts_total_from_tags_summary() {
 fn jq_maps_tag_names_to_array() {
     let tmp = setup_vault();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", "[.tags[].name] | sort | join(\", \")"])
         .args(["tags", "summary"])
@@ -66,7 +66,7 @@ fn jq_works_on_properties_command() {
 
     // `properties` returns an array of {count, name, type} objects.
     // Extract just the property names and sort them.
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", "[.[].name] | sort | join(\", \")"])
         .args(["properties", "summary"])
@@ -88,7 +88,7 @@ fn jq_works_on_find_property_filter() {
     write_md(tmp.path(), "a.md", "---\nstatus: draft\n---\n");
     write_md(tmp.path(), "b.md", "---\nstatus: done\n---\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".results[].file"])
         .args(["find", "--property", "status=draft"])
@@ -115,7 +115,7 @@ fn jq_works_on_find_links() {
     );
     write_md(tmp.path(), "target.md", "# Target\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".results[0].links | length"])
         .args(["find", "--file", "source.md", "--fields", "links"])
@@ -140,7 +140,7 @@ fn jq_works_on_find_sections() {
         "# Introduction\n\nSome text.\n\n## Details\n\nMore text.\n\n### Sub\n\nDeep.\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".results[0].sections | length"])
         .args(["find", "--file", "doc.md", "--fields", "sections"])
@@ -164,7 +164,7 @@ fn jq_works_on_find_sections() {
 fn jq_with_format_text_errors() {
     let tmp = setup_vault();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["--jq", ".total"])
@@ -189,7 +189,7 @@ fn jq_with_format_text_errors() {
 fn jq_with_format_json_works() {
     let tmp = setup_vault();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "json"])
         .args(["--jq", ".total"])
@@ -214,7 +214,7 @@ fn jq_with_format_json_works() {
 fn jq_invalid_filter_exits_nonzero() {
     let tmp = setup_vault();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", "this is not %%% valid jq"])
         .args(["tags", "summary"])
@@ -239,7 +239,7 @@ fn jq_runtime_error_exits_nonzero() {
     let tmp = setup_vault();
 
     // Explicit jq runtime error raised via error("deliberate") to verify non-zero exit on runtime failure
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", "error(\"deliberate\")"])
         .args(["tags", "summary"])
@@ -264,7 +264,7 @@ fn jq_filter_error_is_json_when_format_json() {
     let tmp = setup_vault();
 
     // With --format json (the default), jq errors should be emitted as structured JSON
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "json"])
         .args(["--jq", "error(\"structured-error\")"])
@@ -295,7 +295,7 @@ fn jq_works_on_set_command() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n# Body\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".modified | length"])
         .args(["set", "--property", "status=done", "--file", "note.md"])
@@ -324,7 +324,7 @@ fn jq_works_on_remove_command() {
         "---\ntitle: Note\nstatus: draft\n---\n# Body\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".modified | length"])
         .args(["remove", "--property", "status", "--file", "note.md"])
@@ -353,7 +353,7 @@ fn jq_works_on_append_command() {
         "---\ntitle: Note\naliases:\n  - old\n---\n# Body\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".modified | length"])
         .args(["append", "--property", "aliases=new", "--file", "note.md"])
@@ -381,7 +381,7 @@ fn jq_works_on_append_command() {
 fn jq_multiple_outputs_joined_by_newline() {
     let tmp = setup_vault();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--jq", ".tags[].name"])
         .args(["tags", "summary"])

--- a/crates/hyalo-cli/tests/e2e_links.rs
+++ b/crates/hyalo-cli/tests/e2e_links.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -81,13 +81,12 @@ Auth docs.
 #[test]
 fn summary_includes_link_health() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
-            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -143,13 +142,12 @@ fn summary_includes_link_health() {
 #[test]
 fn summary_broken_links_includes_nonexistent_target() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
-            "--no-hints",
             "summary",
             "--format",
             "json",
@@ -179,7 +177,7 @@ fn summary_broken_links_includes_nonexistent_target() {
 #[test]
 fn summary_text_includes_links_line() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -221,13 +219,12 @@ fn summary_text_includes_links_line() {
 #[test]
 fn find_broken_links_filter() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
-            "--no-hints",
             "find",
             "--broken-links",
             "--format",
@@ -281,13 +278,12 @@ fn find_broken_links_filter() {
 #[test]
 fn find_broken_links_entries_have_null_path() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
-            "--no-hints",
             "find",
             "--broken-links",
             "--format",
@@ -323,13 +319,12 @@ fn find_broken_links_entries_have_null_path() {
 fn find_broken_links_combined_with_glob_filter() {
     let tmp = setup_vault();
     // Restrict to b.md only via glob — should return just that file
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
-            "--no-hints",
             "find",
             "--broken-links",
             "--glob",
@@ -371,7 +366,7 @@ fn find_broken_links_combined_with_glob_filter() {
 #[test]
 fn links_fix_dry_run_reports_broken_and_fixable() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -447,7 +442,7 @@ fn links_fix_dry_run_reports_broken_and_fixable() {
 #[test]
 fn links_fix_dry_run_detects_fuzzy_match() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -496,7 +491,7 @@ fn links_fix_apply_reduces_broken_links() {
     let tmp = setup_vault();
 
     // Apply fixes
-    let apply_output = hyalo()
+    let apply_output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -539,7 +534,7 @@ fn links_fix_apply_reduces_broken_links() {
 
     // Re-run links fix in dry-run mode to measure the remaining broken link count
     // (same unit: number of broken links, not files).
-    let after_output = hyalo()
+    let after_output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -580,13 +575,12 @@ fn links_fix_apply_reduces_broken_links() {
 #[test]
 fn links_fix_text_format() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
                 .to_str()
                 .expect("temp path should be valid UTF-8"),
-            "--no-hints",
             "links",
             "fix",
             "--format",
@@ -629,7 +623,7 @@ fn links_fix_text_format() {
 fn links_fix_high_threshold_suppresses_fuzzy_fixes() {
     let tmp = setup_vault();
     // With threshold=0.99 the typo "Authnticaton" should not match authentication.md
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -676,7 +670,7 @@ fn links_fix_high_threshold_suppresses_fuzzy_fixes() {
 fn links_fix_default_threshold_finds_fuzzy_match() {
     let tmp = setup_vault();
     // With the default threshold, "Authnticaton" should fuzzy-match authentication.md
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -697,7 +691,7 @@ fn links_fix_default_threshold_finds_fuzzy_match() {
     let fixable = json["fixable"]
         .as_u64()
         .expect("'fixable' should be a number");
-    let high_threshold_output = hyalo()
+    let high_threshold_output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -747,7 +741,7 @@ See [[sort-reverse]] for reverse sorting.
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path()
@@ -817,7 +811,7 @@ Some text.
 "),
     );
 
-    let out = common::hyalo()
+    let out = common::hyalo_no_hints()
         .args(["links", "fix", "--ignore-target", "{{", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
@@ -856,7 +850,7 @@ See [[missing]] and [hugo]({{ .RelPermalink }}) and [hugo2]({{ .Site.BaseURL }})
     );
 
     // Two distinct --ignore-target patterns: one matches RelPermalink, the other BaseURL
-    let out = common::hyalo()
+    let out = common::hyalo_no_hints()
         .args([
             "links",
             "fix",
@@ -888,7 +882,7 @@ See [[missing]] and [hugo]({{ .RelPermalink }}) and [hugo2]({{ .Site.BaseURL }})
 fn links_fix_ignore_target_absent() {
     // With no matching ignore_target, count should be 0
     let tmp = setup_vault();
-    let out = common::hyalo()
+    let out = common::hyalo_no_hints()
         .args([
             "links",
             "fix",

--- a/crates/hyalo-cli/tests/e2e_mv.rs
+++ b/crates/hyalo-cli/tests/e2e_mv.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use std::fs;
 use tempfile::TempDir;
 
@@ -34,7 +34,7 @@ Content.
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "b.md", "--to", "archive/b.md"])
         .output()
@@ -70,7 +70,7 @@ fn mv_updates_wikilink_with_path() {
     write_md(tmp.path(), "a.md", "See [[backlog/item]] for details.\n");
     write_md(tmp.path(), "backlog/item.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "backlog/item.md", "--to", "archive/item.md"])
         .output()
@@ -98,7 +98,7 @@ fn mv_preserves_wikilink_alias() {
     write_md(tmp.path(), "a.md", "See [[sub/b|my note]] here.\n");
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "sub/b.md", "--to", "archive/b.md"])
         .output()
@@ -122,7 +122,7 @@ fn mv_preserves_wikilink_fragment() {
     write_md(tmp.path(), "a.md", "See [[sub/b#section]] here.\n");
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "sub/b.md", "--to", "archive/b.md"])
         .output()
@@ -146,7 +146,7 @@ fn mv_updates_inbound_markdown_link() {
     write_md(tmp.path(), "a.md", "See [note](b.md) here.\n");
     write_md(tmp.path(), "b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "b.md", "--to", "sub/b.md"])
         .output()
@@ -170,7 +170,7 @@ fn mv_updates_outbound_relative_link() {
     write_md(tmp.path(), "a.md", "Target.\n");
     write_md(tmp.path(), "b.md", "See [note](a.md) here.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "b.md", "--to", "sub/b.md"])
         .output()
@@ -194,7 +194,7 @@ fn mv_outbound_wikilink_unchanged() {
     write_md(tmp.path(), "a.md", "Target.\n");
     write_md(tmp.path(), "b.md", "See [[a]] here.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "b.md", "--to", "sub/b.md"])
         .output()
@@ -228,7 +228,7 @@ Real [[sub/b]] here.
     );
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "sub/b.md", "--to", "archive/b.md"])
         .output()
@@ -264,7 +264,7 @@ fn mv_skips_links_in_inline_code() {
     );
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "sub/b.md", "--to", "archive/b.md"])
         .output()
@@ -292,7 +292,7 @@ fn mv_dry_run_does_not_modify() {
     write_md(tmp.path(), "a.md", "See [[sub/b]] here.\n");
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "mv",
@@ -332,7 +332,7 @@ fn mv_target_already_exists_error() {
     write_md(tmp.path(), "a.md", "Content A.\n");
     write_md(tmp.path(), "b.md", "Content B.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "a.md", "--to", "b.md"])
         .output()
@@ -348,7 +348,7 @@ fn mv_source_not_found_error() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "a.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "nonexistent.md", "--to", "new.md"])
         .output()
@@ -364,7 +364,7 @@ fn mv_creates_parent_directory() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "a.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "a.md", "--to", "deep/nested/a.md"])
         .output()
@@ -385,8 +385,8 @@ fn mv_text_format() {
     write_md(tmp.path(), "a.md", "See [[sub/b]] here.\n");
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["mv", "--file", "sub/b.md", "--to", "archive/b.md"])
         .output()
@@ -410,7 +410,7 @@ fn mv_no_links_to_update() {
     write_md(tmp.path(), "a.md", "No links here.\n");
     write_md(tmp.path(), "b.md", "Also no links.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "a.md", "--to", "sub/a.md"])
         .output()
@@ -439,7 +439,7 @@ fn mv_multiple_links_same_file() {
     );
     write_md(tmp.path(), "sub/b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "sub/b.md", "--to", "archive/b.md"])
         .output()
@@ -466,7 +466,7 @@ fn mv_target_must_end_with_md() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "a.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "a.md", "--to", "b.txt"])
         .output()
@@ -483,7 +483,7 @@ fn mv_markdown_link_with_fragment() {
     write_md(tmp.path(), "a.md", "See [note](b.md#section) here.\n");
     write_md(tmp.path(), "b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "b.md", "--to", "sub/b.md"])
         .output()
@@ -507,7 +507,7 @@ fn mv_cross_directory_markdown_link() {
     write_md(tmp.path(), "sub/a.md", "See [note](../b.md) here.\n");
     write_md(tmp.path(), "b.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "b.md", "--to", "other/b.md"])
         .output()
@@ -537,7 +537,7 @@ fn mv_updates_wikilink_with_path_separator() {
         "See [[backlog/item]] for context.\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "backlog/item.md", "--to", "archive/item.md"])
         .output()
@@ -571,7 +571,7 @@ fn mv_wikilink_with_path_from_subdirectory_not_false_positive() {
     write_md(tmp.path(), "other/unrelated.md", "# Unrelated\n");
     write_md(tmp.path(), "sub/source.md", "See [[other/target]] here.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "mv",
@@ -606,7 +606,7 @@ fn mv_same_source_and_destination_error() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "a.md", "Content.\n");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "a.md", "--to", "a.md"])
         .output()
@@ -662,7 +662,7 @@ fn mv_absolute_links_bare_subdir() {
     let docs = build_absolute_link_vault(tmp.path());
     let docs_str = docs.to_str().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", docs_str])
         .args([
             "mv",
@@ -695,7 +695,7 @@ fn mv_absolute_links_absolute_subdir_path() {
     build_absolute_link_vault(tmp.path());
 
     let dir_arg = format!("{}/docs", tmp.path().to_str().unwrap());
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", &dir_arg])
         .args([
             "mv",
@@ -728,7 +728,7 @@ fn mv_absolute_links_no_leaked_dir_in_rewrites() {
     build_absolute_link_vault(tmp.path());
     let docs = tmp.path().join("docs");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", docs.to_str().unwrap()])
         .args([
             "mv",
@@ -769,7 +769,7 @@ fn mv_site_prefix_cli_flag_overrides_auto_derive() {
     build_absolute_link_vault(tmp.path());
     let docs = tmp.path().join("docs");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", docs.to_str().unwrap()])
         .args(["--site-prefix", "docs"])
         .args([
@@ -802,7 +802,7 @@ fn mv_site_prefix_cli_empty_disables_prefix() {
     build_absolute_link_vault(tmp.path());
     let docs = tmp.path().join("docs");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", docs.to_str().unwrap()])
         .args(["--site-prefix", ""])
         .args([
@@ -847,7 +847,7 @@ See [me](a.md) for details.
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["mv", "--file", "a.md", "--to", "archive/a.md"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_properties.rs
+++ b/crates/hyalo-cli/tests/e2e_properties.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, sample_frontmatter, write_md};
+use common::{hyalo_no_hints, md, sample_frontmatter, write_md};
 use std::fs;
 use tempfile::TempDir;
 
@@ -41,8 +41,8 @@ priority: 1
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "summary"])
         .output()
         .unwrap();
@@ -73,8 +73,8 @@ priority: 1
 fn properties_empty_dir() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "summary"])
         .output()
         .unwrap();
@@ -107,8 +107,8 @@ only_in_sub: yes
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "summary", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -145,7 +145,7 @@ title: B
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
@@ -170,8 +170,8 @@ fn properties_glob_no_match() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", sample_frontmatter());
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "summary", "--glob", "nonexistent/*.md"])
         .output()
         .unwrap();
@@ -201,8 +201,8 @@ fn find_properties_single_file() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "file.md", sample_frontmatter());
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--file", "file.md", "--fields", "properties"])
         .output()
         .unwrap();
@@ -265,8 +265,8 @@ title: Sub B
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--glob", "sub/*.md", "--fields", "properties"])
         .output()
         .unwrap();
@@ -288,8 +288,8 @@ fn find_properties_file_without_frontmatter() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--file", "plain.md", "--fields", "properties"])
         .output()
         .unwrap();
@@ -330,8 +330,8 @@ status: draft
         "---\n: invalid yaml [[[{\n---\n# Bad\n",
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "summary"])
         .output()
         .unwrap();
@@ -369,7 +369,7 @@ fn properties_rename_basic() {
     write_md(tmp.path(), "b.md", "---\ntitle: B\nkeywords: other\n---\n");
     write_md(tmp.path(), "c.md", "---\ntitle: C\n---\n"); // no keywords
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "properties",
@@ -400,7 +400,7 @@ fn properties_rename_conflict_skips() {
         "---\ntitle: Note\nfoo: old\nbar: existing\n---\n",
     );
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["properties", "rename", "--from", "foo", "--to", "bar"]);
     let output = cmd.output().unwrap();
@@ -422,7 +422,7 @@ fn properties_rename_with_glob_scope() {
     write_md(tmp.path(), "notes/a.md", "---\nkeywords: test\n---\n");
     write_md(tmp.path(), "other/b.md", "---\nkeywords: test\n---\n");
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "properties",
@@ -450,7 +450,7 @@ fn properties_rename_with_glob_scope() {
 #[test]
 fn properties_rename_same_name_exits_1() {
     let tmp = TempDir::new().unwrap();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["properties", "rename", "--from", "foo", "--to", "foo"]);
     let output = cmd.output().unwrap();
@@ -475,11 +475,10 @@ fn properties_glob_negation_excludes_files() {
         "---\ntitle: Exclude\nexclusive_prop: only_here\n---\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
-            "--no-hints",
             "properties",
             "summary",
             "--glob",
@@ -516,7 +515,7 @@ fn properties_bare_defaults_to_summary() {
         "---\ntitle: A\nstatus: draft\n---\n# A\n",
     );
 
-    let output = common::hyalo()
+    let output = common::hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .arg("properties")
         .output()

--- a/crates/hyalo-cli/tests/e2e_quiet.rs
+++ b/crates/hyalo-cli/tests/e2e_quiet.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo_no_hints, write_md};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,7 +32,7 @@ fn warning_appears_without_quiet() {
     write_valid(tmp.path(), "good.md");
     write_invalid_frontmatter(tmp.path(), "bad.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--dir")
         .arg(tmp.path())
         .arg("tags")
@@ -54,7 +54,7 @@ fn warning_suppressed_with_quiet_long() {
     write_valid(tmp.path(), "good.md");
     write_invalid_frontmatter(tmp.path(), "bad.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--quiet")
         .arg("--dir")
         .arg(tmp.path())
@@ -79,7 +79,7 @@ fn warning_suppressed_with_quiet_short() {
     write_valid(tmp.path(), "good.md");
     write_invalid_frontmatter(tmp.path(), "bad.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("-q")
         .arg("--dir")
         .arg(tmp.path())
@@ -102,7 +102,7 @@ fn warning_suppressed_on_find_with_quiet() {
     write_valid(tmp.path(), "good.md");
     write_invalid_frontmatter(tmp.path(), "bad.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("-q")
         .arg("--dir")
         .arg(tmp.path())
@@ -124,7 +124,7 @@ fn warning_suppressed_on_properties_with_quiet() {
     write_valid(tmp.path(), "good.md");
     write_invalid_frontmatter(tmp.path(), "bad.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("-q")
         .arg("--dir")
         .arg(tmp.path())
@@ -165,7 +165,7 @@ fn no_dedup_summary_for_unique_warnings() {
         write_invalid_frontmatter(tmp.path(), &format!("bad{i}.md"));
     }
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--dir")
         .arg(tmp.path())
         .arg("tags")
@@ -193,7 +193,7 @@ fn no_dedup_summary_when_no_warnings_at_all() {
     let tmp = tempfile::tempdir().unwrap();
     write_valid(tmp.path(), "only.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--dir")
         .arg(tmp.path())
         .arg("tags")
@@ -208,15 +208,14 @@ fn no_dedup_summary_when_no_warnings_at_all() {
     );
 }
 
-/// The `--hints has no effect` warning is a static string (no per-file info).
-/// It fires exactly once — verify it appears exactly once and is not
-/// duplicated or suppressed.
+/// `--hints` on mutation commands (set/remove/append) now generates hints.
+/// Verify no spurious warning is emitted and the output contains a hints envelope.
 #[test]
 fn hints_warning_appears_exactly_once() {
     let tmp = tempfile::tempdir().unwrap();
     write_valid(tmp.path(), "note.md");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--dir")
         .arg(tmp.path())
         .arg("--hints")
@@ -228,15 +227,23 @@ fn hints_warning_appears_exactly_once() {
         .output()
         .unwrap();
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(
-        stderr.matches("warning:").count(),
-        1,
-        "expected exactly 1 warning line, got:\n{stderr}"
-    );
     assert!(
-        stderr.contains("--hints has no effect"),
-        "expected --hints warning, got:\n{stderr}"
+        output.status.success(),
+        "set --hints should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("--hints has no effect"),
+        "should not warn about --hints on mutation commands; got:\n{stderr}"
+    );
+    // The output should be a valid hints envelope
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {stdout}"));
+    assert!(
+        json.get("hints").is_some(),
+        "set --hints should produce hints envelope; got: {stdout}"
     );
 }
 
@@ -250,7 +257,7 @@ fn quiet_suppresses_all_output_including_summary() {
         write_invalid_frontmatter(tmp.path(), &format!("bad{i}.md"));
     }
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .arg("--quiet")
         .arg("--dir")
         .arg(tmp.path())

--- a/crates/hyalo-cli/tests/e2e_read.rs
+++ b/crates/hyalo-cli/tests/e2e_read.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -66,7 +66,7 @@ No frontmatter here.
 #[test]
 fn read_full_body_text() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md"])
         .output()
@@ -86,7 +86,7 @@ fn read_full_body_text() {
 #[test]
 fn read_full_body_json() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--format", "json"])
         .output()
@@ -106,7 +106,7 @@ fn read_full_body_json() {
 fn read_defaults_to_text_format() {
     let tmp = setup();
     // Without --format, read should output plain text (not JSON)
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md"])
         .output()
@@ -126,7 +126,7 @@ fn read_defaults_to_text_format() {
 #[test]
 fn read_section_exact_match() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--section", "Solution"])
         .output()
@@ -145,7 +145,7 @@ fn read_section_exact_match() {
 #[test]
 fn read_section_with_hashes() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--section", "## Solution"])
         .output()
@@ -160,7 +160,7 @@ fn read_section_with_hashes() {
 #[test]
 fn read_section_case_insensitive() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--section", "solution"])
         .output()
@@ -174,7 +174,7 @@ fn read_section_case_insensitive() {
 #[test]
 fn read_section_multiple_matches() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--section", "Problem"])
         .output()
@@ -189,7 +189,7 @@ fn read_section_multiple_matches() {
 #[test]
 fn read_section_no_match() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--section", "Nonexistent"])
         .output()
@@ -204,7 +204,7 @@ fn read_section_no_match() {
 fn read_section_no_substring_match() {
     let tmp = setup();
     // "XYZ" is not a substring of any heading in note.md
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--section", "XYZ"])
         .output()
@@ -219,7 +219,7 @@ fn read_section_no_substring_match() {
 fn read_section_substring_match() {
     let tmp = setup();
     // "Prob" is a substring of "Problem" — should now succeed
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--section", "Prob"])
         .output()
@@ -245,7 +245,7 @@ fn read_section_with_count_suffix() {
 "),
     );
     // 'Tasks' is a substring of 'Tasks [4/4]'
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "tasks.md", "--section", "Tasks"])
         .output()
@@ -263,7 +263,7 @@ fn read_section_with_count_suffix() {
 #[test]
 fn read_lines_range() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "read", "--file", "note.md", "--lines", "1:3", "--format", "json",
@@ -283,7 +283,7 @@ fn read_lines_range() {
 #[test]
 fn read_lines_single() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "read", "--file", "note.md", "--lines", "1", "--format", "json",
@@ -300,7 +300,7 @@ fn read_lines_single() {
 #[test]
 fn read_lines_open_end() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--lines", "1:"])
         .output()
@@ -316,8 +316,8 @@ fn read_lines_open_end() {
 #[test]
 fn read_lines_open_start() {
     let tmp = setup();
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--lines", ":2"])
         .output()
         .unwrap();
@@ -331,7 +331,7 @@ fn read_lines_open_start() {
 #[test]
 fn read_lines_invalid() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--lines", "abc"])
         .output()
@@ -347,8 +347,8 @@ fn read_lines_invalid() {
 #[test]
 fn read_frontmatter_only() {
     let tmp = setup();
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--frontmatter"])
         .output()
         .unwrap();
@@ -364,7 +364,7 @@ fn read_frontmatter_only() {
 #[test]
 fn read_frontmatter_with_section() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "read",
@@ -386,7 +386,7 @@ fn read_frontmatter_with_section() {
 #[test]
 fn read_frontmatter_json() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "read",
@@ -409,7 +409,7 @@ fn read_frontmatter_json() {
 fn read_frontmatter_with_lines() {
     let tmp = setup();
     // --frontmatter + --lines should show frontmatter + sliced body
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "read",
@@ -435,7 +435,7 @@ fn read_frontmatter_with_lines() {
 #[test]
 fn read_file_not_found() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "missing.md"])
         .output()
@@ -449,7 +449,7 @@ fn read_file_not_found() {
 #[test]
 fn read_file_requires_file_flag() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read"])
         .output()
@@ -466,7 +466,7 @@ fn read_file_requires_file_flag() {
 #[test]
 fn read_no_frontmatter_file() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "no-frontmatter.md"])
         .output()
@@ -481,7 +481,7 @@ fn read_no_frontmatter_file() {
 #[test]
 fn read_empty_file() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "empty.md"])
         .output()
@@ -500,8 +500,8 @@ fn read_frontmatter_only_file_returns_empty_body() {
     );
 
     // Text output: body should be empty
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "fm-only.md"])
         .output()
         .unwrap();
@@ -514,7 +514,7 @@ fn read_frontmatter_only_file_returns_empty_body() {
     );
 
     // JSON output: content field should be empty
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "fm-only.md", "--format", "json"])
         .output()
@@ -539,7 +539,7 @@ fn read_frontmatter_only_file_returns_empty_body() {
 #[test]
 fn read_with_jq_explicit_json() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "read", "--file", "note.md", "--format", "json", "--jq", ".file",
@@ -556,7 +556,7 @@ fn read_with_jq_explicit_json() {
 fn read_with_jq_auto_promotes_to_json() {
     let tmp = setup();
     // --jq without --format json should auto-promote to JSON (not error)
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "note.md", "--jq", ".file"])
         .output()
@@ -570,7 +570,7 @@ fn read_with_jq_auto_promotes_to_json() {
 #[test]
 fn read_section_json_output() {
     let tmp = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args([
             "read",
@@ -606,7 +606,7 @@ fn read_frontmatter_broken_errors() {
         "---\ntitle: Unclosed\nNo closing delimiter here\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "broken.md", "--frontmatter"])
         .output()
@@ -635,7 +635,7 @@ fn read_frontmatter_valid_works() {
         "---\ntitle: Good File\nstatus: ok\n---\n# Body\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["read", "--file", "valid.md", "--frontmatter"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_remove.rs
+++ b/crates/hyalo-cli/tests/e2e_remove.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use std::fs;
 use tempfile::TempDir;
 
@@ -12,7 +12,7 @@ fn remove_json(
     tmp: &TempDir,
     extra_args: &[&str],
 ) -> (std::process::ExitStatus, serde_json::Value, String) {
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.arg("remove");
     cmd.args(extra_args);
@@ -346,7 +346,7 @@ status: old
 #[test]
 fn remove_requires_file_or_glob() {
     let tmp = TempDir::new().unwrap();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["remove", "--property", "status"]);
     let output = cmd.output().unwrap();
@@ -362,7 +362,7 @@ fn remove_requires_file_or_glob() {
 fn remove_empty_property_name_returns_error() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["remove", "--property", "=value", "--file", "note.md"]);
     let output = cmd.output().unwrap();
@@ -378,7 +378,7 @@ fn remove_empty_property_name_returns_error() {
 fn remove_requires_at_least_one_mutation() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["remove", "--file", "note.md"]);
     let output = cmd.output().unwrap();
@@ -417,7 +417,7 @@ fn remove_multi_file_modifies_all() {
     write_md(tmp.path(), "a.md", "---\ntitle: A\nstatus: draft\n---\n");
     write_md(tmp.path(), "b.md", "---\ntitle: B\nstatus: draft\n---\n");
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "remove",
@@ -462,7 +462,7 @@ title: B
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["remove", "--property", "status", "--glob", "*.md"])
@@ -497,7 +497,7 @@ tags:
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["remove", "--tag", "rust", "--file", "note.md"])

--- a/crates/hyalo-cli/tests/e2e_set.rs
+++ b/crates/hyalo-cli/tests/e2e_set.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use std::fs;
 use tempfile::TempDir;
 
@@ -12,7 +12,7 @@ fn set_json(
     tmp: &TempDir,
     extra_args: &[&str],
 ) -> (std::process::ExitStatus, serde_json::Value, String) {
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.arg("set");
     cmd.args(extra_args);
@@ -206,7 +206,7 @@ title: Note
 #[test]
 fn set_requires_file_or_glob() {
     let tmp = TempDir::new().unwrap();
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["set", "--property", "status=done"]);
     let output = cmd.output().unwrap();
@@ -222,7 +222,7 @@ fn set_requires_file_or_glob() {
 fn set_requires_at_least_one_mutation() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["set", "--file", "note.md"]);
     let output = cmd.output().unwrap();
@@ -238,7 +238,7 @@ fn set_requires_at_least_one_mutation() {
 fn set_empty_property_name_returns_error() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["set", "--property", "=value", "--file", "note.md"]);
     let output = cmd.output().unwrap();
@@ -254,7 +254,7 @@ fn set_empty_property_name_returns_error() {
 fn set_invalid_kv_no_equals_returns_error() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "note.md", "---\ntitle: x\n---\n");
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["set", "--property", "no-equals-sign", "--file", "note.md"]);
     let output = cmd.output().unwrap();
@@ -339,7 +339,7 @@ title: Note
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["--format", "text"])
         .args(["set", "--property", "status=done", "--file", "note.md"])
@@ -932,7 +932,7 @@ title: Good
         "---\n: invalid yaml [[[{\n---\n# Bad\n",
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--property", "status=done", "--glob", "*.md"])
         .output()

--- a/crates/hyalo-cli/tests/e2e_short_flags.rs
+++ b/crates/hyalo-cli/tests/e2e_short_flags.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
 /// Helper: create a temp dir with a sample file for testing short flags.
@@ -47,7 +47,7 @@ Other body.
 #[test]
 fn short_d_for_dir() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["-d", dir.path().to_str().unwrap(), "find"])
         .output()
         .unwrap();
@@ -61,7 +61,7 @@ fn short_d_for_dir() {
 #[test]
 fn find_short_p_for_property() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "find",
             "-p",
@@ -80,7 +80,7 @@ fn find_short_p_for_property() {
 #[test]
 fn find_short_t_for_tag() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["find", "-t", "research", "-d", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
@@ -93,7 +93,7 @@ fn find_short_t_for_tag() {
 #[test]
 fn find_short_s_for_section() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["find", "-s", "Heading", "-d", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
@@ -105,7 +105,7 @@ fn find_short_s_for_section() {
 #[test]
 fn find_short_f_for_file() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["find", "-f", "note.md", "-d", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
@@ -118,7 +118,7 @@ fn find_short_f_for_file() {
 #[test]
 fn find_short_g_for_glob() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["find", "-g", "other*", "-d", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
@@ -131,15 +131,8 @@ fn find_short_g_for_glob() {
 #[test]
 fn find_short_n_for_limit() {
     let dir = setup();
-    let output = hyalo()
-        .args([
-            "--no-hints",
-            "find",
-            "-n",
-            "1",
-            "-d",
-            dir.path().to_str().unwrap(),
-        ])
+    let output = hyalo_no_hints()
+        .args(["find", "-n", "1", "-d", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -156,7 +149,7 @@ fn find_short_n_for_limit() {
 #[test]
 fn read_short_f_for_file() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["read", "-f", "note.md", "-d", dir.path().to_str().unwrap()])
         .output()
         .unwrap();
@@ -168,7 +161,7 @@ fn read_short_f_for_file() {
 #[test]
 fn read_short_s_for_section() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "read",
             "-f",
@@ -188,7 +181,7 @@ fn read_short_s_for_section() {
 #[test]
 fn read_short_l_for_lines() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "read",
             "-f",
@@ -210,7 +203,7 @@ fn read_short_l_for_lines() {
 #[test]
 fn properties_short_g_for_glob() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "properties",
             "summary",
@@ -229,7 +222,7 @@ fn properties_short_g_for_glob() {
 #[test]
 fn tags_short_g_for_glob() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "tags",
             "summary",
@@ -248,7 +241,7 @@ fn tags_short_g_for_glob() {
 #[test]
 fn summary_short_g_and_n() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "summary",
             "-g",
@@ -268,7 +261,7 @@ fn summary_short_g_and_n() {
 #[test]
 fn set_short_p_t_f() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "set",
             "-p",
@@ -285,7 +278,7 @@ fn set_short_p_t_f() {
     assert!(output.status.success());
 
     // Verify it took effect
-    let check = hyalo()
+    let check = hyalo_no_hints()
         .args([
             "find",
             "-p",
@@ -305,7 +298,7 @@ fn set_short_p_t_f() {
 fn remove_short_p_t_f() {
     let dir = setup();
     // First set a tag
-    let precondition = hyalo()
+    let precondition = hyalo_no_hints()
         .args([
             "set",
             "-t",
@@ -323,7 +316,7 @@ fn remove_short_p_t_f() {
     );
 
     // Now remove it with short flags
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "remove",
             "-t",
@@ -343,7 +336,7 @@ fn remove_short_p_t_f() {
 #[test]
 fn append_short_p_f() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "append",
             "-p",
@@ -363,7 +356,7 @@ fn append_short_p_f() {
 #[test]
 fn task_read_short_f_l() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "task",
             "read",
@@ -382,7 +375,7 @@ fn task_read_short_f_l() {
 #[test]
 fn task_toggle_short_f_l() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "task",
             "toggle",
@@ -401,7 +394,7 @@ fn task_toggle_short_f_l() {
 #[test]
 fn task_set_status_short_f_l_s() {
     let dir = setup();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "task",
             "set-status",

--- a/crates/hyalo-cli/tests/e2e_site_prefix.rs
+++ b/crates/hyalo-cli/tests/e2e_site_prefix.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo_no_hints, write_md};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -35,8 +35,8 @@ fn build_vault(root: &std::path::Path) {
 
 /// Run `hyalo --dir <dir_arg> find --fields links` and return the parsed JSON.
 fn find_links(dir_arg: &str) -> serde_json::Value {
-    let output = hyalo()
-        .args(["--dir", dir_arg, "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", dir_arg])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
         .unwrap();
@@ -87,8 +87,8 @@ fn find_links_absolute_path_with_dotslash_dir() {
     // derived prefix must still be "docs", not "".
     let docs = format!("{}/docs/", tmp.path().to_str().unwrap());
 
-    let output = hyalo()
-        .args(["--dir", docs.trim_end_matches('/'), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", docs.trim_end_matches('/')])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
         .unwrap();
@@ -112,8 +112,8 @@ fn find_links_site_prefix_cli_flag() {
     build_vault(tmp.path());
     let docs = tmp.path().join("docs");
 
-    let output = hyalo()
-        .args(["--dir", docs.to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", docs.to_str().unwrap()])
         .args(["--site-prefix", "docs"])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
@@ -152,12 +152,8 @@ fn find_links_site_prefix_config_file() {
     )
     .unwrap();
 
-    let output = hyalo()
-        .args([
-            "--dir",
-            tmp.path().join("docs").to_str().unwrap(),
-            "--no-hints",
-        ])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().join("docs").to_str().unwrap()])
         .args(["find", "--fields", "links", "--file", "index.md"])
         .output()
         .unwrap();
@@ -185,7 +181,7 @@ fn backlinks_absolute_link_indexed_correctly() {
     build_vault(tmp.path());
     let docs = tmp.path().join("docs");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", docs.to_str().unwrap()])
         .args(["backlinks", "--file", "pages/about.md"])
         .output()
@@ -215,7 +211,7 @@ fn backlinks_absolute_link_indexed_correctly() {
 /// Run backlinks and return total count.  Used to verify that all --dir styles
 /// produce the same effective site_prefix.
 fn backlink_count(dir_arg: &str) -> u64 {
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", dir_arg])
         .args(["backlinks", "--file", "pages/about.md"])
         .output()
@@ -249,7 +245,7 @@ fn site_prefix_wrong_prefix_misses_absolute_links() {
     build_vault(tmp.path());
     let docs_abs = tmp.path().join("docs");
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", docs_abs.to_str().unwrap()])
         .args(["--site-prefix", "wrong"])
         .args(["backlinks", "--file", "pages/about.md"])

--- a/crates/hyalo-cli/tests/e2e_suggest.rs
+++ b/crates/hyalo-cli/tests/e2e_suggest.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo_no_hints, write_md};
 
 // ---------------------------------------------------------------------------
 // e2e tests for subcommand-flag suggestion
@@ -27,7 +27,7 @@ fn suggest_task_toggle_as_flag() {
     let tmp = tempfile::tempdir().unwrap();
     setup_file(&tmp);
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["task", "--toggle", "--file", "tasks.md", "--line", "4"])
         .output()
@@ -50,7 +50,7 @@ fn suggest_task_toggle_as_flag() {
 fn suggest_properties_rename_as_flag() {
     let tmp = tempfile::tempdir().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["properties", "--rename", "--from", "old", "--to", "new"])
         .output()
@@ -73,7 +73,7 @@ fn suggest_properties_rename_as_flag() {
 fn suggest_tags_summary_as_flag() {
     let tmp = tempfile::tempdir().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "--summary"])
         .output()
@@ -101,7 +101,7 @@ fn no_suggestion_for_valid_task_toggle() {
     let tmp = tempfile::tempdir().unwrap();
     setup_file(&tmp);
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["task", "toggle", "--file", "tasks.md", "--line", "4"])
         .output()
@@ -128,7 +128,7 @@ fn no_suggestion_for_valid_task_toggle() {
 fn suggest_property_when_filter_used() {
     let tmp = tempfile::tempdir().unwrap();
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--filter", "status=draft"])
         .output()
@@ -153,7 +153,7 @@ fn suggest_property_when_filter_used() {
 
 #[test]
 fn suggest_version_for_typo() {
-    let output = hyalo().arg("versio").output().unwrap();
+    let output = hyalo_no_hints().arg("versio").output().unwrap();
 
     assert!(
         !output.status.success(),
@@ -168,7 +168,7 @@ fn suggest_version_for_typo() {
 
 #[test]
 fn suggest_help_for_typo() {
-    let output = hyalo().arg("hep").output().unwrap();
+    let output = hyalo_no_hints().arg("hep").output().unwrap();
 
     assert!(
         !output.status.success(),

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md};
+use common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
 fn setup_vault_nested() -> TempDir {
@@ -119,12 +119,11 @@ No tasks here.
 #[test]
 fn summary_json_has_all_fields() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -159,12 +158,11 @@ fn summary_json_has_all_fields() {
 #[test]
 fn summary_file_counts_by_directory() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -193,12 +191,11 @@ fn summary_file_counts_by_directory() {
 #[test]
 fn summary_task_counts() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -216,12 +213,11 @@ fn summary_task_counts() {
 #[test]
 fn summary_status_groups() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -254,12 +250,11 @@ fn summary_status_groups() {
 #[test]
 fn summary_tag_counts() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -289,12 +284,11 @@ fn summary_tag_counts() {
 #[test]
 fn summary_property_summary() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -321,12 +315,11 @@ fn summary_property_summary() {
 #[test]
 fn summary_recent_files_limited() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--recent",
             "2",
             "--format",
@@ -346,12 +339,11 @@ fn summary_recent_files_limited() {
 #[test]
 fn summary_text_format() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "text",
         ])
@@ -372,12 +364,11 @@ fn summary_text_format() {
 #[test]
 fn summary_glob_filter() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--glob",
             "notes/*.md",
             "--format",
@@ -395,12 +386,11 @@ fn summary_glob_filter() {
 #[test]
 fn summary_jq_filter() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--jq",
             ".tasks.total",
         ])
@@ -414,12 +404,11 @@ fn summary_jq_filter() {
 #[test]
 fn summary_empty_vault() {
     let tmp = TempDir::new().unwrap();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -438,12 +427,11 @@ fn summary_empty_vault() {
 #[test]
 fn summary_depth_zero_collapses_all_dirs() {
     let tmp = setup_vault_nested();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--depth",
             "0",
             "--format",
@@ -465,12 +453,11 @@ fn summary_depth_zero_collapses_all_dirs() {
 #[test]
 fn summary_depth_one_collapses_sub_into_parent() {
     let tmp = setup_vault_nested();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--depth",
             "1",
             "--format",
@@ -498,12 +485,11 @@ fn summary_depth_one_collapses_sub_into_parent() {
 #[test]
 fn summary_depth_no_flag_shows_all_directories() {
     let tmp = setup_vault_nested();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -525,12 +511,11 @@ fn summary_depth_no_flag_shows_all_directories() {
 #[test]
 fn summary_recent_zero() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--recent",
             "0",
             "--format",
@@ -549,12 +534,11 @@ fn summary_recent_zero() {
 #[test]
 fn summary_json_has_orphans_field() {
     let tmp = setup_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -604,12 +588,11 @@ No links to me
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -662,12 +645,11 @@ See [[a]]
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -704,12 +686,11 @@ No links
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -737,12 +718,11 @@ No links
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "text",
         ])
@@ -764,12 +744,11 @@ No links
 #[test]
 fn summary_orphans_empty_vault() {
     let tmp = TempDir::new().unwrap();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -823,12 +802,11 @@ No links
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--glob",
             "notes/*.md",
             "--format",
@@ -865,12 +843,11 @@ No links
 fn summary_glob_negation_excludes_files() {
     let tmp = setup_vault();
     // Exclude one of the root-level files; the summary file count should be reduced
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--glob",
             "!notes/**/*.md",
             "--format",
@@ -946,7 +923,7 @@ No links.
     );
 
     // Disk scan with site_prefix
-    let disk_out = hyalo()
+    let disk_out = hyalo_no_hints()
         .args([
             "--dir",
             dir_str,
@@ -956,7 +933,6 @@ No links.
             "json",
         ])
         .arg("summary")
-        .arg("--no-hints")
         .output()
         .unwrap();
     assert!(
@@ -973,7 +949,7 @@ No links.
         .collect();
 
     // Create index with same site_prefix
-    let idx_create = hyalo()
+    let idx_create = hyalo_no_hints()
         .args(["--dir", dir_str, "--site-prefix", "docs"])
         .arg("create-index")
         .output()
@@ -986,7 +962,7 @@ No links.
 
     // Index-based summary
     let index_path = tmp.path().join(".hyalo-index");
-    let idx_out = hyalo()
+    let idx_out = hyalo_no_hints()
         .args([
             "--dir",
             dir_str,
@@ -998,7 +974,6 @@ No links.
             "json",
         ])
         .arg("summary")
-        .arg("--no-hints")
         .output()
         .unwrap();
     assert!(
@@ -1086,12 +1061,11 @@ No links.
 #[test]
 fn summary_dead_ends_json() {
     let tmp = setup_dead_end_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -1137,12 +1111,11 @@ fn summary_dead_ends_json() {
 #[test]
 fn summary_dead_ends_text_format() {
     let tmp = setup_dead_end_vault();
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "text",
         ])
@@ -1187,12 +1160,11 @@ No links.
 "),
     );
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])
@@ -1213,15 +1185,8 @@ fn summary_dead_end_parity_disk_vs_index() {
     let dir_str = tmp.path().to_str().unwrap();
 
     // Disk scan
-    let disk_out = hyalo()
-        .args([
-            "--dir",
-            dir_str,
-            "--no-hints",
-            "summary",
-            "--format",
-            "json",
-        ])
+    let disk_out = hyalo_no_hints()
+        .args(["--dir", dir_str, "summary", "--format", "json"])
         .output()
         .unwrap();
     assert!(
@@ -1238,7 +1203,7 @@ fn summary_dead_end_parity_disk_vs_index() {
         .collect();
 
     // Create index
-    let idx_create = hyalo()
+    let idx_create = hyalo_no_hints()
         .args(["--dir", dir_str, "create-index"])
         .output()
         .unwrap();
@@ -1250,14 +1215,13 @@ fn summary_dead_end_parity_disk_vs_index() {
 
     // Index-based summary
     let index_path = tmp.path().join(".hyalo-index");
-    let idx_out = hyalo()
+    let idx_out = hyalo_no_hints()
         .args([
             "--dir",
             dir_str,
             "--index",
             index_path.to_str().unwrap(),
             "summary",
-            "--no-hints",
             "--format",
             "json",
         ])

--- a/crates/hyalo-cli/tests/e2e_tags.rs
+++ b/crates/hyalo-cli/tests/e2e_tags.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, md, write_md, write_tagged};
+use common::{hyalo_no_hints, md, write_md, write_tagged};
 use tempfile::TempDir;
 
 /// Helper: extract the results array from a `{total, results}` envelope.
@@ -21,8 +21,8 @@ fn tags_summary_returns_counts() {
     write_tagged(tmp.path(), "b.md", &["rust", "iteration"]);
     write_md(tmp.path(), "c.md", "No frontmatter.\n");
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -41,8 +41,8 @@ fn tags_summary_returns_counts() {
 fn tags_empty_vault() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -60,8 +60,8 @@ fn tags_with_glob() {
     write_tagged(tmp.path(), "sub/b.md", &["beta"]);
     write_tagged(tmp.path(), "root.md", &["gamma"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "summary", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -85,8 +85,8 @@ fn tags_glob_no_match() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "summary", "--glob", "nonexistent/*.md"])
         .output()
         .unwrap();
@@ -117,7 +117,7 @@ fn tags_text_format() {
     write_tagged(tmp.path(), "note.md", &["rust"]);
     write_tagged(tmp.path(), "other.md", &["rust", "cli"]);
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
@@ -144,8 +144,8 @@ fn tags_file_without_frontmatter() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "plain.md", "Just a plain markdown file.\n");
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -170,8 +170,8 @@ tags: rust
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["tags", "summary"])
         .output()
         .unwrap();
@@ -192,8 +192,8 @@ fn find_tag_exact_match() {
     write_tagged(tmp.path(), "a.md", &["iteration"]);
     write_tagged(tmp.path(), "b.md", &["links"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--tag", "iteration", "--fields", "tags"])
         .output()
         .unwrap();
@@ -213,8 +213,8 @@ fn find_tag_nested_match() {
     write_tagged(tmp.path(), "c.md", &["inbox"]);
     write_tagged(tmp.path(), "d.md", &["inboxes"]); // must NOT match
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--tag", "inbox"])
         .output()
         .unwrap();
@@ -235,8 +235,8 @@ fn find_tag_no_match_returns_empty_array() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--tag", "nonexistent"])
         .output()
         .unwrap();
@@ -254,8 +254,8 @@ fn find_tag_with_glob() {
     write_tagged(tmp.path(), "sub/b.md", &["python"]);
     write_tagged(tmp.path(), "root.md", &["rust"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--tag", "rust", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -274,8 +274,8 @@ fn find_tag_case_insensitive() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["Rust"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--tag", "rust"])
         .output()
         .unwrap();
@@ -303,8 +303,8 @@ title: Note
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -325,8 +325,8 @@ fn set_tag_glob_pattern() {
     write_tagged(tmp.path(), "sub/a.md", &["existing"]);
     write_tagged(tmp.path(), "sub/b.md", &["existing"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--tag", "new-tag", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -342,8 +342,8 @@ fn set_tag_idempotent() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -368,8 +368,8 @@ title: Note
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--tag", "plan", "--file", "note.md"])
         .output()
         .unwrap();
@@ -385,8 +385,8 @@ title: Note
 fn set_tag_file_not_found() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--tag", "rust", "--file", "nonexistent.md"])
         .output()
         .unwrap();
@@ -406,8 +406,8 @@ No frontmatter here.
 "),
     );
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--tag", "rust", "--file", "plain.md"])
         .output()
         .unwrap();
@@ -431,8 +431,8 @@ fn remove_tag_single_file() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust", "cli"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["remove", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -453,8 +453,8 @@ fn remove_tag_glob_pattern() {
     write_tagged(tmp.path(), "sub/a.md", &["rust", "cli"]);
     write_tagged(tmp.path(), "sub/b.md", &["rust", "python"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["remove", "--tag", "rust", "--glob", "sub/*.md"])
         .output()
         .unwrap();
@@ -469,8 +469,8 @@ fn remove_tag_absent_tag_idempotent() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["cli"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["remove", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -486,8 +486,8 @@ fn remove_tag_empties_tags_property() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["remove", "--tag", "rust", "--file", "note.md"])
         .output()
         .unwrap();
@@ -502,8 +502,8 @@ fn remove_tag_empties_tags_property() {
 fn remove_tag_file_not_found() {
     let tmp = TempDir::new().unwrap();
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["remove", "--tag", "rust", "--file", "nonexistent.md"])
         .output()
         .unwrap();
@@ -516,8 +516,8 @@ fn remove_tag_from_file_with_no_frontmatter() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "plain.md", "No frontmatter here.\n");
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["remove", "--tag", "rust", "--file", "plain.md"])
         .output()
         .unwrap();
@@ -533,8 +533,8 @@ fn find_tag_empty_tags_list() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "empty.md", &[]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["find", "--tag", "rust"])
         .output()
         .unwrap();
@@ -554,8 +554,8 @@ fn set_tag_without_file_or_glob_is_user_error() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["existing"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["set", "--tag", "new-tag"])
         .output()
         .unwrap();
@@ -575,8 +575,8 @@ fn remove_tag_without_file_or_glob_is_user_error() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["rust"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .args(["remove", "--tag", "rust"])
         .output()
         .unwrap();
@@ -602,8 +602,8 @@ fn tags_rename_basic() {
     write_tagged(tmp.path(), "b.md", &["filtering"]);
     write_tagged(tmp.path(), "c.md", &["cli"]); // no "filtering"
 
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["tags", "rename", "--from", "filtering", "--to", "filters"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -622,8 +622,8 @@ fn tags_rename_already_has_new_tag() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "note.md", &["old-name", "new-name"]);
 
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["tags", "rename", "--from", "old-name", "--to", "new-name"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -641,8 +641,8 @@ fn tags_rename_already_has_new_tag() {
 #[test]
 fn tags_rename_same_name_exits_1() {
     let tmp = TempDir::new().unwrap();
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["tags", "rename", "--from", "foo", "--to", "foo"]);
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
@@ -654,8 +654,8 @@ fn tags_rename_with_glob_scope() {
     write_tagged(tmp.path(), "notes/a.md", &["old-tag"]);
     write_tagged(tmp.path(), "other/b.md", &["old-tag"]);
 
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "tags",
         "rename",
@@ -681,8 +681,8 @@ fn tags_rename_with_glob_scope() {
 #[test]
 fn tags_rename_invalid_tag_exits_1() {
     let tmp = TempDir::new().unwrap();
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["tags", "rename", "--from", "valid", "--to", "invalid tag!"]);
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
@@ -698,8 +698,8 @@ fn tags_rename_scalar_tag() {
         "---\ntitle: Note\ntags: old-tag\n---\n",
     );
 
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["tags", "rename", "--from", "old-tag", "--to", "new-tag"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -731,8 +731,8 @@ fn tags_rename_scalar_tag_already_has_new() {
     // Instead, verify the simple scalar rename writes back as a scalar string.
     write_md(tmp.path(), "note.md", "---\ntags: alpha\n---\n");
 
-    let mut cmd = hyalo();
-    cmd.args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"]);
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["tags", "rename", "--from", "alpha", "--to", "beta"]);
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -754,11 +754,10 @@ fn tags_glob_negation_excludes_files() {
     write_tagged(tmp.path(), "keep.md", &["rust", "cli"]);
     write_tagged(tmp.path(), "exclude.md", &["exclusive-tag"]);
 
-    let output = hyalo()
+    let output = hyalo_no_hints()
         .args([
             "--dir",
             tmp.path().to_str().unwrap(),
-            "--no-hints",
             "tags",
             "summary",
             "--glob",
@@ -791,8 +790,8 @@ fn tags_bare_defaults_to_summary() {
     let tmp = TempDir::new().unwrap();
     write_tagged(tmp.path(), "a.md", &["rust", "cli"]);
 
-    let output = hyalo()
-        .args(["--dir", tmp.path().to_str().unwrap(), "--no-hints"])
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
         .arg("tags")
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e_task.rs
+++ b/crates/hyalo-cli/tests/e2e_task.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{hyalo, write_md};
+use common::{hyalo_no_hints, write_md};
 use std::fs;
 
 // ---------------------------------------------------------------------------
@@ -43,7 +43,7 @@ fn run_task_read(
     file: &str,
     line: usize,
 ) -> (std::process::ExitStatus, String, String) {
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args(["task", "read", "--file", file, "--line", &line.to_string()]);
     let output = cmd.output().unwrap();
@@ -76,7 +76,7 @@ fn run_task_toggle(
     file: &str,
     line: usize,
 ) -> (std::process::ExitStatus, serde_json::Value, String) {
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
@@ -109,7 +109,7 @@ fn run_task_set_status(
     line: usize,
     status_char: &str,
 ) -> (std::process::ExitStatus, serde_json::Value, String) {
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
@@ -280,7 +280,7 @@ fn task_toggle_non_task_line_exits_1() {
     let tmp = tempfile::tempdir().unwrap();
     setup_task_file(&tmp);
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
@@ -360,7 +360,7 @@ fn task_set_status_non_task_line_exits_1() {
     let tmp = tempfile::tempdir().unwrap();
     setup_task_file(&tmp);
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
@@ -383,7 +383,7 @@ fn task_set_status_multi_char_status_exits_1() {
     let tmp = tempfile::tempdir().unwrap();
     setup_task_file(&tmp);
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
@@ -411,7 +411,7 @@ fn task_set_status_empty_string_exits_1() {
     let tmp = tempfile::tempdir().unwrap();
     setup_task_file(&tmp);
 
-    let mut cmd = hyalo();
+    let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -441,3 +441,26 @@ Research across tools:
 **Consequences:**
 - Orphan counts will be inflated for SSG repos that use frontmatter-based navigation
 - This is expected and documented behavior, not a bug
+
+## DEC-040: Context-Aware Hints with Descriptions (2026-03-30)
+
+**Context:** [[iteration-80-smarter-hints]] evolved the hint system introduced in [[backlog/done/discoverable-drill-down-commands]] (DEC-031). Two changes: (1) hints now include a human-readable description alongside the command, and (2) hints are generated for all commands — not just the original four (find, summary, properties summary, tags summary).
+
+**Decision:** Change the hint format from a flat string array to an array of `{"description": "...", "cmd": "..."}` objects. Extend hint generation to all 15 command variants including mutations, read, backlinks, mv, task operations, links fix, create-index, and drop-index.
+
+**Why these tradeoffs:**
+
+1. **Descriptions make hints self-documenting.** An LLM seeing `{"description": "Find files with open tasks", "cmd": "hyalo find --task todo"}` understands intent without parsing the command. Humans scanning text output benefit from the `# description` suffix too.
+
+2. **Breaking JSON change is acceptable.** The `--hints` envelope is a UX feature, not a stable API contract. Consumers using `--jq` never see hints (they are suppressed). The `data` field remains structurally identical.
+
+3. **All-command coverage teaches the full CLI.** Mutation hints suggest verification commands (`hyalo find --file X`), dry-run hints suggest `--apply`, and create-index suggests drop-index. This turns every command into a learning opportunity.
+
+4. **Performance constraint preserved.** All hint generation operates on the already-computed JSON output — no additional file I/O. Hints are O(n) on result count with a hard cap of ~5 hints per command.
+
+**Consequences:**
+- JSON envelope: `{"data": ..., "hints": [{"description": "...", "cmd": "..."}]}`
+- Text format: `  -> hyalo cmd  # description`
+- Updates DEC-031 point 3 (envelope format) — string array → object array
+- `HintSource` enum expanded from 4 to 15 variants
+- 12 generator functions in `hints.rs` covering all command families

--- a/hyalo-knowledgebase/iterations/iteration-80-smarter-hints.md
+++ b/hyalo-knowledgebase/iterations/iteration-80-smarter-hints.md
@@ -1,12 +1,12 @@
 ---
-title: "Context-aware smarter hints"
+title: Context-aware smarter hints
 type: iteration
 date: 2026-03-30
 tags:
   - ux
   - feature
   - dogfood
-status: planned
+status: in-progress
 priority: 2
 branch: iter-80/smarter-hints
 ---
@@ -34,10 +34,10 @@ This is an ongoing effort — hint quality should be iterated on over time.
 
 ## Tasks
 
-- [ ] Audit current hint generation — identify what's static vs context-aware
-- [ ] Implement context-aware hint logic based on result shape
-- [ ] Add tests for conditional hint generation
-- [ ] Iterate on hint quality based on dogfooding feedback
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x] Audit current hint generation — identify what's static vs context-aware
+- [x] Implement context-aware hint logic based on result shape
+- [x] Add tests for conditional hint generation
+- [x] Iterate on hint quality based on dogfooding feedback
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`


### PR DESCRIPTION
## Summary
- Evolve hint system from flat string arrays to `{"description": "...", "cmd": "..."}` objects that inspect result data to suggest relevant drill-downs
- Extend hint generation from 4 commands (summary, find, properties, tags) to all 15 command variants including mutations, read, backlinks, mv, task, links fix, create-index, and drop-index
- Add context-aware logic: broad queries suggest `summary`, results with tasks suggest `--task todo`, mutation output suggests verification commands, dry-run suggests applying
- Sort/limit hints preserve existing filters (property, tag, task) from the original query
- Update help texts, README, and add DEC-040 to decision log documenting the format change

## Test plan
- [x] 39 unit tests covering all 12 hint generator functions, utility helpers, priority ordering, and filter preservation
- [x] 40 e2e tests in `e2e_hints.rs` covering all command families (7 new tests for read, backlinks, mv, task, links-fix, create-index, drop-index)
- [x] `cargo fmt` / `cargo clippy` / `cargo test` all pass
- [x] Self-review: fixed template placeholder violation, guarded mv `from` field, preserved filters in sort/limit hints
- [x] Dogfooded with release binary against hyalo-knowledgebase — verified JSON envelope format, text hint rendering, `--jq` suppression, and hint relevance across commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)