### PR TITLE
feat: add `hyalo completion` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,11 +485,12 @@ checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hyalo-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "dunce",
  "globset",
  "hyalo-core",
@@ -500,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hyalo-core = { path = "crates/hyalo-core", version = "0.9.0" }
 anyhow = "1"
 assert_cmd = "2"
 clap = "4.6.0"
+clap_complete = "4.6.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 dunce = "1"
 globset = "0.4"

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -21,6 +21,7 @@ hyalo-core = { workspace = true }
 anyhow = { workspace = true }
 indexmap = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+clap_complete = { workspace = true }
 dunce = { workspace = true }
 jaq-core = { workspace = true }
 jaq-json = { workspace = true }

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -680,6 +680,25 @@ Repeatable (AND).\n\
         #[command(subcommand)]
         action: LinksAction,
     },
+    /// Generate shell completions for the given shell
+    #[command(
+        display_order = 900,
+        long_about = "Generate shell completion scripts.\n\n\
+            Prints a completion script for the specified shell to stdout.\n\
+            Source or install the output in your shell's completion directory.\n\n\
+            EXAMPLES:\n\
+            \u{00a0} bash:        hyalo completion bash  > ~/.local/share/bash-completion/completions/hyalo\n\
+            \u{00a0} zsh:         hyalo completion zsh   > ~/.local/share/zsh/site-functions/_hyalo\n\
+            \u{00a0} fish:        hyalo completion fish  > ~/.config/fish/completions/hyalo.fish\n\
+            \u{00a0} elvish:      hyalo completion elvish > ~/.config/elvish/lib/completions/hyalo.elv\n\
+            \u{00a0} powershell:  hyalo completion powershell > _hyalo.ps1\n\n\
+            SIDE EFFECTS: None (prints to stdout)."
+    )]
+    Completion {
+        /// Target shell
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
 }
 
 #[derive(Subcommand)]

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -35,7 +35,8 @@ pub(crate) const HELP_EXAMPLES: &str = "EXAMPLES:
   List saved views:             hyalo views list
   Use a view:                   hyalo find --view todo
   Use view with overrides:      hyalo find --view todo --limit 5
-  Remove a view:                hyalo views remove todo";
+  Remove a view:                hyalo views remove todo
+  Generate shell completions:   hyalo completion bash";
 
 /// Long help (shown by `--help`): command reference, cookbook, and output shapes.
 pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
@@ -98,6 +99,9 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
 
   Drop-index (delete snapshot index):
     hyalo drop-index [-p/--path PATH]
+
+  Completion (generate shell completions):
+    hyalo completion <SHELL>    # bash, zsh, fish, elvish, powershell
 
   Global flags (apply to all commands):
     -d/--dir <DIR>          Root directory (default: ., override via .hyalo.toml)

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -610,9 +610,12 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 IndexResolution::Outcome(outcome) => Ok(outcome),
             },
         },
-        // `Init` and `Deinit` are handled as early returns before dispatch is called.
+        // `Init`, `Deinit`, and `Completion` are handled as early returns before dispatch is called.
         Commands::Init { .. } => unreachable!("Init is dispatched before this match reached"),
         Commands::Deinit => unreachable!("Deinit is dispatched before this match reached"),
+        Commands::Completion { .. } => {
+            unreachable!("Completion is dispatched before this match reached")
+        }
         Commands::Views { action } => {
             let action = action.unwrap_or(ViewsAction::List);
             match action {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -170,7 +170,12 @@ fn run_inner() -> Result<(), AppError> {
     // Dispatch it before the rest of the setup.
     // The global --dir flag is used as the dir value for .hyalo.toml.
     // Reject --count early — init is not a list command.
-    if cli.count && matches!(cli.command, Commands::Init { .. } | Commands::Deinit) {
+    if cli.count
+        && matches!(
+            cli.command,
+            Commands::Init { .. } | Commands::Deinit | Commands::Completion { .. }
+        )
+    {
         eprintln!("{COUNT_UNSUPPORTED_ERROR}");
         return Err(AppError::Exit(2));
     }
@@ -194,6 +199,11 @@ fn run_inner() -> Result<(), AppError> {
             Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
             Err(e) => return Err(AppError::Internal(e)),
         }
+    }
+    if let Commands::Completion { shell } = cli.command {
+        let mut cmd = Cli::command();
+        clap_complete::generate(shell, &mut cmd, "hyalo", &mut std::io::stdout());
+        return Ok(());
     }
     // Merge: CLI args override config, config overrides hardcoded defaults.
     // Track whether --dir was explicitly passed (not from config) so hints
@@ -565,6 +575,7 @@ fn run_inner() -> Result<(), AppError> {
             | Commands::Tags { .. }
             | Commands::Init { .. }
             | Commands::Deinit
+            | Commands::Completion { .. }
             | Commands::Views { .. } => None,
         }
     } else {

--- a/crates/hyalo-cli/tests/e2e_completion.rs
+++ b/crates/hyalo-cli/tests/e2e_completion.rs
@@ -1,0 +1,57 @@
+mod common;
+
+use common::hyalo_no_hints;
+
+#[test]
+fn completion_all_shells_produce_output() {
+    for shell in ["bash", "zsh", "fish", "elvish", "powershell"] {
+        let output = hyalo_no_hints()
+            .args(["completion", shell])
+            .output()
+            .unwrap();
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "{shell}: stderr: {stderr}");
+
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            stdout.contains("hyalo"),
+            "{shell} completions should reference the binary name"
+        );
+    }
+}
+
+#[test]
+fn completion_missing_shell_fails() {
+    let output = hyalo_no_hints().args(["completion"]).output().unwrap();
+
+    assert!(
+        !output.status.success(),
+        "completion without a shell argument should fail"
+    );
+}
+
+#[test]
+fn completion_invalid_shell_fails() {
+    let output = hyalo_no_hints()
+        .args(["completion", "invalid-shell"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "completion with an invalid shell should fail"
+    );
+}
+
+#[test]
+fn completion_listed_in_help() {
+    let output = hyalo_no_hints().arg("-h").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(
+        stdout.contains("completion"),
+        "completion command should appear in help output"
+    );
+}


### PR DESCRIPTION
Add a new `completion` subcommand that generates shell completion scripts for bash, zsh, fish, elvish, and powershell using `clap_complete`.

- Add `clap_complete` 4.6.0 as workspace dependency
- Add `Completion` variant to `Commands` enum with `display_order=900` (listed last before help)
- Dispatch completion early in `run.rs` (no vault setup needed)
- Add long_about with installation examples for each shell
- Add completion to COMMAND REFERENCE and EXAMPLES in help text
- Add e2e tests covering all shells, missing/invalid args, and help

Co-authored-by: Copilot <copilot@github.com>