### PR TITLE
Add bulk task operations: --all, --section, repeatable --line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ Then use target/release/hyalo to work with the documentation in `./hyalo-knowled
 - **Title regex**: `hyalo find --property 'title~=link' --format text`
 - **Overview**: `hyalo summary`, `hyalo properties`, `hyalo tags`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append` (e.g., `hyalo set --property status=completed --file iterations/iteration-16-robustness.md`)
-- Only fall back to Edit for body content changes (markdown prose, task checkboxes) that hyalo can't handle
+- **Toggle tasks**: `hyalo task toggle --file <path> --all` (whole file), `--section "Tasks"` (by heading), `--line 5,7,9` (specific lines)
+- Only fall back to Edit for body content changes (markdown prose) that hyalo can't handle
 - **Do NOT pass `--dir hyalo-knowledgebase/`** — `.hyalo.toml` already sets it as the default
 - **Follow hints**: hyalo outputs drill-down hints by default — read and follow them to navigate deeper into the knowledgebase. Use `--no-hints` only when you need raw output.
 

--- a/README.md
+++ b/README.md
@@ -425,15 +425,28 @@ hyalo append --property aliases=old-name --where-tag renamed --glob '**/*.md'
 
 ### task
 
-Read, toggle, or set the status of a single task checkbox by line number.
+Read, toggle, or set the status of task checkboxes. Supports three mutually exclusive selectors: `--line` (single, comma-separated, or repeatable), `--section`, and `--all`.
 
 ```sh
-hyalo task read --file path/to/note.md --line 42
-hyalo task toggle --file path/to/note.md --line 42
-hyalo task set-status --file path/to/note.md --line 42 --status /
+# Single task
+hyalo task read --file note.md --line 42
+hyalo task toggle --file note.md --line 42
+
+# Multiple tasks by line number (comma-separated or repeatable)
+hyalo task toggle --file note.md --line 5,7,9
+hyalo task toggle --file note.md --line 5 --line 7 --line 9
+
+# All tasks under a heading (case-insensitive substring, ##-pinned, or /regex/)
+hyalo task toggle --file note.md --section "Acceptance criteria"
+
+# Every task in the file
+hyalo task toggle --file note.md --all
+
+# Set custom status on all tasks in a section
+hyalo task set-status --file note.md --section Tasks --status /
 ```
 
-Tasks are markdown checkboxes (`- [ ]`, `- [x]`, `- [/]`, etc.) in the file body. Checkboxes inside fenced code blocks and `%%comment%%` blocks are ignored.
+Tasks are markdown checkboxes (`- [ ]`, `- [x]`, `- [/]`, etc.) in the file body. Checkboxes inside fenced code blocks and `%%comment%%` blocks are ignored. Bulk mutations use a single atomic read-modify-write pass.
 
 ### backlinks
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -335,17 +335,15 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         action: Option<TagsAction>,
     },
-    /// Read, toggle, or set status on a single task checkbox
-    #[command(
-        long_about = "Read, toggle, or set status on a single task checkbox.\n\n\
+    /// Read, toggle, or set status on task checkboxes (single, bulk, or by section)
+    #[command(long_about = "Read, toggle, or set status on task checkboxes.\n\n\
             Subcommands:\n\
-            - read: Show task details at a specific line number.\n\
+            - read: Show task details for one or more tasks.\n\
             - toggle: Flip completion state ([ ] <-> [x], custom -> [x]).\n\
             - set-status: Set an arbitrary single-character status.\n\n\
-            INPUT: File (--file) and line number (--line).\n\
+            INPUT: --file and one of: --line (repeatable/comma-separated), --section <heading>, or --all.\n\
             SCOPE: Single file only.\n\
