### PR TITLE
Add views: saved find queries with --view flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hyalo-cli"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-core"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ members = ["crates/*"]
 default-members = ["crates/hyalo-cli"]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ractive/hyalo"
 
 [workspace.dependencies]
 # Internal crates
-hyalo-core = { path = "crates/hyalo-core", version = "0.7.3" }
+hyalo-core = { path = "crates/hyalo-core", version = "0.8.0" }
 
 # External dependencies
 anyhow = "1"

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -4,6 +4,11 @@ use clap::{Parser, Subcommand};
 
 use crate::output::Format;
 
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde skip_serializing_if requires &bool
+pub(crate) fn is_false(v: &bool) -> bool {
+    !v
+}
+
 pub(crate) fn parse_limit(s: &str) -> Result<usize, String> {
     let n: usize = s
         .parse()
@@ -145,6 +150,99 @@ pub(crate) struct Cli {
     pub command: Commands,
 }
 
+/// All filter arguments for `hyalo find`, extracted so they can be serialized as views.
+#[derive(Debug, Clone, Default, clap::Args, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct FindFilters {
+    /// Regex body text search (case-insensitive by default; use (?-i) to override). Mutually exclusive with PATTERN
+    #[arg(long, short = 'e', value_name = "REGEX")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regexp: Option<String>,
+    /// Property filter: K=V (eq), K!=V (neq), K>=V, K<=V, K>V, K<V, K (exists), !K (absent), K~=pat or K~=/pat/i (regex). Repeatable (AND)
+    #[arg(short, long = "property", value_name = "FILTER")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub properties: Vec<String>,
+    /// Tag filter: exact or prefix match (e.g. 'project' matches 'project/backend' but not 'projects'). Repeatable (AND)
+    #[arg(short, long, value_name = "TAG")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tag: Vec<String>,
+    /// Task presence filter: 'todo', 'done', 'any', or a single status character
+    #[arg(long, value_name = "STATUS")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    /// Section heading filter: case-insensitive substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
+    /// prefix '##' to pin heading level; use '/regex/' for regex (e.g. '/DEC-03[12]/'). Repeatable (OR)
+    #[arg(short, long = "section", value_name = "HEADING")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub sections: Vec<String>,
+    /// Target file(s) (repeatable). Mutually exclusive with --glob
+    #[arg(short, long, conflicts_with = "glob")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub file: Vec<String>,
+    /// Glob pattern(s) to select files, relative to --dir (repeatable); prefix '!' to negate (e.g. '!**/draft-*')
+    #[arg(short, long, conflicts_with = "file")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub glob: Vec<String>,
+    /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections, tasks, links, backlinks, title (default: properties, tags, sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
+    #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<String>,
+    /// Sort order: 'file' (default), 'modified', 'backlinks_count', 'links_count', 'title', 'date', or 'property:<KEY>' for any frontmatter property
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<String>,
+    /// Reverse the sort order (ascending becomes descending and vice versa)
+    #[arg(long)]
+    #[serde(skip_serializing_if = "is_false")]
+    pub reverse: bool,
+    /// Maximum number of results to return (must be at least 1)
+    #[arg(short = 'n', long, value_parser = parse_limit)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    /// Only return files with at least one unresolved link (auto-includes links field)
+    #[arg(long)]
+    #[serde(skip_serializing_if = "is_false")]
+    pub broken_links: bool,
+    /// Filter by title: case-insensitive substring match against the displayed title
+    /// (frontmatter 'title' property or first H1 heading). Use /regex/ for regex
+    /// (e.g. '/^The/' or '/^The/i').
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+impl FindFilters {
+    /// Merge CLI overrides onto a view's filters.
+    /// - Vec fields: CLI extends the view
+    /// - Option fields: CLI overrides if Some
+    /// - Bool fields: OR (CLI can turn on, not off)
+    pub(crate) fn merge_from(&mut self, overlay: &Self) {
+        if overlay.regexp.is_some() {
+            self.regexp.clone_from(&overlay.regexp);
+        }
+        self.properties.extend(overlay.properties.iter().cloned());
+        self.tag.extend(overlay.tag.iter().cloned());
+        if overlay.task.is_some() {
+            self.task.clone_from(&overlay.task);
+        }
+        self.sections.extend(overlay.sections.iter().cloned());
+        self.file.extend(overlay.file.iter().cloned());
+        self.glob.extend(overlay.glob.iter().cloned());
+        self.fields.extend(overlay.fields.iter().cloned());
+        if overlay.sort.is_some() {
+            self.sort.clone_from(&overlay.sort);
+        }
+        self.reverse = self.reverse || overlay.reverse;
+        if overlay.limit.is_some() {
+            self.limit = overlay.limit;
+        }
+        self.broken_links = self.broken_links || overlay.broken_links;
+        if overlay.title.is_some() {
+            self.title.clone_from(&overlay.title);
+        }
+    }
+}
+
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     /// Search and filter markdown files — returns file objects with metadata, structure, tasks, and links
@@ -175,48 +273,11 @@ pub(crate) enum Commands {
         /// Case-insensitive body text search (searches body only, not frontmatter)
         #[arg(value_name = "PATTERN", conflicts_with = "regexp")]
         pattern: Option<String>,
-        /// Regex body text search (case-insensitive by default; use (?-i) to override). Mutually exclusive with PATTERN
-        #[arg(long, short = 'e', value_name = "REGEX")]
-        regexp: Option<String>,
-        /// Property filter: K=V (eq), K!=V (neq), K>=V, K<=V, K>V, K<V, K (exists), !K (absent), K~=pat or K~=/pat/i (regex). Repeatable (AND)
-        #[arg(short, long = "property", value_name = "FILTER")]
-        properties: Vec<String>,
-        /// Tag filter: exact or prefix match (e.g. 'project' matches 'project/backend' but not 'projects'). Repeatable (AND)
-        #[arg(short, long, value_name = "TAG")]
-        tag: Vec<String>,
-        /// Task presence filter: 'todo', 'done', 'any', or a single status character
-        #[arg(long, value_name = "STATUS")]
-        task: Option<String>,
-        /// Section heading filter: case-insensitive substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
-        /// prefix '##' to pin heading level; use '/regex/' for regex (e.g. '/DEC-03[12]/'). Repeatable (OR)
-        #[arg(short, long = "section", value_name = "HEADING")]
-        sections: Vec<String>,
-        /// Target file(s) (repeatable). Mutually exclusive with --glob
-        #[arg(short, long, conflicts_with = "glob")]
-        file: Vec<String>,
-        /// Glob pattern(s) to select files, relative to --dir (repeatable); prefix '!' to negate (e.g. '!**/draft-*')
-        #[arg(short, long, conflicts_with = "file")]
-        glob: Vec<String>,
-        /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections, tasks, links, backlinks, title (default: properties, tags, sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
-        #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
-        fields: Vec<String>,
-        /// Sort order: 'file' (default), 'modified', 'backlinks_count', 'links_count', 'title', 'date', or 'property:<KEY>' for any frontmatter property
-        #[arg(long)]
-        sort: Option<String>,
-        /// Reverse the sort order (ascending becomes descending and vice versa)
-        #[arg(long)]
-        reverse: bool,
-        /// Maximum number of results to return (must be at least 1)
-        #[arg(short = 'n', long, value_parser = parse_limit)]
-        limit: Option<usize>,
-        /// Only return files with at least one unresolved link (auto-includes links field)
-        #[arg(long)]
-        broken_links: bool,
-        /// Filter by title: case-insensitive substring match against the displayed title
-        /// (frontmatter 'title' property or first H1 heading). Use /regex/ for regex
-        /// (e.g. '/^The/' or '/^The/i').
-        #[arg(long)]
-        title: Option<String>,
+        /// Use a saved view (named filter set from .hyalo.toml)
+        #[arg(long, value_name = "NAME")]
+        view: Option<String>,
+        #[command(flatten)]
+        filters: FindFilters,
     },
     /// Read file body content, optionally filtered by section or line range (read-only)
     #[command(long_about = "Read the body content of a markdown file.\n\n\
@@ -532,6 +593,21 @@ Repeatable (AND).\n\
         #[arg(long)]
         dry_run: bool,
     },
+    /// Manage saved views (named find filter sets stored in .hyalo.toml)
+    #[command(
+        long_about = "Manage saved views — named find queries stored in .hyalo.toml.\n\n\
+            Views let you save frequently used filter combinations under a name\n\
+            and recall them with `hyalo find --view <name>`.\n\n\
+            Subcommands:\n\
+            - list: Show all saved views and their filters.\n\
+            - set: Create or update a view.\n\
+            - remove: Delete a view.\n\n\
+            SIDE EFFECTS: 'set' and 'remove' modify .hyalo.toml. 'list' is read-only."
+    )]
+    Views {
+        #[command(subcommand)]
+        action: ViewsAction,
+    },
     /// Detect and repair broken links across the vault
     #[command(
         long_about = "Detect and repair broken wikilinks and markdown links.\n\n\
@@ -549,6 +625,38 @@ Repeatable (AND).\n\
     Links {
         #[command(subcommand)]
         action: LinksAction,
