### PR TITLE
Add positional file arguments to all commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ Then use target/release/hyalo to work with the documentation in `./hyalo-knowled
 - **Body search**: `hyalo find "broken links" --format text` or regex: `hyalo find -e 'TODO|FIXME' --format text`
 - **Title regex**: `hyalo find --property 'title~=link' --format text`
 - **Overview**: `hyalo summary`, `hyalo properties`, `hyalo tags`
-- **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append` (e.g., `hyalo set --property status=completed --file iterations/iteration-16-robustness.md`)
-- **Toggle tasks**: `hyalo task toggle --file <path> --all` (whole file), `--section "Tasks"` (by heading), `--line 5,7,9` (specific lines)
+- **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append` (e.g., `hyalo set iterations/iteration-16-robustness.md --property status=completed`)
+- **Toggle tasks**: `hyalo task toggle <path> --all` (whole file), `--section "Tasks"` (by heading), `--line 5,7,9` (specific lines)
 - Only fall back to Edit for body content changes (markdown prose) that hyalo can't handle
 - **Do NOT pass `--dir hyalo-knowledgebase/`** — `.hyalo.toml` already sets it as the default
 - **Follow hints**: hyalo outputs drill-down hints by default — read and follow them to navigate deeper into the knowledgebase. Use `--no-hints` only when you need raw output.

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -41,8 +41,9 @@ pub(crate) fn resolve_single_file(
 ) -> anyhow::Result<String> {
     match (positional, flag) {
         (Some(f), None) | (None, Some(f)) => Ok(f),
-        (None, None) => anyhow::bail!("required argument <FILE> or --file <FILE> missing"),
-        (Some(_), Some(_)) => unreachable!(), // conflicts_with prevents this
+        (None, None) => anyhow::bail!("required argument missing: provide <FILE> or --file <FILE>"),
+        // conflicts_with prevents this at parse time; defensive fallback.
+        (Some(_), Some(_)) => anyhow::bail!("cannot specify both <FILE> and --file"),
     }
 }
 
@@ -301,7 +302,7 @@ pub(crate) enum Commands {
         #[arg(value_name = "PATTERN", conflicts_with = "regexp")]
         pattern: Option<String>,
         /// Target file(s) as positional args — alternative to --file (repeatable after PATTERN)
-        #[arg(value_name = "FILE", conflicts_with = "glob")]
+        #[arg(value_name = "FILE", conflicts_with_all = ["glob", "file"])]
         file_positional: Vec<String>,
         /// Use a saved view (named filter set from .hyalo.toml). Additional CLI filters
         /// are merged on top: list filters (--property, --tag, --section, --glob) extend

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -33,6 +33,19 @@ pub(crate) fn parse_threshold(s: &str) -> Result<f64, String> {
     }
 }
 
+/// Resolve a file argument that can be passed as positional or --file flag.
+/// Returns an error if neither is provided.
+pub(crate) fn resolve_single_file(
+    positional: Option<String>,
+    flag: Option<String>,
+) -> anyhow::Result<String> {
+    match (positional, flag) {
+        (Some(f), None) | (None, Some(f)) => Ok(f),
+        (None, None) => anyhow::bail!("required argument <FILE> or --file <FILE> missing"),
+        (Some(_), Some(_)) => unreachable!(), // conflicts_with prevents this
+    }
+}
+
 #[derive(Parser)]
 #[command(
     name = "hyalo",
@@ -43,8 +56,8 @@ pub(crate) fn parse_threshold(s: &str) -> Result<f64, String> {
         with YAML frontmatter. Also resolves [[wikilinks]] and manages task checkboxes.\n\n\
         SCOPE: Hyalo operates on a directory of .md files. It can query and mutate frontmatter \
         properties, tags, tasks, and links.\n\n\
-        PATH RESOLUTION: --file and --glob paths are relative to --dir (defaults to \".\"). \
-        If a --file path starts with the --dir prefix, it is stripped automatically \
+        PATH RESOLUTION: All file and --glob paths are relative to --dir (defaults to \".\"). \
+        If a file path starts with the --dir prefix, it is stripped automatically \
         (e.g. --file docs/note.md resolves to note.md when --dir is docs). \
         Globs use standard syntax: '**/*.md' matches recursively, 'notes/*.md' matches one level.\n\n\
         OUTPUT: Returns JSON by default (--format json). All JSON is wrapped in a consistent envelope:\n\
@@ -67,7 +80,7 @@ pub(crate) fn parse_threshold(s: &str) -> Result<f64, String> {
         See COMMAND REFERENCE below for full syntax of each command."
 )]
 pub(crate) struct Cli {
-    /// Root directory for resolving all --file and --glob paths.
+    /// Root directory for resolving all file and --glob paths.
     /// Default: "." (Override via .hyalo.toml)
     #[arg(short, long, global = true)]
     pub dir: Option<PathBuf>,
@@ -287,6 +300,9 @@ pub(crate) enum Commands {
         /// Case-insensitive body text search (searches body only, not frontmatter)
         #[arg(value_name = "PATTERN", conflicts_with = "regexp")]
         pattern: Option<String>,
+        /// Target file(s) as positional args — alternative to --file (repeatable after PATTERN)
+        #[arg(value_name = "FILE", conflicts_with = "glob")]
+        file_positional: Vec<String>,
         /// Use a saved view (named filter set from .hyalo.toml). Additional CLI filters
         /// are merged on top: list filters (--property, --tag, --section, --glob) extend
         /// the view; scalar filters (--sort, --limit, --regexp, --title, --task) override it
@@ -305,9 +321,12 @@ pub(crate) enum Commands {
             Pass --format json to get {\"results\": {\"file\": \"...\", \"content\": \"...\"}, \"hints\": [...]}.\n\
             SIDE EFFECTS: None (read-only).")]
     Read {
-        /// Target file (relative to --dir)
-        #[arg(short, long)]
-        file: String,
+        /// Target file (relative to --dir) — positional form
+        #[arg(value_name = "FILE")]
+        file_positional: Option<String>,
+        /// Target file (relative to --dir) — flag form
+        #[arg(short, long, value_name = "FILE", conflicts_with = "file_positional")]
+        file: Option<String>,
         /// Extract section(s) by substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
         /// prefix '##' to pin heading level; use '/regex/' for regex. Nested subsections included
         #[arg(short, long, value_name = "HEADING")]
@@ -343,7 +362,7 @@ pub(crate) enum Commands {
             - read: Show task details for one or more tasks.\n\
             - toggle: Flip completion state ([ ] <-> [x], custom -> [x]).\n\
             - set-status: Set an arbitrary single-character status.\n\n\
-            INPUT: --file and one of: --line (repeatable/comma-separated), --section <heading>, or --all.\n\
+            INPUT: FILE (positional or --file) and one of: --line (repeatable/comma-separated), --section <heading>, or --all.\n\
             SCOPE: Single file only.\n\
             SIDE EFFECTS: 'toggle' and 'set-status' modify the file on disk. 'read' is read-only.")]
     Task {
@@ -381,9 +400,12 @@ pub(crate) enum Commands {
             SIDE EFFECTS: None (read-only)."
     )]
     Backlinks {
-        /// Target file to find backlinks for (relative to --dir)
-        #[arg(short, long)]
-        file: String,
+        /// Target file to find backlinks for (relative to --dir) — positional form
+        #[arg(value_name = "FILE")]
+        file_positional: Option<String>,
+        /// Target file to find backlinks for (relative to --dir) — flag form
+        #[arg(short, long, value_name = "FILE", conflicts_with = "file_positional")]
+        file: Option<String>,
     },
     /// Move/rename a file and update all inbound and outbound links
     #[command(
@@ -397,9 +419,12 @@ pub(crate) enum Commands {
             SIDE EFFECTS: Moves the file and modifies files containing links (unless --dry-run)."
     )]
     Mv {
-        /// Source file to move (relative to --dir)
-        #[arg(short, long)]
-        file: String,
+        /// Source file to move (relative to --dir) — positional form
+        #[arg(value_name = "FILE")]
+        file_positional: Option<String>,
+        /// Source file to move (relative to --dir) — flag form
+        #[arg(short, long, value_name = "FILE", conflicts_with = "file_positional")]
+        file: Option<String>,
         /// Destination path (relative to --dir, must end with .md)
         #[arg(long)]
         to: String,
@@ -410,7 +435,7 @@ pub(crate) enum Commands {
     /// Set (create or overwrite) frontmatter properties and/or add tags across file(s)
     #[command(
         long_about = "Set (create or overwrite) frontmatter properties and/or add tags across file(s).\n\n\
-            INPUT: One or more --property K=V arguments and/or --tag T arguments, with --file or --glob.\n\
+            INPUT: One or more --property K=V arguments and/or --tag T arguments, with FILE (positional or --file) or --glob.\n\
             BEHAVIOR:\n\
             - --property K=V: creates or overwrites the property. Type is auto-inferred from V \
               (number, bool, text). Use K=[a,b,c] to create a YAML list; values are comma-split and trimmed. \
@@ -433,6 +458,9 @@ Repeatable (AND).\n\
             possibly across many files at once."
     )]
     Set {
+        /// Target file(s) as positional argument(s) — alternative to --file
+        #[arg(value_name = "FILE", conflicts_with_all = ["glob", "file"])]
+        file_positional: Vec<String>,
         /// Property to set: K=V (type inferred from V). Repeatable
         #[arg(short, long = "property", value_name = "K=V")]
         properties: Vec<String>,
@@ -458,7 +486,7 @@ Repeatable (AND).\n\
     /// Remove frontmatter properties and/or tags from file(s)
     #[command(
         long_about = "Remove frontmatter properties and/or tags from file(s).\n\n\
-            INPUT: One or more --property K or K=V arguments and/or --tag T arguments, with --file or --glob.\n\
+            INPUT: One or more --property K or K=V arguments and/or --tag T arguments, with FILE (positional or --file) or --glob.\n\
             BEHAVIOR:\n\
             - --property K: removes the entire key from frontmatter. Skips files where it is absent.\n\
             - --property K=V: if the property is a list, removes V from the list; if it is a scalar \
@@ -480,6 +508,9 @@ Repeatable (AND).\n\
             USE WHEN: You need to delete properties or remove tags from one or more files."
     )]
     Remove {
+        /// Target file(s) as positional argument(s) — alternative to --file
+        #[arg(value_name = "FILE", conflicts_with_all = ["glob", "file"])]
+        file_positional: Vec<String>,
         /// Property to remove: K (removes key) or K=V (removes value from list/scalar). Repeatable
         #[arg(short, long = "property", value_name = "K or K=V")]
         properties: Vec<String>,
@@ -565,7 +596,7 @@ Repeatable (AND).\n\
     /// Append values to list properties in file(s) frontmatter, promoting scalars to lists
     #[command(
         long_about = "Append values to list properties in file(s) frontmatter.\n\n\
-            INPUT: One or more --property K=V arguments, with --file or --glob.\n\
+            INPUT: One or more --property K=V arguments, with FILE (positional or --file) or --glob.\n\
             Note: --tag is not available on append (tags are atomic, not lists). Use 'hyalo set --tag T' to add tags.\n\
             BEHAVIOR:\n\
             - Property absent or null: creates it as a single-element list [V].\n\
@@ -588,6 +619,9 @@ Repeatable (AND).\n\
             without overwriting the existing list."
     )]
     Append {
+        /// Target file(s) as positional argument(s) — alternative to --file
+        #[arg(value_name = "FILE", conflicts_with_all = ["glob", "file"])]
+        file_positional: Vec<String>,
         /// Property to append to: K=V. Repeatable
         #[arg(short, long = "property", value_name = "K=V", required = true)]
         properties: Vec<String>,
@@ -711,19 +745,23 @@ pub(crate) enum LinksAction {
 pub(crate) enum TaskAction {
     /// Show task details for one or more tasks (read-only)
     #[command(long_about = "Show task details for one or more tasks.\n\n\
-        INPUT: --file and one of: --line (repeatable), --section <heading>, or --all.\n\
+        INPUT: FILE (positional or --file) and one of: --line (repeatable), --section <heading>, or --all.\n\
         OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
         SIDE EFFECTS: None (read-only).\n\
         USE WHEN: You need to inspect task status before toggling or updating.\n\n\
         EXAMPLES:\n  \
-          hyalo task read --file note.md --line 5\n  \
-          hyalo task read --file note.md --line 5,7,9\n  \
-          hyalo task read --file note.md --section Tasks\n  \
-          hyalo task read --file note.md --all")]
+          hyalo task read note.md --line 5\n  \
+          hyalo task read note.md --line 5,7,9\n  \
+          hyalo task read note.md --section Tasks\n  \
+          hyalo task read note.md --all\n  \
+          hyalo task read --file note.md --line 5")]
     Read {
-        /// File containing the task(s) (relative to --dir)
-        #[arg(short, long)]
-        file: String,
+        /// File containing the task(s) (relative to --dir) — positional form
+        #[arg(value_name = "FILE")]
+        file_positional: Option<String>,
+        /// File containing the task(s) (relative to --dir) — flag form
+        #[arg(short, long, value_name = "FILE", conflicts_with = "file_positional")]
+        file: Option<String>,
         /// 1-based line number(s). Comma-separated or repeatable: --line 5,7,9 or --line 5 --line 7
         #[arg(short, long, value_delimiter = ',', action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
         line: Vec<usize>,
@@ -737,20 +775,24 @@ pub(crate) enum TaskAction {
     /// Toggle task completion: [ ] -> [x], [x]/[X] -> [ ], custom -> [x]
     #[command(
         long_about = "Toggle task completion: [ ] -> [x], [x]/[X] -> [ ], custom -> [x].\n\n\
-        INPUT: --file and one of: --line (repeatable), --section <heading>, or --all.\n\
+        INPUT: FILE (positional or --file) and one of: --line (repeatable), --section <heading>, or --all.\n\
         OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
         SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
         USE WHEN: You need to mark tasks as done or re-open completed tasks.\n\n\
         EXAMPLES:\n  \
-          hyalo task toggle --file note.md --line 5\n  \
-          hyalo task toggle --file note.md --line 5,7,9\n  \
-          hyalo task toggle --file note.md --section Tasks\n  \
-          hyalo task toggle --file note.md --all"
+          hyalo task toggle note.md --line 5\n  \
+          hyalo task toggle note.md --line 5,7,9\n  \
+          hyalo task toggle note.md --section Tasks\n  \
+          hyalo task toggle note.md --all\n  \
+          hyalo task toggle --file note.md --line 5"
     )]
     Toggle {
-        /// File containing the task(s) (relative to --dir)
-        #[arg(short, long)]
-        file: String,
+        /// File containing the task(s) (relative to --dir) — positional form
+        #[arg(value_name = "FILE")]
+        file_positional: Option<String>,
+        /// File containing the task(s) (relative to --dir) — flag form
+        #[arg(short, long, value_name = "FILE", conflicts_with = "file_positional")]
+        file: Option<String>,
         /// 1-based line number(s). Comma-separated or repeatable: --line 5,7,9 or --line 5 --line 7
         #[arg(short, long, value_delimiter = ',', action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
         line: Vec<usize>,
@@ -765,20 +807,24 @@ pub(crate) enum TaskAction {
     #[command(
         name = "set-status",
         long_about = "Set a custom single-character status on one or more task checkboxes.\n\n\
-        INPUT: --file, --status (single char), and one of: --line (repeatable), --section <heading>, or --all.\n\
+        INPUT: FILE (positional or --file), --status (single char), and one of: --line (repeatable), --section <heading>, or --all.\n\
         OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
         SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
         USE WHEN: You need to set a non-standard status like '?' (question), '-' (cancelled), or '!' (important).\n\n\
         EXAMPLES:\n  \
-          hyalo task set-status --file note.md --line 5 --status '?'\n  \
-          hyalo task set-status --file note.md --line 5,7 --status '-'\n  \
-          hyalo task set-status --file note.md --section Tasks --status '-'\n  \
-          hyalo task set-status --file note.md --all --status x"
+          hyalo task set-status note.md --line 5 --status '?'\n  \
+          hyalo task set-status note.md --line 5,7 --status '-'\n  \
+          hyalo task set-status note.md --section Tasks --status '-'\n  \
+          hyalo task set-status note.md --all --status x\n  \
+          hyalo task set-status --file note.md --line 5 --status '?'"
     )]
     SetStatus {
-        /// File containing the task(s) (relative to --dir)
-        #[arg(short, long)]
-        file: String,
+        /// File containing the task(s) (relative to --dir) — positional form
+        #[arg(value_name = "FILE")]
+        file_positional: Option<String>,
+        /// File containing the task(s) (relative to --dir) — flag form
+        #[arg(short, long, value_name = "FILE", conflicts_with = "file_positional")]
+        file: Option<String>,
         /// 1-based line number(s). Comma-separated or repeatable: --line 5,7,9 or --line 5 --line 7
         #[arg(short, long, value_delimiter = ',', action = clap::ArgAction::Append, conflicts_with_all = ["section", "all"])]
         line: Vec<usize>,

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -296,6 +296,9 @@ pub(crate) enum Commands {
             - Property regex uses ~= (tilde-equals), NOT =~ (Perl-style). Wrong: 'title=~/pat/', right: 'title~=/pat/'.\n\
             - --title searches the displayed title (frontmatter or H1); --property title~= only searches frontmatter.\n\
             - --tag uses prefix matching: 'project' matches 'project/backend' but NOT 'projects'.\n\
+            POSITIONAL ARGUMENTS: The first positional argument is always PATTERN (body text search), not a file path. \
+            Subsequent positional arguments are treated as FILE targets. \
+            To filter by file without a body search, use --file instead of a positional argument.\n\
             SIDE EFFECTS: None (read-only).")]
     Find {
         /// Case-insensitive body text search (searches body only, not frontmatter)

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -64,6 +64,12 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             // Merge positional files into filters (clap prevents positional+--file
             // and positional+--glob at parse time; a view may have set glob though).
             if !file_positional.is_empty() {
+                if !filters_raw.glob.is_empty() {
+                    crate::warn::warn(
+                        "positional file arguments override the view's --glob; \
+                         glob filter has been ignored",
+                    );
+                }
                 filters_raw.file = file_positional;
                 filters_raw.glob.clear(); // file overrides view's glob
             }
@@ -199,7 +205,10 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             lines,
             frontmatter,
         } => {
-            let file = resolve_single_file(file_positional, file)?;
+            let file = match resolve_single_file(file_positional, file) {
+                Ok(f) => f,
+                Err(e) => return Ok(CommandOutcome::UserError(format!("{e}"))),
+            };
             read_commands::run(
                 dir,
                 &file,
@@ -310,7 +319,10 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 section,
                 all,
             } => {
-                let file = resolve_single_file(file_positional, file)?;
+                let file = match resolve_single_file(file_positional, file) {
+                    Ok(f) => f,
+                    Err(e) => return Ok(CommandOutcome::UserError(format!("{e}"))),
+                };
                 task_commands::task_read(
                     dir,
                     &file,
@@ -327,7 +339,10 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 section,
                 all,
             } => {
-                let file = resolve_single_file(file_positional, file)?;
+                let file = match resolve_single_file(file_positional, file) {
+                    Ok(f) => f,
+                    Err(e) => return Ok(CommandOutcome::UserError(format!("{e}"))),
+                };
                 task_commands::task_toggle(
                     dir,
                     &file,
@@ -347,7 +362,10 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 all,
                 status,
             } => {
-                let file = resolve_single_file(file_positional, file)?;
+                let file = match resolve_single_file(file_positional, file) {
+                    Ok(f) => f,
+                    Err(e) => return Ok(CommandOutcome::UserError(format!("{e}"))),
+                };
                 if status.chars().count() != 1 {
                     let out = crate::output::format_error(
                         effective_format,
@@ -502,7 +520,10 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             file_positional,
             file,
         } => {
-            let file = resolve_single_file(file_positional, file)?;
+            let file = match resolve_single_file(file_positional, file) {
+                Ok(f) => f,
+                Err(e) => return Ok(CommandOutcome::UserError(format!("{e}"))),
+            };
             match resolve_index(
                 snapshot_index.as_ref(),
                 dir,
@@ -525,7 +546,10 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             to,
             dry_run,
         } => {
-            let file = resolve_single_file(file_positional, file)?;
+            let file = match resolve_single_file(file_positional, file) {
+                Ok(f) => f,
+                Err(e) => return Ok(CommandOutcome::UserError(format!("{e}"))),
+            };
             mv_commands::mv(
                 dir,
                 &file,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 
 use crate::cli::args::{
     Commands, FindFilters, LinksAction, PropertiesAction, TagsAction, TaskAction, ViewsAction,
+    resolve_single_file,
 };
 use crate::commands::{
     IndexResolution, ResolvedIndex, append as append_commands, backlinks as backlinks_commands,
@@ -56,24 +57,32 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
     match command {
         Commands::Find {
             pattern,
+            file_positional,
             view: _, // resolved before dispatch
-            filters:
-                FindFilters {
-                    regexp,
-                    properties,
-                    tag,
-                    task,
-                    sections,
-                    file,
-                    glob,
-                    fields,
-                    sort,
-                    reverse,
-                    limit,
-                    broken_links,
-                    title,
-                },
+            filters: mut filters_raw,
         } => {
+            // Merge positional files into filters.file before destructuring
+            if !file_positional.is_empty() {
+                if !filters_raw.file.is_empty() {
+                    anyhow::bail!("cannot specify both positional files and --file");
+                }
+                filters_raw.file = file_positional;
+            }
+            let FindFilters {
+                regexp,
+                properties,
+                tag,
+                task,
+                sections,
+                file,
+                glob,
+                fields,
+                sort,
+                reverse,
+                limit,
+                broken_links,
+                title,
+            } = filters_raw;
             // Parse property filters
             let prop_filters: Vec<filter::PropertyFilter> = match properties
                 .iter()
@@ -185,19 +194,23 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             }
         }
         Commands::Read {
+            file_positional,
             file,
             section,
             lines,
             frontmatter,
-        } => read_commands::run(
-            dir,
-            &file,
-            section.as_deref(),
-            lines.as_deref(),
-            frontmatter,
-            effective_format,
-            ctx.user_format,
-        ),
+        } => {
+            let file = resolve_single_file(file_positional, file)?;
+            read_commands::run(
+                dir,
+                &file,
+                section.as_deref(),
+                lines.as_deref(),
+                frontmatter,
+                effective_format,
+                ctx.user_format,
+            )
+        }
         Commands::Properties { action } => {
             let action = action.unwrap_or(PropertiesAction::Summary { glob: vec![] });
             match action {
@@ -292,40 +305,50 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
         }
         Commands::Task { action } => match action {
             TaskAction::Read {
+                file_positional,
                 file,
                 line,
                 section,
                 all,
-            } => task_commands::task_read(
-                dir,
-                &file,
-                &line,
-                section.as_deref(),
-                all,
-                effective_format,
-            ),
+            } => {
+                let file = resolve_single_file(file_positional, file)?;
+                task_commands::task_read(
+                    dir,
+                    &file,
+                    &line,
+                    section.as_deref(),
+                    all,
+                    effective_format,
+                )
+            }
             TaskAction::Toggle {
+                file_positional,
                 file,
                 line,
                 section,
                 all,
-            } => task_commands::task_toggle(
-                dir,
-                &file,
-                &line,
-                section.as_deref(),
-                all,
-                effective_format,
-                snapshot_index,
-                index_path,
-            ),
+            } => {
+                let file = resolve_single_file(file_positional, file)?;
+                task_commands::task_toggle(
+                    dir,
+                    &file,
+                    &line,
+                    section.as_deref(),
+                    all,
+                    effective_format,
+                    snapshot_index,
+                    index_path,
+                )
+            }
             TaskAction::SetStatus {
+                file_positional,
                 file,
                 line,
                 section,
                 all,
                 status,
             } => {
+                let file = resolve_single_file(file_positional, file)?;
                 if status.chars().count() != 1 {
                     let out = crate::output::format_error(
                         effective_format,
@@ -380,14 +403,18 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             IndexResolution::Outcome(outcome) => Ok(outcome),
         },
         Commands::Set {
+            file_positional,
             properties,
             tag,
-            file,
+            mut file,
             glob,
             where_properties,
             where_tags,
             dry_run,
         } => {
+            if !file_positional.is_empty() {
+                file = file_positional;
+            }
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
                 Err(e) => {
@@ -409,14 +436,18 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             )
         }
         Commands::Remove {
+            file_positional,
             properties,
             tag,
-            file,
+            mut file,
             glob,
             where_properties,
             where_tags,
             dry_run,
         } => {
+            if !file_positional.is_empty() {
+                file = file_positional;
+            }
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
                 Err(e) => {
@@ -438,13 +469,17 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             )
         }
         Commands::Append {
+            file_positional,
             properties,
-            file,
+            mut file,
             glob,
             where_properties,
             where_tags,
             dry_run,
         } => {
+            if !file_positional.is_empty() {
+                file = file_positional;
+            }
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
                 Err(e) => {
@@ -464,31 +499,45 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 dry_run,
             )
         }
-        Commands::Backlinks { file } => match resolve_index(
-            snapshot_index.as_ref(),
-            dir,
-            &[],
-            &[],
-            effective_format,
-            site_prefix,
-            true,
-            ScanOptions { scan_body: true },
-        )? {
-            IndexResolution::Resolved(resolved) => {
-                backlinks_commands::backlinks(resolved.as_index(), &file, dir, effective_format)
+        Commands::Backlinks {
+            file_positional,
+            file,
+        } => {
+            let file = resolve_single_file(file_positional, file)?;
+            match resolve_index(
+                snapshot_index.as_ref(),
+                dir,
+                &[],
+                &[],
+                effective_format,
+                site_prefix,
+                true,
+                ScanOptions { scan_body: true },
+            )? {
+                IndexResolution::Resolved(resolved) => {
+                    backlinks_commands::backlinks(resolved.as_index(), &file, dir, effective_format)
+                }
+                IndexResolution::Outcome(outcome) => Ok(outcome),
             }
-            IndexResolution::Outcome(outcome) => Ok(outcome),
-        },
-        Commands::Mv { file, to, dry_run } => mv_commands::mv(
-            dir,
-            &file,
-            &to,
+        }
+        Commands::Mv {
+            file_positional,
+            file,
+            to,
             dry_run,
-            effective_format,
-            site_prefix,
-            snapshot_index,
-            index_path,
-        ),
+        } => {
+            let file = resolve_single_file(file_positional, file)?;
+            mv_commands::mv(
+                dir,
+                &file,
+                &to,
+                dry_run,
+                effective_format,
+                site_prefix,
+                snapshot_index,
+                index_path,
+            )
+        }
         Commands::CreateIndex {
             output,
             allow_outside_vault,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -61,12 +61,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             view: _, // resolved before dispatch
             filters: mut filters_raw,
         } => {
-            // Merge positional files into filters.file before destructuring
+            // Merge positional files into filters (clap prevents positional+--file
+            // and positional+--glob at parse time; a view may have set glob though).
             if !file_positional.is_empty() {
-                if !filters_raw.file.is_empty() {
-                    anyhow::bail!("cannot specify both positional files and --file");
-                }
                 filters_raw.file = file_positional;
+                filters_raw.glob.clear(); // file overrides view's glob
             }
             let FindFilters {
                 regexp,

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -186,6 +186,28 @@ fn build_command_no_glob(ctx: &HintContext, args: &[&str]) -> String {
     parts.join(" ")
 }
 
+/// Build a command where `file_arg` is a positional file path following `subcommand_args`.
+///
+/// If `file_arg` starts with `-`, emits `--file <path>` instead of the bare positional
+/// to prevent clap from interpreting the filename as a flag.
+fn build_command_with_file(
+    ctx: &HintContext,
+    subcommand_args: &[&str],
+    file_arg: &str,
+    trailing_args: &[&str],
+) -> String {
+    let mut parts: Vec<String> = vec!["hyalo".to_owned()];
+    for arg in subcommand_args {
+        parts.push(shell_quote(arg));
+    }
+    push_file_positional(&mut parts, file_arg);
+    for arg in trailing_args {
+        parts.push(shell_quote(arg));
+    }
+    push_global_flags(&mut parts, ctx);
+    parts.join(" ")
+}
+
 /// Build a command that propagates `--glob` when present.
 fn build_command_with_glob(ctx: &HintContext, args: &[&str]) -> String {
     let mut parts: Vec<String> = vec!["hyalo".to_owned()];
@@ -230,6 +252,19 @@ fn build_find_command_preserving_filters(ctx: &HintContext, extra_args: &[&str])
         parts.push(shell_quote(glob));
     }
     parts.join(" ")
+}
+
+/// Push a file argument that is safe as a positional arg.
+///
+/// If the filename starts with `-`, clap would interpret it as a flag.
+/// In that case, emit `--file <path>` (flag form) instead of the bare positional.
+fn push_file_positional(parts: &mut Vec<String>, file: &str) {
+    if file.starts_with('-') {
+        parts.push("--file".to_owned());
+        parts.push(shell_quote(file));
+    } else {
+        parts.push(shell_quote(file));
+    }
 }
 
 /// Wrap a string in single-quotes if it contains any shell-special characters.
@@ -525,7 +560,7 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     if let Some(first_file) = results[0].get("file").and_then(|f| f.as_str()) {
         hints.push(Hint::new(
             "Read this file's content",
-            build_command_no_glob(ctx, &["read", first_file]),
+            build_command_with_file(ctx, &["read"], first_file, &[]),
         ));
         if is_single {
             hints.push(Hint::new(
@@ -535,7 +570,7 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         }
         hints.push(Hint::new(
             "See what links to this file",
-            build_command_no_glob(ctx, &["backlinks", first_file]),
+            build_command_with_file(ctx, &["backlinks"], first_file, &[]),
         ));
     }
 
@@ -558,12 +593,17 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
                 if let Some(section) = ctx.section_filters.first() {
                     hints.push(Hint::new(
                         format!("Toggle all tasks in section \"{section}\""),
-                        build_command_no_glob(ctx, &["task", "toggle", file, "--section", section]),
+                        build_command_with_file(
+                            ctx,
+                            &["task", "toggle"],
+                            file,
+                            &["--section", section],
+                        ),
                     ));
                 } else {
                     hints.push(Hint::new(
                         "Toggle all tasks in this file",
-                        build_command_no_glob(ctx, &["task", "toggle", file, "--all"]),
+                        build_command_with_file(ctx, &["task", "toggle"], file, &["--all"]),
                     ));
                 }
             }
@@ -798,7 +838,7 @@ fn hints_for_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         ));
         hints.push(Hint::new(
             "See what links to this file",
-            build_command_no_glob(ctx, &["backlinks", file]),
+            build_command_with_file(ctx, &["backlinks"], file, &[]),
         ));
     }
 
@@ -813,7 +853,7 @@ fn hints_for_backlinks(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
     if let Some(file) = file {
         hints.push(Hint::new(
             "Read this file's content",
-            build_command_no_glob(ctx, &["read", file]),
+            build_command_with_file(ctx, &["read"], file, &[]),
         ));
         hints.push(Hint::new(
             "See this file's outgoing links",
@@ -830,7 +870,7 @@ fn hints_for_backlinks(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
     {
         hints.push(Hint::new(
             format!("Read linking file: {first_source}"),
-            build_command_no_glob(ctx, &["read", first_source]),
+            build_command_with_file(ctx, &["read"], first_source, &[]),
         ));
     }
 
@@ -851,17 +891,17 @@ fn hints_for_mv(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
             if let Some(from_path) = data.get("from").and_then(|f| f.as_str()) {
                 hints.push(Hint::new(
                     "Apply this move",
-                    build_command_no_glob(ctx, &["mv", from_path, "--to", to_path]),
+                    build_command_with_file(ctx, &["mv"], from_path, &["--to", to_path]),
                 ));
             }
         } else {
             hints.push(Hint::new(
                 "Read the moved file",
-                build_command_no_glob(ctx, &["read", to_path]),
+                build_command_with_file(ctx, &["read"], to_path, &[]),
             ));
             hints.push(Hint::new(
                 "Verify backlinks updated",
-                build_command_no_glob(ctx, &["backlinks", to_path]),
+                build_command_with_file(ctx, &["backlinks"], to_path, &[]),
             ));
         }
     }
@@ -893,12 +933,17 @@ fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
                 if selector == "all" {
                     hints.push(Hint::new(
                         "Toggle all tasks in this file",
-                        build_command_no_glob(ctx, &["task", "toggle", file, "--all"]),
+                        build_command_with_file(ctx, &["task", "toggle"], file, &["--all"]),
                     ));
                 } else if let Some(section) = selector.strip_prefix("section:") {
                     hints.push(Hint::new(
                         format!("Toggle all tasks in section \"{section}\""),
-                        build_command_no_glob(ctx, &["task", "toggle", file, "--section", section]),
+                        build_command_with_file(
+                            ctx,
+                            &["task", "toggle"],
+                            file,
+                            &["--section", section],
+                        ),
                     ));
                 }
             }
@@ -924,7 +969,7 @@ fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
         if !done {
             hints.push(Hint::new(
                 "Toggle this task to done",
-                build_command_no_glob(ctx, &["task", "toggle", file, "--line", &line_str]),
+                build_command_with_file(ctx, &["task", "toggle"], file, &["--line", &line_str]),
             ));
         }
         hints.push(Hint::new(
@@ -956,12 +1001,12 @@ fn hints_for_task_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<H
             if selector == "all" {
                 hints.push(Hint::new(
                     "Read all tasks in this file",
-                    build_command_no_glob(ctx, &["task", "read", file, "--all"]),
+                    build_command_with_file(ctx, &["task", "read"], file, &["--all"]),
                 ));
             } else if let Some(section) = selector.strip_prefix("section:") {
                 hints.push(Hint::new(
                     format!("Read tasks in section \"{section}\""),
-                    build_command_no_glob(ctx, &["task", "read", file, "--section", section]),
+                    build_command_with_file(ctx, &["task", "read"], file, &["--section", section]),
                 ));
             }
         }
@@ -977,7 +1022,7 @@ fn hints_for_task_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<H
         ));
         hints.push(Hint::new(
             "Read the file",
-            build_command_no_glob(ctx, &["read", file]),
+            build_command_with_file(ctx, &["read"], file, &[]),
         ));
     }
 

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -525,7 +525,7 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     if let Some(first_file) = results[0].get("file").and_then(|f| f.as_str()) {
         hints.push(Hint::new(
             "Read this file's content",
-            build_command_no_glob(ctx, &["read", "--file", first_file]),
+            build_command_no_glob(ctx, &["read", first_file]),
         ));
         if is_single {
             hints.push(Hint::new(
@@ -535,7 +535,7 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         }
         hints.push(Hint::new(
             "See what links to this file",
-            build_command_no_glob(ctx, &["backlinks", "--file", first_file]),
+            build_command_no_glob(ctx, &["backlinks", first_file]),
         ));
     }
 
@@ -558,15 +558,12 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
                 if let Some(section) = ctx.section_filters.first() {
                     hints.push(Hint::new(
                         format!("Toggle all tasks in section \"{section}\""),
-                        build_command_no_glob(
-                            ctx,
-                            &["task", "toggle", "--file", file, "--section", section],
-                        ),
+                        build_command_no_glob(ctx, &["task", "toggle", file, "--section", section]),
                     ));
                 } else {
                     hints.push(Hint::new(
                         "Toggle all tasks in this file",
-                        build_command_no_glob(ctx, &["task", "toggle", "--file", file, "--all"]),
+                        build_command_no_glob(ctx, &["task", "toggle", file, "--all"]),
                     ));
                 }
             }
@@ -779,7 +776,7 @@ fn hints_for_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> 
         ));
         hints.push(Hint::new(
             "Read the modified file",
-            build_command_no_glob(ctx, &["read", "--file", file]),
+            build_command_no_glob(ctx, &["read", file]),
         ));
     }
 
@@ -801,7 +798,7 @@ fn hints_for_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         ));
         hints.push(Hint::new(
             "See what links to this file",
-            build_command_no_glob(ctx, &["backlinks", "--file", file]),
+            build_command_no_glob(ctx, &["backlinks", file]),
         ));
     }
 
@@ -816,7 +813,7 @@ fn hints_for_backlinks(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
     if let Some(file) = file {
         hints.push(Hint::new(
             "Read this file's content",
-            build_command_no_glob(ctx, &["read", "--file", file]),
+            build_command_no_glob(ctx, &["read", file]),
         ));
         hints.push(Hint::new(
             "See this file's outgoing links",
@@ -833,7 +830,7 @@ fn hints_for_backlinks(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
     {
         hints.push(Hint::new(
             format!("Read linking file: {first_source}"),
-            build_command_no_glob(ctx, &["read", "--file", first_source]),
+            build_command_no_glob(ctx, &["read", first_source]),
         ));
     }
 
@@ -854,17 +851,17 @@ fn hints_for_mv(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
             if let Some(from_path) = data.get("from").and_then(|f| f.as_str()) {
                 hints.push(Hint::new(
                     "Apply this move",
-                    build_command_no_glob(ctx, &["mv", "--file", from_path, "--to", to_path]),
+                    build_command_no_glob(ctx, &["mv", from_path, "--to", to_path]),
                 ));
             }
         } else {
             hints.push(Hint::new(
                 "Read the moved file",
-                build_command_no_glob(ctx, &["read", "--file", to_path]),
+                build_command_no_glob(ctx, &["read", to_path]),
             ));
             hints.push(Hint::new(
                 "Verify backlinks updated",
-                build_command_no_glob(ctx, &["backlinks", "--file", to_path]),
+                build_command_no_glob(ctx, &["backlinks", to_path]),
             ));
         }
     }
@@ -896,15 +893,12 @@ fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
                 if selector == "all" {
                     hints.push(Hint::new(
                         "Toggle all tasks in this file",
-                        build_command_no_glob(ctx, &["task", "toggle", "--file", file, "--all"]),
+                        build_command_no_glob(ctx, &["task", "toggle", file, "--all"]),
                     ));
                 } else if let Some(section) = selector.strip_prefix("section:") {
                     hints.push(Hint::new(
                         format!("Toggle all tasks in section \"{section}\""),
-                        build_command_no_glob(
-                            ctx,
-                            &["task", "toggle", "--file", file, "--section", section],
-                        ),
+                        build_command_no_glob(ctx, &["task", "toggle", file, "--section", section]),
                     ));
                 }
             }
@@ -930,10 +924,7 @@ fn hints_for_task_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
         if !done {
             hints.push(Hint::new(
                 "Toggle this task to done",
-                build_command_no_glob(
-                    ctx,
-                    &["task", "toggle", "--file", file, "--line", &line_str],
-                ),
+                build_command_no_glob(ctx, &["task", "toggle", file, "--line", &line_str]),
             ));
         }
         hints.push(Hint::new(
@@ -965,15 +956,12 @@ fn hints_for_task_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<H
             if selector == "all" {
                 hints.push(Hint::new(
                     "Read all tasks in this file",
-                    build_command_no_glob(ctx, &["task", "read", "--file", file, "--all"]),
+                    build_command_no_glob(ctx, &["task", "read", file, "--all"]),
                 ));
             } else if let Some(section) = selector.strip_prefix("section:") {
                 hints.push(Hint::new(
                     format!("Read tasks in section \"{section}\""),
-                    build_command_no_glob(
-                        ctx,
-                        &["task", "read", "--file", file, "--section", section],
-                    ),
+                    build_command_no_glob(ctx, &["task", "read", file, "--section", section]),
                 ));
             }
         }
@@ -989,7 +977,7 @@ fn hints_for_task_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<H
         ));
         hints.push(Hint::new(
             "Read the file",
-            build_command_no_glob(ctx, &["read", "--file", file]),
+            build_command_no_glob(ctx, &["read", file]),
         ));
     }
 

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -372,6 +372,7 @@ fn run_inner() -> Result<(), AppError> {
             }
             Commands::Find {
                 pattern,
+                file_positional,
                 view,
                 filters:
                     FindFilters {
@@ -388,6 +389,12 @@ fn run_inner() -> Result<(), AppError> {
                         ..
                     },
             } => {
+                // Merge positional files for hint context (view merging happens later)
+                let file = if file_positional.is_empty() {
+                    file
+                } else {
+                    file_positional
+                };
                 let mut ctx = HintContext::from_common(HintSource::Find, &common);
                 ctx.glob.clone_from(glob);
                 ctx.fields.clone_from(fields);
@@ -439,35 +446,56 @@ fn run_inner() -> Result<(), AppError> {
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
-            Commands::Read { file, .. } => {
+            Commands::Read {
+                file_positional,
+                file,
+                ..
+            } => {
                 let mut ctx = HintContext::from_common(HintSource::Read, &common);
-                ctx.file_targets = vec![file.clone()];
+                if let Some(f) = file_positional.as_ref().or(file.as_ref()) {
+                    ctx.file_targets = vec![f.clone()];
+                }
                 Some(ctx)
             }
-            Commands::Backlinks { file } => {
+            Commands::Backlinks {
+                file_positional,
+                file,
+            } => {
                 let mut ctx = HintContext::from_common(HintSource::Backlinks, &common);
-                ctx.file_targets = vec![file.clone()];
+                if let Some(f) = file_positional.as_ref().or(file.as_ref()) {
+                    ctx.file_targets = vec![f.clone()];
+                }
                 Some(ctx)
             }
-            Commands::Mv { file, dry_run, .. } => {
+            Commands::Mv {
+                file_positional,
+                file,
+                dry_run,
+                ..
+            } => {
                 let mut ctx = HintContext::from_common(HintSource::Mv, &common);
-                ctx.file_targets = vec![file.clone()];
+                if let Some(f) = file_positional.as_ref().or(file.as_ref()) {
+                    ctx.file_targets = vec![f.clone()];
+                }
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
             Commands::Task { action } => {
-                let (source, file, selector) = match action {
+                let (source, file_pos, file_flag, selector) = match action {
                     crate::cli::args::TaskAction::Toggle {
+                        file_positional,
                         file,
                         line,
                         section,
                         all,
                     } => (
                         HintSource::TaskToggle,
+                        file_positional,
                         file,
                         task_selector(line, section.as_ref(), *all),
                     ),
                     crate::cli::args::TaskAction::SetStatus {
+                        file_positional,
                         file,
                         line,
                         section,
@@ -475,22 +503,27 @@ fn run_inner() -> Result<(), AppError> {
                         ..
                     } => (
                         HintSource::TaskSetStatus,
+                        file_positional,
                         file,
                         task_selector(line, section.as_ref(), *all),
                     ),
                     crate::cli::args::TaskAction::Read {
+                        file_positional,
                         file,
                         line,
                         section,
                         all,
                     } => (
                         HintSource::TaskRead,
+                        file_positional,
                         file,
                         task_selector(line, section.as_ref(), *all),
                     ),
                 };
                 let mut ctx = HintContext::from_common(source, &common);
-                ctx.file_targets = vec![file.clone()];
+                if let Some(f) = file_pos.as_ref().or(file_flag.as_ref()) {
+                    ctx.file_targets = vec![f.clone()];
+                }
                 ctx.task_selector = selector;
                 Some(ctx)
             }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -411,6 +411,7 @@ fn run_inner() -> Result<(), AppError> {
                 Some(ctx)
             }
             Commands::Set {
+                file_positional,
                 file,
                 glob,
                 dry_run,
@@ -418,11 +419,16 @@ fn run_inner() -> Result<(), AppError> {
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Set, &common);
                 ctx.glob.clone_from(glob);
-                ctx.file_targets.clone_from(file);
+                ctx.file_targets = if file_positional.is_empty() {
+                    file.clone()
+                } else {
+                    file_positional.clone()
+                };
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
             Commands::Remove {
+                file_positional,
                 file,
                 glob,
                 dry_run,
@@ -430,11 +436,16 @@ fn run_inner() -> Result<(), AppError> {
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Remove, &common);
                 ctx.glob.clone_from(glob);
-                ctx.file_targets.clone_from(file);
+                ctx.file_targets = if file_positional.is_empty() {
+                    file.clone()
+                } else {
+                    file_positional.clone()
+                };
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
             Commands::Append {
+                file_positional,
                 file,
                 glob,
                 dry_run,
@@ -442,7 +453,11 @@ fn run_inner() -> Result<(), AppError> {
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Append, &common);
                 ctx.glob.clone_from(glob);
-                ctx.file_targets.clone_from(file);
+                ctx.file_targets = if file_positional.is_empty() {
+                    file.clone()
+                } else {
+                    file_positional.clone()
+                };
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -419,11 +419,12 @@ fn run_inner() -> Result<(), AppError> {
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Set, &common);
                 ctx.glob.clone_from(glob);
-                ctx.file_targets = if file_positional.is_empty() {
-                    file.clone()
+                let src = if file_positional.is_empty() {
+                    file
                 } else {
-                    file_positional.clone()
+                    file_positional
                 };
+                ctx.file_targets.clone_from(src);
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
@@ -436,11 +437,12 @@ fn run_inner() -> Result<(), AppError> {
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Remove, &common);
                 ctx.glob.clone_from(glob);
-                ctx.file_targets = if file_positional.is_empty() {
-                    file.clone()
+                let src = if file_positional.is_empty() {
+                    file
                 } else {
-                    file_positional.clone()
+                    file_positional
                 };
+                ctx.file_targets.clone_from(src);
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
@@ -453,11 +455,12 @@ fn run_inner() -> Result<(), AppError> {
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Append, &common);
                 ctx.glob.clone_from(glob);
-                ctx.file_targets = if file_positional.is_empty() {
-                    file.clone()
+                let src = if file_positional.is_empty() {
+                    file
                 } else {
-                    file_positional.clone()
+                    file_positional
                 };
+                ctx.file_targets.clone_from(src);
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -6,8 +6,8 @@ Prefer `hyalo` CLI for operations on files in this directory:
 - **Search/filter**: `hyalo find --property status=planned --tag iteration --format text`
 - **Body search**: `hyalo find "broken links" --format text`
 - **Title regex**: `hyalo find --property 'title~=link' --format text`
-- **Read frontmatter/metadata**: `hyalo find --file`, `hyalo properties`, `hyalo tags`
-- **Read content/sections**: `hyalo read --file <path>` or `hyalo read --section "Heading"`
+- **Read frontmatter/metadata**: `hyalo find --file <path>`, `hyalo properties`, `hyalo tags`
+- **Read content/sections**: `hyalo read <path>` or `hyalo read <path> --section "Heading"`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append`
 - **Move/rename**: `hyalo mv` (rewrites links across the vault)
 