-            SIDE EFFECTS: 'toggle' and 'set-status' modify the file on disk. 'read' is read-only."
-    )]
+            SIDE EFFECTS: 'toggle' and 'set-status' modify the file on disk. 'read' is read-only.")]
     Task {
         #[command(subcommand)]
         action: TaskAction,

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -709,52 +709,83 @@ pub(crate) enum LinksAction {
 
 #[derive(Subcommand)]
 pub(crate) enum TaskAction {
-    /// Show task details at a specific line number (read-only)
-    #[command(long_about = "Show task details at a specific line number.\n\n\
-        INPUT: --file and --line (1-based, counting from line 1 of the file including frontmatter).\n\
-        OUTPUT: {\"file\": \"...\", \"line\": N, \"status\": \"x\", \"text\": \"...\", \"done\": true}\n\
+    /// Show task details for one or more tasks (read-only)
+    #[command(long_about = "Show task details for one or more tasks.\n\n\
+        INPUT: --file and one of: --line (repeatable), --section <heading>, or --all.\n\
+        OUTPUT: single task object when one line resolved; {\"results\":[...],\"total\":N} for multiple.\n\
         SIDE EFFECTS: None (read-only).\n\
-        USE WHEN: You need to inspect a task's current status before toggling or updating it.")]
+        USE WHEN: You need to inspect task status before toggling or updating.\n\n\
+        EXAMPLES:\n  \
+          hyalo task read --file note.md --line 5\n  \
+          hyalo task read --file note.md --line 5 --line 7\n  \
+          hyalo task read --file note.md --section Tasks\n  \
+          hyalo task read --file note.md --all")]
     Read {
-        /// File containing the task (relative to --dir)
+        /// File containing the task(s) (relative to --dir)
         #[arg(short, long)]
         file: String,
-        /// 1-based line number of the task (counted from line 1 of the file, including frontmatter). Use 'hyalo find --task todo' to discover task line numbers
-        #[arg(short, long)]
-        line: usize,
+        /// 1-based line number of a task. Repeatable: --line 5 --line 7
+        #[arg(short, long, action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
+        line: Vec<usize>,
+        /// Select all tasks under a heading (case-insensitive substring, ##-pinned, or /regex/)
+        #[arg(long, conflicts_with_all = ["line", "all"])]
+        section: Option<String>,
+        /// Select all tasks in the file
+        #[arg(long, conflicts_with_all = ["line", "section"])]
+        all: bool,
     },
     /// Toggle task completion: [ ] -> [x], [x]/[X] -> [ ], custom -> [x]
     #[command(
         long_about = "Toggle task completion: [ ] -> [x], [x]/[X] -> [ ], custom -> [x].\n\n\
-        INPUT: --file and --line (1-based, counting from line 1 of the file including frontmatter).\n\
-        OUTPUT: {\"file\": \"...\", \"line\": N, \"status\": \"x\", \"text\": \"...\", \"done\": true}\n\
+        INPUT: --file and one of: --line (repeatable), --section <heading>, or --all.\n\
+        OUTPUT: single task object when one line resolved; {\"results\":[...],\"total\":N} for multiple.\n\
         SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
-        USE WHEN: You need to mark a task as done or re-open a completed task."
+        USE WHEN: You need to mark tasks as done or re-open completed tasks.\n\n\
+        EXAMPLES:\n  \
+          hyalo task toggle --file note.md --line 5\n  \
+          hyalo task toggle --file note.md --section Tasks\n  \
+          hyalo task toggle --file note.md --all"
     )]
     Toggle {
-        /// File containing the task (relative to --dir)
+        /// File containing the task(s) (relative to --dir)
         #[arg(short, long)]
         file: String,
-        /// 1-based line number of the task (counted from line 1 of the file, including frontmatter). Use 'hyalo find --task todo' to discover task line numbers
-        #[arg(short, long)]
-        line: usize,
+        /// 1-based line number of a task. Repeatable: --line 5 --line 7
+        #[arg(short, long, action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
+        line: Vec<usize>,
+        /// Select all tasks under a heading (case-insensitive substring, ##-pinned, or /regex/)
+        #[arg(long, conflicts_with_all = ["line", "all"])]
+        section: Option<String>,
+        /// Select all tasks in the file
+        #[arg(long, conflicts_with_all = ["line", "section"])]
+        all: bool,
     },
-    /// Set a custom single-character status on a task
+    /// Set a custom single-character status on one or more tasks
     #[command(
         name = "set-status",
-        long_about = "Set a custom single-character status on a task checkbox.\n\n\
-        INPUT: --file, --line (1-based, counting from line 1 of the file including frontmatter), and --status (single char).\n\
-        OUTPUT: {\"file\": \"...\", \"line\": N, \"status\": \"?\", \"text\": \"...\", \"done\": false}\n\
+        long_about = "Set a custom single-character status on one or more task checkboxes.\n\n\
+        INPUT: --file, --status (single char), and one of: --line (repeatable), --section <heading>, or --all.\n\
+        OUTPUT: single task object when one line resolved; {\"results\":[...],\"total\":N} for multiple.\n\
         SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
-        USE WHEN: You need to set a non-standard status like '?' (question), '-' (cancelled), or '!' (important)."
+        USE WHEN: You need to set a non-standard status like '?' (question), '-' (cancelled), or '!' (important).\n\n\
+        EXAMPLES:\n  \
+          hyalo task set-status --file note.md --line 5 --status '?'\n  \
+          hyalo task set-status --file note.md --section Tasks --status '-'\n  \
+          hyalo task set-status --file note.md --all --status x"
     )]
     SetStatus {
-        /// File containing the task (relative to --dir)
+        /// File containing the task(s) (relative to --dir)
         #[arg(short, long)]
         file: String,
-        /// 1-based line number of the task (counted from line 1 of the file, including frontmatter). Use 'hyalo find --task todo' to discover task line numbers
-        #[arg(short, long)]
-        line: usize,
+        /// 1-based line number of a task. Repeatable: --line 5 --line 7
+        #[arg(short, long, action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
+        line: Vec<usize>,
+        /// Select all tasks under a heading (case-insensitive substring, ##-pinned, or /regex/)
+        #[arg(long, conflicts_with_all = ["line", "all"])]
+        section: Option<String>,
+        /// Select all tasks in the file
+        #[arg(long, conflicts_with_all = ["line", "section"])]
+        all: bool,
         /// Single character to set as the task status (e.g. '?', '-', '!')
         #[arg(short, long)]
         status: String,

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -712,7 +712,7 @@ pub(crate) enum TaskAction {
     /// Show task details for one or more tasks (read-only)
     #[command(long_about = "Show task details for one or more tasks.\n\n\
         INPUT: --file and one of: --line (repeatable), --section <heading>, or --all.\n\
-        OUTPUT: single task object when one line resolved; {\"results\":[...],\"total\":N} for multiple.\n\
+        OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
         SIDE EFFECTS: None (read-only).\n\
         USE WHEN: You need to inspect task status before toggling or updating.\n\n\
         EXAMPLES:\n  \
@@ -738,7 +738,7 @@ pub(crate) enum TaskAction {
     #[command(
         long_about = "Toggle task completion: [ ] -> [x], [x]/[X] -> [ ], custom -> [x].\n\n\
         INPUT: --file and one of: --line (repeatable), --section <heading>, or --all.\n\
-        OUTPUT: single task object when one line resolved; {\"results\":[...],\"total\":N} for multiple.\n\
+        OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
         SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
         USE WHEN: You need to mark tasks as done or re-open completed tasks.\n\n\
         EXAMPLES:\n  \
@@ -766,7 +766,7 @@ pub(crate) enum TaskAction {
         name = "set-status",
         long_about = "Set a custom single-character status on one or more task checkboxes.\n\n\
         INPUT: --file, --status (single char), and one of: --line (repeatable), --section <heading>, or --all.\n\
-        OUTPUT: single task object when one line resolved; {\"results\":[...],\"total\":N} for multiple.\n\
+        OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
         SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
         USE WHEN: You need to set a non-standard status like '?' (question), '-' (cancelled), or '!' (important).\n\n\
         EXAMPLES:\n  \

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -717,15 +717,15 @@ pub(crate) enum TaskAction {
         USE WHEN: You need to inspect task status before toggling or updating.\n\n\
         EXAMPLES:\n  \
           hyalo task read --file note.md --line 5\n  \
-          hyalo task read --file note.md --line 5 --line 7\n  \
+          hyalo task read --file note.md --line 5,7,9\n  \
           hyalo task read --file note.md --section Tasks\n  \
           hyalo task read --file note.md --all")]
     Read {
         /// File containing the task(s) (relative to --dir)
         #[arg(short, long)]
         file: String,
-        /// 1-based line number of a task. Repeatable: --line 5 --line 7
-        #[arg(short, long, action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
+        /// 1-based line number(s). Comma-separated or repeatable: --line 5,7,9 or --line 5 --line 7
+        #[arg(short, long, value_delimiter = ',', action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
         line: Vec<usize>,
         /// Select all tasks under a heading (case-insensitive substring, ##-pinned, or /regex/)
         #[arg(long, conflicts_with_all = ["line", "all"])]
@@ -743,6 +743,7 @@ pub(crate) enum TaskAction {
         USE WHEN: You need to mark tasks as done or re-open completed tasks.\n\n\
         EXAMPLES:\n  \
           hyalo task toggle --file note.md --line 5\n  \
+          hyalo task toggle --file note.md --line 5,7,9\n  \
           hyalo task toggle --file note.md --section Tasks\n  \
           hyalo task toggle --file note.md --all"
     )]
@@ -750,8 +751,8 @@ pub(crate) enum TaskAction {
         /// File containing the task(s) (relative to --dir)
         #[arg(short, long)]
         file: String,
-        /// 1-based line number of a task. Repeatable: --line 5 --line 7
-        #[arg(short, long, action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
+        /// 1-based line number(s). Comma-separated or repeatable: --line 5,7,9 or --line 5 --line 7
+        #[arg(short, long, value_delimiter = ',', action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
         line: Vec<usize>,
         /// Select all tasks under a heading (case-insensitive substring, ##-pinned, or /regex/)
         #[arg(long, conflicts_with_all = ["line", "all"])]
@@ -770,6 +771,7 @@ pub(crate) enum TaskAction {
         USE WHEN: You need to set a non-standard status like '?' (question), '-' (cancelled), or '!' (important).\n\n\
         EXAMPLES:\n  \
           hyalo task set-status --file note.md --line 5 --status '?'\n  \
+          hyalo task set-status --file note.md --line 5,7 --status '-'\n  \
           hyalo task set-status --file note.md --section Tasks --status '-'\n  \
           hyalo task set-status --file note.md --all --status x"
     )]
@@ -777,8 +779,8 @@ pub(crate) enum TaskAction {
         /// File containing the task(s) (relative to --dir)
         #[arg(short, long)]
         file: String,
-        /// 1-based line number of a task. Repeatable: --line 5 --line 7
-        #[arg(short, long, action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
+        /// 1-based line number(s). Comma-separated or repeatable: --line 5,7,9 or --line 5 --line 7
+        #[arg(short, long, value_delimiter = ',', action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
         line: Vec<usize>,
         /// Select all tasks under a heading (case-insensitive substring, ##-pinned, or /regex/)
         #[arg(long, conflicts_with_all = ["line", "all"])]

--- a/crates/hyalo-cli/src/commands/tasks.rs
+++ b/crates/hyalo-cli/src/commands/tasks.rs
@@ -68,8 +68,7 @@ fn resolve_task_lines(
 }
 
 /// Format results: single object when exactly 1 task, Vec when multiple.
-/// `format_output` wraps in the standard `{"results": ..., "hints": [...]}` envelope,
-/// so we just pass the raw value (single object or Vec).
+/// The output pipeline later wraps this in the `{"results": ..., "hints": [...]}` envelope.
 fn format_results(results: &[TaskReadResult], format: Format) -> String {
     if let [single] = results {
         crate::output::format_output(format, single)

--- a/crates/hyalo-cli/src/commands/tasks.rs
+++ b/crates/hyalo-cli/src/commands/tasks.rs
@@ -1,22 +1,94 @@
 #![allow(clippy::missing_errors_doc)]
-use anyhow::Result;
+use anyhow::{Result, bail};
 use std::path::Path;
 
 use crate::commands::resolve_error_to_outcome;
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::discovery;
+use hyalo_core::heading::{SectionFilter, parse_atx_heading};
 use hyalo_core::index::{SnapshotIndex, format_modified};
 use hyalo_core::types::{TaskInfo, TaskReadResult};
 
 // ---------------------------------------------------------------------------
-// `hyalo task read` — read single task at a line
+// Output types
 // ---------------------------------------------------------------------------
 
-/// Read the task at a specific 1-based line number in a single file.
+// ---------------------------------------------------------------------------
+// Selector resolution
+// ---------------------------------------------------------------------------
+
+/// Resolve task selectors to a sorted, deduplicated list of 1-based line numbers.
+fn resolve_task_lines(
+    full_path: &Path,
+    lines: &[usize],
+    section: Option<&str>,
+    all: bool,
+) -> Result<Vec<usize>> {
+    if !lines.is_empty() {
+        let mut sorted = lines.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        return Ok(sorted);
+    }
+
+    if let Some(section_str) = section {
+        let filter = SectionFilter::parse(section_str)
+            .map_err(|e| anyhow::anyhow!("invalid --section: {e}"))?;
+        let tasks = hyalo_core::tasks::find_task_lines(full_path)?;
+        let matched: Vec<usize> = tasks
+            .iter()
+            .filter(|t| {
+                // t.section is formatted as "## heading text" — parse it back
+                if t.section.is_empty() {
+                    return false;
+                }
+                if let Some((level, text)) = parse_atx_heading(&t.section) {
+                    filter.matches(level, text)
+                } else {
+                    false
+                }
+            })
+            .map(|t| t.line)
+            .collect();
+        if matched.is_empty() {
+            bail!("no tasks found in section {section_str:?}");
+        }
+        return Ok(matched);
+    }
+
+    if all {
+        let tasks = hyalo_core::tasks::find_task_lines(full_path)?;
+        if tasks.is_empty() {
+            bail!("no tasks found in file");
+        }
+        return Ok(tasks.iter().map(|t| t.line).collect());
+    }
+
+    bail!("specify at least one of --line, --section, or --all")
+}
+
+/// Format results: single object when exactly 1 task, Vec when multiple.
+/// `format_output` wraps in the standard `{"results": ..., "hints": [...]}` envelope,
+/// so we just pass the raw value (single object or Vec).
+fn format_results(results: &[TaskReadResult], format: Format) -> String {
+    if let [single] = results {
+        crate::output::format_output(format, single)
+    } else {
+        crate::output::format_output(format, &results)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `hyalo task read` — read task(s) at given line(s)
+// ---------------------------------------------------------------------------
+
+/// Read one or more tasks by line selector.
 pub fn task_read(
     dir: &Path,
     file_arg: &str,
-    line: usize,
+    lines: &[usize],
+    section: Option<&str>,
+    all: bool,
     format: Format,
 ) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match discovery::resolve_file(dir, file_arg) {
@@ -24,9 +96,10 @@ pub fn task_read(
         Err(e) => return Ok(resolve_error_to_outcome(e, format)),
     };
 
-    match hyalo_core::tasks::read_task(&full_path, line)? {
-        None => {
-            let msg = format!("line {line} is not a task");
+    let resolved = match resolve_task_lines(&full_path, lines, section, all) {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = e.to_string();
             let out = crate::output::format_error(
                 format,
                 &msg,
@@ -36,32 +109,53 @@ pub fn task_read(
                 ),
                 None,
             );
-            Ok(CommandOutcome::UserError(out))
+            return Ok(CommandOutcome::UserError(out));
         }
-        Some(info) => {
-            let result = TaskReadResult {
-                file: rel_path,
-                line: info.line,
-                status: info.status,
-                text: info.text,
-                done: info.done,
-            };
-            Ok(CommandOutcome::success(crate::output::format_output(
-                format, &result,
-            )))
+    };
+
+    let mut results = Vec::with_capacity(resolved.len());
+    for line in resolved {
+        match hyalo_core::tasks::read_task(&full_path, line)? {
+            None => {
+                let msg = format!("line {line} is not a task");
+                let out = crate::output::format_error(
+                    format,
+                    &msg,
+                    Some(&rel_path),
+                    Some(
+                        "use `hyalo find --task any --file <path>` to list all tasks with their line numbers",
+                    ),
+                    None,
+                );
+                return Ok(CommandOutcome::UserError(out));
+            }
+            Some(info) => {
+                results.push(TaskReadResult {
+                    file: rel_path.clone(),
+                    line: info.line,
+                    status: info.status,
+                    text: info.text,
+                    done: info.done,
+                });
+            }
         }
     }
+
+    Ok(CommandOutcome::success(format_results(&results, format)))
 }
 
 // ---------------------------------------------------------------------------
 // `hyalo task toggle` — toggle task completion
 // ---------------------------------------------------------------------------
 
-/// Toggle task completion at a specific 1-based line number.
+/// Toggle one or more tasks by line selector.
+#[allow(clippy::too_many_arguments)]
 pub fn task_toggle(
     dir: &Path,
     file_arg: &str,
-    line: usize,
+    lines: &[usize],
+    section: Option<&str>,
+    all: bool,
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
@@ -71,19 +165,36 @@ pub fn task_toggle(
         Err(e) => return Ok(resolve_error_to_outcome(e, format)),
     };
 
-    match hyalo_core::tasks::toggle_task(&full_path, line) {
-        Ok(info) => {
-            patch_index(&full_path, &rel_path, &info, snapshot_index, index_path)?;
-            let result = TaskReadResult {
-                file: rel_path,
-                line: info.line,
-                status: info.status,
-                text: info.text,
-                done: info.done,
-            };
-            Ok(CommandOutcome::success(crate::output::format_output(
-                format, &result,
-            )))
+    let resolved = match resolve_task_lines(&full_path, lines, section, all) {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = e.to_string();
+            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                format,
+                &msg,
+                Some(&rel_path),
+                None,
+                None,
+            )));
+        }
+    };
+
+    match hyalo_core::tasks::toggle_tasks(&full_path, &resolved) {
+        Ok(infos) => {
+            for info in &infos {
+                patch_index(&full_path, &rel_path, info, snapshot_index, index_path)?;
+            }
+            let results: Vec<TaskReadResult> = infos
+                .into_iter()
+                .map(|info| TaskReadResult {
+                    file: rel_path.clone(),
+                    line: info.line,
+                    status: info.status,
+                    text: info.text,
+                    done: info.done,
+                })
+                .collect();
+            Ok(CommandOutcome::success(format_results(&results, format)))
         }
         Err(e) => {
             let msg = e.to_string();
@@ -102,11 +213,14 @@ pub fn task_toggle(
 // `hyalo task set-status` — set custom status character
 // ---------------------------------------------------------------------------
 
-/// Set a custom single-character status on a task at a specific 1-based line number.
+/// Set status on one or more tasks by line selector.
+#[allow(clippy::too_many_arguments)]
 pub fn task_set_status(
     dir: &Path,
     file_arg: &str,
-    line: usize,
+    lines: &[usize],
+    section: Option<&str>,
+    all: bool,
     status: char,
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
@@ -117,19 +231,36 @@ pub fn task_set_status(
         Err(e) => return Ok(resolve_error_to_outcome(e, format)),
     };
 
-    match hyalo_core::tasks::set_task_status(&full_path, line, status) {
-        Ok(info) => {
-            patch_index(&full_path, &rel_path, &info, snapshot_index, index_path)?;
-            let result = TaskReadResult {
-                file: rel_path,
-                line: info.line,
-                status: info.status,
-                text: info.text,
-                done: info.done,
-            };
-            Ok(CommandOutcome::success(crate::output::format_output(
-                format, &result,
-            )))
+    let resolved = match resolve_task_lines(&full_path, lines, section, all) {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = e.to_string();
+            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                format,
+                &msg,
+                Some(&rel_path),
+                None,
+                None,
+            )));
+        }
+    };
+
+    match hyalo_core::tasks::set_tasks_status(&full_path, &resolved, status) {
+        Ok(infos) => {
+            for info in &infos {
+                patch_index(&full_path, &rel_path, info, snapshot_index, index_path)?;
+            }
+            let results: Vec<TaskReadResult> = infos
+                .into_iter()
+                .map(|info| TaskReadResult {
+                    file: rel_path.clone(),
+                    line: info.line,
+                    status: info.status,
+                    text: info.text,
+                    done: info.done,
+                })
+                .collect();
+            Ok(CommandOutcome::success(format_results(&results, format)))
         }
         Err(e) => {
             let msg = e.to_string();
@@ -212,7 +343,9 @@ mod tests {
     fn task_read_finds_task() {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "- [ ] My task\n").unwrap();
-        let out = unwrap_success(task_read(tmp.path(), "note.md", 1, Format::Json).unwrap());
+        let out = unwrap_success(
+            task_read(tmp.path(), "note.md", &[1], None, false, Format::Json).unwrap(),
+        );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["line"], 1);
         assert_eq!(parsed["status"], " ");
@@ -225,14 +358,14 @@ mod tests {
     fn task_read_non_task_line_returns_user_error() {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "Just a regular line\n").unwrap();
-        let outcome = task_read(tmp.path(), "note.md", 1, Format::Json).unwrap();
+        let outcome = task_read(tmp.path(), "note.md", &[1], None, false, Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
     #[test]
     fn task_read_file_not_found() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome = task_read(tmp.path(), "nope.md", 1, Format::Json).unwrap();
+        let outcome = task_read(tmp.path(), "nope.md", &[1], None, false, Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -243,7 +376,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "- [ ] My task\n").unwrap();
         let out = unwrap_success(
-            task_toggle(tmp.path(), "note.md", 1, Format::Json, &mut None, None).unwrap(),
+            task_toggle(
+                tmp.path(),
+                "note.md",
+                &[1],
+                None,
+                false,
+                Format::Json,
+                &mut None,
+                None,
+            )
+            .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["status"], "x");
@@ -258,7 +401,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "- [x] Done task\n").unwrap();
         let out = unwrap_success(
-            task_toggle(tmp.path(), "note.md", 1, Format::Json, &mut None, None).unwrap(),
+            task_toggle(
+                tmp.path(),
+                "note.md",
+                &[1],
+                None,
+                false,
+                Format::Json,
+                &mut None,
+                None,
+            )
+            .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["status"], " ");
@@ -269,7 +422,17 @@ mod tests {
     fn task_toggle_non_task_returns_user_error() {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "Not a task\n").unwrap();
-        let outcome = task_toggle(tmp.path(), "note.md", 1, Format::Json, &mut None, None).unwrap();
+        let outcome = task_toggle(
+            tmp.path(),
+            "note.md",
+            &[1],
+            None,
+            false,
+            Format::Json,
+            &mut None,
+            None,
+        )
+        .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -280,7 +443,18 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "- [ ] My task\n").unwrap();
         let out = unwrap_success(
-            task_set_status(tmp.path(), "note.md", 1, '?', Format::Json, &mut None, None).unwrap(),
+            task_set_status(
+                tmp.path(),
+                "note.md",
+                &[1],
+                None,
+                false,
+                '?',
+                Format::Json,
+                &mut None,
+                None,
+            )
+            .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["status"], "?");
@@ -295,7 +469,18 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "- [ ] My task\n").unwrap();
         let out = unwrap_success(
-            task_set_status(tmp.path(), "note.md", 1, 'x', Format::Json, &mut None, None).unwrap(),
+            task_set_status(
+                tmp.path(),
+                "note.md",
+                &[1],
+                None,
+                false,
+                'x',
+                Format::Json,
+                &mut None,
+                None,
+            )
+            .unwrap(),
         );
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["status"], "x");
@@ -306,8 +491,18 @@ mod tests {
     fn task_set_status_non_task_returns_user_error() {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("note.md"), "# Heading\n").unwrap();
-        let outcome =
-            task_set_status(tmp.path(), "note.md", 1, 'x', Format::Json, &mut None, None).unwrap();
+        let outcome = task_set_status(
+            tmp.path(),
+            "note.md",
+            &[1],
+            None,
+            false,
+            'x',
+            Format::Json,
+            &mut None,
+            None,
+        )
+        .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 }

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -284,18 +284,41 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             }
         }
         Commands::Task { action } => match action {
-            TaskAction::Read { file, line } => {
-                task_commands::task_read(dir, &file, line, effective_format)
-            }
-            TaskAction::Toggle { file, line } => task_commands::task_toggle(
+            TaskAction::Read {
+                file,
+                line,
+                section,
+                all,
+            } => task_commands::task_read(
                 dir,
                 &file,
+                &line,
+                section.as_deref(),
+                all,
+                effective_format,
+            ),
+            TaskAction::Toggle {
+                file,
                 line,
+                section,
+                all,
+            } => task_commands::task_toggle(
+                dir,
+                &file,
+                &line,
+                section.as_deref(),
+                all,
                 effective_format,
                 snapshot_index,
                 index_path,
             ),
-            TaskAction::SetStatus { file, line, status } => {
+            TaskAction::SetStatus {
+                file,
+                line,
+                section,
+                all,
+                status,
+            } => {
                 if status.chars().count() != 1 {
                     let out = crate::output::format_error(
                         effective_format,
@@ -314,7 +337,9 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 task_commands::task_set_status(
                     dir,
                     &file,
-                    line,
+                    &line,
+                    section.as_deref(),
+                    all,
                     ch,
                     effective_format,
                     snapshot_index,

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -909,7 +909,12 @@ fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
                 }
             }
         }
-        return hints;
+        // For "all" and "section:" selectors, return early — the bulk hints are sufficient.
+        // For "lines" selector, fall through to the single-task hint path which handles
+        // individual line-based suggestions.
+        if selector != "lines" {
+            return hints;
+        }
     }
 
     // Single-task read path (backward compatible).

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -67,10 +67,14 @@ pub struct HintContext {
     pub tag_filters: Vec<String>,
     pub task_filter: Option<String>,
     pub file_targets: Vec<String>,
+    pub section_filters: Vec<String>,
     /// Set when the query was produced by `--view <name>`; suppresses the
     /// "save as view" hint to avoid suggesting the user save a view they
     /// already have.
     pub view_name: Option<String>,
+    /// Task selector used: "all", "section:<name>", or "lines" (for multi-line).
+    /// `None` means single-line or no task context.
+    pub task_selector: Option<String>,
     // Mutation context
     pub dry_run: bool,
     // Index context
@@ -107,7 +111,9 @@ impl HintContext {
             tag_filters: vec![],
             task_filter: None,
             file_targets: vec![],
+            section_filters: vec![],
             view_name: None,
+            task_selector: None,
             dry_run: false,
             index_path: None,
         }
@@ -533,6 +539,40 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         ));
     }
 
+    // --- Task bulk operation hints ---
+    // When find results target a single file and include task data, suggest bulk task ops.
+    if ctx.file_targets.len() == 1 {
+        let file = &ctx.file_targets[0];
+        let has_open_tasks = results.iter().any(|item| {
+            item.get("tasks")
+                .and_then(|t| t.as_array())
+                .is_some_and(|tasks| {
+                    tasks
+                        .iter()
+                        .any(|t| t.get("done") == Some(&serde_json::Value::Bool(false)))
+                })
+        });
+        if has_open_tasks {
+            let remaining = MAX_HINTS.saturating_sub(hints.len());
+            if remaining > 0 {
+                if let Some(section) = ctx.section_filters.first() {
+                    hints.push(Hint::new(
+                        format!("Toggle all tasks in section \"{section}\""),
+                        build_command_no_glob(
+                            ctx,
+                            &["task", "toggle", "--file", file, "--section", section],
+                        ),
+                    ));
+                } else {
+                    hints.push(Hint::new(
+                        "Toggle all tasks in this file",
+                        build_command_no_glob(ctx, &["task", "toggle", "--file", file, "--all"]),
+                    ));
+                }
+            }
+        }
+    }
+
     // --- Broad query → suggest summary ---
     let has_no_filters = ctx.property_filters.is_empty()
         && ctx.tag_filters.is_empty()
@@ -832,10 +872,47 @@ fn hints_for_mv(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     hints
 }
 
+/// Check if task output data (single or array) contains any open (not done) tasks.
+fn task_result_has_open(data: &serde_json::Value) -> bool {
+    // Array case (bulk result)
+    if let Some(arr) = data.as_array() {
+        return arr
+            .iter()
+            .any(|t| t.get("done") == Some(&serde_json::Value::Bool(false)));
+    }
+    // Single task case
+    data.get("done") == Some(&serde_json::Value::Bool(false))
+}
+
 /// Hints for `task read` — suggest toggling or viewing remaining tasks.
 fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let mut hints = Vec::new();
 
+    // For bulk reads (--all / --section), suggest toggling the same scope.
+    if let Some(selector) = &ctx.task_selector {
+        if let Some(file) = ctx.file_targets.first() {
+            let has_open = task_result_has_open(data);
+            if has_open {
+                if selector == "all" {
+                    hints.push(Hint::new(
+                        "Toggle all tasks in this file",
+                        build_command_no_glob(ctx, &["task", "toggle", "--file", file, "--all"]),
+                    ));
+                } else if let Some(section) = selector.strip_prefix("section:") {
+                    hints.push(Hint::new(
+                        format!("Toggle all tasks in section \"{section}\""),
+                        build_command_no_glob(
+                            ctx,
+                            &["task", "toggle", "--file", file, "--section", section],
+                        ),
+                    ));
+                }
+            }
+        }
+        return hints;
+    }
+
+    // Single-task read path (backward compatible).
     let file = data.get("file").and_then(|f| f.as_str());
     let line = data.get("line").and_then(serde_json::Value::as_u64);
     let done = data
@@ -871,9 +948,31 @@ fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
 fn hints_for_task_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let mut hints = Vec::new();
 
-    let file = data.get("file").and_then(|f| f.as_str());
+    let file = ctx
+        .file_targets
+        .first()
+        .map(String::as_str)
+        .or_else(|| data.get("file").and_then(|f| f.as_str()));
 
     if let Some(file) = file {
+        // Suggest reading the scope that was just mutated.
+        if let Some(selector) = &ctx.task_selector {
+            if selector == "all" {
+                hints.push(Hint::new(
+                    "Read all tasks in this file",
+                    build_command_no_glob(ctx, &["task", "read", "--file", file, "--all"]),
+                ));
+            } else if let Some(section) = selector.strip_prefix("section:") {
+                hints.push(Hint::new(
+                    format!("Read tasks in section \"{section}\""),
+                    build_command_no_glob(
+                        ctx,
+                        &["task", "read", "--file", file, "--section", section],
+                    ),
+                ));
+            }
+        }
+
         hints.push(Hint::new(
             "See remaining open tasks",
             build_command_no_glob(

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -12,6 +12,19 @@ use crate::output::{CommandOutcome, Format};
 use crate::output_pipeline::{COUNT_UNSUPPORTED_ERROR, OutputPipeline};
 use hyalo_core::index::SnapshotIndex;
 
+/// Derive the task selector string for hint context.
+fn task_selector(line: &[usize], section: Option<&String>, all: bool) -> Option<String> {
+    if all {
+        Some("all".to_owned())
+    } else if let Some(s) = section {
+        Some(format!("section:{s}"))
+    } else if line.len() > 1 {
+        Some("lines".to_owned())
+    } else {
+        None
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn run() {
     match run_inner() {
@@ -371,6 +384,7 @@ fn run_inner() -> Result<(), AppError> {
                         fields,
                         sort,
                         limit,
+                        sections,
                         ..
                     },
             } => {
@@ -385,6 +399,7 @@ fn run_inner() -> Result<(), AppError> {
                 ctx.tag_filters.clone_from(tag);
                 ctx.task_filter.clone_from(task);
                 ctx.file_targets.clone_from(file);
+                ctx.section_filters.clone_from(sections);
                 ctx.view_name.clone_from(view);
                 Some(ctx)
             }
@@ -440,23 +455,45 @@ fn run_inner() -> Result<(), AppError> {
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
-            Commands::Task { action } => match action {
-                crate::cli::args::TaskAction::Toggle { file, .. } => {
-                    let mut ctx = HintContext::from_common(HintSource::TaskToggle, &common);
-                    ctx.file_targets = vec![file.clone()];
-                    Some(ctx)
-                }
-                crate::cli::args::TaskAction::SetStatus { file, .. } => {
-                    let mut ctx = HintContext::from_common(HintSource::TaskSetStatus, &common);
-                    ctx.file_targets = vec![file.clone()];
-                    Some(ctx)
-                }
-                crate::cli::args::TaskAction::Read { file, .. } => {
-                    let mut ctx = HintContext::from_common(HintSource::TaskRead, &common);
-                    ctx.file_targets = vec![file.clone()];
-                    Some(ctx)
-                }
-            },
+            Commands::Task { action } => {
+                let (source, file, selector) = match action {
+                    crate::cli::args::TaskAction::Toggle {
+                        file,
+                        line,
+                        section,
+                        all,
+                    } => (
+                        HintSource::TaskToggle,
+                        file,
+                        task_selector(line, section.as_ref(), *all),
+                    ),
+                    crate::cli::args::TaskAction::SetStatus {
+                        file,
+                        line,
+                        section,
+                        all,
+                        ..
+                    } => (
+                        HintSource::TaskSetStatus,
+                        file,
+                        task_selector(line, section.as_ref(), *all),
+                    ),
+                    crate::cli::args::TaskAction::Read {
+                        file,
+                        line,
+                        section,
+                        all,
+                    } => (
+                        HintSource::TaskRead,
+                        file,
+                        task_selector(line, section.as_ref(), *all),
+                    ),
+                };
+                let mut ctx = HintContext::from_common(source, &common);
+                ctx.file_targets = vec![file.clone()];
+                ctx.task_selector = selector;
+                Some(ctx)
+            }
             Commands::Links { action } => match action {
                 crate::cli::args::LinksAction::Fix { apply, glob, .. } => {
                     let mut ctx = HintContext::from_common(HintSource::LinksFix, &common);

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -166,7 +166,7 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates; `--property 'K=[a,b,c]'` creates YAML sequences; `--file` is repeatable)
 - **remove** — delete properties or tags
 - **append** — add to list properties
-- **task** — read, toggle, or set status on checkboxes
+- **task** — read, toggle, or set status on checkboxes (supports `--line 5,7`, `--section "Tasks"`, `--all`)
 - **mv** — move/rename a file and rewrite all inbound links across the vault (`--dry-run` to preview)
 - **backlinks** — reverse link lookup: lists all files that link to a given file
 - **create-index** — build a snapshot index for faster repeated read-only queries

--- a/crates/hyalo-cli/tests/e2e_help.rs
+++ b/crates/hyalo-cli/tests/e2e_help.rs
@@ -88,7 +88,7 @@ fn subcommand_help_unchanged_by_enriched_root() {
     let stdout = String::from_utf8(output.stdout).unwrap();
 
     assert!(
-        stdout.contains("Read, toggle, or set status on a single task"),
+        stdout.contains("Read, toggle, or set status on task checkboxes"),
         "subcommand --help should contain its own long_about"
     );
     assert!(

--- a/crates/hyalo-cli/tests/e2e_task.rs
+++ b/crates/hyalo-cli/tests/e2e_task.rs
@@ -742,7 +742,7 @@ fn task_toggle_all() {
     assert!(status.success(), "stderr: {stderr}");
 
     let results = json["results"].as_array().expect("expected results array");
-    // 5 tasks total in the file: Task A, Task B, AC one, AC two, AC three, Other task = 6
+    // 6 tasks total in the file: Task A, Task B, AC one, AC two, AC three, Other task
     assert_eq!(results.len(), 6, "expected 6 tasks in file");
 
     let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
@@ -852,12 +852,16 @@ fn task_single_line_returns_flat_object() {
     assert!(status.success(), "stderr: {stderr}");
 
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    // Should NOT have a "results" key — it's a flat object
+    // Single-line result is still wrapped in the output envelope with a "results" key,
+    // but the value is a single object (not an array).
     assert!(
         json.get("results").is_some(),
         "single-line result should be in envelope with results"
     );
-    // The results field should be the task itself (not an array)
+    assert!(
+        !json["results"].is_array(),
+        "single-line result should be a flat object, not an array"
+    );
     assert_eq!(json["results"]["text"], "Task A");
 }
 

--- a/crates/hyalo-cli/tests/e2e_task.rs
+++ b/crates/hyalo-cli/tests/e2e_task.rs
@@ -440,6 +440,405 @@ fn task_set_status_empty_string_exits_1() {
 }
 
 // ---------------------------------------------------------------------------
+// Bulk operations fixture
+// ---------------------------------------------------------------------------
+
+/// Multi-section fixture for bulk operation tests.
+///
+/// ```text
+///  1: ---
+///  2: title: Bulk Test
+///  3: ---
+///  4: # Tasks
+///  5: - [ ] Task A
+///  6: - [ ] Task B
+///  7:
+///  8: ## Acceptance criteria
+///  9: - [ ] AC one
+/// 10: - [ ] AC two
+/// 11: - [x] AC three
+/// 12:
+/// 13: ## Other section
+/// 14: - [ ] Other task
+/// ```
+fn setup_bulk_file(tmp: &tempfile::TempDir) {
+    let content = "---\ntitle: Bulk Test\n---\n# Tasks\n- [ ] Task A\n- [ ] Task B\n\n## Acceptance criteria\n- [ ] AC one\n- [ ] AC two\n- [x] AC three\n\n## Other section\n- [ ] Other task\n";
+    write_md(tmp.path(), "bulk.md", content);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: run arbitrary task subcommand with extra args
+// ---------------------------------------------------------------------------
+
+fn run_task_cmd(
+    tmp: &tempfile::TempDir,
+    args: &[&str],
+) -> (std::process::ExitStatus, String, String) {
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(args);
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (output.status, stdout, stderr)
+}
+
+fn run_task_cmd_json(
+    tmp: &tempfile::TempDir,
+    args: &[&str],
+) -> (std::process::ExitStatus, serde_json::Value, String) {
+    let (status, stdout, stderr) = run_task_cmd(tmp, args);
+    let json: serde_json::Value = if status.success() {
+        serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}"))
+    } else {
+        serde_json::Value::Null
+    };
+    (status, json, stderr)
+}
+
+// ---------------------------------------------------------------------------
+// Bulk: repeatable --line
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_toggle_multiple_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task", "toggle", "--file", "bulk.md", "--line", "5", "--line", "6",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["status"], "x");
+    assert_eq!(results[0]["text"], "Task A");
+    assert_eq!(results[1]["status"], "x");
+    assert_eq!(results[1]["text"], "Task B");
+
+    let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
+    assert!(content.contains("- [x] Task A"));
+    assert!(content.contains("- [x] Task B"));
+}
+
+#[test]
+fn task_read_multiple_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task", "read", "--file", "bulk.md", "--line", "9", "--line", "10",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["text"], "AC one");
+    assert_eq!(results[1]["text"], "AC two");
+}
+
+#[test]
+fn task_set_status_multiple_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task",
+            "set-status",
+            "--file",
+            "bulk.md",
+            "--line",
+            "5",
+            "--line",
+            "6",
+            "--status",
+            "?",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["status"], "?");
+    assert_eq!(results[1]["status"], "?");
+
+    let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
+    assert!(content.contains("- [?] Task A"));
+    assert!(content.contains("- [?] Task B"));
+}
+
+// ---------------------------------------------------------------------------
+// Bulk: --section
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_toggle_section() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task",
+            "toggle",
+            "--file",
+            "bulk.md",
+            "--section",
+            "Acceptance criteria",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 3, "section has 3 tasks");
+    // [ ] -> [x], [ ] -> [x], [x] -> [ ]
+    assert_eq!(results[0]["status"], "x");
+    assert_eq!(results[1]["status"], "x");
+    assert_eq!(results[2]["status"], " ");
+
+    let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
+    assert!(content.contains("- [x] AC one"));
+    assert!(content.contains("- [x] AC two"));
+    assert!(content.contains("- [ ] AC three"));
+    // Other section untouched
+    assert!(content.contains("- [ ] Other task"));
+}
+
+#[test]
+fn task_read_section() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task",
+            "read",
+            "--file",
+            "bulk.md",
+            "--section",
+            "Acceptance criteria",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0]["text"], "AC one");
+    assert_eq!(results[1]["text"], "AC two");
+    assert_eq!(results[2]["text"], "AC three");
+}
+
+#[test]
+fn task_set_status_section() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, _json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task",
+            "set-status",
+            "--file",
+            "bulk.md",
+            "--section",
+            "Other section",
+            "--status",
+            "-",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
+    assert!(content.contains("- [-] Other task"));
+}
+
+#[test]
+fn task_section_substring_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    // "Acceptance" is a substring of "Acceptance criteria"
+    let (status, json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task",
+            "read",
+            "--file",
+            "bulk.md",
+            "--section",
+            "Acceptance",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 3);
+}
+
+#[test]
+fn task_section_no_match_exits_1() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, _stdout, _stderr) = run_task_cmd(
+        &tmp,
+        &[
+            "task",
+            "read",
+            "--file",
+            "bulk.md",
+            "--section",
+            "Nonexistent",
+        ],
+    );
+    assert!(!status.success());
+}
+
+// ---------------------------------------------------------------------------
+// Bulk: --all
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_toggle_all() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) =
+        run_task_cmd_json(&tmp, &["task", "toggle", "--file", "bulk.md", "--all"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    // 5 tasks total in the file: Task A, Task B, AC one, AC two, AC three, Other task = 6
+    assert_eq!(results.len(), 6, "expected 6 tasks in file");
+
+    let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
+    // All [ ] become [x], the one [x] becomes [ ]
+    assert!(content.contains("- [x] Task A"));
+    assert!(content.contains("- [x] Task B"));
+    assert!(content.contains("- [x] AC one"));
+    assert!(content.contains("- [x] AC two"));
+    assert!(content.contains("- [ ] AC three"));
+    assert!(content.contains("- [x] Other task"));
+}
+
+#[test]
+fn task_read_all() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) =
+        run_task_cmd_json(&tmp, &["task", "read", "--file", "bulk.md", "--all"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 6);
+}
+
+#[test]
+fn task_set_status_all() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, _json, stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task",
+            "set-status",
+            "--file",
+            "bulk.md",
+            "--all",
+            "--status",
+            "x",
+        ],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
+    assert!(content.contains("- [x] Task A"));
+    assert!(content.contains("- [x] Task B"));
+    assert!(content.contains("- [x] AC one"));
+    assert!(content.contains("- [x] AC two"));
+    assert!(content.contains("- [x] AC three"));
+    assert!(content.contains("- [x] Other task"));
+}
+
+// ---------------------------------------------------------------------------
+// Bulk: error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_no_selector_exits_2() {
+    // No --line, --section, or --all -> clap should reject or dispatch should error
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, _stdout, _stderr) = run_task_cmd(&tmp, &["task", "toggle", "--file", "bulk.md"]);
+    assert!(!status.success());
+}
+
+#[test]
+fn task_conflicting_selectors_exits_2() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, _stdout, _stderr) = run_task_cmd(
+        &tmp,
+        &[
+            "task", "toggle", "--file", "bulk.md", "--line", "5", "--all",
+        ],
+    );
+    assert!(!status.success());
+}
+
+#[test]
+fn task_all_on_empty_file_exits_1() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "empty.md",
+        "---\ntitle: Empty\n---\nNo tasks here.\n",
+    );
+
+    let (status, _stdout, _stderr) =
+        run_task_cmd(&tmp, &["task", "toggle", "--file", "empty.md", "--all"]);
+    assert!(!status.success());
+}
+
+// ---------------------------------------------------------------------------
+// Backward compatibility: single --line returns single object (no results wrapper)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_single_line_returns_flat_object() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, stdout, stderr) =
+        run_task_cmd(&tmp, &["task", "read", "--file", "bulk.md", "--line", "5"]);
+    assert!(status.success(), "stderr: {stderr}");
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    // Should NOT have a "results" key — it's a flat object
+    assert!(
+        json.get("results").is_some(),
+        "single-line result should be in envelope with results"
+    );
+    // The results field should be the task itself (not an array)
+    assert_eq!(json["results"]["text"], "Task A");
+}
+
+// ---------------------------------------------------------------------------
 // task read — line 0 boundary case
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e_task.rs
+++ b/crates/hyalo-cli/tests/e2e_task.rs
@@ -546,6 +546,29 @@ fn task_read_multiple_lines() {
 }
 
 #[test]
+fn task_toggle_comma_separated_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_bulk_file(&tmp);
+
+    let (status, json, stderr) = run_task_cmd_json(
+        &tmp,
+        &["task", "toggle", "--file", "bulk.md", "--line", "5,6"],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+
+    let results = json["results"].as_array().expect("expected results array");
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["status"], "x");
+    assert_eq!(results[0]["text"], "Task A");
+    assert_eq!(results[1]["status"], "x");
+    assert_eq!(results[1]["text"], "Task B");
+
+    let content = fs::read_to_string(tmp.path().join("bulk.md")).unwrap();
+    assert!(content.contains("- [x] Task A"));
+    assert!(content.contains("- [x] Task B"));
+}
+
+#[test]
 fn task_set_status_multiple_lines() {
     let tmp = tempfile::tempdir().unwrap();
     setup_bulk_file(&tmp);

--- a/crates/hyalo-core/src/tasks.rs
+++ b/crates/hyalo-core/src/tasks.rs
@@ -168,7 +168,7 @@ impl FileVisitor for TaskCounter {
 
 /// Visitor that collects tasks with section context for the `find` command.
 /// Tracks the current ATX heading to populate `FindTaskInfo.section`.
-pub struct TaskExtractor {
+pub(crate) struct TaskExtractor {
     current_section: String,
     tasks: Vec<crate::types::FindTaskInfo>,
 }
@@ -509,6 +509,7 @@ pub fn find_task_lines(path: &Path) -> Result<Vec<crate::types::FindTaskInfo>> {
 }
 
 /// Toggle multiple tasks in one atomic read-modify-write pass. Lines are 1-based.
+/// Duplicate lines are deduplicated; results are returned in sorted line order.
 /// Errors if any line is not a task checkbox.
 pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
     let content = std::fs::read_to_string(path)
@@ -520,10 +521,14 @@ pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
         file_lines.len()
     };
 
-    let mut results = Vec::with_capacity(lines.len());
-    let mut replacements: Vec<(usize, String)> = Vec::with_capacity(lines.len());
+    let mut deduped = lines.to_vec();
+    deduped.sort_unstable();
+    deduped.dedup();
 
-    for &line in lines {
+    let mut results = Vec::with_capacity(deduped.len());
+    let mut replacements: Vec<(usize, String)> = Vec::with_capacity(deduped.len());
+
+    for &line in &deduped {
         if line == 0 || line > line_count {
             bail!("line {line} is out of range (file has {line_count} lines)");
         }
@@ -549,6 +554,7 @@ pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
 }
 
 /// Set a custom status character on multiple tasks in one atomic read-modify-write pass.
+/// Duplicate lines are deduplicated; results are returned in sorted line order.
 /// Lines are 1-based. Errors if any line is not a task checkbox.
 pub fn set_tasks_status(path: &Path, lines: &[usize], status: char) -> Result<Vec<TaskInfo>> {
     let content = std::fs::read_to_string(path)
@@ -560,10 +566,14 @@ pub fn set_tasks_status(path: &Path, lines: &[usize], status: char) -> Result<Ve
         file_lines.len()
     };
 
-    let mut results = Vec::with_capacity(lines.len());
-    let mut replacements: Vec<(usize, String)> = Vec::with_capacity(lines.len());
+    let mut deduped = lines.to_vec();
+    deduped.sort_unstable();
+    deduped.dedup();
 
-    for &line in lines {
+    let mut results = Vec::with_capacity(deduped.len());
+    let mut replacements: Vec<(usize, String)> = Vec::with_capacity(deduped.len());
+
+    for &line in &deduped {
         if line == 0 || line > line_count {
             bail!("line {line} is out of range (file has {line_count} lines)");
         }
@@ -586,12 +596,16 @@ pub fn set_tasks_status(path: &Path, lines: &[usize], status: char) -> Result<Ve
 /// Build a new file content string by applying line replacements.
 /// `replacements` is a list of (1-based line number, new line content).
 fn build_new_content(original: &str, lines: &[&str], replacements: &[(usize, String)]) -> String {
+    let repl_map: std::collections::HashMap<usize, &str> = replacements
+        .iter()
+        .map(|(ln, s)| (*ln, s.as_str()))
+        .collect();
     let mut buf = String::with_capacity(original.len());
     for (i, &l) in lines.iter().enumerate() {
         if i > 0 {
             buf.push('\n');
         }
-        if let Some((_, repl)) = replacements.iter().find(|(ln, _)| *ln == i + 1) {
+        if let Some(repl) = repl_map.get(&(i + 1)) {
             buf.push_str(repl);
         } else {
             buf.push_str(l);

--- a/crates/hyalo-core/src/tasks.rs
+++ b/crates/hyalo-core/src/tasks.rs
@@ -168,7 +168,7 @@ impl FileVisitor for TaskCounter {
 
 /// Visitor that collects tasks with section context for the `find` command.
 /// Tracks the current ATX heading to populate `FindTaskInfo.section`.
-pub(crate) struct TaskExtractor {
+pub struct TaskExtractor {
     current_section: String,
     tasks: Vec<crate::types::FindTaskInfo>,
 }
@@ -462,21 +462,7 @@ pub fn toggle_task(path: &Path, line: usize) -> Result<TaskInfo> {
     let (modified_line, info) = mutate_task_line(target, line, new_status)
         .ok_or_else(|| anyhow::anyhow!("failed to mutate task on line {line}"))?;
 
-    let new_content = {
-        let mut buf = String::with_capacity(content.len() + modified_line.len());
-        for (i, l) in lines.iter().enumerate() {
-            if i > 0 {
-                buf.push('\n');
-            }
-            if i == line - 1 {
-                buf.push_str(&modified_line);
-            } else {
-                buf.push_str(l);
-            }
-        }
-        buf
-    };
-
+    let new_content = build_new_content(&content, &lines, &[(line, modified_line)]);
     crate::fs_util::atomic_write(path, new_content.as_bytes())
         .with_context(|| format!("failed to write {}", path.display()))?;
 
@@ -507,25 +493,111 @@ pub fn set_task_status(path: &Path, line: usize, status: char) -> Result<TaskInf
     let (modified_line, info) = mutate_task_line(target, line, status)
         .ok_or_else(|| anyhow::anyhow!("failed to mutate task on line {line}"))?;
 
-    let new_content = {
-        let mut buf = String::with_capacity(content.len() + modified_line.len());
-        for (i, l) in lines.iter().enumerate() {
-            if i > 0 {
-                buf.push('\n');
-            }
-            if i == line - 1 {
-                buf.push_str(&modified_line);
-            } else {
-                buf.push_str(l);
-            }
-        }
-        buf
-    };
-
+    let new_content = build_new_content(&content, &lines, &[(line, modified_line)]);
     crate::fs_util::atomic_write(path, new_content.as_bytes())
         .with_context(|| format!("failed to write {}", path.display()))?;
 
     Ok(info)
+}
+
+/// Scan a file and return all task lines with section context.
+/// Skips frontmatter, fenced code blocks, and comment blocks.
+pub fn find_task_lines(path: &Path) -> Result<Vec<crate::types::FindTaskInfo>> {
+    let mut extractor = TaskExtractor::new();
+    scanner::scan_file_multi(path, &mut [&mut extractor])?;
+    Ok(extractor.into_tasks())
+}
+
+/// Toggle multiple tasks in one atomic read-modify-write pass. Lines are 1-based.
+/// Errors if any line is not a task checkbox.
+pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let file_lines: Vec<&str> = content.split('\n').collect();
+    let line_count = if file_lines.last() == Some(&"") {
+        file_lines.len() - 1
+    } else {
+        file_lines.len()
+    };
+
+    let mut results = Vec::with_capacity(lines.len());
+    let mut replacements: Vec<(usize, String)> = Vec::with_capacity(lines.len());
+
+    for &line in lines {
+        if line == 0 || line > line_count {
+            bail!("line {line} is out of range (file has {line_count} lines)");
+        }
+        let target = file_lines[line - 1];
+        let (current_status, _done) = detect_task_checkbox(target)
+            .ok_or_else(|| anyhow::anyhow!("line {line} is not a task checkbox"))?;
+        let new_status = if current_status == 'x' || current_status == 'X' {
+            ' '
+        } else {
+            'x'
+        };
+        let (modified_line, info) = mutate_task_line(target, line, new_status)
+            .ok_or_else(|| anyhow::anyhow!("failed to mutate task on line {line}"))?;
+        replacements.push((line, modified_line));
+        results.push(info);
+    }
+
+    let new_content = build_new_content(&content, &file_lines, &replacements);
+    crate::fs_util::atomic_write(path, new_content.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+
+    Ok(results)
+}
+
+/// Set a custom status character on multiple tasks in one atomic read-modify-write pass.
+/// Lines are 1-based. Errors if any line is not a task checkbox.
+pub fn set_tasks_status(path: &Path, lines: &[usize], status: char) -> Result<Vec<TaskInfo>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let file_lines: Vec<&str> = content.split('\n').collect();
+    let line_count = if file_lines.last() == Some(&"") {
+        file_lines.len() - 1
+    } else {
+        file_lines.len()
+    };
+
+    let mut results = Vec::with_capacity(lines.len());
+    let mut replacements: Vec<(usize, String)> = Vec::with_capacity(lines.len());
+
+    for &line in lines {
+        if line == 0 || line > line_count {
+            bail!("line {line} is out of range (file has {line_count} lines)");
+        }
+        let target = file_lines[line - 1];
+        detect_task_checkbox(target)
+            .ok_or_else(|| anyhow::anyhow!("line {line} is not a task checkbox"))?;
+        let (modified_line, info) = mutate_task_line(target, line, status)
+            .ok_or_else(|| anyhow::anyhow!("failed to mutate task on line {line}"))?;
+        replacements.push((line, modified_line));
+        results.push(info);
+    }
+
+    let new_content = build_new_content(&content, &file_lines, &replacements);
+    crate::fs_util::atomic_write(path, new_content.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+
+    Ok(results)
+}
+
+/// Build a new file content string by applying line replacements.
+/// `replacements` is a list of (1-based line number, new line content).
+fn build_new_content(original: &str, lines: &[&str], replacements: &[(usize, String)]) -> String {
+    let mut buf = String::with_capacity(original.len());
+    for (i, &l) in lines.iter().enumerate() {
+        if i > 0 {
+            buf.push('\n');
+        }
+        if let Some((_, repl)) = replacements.iter().find(|(ln, _)| *ln == i + 1) {
+            buf.push_str(repl);
+        } else {
+            buf.push_str(l);
+        }
+    }
+    buf
 }
 
 // ---------------------------------------------------------------------------

--- a/hyalo-knowledgebase/iterations/iteration-98-bulk-task-ops.md
+++ b/hyalo-knowledgebase/iterations/iteration-98-bulk-task-ops.md
@@ -1,0 +1,52 @@
+---
+title: "Iteration 98: Bulk Task Operations"
+type: iteration
+date: 2026-04-06
+tags:
+  - iteration
+  - cli
+  - ux
+  - tasks
+status: completed
+branch: iter-98/bulk-task-ops
+---
+
+Make `hyalo task toggle/set-status/read` ergonomic for bulk operations. Currently each
+invocation targets a single `--line`, forcing agents into ugly shell loops. Add three
+mutually exclusive task selectors: repeatable `--line`, `--section`, and `--all`.
+
+## Motivation
+
+LLM agents repeatedly struggle with the single-line-per-call constraint. They resort to
+`for line in 23 24 25 ...; do hyalo task toggle --file f --line $line; done` which is
+token-wasteful, error-prone, and unergonomic. The `--toggle` vs `toggle` subcommand
+confusion (already mitigated by suggest.rs) compounds the problem.
+
+## Design
+
+Three mutually exclusive selectors (exactly one required):
+
+| Selector | Example | Behavior |
+|---|---|---|
+| `--line` (repeatable) | `--line 23 --line 24 --line 25` | Target specific lines |
+| `--section` | `--section "Acceptance criteria"` | All tasks under that heading |
+| `--all` | `--all` | Every task in the file |
+
+All three work with `read`, `toggle`, and `set-status`. `--file` is always required.
+
+Core does a single read-modify-write pass for multi-line mutations (not N separate file rewrites).
+
+## Tasks
+
+- [x] Make `--line` repeatable (`Vec<usize>`) in CLI args for all three task subcommands
+- [x] Add `--section` selector using SectionScanner logic to find tasks under a heading
+- [x] Add `--all` selector to target every task in the file
+- [x] Make selectors mutually exclusive with clear error on conflict
+- [x] Update core `toggle_task`/`set_task_status` to accept multiple lines in single pass
+- [x] Update `task_read` to return multiple tasks
+- [x] Update help text for task subcommands to document new selectors
+- [x] Update suggest.rs if needed for new flag patterns
+- [x] Add e2e tests for repeatable `--line`
+- [x] Add e2e tests for `--section`
+- [x] Add e2e tests for `--all`
+- [x] Run fmt, clippy, test quality gates


### PR DESCRIPTION
## Summary
- **Repeatable `--line`**: `hyalo task toggle --file f.md --line 5,7,9` (comma-separated) or `--line 5 --line 7` targets specific lines in one call
- **`--section` selector**: `hyalo task toggle --file f.md --section "Acceptance criteria"` targets all tasks under a heading (case-insensitive substring, `##`-pinned, or `/regex/`)
- **`--all` selector**: `hyalo task toggle --file f.md --all` targets every task in the file
- All mutations use a single atomic read-modify-write pass (not N separate file rewrites)
- Backward compatible: single `--line` still returns a flat object
- **Contextual hints**: `find` results with open tasks now suggest `task toggle --all` / `--section`; task commands with bulk selectors propagate scope into follow-up hints

## Motivation
LLM agents repeatedly struggle with single-task-per-call, resorting to `for line in 23 24 25; do hyalo task toggle --file f --line $line; done` — token-wasteful and error-prone.

## Test plan
- [x] 17 new e2e tests: multi-line toggle/read/set-status, comma-separated syntax, section matching (exact + substring), --all, error cases (no selector, conflicting selectors, empty file), backward compat
- [x] All 521+ existing tests pass
- [x] `cargo fmt` + `cargo clippy` clean
- [x] Dogfooded: `hyalo task toggle --file ... --all` toggled 12 tasks in one command
- [x] Verified hints appear correctly for find + task commands
- [x] Updated README, CLAUDE.md, and hyalo skill files

🤖 Generated with [Claude Code](https://claude.com/claude-code)