+    },
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)] // Set variant holds FindFilters by design; boxing would complicate dispatch
+pub(crate) enum ViewsAction {
+    /// List all saved views
+    #[command(
+        long_about = "Show all saved views and their filter configurations.\n\n\
+        OUTPUT: JSON array of view objects with name and filters.\n\
+        SIDE EFFECTS: None (read-only)."
+    )]
+    List,
+    /// Create or update a saved view
+    #[command(long_about = "Save a combination of find filters under a name.\n\n\
+        The view is stored in .hyalo.toml and can be recalled with `hyalo find --view <name>`.\n\
+        Overwrites if the view already exists.\n\n\
+        SIDE EFFECTS: Modifies .hyalo.toml.")]
+    Set {
+        /// View name
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[command(flatten)]
+        filters: FindFilters,
+    },
+    /// Delete a saved view
+    #[command(long_about = "Remove a saved view from .hyalo.toml.\n\n\
+        SIDE EFFECTS: Modifies .hyalo.toml.")]
+    Remove {
+        /// View name to delete
+        #[arg(value_name = "NAME")]
+        name: String,
     },
 }
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -226,8 +226,16 @@ impl FindFilters {
             self.task.clone_from(&overlay.task);
         }
         self.sections.extend(overlay.sections.iter().cloned());
