### PR TITLE
Fix hints for array-valued status properties

### DIFF
--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -166,7 +166,18 @@ pub fn summary(
         }
 
         // Status grouping — flatten arrays so each element becomes its own group.
+        // Deduplicate within a single entry to avoid counting the same file twice
+        // when an array contains duplicate values.
         if let Some(status_val) = entry.properties.get("status") {
+            let mut seen = std::collections::HashSet::new();
+            let mut push_status = |s: String| {
+                if seen.insert(s.clone()) {
+                    status_groups
+                        .entry(s)
+                        .or_default()
+                        .push(entry.rel_path.clone());
+                }
+            };
             match status_val {
                 serde_json::Value::Array(arr) => {
                     for item in arr {
@@ -174,24 +185,11 @@ pub fn summary(
                             serde_json::Value::String(s) => s.clone(),
                             other => other.to_string(),
                         };
-                        status_groups
-                            .entry(s)
-                            .or_default()
-                            .push(entry.rel_path.clone());
+                        push_status(s);
                     }
                 }
-                serde_json::Value::String(s) => {
-                    status_groups
-                        .entry(s.clone())
-                        .or_default()
-                        .push(entry.rel_path.clone());
-                }
-                other => {
-                    status_groups
-                        .entry(other.to_string())
-                        .or_default()
-                        .push(entry.rel_path.clone());
-                }
+                serde_json::Value::String(s) => push_status(s.clone()),
+                other => push_status(other.to_string()),
             }
         }
 

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -165,16 +165,34 @@ pub fn summary(
                 .or_insert_with(|| (tag.clone(), 1));
         }
 