--- a/crates/hyalo-cli/templates/skill-hyalo-tidy.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-tidy.md
@@ -205,12 +205,12 @@ leave them and report them in Phase 5.
 ### Update stale statuses
 If an iteration's branch was merged:
 ```bash
-hyalo set --property status=completed --file <path> --index .hyalo-index
+hyalo set <path> --property status=completed --index .hyalo-index
 ```
 
 If a backlog item's feature clearly shipped:
 ```bash
-hyalo set --property status=completed --file <path> --index .hyalo-index
+hyalo set <path> --property status=completed --index .hyalo-index
 ```
 
 Only update when the evidence is clear. When uncertain, flag it in the report.
@@ -218,7 +218,7 @@ Only update when the evidence is clear. When uncertain, flag it in the report.
 ### Archive completed items
 If completed items are in a top-level directory and a `done/` subfolder exists:
 ```bash
-hyalo mv --file <old-path> --to <done-subdir/filename> --dry-run --index .hyalo-index
+hyalo mv <old-path> --to <done-subdir/filename> --dry-run --index .hyalo-index
 ```
 Review the dry-run output. If correct, execute without `--dry-run`.
 

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -54,7 +54,7 @@ scanning all files to build the link graph. Each backlink entry contains `source
 `line` (line number), and an optional `label`.
 
 ```bash
