### PR TITLE
Rename `task set-status` to `task set`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Most flags have short aliases for quick interactive use:
 | `-n` | `--limit` | find |
 | `-n` | `--recent` | summary |
 | `-l` | `--lines` | read |
-| `-l` | `--line` | task read, task toggle, task set-status |
-| `-s` | `--status` | task set-status |
+| `-l` | `--line` | task read, task toggle, task set |
+| `-s` | `--status` | task set |
 | `-o` | `--output` | create-index |
 
 Glob patterns use standard shell semantics: `*` matches within a single directory, `**` matches across directory boundaries. For example, `*.md` matches top-level files only, while `**/*.md` matches all `.md` files recursively.
@@ -443,7 +443,7 @@ hyalo task toggle --file note.md --section "Acceptance criteria"
 hyalo task toggle --file note.md --all
 
 # Set custom status on all tasks in a section
-hyalo task set-status --file note.md --section Tasks --status /
+hyalo task set --file note.md --section Tasks --status /
 ```
 
 Tasks are markdown checkboxes (`- [ ]`, `- [x]`, `- [/]`, etc.) in the file body. Checkboxes inside fenced code blocks and `%%comment%%` blocks are ignored. Bulk mutations use a single atomic read-modify-write pass.

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -365,10 +365,10 @@ pub(crate) enum Commands {
             Subcommands:\n\
             - read: Show task details for one or more tasks.\n\
             - toggle: Flip completion state ([ ] <-> [x], custom -> [x]).\n\
-            - set-status: Set an arbitrary single-character status.\n\n\
+            - set: Set an arbitrary single-character status.\n\n\
             INPUT: FILE (positional or --file) and one of: --line (repeatable/comma-separated), --section <heading>, or --all.\n\
             SCOPE: Single file only.\n\
-            SIDE EFFECTS: 'toggle' and 'set-status' modify the file on disk. 'read' is read-only.")]
+            SIDE EFFECTS: 'toggle' and 'set' modify the file on disk. 'read' is read-only.")]
     Task {
         #[command(subcommand)]
         action: TaskAction,
@@ -828,18 +828,19 @@ pub(crate) enum TaskAction {
     },
     /// Set a custom single-character status on one or more tasks
     #[command(
-        name = "set-status",
+        name = "set",
+        alias = "set-status",
         long_about = "Set a custom single-character status on one or more task checkboxes.\n\n\
         INPUT: FILE (positional or --file), --status (single char), and one of: --line (repeatable), --section <heading>, or --all.\n\
         OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
         SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
         USE WHEN: You need to set a non-standard status like '?' (question), '-' (cancelled), or '!' (important).\n\n\
         EXAMPLES:\n  \
-          hyalo task set-status note.md --line 5 --status '?'\n  \
-          hyalo task set-status note.md --line 5,7 --status '-'\n  \
-          hyalo task set-status note.md --section Tasks --status '-'\n  \
-          hyalo task set-status note.md --all --status x\n  \
-          hyalo task set-status --file note.md --line 5 --status '?'"
+          hyalo task set note.md --line 5 --status '?'\n  \
+          hyalo task set note.md --line 5,7 --status '-'\n  \
+          hyalo task set note.md --section Tasks --status '-'\n  \
+          hyalo task set note.md --all --status x\n  \
+          hyalo task set --file note.md --line 5 --status '?'"
     )]
     SetStatus {
         /// File containing the task(s) (relative to --dir) — positional form

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -842,7 +842,7 @@ pub(crate) enum TaskAction {
           hyalo task set note.md --all --status x\n  \
           hyalo task set --file note.md --line 5 --status '?'"
     )]
-    SetStatus {
+    Set {
         /// File containing the task(s) (relative to --dir) — positional form
         #[arg(value_name = "FILE")]
         file_positional: Option<String>,

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -71,7 +71,7 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
   Task (single-task operations):
     hyalo task read       -f/--file F -l/--line N           Read task at a line
     hyalo task toggle     -f/--file F -l/--line N           Toggle completion
-    hyalo task set-status -f/--file F -l/--line N -s/--status C
+    hyalo task set        -f/--file F -l/--line N -s/--status C
 
   Backlinks (reverse link lookup, read-only):
     hyalo backlinks -f/--file F
@@ -232,7 +232,7 @@ COOKBOOK:
   hyalo task toggle --file todo.md --line 5
 
   # Set a custom task status (e.g. cancelled)
-  hyalo task set-status --file todo.md --line 5 --status -
+  hyalo task set --file todo.md --line 5 --status -
 
   # Fix broken links (dry-run preview)
   hyalo links fix
@@ -281,7 +281,7 @@ OUTPUT SHAPES (JSON, default):
   # tags rename
   {\"results\": {\"from\": \"old\", \"to\": \"new\", \"modified\": [...], \"skipped\": [...], \"total\": N}, \"hints\": [...]}
 
-  # task read / toggle / set-status
+  # task read / toggle / set
   {\"results\": {\"file\": \"todo.md\", \"line\": 5, \"status\": \"x\", \"text\": \"Fix bug\", \"done\": true}, \"hints\": [...]}
 
   # summary

--- a/crates/hyalo-cli/src/commands/tasks.rs
+++ b/crates/hyalo-cli/src/commands/tasks.rs
@@ -209,7 +209,7 @@ pub fn task_toggle(
 }
 
 // ---------------------------------------------------------------------------
-// `hyalo task set-status` — set custom status character
+// `hyalo task set` — set custom status character
 // ---------------------------------------------------------------------------
 
 /// Set status on one or more tasks by line selector.

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -354,7 +354,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     index_path,
                 )
             }
-            TaskAction::SetStatus {
+            TaskAction::Set {
                 file_positional,
                 file,
                 line,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -522,7 +522,7 @@ fn run_inner() -> Result<(), AppError> {
                         file,
                         task_selector(line, section.as_ref(), *all),
                     ),
-                    crate::cli::args::TaskAction::SetStatus {
+                    crate::cli::args::TaskAction::Set {
                         file_positional,
                         file,
                         line,

--- a/crates/hyalo-cli/src/suggest.rs
+++ b/crates/hyalo-cli/src/suggest.rs
@@ -67,15 +67,7 @@ pub fn suggest_subcommand_correction(args: &[String], cmd: &clap::Command) -> Op
         .get_subcommands()
         .find(|s| s.get_name() == parent_name)?;
 
-    // Collect sub-subcommand names from the parent.
-    let sub_names: Vec<&str> = parent_cmd
-        .get_subcommands()
-        .map(clap::Command::get_name)
-        .collect();
-
-    if sub_names.is_empty() {
-        return None;
-    }
+    parent_cmd.get_subcommands().next()?;
 
     // Scan args after the parent for `--<name>` where `<name>` matches a sub-subcommand
     // name or alias. Also skip flag values here for consistency.

--- a/crates/hyalo-cli/src/suggest.rs
+++ b/crates/hyalo-cli/src/suggest.rs
@@ -77,8 +77,8 @@ pub fn suggest_subcommand_correction(args: &[String], cmd: &clap::Command) -> Op
         return None;
     }
 
-    // Scan args after the parent for `--<name>` where `<name>` matches a sub-subcommand.
-    // Also skip flag values here for consistency.
+    // Scan args after the parent for `--<name>` where `<name>` matches a sub-subcommand
+    // name or alias. Also skip flag values here for consistency.
     let mut found_flag_pos: Option<usize> = None;
     let mut found_sub_name: Option<&str> = None;
     skip_next = false;
@@ -92,9 +92,14 @@ pub fn suggest_subcommand_correction(args: &[String], cmd: &clap::Command) -> Op
             break;
         }
         if let Some(flag_value) = arg.strip_prefix("--") {
-            if let Some(name) = sub_names.iter().find(|&&n| n == flag_value) {
+            // Match against the canonical name first, then any aliases (including hidden).
+            let matched = parent_cmd.get_subcommands().find(|sub| {
+                sub.get_name() == flag_value
+                    || sub.get_all_aliases().any(|alias| alias == flag_value)
+            });
+            if let Some(sub) = matched {
                 found_flag_pos = Some(i);
-                found_sub_name = Some(name);
+                found_sub_name = Some(sub.get_name());
                 break;
             }
             // Check if this flag takes a value (look in parent_cmd's args too)
@@ -153,7 +158,7 @@ mod tests {
                     .arg(Arg::new("line").short('l').long("line").num_args(1))
                     .subcommand(Command::new("read"))
                     .subcommand(Command::new("toggle"))
-                    .subcommand(Command::new("set-status")),
+                    .subcommand(Command::new("set").alias("set-status")),
             )
             .subcommand(
                 Command::new("properties")
@@ -210,7 +215,7 @@ mod tests {
 
     #[test]
     fn set_status_hyphenated() {
-        // hyalo task --set-status --file f --line 1 --status ? -> hyalo task set-status --file f --line 1 --status ?
+        // hyalo task --set-status --file f --line 1 --status ? -> hyalo task set --file f --line 1 --status ?
         let cmd = make_cmd();
         let result = suggest_subcommand_correction(
             &args("hyalo task --set-status --file f --line 1 --status ?"),
@@ -218,7 +223,7 @@ mod tests {
         );
         assert_eq!(
             result,
-            Some("hyalo task set-status --file f --line 1 --status '?'".to_owned())
+            Some("hyalo task set --file f --line 1 --status '?'".to_owned())
         );
     }
 

--- a/crates/hyalo-cli/tests/e2e_help.rs
+++ b/crates/hyalo-cli/tests/e2e_help.rs
@@ -67,7 +67,7 @@ fn long_help_command_reference_lists_all_commands() {
         "hyalo summary",
         "hyalo task read",
         "hyalo task toggle",
-        "hyalo task set-status",
+        "hyalo task set",
         "hyalo init",
         "hyalo deinit",
         "hyalo views list",

--- a/crates/hyalo-cli/tests/e2e_positional_file.rs
+++ b/crates/hyalo-cli/tests/e2e_positional_file.rs
@@ -341,7 +341,7 @@ fn task_toggle_positional_file() {
 }
 
 // ---------------------------------------------------------------------------
-// task set-status: positional file
+// task set: positional file
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -350,15 +350,7 @@ fn task_set_status_positional_file() {
     // Set line 13 (- [ ] First task) to status '?'
     let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "task",
-            "set-status",
-            "note.md",
-            "--line",
-            "13",
-            "--status",
-            "?",
-        ])
+        .args(["task", "set", "note.md", "--line", "13", "--status", "?"])
         .output()
         .unwrap();
 

--- a/crates/hyalo-cli/tests/e2e_short_flags.rs
+++ b/crates/hyalo-cli/tests/e2e_short_flags.rs
@@ -392,12 +392,33 @@ fn task_toggle_short_f_l() {
 }
 
 #[test]
-fn task_set_status_short_f_l_s() {
+fn task_set_short_f_l_s() {
     let dir = setup();
     let output = hyalo_no_hints()
         .args([
             "task",
             "set",
+            "-f",
+            "note.md",
+            "-l",
+            "11",
+            "-s",
+            "/",
+            "-d",
+            dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+}
+
+#[test]
+fn task_set_status_alias_short_flags() {
+    let dir = setup();
+    let output = hyalo_no_hints()
+        .args([
+            "task",
+            "set-status",
             "-f",
             "note.md",
             "-l",

--- a/crates/hyalo-cli/tests/e2e_short_flags.rs
+++ b/crates/hyalo-cli/tests/e2e_short_flags.rs
@@ -397,7 +397,7 @@ fn task_set_status_short_f_l_s() {
     let output = hyalo_no_hints()
         .args([
             "task",
-            "set-status",
+            "set",
             "-f",
             "note.md",
             "-l",

--- a/crates/hyalo-cli/tests/e2e_task.rs
+++ b/crates/hyalo-cli/tests/e2e_task.rs
@@ -103,7 +103,7 @@ fn run_task_toggle(
 }
 
 // ---------------------------------------------------------------------------
-// Helper: run `task set-status`
+// Helper: run `task set`
 // ---------------------------------------------------------------------------
 
 fn run_task_set_status(
@@ -116,7 +116,7 @@ fn run_task_set_status(
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
-        "set-status",
+        "set",
         "--file",
         file,
         "--line",
@@ -302,7 +302,7 @@ fn task_toggle_non_task_line_exits_1() {
 }
 
 // ---------------------------------------------------------------------------
-// task set-status — success cases
+// task set — success cases
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -357,7 +357,7 @@ fn task_set_status_x_sets_done_true() {
 }
 
 // ---------------------------------------------------------------------------
-// task set-status — error cases
+// task set — error cases
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -369,7 +369,7 @@ fn task_set_status_non_task_line_exits_1() {
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
-        "set-status",
+        "set",
         "--file",
         "tasks.md",
         "--line",
@@ -392,7 +392,7 @@ fn task_set_status_multi_char_status_exits_1() {
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
-        "set-status",
+        "set",
         "--file",
         "tasks.md",
         "--line",
@@ -420,7 +420,7 @@ fn task_set_status_empty_string_exits_1() {
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
     cmd.args([
         "task",
-        "set-status",
+        "set",
         "--file",
         "tasks.md",
         "--line",
@@ -576,16 +576,7 @@ fn task_set_status_multiple_lines() {
     let (status, json, stderr) = run_task_cmd_json(
         &tmp,
         &[
-            "task",
-            "set-status",
-            "--file",
-            "bulk.md",
-            "--line",
-            "5",
-            "--line",
-            "6",
-            "--status",
-            "?",
+            "task", "set", "--file", "bulk.md", "--line", "5", "--line", "6", "--status", "?",
         ],
     );
     assert!(status.success(), "stderr: {stderr}");
@@ -671,7 +662,7 @@ fn task_set_status_section() {
         &tmp,
         &[
             "task",
-            "set-status",
+            "set",
             "--file",
             "bulk.md",
             "--section",
@@ -775,15 +766,7 @@ fn task_set_status_all() {
 
     let (status, _json, stderr) = run_task_cmd_json(
         &tmp,
-        &[
-            "task",
-            "set-status",
-            "--file",
-            "bulk.md",
-            "--all",
-            "--status",
-            "x",
-        ],
+        &["task", "set", "--file", "bulk.md", "--all", "--status", "x"],
     );
     assert!(status.success(), "stderr: {stderr}");
 

--- a/crates/hyalo-core/src/content_search.rs
+++ b/crates/hyalo-core/src/content_search.rs
@@ -38,7 +38,10 @@ impl ContentSearchVisitor {
         let lowered = pattern.to_ascii_lowercase();
         let finder = memmem::Finder::new(lowered.as_bytes()).into_owned();
         Self {
-            mode: SearchMode::Substring { lowered, finder: Box::new(finder) },
+            mode: SearchMode::Substring {
+                lowered,
+                finder: Box::new(finder),
+            },
             current_section: String::new(),
             matches: Vec::new(),
             line_scratch: Vec::new(),

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -101,7 +101,7 @@ pub struct OutlineSection {
 // ---------------------------------------------------------------------------
 
 /// A single task (checkbox) with its location and state.
-/// Used by `task read`, `task toggle`, `task set-status`.
+/// Used by `task read`, `task toggle`, `task set`.
 #[derive(Debug, Clone, Serialize)]
 pub struct TaskInfo {
     pub line: usize,
@@ -111,7 +111,7 @@ pub struct TaskInfo {
 }
 
 /// Result of reading or mutating a single task.
-/// Used by `task read`, `task toggle`, `task set-status`.
+/// Used by `task read`, `task toggle`, `task set`.
 #[derive(Debug, Clone, Serialize)]
 pub struct TaskReadResult {
     pub file: String,


### PR DESCRIPTION
## Summary
- Rename `task set-status` subcommand to `task set` for better ergonomics
- Keep `set-status` as an alias for backwards compatibility
- Update all help texts, suggestion engine, tests, README, and doc comments
- Apply `cargo fmt` to clippy Box fix in `content_search.rs`

## Test plan
- [x] All 530+ tests pass (`cargo test --workspace`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `hyalo task set` works as primary command
- [x] `hyalo task set-status` still works as alias
- [ ] Verify suggestion engine handles `--set-status` typo correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed task status subcommand from `set-status` to `set`, keeping `set-status` as a backward-compatible alias.
  * CLI now canonicalizes suggestions to the `set` name while still recognizing the alias.

* **Documentation**
  * Updated README, help text, and in-app command references to use `hyalo task set`.

* **Tests**
  * Updated e2e tests to assert and cover the new `task set` syntax (alias preserved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->