### PR TITLE
Make --index path optional, default to .hyalo-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,9 +605,10 @@ The snapshot index is a MessagePack file that captures a point-in-time snapshot 
 hyalo create-index
 
 # Run read-only queries against the index (no disk scan)
-hyalo find --property status=in-progress --index .hyalo-index
-hyalo summary --index .hyalo-index
-hyalo tags summary --index .hyalo-index
+# --index alone defaults to .hyalo-index in the vault directory
+hyalo find --property status=in-progress --index
+hyalo summary --index
+hyalo tags summary --index
 
 # Drop the index when done
 hyalo drop-index

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -139,6 +139,9 @@ pub(crate) struct Cli {
 
     /// Use a pre-built snapshot index instead of scanning files from disk.
     ///
+    /// When passed without a value, uses `.hyalo-index` in the vault
+    /// directory. Pass a path to use a different index file.
+    ///
     /// Read-only commands (find, summary, tags summary, properties summary,
     /// backlinks) use the index to skip disk scans entirely.
     ///
@@ -151,7 +154,7 @@ pub(crate) struct Cli {
     ///
     /// If the index file is incompatible (e.g. after a hyalo upgrade) hyalo
     /// falls back to a full disk scan automatically.
-    #[arg(long, global = true, value_name = "PATH")]
+    #[arg(long, global = true, value_name = "PATH", num_args = 0..=1, default_missing_value = ".hyalo-index")]
     pub index: Option<PathBuf>,
 
     /// Suppress all warnings printed to stderr.

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -139,8 +139,8 @@ pub(crate) struct Cli {
 
     /// Use a pre-built snapshot index instead of scanning files from disk.
     ///
-    /// When passed without a value, uses `.hyalo-index` in the vault
-    /// directory. Pass a path to use a different index file.
+    /// When passed without a value (`--index`), uses `.hyalo-index` in the
+    /// vault directory. Use `--index=PATH` for a different index file.
     ///
     /// Read-only commands (find, summary, tags summary, properties summary,
     /// backlinks) use the index to skip disk scans entirely.
@@ -154,7 +154,7 @@ pub(crate) struct Cli {
     ///
     /// If the index file is incompatible (e.g. after a hyalo upgrade) hyalo
     /// falls back to a full disk scan automatically.
-    #[arg(long, global = true, value_name = "PATH", num_args = 0..=1, default_missing_value = ".hyalo-index")]
+    #[arg(long, global = true, value_name = "PATH", num_args = 0..=1, default_missing_value = ".hyalo-index", require_equals = true)]
     pub index: Option<PathBuf>,
 
     /// Suppress all warnings printed to stderr.

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -29,7 +29,7 @@ pub(crate) const HELP_EXAMPLES: &str = "EXAMPLES:
   Move (dry-run preview):       hyalo mv --file old.md --to sub/new.md --dry-run
   Fix broken links (preview):   hyalo links fix
   Build a snapshot index:       hyalo create-index
-  Query using the index:        hyalo find --property status=draft --index .hyalo-index
+  Query using the index:        hyalo find --property status=draft --index
   Delete the snapshot index:    hyalo drop-index
   Save a view:                  hyalo views set todo --task todo
   List saved views:             hyalo views list
@@ -243,8 +243,8 @@ COOKBOOK:
   # Build a snapshot index for faster repeated queries
   hyalo create-index
 
-  # Use the index for a find query
-  hyalo find --property status=draft --index .hyalo-index
+  # Use the index for a find query (defaults to .hyalo-index in vault dir)
+  hyalo find --property status=draft --index
 
   # Clean up the index after use
   hyalo drop-index

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -111,7 +111,7 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
     --hints                 Force hints on (already the default; suppressed by --jq)
     --no-hints              Disable drill-down hints (enabled by default, override via .hyalo.toml)
     --site-prefix <PREFIX>  Override site prefix for absolute link resolution (auto-derived from --dir)
-    --index <PATH>          Use pre-built snapshot index (see create-index)
+    --index[=PATH]          Use pre-built snapshot index (default: .hyalo-index in vault dir)
     -q/--quiet              Suppress all warnings to stderr
 
 COOKBOOK:

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -1142,16 +1142,25 @@ fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
 fn hints_for_create_index(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let mut hints = Vec::new();
 
+    // Use bare `--index` (defaults to .hyalo-index in vault dir) for the default path.
+    // Only include the explicit path when the index was created at a non-default location.
     let index_path = data
         .get("path")
         .and_then(|p| p.as_str())
-        .or(ctx.index_path.as_deref())
-        .unwrap_or(".hyalo-index");
+        .or(ctx.index_path.as_deref());
 
-    hints.push(Hint::new(
-        "Query using the index",
-        build_command_no_glob(ctx, &["find", "--index", index_path]),
-    ));
+    let is_default = index_path.is_none_or(|p| p == ".hyalo-index" || p.ends_with("/.hyalo-index"));
+
+    let hint_cmd = if is_default {
+        build_command_no_glob(ctx, &["find", "--index"])
+    } else {
+        build_command_no_glob(
+            ctx,
+            &["find", "--index", index_path.unwrap_or(".hyalo-index")],
+        )
+    };
+
+    hints.push(Hint::new("Query using the index", hint_cmd));
     hints.push(Hint::new(
         "Delete the index when done",
         build_command_no_glob(ctx, &["drop-index"]),

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -1149,11 +1149,9 @@ fn hints_for_create_index(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hi
         .and_then(|p| p.as_str())
         .or(ctx.index_path.as_deref());
 
-    let is_default = index_path.is_none_or(|p| {
-        std::path::Path::new(p)
-            .file_name()
-            .is_some_and(|f| f == ".hyalo-index")
-    });
+    // Only treat as default when no path was reported or it's the bare default name.
+    // Custom paths like `sub/.hyalo-index` must emit the explicit path in the hint.
+    let is_default = index_path.is_none_or(|p| p == ".hyalo-index");
 
     let hint_cmd = if is_default {
         build_command_no_glob(ctx, &["find", "--index"])

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -1149,7 +1149,11 @@ fn hints_for_create_index(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hi
         .and_then(|p| p.as_str())
         .or(ctx.index_path.as_deref());
 
-    let is_default = index_path.is_none_or(|p| p == ".hyalo-index" || p.ends_with("/.hyalo-index"));
+    let is_default = index_path.is_none_or(|p| {
+        std::path::Path::new(p)
+            .file_name()
+            .is_some_and(|f| f == ".hyalo-index")
+    });
 
     let hint_cmd = if is_default {
         build_command_no_glob(ctx, &["find", "--index"])

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -587,6 +587,14 @@ fn run_inner() -> Result<(), AppError> {
     // Read-only commands use it to skip disk scans. Mutation commands use it to
     // keep the index up-to-date after each file write (they still read/write
     // individual files on disk, but patch the index entry in-place).
+    //
+    // Resolve relative --index paths against the vault directory so that
+    // `--index .hyalo-index` (the default) works regardless of CWD.
+    if let Some(ref p) = cli.index
+        && p.is_relative()
+    {
+        cli.index = Some(dir.join(p));
+    }
     let uses_index = !matches!(
         &cli.command,
         Commands::Init { .. }

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -264,15 +264,15 @@ hyalo summary --format text
 # Step 2: Create index if >500 files (one scan, reused by all subsequent queries)
 hyalo create-index
 
-# Step 3: Use --index on ALL subsequent commands
-hyalo find --property status=in-progress --index .hyalo-index
-hyalo summary --index .hyalo-index
-hyalo tags summary --index .hyalo-index
-hyalo backlinks some-note.md --index .hyalo-index
+# Step 3: Use --index on ALL subsequent commands (defaults to .hyalo-index in vault dir)
+hyalo find --property status=in-progress --index
+hyalo summary --index
+hyalo tags summary --index
+hyalo backlinks some-note.md --index
 
 # Mutations also work with --index — they patch the index after each write
-hyalo set note.md --property status=completed --index .hyalo-index
-hyalo task toggle note.md --line 5 --index .hyalo-index
+hyalo set note.md --property status=completed --index
+hyalo task toggle note.md --line 5 --index
 
 # Drop the index when done
 hyalo drop-index

--- a/crates/hyalo-cli/tests/e2e_bm25.rs
+++ b/crates/hyalo-cli/tests/e2e_bm25.rs
@@ -509,10 +509,7 @@ fn bm25_via_index() {
         String::from_utf8_lossy(&index_output.stderr)
     );
 
-    let index_path = tmp.path().join(".hyalo-index");
-    let index_path_str = index_path.to_str().unwrap();
-
-    let (status, json, stderr) = find_json(&tmp, &["rust", "--index", index_path_str]);
+    let (status, json, stderr) = find_json(&tmp, &["rust", "--index"]);
     assert!(status.success(), "stderr: {stderr}");
 
     let arr = unwrap_results(&json);
@@ -781,14 +778,8 @@ fn bm25_phrase_search_via_index() {
         String::from_utf8_lossy(&index_output.stderr)
     );
 
-    let index_path = tmp.path().join(".hyalo-index");
-    let index_path_str = index_path.to_str().unwrap();
-
     // Phrase search via the built index
-    let (status, json, stderr) = find_json(
-        &tmp,
-        &["\"systems programming\"", "--index", index_path_str],
-    );
+    let (status, json, stderr) = find_json(&tmp, &["\"systems programming\"", "--index"]);
     assert!(status.success(), "stderr: {stderr}");
 
     let arr = unwrap_results(&json);

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -1456,3 +1456,31 @@ fn bare_index_flag_without_index_file_falls_back_to_disk_scan() {
         "bare --index without an index file should fall back to disk scan"
     );
 }
+
+#[test]
+fn bare_index_works_from_different_cwd() {
+    let tmp = setup_vault();
+    create_default_index(&tmp);
+
+    // Run from a different CWD (root dir) — bare --index should still resolve
+    // to {dir}/.hyalo-index, not {cwd}/.hyalo-index.
+    let other_dir = TempDir::new().unwrap();
+    let output = hyalo_no_hints()
+        .current_dir(other_dir.path())
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--index"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "bare --index from different CWD should work: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let files = sorted_files(&json);
+    assert!(
+        !files.is_empty(),
+        "bare --index from different CWD should find files via <dir>/.hyalo-index"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -255,10 +255,10 @@ fn drop_index_nonexistent_returns_error() {
 #[test]
 fn find_with_index_returns_same_files_as_disk_scan() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let disk_json = run_find(&tmp, &[]);
-    let index_json = run_find(&tmp, &["--index", index_path.to_str().unwrap()]);
+    let index_json = run_find(&tmp, &["--index"]);
 
     let mut disk_files = sorted_files(&disk_json);
     let mut index_files = sorted_files(&index_json);
@@ -274,10 +274,10 @@ fn find_with_index_returns_same_files_as_disk_scan() {
 #[test]
 fn find_with_index_preserves_properties() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let disk_json = run_find(&tmp, &[]);
-    let index_json = run_find(&tmp, &["--index", index_path.to_str().unwrap()]);
+    let index_json = run_find(&tmp, &["--index"]);
 
     // For each file returned by disk scan, check that index scan has matching properties.
     for disk_entry in unwrap_results(&disk_json) {
@@ -301,17 +301,9 @@ fn find_with_index_preserves_properties() {
 #[test]
 fn find_with_index_property_filter() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
-    let json = run_find(
-        &tmp,
-        &[
-            "--property",
-            "status=draft",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["--property", "status=draft", "--index"]);
 
     let files = sorted_files(&json);
     assert_eq!(files, vec!["alpha.md", "gamma.md"]);
@@ -330,12 +322,9 @@ fn find_with_index_property_filter() {
 #[test]
 fn find_with_index_tag_filter() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
-    let json = run_find(
-        &tmp,
-        &["--tag", "rust", "--index", index_path.to_str().unwrap()],
-    );
+    let json = run_find(&tmp, &["--tag", "rust", "--index"]);
 
     let mut files = sorted_files(&json);
     files.sort();
@@ -345,13 +334,10 @@ fn find_with_index_tag_filter() {
 #[test]
 fn find_with_index_content_search_falls_back_to_disk() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     // "fascinating" only appears in beta.md body.
-    let json = run_find(
-        &tmp,
-        &["fascinating", "--index", index_path.to_str().unwrap()],
-    );
+    let json = run_find(&tmp, &["fascinating", "--index"]);
 
     let files = sorted_files(&json);
     assert_eq!(files, vec!["beta.md"]);
@@ -360,16 +346,9 @@ fn find_with_index_content_search_falls_back_to_disk() {
 #[test]
 fn find_with_index_content_search_no_match() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
-    let json = run_find(
-        &tmp,
-        &[
-            "this-string-does-not-exist-anywhere",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["this-string-does-not-exist-anywhere", "--index"]);
 
     assert!(unwrap_results(&json).is_empty());
 }
@@ -381,7 +360,7 @@ fn find_with_index_content_search_no_match() {
 #[test]
 fn summary_with_index_matches_disk_scan() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let disk_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -393,13 +372,7 @@ fn summary_with_index_matches_disk_scan() {
 
     let index_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "--index",
-            index_path.to_str().unwrap(),
-            "summary",
-            "--format",
-            "json",
-        ])
+        .args(["--index", "summary", "--format", "json"])
         .output()
         .unwrap();
     assert!(
@@ -426,17 +399,11 @@ fn summary_with_index_matches_disk_scan() {
 #[test]
 fn summary_with_index_file_count() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "--index",
-            index_path.to_str().unwrap(),
-            "summary",
-            "--format",
-            "json",
-        ])
+        .args(["--index", "summary", "--format", "json"])
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -452,7 +419,7 @@ fn summary_with_index_file_count() {
 #[test]
 fn tags_summary_with_index_matches_disk_scan() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let disk_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -464,7 +431,7 @@ fn tags_summary_with_index_matches_disk_scan() {
 
     let index_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["--index", index_path.to_str().unwrap(), "tags", "summary"])
+        .args(["--index", "tags", "summary"])
         .output()
         .unwrap();
     assert!(
@@ -507,7 +474,7 @@ fn tags_summary_with_index_matches_disk_scan() {
 #[test]
 fn properties_summary_with_index_matches_disk_scan() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let disk_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -519,12 +486,7 @@ fn properties_summary_with_index_matches_disk_scan() {
 
     let index_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "--index",
-            index_path.to_str().unwrap(),
-            "properties",
-            "summary",
-        ])
+        .args(["--index", "properties", "summary"])
         .output()
         .unwrap();
     assert!(
@@ -562,18 +524,12 @@ fn properties_summary_with_index_matches_disk_scan() {
 #[test]
 fn backlinks_with_index_finds_wikilinks() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     // gamma.md links to alpha.md via [[alpha]]
     let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "--index",
-            index_path.to_str().unwrap(),
-            "backlinks",
-            "--file",
-            "alpha.md",
-        ])
+        .args(["--index", "backlinks", "--file", "alpha.md"])
         .output()
         .unwrap();
     assert!(
@@ -600,7 +556,7 @@ fn backlinks_with_index_finds_wikilinks() {
 #[test]
 fn backlinks_with_index_matches_disk_scan() {
     let tmp = setup_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let disk_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -612,13 +568,7 @@ fn backlinks_with_index_matches_disk_scan() {
 
     let index_output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "--index",
-            index_path.to_str().unwrap(),
-            "backlinks",
-            "--file",
-            "beta.md",
-        ])
+        .args(["--index", "backlinks", "--file", "beta.md"])
         .output()
         .unwrap();
     assert!(index_output.status.success());
@@ -645,7 +595,8 @@ fn incompatible_index_falls_back_to_disk_scan() {
 
     let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args(["--index", garbage_path.to_str().unwrap(), "find"])
+        .arg(format!("--index={}", garbage_path.display()))
+        .arg("find")
         .output()
         .unwrap();
 
@@ -681,13 +632,8 @@ fn incompatible_index_falls_back_for_summary() {
 
     let output = hyalo_no_hints()
         .args(["--dir", tmp.path().to_str().unwrap()])
-        .args([
-            "--index",
-            garbage_path.to_str().unwrap(),
-            "summary",
-            "--format",
-            "json",
-        ])
+        .arg(format!("--index={}", garbage_path.display()))
+        .args(["summary", "--format", "json"])
         .output()
         .unwrap();
 
@@ -709,7 +655,7 @@ fn incompatible_index_falls_back_for_summary() {
 fn run_with_index(tmp: &TempDir, index_path: &std::path::Path, args: &[&str]) -> serde_json::Value {
     let mut cmd = hyalo_no_hints();
     cmd.args(["--dir", tmp.path().to_str().unwrap()]);
-    cmd.args(["--index", index_path.to_str().unwrap()]);
+    cmd.arg(format!("--index={}", index_path.display()));
     cmd.args(args);
     let output = cmd.output().unwrap();
     assert!(
@@ -737,15 +683,7 @@ fn set_with_index_updates_index_for_subsequent_find() {
     );
 
     // Query the index — should see the updated property without re-scanning
-    let json = run_find(
-        &tmp,
-        &[
-            "--property",
-            "reviewed=true",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["--property", "reviewed=true", "--index"]);
 
     let files = sorted_files(&json);
     assert_eq!(files, vec!["alpha.md"]);
@@ -773,7 +711,6 @@ fn remove_with_index_updates_index_for_subsequent_find() {
             "--file",
             "alpha.md",
             "--index",
-            index_path.to_str().unwrap(),
         ],
     );
     assert_eq!(unwrap_results(&before).len(), 1);
@@ -786,15 +723,7 @@ fn remove_with_index_updates_index_for_subsequent_find() {
     );
 
     // Query the index — alpha should no longer match status=draft
-    let after = run_find(
-        &tmp,
-        &[
-            "--property",
-            "status=draft",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let after = run_find(&tmp, &["--property", "status=draft", "--index"]);
 
     let files = sorted_files(&after);
     assert!(
@@ -822,15 +751,7 @@ fn append_with_index_updates_index_for_subsequent_find() {
     );
 
     // Find by the new property via index
-    let json = run_find(
-        &tmp,
-        &[
-            "--property",
-            "aliases",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["--property", "aliases", "--index"]);
 
     let files = sorted_files(&json);
     assert_eq!(files, vec!["alpha.md"]);
@@ -846,14 +767,7 @@ fn task_toggle_with_index_updates_index() {
     let before = run_find(
         &tmp,
         &[
-            "--task",
-            "todo",
-            "--file",
-            "alpha.md",
-            "--fields",
-            "tasks",
-            "--index",
-            index_path.to_str().unwrap(),
+            "--task", "todo", "--file", "alpha.md", "--fields", "tasks", "--index",
         ],
     );
     let todo_tasks: Vec<&serde_json::Value> = unwrap_results(&before)[0]["tasks"]
@@ -885,14 +799,7 @@ fn task_toggle_with_index_updates_index() {
     // Query the index — the task should now be done
     let after = run_find(
         &tmp,
-        &[
-            "--file",
-            "alpha.md",
-            "--fields",
-            "tasks",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
+        &["--file", "alpha.md", "--fields", "tasks", "--index"],
     );
     let tasks = unwrap_results(&after)[0]["tasks"].as_array().unwrap();
     let toggled = tasks
@@ -918,7 +825,7 @@ fn mv_with_index_updates_index_path() {
     );
 
     // The index should now have archive/gamma.md and not gamma.md
-    let json = run_find(&tmp, &["--index", index_path.to_str().unwrap()]);
+    let json = run_find(&tmp, &["--index"]);
     let files = sorted_files(&json);
     assert!(
         files.contains(&"archive/gamma.md".to_owned()),
@@ -930,15 +837,7 @@ fn mv_with_index_updates_index_path() {
     );
 
     // Properties/tags on the moved file are still queryable
-    let json = run_find(
-        &tmp,
-        &[
-            "--property",
-            "status=draft",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["--property", "status=draft", "--index"]);
     let files = sorted_files(&json);
     assert!(
         files.contains(&"archive/gamma.md".to_owned()),
@@ -976,23 +875,12 @@ fn tags_rename_with_index_updates_index() {
     );
 
     // Query via index — alpha.md should have 'command-line' tag, not 'cli'
-    let json = run_find(
-        &tmp,
-        &[
-            "--tag",
-            "command-line",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["--tag", "command-line", "--index"]);
     let files = sorted_files(&json);
     assert_eq!(files, vec!["alpha.md"]);
 
     // Old tag should find nothing
-    let old = run_find(
-        &tmp,
-        &["--tag", "cli", "--index", index_path.to_str().unwrap()],
-    );
+    let old = run_find(&tmp, &["--tag", "cli", "--index"]);
     assert!(
         unwrap_results(&old).is_empty(),
         "old tag 'cli' should match nothing after rename"
@@ -1019,27 +907,11 @@ fn properties_rename_with_index_updates_index() {
     );
 
     // Query via index — alpha.md should have 'importance', not 'priority'
-    let json = run_find(
-        &tmp,
-        &[
-            "--property",
-            "importance",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["--property", "importance", "--index"]);
     let files = sorted_files(&json);
     assert_eq!(files, vec!["alpha.md"]);
 
-    let old = run_find(
-        &tmp,
-        &[
-            "--property",
-            "priority",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let old = run_find(&tmp, &["--property", "priority", "--index"]);
     assert!(
         unwrap_results(&old).is_empty(),
         "old property 'priority' should match nothing after rename"
@@ -1069,15 +941,7 @@ fn chained_mutations_with_index_keep_index_consistent() {
     );
 
     // Query via index — should reflect all three mutations
-    let json = run_find(
-        &tmp,
-        &[
-            "--file",
-            "alpha.md",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
-    );
+    let json = run_find(&tmp, &["--file", "alpha.md", "--index"]);
     let entry = &unwrap_results(&json)[0];
     assert_eq!(entry["properties"]["status"], "archived");
     let tags: Vec<&str> = entry["tags"]
@@ -1206,16 +1070,11 @@ fn find_property_regex_yaml_array_disk_and_index_agree() {
     let disk_total = run_find_jq(&tmp, ".total", &["--property", "status~=deprecated"]);
 
     // Build index, then query via it.
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
     let index_total = run_find_jq(
         &tmp,
         ".total",
-        &[
-            "--property",
-            "status~=deprecated",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
+        &["--property", "status~=deprecated", "--index"],
     );
 
     assert_eq!(
@@ -1236,18 +1095,13 @@ fn find_property_regex_yaml_array_disk_and_index_agree() {
 #[test]
 fn find_property_exact_yaml_array_index_returns_correct_count() {
     let tmp = setup_array_status_vault();
-    let index_path = create_default_index(&tmp);
+    create_default_index(&tmp);
 
     let disk_total = run_find_jq(&tmp, ".total", &["--property", "status=deprecated"]);
     let index_total = run_find_jq(
         &tmp,
         ".total",
-        &[
-            "--property",
-            "status=deprecated",
-            "--index",
-            index_path.to_str().unwrap(),
-        ],
+        &["--property", "status=deprecated", "--index"],
     );
 
     assert_eq!(
@@ -1564,14 +1418,27 @@ fn bare_index_flag_defaults_to_hyalo_index_in_vault_dir() {
     let index_json = run_find(&tmp, &["--index"]);
     let disk_json = run_find(&tmp, &[]);
 
-    let mut index_files = sorted_files(&index_json);
-    let mut disk_files = sorted_files(&disk_json);
-    index_files.sort();
-    disk_files.sort();
+    assert_eq!(
+        sorted_files(&disk_json),
+        sorted_files(&index_json),
+        "bare --index should use .hyalo-index and return the same file set as a disk scan"
+    );
+}
+
+#[test]
+fn explicit_index_path_with_equals_syntax() {
+    let tmp = setup_vault();
+    let index_path = create_default_index(&tmp);
+
+    // Use --index=path (explicit, require_equals form)
+    let arg = format!("--index={}", index_path.display());
+    let index_json = run_find(&tmp, &[&arg]);
+    let disk_json = run_find(&tmp, &[]);
 
     assert_eq!(
-        disk_files, index_files,
-        "bare --index should use .hyalo-index and return the same file set as a disk scan"
+        sorted_files(&disk_json),
+        sorted_files(&index_json),
+        "--index=path should work with explicit equals syntax"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e_index.rs
+++ b/crates/hyalo-cli/tests/e2e_index.rs
@@ -1550,3 +1550,42 @@ Target content
         "symlinked file inside vault should be included: {files:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Bare --index flag (no path argument)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_index_flag_defaults_to_hyalo_index_in_vault_dir() {
+    let tmp = setup_vault();
+    create_default_index(&tmp);
+
+    // Use bare --index (no path) — should auto-resolve to {dir}/.hyalo-index
+    let index_json = run_find(&tmp, &["--index"]);
+    let disk_json = run_find(&tmp, &[]);
+
+    let mut index_files = sorted_files(&index_json);
+    let mut disk_files = sorted_files(&disk_json);
+    index_files.sort();
+    disk_files.sort();
+
+    assert_eq!(
+        disk_files, index_files,
+        "bare --index should use .hyalo-index and return the same file set as a disk scan"
+    );
+}
+
+#[test]
+fn bare_index_flag_without_index_file_falls_back_to_disk_scan() {
+    let tmp = setup_vault();
+    // Do NOT create an index — bare --index should fall back gracefully.
+
+    let result = run_find(&tmp, &["--index"]);
+    let files = sorted_files(&result);
+
+    // Should still return results via disk scan fallback.
+    assert!(
+        !files.is_empty(),
+        "bare --index without an index file should fall back to disk scan"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -987,7 +987,6 @@ No links.
     );
 
     // Index-based summary
-    let index_path = tmp.path().join(".hyalo-index");
     let idx_out = hyalo_no_hints()
         .args([
             "--dir",
@@ -995,7 +994,6 @@ No links.
             "--site-prefix",
             "docs",
             "--index",
-            index_path.to_str().unwrap(),
             "--format",
             "json",
         ])
@@ -1245,17 +1243,8 @@ fn summary_dead_end_parity_disk_vs_index() {
     );
 
     // Index-based summary
-    let index_path = tmp.path().join(".hyalo-index");
     let idx_out = hyalo_no_hints()
-        .args([
-            "--dir",
-            dir_str,
-            "--index",
-            index_path.to_str().unwrap(),
-            "summary",
-            "--format",
-            "json",
-        ])
+        .args(["--dir", dir_str, "--index", "summary", "--format", "json"])
         .output()
         .unwrap();
     assert!(


### PR DESCRIPTION
## Summary

- `--index` (bare, no path) now defaults to `.hyalo-index` in the vault directory
- `--index=path/to/file` for explicit paths (uses `require_equals` to prevent arg-swallowing)
- Relative `--index` paths resolved against vault dir, not CWD
- `create-index` hint emits bare `--index` for the default path
- Updated README, help text, skill template to show the shorter form
- All existing `--index .hyalo-index` test usages simplified to bare `--index`

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all tests)
- [x] `hyalo find --index` works (bare, defaults to .hyalo-index)
- [x] `hyalo find --index=path` works (explicit path with equals)
- [x] Bare `--index` from a different CWD resolves correctly
- [x] `--index` without index file falls back to disk scan
- [x] Local review: arg-swallowing fixed with require_equals
- [x] Copilot review: CWD test added
- [x] CodeRabbit review: is_default check tightened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--index` flag now accepts no value (or an explicit path), defaulting to `.hyalo-index` in the vault for shorter commands.

* **Bug Fixes**
  * Relative index paths are resolved against the vault directory so the default index works regardless of current working directory.

* **Documentation**
  * Usage examples and help text updated to show the simplified `--index` syntax.

* **Tests**
  * E2E tests updated to validate the new `--index` behaviors and fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->