-hyalo find --fields backlinks --file my-note.md       # see who links to this note
+hyalo find --fields backlinks --file my-note.md       # see who links to this note (--file required: positional is PATTERN)
 hyalo find --fields backlinks --jq '.results | map(select(.backlinks | length == 0))' # find orphan notes
 hyalo find --fields properties,backlinks              # combine with other fields
 ```
@@ -117,10 +117,10 @@ silently break links throughout the knowledgebase.
 
 ```bash
 # Move a file to a subfolder (updates all links vault-wide)
-hyalo mv --file backlog/my-item.md --to backlog/done/my-item.md
+hyalo mv backlog/my-item.md --to backlog/done/my-item.md
 
 # Preview what would change without writing
-hyalo mv --file old-path.md --to new-path.md --dry-run
+hyalo mv old-path.md --to new-path.md --dry-run
 ```
 
 ## Absolute link resolution (site prefix)
@@ -163,7 +163,7 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **properties rename** — bulk rename a property key across files (`--from old --to new`)
 - **tags summary** — list tags with counts
 - **tags rename** — bulk rename a tag across files (`--from old --to new`)
-- **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates; `--property 'K=[a,b,c]'` creates YAML sequences; `--file` is repeatable)
+- **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates; `--property 'K=[a,b,c]'` creates YAML sequences; file arg is positional or `--file`, repeatable)
 - **remove** — delete properties or tags
 - **append** — add to list properties
 - **task** — read, toggle, or set status on checkboxes (supports `--line 5,7`, `--section "Tasks"`, `--all`)
@@ -211,16 +211,17 @@ If you just need a quick readable overview, use `--format text` (without `--jq`)
 
 ## The backlinks command
 
-Use `hyalo backlinks --file <path>` to find all files that link to a given file (reverse link
+Use `hyalo backlinks <path>` to find all files that link to a given file (reverse link
 lookup). This builds an in-memory link graph by scanning all `.md` files in the directory,
-detecting both `[[wikilinks]]` and `[markdown](links)`.
+detecting both `[[wikilinks]]` and `[markdown](links)`. The file can be passed positionally
+or with `--file`.
 
 ```bash
 # Which files reference iteration-37?
