### PR TITLE
Replace ~= regex prefix with /regex/ delimiters

### DIFF
--- a/.claude/skills/hyalo/SKILL.md
+++ b/.claude/skills/hyalo/SKILL.md
@@ -41,7 +41,7 @@ hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
 ```
 
 `--section` uses case-insensitive **substring** matching by default — `"Tasks"` matches
-`"Tasks [4/4]"`, `"My Tasks"`, etc. Use `"~=/regex/"` for regex. Prefix `##` to pin heading level.
+`"Tasks [4/4]"`, `"My Tasks"`, etc. Use `"/regex/"` for regex. Prefix `##` to pin heading level.
 
 `--glob` supports negation with `!` prefix to exclude files: `--glob '!**/draft-*'`.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ hyalo find --section "Tasks" --task todo          # matches "Tasks", "Tasks [4/4
 hyalo find --section "## Design" "TODO"           # content search scoped to level-2 Design sections
 hyalo find --section "# Introduction" --fields sections  # level-pinned: only # Introduction, not ## Introduction
 hyalo find --section "Tasks" --section "Notes"    # OR: match either section
-hyalo find --section "~=/DEC-03[12]/"             # regex section match
+hyalo find --section "/DEC-03[12]/"               # regex section match
 
 # Scope to file(s) (--file is repeatable)
 hyalo find --file path/to/note.md

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -218,7 +218,7 @@ pub(crate) enum Commands {
     #[command(long_about = "Read the body content of a markdown file.\n\n\
             Returns the raw text after the YAML frontmatter block. Use --section to extract a \
             specific section by heading (case-insensitive whole-string match; use leading '#' to \
-            pin heading level, e.g. '## Tasks'; nested subsections are included), \
+            pin heading level, e.g. '## Tasks'; use '/regex/' for regex matching; nested subsections are included), \
             --lines to slice a line range, and --frontmatter to include the YAML frontmatter.\n\n\
             OUTPUT: Defaults to plain text (note: this overrides the global --format json default). \
             Pass --format json explicitly to get \

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -161,7 +161,7 @@ pub(crate) enum Commands {
             - --section HEADING: section scope filter (exclude files without a matching section; within \
             matching files, restrict tasks and content matches to the section scope; case-insensitive \
             substring (contains) match by default, e.g. 'Tasks' matches 'Tasks [4/4]'; use leading '#' \
-            to pin heading level, e.g. '## Tasks'; use '~=/regex/' for regex matching). Repeatable (OR). \
+            to pin heading level, e.g. '## Tasks'; use '/regex/' for regex matching). Repeatable (OR). \
             Nested subsections are included.\n\n\
             FIELDS: Use --fields to limit which fields appear (default: all). \
             Properties are a {key: value} map; use --fields properties-typed for [{name, type, value}] array.\n\
@@ -184,7 +184,7 @@ pub(crate) enum Commands {
         #[arg(long, value_name = "STATUS")]
         task: Option<String>,
         /// Section heading filter: case-insensitive substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
-        /// prefix '##' to pin heading level; prefix '~=' for regex (e.g. '~=/DEC-03[12]/'). Repeatable (OR)
+        /// prefix '##' to pin heading level; use '/regex/' for regex (e.g. '/DEC-03[12]/'). Repeatable (OR)
         #[arg(short, long = "section", value_name = "HEADING")]
         sections: Vec<String>,
         /// Target file(s) (repeatable). Mutually exclusive with --glob
@@ -209,8 +209,8 @@ pub(crate) enum Commands {
         #[arg(long)]
         broken_links: bool,
         /// Filter by title: case-insensitive substring match against the displayed title
-        /// (frontmatter 'title' property or first H1 heading). Prefix with '~=' for regex
-        /// (e.g. '~=^The' or '~=/^The/i').
+        /// (frontmatter 'title' property or first H1 heading). Use /regex/ for regex
+        /// (e.g. '/^The/' or '/^The/i').
         #[arg(long)]
         title: Option<String>,
     },
@@ -232,7 +232,7 @@ pub(crate) enum Commands {
         #[arg(short, long)]
         file: String,
         /// Extract section(s) by substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
-        /// prefix '##' to pin heading level; prefix '~=' for regex. Nested subsections included
+        /// prefix '##' to pin heading level; use '/regex/' for regex. Nested subsections included
         #[arg(short, long, value_name = "HEADING")]
         section: Option<String>,
         /// Slice output by line range: 5:10, 5:, :10, or 5 (1-based, inclusive, relative to body content)

--- a/crates/hyalo-cli/src/commands/find/build.rs
+++ b/crates/hyalo-cli/src/commands/find/build.rs
@@ -70,9 +70,10 @@ impl TitleMatcher {
                     )));
                 }
 
