### PR TITLE
Iter 95: Views for AI agents — hints, help text, skill templates

### DIFF
--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -272,6 +272,10 @@ pub(crate) enum Commands {
             FIELDS: Use --fields to limit which fields appear (default: all). \
             Properties are a {key: value} map; use --fields properties-typed for [{name, type, value}] array.\n\
             JQ: --jq operates on the full envelope. Examples: --jq '.results[].file', --jq '.total'.\n\
+            VIEWS: --view <name> loads a saved filter set from .hyalo.toml. Additional CLI flags \
+merge on top: list filters (--property, --tag, --section, --glob) extend the view's \
+lists; scalar filters (--regexp, --sort, --limit, --title, --task) override; bool \
+flags (--broken-links, --reverse) OR. Example: hyalo find --view drafts --limit 5\n\
             COMMON MISTAKES:\n\
             - Property regex uses ~= (tilde-equals), NOT =~ (Perl-style). Wrong: 'title=~/pat/', right: 'title~=/pat/'.\n\
             - --title searches the displayed title (frontmatter or H1); --property title~= only searches frontmatter.\n\
@@ -281,7 +285,9 @@ pub(crate) enum Commands {
         /// Case-insensitive body text search (searches body only, not frontmatter)
         #[arg(value_name = "PATTERN", conflicts_with = "regexp")]
         pattern: Option<String>,
-        /// Use a saved view (named filter set from .hyalo.toml)
+        /// Use a saved view (named filter set from .hyalo.toml). Additional CLI filters
+        /// are merged on top: list filters (--property, --tag, --section, --glob) extend
+        /// the view; scalar filters (--sort, --limit, --regexp, --title, --task) override it
         #[arg(long, value_name = "NAME")]
         view: Option<String>,
         #[command(flatten)]
@@ -605,7 +611,8 @@ Repeatable (AND).\n\
     #[command(
         long_about = "Manage saved views — named find queries stored in .hyalo.toml.\n\n\
             Views let you save frequently used filter combinations under a name\n\
-            and recall them with `hyalo find --view <name>`.\n\n\
+            and recall them with `hyalo find --view <name>`. CLI flags passed alongside\n\
+            --view are merged on top — list filters extend, scalars override.\n\n\
             Subcommands:\n\
             - list: Show all saved views and their filters.\n\
             - set: Create or update a view.\n\
@@ -649,6 +656,7 @@ pub(crate) enum ViewsAction {
     /// Create or update a saved view
     #[command(long_about = "Save a combination of find filters under a name.\n\n\
         The view is stored in .hyalo.toml and can be recalled with `hyalo find --view <name>`.\n\
+        You can combine --view with additional CLI filters to extend or override the saved set.\n\
         Overwrites if the view already exists.\n\n\
         SIDE EFFECTS: Modifies .hyalo.toml.")]
     Set {

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -273,9 +273,9 @@ pub(crate) enum Commands {
             Properties are a {key: value} map; use --fields properties-typed for [{name, type, value}] array.\n\
             JQ: --jq operates on the full envelope. Examples: --jq '.results[].file', --jq '.total'.\n\
             VIEWS: --view <name> loads a saved filter set from .hyalo.toml. Additional CLI flags \
-merge on top: list filters (--property, --tag, --section, --glob) extend the view's \
-lists; scalar filters (--regexp, --sort, --limit, --title, --task) override; bool \
-flags (--broken-links, --reverse) OR. Example: hyalo find --view drafts --limit 5\n\
+            merge on top: list filters (--property, --tag, --section, --glob) extend the view's \
+            lists; scalar filters (--regexp, --sort, --limit, --title, --task) override; bool \
+            flags (--broken-links, --reverse) OR. Example: hyalo find --view drafts --limit 5\n\
             COMMON MISTAKES:\n\
             - Property regex uses ~= (tilde-equals), NOT =~ (Perl-style). Wrong: 'title=~/pat/', right: 'title~=/pat/'.\n\
             - --title searches the displayed title (frontmatter or H1); --property title~= only searches frontmatter.\n\

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -400,12 +400,33 @@ fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> 
         .collect()
 }
 
+/// Slugify a string to the charset valid for view names: `[a-z0-9_-]`.
+/// Replaces invalid chars with `-`, collapses runs of `-`, and trims leading/trailing `-`.
+fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            // Replace any non-allowed char with a hyphen (collapsed below).
+            if !out.ends_with('-') {
+                out.push('-');
+            }
+        }
+    }
+    out.trim_matches('-').to_owned()
+}
+
 /// Derive a short, human-readable name from the active filters.
 fn auto_view_name(ctx: &HintContext) -> String {
     let mut parts: Vec<String> = Vec::new();
 
     for pf in &ctx.property_filters {
-        if let Some(pos) = pf.find('=') {
+        if let Some(pos) = pf.find("~=") {
+            // Regex filter (K~=pattern): use the key, not the pattern.
+            let key = &pf[..pos];
+            parts.push(key.to_lowercase());
+        } else if let Some(pos) = pf.find('=') {
             let val = &pf[pos + 1..];
             if !val.is_empty() {
                 parts.push(val.to_lowercase());
@@ -423,27 +444,24 @@ fn auto_view_name(ctx: &HintContext) -> String {
         parts.push(task.to_lowercase());
     }
 
-    if ctx.has_regex_search {
-        parts.push("regex".to_owned());
-    }
-
-    let name = parts.join("-");
-    let name: String = name.chars().take(40).collect();
-    if name.is_empty() {
+    let slug = slugify(&parts.join("-"));
+    let truncated: String = slug.chars().take(40).collect();
+    // Trim any trailing `-` left by truncation mid-word.
+    let trimmed = truncated.trim_end_matches('-');
+    if trimmed.is_empty() {
         "my-view".to_owned()
     } else {
-        name
+        trimmed.to_owned()
     }
 }
 
 /// Build the `hyalo views set <name> <filters…>` command string.
 fn build_views_set_command(ctx: &HintContext, view_name: &str) -> String {
-    let mut parts: Vec<String> = vec![
-        "hyalo".to_owned(),
-        "views".to_owned(),
-        "set".to_owned(),
-        shell_quote(view_name),
-    ];
+    let mut parts: Vec<String> = vec!["hyalo".to_owned()];
+    push_global_flags(&mut parts, ctx);
+    parts.push("views".to_owned());
+    parts.push("set".to_owned());
+    parts.push(shell_quote(view_name));
     for pf in &ctx.property_filters {
         parts.push("--property".to_owned());
         parts.push(shell_quote(pf));
@@ -459,17 +477,20 @@ fn build_views_set_command(ctx: &HintContext, view_name: &str) -> String {
     parts.join(" ")
 }
 
-/// Suggest saving the current query as a view when at least two filter
-/// dimensions are active and the query did not itself come from a view.
+/// Suggest saving the current query as a view when at least two
+/// view-serializable filter dimensions are active and the query did not
+/// itself come from a view. Excludes body/regex search since the actual
+/// pattern value is not available in `HintContext`.
 fn suggest_save_as_view(ctx: &HintContext) -> Option<Hint> {
     if ctx.view_name.is_some() {
         return None;
     }
 
-    let filter_count = ctx.property_filters.len()
-        + ctx.tag_filters.len()
-        + usize::from(ctx.task_filter.is_some())
-        + usize::from(ctx.has_regex_search);
+    // Only count filters that can be round-tripped into a `views set` command.
+    // Body/regex search is excluded because HintContext only stores a bool,
+    // not the actual pattern string.
+    let filter_count =
+        ctx.property_filters.len() + ctx.tag_filters.len() + usize::from(ctx.task_filter.is_some());
 
     if filter_count < 2 {
         return None;

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -67,6 +67,10 @@ pub struct HintContext {
     pub tag_filters: Vec<String>,
     pub task_filter: Option<String>,
     pub file_targets: Vec<String>,
+    /// Set when the query was produced by `--view <name>`; suppresses the
+    /// "save as view" hint to avoid suggesting the user save a view they
+    /// already have.
+    pub view_name: Option<String>,
     // Mutation context
     pub dry_run: bool,
     // Index context
@@ -103,6 +107,7 @@ impl HintContext {
             tag_filters: vec![],
             task_filter: None,
             file_targets: vec![],
+            view_name: None,
             dry_run: false,
             index_path: None,
         }
@@ -395,6 +400,86 @@ fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> 
         .collect()
 }
 
+/// Derive a short, human-readable name from the active filters.
+fn auto_view_name(ctx: &HintContext) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    for pf in &ctx.property_filters {
+        if let Some(pos) = pf.find('=') {
+            let val = &pf[pos + 1..];
+            if !val.is_empty() {
+                parts.push(val.to_lowercase());
+            }
+        } else if let Some(stripped) = pf.strip_prefix('!') {
+            parts.push(format!("no-{stripped}"));
+        }
+    }
+
+    for tf in &ctx.tag_filters {
+        parts.push(tf.to_lowercase());
+    }
+
+    if let Some(task) = &ctx.task_filter {
+        parts.push(task.to_lowercase());
+    }
+
+    if ctx.has_regex_search {
+        parts.push("regex".to_owned());
+    }
+
+    let name = parts.join("-");
+    let name: String = name.chars().take(40).collect();
+    if name.is_empty() {
+        "my-view".to_owned()
+    } else {
+        name
+    }
+}
+
+/// Build the `hyalo views set <name> <filters…>` command string.
+fn build_views_set_command(ctx: &HintContext, view_name: &str) -> String {
+    let mut parts: Vec<String> = vec![
+        "hyalo".to_owned(),
+        "views".to_owned(),
+        "set".to_owned(),
+        shell_quote(view_name),
+    ];
+    for pf in &ctx.property_filters {
+        parts.push("--property".to_owned());
+        parts.push(shell_quote(pf));
+    }
+    for tf in &ctx.tag_filters {
+        parts.push("--tag".to_owned());
+        parts.push(shell_quote(tf));
+    }
+    if let Some(task) = &ctx.task_filter {
+        parts.push("--task".to_owned());
+        parts.push(shell_quote(task));
+    }
+    parts.join(" ")
+}
+
+/// Suggest saving the current query as a view when at least two filter
+/// dimensions are active and the query did not itself come from a view.
+fn suggest_save_as_view(ctx: &HintContext) -> Option<Hint> {
+    if ctx.view_name.is_some() {
+        return None;
+    }
+
+    let filter_count = ctx.property_filters.len()
+        + ctx.tag_filters.len()
+        + usize::from(ctx.task_filter.is_some())
+        + usize::from(ctx.has_regex_search);
+
+    if filter_count < 2 {
+        return None;
+    }
+
+    let name = auto_view_name(ctx);
+    let cmd = build_views_set_command(ctx, &name);
+    Some(Hint::new("Save this query as a view", cmd))
+}
+
 fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     // find returns a bare array as the raw command output (the envelope is built later).
     let Some(results) = data.as_array() else {
@@ -547,6 +632,14 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
                     build_find_command_preserving_filters(ctx, &["--limit", "10"]),
                 ));
             }
+        }
+    }
+
+    // Suggest saving as a view for non-trivial queries (independent of result count).
+    if let Some(view_hint) = suggest_save_as_view(ctx) {
+        let remaining = MAX_HINTS.saturating_sub(hints.len());
+        if remaining > 0 {
+            hints.push(view_hint);
         }
     }
 

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -397,6 +397,7 @@ fn run_inner() -> Result<(), AppError> {
             }
             Commands::Find {
                 pattern,
+                view,
                 filters:
                     FindFilters {
                         glob,
@@ -410,7 +411,6 @@ fn run_inner() -> Result<(), AppError> {
                         limit,
                         ..
                     },
-                ..
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Find, &common);
                 ctx.glob.clone_from(glob);
@@ -423,6 +423,7 @@ fn run_inner() -> Result<(), AppError> {
                 ctx.tag_filters.clone_from(tag);
                 ctx.task_filter.clone_from(task);
                 ctx.file_targets.clone_from(file);
+                ctx.view_name.clone_from(view);
                 Some(ctx)
             }
             Commands::Set {

--- a/crates/hyalo-cli/templates/skill-hyalo-tidy.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-tidy.md
@@ -42,6 +42,13 @@ hyalo summary --format text
 
 # 2. Create snapshot index (one scan, reused by all subsequent queries)
 hyalo create-index
+
+# 3. Save recurring diagnostic queries as views for reuse
+hyalo views set stale-in-progress --property status=in-progress --fields tasks
+hyalo views set missing-status --property '!status'
+hyalo views set missing-type --property '!type'
+hyalo views set orphans --fields backlinks
+hyalo views set completed-with-todos --property status=completed --task todo --fields tasks
 ```
 
 The snapshot index captures every file's metadata in a binary file (`.hyalo-index`).
@@ -133,13 +140,13 @@ Focus on **actionable orphans**: active/planned items that should be cross-refer
 ### Stale statuses
 ```bash
 # In-progress items — should any be completed?
-hyalo find --property status=in-progress --index .hyalo-index --jq '.results | map({file, date: .properties.date, branch: .properties.branch})'
+hyalo find --view stale-in-progress --index .hyalo-index --jq '.results | map({file, date: .properties.date, branch: .properties.branch})'
 
 # Planned items where all tasks are done
 hyalo find --property status=planned --index .hyalo-index --jq '.results | map(select((.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)'
 
 # In-progress items sorted by date (oldest first — possibly stale)
-hyalo find --property status=in-progress --index .hyalo-index --jq '.results | map(select(.properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})'
+hyalo find --view stale-in-progress --index .hyalo-index --jq '.results | map(select(.properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})'
 ```
 Cross-reference with git merges from Phase 2. If the branch was merged, update status.
 
@@ -153,8 +160,8 @@ flag it.
 
 ### Missing metadata
 ```bash
-hyalo find --property '!status' --index .hyalo-index --jq 'map(.file)'
-hyalo find --property '!type' --index .hyalo-index --jq 'map(.file)'
+hyalo find --view missing-status --index .hyalo-index --jq '.results | map(.file)'
+hyalo find --view missing-type --index .hyalo-index --jq '.results | map(.file)'
 ```
 
 ### Tag inconsistencies
@@ -166,7 +173,7 @@ more files.
 ### Task completion vs status mismatch
 ```bash
 # Completed items with unchecked tasks — systemic or one-off?
-hyalo find --property status=completed --task todo --index .hyalo-index --jq 'map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})'
+hyalo find --view completed-with-todos --index .hyalo-index --jq 'map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})'
 ```
 If many completed items have unchecked tasks, this is a workflow pattern — note it once
 in the report rather than listing every file.

--- a/crates/hyalo-cli/templates/skill-hyalo-tidy.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-tidy.md
@@ -128,7 +128,7 @@ Note the counts for the health dashboard. Actual fixes happen in Phase 4.
 
 ### Orphan files
 ```bash
-hyalo find --fields backlinks --index .hyalo-index --jq '.results | map(select(.backlinks | length == 0)) | map(.file)'
+hyalo find --view orphans --index .hyalo-index --jq '.results | map(select(.backlinks | length == 0)) | map(.file)'
 ```
 Not all orphans are problems. Expect these to be legitimately orphaned:
 - Top-level files (SEED.md, project-pitch.md, decision-log.md)
@@ -173,7 +173,7 @@ more files.
 ### Task completion vs status mismatch
 ```bash
 # Completed items with unchecked tasks — systemic or one-off?
-hyalo find --view completed-with-todos --index .hyalo-index --jq 'map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})'
+hyalo find --view completed-with-todos --index .hyalo-index --jq '.results | map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})'
 ```
 If many completed items have unchecked tasks, this is a workflow pattern — note it once
 in the report rather than listing every file.

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -171,6 +171,34 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **backlinks** — reverse link lookup: lists all files that link to a given file
 - **create-index** — build a snapshot index for faster repeated read-only queries
 - **drop-index** — delete a snapshot index file created with create-index
+- **views list** — show all saved views and their filters
+- **views set** — save a find query as a named view (`hyalo views set todo --task todo`)
+- **views remove** — delete a saved view
+
+## Views — saved find queries
+
+Views save frequently-used filter combinations under a name in `.hyalo.toml`.
+They compose: CLI flags passed alongside `--view` extend or override the saved filters.
+
+**Before constructing a complex `hyalo find`, check if a matching view exists:**
+```bash
+hyalo views list --format text
+```
+
+**If you run the same multi-filter find command 3+ times, save it as a view:**
+```bash
+hyalo views set stale-iterations --property type=iteration --property status=in-progress
+hyalo find --view stale-iterations                    # reuse later
+hyalo find --view stale-iterations --limit 5          # compose with overrides
+```
+
+hyalo suggests saving non-trivial queries as views in its hint output — follow those hints.
+
+**Manage views:**
+- `hyalo views list` — show all saved views
+- `hyalo views set <name> [filters...]` — create or update a view
+- `hyalo views remove <name>` — delete a view
+- `hyalo find --view <name> [extra filters...]` — use a view, optionally with overrides
 
 ## The --format text flag
 

--- a/crates/hyalo-cli/tests/e2e_views.rs
+++ b/crates/hyalo-cli/tests/e2e_views.rs
@@ -3,6 +3,7 @@ mod common;
 use std::fs;
 
 use common::{hyalo, hyalo_no_hints, write_md};
+use serde_json::Value;
 use tempfile::TempDir;
 
 fn setup() -> TempDir {
@@ -195,5 +196,90 @@ fn views_set_preserves_existing_config() {
     assert!(
         content.contains("[views.drafts]"),
         "view not written: {content}"
+    );
+}
+
+#[test]
+fn hint_suggests_saving_non_trivial_query_as_view() {
+    let tmp = setup();
+    // Two filters = non-trivial → should suggest saving as a view
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args([
+            "find",
+            "--property",
+            "status=draft",
+            "--tag",
+            "project",
+            "--hints",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = json["hints"].as_array().unwrap();
+    let has_view_hint = hints
+        .iter()
+        .any(|h| h["cmd"].as_str().unwrap_or("").contains("views set"));
+    assert!(
+        has_view_hint,
+        "expected 'views set' hint for non-trivial query, got: {hints:?}"
+    );
+}
+
+#[test]
+fn hint_does_not_suggest_view_for_single_filter() {
+    let tmp = setup();
+    // Single filter = trivial → should NOT suggest saving as a view
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["find", "--property", "status=draft", "--hints"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = json["hints"].as_array().unwrap();
+    let has_view_hint = hints
+        .iter()
+        .any(|h| h["cmd"].as_str().unwrap_or("").contains("views set"));
+    assert!(
+        !has_view_hint,
+        "should not suggest view for single-filter query, got: {hints:?}"
+    );
+}
+
+#[test]
+fn hint_does_not_suggest_view_when_using_view() {
+    let tmp = setup();
+    // Create a view with two filters
+    hyalo()
+        .current_dir(tmp.path())
+        .args([
+            "views",
+            "set",
+            "drafts",
+            "--property",
+            "status=draft",
+            "--tag",
+            "project",
+        ])
+        .output()
+        .unwrap();
+
+    // Use it — should NOT suggest saving again
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["find", "--view", "drafts", "--hints"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = json["hints"].as_array().unwrap();
+    let has_view_hint = hints
+        .iter()
+        .any(|h| h["cmd"].as_str().unwrap_or("").contains("views set"));
+    assert!(
+        !has_view_hint,
+        "should not suggest view when already using --view, got: {hints:?}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e_views.rs
+++ b/crates/hyalo-cli/tests/e2e_views.rs
@@ -252,7 +252,7 @@ fn hint_does_not_suggest_view_for_single_filter() {
 fn hint_does_not_suggest_view_when_using_view() {
     let tmp = setup();
     // Create a view with two filters
-    hyalo()
+    let set_output = hyalo()
         .current_dir(tmp.path())
         .args([
             "views",
@@ -265,6 +265,11 @@ fn hint_does_not_suggest_view_when_using_view() {
         ])
         .output()
         .unwrap();
+    assert!(
+        set_output.status.success(),
+        "views set failed: {}",
+        String::from_utf8_lossy(&set_output.stderr)
+    );
 
     // Use it — should NOT suggest saving again
     let output = hyalo()

--- a/hyalo-knowledgebase/iterations/iteration-95-views-for-agents.md
+++ b/hyalo-knowledgebase/iterations/iteration-95-views-for-agents.md
@@ -1,0 +1,34 @@
+---
+title: "Iteration 95: Views for AI Agents"
+type: iteration
+date: 2026-04-03
+status: in-progress
+branch: iter-95/views-for-agents
+tags:
+  - iteration
+  - views
+  - llm
+  - ux
+---
+
+## Goal
+
+Make views a first-class part of the AI agent workflow. Three workstreams:
+1. Hints suggest saving non-trivial find queries as views
+2. Help text clearly communicates view composability
+3. Skill templates teach agents to discover and create views
+
+## Tasks
+
+- [x] Add `view_name: Option<String>` to `HintContext` struct
+- [x] Populate `view_name` in `run.rs` Find arm
+- [x] Implement `suggest_save_as_view()` in `hints.rs`
+- [x] Call the new hint function from `hints_for_find()`
+- [x] Improve `--view` flag help text (composability)
+- [x] Add VIEWS section to find command `long_about`
+- [x] Improve views command and views set `long_about`
+- [x] Add Views section to `skill-hyalo.md` template
+- [x] Update `skill-hyalo-tidy.md` to use views in Phase 1 and Phase 3
+- [x] Add/update tests for the new hint
+- [x] Add e2e test for `--view` composability
+- [x] Run quality gates: fmt, clippy, test


### PR DESCRIPTION
## Summary

- **View hints:** Non-trivial `find` queries (2+ filter dimensions) now suggest saving as a view via hints. Auto-generates a slugified name from the filters (e.g. `completed-iteration`). Suppressed when the query already uses `--view`.
- **Help text:** `--view` flag, `find --help`, `views --help`, and `views set --help` now clearly explain that views compose with additional CLI filters (list filters extend, scalars override, bools OR).
- **Skill templates:** `skill-hyalo.md` teaches agents to check for existing views before building complex finds, and to save repeated queries. `skill-hyalo-tidy.md` saves 5 diagnostic views in Phase 1 and reuses them throughout Phase 3.

## Test plan

- [x] 3 new e2e tests: hint appears for 2+ filters, suppressed for single filter, suppressed when using `--view`
- [x] All 1064 existing tests pass
- [x] Manual verification: `hyalo find --property status=completed --tag iteration --format text` shows "Save this query as a view" hint
- [x] Manual verification: `hyalo find --view <name>` does NOT show the save hint
- [x] `hyalo find --help` shows VIEWS section with merge semantics
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)