-        self.file.extend(overlay.file.iter().cloned());
-        self.glob.extend(overlay.glob.iter().cloned());
+        // file and glob are mutually exclusive (clap enforces this at parse time).
+        // If the overlay provides either, it replaces the base to avoid an invalid
+        // combination where both file and glob are non-empty.
+        if !overlay.file.is_empty() {
+            self.file.extend(overlay.file.iter().cloned());
+            self.glob.clear();
+        } else if !overlay.glob.is_empty() {
+            self.glob.extend(overlay.glob.iter().cloned());
+            self.file.clear();
+        }
         self.fields.extend(overlay.fields.iter().cloned());
         if overlay.sort.is_some() {
             self.sort.clone_from(&overlay.sort);
@@ -634,7 +642,7 @@ pub(crate) enum ViewsAction {
     /// List all saved views
     #[command(
         long_about = "Show all saved views and their filter configurations.\n\n\
-        OUTPUT: JSON array of view objects with name and filters.\n\
+        OUTPUT: JSON envelope with results (array of view objects) and total count.\n\
         SIDE EFFECTS: None (read-only)."
     )]
     List,

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -30,7 +30,12 @@ pub(crate) const HELP_EXAMPLES: &str = "EXAMPLES:
   Fix broken links (preview):   hyalo links fix
   Build a snapshot index:       hyalo create-index
   Query using the index:        hyalo find --property status=draft --index .hyalo-index
-  Delete the snapshot index:    hyalo drop-index";
+  Delete the snapshot index:    hyalo drop-index
+  Save a view:                  hyalo views set todo --task todo
+  List saved views:             hyalo views list
+  Use a view:                   hyalo find --view todo
+  Use view with overrides:      hyalo find --view todo --limit 5
+  Remove a view:                hyalo views remove todo";
 
 /// Long help (shown by `--help`): command reference, cookbook, and output shapes.
 pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
@@ -75,6 +80,12 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
 
   Mv (move/rename file, updates links, mutates files):
     hyalo mv -f/--file F --to NEW [--dry-run]
+
+  Views (manage saved find queries):
+    hyalo views list                                       List all saved views
+    hyalo views set <NAME> [find filters...]               Save a view (overwrites existing)
+    hyalo views remove <NAME>                              Delete a view
+    hyalo find --view <NAME> [additional filters...]       Use a saved view
 
   Init (configuration, one-time setup):
     hyalo init [--claude] [-d/--dir DIR]

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod set;
 pub mod summary;
 pub mod tags;
 pub mod tasks;
+pub mod views;
 
 use crate::output::{CommandOutcome, Format};
 use anyhow::Result;

--- a/crates/hyalo-cli/src/commands/views.rs
+++ b/crates/hyalo-cli/src/commands/views.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 
 use crate::cli::args::FindFilters;
 use crate::output::CommandOutcome;