-                // Case-insensitive by default
+                // Case-insensitive by default; opt out with (?-i) in pattern
+                let case_insensitive = flags.contains('i') || !inner.contains("(?-i)");
                 match regex::RegexBuilder::new(inner)
-                    .case_insensitive(true)
+                    .case_insensitive(case_insensitive)
                     .size_limit(1 << 20)
                     .build()
                 {

--- a/crates/hyalo-cli/src/commands/find/build.rs
+++ b/crates/hyalo-cli/src/commands/find/build.rs
@@ -2,7 +2,6 @@ use hyalo_core::filter::FindTaskFilter;
 use hyalo_core::types::{FindTaskInfo, OutlineSection};
 
 use crate::output::CommandOutcome;
-use crate::warn;
 
 /// Extract the title value for `--fields title`.
 ///
@@ -45,33 +44,33 @@ impl TitleMatcher {
     ///
     /// Supports:
     /// - Plain text: case-insensitive substring match
-    /// - `~=pattern`: bare regex (always case-insensitive)
-    /// - `~=/pattern/`: delimited regex (case-insensitive by default)
-    /// - `~=/pattern/i`: delimited regex with explicit flags
+    /// - `/pattern/`: regex (case-insensitive by default)
+    /// - `/pattern/i`: regex with explicit flags
     ///
     /// Returns `Err(CommandOutcome::UserError(...))` on invalid regex.
     pub(super) fn parse(pattern: &str) -> Result<Self, CommandOutcome> {
-        if let Some(regex_pat) = pattern.strip_prefix("~=") {
-            if let Some(rest) = regex_pat.strip_prefix('/') {
-                // Delimited form: /pattern/ or /pattern/i
-                let close = rest.rfind('/').ok_or_else(|| {
-                    CommandOutcome::UserError(format!(
-                        "invalid --title regex: {regex_pat}\nregex pattern starting with '/' must end with '/' (e.g. /pattern/ or /pattern/i), got: {regex_pat}"
-                    ))
-                })?;
+        if let Some(rest) = pattern.strip_prefix('/') {
+            // Slash-delimited regex: /pattern/ or /pattern/i
+            if let Some(close) = rest.rfind('/') {
                 let inner = &rest[..close];
                 let flags = &rest[close + 1..];
 
-                // Validate flags
+                // Validate flags — only 'i' is supported
                 for ch in flags.chars() {
                     if ch != 'i' {
                         return Err(CommandOutcome::UserError(format!(
-                            "invalid --title regex: {regex_pat}\nunsupported regex flag {ch:?}: only 'i' is supported"
+                            "invalid --title regex: {pattern}\nunsupported regex flag {ch:?}: only 'i' is supported"
                         )));
                     }
                 }
 
-                // --title is case-insensitive by default; explicit /i is redundant but allowed
+                if inner.is_empty() {
+                    return Err(CommandOutcome::UserError(format!(
+                        "invalid --title regex: {pattern}\nregex pattern must not be empty"
+                    )));
+                }
+
+                // Case-insensitive by default
                 match regex::RegexBuilder::new(inner)
                     .case_insensitive(true)
                     .size_limit(1 << 20)
@@ -79,31 +78,14 @@ impl TitleMatcher {
                 {
                     Ok(re) => Ok(Self::Regex(re)),
                     Err(e) => Err(CommandOutcome::UserError(format!(
-                        "invalid --title regex: {regex_pat}\n{e}"
+                        "invalid --title regex: {pattern}\n{e}"
                     ))),
                 }
             } else {
-                // Bare form: always case-insensitive
-                match regex::RegexBuilder::new(regex_pat)
-                    .case_insensitive(true)
-                    .size_limit(1 << 20)
-                    .build()
-                {
-                    Ok(re) => Ok(Self::Regex(re)),
-                    Err(e) => Err(CommandOutcome::UserError(format!(
-                        "invalid --title regex: {regex_pat}\n{e}"
-                    ))),
-                }
+                // Single `/` with no closing slash — treat as literal substring
+                Ok(Self::Substring(pattern.to_lowercase()))
             }
         } else {
-            // Emit a warning if the pattern looks like it was meant to be
-            // a regex or property filter expression.
-            if looks_like_misused_regex(pattern) {
-                warn::warn(format!(
-                    "--title does substring matching by default; \
-                     prefix with '~=' for regex: --title '~={pattern}'"
-                ));
-            }
             Ok(Self::Substring(pattern.to_lowercase()))
         }
     }
@@ -119,27 +101,6 @@ impl TitleMatcher {
             Self::Regex(re) => re.is_match(title_str),
         }
     }
-}
-
-/// Heuristic: does a plain `--title` value look like the user intended regex
-/// or property-filter syntax?
-///
-/// Catches patterns like `/^foo/`, `^foo$`, `.*bar`, etc. that often indicate
-/// regex intent and may not behave as expected when used as a literal substring.
-fn looks_like_misused_regex(pattern: &str) -> bool {
-    // Starts with `/` and contains another `/` → likely /regex/ or /regex/i
-    if matches!(pattern.strip_prefix('/'), Some(rest) if rest.contains('/')) {
-        return true;
-    }
-    // Contains regex anchors or common metacharacters unlikely in titles
-    if pattern.starts_with('^') || pattern.ends_with('$') {
-        return true;
-    }
-    // Contains `.*` or `.+` — almost certainly regex
-    if pattern.contains(".*") || pattern.contains(".+") {
-        return true;
-    }
-    false
 }
 
 /// Return true if `tasks` satisfy `filter`.

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -3468,7 +3468,7 @@ fn find_title_delimited_regex_missing_closing_slash() {
 }
 
 #[test]
-fn find_title_warns_on_suspicious_pattern() {
+fn find_title_slash_regex_matches() {
     let tmp = setup_vault();
     // `/^Alpha/` is now valid regex syntax — it should match "Alpha" without a warning
     let out = hyalo_no_hints()

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -3491,7 +3491,7 @@ fn find_title_slash_regex_matches() {
 }
 
 #[test]
-fn find_title_bare_regex_with_anchors() {
+fn find_title_slash_regex_with_anchors() {
     let tmp = setup_vault();
     // /^alpha$/ should match "Alpha" (case-insensitive by default)
     let out = hyalo_no_hints()

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -2147,7 +2147,7 @@ fn section_filter_level_pinned_substring() {
 
 #[test]
 fn section_filter_regex_matches() {
-    // ~=/DEC-03[12]/ should match both DEC-031 and DEC-032
+    // /DEC-03[12]/ should match both DEC-031 and DEC-032
     let tmp = setup_substring_section_vault();
     let (status, json, stderr) = find_json(
         &tmp,
@@ -2155,7 +2155,7 @@ fn section_filter_regex_matches() {
             "--file",
             "decision.md",
             "--section",
-            "~=/DEC-03[12]/",
+            "/DEC-03[12]/",
             "--task",
             "any",
             "--fields",
@@ -2172,7 +2172,7 @@ fn section_filter_regex_matches() {
 
 #[test]
 fn section_filter_regex_anchored() {
-    // ~=/^Tasks$/ should match heading "Tasks" exactly but NOT "Tasks [4/4]"
+    // /^Tasks$/ should match heading "Tasks" exactly but NOT "Tasks [4/4]"
     let tmp = setup_substring_section_vault();
     let (status, json, _) = find_json(
         &tmp,
@@ -2180,7 +2180,7 @@ fn section_filter_regex_anchored() {
             "--file",
             "tasks.md",
             "--section",
-            "~=/^Tasks$/",
+            "/^Tasks$/",
             "--task",
             "any",
         ],
@@ -2199,7 +2199,7 @@ fn section_filter_regex_invalid_exits_1() {
     let tmp = setup_section_vault();
     let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
-    cmd.args(["find", "--section", "~=/[invalid/"]);
+    cmd.args(["find", "--section", "/[invalid/"]);
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
@@ -3311,7 +3311,7 @@ fn find_title_case_insensitive() {
 fn find_title_regex_mode() {
     let tmp = setup_vault();
     let out = hyalo_no_hints()
-        .args(["find", "--title", "~=^(Alpha|Beta)$", "--format", "json"])
+        .args(["find", "--title", "/^(Alpha|Beta)$/", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3357,7 +3357,7 @@ fn find_title_frontmatter_match() {
 fn find_title_invalid_regex_returns_error() {
     let tmp = setup_vault();
     let out = hyalo_no_hints()
-        .args(["find", "--title", "~=[unclosed", "--format", "json"])
+        .args(["find", "--title", "/[unclosed/", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3376,9 +3376,9 @@ fn find_title_invalid_regex_returns_error() {
 #[test]
 fn find_title_delimited_regex() {
     let tmp = setup_vault();
-    // `~=/^Alpha$/` should match only "Alpha" (case-insensitive by default)
+    // `/^Alpha$/` should match only "Alpha" (case-insensitive by default)
     let out = hyalo_no_hints()
-        .args(["find", "--title", "~=/^Alpha$/", "--format", "json"])
+        .args(["find", "--title", "/^Alpha$/", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3401,10 +3401,10 @@ fn find_title_delimited_regex() {
 #[test]
 fn find_title_delimited_regex_case_insensitive_default() {
     let tmp = setup_vault();
-    // `~=/^alpha$/` without 'i' flag should still match "Alpha"
+    // `/^alpha$/` without 'i' flag should still match "Alpha"
     // because --title defaults to case-insensitive
     let out = hyalo_no_hints()
-        .args(["find", "--title", "~=/^alpha$/", "--format", "json"])
+        .args(["find", "--title", "/^alpha$/", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3427,9 +3427,9 @@ fn find_title_delimited_regex_case_insensitive_default() {
 #[test]
 fn find_title_delimited_regex_with_flag() {
     let tmp = setup_vault();
-    // `~=/^alpha$/i` with explicit 'i' flag should also work
+    // `/^alpha$/i` with explicit 'i' flag should also work
     let out = hyalo_no_hints()
-        .args(["find", "--title", "~=/^alpha$/i", "--format", "json"])
+        .args(["find", "--title", "/^alpha$/i", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3452,27 +3452,25 @@ fn find_title_delimited_regex_with_flag() {
 #[test]
 fn find_title_delimited_regex_missing_closing_slash() {
     let tmp = setup_vault();
+    // A single leading slash with no closing slash is treated as a substring
+    // match (not an error) since `/pattern/` is the only regex syntax now.
     let out = hyalo_no_hints()
-        .args(["find", "--title", "~=/unclosed", "--format", "json"])
+        .args(["find", "--title", "/unclosed", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
         .unwrap();
     assert!(
-        !out.status.success(),
-        "missing closing slash should exit with error"
-    );
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("must end with '/'"),
-        "stderr should mention missing closing slash: {stderr}"
+        out.status.success(),
+        "single slash without closing slash is a substring match, not an error: stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
     );
 }
 
 #[test]
 fn find_title_warns_on_suspicious_pattern() {
     let tmp = setup_vault();
-    // `/^Alpha/` without ~= prefix looks like the user forgot ~=
+    // `/^Alpha/` is now valid regex syntax — it should match "Alpha" without a warning
     let out = hyalo_no_hints()
         .args(["find", "--title", "/^Alpha/", "--format", "json"])
         .arg("--dir")
@@ -3481,44 +3479,23 @@ fn find_title_warns_on_suspicious_pattern() {
         .unwrap();
     assert!(
         out.status.success(),
-        "should succeed (substring match): stderr: {}",
+        "regex /^Alpha/ should succeed: stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = unwrap_results(&json);
     assert!(
-        stderr.contains("--title does substring matching"),
-        "should warn about likely misuse: {stderr}"
-    );
-}
-
-#[test]
-fn find_title_warns_on_anchor_pattern() {
-    let tmp = setup_vault();
-    // `^Alpha` looks like regex — should warn
-    let out = hyalo_no_hints()
-        .args(["find", "--title", "^Alpha", "--format", "json"])
-        .arg("--dir")
-        .arg(tmp.path())
-        .output()
-        .unwrap();
-    assert!(
-        out.status.success(),
-        "should succeed: stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("--title does substring matching"),
-        "should warn about anchor usage: {stderr}"
+        results.iter().any(|v| v["file"] == "alpha.md"),
+        "/^Alpha/ should match alpha.md: {results:?}"
     );
 }
 
 #[test]
 fn find_title_bare_regex_with_anchors() {
     let tmp = setup_vault();
-    // Bare ~=^Alpha$ should match (case-insensitive)
+    // /^alpha$/ should match "Alpha" (case-insensitive by default)
     let out = hyalo_no_hints()
-        .args(["find", "--title", "~=^alpha$", "--format", "json"])
+        .args(["find", "--title", "/^alpha$/", "--format", "json"])
         .arg("--dir")
         .arg(tmp.path())
         .output()
@@ -3533,7 +3510,7 @@ fn find_title_bare_regex_with_anchors() {
     assert_eq!(
         results.len(),
         1,
-        "bare regex with anchors should match: {results:?}"
+        "delimited regex with anchors should match: {results:?}"
     );
     assert_eq!(results[0]["file"], "alpha.md");
 }

--- a/crates/hyalo-core/src/heading.rs
+++ b/crates/hyalo-core/src/heading.rs
@@ -72,20 +72,46 @@ impl SectionFilter {
     /// Parse a `--section` value into a `SectionFilter`.
     ///
     /// Parsing rules:
-    /// - If the value starts with `~=`, parse the rest as a regex (bare or `/pattern/flags`).
+    /// - If the value starts with `/` and contains a closing `/`, parse as regex.
     /// - If the value starts with `#`, parse as a level-pinned substring filter.
     /// - Otherwise, use case-insensitive substring matching.
     ///
     /// Returns an error if the `#` prefix doesn't form a valid ATX heading or the
     /// regex pattern fails to compile.
     pub fn parse(input: &str) -> Result<Self, String> {
-        if let Some(regex_part) = input.strip_prefix("~=") {
-            // Regex mode: ~=/pattern/flags or ~=pattern
-            let compiled = parse_section_regex(regex_part)?;
-            return Ok(Self {
-                level: None,
-                mode: SectionMatchMode::Regex(compiled),
-            });
+        if let Some(rest) = input.strip_prefix('/') {
+            // Slash-delimited regex: /pattern/ or /pattern/i
+            if let Some(close) = rest.rfind('/') {
+                let pattern = &rest[..close];
+                let flags = &rest[close + 1..];
+
+                // Validate flags — only 'i' is supported
+                for ch in flags.chars() {
+                    if ch != 'i' {
+                        return Err(format!(
+                            "unsupported section regex flag {ch:?}: only 'i' is supported"
+                        ));
+                    }
+                }
+
+                if pattern.is_empty() {
+                    return Err("section regex pattern must not be empty".to_owned());
+                }
+
+                // Default to case-insensitive (section matching is case-insensitive by convention).
+                let case_insensitive = flags.contains('i') || !pattern.contains("(?-i)");
+                let compiled = regex::RegexBuilder::new(pattern)
+                    .case_insensitive(case_insensitive)
+                    .size_limit(1 << 20)
+                    .build()
+                    .map_err(|e| format!("invalid section regex {input:?}: {e}"))?;
+
+                return Ok(Self {
+                    level: None,
+                    mode: SectionMatchMode::Regex(compiled),
+                });
+            }
+            // Single `/` with no closing slash — fall through to substring
         }
 
         if input.starts_with('#') {
@@ -158,57 +184,6 @@ fn ascii_contains_ignore_case(haystack: &str, needle: &str) -> bool {
         return true;
     }
     false
-}
-
-/// Parse the part after `~=` as a regex, supporting `/pattern/flags` notation.
-///
-/// Compiled with a 1 MiB size limit to prevent pathological regex compilation.
-/// Default is case-insensitive (section headings are case-insensitive by convention).
-///
-/// Supported flags:
-/// - `i` — case-insensitive (default, explicit for clarity)
-///
-/// Examples:
-/// - `~=foo` → `(?i)foo` (always case-insensitive by default)
-/// - `~=/foo/` → `(?i)foo`
-/// - `~=/foo/i` → `(?i)foo`
-/// - `~=/^Tasks$/` → `(?i)^Tasks$`
-fn parse_section_regex(input: &str) -> Result<Regex, String> {
-    const SIZE_LIMIT: usize = 1 << 20; // 1 MiB
-
-    let (pattern, flags) = if let Some(rest) = input.strip_prefix('/') {
-        // Delimited form: `/pattern/flags`
-        let close = rest
-            .rfind('/')
-            .ok_or_else(|| format!("section regex starting with '/' must have a closing '/' (e.g. /pattern/ or /pattern/i), got: /{rest}"))?;
-        (&rest[..close], &rest[close + 1..])
-    } else {
-        // Bare form
-        (input, "")
-    };
-
-    if pattern.is_empty() {
-        return Err("section regex pattern must not be empty".to_owned());
-    }
-
-    // Validate flags — only 'i' is supported
-    for ch in flags.chars() {
-        if ch != 'i' {
-            return Err(format!(
-                "unsupported section regex flag {ch:?}: only 'i' is supported"
-            ));
-        }
-    }
-
-    // Default to case-insensitive (section matching is case-insensitive by convention).
-    // Explicit `i` flag overrides even `(?-i)` in the pattern body.
-    let case_insensitive = flags.contains('i') || !pattern.contains("(?-i)");
-
-    regex::RegexBuilder::new(pattern)
-        .case_insensitive(case_insensitive)
-        .size_limit(SIZE_LIMIT)
-        .build()
-        .map_err(|e| format!("invalid section regex {input:?}: {e}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -398,7 +373,7 @@ mod tests {
 
     #[test]
     fn parse_regex_bare() {
-        let f = SectionFilter::parse("~=Tasks").unwrap();
+        let f = SectionFilter::parse("/Tasks/").unwrap();
         assert!(f.matches(1, "Tasks"));
         assert!(f.matches(2, "My Tasks"));
         assert!(!f.matches(1, "Notes"));
@@ -406,27 +381,27 @@ mod tests {
 
     #[test]
     fn parse_regex_slash_delimited() {
-        let f = SectionFilter::parse("~=/Tasks/").unwrap();
+        let f = SectionFilter::parse("/Tasks/").unwrap();
         assert!(f.matches(1, "Tasks"));
         assert!(f.matches(2, "My Tasks [4/4]"));
     }
 
     #[test]
     fn parse_regex_with_anchors() {
-        let f = SectionFilter::parse("~=/^Tasks$/").unwrap();
+        let f = SectionFilter::parse("/^Tasks$/").unwrap();
         assert!(f.matches(1, "Tasks"));
         assert!(!f.matches(2, "My Tasks"));
     }
 
     #[test]
     fn parse_regex_with_i_flag() {
-        let f = SectionFilter::parse("~=/tasks/i").unwrap();
+        let f = SectionFilter::parse("/tasks/i").unwrap();
         assert!(f.matches(1, "TASKS"));
     }
 
     #[test]
     fn parse_regex_character_class() {
-        let f = SectionFilter::parse("~=/DEC-03[12]/").unwrap();
+        let f = SectionFilter::parse("/DEC-03[12]/").unwrap();
         assert!(f.matches(1, "DEC-031: Some Title"));
         assert!(f.matches(1, "DEC-032: Another"));
         assert!(!f.matches(1, "DEC-033: Nope"));
@@ -434,8 +409,8 @@ mod tests {
 
     #[test]
     fn parse_regex_empty_pattern_errors() {
-        assert!(SectionFilter::parse("~=").is_err());
-        assert!(SectionFilter::parse("~=/./").is_ok()); // valid
+        assert!(SectionFilter::parse("//").is_err());
+        assert!(SectionFilter::parse("/./").is_ok()); // valid
     }
 
     // --- SectionFilter::matches ---

--- a/crates/hyalo-core/src/heading.rs
+++ b/crates/hyalo-core/src/heading.rs
@@ -59,7 +59,9 @@ enum SectionMatchMode {
 /// Supports three forms:
 /// - `"Tasks"` — case-insensitive substring match at any level
 /// - `"## Tasks"` — level-pinned, substring match on text after stripping `##` prefix
-/// - `"~=/pattern/flags"` — regex match (bare `~=pattern` or `~=/pattern/` or `~=/pattern/i`)
+/// - `"/pattern/"` — regex match (case-insensitive by default)
+/// - `"/pattern/i"` — regex match with explicit case-insensitive flag
+/// - `"/pattern/(?-i)"` — regex match with case-sensitive opt-out inline
 #[derive(Debug, Clone)]
 pub struct SectionFilter {
     /// If `Some`, match only headings at this exact level.
@@ -372,11 +374,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_regex_bare() {
-        let f = SectionFilter::parse("/Tasks/").unwrap();
-        assert!(f.matches(1, "Tasks"));
-        assert!(f.matches(2, "My Tasks"));
-        assert!(!f.matches(1, "Notes"));
+    fn parse_single_slash_falls_through_to_substring() {
+        let f = SectionFilter::parse("/unclosed").unwrap();
+        // No closing slash → treated as substring, not regex
+        assert!(f.matches(1, "/unclosed heading"));
+        assert!(!f.matches(1, "Tasks"));
     }
 
     #[test]
@@ -411,6 +413,15 @@ mod tests {
     fn parse_regex_empty_pattern_errors() {
         assert!(SectionFilter::parse("//").is_err());
         assert!(SectionFilter::parse("/./").is_ok()); // valid
+    }
+
+    #[test]
+    fn parse_regex_unsupported_flag_errors() {
+        let err = SectionFilter::parse("/foo/x").unwrap_err();
+        assert!(
+            err.contains("unsupported"),
+            "expected flag error, got: {err}"
+        );
     }
 
     // --- SectionFilter::matches ---

--- a/hyalo-knowledgebase/iterations/iteration-88-count-flag.md
+++ b/hyalo-knowledgebase/iterations/iteration-88-count-flag.md
@@ -1,12 +1,12 @@
 ---
-title: "Global --count flag for list commands"
+title: Global --count flag for list commands
 type: iteration
 date: 2026-03-31
 tags:
   - iteration
   - cli
   - ux
-status: in-progress
+status: completed
 branch: iter-88/count-flag
 ---
 

--- a/hyalo-knowledgebase/iterations/iteration-89-slash-regex-syntax.md
+++ b/hyalo-knowledgebase/iterations/iteration-89-slash-regex-syntax.md
@@ -1,0 +1,36 @@
+---
+title: "Replace ~= with /regex/ delimiters for --title and --section"
+type: iteration
+date: 2026-03-31
+tags:
+  - iteration
+  - cli
+  - ux
+  - breaking-change
+status: in-progress
+branch: iter-89/slash-regex-syntax
+---
+
+## Goal
+
+Replace the verbose `~=/regex/` prefix syntax with direct `/regex/` delimiters for `--title` and `--section` flags. The `/regex/` pattern (awk, sed, JavaScript) is universally recognized and saves keystrokes. `--property K~=pattern` is unchanged (it's an operator, not a prefix).
+
+## Before → After
+
+```bash
+--title '~=/^The/i'         →  --title '/^The/i'
+--section '~=/DEC-03[12]/'  →  --section '/DEC-03[12]/'
+```
+
+## Tasks
+
+- [x] Replace `~=` detection with `/regex/` in `TitleMatcher::parse()` (build.rs)
+- [x] Remove `looks_like_misused_regex()` heuristic and warning
+- [x] Replace `~=` detection with `/regex/` in `SectionFilter::parse()` (heading.rs)
+- [x] Remove `parse_section_regex()` helper
+- [x] Update CLI help text (args.rs)
+- [x] Update e2e tests (e2e_find.rs)
+- [x] Update unit tests (heading.rs)
+- [x] Update README.md and SKILL.md
+- [x] Create iteration file
+- [ ] Create PR and review


### PR DESCRIPTION
## Summary
- Replaces the verbose `~=` prefix with `/regex/` delimiters for `--title` and `--section` flags (breaking change)
- `/regex/` syntax is universally recognized (awk, sed, JavaScript) and saves keystrokes
- `--property K~=pattern` is unchanged (it's an operator like `=`, `!=`)
- Removes `looks_like_misused_regex()` warning heuristic and `parse_section_regex()` helper
- Both parsers now respect `(?-i)` opt-out consistently

## Examples
```bash
# Before
hyalo find --title '~=/^The/i'
hyalo find --section '~=/DEC-03[12]/'

# After
hyalo find --title '/^The/i'
hyalo find --section '/DEC-03[12]/'
```

## Test plan
- [x] `cargo fmt` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass
- [x] Dogfood: `hyalo find --title '/iter/' --format text` works
- [x] Dogfood: `hyalo find --section '/Tasks/' --format text` works
- [x] Help text updated for `--title`, `--section` in find and read commands
- [x] Edge cases: single `/` fallthrough, unsupported flags, `(?-i)` opt-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)