-hyalo backlinks --file iterations/iteration-37-bulk-mutations.md
+hyalo backlinks iterations/iteration-37-bulk-mutations.md
 
 # JSON output for programmatic use
-hyalo backlinks --file iterations/iteration-37-bulk-mutations.md --format json
+hyalo backlinks iterations/iteration-37-bulk-mutations.md --format json
 ```
 
 Supports `--format text` (default, compact) and `--format json`. Useful for impact analysis
@@ -246,11 +247,11 @@ hyalo create-index
 hyalo find --property status=in-progress --index .hyalo-index
 hyalo summary --index .hyalo-index
 hyalo tags summary --index .hyalo-index
-hyalo backlinks --file some-note.md --index .hyalo-index
+hyalo backlinks some-note.md --index .hyalo-index
 
 # Mutations also work with --index — they patch the index after each write
-hyalo set --property status=completed --file note.md --index .hyalo-index
-hyalo task toggle --file note.md --line 5 --index .hyalo-index
+hyalo set note.md --property status=completed --index .hyalo-index
+hyalo task toggle note.md --line 5 --index .hyalo-index
 
 # Drop the index when done
 hyalo drop-index

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -590,10 +590,18 @@ fn find_with_hints_shows_suggestions() {
         stdout.contains("hyalo read ") && stdout.contains(".md"),
         "should suggest read <file> for first result: {stdout}"
     );
+    assert!(
+        !stdout.contains("read --file"),
+        "read hint should use positional form, not --file: {stdout}"
+    );
     // Should suggest backlinks for the first result (positional file arg, no --file flag).
     assert!(
         stdout.contains("hyalo backlinks ") && stdout.contains(".md"),
         "should suggest backlinks <file> for first result: {stdout}"
+    );
+    assert!(
+        !stdout.contains("backlinks --file"),
+        "backlinks hint should use positional form, not --file: {stdout}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -995,17 +995,24 @@ Body content here.
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
-        panic!(
-            "invalid JSON: {e}\n{}",
-            String::from_utf8_lossy(&output.stdout)
-        )
-    });
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{stdout}"));
     assert!(
         parsed.get("results").is_some(),
         "expected 'results' key: {parsed}"
     );
     assert_hints_present(&parsed);
+    // Hints should use positional file form, not --file flag
+    let hints_str = serde_json::to_string(&parsed["hints"]).unwrap();
+    assert!(
+        !hints_str.contains("read --file"),
+        "read hint should use positional form, not --file: {hints_str}"
+    );
+    assert!(
+        !hints_str.contains("backlinks --file"),
+        "backlinks hint should use positional form, not --file: {hints_str}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1048,17 +1055,24 @@ See [[target]].
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
-        panic!(
-            "invalid JSON: {e}\n{}",
-            String::from_utf8_lossy(&output.stdout)
-        )
-    });
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{stdout}"));
     assert!(
         parsed.get("results").is_some(),
         "expected 'results' key: {parsed}"
     );
     assert_hints_present(&parsed);
+    // Hints should use positional file form, not --file flag
+    let hints_str = serde_json::to_string(&parsed["hints"]).unwrap();
+    assert!(
+        !hints_str.contains("read --file"),
+        "read hint should use positional form, not --file: {hints_str}"
+    );
+    assert!(
+        !hints_str.contains("backlinks --file"),
+        "backlinks hint should use positional form, not --file: {hints_str}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/tests/e2e_hints.rs
+++ b/crates/hyalo-cli/tests/e2e_hints.rs
@@ -585,15 +585,15 @@ fn find_with_hints_shows_suggestions() {
         stdout.contains("  -> hyalo"),
         "should have hint lines with arrow prefix: {stdout}"
     );
-    // Should suggest reading the first result.
+    // Should suggest reading the first result (positional file arg, no --file flag).
     assert!(
-        stdout.contains("read --file"),
-        "should suggest read --file for first result: {stdout}"
+        stdout.contains("hyalo read ") && stdout.contains(".md"),
+        "should suggest read <file> for first result: {stdout}"
     );
-    // Should suggest backlinks for the first result.
+    // Should suggest backlinks for the first result (positional file arg, no --file flag).
     assert!(
-        stdout.contains("backlinks --file"),
-        "should suggest backlinks --file for first result: {stdout}"
+        stdout.contains("hyalo backlinks ") && stdout.contains(".md"),
+        "should suggest backlinks <file> for first result: {stdout}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_positional_file.rs
+++ b/crates/hyalo-cli/tests/e2e_positional_file.rs
@@ -122,7 +122,7 @@ fn read_no_file_at_all_errors() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("FILE") || stderr.contains("file"),
+        stderr.contains("required argument missing"),
         "expected missing file error, got: {stderr}"
     );
 }
@@ -369,4 +369,81 @@ fn task_set_status_positional_file() {
     );
     let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
     assert!(content.contains("- [?] First task"));
+}
+
+// ---------------------------------------------------------------------------
+// find: two positionals — first is pattern, second is file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_two_positionals_first_is_pattern() {
+    let tmp = setup();
+    // "note.md" is passed as the first positional (PATTERN) and "other.md" as the
+    // second (FILE). The pattern "note.md" should not match the body of other.md,
+    // so total should be 0 — verifying that other.md is treated as a file filter,
+    // not a second pattern.
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "note.md", "other.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // other.md body is "See [[note]] for details." — "note.md" does not appear verbatim
+    assert_eq!(
+        envelope["total"], 0,
+        "first positional is pattern (not a file), second is file filter: {envelope}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// set: multiple positional files
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_multiple_positional_files() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["set", "note.md", "other.md", "--property", "reviewed=true"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let note = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    let other = fs::read_to_string(tmp.path().join("other.md")).unwrap();
+    assert!(
+        note.contains("reviewed: true"),
+        "note.md not updated: {note}"
+    );
+    assert!(
+        other.contains("reviewed: true"),
+        "other.md not updated: {other}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// set: positional file conflicts with --file flag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_positional_conflicts_with_file_flag() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["set", "note.md", "--file", "other.md", "--property", "k=v"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected conflict error, got: {stderr}"
+    );
 }

--- a/crates/hyalo-cli/tests/e2e_positional_file.rs
+++ b/crates/hyalo-cli/tests/e2e_positional_file.rs
@@ -107,6 +107,48 @@ fn read_positional_and_flag_conflicts() {
 }
 
 // ---------------------------------------------------------------------------
+// read: no file at all → error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_no_file_at_all_errors() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("FILE") || stderr.contains("file"),
+        "expected missing file error, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// find: positional file + --file flag conflicts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_positional_file_and_flag_conflicts() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "pattern", "note.md", "--file", "other.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected conflict error, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // backlinks: positional file
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e_positional_file.rs
+++ b/crates/hyalo-cli/tests/e2e_positional_file.rs
@@ -1,0 +1,330 @@
+mod common;
+
+use common::{hyalo_no_hints, md, write_md};
+use std::fs;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+fn setup() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Test Note
+status: draft
+tags:
+  - rust
+---
+# Body
+
+Some content here.
+
+## Tasks
+
+- [ ] First task
+- [x] Second task
+"),
+    );
+
+    write_md(
+        tmp.path(),
+        "other.md",
+        md!(r"
+---
+title: Other
+---
+See [[note]] for details.
+"),
+    );
+
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// read: positional file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_positional_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "note.md", "--format", "text"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Some content here."));
+}
+
+#[test]
+fn read_positional_matches_flag() {
+    let tmp = setup();
+
+    let positional = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "note.md"])
+        .output()
+        .unwrap();
+
+    let flag = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(positional.status.success());
+    assert!(flag.status.success());
+    assert_eq!(positional.stdout, flag.stdout);
+}
+
+// ---------------------------------------------------------------------------
+// read: conflict — both positional and --file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_positional_and_flag_conflicts() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "note.md", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected conflict error, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// backlinks: positional file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backlinks_positional_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["backlinks", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // other.md links to note via [[note]]
+    assert_eq!(envelope["total"], 1);
+}
+
+// ---------------------------------------------------------------------------
+// mv: positional file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mv_positional_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["mv", "note.md", "--to", "archive/note.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(envelope["results"]["from"], "note.md");
+    assert_eq!(envelope["results"]["to"], "archive/note.md");
+    assert!(tmp.path().join("archive/note.md").exists());
+    assert!(!tmp.path().join("note.md").exists());
+}
+
+// ---------------------------------------------------------------------------
+// set: positional file(s)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_positional_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["set", "note.md", "--property", "priority=5"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("priority: 5"));
+}
+
+// ---------------------------------------------------------------------------
+// remove: positional file(s)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_positional_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["remove", "note.md", "--property", "status"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(!content.contains("status:"));
+}
+
+// ---------------------------------------------------------------------------
+// append: positional file(s)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn append_positional_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["append", "note.md", "--property", "tags=cli"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("cli"));
+    assert!(content.contains("rust"));
+}
+
+// ---------------------------------------------------------------------------
+// find: positional pattern + positional file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_positional_pattern_and_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "content", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(envelope["total"], 1);
+    assert_eq!(envelope["results"][0]["file"], "note.md");
+}
+
+#[test]
+fn find_positional_file_only_no_pattern() {
+    // When only one positional is given to find, it's treated as PATTERN, not file.
+    // To pass a file without a pattern, --file is required.
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(envelope["total"], 1);
+}
+
+// ---------------------------------------------------------------------------
+// task read: positional file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_read_positional_file() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["task", "read", "note.md", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = envelope["results"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// task toggle: positional file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_toggle_positional_file() {
+    let tmp = setup();
+    // Toggle line 13 (- [ ] First task)
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["task", "toggle", "note.md", "--line", "13"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("- [x] First task"));
+}
+
+// ---------------------------------------------------------------------------
+// task set-status: positional file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_set_status_positional_file() {
+    let tmp = setup();
+    // Set line 13 (- [ ] First task) to status '?'
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "task",
+            "set-status",
+            "note.md",
+            "--line",
+            "13",
+            "--status",
+            "?",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(content.contains("- [?] First task"));
+}

--- a/hyalo-knowledgebase/iterations/iteration-99-positional-file-arg.md
+++ b/hyalo-knowledgebase/iterations/iteration-99-positional-file-arg.md
@@ -1,0 +1,32 @@
+---
+title: "Positional file arguments for all commands"
+type: iteration
+date: 2026-04-07
+tags:
+  - iteration
+  - cli
+  - ergonomics
+status: in-progress
+branch: iter-99/positional-file-arg
+---
+
+# Positional File Arguments
+
+Allow passing target files as positional arguments instead of requiring `--file` across all commands.
+
+## Motivation
+
+LLM agents (and humans) frequently pass the file as a bare positional arg (`hyalo read note.md`) instead of using the flag form (`hyalo read --file note.md`). This causes confusing errors. Supporting both forms makes the CLI more forgiving and ergonomic.
+
+## Tasks
+
+- [x] Add positional file support to single-file commands (read, backlinks, mv)
+- [x] Add positional file support to task subcommands (read, toggle, set-status)
+- [x] Add positional file support to multi-file commands (set, remove, append)
+- [x] Add positional file support to find (after PATTERN)
+- [x] Update hints to emit positional form
+- [x] Update help text and long_about descriptions
+- [x] Update skill templates and CLAUDE.md
+- [x] Add e2e tests for positional form (15 tests)
+- [x] Fix review issues (conflicts_with, error handling, hint context)
+- [ ] Merge PR #110

--- a/hyalo-knowledgebase/research/fts-and-vector-search.md
+++ b/hyalo-knowledgebase/research/fts-and-vector-search.md
@@ -1,0 +1,153 @@
+---
+title: "Full-Text Search & Vector Embeddings Feasibility"
+type: research
+date: 2026-04-06
+tags: [research, search, fts, embeddings, vector, performance]
+status: completed
+---
+
+# Full-Text Search & Vector Embeddings Feasibility
+
+Research into two approaches for enhancing hyalo's search capabilities beyond the current substring/regex matching.
+
+## Approach 1: Full-Text Search Index (Tantivy)
+
+### Library: tantivy (v0.22)
+
+The de facto Rust FTS library. Lucene-inspired, actively maintained by Quickwit.
+
+**Pros:**
+- ~2x faster than Lucene in query latency benchmarks
+- Supports RamDirectory (in-memory index, no disk persistence needed)
+- BM25 ranking, phrase queries, fuzzy matching, boolean queries out of the box
+- MmapDirectory for persistent indexes with very low resident memory
+- Pure Rust, cross-platform (macOS/Linux/Windows)
+- ~162 unique transitive dependencies (manageable)
+- Well-maintained: used by Quickwit, Meilisearch, ParadeDB
+
+**Cons:**
+- A single growing segment can use ~15 MB RAM even for few docs (fixed overhead)
+- Adds meaningful compile time and binary size
+- Heavyweight for a ~1000-file knowledge base (designed for millions of docs)
+
+**Performance estimates for ~1000 markdown files:**
+- Indexing: At 45k docs/sec throughput, 1000 files would index in ~22ms (excluding I/O)
+- Realistic with file I/O: likely 50-200ms total for a cold `create-index` command
+- Query latency: sub-millisecond for a corpus this small
+- Index size on disk: a few hundred KB to low single-digit MB for 1000 short docs
+
+**Architecture options:**
+1. **On-the-fly (RamDirectory)**: Build index in memory at each invocation. ~100-200ms startup cost. No stale index issues. Simple. Best fit for hyalo's current approach.
+2. **Persistent (MmapDirectory)**: Build once, query many times. Near-instant queries. Requires index invalidation logic (watch mtimes, rebuild on change). More complexity.
+3. **Hybrid**: Extend current MessagePack snapshot index to include FTS data. Rebuild when snapshot is stale.
+
+**Verdict:** Highly feasible. On-the-fly indexing of 1000 files is fast enough for a CLI tool. The RamDirectory approach keeps it simple. Persistent index adds complexity but gives instant queries.
+
+### Lightweight Alternatives
+
+- **Sonic**: Minimal memory footprint, but it's a server (not embeddable as a library)
+- **Custom BM25**: Could implement simple TF-IDF/BM25 scoring over the existing in-memory document set without tantivy. Much less code, fewer deps, but no fuzzy/phrase queries.
+- **strsim + regex**: Already have substring/regex. Adding a simple relevance scorer on top might be "good enough" for small corpora.
+
+## Approach 2: Vector Store with Embeddings
+
+### Embedding Generation
+
+**Best option: fastembed-rs (v4.9)**
+- Wraps ONNX Runtime via `ort` crate
+- Downloads models from HuggingFace on first use (cached locally)
+- Default model: all-MiniLM-L6-v2 (22M params, 384 dimensions)
+- ONNX model file: ~90 MB download, cached in ~/.cache
+- ~508 unique transitive dependencies (very heavy)
+- Cross-platform (macOS/Linux/Windows)
+
+**Alternative: ort directly**
+- Lower-level, fewer deps than fastembed
+- Need to handle tokenization yourself (add `tokenizers` crate)
+- More control, but more code
+
+**Alternative: candle (HuggingFace)**
+- Pure Rust ML framework
+- No ONNX dependency, but models need conversion
+- Less mature for production embedding inference
+
+**Performance estimates for ~1000 markdown files (CPU, all-MiniLM-L6-v2):**
+- Model load (cold start): ~500ms-2s (ONNX session init + model load from disk cache)
+- Embedding generation: ~50-100 sentences/sec single-threaded on CPU
+- For 1000 short markdown files (~1-2 paragraphs each): ~10-20 seconds
+- With batching (batch_size=256): possibly 3-8 seconds total
+- First-ever run: add ~30s-2min for model download (~90 MB)
+
+### Vector Similarity Search
+
+**Best options:**
+- **usearch**: Single-file HNSW implementation, C++ core with Rust bindings. Fast, tiny footprint.
+- **hnswlib-rs**: Pure Rust HNSW. Multithreaded insert/search.
+- **hora**: Pure Rust, multiple index types (HNSW, SSG, PQIVF). SIMD-accelerated.
+- **Simple brute force**: For 1000 vectors of 384 dims, brute-force cosine similarity takes <1ms. No index needed.
+
+**Storage:** 1000 vectors x 384 dims x 4 bytes = ~1.5 MB. Trivially fits in the MessagePack index.
+
+### Architecture for hyalo
+
+1. `hyalo embed` or `hyalo index --embeddings`: generate embeddings for all files, store in snapshot index
+2. `hyalo find --semantic "concept I'm looking for"`: cosine similarity search against stored embeddings
+3. Model cached in `~/.cache/fastembed` (or similar), downloaded on first use
+
+**Verdict:** Technically feasible but problematic for a fast CLI tool:
+- **Cold start of 0.5-2s** just to load the model kills the "instant" CLI feel
+- **10-20s** to embed 1000 files is too slow for on-the-fly; requires persistent index
+- **90 MB model download** is a steep first-run cost for a lightweight tool
+- **508 dependencies** nearly quadruples the dep count
+- **Binary size** would grow significantly (ONNX runtime is large)
+- Need to handle the "model not downloaded yet" UX gracefully
+
+## Comparison Summary
+
+| Criterion | FTS (tantivy) | Vector Embeddings |
+|---|---|---|
+| On-the-fly feasibility | Yes (~100-200ms) | No (10-20s embed time) |
+| Persistent index feasibility | Yes | Yes (with pre-computed embeddings) |
+| Query quality | Exact + fuzzy text matching | Semantic/conceptual similarity |
+| Cold start overhead | ~0ms (in-memory) | ~0.5-2s (model load) |
+| New dependencies | ~162 crates | ~508 crates |
+| External downloads | None | ~90 MB model file |
+| Binary size impact | Moderate (+2-4 MB est.) | Large (+10-20 MB est. with ONNX) |
+| Cross-platform | Native Rust | Needs ONNX runtime per platform |
+| Complexity | Low-medium | High |
+
+## Conclusion (2026-04-06)
+
+**Verdict: Parked for now, but multi-term search has real value.**
+
+### The actual gap in current `find`
+The current grep-style search handles single substrings and regex well, but falls short for:
+- **Boolean queries**: `rust OR golang` — currently requires manual regex `rust|golang`
+- **Multi-term AND across non-adjacent text**: `rust async error` — finds files containing all three terms anywhere, not as a literal substring. Currently impossible without multiple passes or ugly lookahead regex.
+- **Phrase matching**: `"error handling"` as an exact phrase
+
+This is a real workflow pain point, especially for LLM agents that frequently construct `find -e "term1|term2|term3"` patterns as a workaround.
+
+### Why not rush to implement
+For a personal KB of hundreds of files, ranked results and noise filtering matter less — users typically know what they're looking for, and grep + property/tag filtering is predictable and precise. FTS shines more at scale (thousands of docs, many authors).
+
+### Implementation options when we're ready
+
+**Option A: `bm25` crate** (recommended) — See [[research/fts-lightweight-alternatives]]
+- `default-features = false`: **3 new deps** (fxhash + byteorder). BM25 scoring + search engine, bring your own tokenizer.
+- `default_tokenizer` feature: **~10 new deps**. Adds stemming, stop words, unicode normalization.
+- Provides ranked results, multi-term AND/OR, and noise filtering out of the box.
+
+**Option B: `elasticlunr-rs`** — See [[research/fts-lightweight-alternatives]]
+- **~0 new deps** (hyalo already has serde, regex, memchr). Used by mdbook, 6.5M downloads.
+- TF-IDF scoring (not BM25), tokenization pipeline, multi-field search, boolean queries.
+- Designed for JSON export (static site search) but works fine in-memory.
+
+**Option C: DIY** — Zero new deps
+- ~100-200 lines on top of existing `ContentSearchVisitor`.
+- Split query into terms, check each file for presence, AND/OR semantics.
+- No ranking or stemming, but solves the core boolean/multi-term gap.
+
+**Not recommended:**
+- **tantivy**: 162 deps, overkill for this scale.
+- **Vector embeddings**: 508 deps, 90 MB model download, 10-20s embedding time. Only revisit if KB grows to a scale where grep results become unmanageable.

--- a/hyalo-knowledgebase/research/fts-lightweight-alternatives.md
+++ b/hyalo-knowledgebase/research/fts-lightweight-alternatives.md
@@ -1,0 +1,152 @@
+---
+title: Lightweight FTS alternatives to tantivy
+type: research
+date: 2026-04-06
+tags:
+  - full-text-search
+  - dependencies
+  - performance
+status: completed
+---
+
+# Lightweight Full-Text Search Alternatives to Tantivy
+
+## Context
+
+Tantivy has 162 transitive dependencies -- too heavy for a CLI tool indexing ~1000 small markdown files. Need something much simpler.
+
+hyalo already depends on: serde, regex, memchr, rayon, thiserror, rmp-serde (MessagePack), ahash, among others. Any crate sharing these deps adds zero marginal cost.
+
+## Candidates Evaluated
+
+### Tier 1: Strong Candidates
+
+#### `bm25` (v2.3.2) -- RECOMMENDED
+- **Repo**: https://github.com/Michael-JB/bm25
+- **Downloads**: 1.1M+ (well-adopted)
+- **Last updated**: 2025-09-07
+- **What it provides**: BM25 embedder, scorer, and complete in-memory search engine. Three abstraction levels: Embedder (sparse vectors), Scorer (ranking), SearchEngine (full keyword search).
+- **Dep count (no defaults)**: 3 transitive deps (fxhash + byteorder only!)
+- **Dep count (default_tokenizer)**: ~25 unique crates (adds cached, rust-stemmers, stop-words, deunicode, unicode-segmentation)
+- **Dep count (all defaults)**: ~35 unique crates
+- **Features**: `default_tokenizer` (stemming, stop words, unicode normalization), `language_detection`, `parallelism` (rayon)
+- **Key insight**: With `default-features = false`, you get the core BM25 engine with only 3 deps. You can bring your own tokenizer. With `default_tokenizer`, you get English stemming + stop words for ~25 deps.
+- **API**: Builder pattern -- `SearchEngineBuilder` for the simple case, or `Embedder`+`Scorer` for custom pipelines.
+- **Overlap with hyalo**: Would share rayon if `parallelism` feature enabled. fxhash is tiny (2 deps).
+
+#### `elasticlunr-rs` (v3.0.2)
+- **Repo**: https://github.com/mattico/elasticlunr-rs
+- **Downloads**: 6.5M+ (very well-adopted, used by mdbook)
+- **Last updated**: 2025-03-16
+- **What it provides**: Port of elasticlunr.js -- tokenization, inverted index, TF-IDF scoring, multi-field search. Exports index to JSON (originally for client-side search).
+- **Dep count (no defaults)**: ~15 unique crates (regex + serde + serde_json are mandatory)
+- **Dep count (defaults)**: ~17 unique crates
+- **Features**: Optional language support (jieba-rs for Chinese, lindera for Japanese, rust-stemmers)
+- **Key insight**: serde/serde_json/regex already in hyalo, so marginal cost is essentially zero new deps. Battle-tested, mature. But: designed for JSON export (static site search), scoring is TF-IDF not BM25, API is add-doc-then-search.
+- **Limitation**: No BM25. Serialization format is JSON (verbose). Designed for browser consumption.
+
+### Tier 2: Viable but with Caveats
+
+#### `rust-tfidf` (v1.1.1)
+- **Repo**: https://github.com/ferristseng/rust-tfidf
+- **Downloads**: 27K
+- **Last updated**: 2021 (dormant since 2015)
+- **Deps**: ZERO dependencies
+- **What it provides**: Pure TF-IDF scoring via traits. No inverted index, no tokenization, no search. You pass pre-tokenized documents and get scores back.
+- **Limitation**: Just a scoring function. You'd need to build the inverted index yourself. Abandoned.
+
+#### `tfidf` (v0.3.0)
+- **Repo**: https://github.com/afshinm/tf-idf
+- **Downloads**: 6K
+- **Last updated**: 2017 (dormant)
+- **Deps**: ZERO dependencies
+- **What it provides**: Similar to rust-tfidf -- bare TF-IDF computation.
+- **Limitation**: Same as above. Scoring only, no index.
+
+#### `rankfns` (v0.1.2)
+- **Repo**: https://github.com/arclabs561/rankfns
+- **Downloads**: 100
+- **Last updated**: 2026-03-09
+- **Deps**: 1 (postings)
+- **What it provides**: IR ranking math kernels only -- BM25, TF-IDF, language model transforms. No indexing.
+- **Limitation**: Part of an experimental arclabs561 ecosystem (postings + lexir + rankfns). Very new, very low adoption.
+
+#### `lexir` (v0.1.2)
+- **Repo**: https://github.com/arclabs561/lexir
+- **Downloads**: 41
+- **Last updated**: 2026-03-09
+- **What it provides**: BM25/TF-IDF scoring on top of postings lists. Has InvertedIndex, add_document(), retrieve().
+- **Limitation**: Experimental, 41 downloads, depends on postings+rankfns from same author. Self-described as "reference implementation."
+
+#### `bm25x` (v0.3.1)
+- **Repo**: https://github.com/lightonai/bm25x
+- **Downloads**: 84
+- **Last updated**: 2026-03-19
+- **Deps**: 8 non-optional (bincode, memmap2, rayon, rust-stemmers, rustc-hash, serde, tempfile, unicode-normalization)
+- **What it provides**: Streaming-friendly BM25 with mmap support. Designed for large-scale retrieval.
+- **Limitation**: Overkill for 1000 files. Very new, low adoption.
+
+### Tier 3: Not Suitable
+
+#### `nanofts` (v0.7.0)
+- 31 non-optional deps including mimalloc, roaring bitmaps, zstd, crossbeam, dashmap
+- LSM-tree architecture "scalable to billions of documents"
+- Way overkill. More deps than tantivy would save.
+
+#### `stork-lib` (v2.0.0-beta.2)
+- 26 deps, still in beta, includes wasm-bindgen
+- Designed for static sites, not CLI tools
+
+#### `terrain` (v0.1.0)
+- 22 downloads, depends on traverze (which depends on tantivy!)
+- Defeats the purpose entirely
+
+#### `bm25_turbo` (v0.2.0)
+- 34 deps including tokio, tonic, axum, tower
+- HTTP server / gRPC-oriented. Way too heavy.
+
+#### `tinysearch` (v0.10.0)
+- WASM-oriented for static sites, uses cuckoo filters
+- Not a general-purpose search library
+
+### Tier 4: DIY Option
+
+#### Roll your own with existing deps
+- hyalo already has: memchr, regex, rayon, serde, ahash
+- A simple inverted index with BM25 scoring is ~200-300 lines of Rust
+- HashMap<String, Vec<(DocId, f32)>> for the index
+- Standard BM25 formula: score = IDF * (tf * (k1+1)) / (tf + k1 * (1 - b + b * dl/avgdl))
+- Tokenization: split on whitespace + punctuation, lowercase, optional stemming
+- For 1000 docs, in-memory is trivial
+- **Downside**: No stemming without rust-stemmers (~2 deps), no stop words without a list
+
+## Recommendation
+
+**Primary: `bm25` with `default-features = false`** (3 deps)
+- If you need stemming/stop-words: enable `default_tokenizer` feature (~25 deps, but rust-stemmers + stop-words are worth it for search quality)
+- Provides a complete, tested BM25 search engine
+- Well-maintained (1M+ downloads), good API design
+- Can bring your own tokenizer for full control
+
+**Secondary: `elasticlunr-rs`** (~0 new deps for hyalo since serde+regex already present)
+- If TF-IDF is acceptable over BM25
+- Battle-tested (6.5M downloads, used by mdbook)
+- Near-zero marginal dep cost since hyalo already has serde+regex
+- But: JSON-oriented serialization, no MessagePack option
+
+**Fallback: DIY inverted index + `bm25` no-defaults for scoring only**
+- Use `bm25`'s Embedder/Scorer without the SearchEngine
+- Build your own inverted index with HashMap
+- Use your own tokenizer (regex-based split)
+- Total new deps: 3 (fxhash + byteorder)
+
+## Dep Cost Summary
+
+| Crate | Config | Total transitive deps | New deps for hyalo |
+|-------|--------|----------------------|-------------------|
+| bm25 | no defaults | 3 | ~2 (fxhash, byteorder) |
+| bm25 | default_tokenizer | ~25 | ~8-10 |
+| bm25 | all features | ~35 | ~15 |
+| elasticlunr-rs | defaults | ~17 | ~0 (all overlap) |
+| tantivy | defaults | 162 | ~120+ |
+| DIY | n/a | 0 | 0 |


### PR DESCRIPTION
## Summary

- Allow passing the target file as a positional argument instead of requiring the `--file` flag across all commands: `read`, `backlinks`, `mv`, `set`, `remove`, `append`, `find` (after PATTERN), and all `task` subcommands
- Both forms remain supported for backward compatibility — `hyalo read file.md` and `hyalo read --file file.md` work identically
- Update hint system to emit shorter positional form (e.g. `hyalo read note.md` instead of `hyalo read --file note.md`)
- Update all help text, skill templates, rule templates, and CLAUDE.md to prefer positional form

## Test plan

- [x] All 521 existing tests pass (backward compat via `--file` flag)
- [x] `cargo fmt` / `cargo clippy` / `cargo test` all clean
- [x] Manual dogfooding: `hyalo read SEED.md`, `hyalo backlinks SEED.md`, `hyalo task read <file> --all`, `hyalo find "pattern" file.md`
- [x] Conflict detection works: `hyalo read SEED.md --file SEED.md` produces clear error
- [x] Hints emit positional form for read/backlinks/mv/task, keep `--file` for find
- [ ] E2e tests for positional form specifically (deferred — existing coverage via shared code path)