@@ -11,19 +11,33 @@ const TOML_PATH: &str = ".hyalo.toml";
 /// Load all views from `.hyalo.toml`.
 /// Returns an empty map if the file doesn't exist or has no views.
 pub(crate) fn load_views() -> HashMap<String, FindFilters> {
-    let Ok(contents) = fs::read_to_string(TOML_PATH) else {
-        return HashMap::new();
+    let contents = match fs::read_to_string(TOML_PATH) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return HashMap::new(),
+        Err(e) => {
+            crate::warn::warn(format!("could not read .hyalo.toml for views: {e}"));
+            return HashMap::new();
+        }
     };
-    let Ok(table) = toml::from_str::<toml::Table>(&contents) else {
-        return HashMap::new();
+    let table: toml::Table = match toml::from_str(&contents) {
+        Ok(t) => t,
+        Err(e) => {
+            crate::warn::warn(format!("malformed .hyalo.toml: {e}"));
+            return HashMap::new();
+        }
     };
     let Some(toml::Value::Table(views_table)) = table.get("views") else {
         return HashMap::new();
     };
     let mut views = HashMap::new();
     for (name, value) in views_table {
-        if let Ok(filters) = value.clone().try_into::<FindFilters>() {
-            views.insert(name.clone(), filters);
+        match value.clone().try_into::<FindFilters>() {
+            Ok(filters) => {
+                views.insert(name.clone(), filters);
+            }
+            Err(e) => {
+                crate::warn::warn(format!("skipping malformed view '{name}': {e}"));
+            }
         }
     }
     views
@@ -58,10 +72,15 @@ pub(crate) fn list_views() -> Result<CommandOutcome> {
 
 /// Save a view to `.hyalo.toml`.
 pub(crate) fn set_view(name: &str, filters: &FindFilters) -> Result<CommandOutcome> {
-    // Validate name: must be non-empty, no whitespace, no dots (TOML key safety)
-    if name.is_empty() || name.contains(char::is_whitespace) || name.contains('.') {
+    // Validate name: alphanumeric, hyphens, and underscores only (TOML bare-key safe)
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
         return Ok(CommandOutcome::UserError(format!(
-            "Error: invalid view name '{name}': must be non-empty, with no whitespace or dots"
+            "Error: invalid view name '{name}': must be non-empty and contain only \
+             alphanumeric characters, hyphens, or underscores"
         )));
     }
 
@@ -84,7 +103,9 @@ pub(crate) fn set_view(name: &str, filters: &FindFilters) -> Result<CommandOutco
         .or_insert_with(|| toml::Value::Table(toml::Table::new()));
 
     let toml::Value::Table(views_table) = views else {
-        bail!("'views' in .hyalo.toml is not a table");
+        return Ok(CommandOutcome::UserError(
+            "Error: 'views' in .hyalo.toml is not a table — check your config file".to_owned(),
+        ));
     };
 
     views_table.insert(name.to_owned(), filters_value);

--- a/crates/hyalo-cli/src/commands/views.rs
+++ b/crates/hyalo-cli/src/commands/views.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+use std::fs;
+
+use anyhow::{Context, Result, bail};
+
+use crate::cli::args::FindFilters;
+use crate::output::CommandOutcome;
+
+const TOML_PATH: &str = ".hyalo.toml";
+
+/// Load all views from `.hyalo.toml`.
+/// Returns an empty map if the file doesn't exist or has no views.
+pub(crate) fn load_views() -> HashMap<String, FindFilters> {
+    let Ok(contents) = fs::read_to_string(TOML_PATH) else {
+        return HashMap::new();
+    };
+    let Ok(table) = toml::from_str::<toml::Table>(&contents) else {
+        return HashMap::new();
+    };
+    let Some(toml::Value::Table(views_table)) = table.get("views") else {
+        return HashMap::new();
+    };
+    let mut views = HashMap::new();
+    for (name, value) in views_table {
+        if let Ok(filters) = value.clone().try_into::<FindFilters>() {
+            views.insert(name.clone(), filters);
+        }
+    }
+    views
+}
+
+/// List all saved views.
+pub(crate) fn list_views() -> Result<CommandOutcome> {
+    let views = load_views();
+    let mut items: Vec<serde_json::Value> = Vec::new();
+    let mut sorted_keys: Vec<&String> = views.keys().collect();
+    sorted_keys.sort();
+    for name in sorted_keys {
+        let filters = &views[name];
+        let filters_json =
+            serde_json::to_value(filters).context("failed to serialize view filters")?;
+        items.push(serde_json::json!({
+            "name": name,
+            "filters": filters_json,
+        }));
+    }
+    let total = items.len();
+    let output = serde_json::to_string_pretty(&serde_json::json!({
+        "results": items,
+        "total": total,
+    }))
+    .context("failed to serialize views list")?;
+    Ok(CommandOutcome::Success {
+        output,
+        total: Some(total as u64),
+    })
+}
+
+/// Save a view to `.hyalo.toml`.
+pub(crate) fn set_view(name: &str, filters: &FindFilters) -> Result<CommandOutcome> {
+    // Validate name: must be non-empty, no whitespace, no dots (TOML key safety)
+    if name.is_empty() || name.contains(char::is_whitespace) || name.contains('.') {
+        return Ok(CommandOutcome::UserError(format!(
+            "Error: invalid view name '{name}': must be non-empty, with no whitespace or dots"
+        )));
+    }
+
+    // Check that at least one filter is set
+    let filters_value =
+        toml::Value::try_from(filters).context("failed to serialize filters to TOML")?;
+    let default_value = toml::Value::try_from(FindFilters::default())
+        .context("failed to serialize default filters")?;
+    if filters_value == default_value {
+        return Ok(CommandOutcome::UserError(
+            "Error: no filters specified — a view must contain at least one filter".to_owned(),
+        ));
+    }
+
+    let mut table = read_toml_table()?;
+
+    // Get or create the views table
+    let views = table
+        .entry("views")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+
+    let toml::Value::Table(views_table) = views else {
+        bail!("'views' in .hyalo.toml is not a table");
+    };
+
+    views_table.insert(name.to_owned(), filters_value);
+
+    write_toml_table(&table)?;
+
+    let output = serde_json::to_string_pretty(&serde_json::json!({
+        "results": {
+            "action": "set",
+            "name": name,
+        }
+    }))
+    .context("failed to serialize result")?;
+    Ok(CommandOutcome::Success {
+        output,
+        total: None,
+    })
+}
+
+/// Remove a view from `.hyalo.toml`.
+pub(crate) fn remove_view(name: &str) -> Result<CommandOutcome> {
+    let mut table = read_toml_table()?;
+
+    let Some(toml::Value::Table(views_table)) = table.get_mut("views") else {
+        return Ok(CommandOutcome::UserError(format!(
+            "Error: view '{name}' not found\n\n  tip: run 'hyalo views list' to see available views"
+        )));
+    };
+
+    if views_table.remove(name).is_none() {
+        return Ok(CommandOutcome::UserError(format!(
+            "Error: view '{name}' not found\n\n  tip: run 'hyalo views list' to see available views"
+        )));
+    }
+
+    // Clean up: remove empty views table
+    if views_table.is_empty() {
+        table.remove("views");
+    }
+
+    write_toml_table(&table)?;
+
+    let output = serde_json::to_string_pretty(&serde_json::json!({
+        "results": {
+            "action": "removed",
+            "name": name,
+        }
+    }))
+    .context("failed to serialize result")?;
+    Ok(CommandOutcome::Success {
+        output,
+        total: None,
+    })
+}
+
+/// Read `.hyalo.toml` as a TOML table, creating an empty table if the file doesn't exist.
+fn read_toml_table() -> Result<toml::Table> {
+    match fs::read_to_string(TOML_PATH) {
+        Ok(contents) => toml::from_str(&contents).context("failed to parse .hyalo.toml"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(toml::Table::new()),
+        Err(e) => Err(e).context("failed to read .hyalo.toml"),
+    }
+}
+
+/// Write a TOML table back to `.hyalo.toml`.
+fn write_toml_table(table: &toml::Table) -> Result<()> {
+    let content = toml::to_string(table).context("failed to serialize .hyalo.toml")?;
+    fs::write(TOML_PATH, content).context("failed to write .hyalo.toml")?;
+    Ok(())
+}

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
@@ -17,6 +18,11 @@ struct ConfigFile {
     /// (e.g. `/docs/page.md`).  When set, this takes precedence over the
     /// auto-derived value (last component of the resolved `dir`).
     site_prefix: Option<String>,
+    /// Named find-filter sets. Stored so `deny_unknown_fields` does not reject
+    /// configs that contain `[views.*]` tables. The views module reads these
+    /// directly from the TOML file; they are not propagated to `ResolvedDefaults`.
+    #[allow(dead_code)]
+    views: Option<HashMap<String, toml::Value>>,
 }
 
 /// Resolved configuration with all defaults applied.

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -2,7 +2,9 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use crate::cli::args::{Commands, LinksAction, PropertiesAction, TagsAction, TaskAction};
+use crate::cli::args::{
+    Commands, FindFilters, LinksAction, PropertiesAction, TagsAction, TaskAction,
+};
 use crate::commands::{
     ResolvedIndex, append as append_commands, backlinks as backlinks_commands,
     create_index as create_index_commands, drop_index as drop_index_commands,
@@ -54,19 +56,23 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
     match command {
         Commands::Find {
             pattern,
-            regexp,
-            properties,
-            tag,
-            task,
-            sections,
-            file,
-            glob,
-            fields,
-            sort,
-            reverse,
-            limit,
-            broken_links,
-            title,
+            view: _, // resolved before dispatch
+            filters:
+                FindFilters {
+                    regexp,
+                    properties,
+                    tag,
+                    task,
+                    sections,
+                    file,
+                    glob,
+                    fields,
+                    sort,
+                    reverse,
+                    limit,
+                    broken_links,
+                    title,
+                },
         } => {
             // Parse property filters
             let prop_filters: Vec<filter::PropertyFilter> = match properties
@@ -506,8 +512,9 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 Err(e) => Err(e),
             },
         },
-        // `Init` and `Deinit` are handled as early returns before dispatch is called.
+        // `Init`, `Deinit`, and `Views` are handled as early returns before dispatch is called.
         Commands::Init { .. } => unreachable!("Init is dispatched before this match reached"),
         Commands::Deinit => unreachable!("Deinit is dispatched before this match reached"),
+        Commands::Views { .. } => unreachable!("Views is dispatched before this match reached"),
     }
 }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -2,7 +2,7 @@ use std::process;
 
 use clap::{CommandFactory, FromArgMatches};
 
-use crate::cli::args::{Cli, Commands};
+use crate::cli::args::{Cli, Commands, FindFilters, ViewsAction};
 use crate::cli::help::{filter_examples, filter_long_help};
 use crate::commands::init as init_commands;
 use crate::dispatch::{CommandContext, dispatch};
@@ -144,7 +144,7 @@ fn run_inner() -> Result<(), AppError> {
             return Err(AppError::Clap(e));
         }
     };
-    let cli = match Cli::from_arg_matches(&matches) {
+    let mut cli = match Cli::from_arg_matches(&matches) {
         Ok(c) => c,
         Err(e) => return Err(AppError::Clap(e)),
     };
@@ -157,7 +157,12 @@ fn run_inner() -> Result<(), AppError> {
     // Dispatch it before the rest of the setup.
     // The global --dir flag is used as the dir value for .hyalo.toml.
     // Reject --count early — init is not a list command.
-    if cli.count && matches!(cli.command, Commands::Init { .. } | Commands::Deinit) {
+    if cli.count
+        && matches!(
+            cli.command,
+            Commands::Init { .. } | Commands::Deinit | Commands::Views { .. }
+        )
+    {
         eprintln!("{COUNT_UNSUPPORTED_ERROR}");
         return Err(AppError::Exit(2));
     }
@@ -180,6 +185,38 @@ fn run_inner() -> Result<(), AppError> {
             }
             Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
             Err(e) => return Err(AppError::Internal(e)),
+        }
+    }
+    if let Commands::Views { ref action } = cli.command {
+        match action {
+            ViewsAction::List => match crate::commands::views::list_views() {
+                Ok(CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output)) => {
+                    println!("{output}");
+                    return Ok(());
+                }
+                Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
+                Err(e) => return Err(AppError::Internal(e)),
+            },
+            ViewsAction::Set { name, filters } => {
+                match crate::commands::views::set_view(name, filters) {
+                    Ok(
+                        CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output),
+                    ) => {
+                        println!("{output}");
+                        return Ok(());
+                    }
+                    Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
+                    Err(e) => return Err(AppError::Internal(e)),
+                }
+            }
+            ViewsAction::Remove { name } => match crate::commands::views::remove_view(name) {
+                Ok(CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output)) => {
+                    println!("{output}");
+                    return Ok(());
+                }
+                Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
+                Err(e) => return Err(AppError::Internal(e)),
+            },
         }
     }
 
@@ -250,6 +287,28 @@ fn run_inner() -> Result<(), AppError> {
     } else {
         config.hints
     };
+
+    // Resolve --view: load the named view from .hyalo.toml and merge CLI overrides.
+    if let Commands::Find {
+        view: Some(ref view_name),
+        ref mut filters,
+        ..
+    } = cli.command
+    {
+        let views = crate::commands::views::load_views();
+        match views.get(view_name) {
+            Some(base) => {
+                let overlay = std::mem::take(filters);
+                *filters = base.clone();
+                filters.merge_from(&overlay);
+            }
+            None => {
+                return Err(AppError::User(format!(
+                    "Error: unknown view '{view_name}'\n\n  tip: run 'hyalo views list' to see available views"
+                )));
+            }
+        }
+    }
 
     // --jq operates on JSON, so it conflicts with an explicit --format text.
     let jq_filter = cli.jq.as_deref();
@@ -336,16 +395,20 @@ fn run_inner() -> Result<(), AppError> {
                 Some(ctx)
             }
             Commands::Find {
-                glob,
                 pattern,
-                regexp,
-                properties,
-                tag,
-                task,
-                file,
-                fields,
-                sort,
-                limit,
+                filters:
+                    FindFilters {
+                        glob,
+                        regexp,
+                        properties,
+                        tag,
+                        task,
+                        file,
+                        fields,
+                        sort,
+                        limit,
+                        ..
+                    },
                 ..
             } => {
                 let mut ctx = HintContext::new(HintSource::Find);
@@ -489,7 +552,8 @@ fn run_inner() -> Result<(), AppError> {
             Commands::Properties { .. }
             | Commands::Tags { .. }
             | Commands::Init { .. }
-            | Commands::Deinit => None,
+            | Commands::Deinit
+            | Commands::Views { .. } => None,
         }
     } else {
         None
@@ -505,6 +569,7 @@ fn run_inner() -> Result<(), AppError> {
             | Commands::CreateIndex { .. }
             | Commands::DropIndex { .. }
             | Commands::Read { .. }
+            | Commands::Views { .. }
     );
     let mut snapshot_index: Option<SnapshotIndex> = if uses_index {
         if let Some(ref index_path) = cli.index {

--- a/crates/hyalo-cli/tests/e2e_views.rs
+++ b/crates/hyalo-cli/tests/e2e_views.rs
@@ -1,0 +1,199 @@
+mod common;
+
+use std::fs;
+
+use common::{hyalo, hyalo_no_hints, write_md};
+use tempfile::TempDir;
+
+fn setup() -> TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "note1.md",
+        "---\nstatus: draft\ntags:\n  - project\n---\nHello world",
+    );
+    write_md(
+        tmp.path(),
+        "note2.md",
+        "---\nstatus: completed\ntags:\n  - research\n---\nGoodbye world",
+    );
+    tmp
+}
+
+#[test]
+fn views_set_and_list() {
+    let tmp = setup();
+    // Set a view
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "set", "drafts", "--property", "status=draft"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "set failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // List views
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "list"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "list failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["results"][0]["name"], "drafts");
+}
+
+#[test]
+fn views_remove() {
+    let tmp = setup();
+    // Set then remove
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "set", "drafts", "--property", "status=draft"])
+        .output()
+        .unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "remove", "drafts"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // List should be empty
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "list"])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn find_with_view() {
+    let tmp = setup();
+    // Set a view
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "set", "drafts", "--property", "status=draft"])
+        .output()
+        .unwrap();
+
+    // Use the view with find
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--view", "drafts"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "find --view failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert!(
+        json["results"][0]["file"]
+            .as_str()
+            .unwrap()
+            .contains("note1")
+    );
+}
+
+#[test]
+fn find_with_view_and_overrides() {
+    let tmp = setup();
+    // Create more files
+    write_md(
+        tmp.path(),
+        "note3.md",
+        "---\nstatus: draft\ntags:\n  - project\n---\nAnother draft",
+    );
+
+    // Set a view with property filter
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "set", "drafts", "--property", "status=draft"])
+        .output()
+        .unwrap();
+
+    // Use view with limit override
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--view", "drafts", "--limit", "1"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["results"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn find_with_unknown_view_errors() {
+    let tmp = setup();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["find", "--view", "nonexistent"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown view"), "stderr: {stderr}");
+}
+
+#[test]
+fn views_remove_nonexistent_errors() {
+    let tmp = setup();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "remove", "nonexistent"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not found"), "stderr: {stderr}");
+}
+
+#[test]
+fn views_set_empty_filters_errors() {
+    let tmp = setup();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "set", "empty"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no filters"), "stderr: {stderr}");
+}
+
+#[test]
+fn views_set_preserves_existing_config() {
+    let tmp = setup();
+    // Write a .hyalo.toml with dir set
+    fs::write(tmp.path().join(".hyalo.toml"), "dir = \".\"\n").unwrap();
+
+    // Set a view
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "set", "drafts", "--property", "status=draft"])
+        .output()
+        .unwrap();
+
+    // Verify dir is preserved
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(content.contains("dir = \".\""), "dir was lost: {content}");
+    assert!(
+        content.contains("[views.drafts]"),
+        "view not written: {content}"
+    );
+}

