### PR TITLE
Upgrade jaq (v2→v3) and toml (v0.8→v1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,15 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,37 +154,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cc"
-version = "1.2.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
 
 [[package]]
 name = "ciborium"
@@ -267,12 +243,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -406,12 +376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,9 +470,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hifijson"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7763b98ba8a24f59e698bf9ab197e7676c640d6455d1580b4ce7dc560f0f0d"
+checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hyalo-cli"
@@ -552,30 +516,6 @@ dependencies = [
  "serde_json",
  "strsim",
  "tempfile",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -646,9 +586,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77526a72eb79412c29fd141767a6549bbfcb1cb40e00556fe16532d5e878e098"
+checksum = "dca0f164c8e9c55fc5aefe60b371df735c719b09930dac185878f2f8c7ab6b68"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -657,32 +597,80 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "1.1.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
+checksum = "f5c5baabe63d1d72cde60ec7548a098036773e3541dbc65c6a44fb38e9cfb272"
 dependencies = [
+ "bstr",
+ "bytes",
  "foldhash",
  "hifijson",
  "indexmap",
  "jaq-core",
  "jaq-std",
- "serde_json",
+ "num-bigint",
+ "num-traits",
+ "ryu",
+ "self_cell",
+ "serde_core",
 ]
 
 [[package]]
 name = "jaq-std"
-version = "2.1.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c264fe397c981705976c71f1bfe020382b9eda52ae950e57fe885e147bdd67d"
+checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
 dependencies = [
  "aho-corasick",
  "base64",
- "chrono",
+ "bstr",
  "jaq-core",
+ "jiff",
  "libm",
  "log",
- "regex-lite",
+ "regex-bites",
  "urlencoding",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -744,6 +732,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +803,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -912,10 +934,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
+name = "regex-bites"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "regex-syntax"
@@ -962,6 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1008,12 @@ dependencies = [
  "smallvec",
  "thiserror",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -1052,18 +1086,12 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
- "serde",
+ "serde_core",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
@@ -1139,44 +1167,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "typed-arena"
@@ -1356,63 +1382,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1425,12 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ globset = "0.4"
 ignore = "0.4"
 indexmap = { version = "2", features = ["serde"] }
 libc = "0.2"
-jaq-core = "2.2.1"
-jaq-json = { version = "1.1.3", features = ["serde_json"] }
-jaq-std = "2.1.2"
+jaq-core = "3.0.0"
+jaq-json = { version = "2.0.0", features = ["serde"] }
+jaq-std = "3.0.0"
 predicates = "3"
 regex = "1"
 rmp-serde = "1"
@@ -34,7 +34,7 @@ serde-saphyr = "0.0.22"
 strsim = "0.11"
 serde_json = "1.0.149"
 tempfile = "3"
-toml = "0.8"
+toml = "1"
 
 [workspace.lints.clippy]
 # Enable the full pedantic group, then allow lints we intentionally skip.

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -65,22 +65,12 @@ fn run_init_in(dir: Option<&str>, claude: bool, cwd: &Path) -> Result<CommandOut
             // If the file is malformed, fall back to overwriting with just `dir`.
             let existing_raw = fs::read_to_string(&toml_path)
                 .with_context(|| format!("failed to read {}", toml_path.display()))?;
-            if let Ok(mut table) = existing_raw.parse::<TomlValue>() {
-                if let Some(map) = table.as_table_mut() {
-                    map.insert("dir".to_owned(), TomlValue::String(dir_value.clone()));
-                    // Serialise back; toml::to_string always produces valid TOML.
-                    if let Ok(s) = toml::to_string(&table) {
-                        s
-                    } else {
-                        writeln!(
-                            summary,
-                            "warning  .hyalo.toml was malformed; existing content replaced"
-                        )
-                        .unwrap();
-                        minimal_toml_dir(&dir_value)
-                    }
+            if let Ok(mut table) = toml::from_str::<toml::Table>(&existing_raw) {
+                table.insert("dir".to_owned(), TomlValue::String(dir_value.clone()));
+                // Serialise back; toml::to_string always produces valid TOML.
+                if let Ok(s) = toml::to_string(&table) {
+                    s
                 } else {
-                    // Valid TOML but not a table (e.g. bare string) — overwrite.
                     writeln!(
                         summary,
                         "warning  .hyalo.toml was malformed; existing content replaced"
@@ -937,7 +927,7 @@ mod tests {
         // A directory name with a non-ASCII character.
         let output = minimal_toml_dir("my\u{1F4C1}notes");
         // Must parse back as valid TOML with the correct value.
-        let parsed: toml::Value = output.parse().expect("must be valid TOML");
+        let parsed: toml::Table = toml::from_str(&output).expect("must be valid TOML");
         assert_eq!(
             parsed.get("dir").and_then(|v| v.as_str()),
             Some("my\u{1F4C1}notes"),
@@ -949,7 +939,7 @@ mod tests {
     fn minimal_toml_dir_produces_valid_toml_for_backslash() {
         // Windows-style path — backslashes must be escaped in TOML strings.
         let output = minimal_toml_dir("C:\\Users\\me\\notes");
-        let parsed: toml::Value = output.parse().expect("must be valid TOML");
+        let parsed: toml::Table = toml::from_str(&output).expect("must be valid TOML");
         assert_eq!(
             parsed.get("dir").and_then(|v| v.as_str()),
             Some("C:\\Users\\me\\notes"),
@@ -994,9 +984,8 @@ mod tests {
         );
         // File overwritten with a valid table.
         let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
-        let parsed: toml::Value = content
-            .parse()
-            .expect("overwritten content must be valid TOML");
+        let parsed: toml::Table =
+            toml::from_str(&content).expect("overwritten content must be valid TOML");
         assert_eq!(
             parsed.get("dir").and_then(|v| v.as_str()),
             Some("docs"),

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use jaq_core::load::{self, Arena, File, Loader};
-use jaq_core::{Compiler, Ctx, Native, RcIter};
+use jaq_core::{Compiler, Ctx, Native, Vars, data};
 use jaq_json::Val;
 use serde::Serialize;
 use serde_json::json;
@@ -11,13 +11,20 @@ use serde_json::json;
 // Filter cache
 // ---------------------------------------------------------------------------
 
+/// The `DataT` implementation used for jaq filter compilation and execution.
+///
+/// `JustLut<Val>` is a minimal wrapper that only provides the compiled lookup
+/// table — sufficient because we don't use lifetime-dependent filters like
+/// `inputs`.
+type D = data::JustLut<Val>;
+
 /// Cache of compiled jaq filters, keyed by filter source string.
 ///
-/// `Filter<Native<Val>>` is fully owned (no lifetime parameters) and `Clone`,
+/// The compiled `Filter` is fully owned (no lifetime parameters) and `Clone`,
 /// so it can be stored directly in a `HashMap`. The `Arena` used during
 /// `Loader::load` is a temporary scratch pad — once `compile` returns, the
 /// `Filter` no longer borrows from it.
-type JaqFilterCache = HashMap<String, jaq_core::Filter<Native<Val>>>;
+type JaqFilterCache = HashMap<String, jaq_core::compile::Filter<Native<D>>>;
 
 /// Output format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -371,21 +378,27 @@ fn format_load_errors(errs: &load::Errors<&str, ()>) -> String {
 /// Compile a jq filter string into a reusable `Filter`.
 ///
 /// The `Arena` used during loading is a temporary scratch pad and is dropped
-/// after this function returns — `Filter<Native<Val>>` owns all its data.
-fn compile_jq_filter(filter_code: &str) -> Result<jaq_core::Filter<Native<Val>>, String> {
+/// after this function returns — the compiled `Filter` owns all its data.
+fn compile_jq_filter(filter_code: &str) -> Result<jaq_core::compile::Filter<Native<D>>, String> {
     let program = File {
         code: filter_code,
         path: (),
     };
-    let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
+    let defs = jaq_core::defs()
+        .chain(jaq_std::defs())
+        .chain(jaq_json::defs());
+    let loader = Loader::new(defs);
     let arena = Arena::default();
 
     let modules = loader
         .load(&arena, program)
         .map_err(|errs| format_load_errors(&errs))?;
 
+    let funs = jaq_core::funs::<D>()
+        .chain(jaq_std::funs::<D>())
+        .chain(jaq_json::funs::<D>());
     Compiler::default()
-        .with_funs(jaq_std::funs().chain(jaq_json::funs()))
+        .with_funs(funs)
         .compile(modules)
         .map_err(|errs| {
             // compile::Errors = Vec<(File<S,P>, Vec<(S, Undefined)>)>
@@ -401,20 +414,22 @@ fn compile_jq_filter(filter_code: &str) -> Result<jaq_core::Filter<Native<Val>>,
 
 /// Execute a pre-compiled jq filter against a JSON value and return the text output.
 fn execute_jq_filter(
-    filter: &jaq_core::Filter<Native<Val>>,
+    filter: &jaq_core::compile::Filter<Native<D>>,
     value: &serde_json::Value,
 ) -> Result<String, String> {
-    let input = Val::from(value.clone());
-    let inputs = RcIter::new(core::iter::empty());
-    let ctx = Ctx::new([], &inputs);
+    let input: Val = serde_json::from_value(value.clone())
+        .map_err(|e| format!("jq input conversion error: {e}"))?;
+    let ctx = Ctx::<D>::new(&filter.lut, Vars::new([]));
 
     let mut parts = Vec::new();
-    for result in filter.run((ctx, input)) {
+    for result in filter.id.run((ctx, input)).map(jaq_core::unwrap_valr) {
         match result {
             Ok(val) => {
                 let s = match val {
-                    Val::Str(s) => (*s).clone(),
-                    other => serde_json::Value::from(other).to_string(),
+                    Val::TStr(ref s) => String::from_utf8_lossy(s).into_owned(),
+                    // For non-string values, `Display` produces valid JSON
+                    // (numbers, booleans, null, arrays, objects).
+                    other => other.to_string(),
                 };
                 parts.push(s);
             }
@@ -431,7 +446,7 @@ fn run_jq_filter_cached(
     value: &serde_json::Value,
     cache: &mut JaqFilterCache,
 ) -> Result<String, String> {
-    if let Some(filter) = cache.get_mut(filter_code) {
+    if let Some(filter) = cache.get(filter_code) {
         return execute_jq_filter(filter, value);
     }
     let compiled = compile_jq_filter(filter_code)?;

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -426,7 +426,10 @@ fn execute_jq_filter(
         match result {
             Ok(val) => {
                 let s = match val {
-                    Val::TStr(ref s) => String::from_utf8_lossy(s).into_owned(),
+                    Val::TStr(ref s) | Val::BStr(ref s) => match std::str::from_utf8(s) {
+                        Ok(valid) => valid.to_owned(),
+                        Err(_) => String::from_utf8_lossy(s).into_owned(),
+                    },
                     // For non-string values, `Display` produces valid JSON
                     // (numbers, booleans, null, arrays, objects).
                     other => other.to_string(),


### PR DESCRIPTION
## Summary
- Upgrade jaq-core 2.2.1→3.0.0, jaq-json 1.1.3→2.0.0 (feature rename: `serde_json`→`serde`), jaq-std 2.1.2→3.0.0
- Upgrade toml 0.8→1.1 (TOML spec 1.1)
- Adapt jaq integration in `output.rs` to v3 API: `JustLut<Val>` data type, `filter.id.run()` execution, `Vars` context, `Val::TStr` string variant
- Fix toml document parsing in `init.rs` — `FromStr<Value>` now parses values not documents, switched to `from_str::<Table>()`

## Test plan
- [x] All 510 existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manual verification: `hyalo summary --jq '.' --format json` produces correct output
- [x] Release build succeeds (`cargo build --release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)