-        // Status grouping
+        // Status grouping — flatten arrays so each element becomes its own group.
         if let Some(status_val) = entry.properties.get("status") {
-            let status_str = match status_val.clone() {
-                serde_json::Value::String(s) => s,
-                other => other.to_string(),
-            };
-            status_groups
-                .entry(status_str)
-                .or_default()
-                .push(entry.rel_path.clone());
+            match status_val {
+                serde_json::Value::Array(arr) => {
+                    for item in arr {
+                        let s = match item {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
+                        status_groups
+                            .entry(s)
+                            .or_default()
+                            .push(entry.rel_path.clone());
+                    }
+                }
+                serde_json::Value::String(s) => {
+                    status_groups
+                        .entry(s.clone())
+                        .or_default()
+                        .push(entry.rel_path.clone());
+                }
+                other => {
+                    status_groups
+                        .entry(other.to_string())
+                        .or_default()
+                        .push(entry.rel_path.clone());
+                }
+            }
         }
 
         // Task counts from pre-indexed tasks
@@ -533,6 +551,60 @@ No tasks here.
         assert_eq!(draft["files"].as_array().unwrap().len(), 2);
         let done = status_groups.iter().find(|g| g["value"] == "done").unwrap();
         assert_eq!(done["files"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn summary_status_grouping_flattens_arrays() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("a.md"),
+            md!(r"
+---
+title: A
+status:
+  - deprecated
+  - non-standard
+---
+Body.
+"),
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join("b.md"),
+            md!(r"
+---
+title: B
+status: deprecated
+---
+Body.
+"),
+        )
+        .unwrap();
+        let val =
+            unwrap_success(run_summary(tmp.path(), &[], 10, None, None, Format::Json).unwrap());
+        let status_groups = val["status"].as_array().unwrap();
+
+        // "deprecated" should appear as its own group with 2 files (a.md array + b.md scalar).
+        let deprecated = status_groups
+            .iter()
+            .find(|g| g["value"] == "deprecated")
+            .expect("expected 'deprecated' status group");
+        assert_eq!(deprecated["files"].as_array().unwrap().len(), 2);
+
+        // "non-standard" should appear as its own group with 1 file.
+        let non_standard = status_groups
+            .iter()
+            .find(|g| g["value"] == "non-standard")
+            .expect("expected 'non-standard' status group");
+        assert_eq!(non_standard["files"].as_array().unwrap().len(), 1);
+
+        // No stringified array group should exist.
+        assert!(
+            !status_groups
+                .iter()
+                .any(|g| g["value"].as_str().unwrap_or("").starts_with('[')),
+            "should not have a stringified array as a status group"
+        );
     }
 
     #[test]

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -428,20 +428,26 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         }
 
         // Collect status property frequencies — skip statuses already filtered on.
+        // Handles both scalar and array-valued status properties.
         let mut status_counts: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
         for item in results {
-            if let Some(status) = item
-                .get("properties")
-                .and_then(|p| p.get("status"))
-                .and_then(|s| s.as_str())
-            {
-                let already_filtered = ctx
-                    .property_filters
-                    .iter()
-                    .any(|f| f == &format!("status={status}"));
-                if !already_filtered {
-                    *status_counts.entry(status).or_insert(0) += 1;
+            if let Some(status_val) = item.get("properties").and_then(|p| p.get("status")) {
+                let values: Vec<&str> = match status_val {
+                    serde_json::Value::String(s) => vec![s.as_str()],
+                    serde_json::Value::Array(arr) => {
+                        arr.iter().filter_map(|v| v.as_str()).collect()
+                    }
+                    _ => vec![],
+                };
+                for status in values {
+                    let already_filtered = ctx
+                        .property_filters
+                        .iter()
+                        .any(|f| f == &format!("status={status}"));
+                    if !already_filtered {
+                        *status_counts.entry(status).or_insert(0) += 1;
+                    }
                 }
             }
         }

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -432,22 +432,22 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         let mut status_counts: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
         for item in results {
-            if let Some(status_val) = item.get("properties").and_then(|p| p.get("status")) {
-                let values: Vec<&str> = match status_val {
-                    serde_json::Value::String(s) => vec![s.as_str()],
-                    serde_json::Value::Array(arr) => {
-                        arr.iter().filter_map(|v| v.as_str()).collect()
-                    }
-                    _ => vec![],
-                };
-                for status in values {
-                    let already_filtered = ctx
-                        .property_filters
-                        .iter()
-                        .any(|f| f == &format!("status={status}"));
-                    if !already_filtered {
-                        *status_counts.entry(status).or_insert(0) += 1;
-                    }
+            let Some(status_val) = item.get("properties").and_then(|p| p.get("status")) else {
+                continue;
+            };
+            // Yield individual &str values from scalar or array status.
+            let iter: Box<dyn Iterator<Item = &str>> = match status_val {
+                serde_json::Value::String(s) => Box::new(std::iter::once(s.as_str())),
+                serde_json::Value::Array(arr) => Box::new(arr.iter().filter_map(|v| v.as_str())),
+                _ => Box::new(std::iter::empty()),
+            };
+            for status in iter {
+                let already_filtered = ctx
+                    .property_filters
+                    .iter()
+                    .any(|f| f == &format!("status={status}"));
+                if !already_filtered {
+                    *status_counts.entry(status).or_insert(0) += 1;
                 }
             }
         }

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -854,45 +854,35 @@ fn find_hints_no_hardcoded_draft() {
 // ---------------------------------------------------------------------------
 
 /// Vault where some files have array-valued status properties.
+/// "deprecated" appears only inside arrays (3 files) — more than "completed" (2 files).
+/// "completed" has the lowest priority so "deprecated" wins on both count and priority,
+/// proving the hint comes from flattening arrays.
 fn setup_array_status_vault() -> TempDir {
     let tmp = TempDir::new().unwrap();
-    // 6 files with status to trigger narrowing hints (>5 results needed).
-    for i in 1..=4 {
+    // 6 files to trigger narrowing hints (>5 results needed).
+    for i in 1..=2 {
         write_md(
             tmp.path(),
             &format!("note-{i}.md"),
-            &format!("---\ntitle: Note {i}\nstatus: active\ntags:\n  - docs\n---\nBody.\n"),
+            &format!(
+                "---\ntitle: Note {i}\nstatus: completed\ntags:\n  - docs\n---\nBody.\n"
+            ),
         );
     }
+    for (i, extra) in [(3, "experimental"), (4, "legacy"), (5, "wip")] {
+        write_md(
+            tmp.path(),
+            &format!("note-{i}.md"),
+            &format!(
+                "---\ntitle: Note {i}\nstatus:\n  - deprecated\n  - {extra}\ntags:\n  - docs\n---\nBody.\n"
+            ),
+        );
+    }
+    // One more file with no status to pad file count.
     write_md(
         tmp.path(),
-        "multi-a.md",
-        md!(r"
----
-title: Multi A
-status:
-  - deprecated
-  - experimental
-tags:
-  - docs
----
-Body.
-"),
-    );
-    write_md(
-        tmp.path(),
-        "multi-b.md",
-        md!(r"
----
-title: Multi B
-status:
-  - deprecated
-  - legacy
-tags:
-  - docs
----
-Body.
-"),
+        "note-6.md",
+        "---\ntitle: Note 6\ntags:\n  - docs\n---\nBody.\n",
     );
     tmp
 }
@@ -940,10 +930,11 @@ fn find_hints_flatten_array_status() {
         "find hints should not contain stringified array syntax: {stdout}"
     );
 
-    // Should suggest a scalar status value (e.g. "active" which appears 4 times).
+    // "deprecated" appears only inside array-valued status (3 files > "active"'s 2),
+    // so the hint must come from flattening arrays — the old code would skip these.
     assert!(
-        stdout.contains("status=active"),
-        "find hints should suggest scalar status value: {stdout}"
+        stdout.contains("status=deprecated"),
+        "find hints should suggest status derived from array-valued fields: {stdout}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -850,6 +850,104 @@ fn find_hints_no_hardcoded_draft() {
 }
 
 // ---------------------------------------------------------------------------
+// Array-valued status: hints must flatten, not stringify
+// ---------------------------------------------------------------------------
+
+/// Vault where some files have array-valued status properties.
+fn setup_array_status_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    // 6 files with status to trigger narrowing hints (>5 results needed).
+    for i in 1..=4 {
+        write_md(
+            tmp.path(),
+            &format!("note-{i}.md"),
+            &format!("---\ntitle: Note {i}\nstatus: active\ntags:\n  - docs\n---\nBody.\n"),
+        );
+    }
+    write_md(
+        tmp.path(),
+        "multi-a.md",
+        md!(r"
+---
+title: Multi A
+status:
+  - deprecated
+  - experimental
+tags:
+  - docs
+---
+Body.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "multi-b.md",
+        md!(r"
+---
+title: Multi B
+status:
+  - deprecated
+  - legacy
+tags:
+  - docs
+---
+Body.
+"),
+    );
+    tmp
+}
+
+#[test]
+fn summary_hints_flatten_array_status() {
+    let tmp = setup_array_status_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["summary", "--hints", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Must NOT suggest a stringified array like status=["deprecated","experimental"].
+    assert!(
+        !stdout.contains("status=["),
+        "hints should not contain stringified array syntax: {stdout}"
+    );
+}
+
+#[test]
+fn find_hints_flatten_array_status() {
+    let tmp = setup_array_status_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--hints", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Must NOT suggest a stringified array.
+    assert!(
+        !stdout.contains("status=["),
+        "find hints should not contain stringified array syntax: {stdout}"
+    );
+
+    // Should suggest a scalar status value (e.g. "active" which appears 4 times).
+    assert!(
+        stdout.contains("status=active"),
+        "find hints should suggest scalar status value: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Helper: assert a JSON value has a non-empty hints array where every element
 // has both "description" and "cmd" string fields.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When a document has an array-valued `status` (e.g., `status: [deprecated, non-standard]`), the summary command was stringifying the entire array as a single group key like `["deprecated","non-standard"]`, causing hints to suggest `--property status=["deprecated","non-standard"]` — invalid filter syntax that matches nothing.
- Fix `summary.rs` to flatten array status values into individual group entries, with per-entry deduplication to handle repeated values.
- Fix `hints.rs` find narrowing to extract individual elements from array-valued status properties (no intermediate Vec allocation).
- Add 1 unit test and 2 e2e tests covering array-valued status in both summary and find hints.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo test --workspace` — all 510 tests pass
- [x] New unit test: `summary_status_grouping_flattens_arrays` — verifies array status is split into individual groups
- [x] New e2e test: `summary_hints_flatten_array_status` — verifies summary hints don't contain `status=[` syntax
- [x] New e2e test: `find_hints_flatten_array_status` — verifies find hints suggest status derived from array-valued fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)