--- a/hyalo-knowledgebase/iterations/iteration-93-init-deinit.md
+++ b/hyalo-knowledgebase/iterations/iteration-93-init-deinit.md
@@ -6,7 +6,7 @@ tags:
   - init
   - cli
   - iteration
-status: planned
+status: completed
 branch: iter-93/init-deinit
 ---
 

--- a/hyalo-knowledgebase/iterations/iteration-94-views.md
+++ b/hyalo-knowledgebase/iterations/iteration-94-views.md
@@ -1,0 +1,133 @@
+---
+title: "Iteration 94: Views (Saved Find Queries)"
+type: iteration
+date: 2026-04-02
+tags:
+  - iteration
+  - cli
+  - find
+  - views
+status: in-progress
+branch: iter-94/views
+---
+
+## Goal
+
+Add named, reusable find queries ("views") stored in `.hyalo.toml`. Users save a combination of find filters under a name and recall them with `--view <name>`. Discoverable via `hyalo views list`.
+
+Benefits: fewer tokens for LLMs, fewer typos, project-specific vocabulary, runtime discoverability.
+
+## Commands
+
+```
+hyalo find --view <name> [additional filters...]   # use a saved view
+hyalo views list                                    # list all views
+hyalo views set <name> [find filters...]            # save a view (overwrites)
+hyalo views remove <name>                           # delete a view
+```
+
+## Design
+
+### Shared `FindFilters` struct
+
+Extract the filter fields from `Commands::Find` into a reusable struct with dual derives — `clap::Args` (for CLI `#[command(flatten)]`) and `serde::Serialize/Deserialize` (for TOML storage):
+
+```rust
+#[derive(Debug, Clone, Default, clap::Args, serde::Serialize, serde::Deserialize)]
+pub(crate) struct FindFilters {
+    pub regexp: Option<String>,       // -e/--regexp
+    pub properties: Vec<String>,      // -p/--property (repeatable)
+    pub tag: Vec<String>,             // -t/--tag (repeatable)
+    pub task: Option<String>,         // --task
+    pub sections: Vec<String>,        // -s/--section (repeatable)
+    pub file: Vec<String>,            // -f/--file (repeatable)
+    pub glob: Vec<String>,            // -g/--glob (repeatable)
+    pub fields: Vec<String>,          // --fields
+    pub sort: Option<String>,         // --sort
+    pub reverse: bool,                // --reverse
+    pub limit: Option<usize>,         // -n/--limit
+    pub broken_links: bool,           // --broken-links
+    pub title: Option<String>,        // --title
+}
+```
+
+Skip empty/default fields on serialization (`skip_serializing_if`) to keep TOML clean.
+
+### Positional `pattern` stays outside `FindFilters`
+
+The positional `PATTERN` arg on `find` would conflict with the positional `NAME` on `views set` if both were in the flattened struct. Keep `pattern` directly on `Commands::Find` (not in `FindFilters`). Views use `regexp` for body search (strictly more powerful). No breaking change.
+
+### TOML schema (nested tables)
+
+```toml
+[views.planned-iterations]
+properties = ["status=planned", "type=iteration"]
+glob = ["iterations/*.md"]
+
+[views.recent-drafts]
+sort = "modified"
+reverse = true
+limit = 10
+```
+
+Each view value is a serialized `FindFilters`. Maps to `HashMap<String, FindFilters>` in serde.
+
+### Merge strategy (`--view` + CLI flags)
+
+`FindFilters::merge_from(&mut self, overlay: &FindFilters)`:
+- **Vec fields** (properties, tag, sections, file, glob, fields): CLI **extends** the view
+- **Option fields** (regexp, task, sort, title, limit): CLI **overrides** if Some
+- **Bool fields** (reverse, broken_links): OR (CLI can turn on, not off)
+
+### View resolution location
+
+In `run.rs`, after config load, before dispatch — same early-return pattern as Init/Deinit. Merge by mutating `filters` in-place on the `Commands::Find` variant.
+
+### TOML persistence
+
+Use `toml::Table` for read-modify-write (same pattern as `init.rs`):
+- Read `.hyalo.toml` as string → parse as `toml::Table`
+- Insert/remove under `views.<name>`
+- Serialize back with `toml::to_string`
+
+## Tasks
+
+- [ ] Extract `FindFilters` struct in `args.rs`, flatten into `Commands::Find` with `--view` flag
+- [ ] Update `dispatch.rs` to destructure from `filters` field
+- [ ] Update `run.rs` hint context to read from `filters.*`
+- [ ] Verify pure refactor: `cargo check && cargo test` pass with no behavior change
+- [ ] Add `views: HashMap<String, FindFilters>` to `ConfigFile` and `ResolvedDefaults` in `config.rs`
+- [ ] Add `Views` command + `ViewsAction::{List, Set, Remove}` enum to `args.rs`
+- [ ] Implement `commands/views.rs` — list, set, remove (TOML read/modify/write)
+- [ ] Wire `Views` early dispatch in `run.rs`
+- [ ] Implement `--view` merge in `run.rs` with `FindFilters::merge_from`
+- [ ] Add views examples to help text
+- [ ] E2E tests: views set/list/remove, find --view, find --view + overrides, unknown view error
+- [ ] Code quality gates: `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `crates/hyalo-cli/src/cli/args.rs` | Extract `FindFilters`; flatten into `Find`; add `--view`; add `Views` + `ViewsAction` |
+| `crates/hyalo-cli/src/config.rs` | Add `views` field to `ConfigFile` + `ResolvedDefaults` |
+| `crates/hyalo-cli/src/run.rs` | `Views` early dispatch; `--view` merge; hint context update |
+| `crates/hyalo-cli/src/dispatch.rs` | Update `Find` destructuring for `FindFilters` |
+| `crates/hyalo-cli/src/commands/mod.rs` | Add `pub mod views;` |
+| `crates/hyalo-cli/src/commands/views.rs` | **New** — list, set, remove |
+| `crates/hyalo-cli/src/cli/help.rs` | Add views examples |
+
+## Verification
+
+```bash
+cargo fmt
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+# Manual:
+hyalo views set planned --property status=planned --property type=iteration --glob 'iterations/*.md'
+hyalo views list
+hyalo find --view planned --format text
+hyalo find --view planned --limit 3 --format text
+hyalo views remove planned
+hyalo find --view nonexistent  # should error
+```


### PR DESCRIPTION
## Summary
- Extract `FindFilters` struct from `Commands::Find` with dual `clap::Args` + `serde` derives for CLI and TOML storage
- Add `hyalo views set/list/remove` subcommands for managing named filter sets in `.hyalo.toml`
- Add `--view <name>` flag to `hyalo find` with merge semantics (Vec fields extend, Option fields override, bool fields OR)
- Bump version to 0.8.0

## Test plan
- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` — all 519 tests pass
- [x] E2E tests: views set/list/remove, find --view, find --view + overrides, unknown view error, empty filters error, config preservation
- [x] Manual dogfooding: `hyalo views set planned --property status=planned --glob 'iterations/*.md'` → `hyalo find --view planned --format text` → `hyalo views remove planned`
- [x] Existing find behavior unchanged (pure refactor of FindFilters extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)