### PR TITLE
Update BM25 docs, search hints, and add search cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,15 @@ hyalo find
 # Files with broken links (unresolved wikilinks or markdown links)
 hyalo find --broken-links
 
-# Content search (case-insensitive substring)
-hyalo find "retry backoff"
-hyalo find "retry" --tag research
+# BM25 ranked full-text search (stemmed, relevance-ranked)
+hyalo find "retry backoff"               # AND: both words required
+hyalo find "retry OR backoff"            # OR: either word matches
+hyalo find "retry -deprecated"           # NOT: exclude "deprecated"
+hyalo find '"retry backoff"'             # Phrase: exact consecutive match
+hyalo find "retry" --tag research        # combine with filters
 
-# Regex content search (case-insensitive by default)
-hyalo find --regexp "retry.*backoff"
+# Regex content search (case-insensitive by default, unranked)
+hyalo find -e "retry.*backoff"
 hyalo find -e "TODO|FIXME|HACK"
 hyalo find -e "fn\s+\w+_test" --tag rust
 

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -561,7 +561,7 @@ fn suggest_save_as_view(ctx: &HintContext) -> Option<Hint> {
     }
 
     // Only count filters that can be round-tripped into a `views set` command.
-    // Body/regex search is excluded because HintContext only stores a bool,
+    // Body/regex search is excluded because `views set` does not support them,
     // not the actual pattern string.
     let filter_count =
         ctx.property_filters.len() + ctx.tag_filters.len() + usize::from(ctx.task_filter.is_some());
@@ -583,7 +583,10 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
 
     if results.is_empty() {
         // When a multi-word BM25 search returns nothing, suggest trying OR instead.
+        // Skip if the query already contains quotes (phrase search) — splitting on
+        // whitespace would produce malformed tokens like `"exact` and `phrase"`.
         if let Some(pat) = &ctx.body_pattern {
+            let has_quotes = pat.contains('"');
             let words: Vec<&str> = pat
                 .split_whitespace()
                 .filter(|w| {
@@ -592,7 +595,7 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
                         && !w.eq_ignore_ascii_case("and")
                 })
                 .collect();
-            if words.len() >= 2 {
+            if !has_quotes && words.len() >= 2 {
                 let or_query = words.join(" OR ");
                 return vec![Hint::new(
                     "Try OR instead of AND (match any word)",

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -62,6 +62,8 @@ pub struct HintContext {
     pub sort: Option<String>,
     pub has_limit: bool,
     pub has_body_search: bool,
+    /// The actual body-search pattern string, when a body search was issued.
+    pub body_pattern: Option<String>,
     pub has_regex_search: bool,
     pub property_filters: Vec<String>,
     pub tag_filters: Vec<String>,
@@ -106,6 +108,7 @@ impl HintContext {
             sort: None,
             has_limit: false,
             has_body_search: false,
+            body_pattern: None,
             has_regex_search: false,
             property_filters: vec![],
             tag_filters: vec![],
@@ -245,6 +248,36 @@ fn build_find_command_preserving_filters(ctx: &HintContext, extra_args: &[&str])
     }
     for arg in extra_args {
         parts.push(shell_quote(arg));
+    }
+    push_global_flags(&mut parts, ctx);
+    for glob in &ctx.glob {
+        parts.push("--glob".to_owned());
+        parts.push(shell_quote(glob));
+    }
+    parts.join(" ")
+}
+
+/// Build a `find` command that replaces the body search pattern with `new_pattern`
+/// while preserving all other existing filters (property, tag, task, file targets,
+/// glob). The pattern is inserted as a positional argument immediately after `find`.
+fn build_find_command_with_pattern(ctx: &HintContext, new_pattern: &str) -> String {
+    let mut parts: Vec<String> = vec!["hyalo".to_owned(), "find".to_owned()];
+    parts.push(shell_quote(new_pattern));
+    for pf in &ctx.property_filters {
+        parts.push("--property".to_owned());
+        parts.push(shell_quote(pf));
+    }
+    for tf in &ctx.tag_filters {
+        parts.push("--tag".to_owned());
+        parts.push(shell_quote(tf));
+    }
+    if let Some(task) = &ctx.task_filter {
+        parts.push("--task".to_owned());
+        parts.push(shell_quote(task));
+    }
+    for ft in &ctx.file_targets {
+        parts.push("--file".to_owned());
+        parts.push(shell_quote(ft));
     }
     push_global_flags(&mut parts, ctx);
     for glob in &ctx.glob {
@@ -549,6 +582,24 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     };
 
     if results.is_empty() {
+        // When a multi-word BM25 search returns nothing, suggest trying OR instead.
+        if let Some(pat) = &ctx.body_pattern {
+            let words: Vec<&str> = pat
+                .split_whitespace()
+                .filter(|w| {
+                    !w.starts_with('-')
+                        && !w.eq_ignore_ascii_case("or")
+                        && !w.eq_ignore_ascii_case("and")
+                })
+                .collect();
+            if words.len() >= 2 {
+                let or_query = words.join(" OR ");
+                return vec![Hint::new(
+                    "Try OR instead of AND (match any word)",
+                    build_find_command_with_pattern(ctx, &or_query),
+                )];
+            }
+        }
         return vec![];
     }
 
@@ -744,6 +795,29 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     // Body search → regex suggestion is intentionally omitted.
     // We cannot produce a concrete regex without knowing the user's intent,
     // and a placeholder like `'pattern'` would violate our no-templates contract.
+
+    // Suggest phrase search when body search has multiple words and many results.
+    if let Some(pat) = &ctx.body_pattern {
+        let has_quotes = pat.contains('"');
+        let words: Vec<&str> = pat
+            .split_whitespace()
+            .filter(|w| {
+                !w.starts_with('-')
+                    && !w.eq_ignore_ascii_case("or")
+                    && !w.eq_ignore_ascii_case("and")
+            })
+            .collect();
+        if !has_quotes && words.len() >= 2 && result_count > 10 {
+            let remaining = MAX_HINTS.saturating_sub(hints.len());
+            if remaining > 0 {
+                let phrase = format!("\"{}\"", words.join(" "));
+                hints.push(Hint::new(
+                    "Try as exact phrase for more precise results",
+                    build_find_command_with_pattern(ctx, &phrase),
+                ));
+            }
+        }
+    }
 
     // Suggest `links fix` when results contain broken links (e.g. from --broken-links).
     // Broken links are serialised with `"path": null` (never omitted) by find's output.

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -411,6 +411,7 @@ fn run_inner() -> Result<(), AppError> {
                 ctx.sort.clone_from(sort);
                 ctx.has_limit = limit.is_some();
                 ctx.has_body_search = pattern.is_some();
+                ctx.body_pattern.clone_from(pattern);
                 ctx.has_regex_search = regexp.is_some();
                 ctx.property_filters.clone_from(properties);
                 ctx.tag_filters.clone_from(tag);

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -33,7 +33,8 @@ hyalo find "error handling" --property status!=completed --tag iteration --secti
 ## BM25 Full-Text Search
 
 The positional argument to `find` triggers BM25 ranked full-text search with automatic
-stemming ("running" matches "run", "runner", etc.). Results are sorted by relevance score.
+stemming ("running" matches "run", "runner", etc.). Results are sorted by relevance score
+by default (unless `--sort` is specified).
 
 ```bash
 hyalo find "rust"                        # single term, stemmed

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -23,12 +23,32 @@ in directories of markdown files. Its killer features are combined filtering (e.
 replicate with Grep/Glob, and bulk mutations (`hyalo set --where-property`) that replace
 multiple Read + Edit calls.
 
-Filters combine freely — content regex + property conditions + tag + section + task status
+Filters combine freely — content search + property conditions + tag + section + task status
 in a single call, something impossible with Grep/Glob alone:
 
 ```bash
-hyalo find -e "pattern" --property status!=completed --tag iteration --section "Tasks" --task todo
+hyalo find "error handling" --property status!=completed --tag iteration --section "Tasks" --task todo
 ```
+
+## BM25 Full-Text Search
+
+The positional argument to `find` triggers BM25 ranked full-text search with automatic
+stemming ("running" matches "run", "runner", etc.). Results are sorted by relevance score.
+
+```bash
+hyalo find "rust"                        # single term, stemmed
+hyalo find "rust programming"            # AND: both terms required (implicit)
+hyalo find "rust OR golang"              # OR: either term matches
+hyalo find "rust -java"                  # NOT: exclude documents with "java"
+hyalo find '"error handling"'            # Phrase: exact consecutive match (after stemming)
+hyalo find '"error handling" -panic'     # Phrase + negation combined
+hyalo find "rust OR golang -obsolete"    # Mixed: either rust or golang, not obsolete
+```
+
+For literal pattern matching (not stemmed), use regex: `hyalo find -e "exact_string"`.
+
+Language support: `--language french` selects the French stemmer. Per-file override via
+frontmatter `language: french`. Config default via `[search] language = "french"` in `.hyalo.toml`.
 
 Property filters support: `K=V` (eq), `K!=V` (neq), `K>=V`/`K<=V`/`K>V`/`K<V` (comparison),
 `K` (existence), `!K` (absence — files missing the property), `K~=pattern` or `K~=/pattern/flags`
@@ -156,7 +176,7 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 
 ## Available commands
 
-- **find** — search/filter by text, regex, property, tag, task status
+- **find** — BM25 ranked full-text search (AND, OR, phrase, negation) or regex; filter by property, tag, task status
 - **read** — extract body content, a section, or line range
 - **summary** — directory overview: file counts, tags, tasks, recent files (use `--depth N` to limit directory listing)
 - **properties summary** — list property names and types

--- a/hyalo-knowledgebase/iterations/iteration-101-bm25-ranked-search.md
+++ b/hyalo-knowledgebase/iterations/iteration-101-bm25-ranked-search.md
@@ -2,7 +2,7 @@
 title: Iteration 101 — BM25 Ranked Search
 type: iteration
 date: 2026-04-09
-status: in-progress
+status: completed
 branch: iter-101/bm25-ranked-search
 tags:
   - iteration

--- a/hyalo-knowledgebase/iterations/iteration-101b-bm25-serializable-index.md
+++ b/hyalo-knowledgebase/iterations/iteration-101b-bm25-serializable-index.md
@@ -8,7 +8,7 @@ tags:
   - bm25
   - performance
   - serialization
-status: in-progress
+status: completed
 branch: iter-101/bm25-index-integration
 related:
   - "[[iterations/iteration-101-bm25-ranked-search]]"

--- a/hyalo-knowledgebase/iterations/iteration-103-boolean-search-operators.md
+++ b/hyalo-knowledgebase/iterations/iteration-103-boolean-search-operators.md
@@ -7,7 +7,7 @@ tags:
   - search
   - bm25
   - ux
-status: in-progress
+status: completed
 branch: iter-103/boolean-search
 related:
   - "[[iterations/iteration-101-bm25-ranked-search]]"

--- a/hyalo-knowledgebase/recipes/search-cookbook.md
+++ b/hyalo-knowledgebase/recipes/search-cookbook.md
@@ -1,0 +1,141 @@
+---
+title: "Search Cookbook — BM25 & Regex Recipes"
+type: reference
+date: 2026-04-12
+tags:
+  - reference
+  - search
+  - bm25
+  - cookbook
+---
+
+# Search Cookbook
+
+Practical recipes for `hyalo find`. Two search modes: **BM25** (ranked full-text with stemming) and **Regex** (pattern matching, unranked).
+
+## BM25 Full-Text Search
+
+### Basic search
+
+```bash
+# Find documents about "authentication"
+# (also matches "authenticate", "authenticating" via stemming)
+hyalo find "authentication"
+
+# Find documents mentioning both "rust" and "performance"
+# (space = AND, both required)
+hyalo find "rust performance"
+```
+
+### OR — match any term
+
+```bash
+# Find documents about either language
+hyalo find "rust OR golang"
+
+# Find docs about any error type
+hyalo find "timeout OR deadlock OR panic"
+```
+
+### Negation — exclude terms
+
+```bash
+# Rust docs that don't mention javascript
+hyalo find "rust -javascript"
+
+# Search for "deploy" but exclude anything about staging
+hyalo find "deploy -staging"
+
+# Combine OR with negation
+hyalo find "rust OR golang -deprecated"
+```
+
+### Phrase search — exact consecutive match
+
+```bash
+# Match the exact phrase (after stemming)
+hyalo find '"error handling"'
+
+# Phrase + negation
+hyalo find '"error handling" -panic'
+
+# Phrase with other terms (AND)
+hyalo find '"dependency injection" testing'
+```
+
+### Combine with filters
+
+```bash
+# BM25 search scoped to a tag
+hyalo find "authentication" --tag security
+
+# Search within in-progress iterations
+hyalo find "refactor" --property status=in-progress --tag iteration
+
+# Search within a specific section
+hyalo find "TODO" --section "Tasks"
+
+# Search only in specific files
+hyalo find "bug" --glob "iterations/*.md"
+
+# Limit and sort
+hyalo find "performance" --limit 5
+hyalo find "testing" --sort modified --reverse --limit 10
+```
+
+### Language-specific stemming
+
+```bash
+# French stemming ("coureur" matches "courir", "course", etc.)
+hyalo find "coureur" --language french
+
+# German stemming
+hyalo find "Veränderung" --language german
+```
+
+## Regex Search
+
+### Basic patterns
+
+```bash
+# Find TODO/FIXME/HACK markers
+hyalo find -e "TODO|FIXME|HACK"
+
+# Find function-like patterns
+hyalo find -e "fn\s+\w+_test"
+
+# Case-sensitive regex (default is case-insensitive)
+hyalo find -e "(?-i)README"
+```
+
+### Combine regex with filters
+
+```bash
+# Regex in tagged files
+hyalo find -e "TODO|FIXME" --tag iteration --property status=in-progress
+
+# Regex scoped to a section
+hyalo find -e "^\s*-\s*\[[ x]\]" --section "Tasks"
+```
+
+## When to use which
+
+| Need | Use |
+|---|---|
+| "Find docs about X" (conceptual search) | `hyalo find "X"` (BM25) |
+| Exact string or pattern match | `hyalo find -e "pattern"` (regex) |
+| Relevance-ranked results | BM25 (scored and sorted) |
+| Line-level matches with context | Regex (returns match lines) |
+| Stemmed matching (run → running) | BM25 |
+| Multiple alternative terms | `hyalo find "X OR Y"` (BM25) |
+| Exclude a concept | `hyalo find "X -Y"` (BM25) |
+| Complex boolean | `hyalo find '"exact phrase" term -excluded'` (BM25) |
+
+## Tips
+
+- **Implicit AND is the default.** `hyalo find "rust performance"` requires *both* words. This matches Google/GitHub behavior.
+- **OR must be explicit.** Write `rust OR golang`, not just `rust golang` (which means AND).
+- **Stemming applies everywhere.** `-running` also excludes "run", "runner". Phrase `"error handling"` matches "errors handled".
+- **Combine BM25 with filters freely.** The BM25 search runs first, then property/tag/section filters narrow the results.
+- **Use `--index` for large vaults.** On 500+ files, `create-index` makes BM25 queries 6x faster by persisting the inverted index.
+- **Score field.** BM25 results include a `score` field — higher is more relevant. Use `--jq '.results | sort_by(-.score) | .[0:3]'` for top 3.

--- a/hyalo-knowledgebase/recipes/search-cookbook.md
+++ b/hyalo-knowledgebase/recipes/search-cookbook.md
@@ -136,6 +136,6 @@ hyalo find -e "^\s*-\s*\[[ x]\]" --section "Tasks"
 - **Implicit AND is the default.** `hyalo find "rust performance"` requires *both* words. This matches Google/GitHub behavior.
 - **OR must be explicit.** Write `rust OR golang`, not just `rust golang` (which means AND).
 - **Stemming applies everywhere.** `-running` also excludes "run", "runner". Phrase `"error handling"` matches "errors handled".
-- **Combine BM25 with filters freely.** The BM25 search runs first, then property/tag/section filters narrow the results.
+- **Combine BM25 with filters freely.** Metadata filters (property, tag, section) and BM25 scoring are logically combined — the result is documents matching all criteria, ranked by relevance.
 - **Use `--index` for large vaults.** On 500+ files, `create-index` makes BM25 queries 6x faster by persisting the inverted index.
 - **Score field.** BM25 results include a `score` field — higher is more relevant. Use `--jq '.results | sort_by(-.score) | .[0:3]'` for top 3.


### PR DESCRIPTION
## Summary

- **README.md**: Replace outdated "case-insensitive substring" examples with BM25 ranked search syntax — AND, OR, phrase, negation
- **Skill template**: Add "BM25 Full-Text Search" section with 7 examples, language support docs, and updated `find` command description
- **Hints**: Two new concrete hints — suggest `OR` when multi-word AND returns 0 results; suggest phrase refinement when >10 results with multi-word query
- **Search cookbook**: New `recipes/search-cookbook.md` with practical BM25 and regex recipes, comparison table, and tips
- **Iteration status**: Mark iterations 101, 101b, 103 as completed

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (663 tests)
- [x] `hyalo find "kubernetes terraform"` shows OR hint on zero results
- [x] README examples are accurate for current BM25 behavior
- [x] Copilot review: 3 findings addressed (phrase-quote guard, filter order docs, sort clarification)
- [x] Local review: 4 findings addressed (stale comment, phrase-quote guard, filter order, sort clarification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intelligent search hints now suggest OR-style queries when a search returns no results and phrase searches when results are large.

* **Documentation**
  * `find` docs updated to describe BM25 ranked full-text search with implicit AND, OR, negation, and quoted phrase matching.
  * Added "Search Cookbook" with BM25 and regex recipes, language/stemming options, tag/metadata filters, and examples.
  * Clarified regex is unranked and available via `-e`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->