### PR TITLE
Fix 4 dogfood UX issues: status sort, views pattern, orphan warning, BM25 hint

### DIFF
--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -770,10 +770,11 @@ pub(crate) enum ViewsAction {
         Overwrites if the view already exists.\n\n\
         SIDE EFFECTS: Modifies .hyalo.toml.")]
     Set {
-        /// View name
+        /// View name (first positional arg)
         #[arg(value_name = "NAME")]
         name: String,
-        /// Optional BM25 search pattern to save with the view
+        /// Optional BM25 search pattern to save with the view (second positional arg).
+        /// Example: `hyalo views set my-view "search terms" --tag foo`
         #[arg(value_name = "PATTERN")]
         pattern: Option<String>,
         #[command(flatten)]

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -173,6 +173,10 @@ pub(crate) struct Cli {
 #[derive(Debug, Clone, Default, clap::Args, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub(crate) struct FindFilters {
+    /// BM25 search pattern (stored in views, not a CLI arg on find — find uses a positional arg instead)
+    #[arg(skip)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
     /// Regex body text search (case-insensitive by default; use (?-i) to override). Mutually exclusive with PATTERN
     #[arg(long, short = 'e', value_name = "REGEX")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -248,6 +252,9 @@ impl FindFilters {
     /// - Option fields: CLI overrides if Some
     /// - Bool fields: OR (CLI can turn on, not off)
     pub(crate) fn merge_from(&mut self, overlay: &Self) {
+        if overlay.pattern.is_some() {
+            self.pattern.clone_from(&overlay.pattern);
+        }
         if overlay.regexp.is_some() {
             self.regexp.clone_from(&overlay.regexp);
         }
@@ -766,6 +773,9 @@ pub(crate) enum ViewsAction {
         /// View name
         #[arg(value_name = "NAME")]
         name: String,
+        /// Optional BM25 search pattern to save with the view
+        #[arg(value_name = "PATTERN")]
+        pattern: Option<String>,
         #[command(flatten)]
         filters: FindFilters,
     },

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -276,17 +276,27 @@ pub fn find(
             // filter is active. Score all docs, then intersect with metadata-passing candidates.
             if !has_section_filter && let Some(bm25_idx) = index.bm25_index() {
                 let all_scored = bm25_idx.score(pat, &stemmer);
-                if is_low_discriminative(&all_scored, bm25_idx.doc_count()) {
-                    crate::warn::warn(
-                        "BM25 search: query matched most documents with low scores — \
-                         try more specific search terms",
-                    );
-                }
                 let map: HashMap<String, f64> = all_scored
                     .into_iter()
                     .filter(|m| candidate_paths.contains(m.rel_path.as_str()))
                     .map(|m| (m.rel_path, m.score))
                     .collect();
+                // Check after filtering to candidates — use candidate count as
+                // denominator so the heuristic matches the slow path and doesn't
+                // false-positive when metadata filters narrow the result set.
+                let filtered: Vec<_> = map
+                    .iter()
+                    .map(|(p, &s)| hyalo_core::bm25::Bm25Match {
+                        rel_path: p.clone(),
+                        score: s,
+                    })
+                    .collect();
+                if is_low_discriminative(&filtered, candidate_paths.len()) {
+                    crate::warn::warn(
+                        "BM25 search: query matched most documents with low scores — \
+                         try more specific search terms",
+                    );
+                }
                 break 'bm25 Some(map);
             }
 

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::bm25::{
-    Bm25InvertedIndex, DocumentInput, PreTokenizedInput, create_stemmer, parse_language,
-    resolve_language, tokenize_document,
+    Bm25InvertedIndex, DocumentInput, PreTokenizedInput, create_stemmer, is_low_discriminative,
+    parse_language, resolve_language, tokenize_document,
 };
 use hyalo_core::content_search::ContentSearchVisitor;
 use hyalo_core::discovery;
@@ -276,6 +276,12 @@ pub fn find(
             // filter is active. Score all docs, then intersect with metadata-passing candidates.
             if !has_section_filter && let Some(bm25_idx) = index.bm25_index() {
                 let all_scored = bm25_idx.score(pat, &stemmer);
+                if is_low_discriminative(&all_scored, bm25_idx.doc_count()) {
+                    crate::warn::warn(
+                        "BM25 search: query matched most documents with low scores — \
+                         try more specific search terms",
+                    );
+                }
                 let map: HashMap<String, f64> = all_scored
                     .into_iter()
                     .filter(|m| candidate_paths.contains(m.rel_path.as_str()))
@@ -407,6 +413,15 @@ pub fn find(
                 let corpus = Bm25InvertedIndex::build_from_tokens(all_pre_tok);
                 corpus.score(pat, &stemmer)
             };
+
+            // Warn if the query has low discriminative power (matches most docs with low scores).
+            let total_corpus_docs = candidates.len();
+            if is_low_discriminative(&scored, total_corpus_docs) {
+                crate::warn::warn(
+                    "BM25 search: query matched most documents with low scores — \
+                     try more specific search terms",
+                );
+            }
 
             // Build a map from rel_path → score (only entries with score > 0).
             let map: HashMap<String, f64> =

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -252,10 +252,11 @@ pub fn summary(
     };
 
     // Build status groups (counts only)
-    let status: Vec<StatusGroup> = status_groups
+    let mut status: Vec<StatusGroup> = status_groups
         .into_iter()
         .map(|(value, count)| StatusGroup { value, count })
         .collect();
+    status.sort_by(|a, b| b.count.cmp(&a.count).then(a.value.cmp(&b.value)));
 
     let tasks = TaskCount {
         total: total_tasks,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -77,6 +77,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 filters_raw.glob.clear(); // file overrides view's glob
             }
             let FindFilters {
+                pattern: _, // pattern is handled in run.rs before dispatch
                 regexp,
                 properties,
                 tag,
@@ -94,6 +95,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 title,
                 language,
             } = filters_raw;
+            if orphan && dead_end {
+                crate::warn::warn(
+                    "--orphan and --dead-end are mutually exclusive (no file can be both); results will always be empty",
+                );
+            }
             // Parse property filters
             let prop_filters: Vec<filter::PropertyFilter> = match properties
                 .iter()
@@ -677,7 +683,12 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let action = action.unwrap_or(ViewsAction::List);
             match action {
                 ViewsAction::List => crate::commands::views::list_views(),
-                ViewsAction::Set { name, filters } => {
+                ViewsAction::Set {
+                    name,
+                    pattern,
+                    mut filters,
+                } => {
+                    filters.pattern = pattern;
                     crate::commands::views::set_view(&name, &filters)
                 }
                 ViewsAction::Remove { name } => crate::commands::views::remove_view(&name),

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -688,6 +688,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     pattern,
                     mut filters,
                 } => {
+                    if pattern.is_some() && filters.regexp.is_some() {
+                        return Ok(CommandOutcome::UserError(
+                            "Error: PATTERN and --regexp are mutually exclusive".to_owned(),
+                        ));
+                    }
                     filters.pattern = pattern;
                     crate::commands::views::set_view(&name, &filters)
                 }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -303,6 +303,18 @@ fn run_inner() -> Result<(), AppError> {
         }
     }
 
+    // If the CLI didn't supply a pattern but the view did, propagate it.
+    if let Commands::Find {
+        ref mut pattern,
+        ref filters,
+        ..
+    } = cli.command
+        && pattern.is_none()
+        && let Some(ref view_pattern) = filters.pattern
+    {
+        *pattern = Some(view_pattern.clone());
+    }
+
     // --jq operates on JSON, so it conflicts with an explicit --format text.
     let jq_filter = cli.jq.as_deref();
 

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -304,12 +304,15 @@ fn run_inner() -> Result<(), AppError> {
     }
 
     // If the CLI didn't supply a pattern but the view did, propagate it.
+    // Skip when --regexp is active — BM25 pattern and regex are mutually exclusive
+    // (clap enforces this for CLI args, but a view's pattern bypasses clap).
     if let Commands::Find {
         ref mut pattern,
         ref filters,
         ..
     } = cli.command
         && pattern.is_none()
+        && filters.regexp.is_none()
         && let Some(ref view_pattern) = filters.pattern
     {
         *pattern = Some(view_pattern.clone());

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -3728,3 +3728,34 @@ fn find_dead_end_composes_with_glob() {
     // Only notes/c.md matches the glob
     assert_eq!(files, vec!["notes/c.md"]);
 }
+
+#[test]
+fn find_orphan_and_dead_end_warns_mutually_exclusive() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\nContent.\n");
+
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "find",
+            "--orphan",
+            "--dead-end",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mutually exclusive"),
+        "expected mutually exclusive warning in stderr, got: {stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert!(
+        results.is_empty(),
+        "orphan+dead-end should return no results"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_summary.rs
+++ b/crates/hyalo-cli/tests/e2e_summary.rs
@@ -1156,3 +1156,69 @@ fn summary_dead_end_parity_disk_vs_index() {
     );
     assert_eq!(disk_dead_ends, 1);
 }
+
+#[test]
+fn summary_status_sorted_by_count_descending() {
+    let tmp = TempDir::new().unwrap();
+
+    // 3 files with status=done, 1 with status=planned
+    write_md(tmp.path(), "done1.md", "---\nstatus: done\n---\nBody one.");
+    write_md(tmp.path(), "done2.md", "---\nstatus: done\n---\nBody two.");
+    write_md(
+        tmp.path(),
+        "done3.md",
+        "---\nstatus: done\n---\nBody three.",
+    );
+    write_md(
+        tmp.path(),
+        "planned1.md",
+        "---\nstatus: planned\n---\nBody four.",
+    );
+
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "summary",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "summary failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let status = json["results"]["status"]
+        .as_array()
+        .expect("field 'status' should be an array");
+
+    // There must be at least two entries
+    assert!(
+        status.len() >= 2,
+        "expected at least 2 status groups, got: {status:?}"
+    );
+
+    // The first entry should be "done" (count=3) before "planned" (count=1)
+    assert_eq!(
+        status[0]["value"], "done",
+        "first status entry should be 'done' (highest count), got: {status:?}"
+    );
+    assert_eq!(
+        status[0]["count"].as_u64().unwrap(),
+        3,
+        "done count should be 3"
+    );
+    assert_eq!(
+        status[1]["value"], "planned",
+        "second status entry should be 'planned', got: {status:?}"
+    );
+    assert_eq!(
+        status[1]["count"].as_u64().unwrap(),
+        1,
+        "planned count should be 1"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_views.rs
+++ b/crates/hyalo-cli/tests/e2e_views.rs
@@ -468,3 +468,92 @@ fn hint_does_not_suggest_view_when_using_view() {
         "should not suggest view when already using --view, got: {hints:?}"
     );
 }
+
+#[test]
+fn views_set_with_bm25_pattern_and_find() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // File that contains the search term and matching tag
+    write_md(
+        tmp.path(),
+        "relevant.md",
+        "---\nstatus: active\ntags:\n  - sometag\n---\nThis document discusses fermentation in detail.",
+    );
+    // File with matching tag but no search term in body
+    write_md(
+        tmp.path(),
+        "other.md",
+        "---\nstatus: active\ntags:\n  - sometag\n---\nThis document is about something else entirely.",
+    );
+    // File with the search term but wrong tag
+    write_md(
+        tmp.path(),
+        "untagged.md",
+        "---\nstatus: active\ntags:\n  - othertag\n---\nThis document discusses fermentation as well.",
+    );
+
+    // Set a view with a BM25 pattern and tag filter
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args([
+            "views",
+            "set",
+            "test-pattern",
+            "fermentation",
+            "--tag",
+            "sometag",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "views set with pattern failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify the view appears in views list with the pattern stored in filters
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "list"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "views list failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    let view = &json["results"][0];
+    assert_eq!(view["name"], "test-pattern");
+    assert_eq!(
+        view["filters"]["pattern"], "fermentation",
+        "pattern should be stored in view filters"
+    );
+    assert!(
+        view["filters"]["tag"]
+            .as_array()
+            .unwrap()
+            .contains(&Value::String("sometag".to_owned())),
+        "tag filter should be stored in view"
+    );
+
+    // Use the view with find — should return only the file with the term AND the tag
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--view", "test-pattern"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "find --view test-pattern failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1, "expected exactly one result: {results:?}");
+    assert!(
+        results[0]["file"].as_str().unwrap().contains("relevant"),
+        "expected relevant.md in results: {results:?}"
+    );
+}

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -1442,4 +1442,54 @@ mod tests {
             "no tokens → should return None"
         );
     }
+
+    // ------------------------------------------------------------------
+    // is_low_discriminative
+    // ------------------------------------------------------------------
+
+    fn make_match(rel_path: &str, score: f64) -> Bm25Match {
+        Bm25Match {
+            rel_path: rel_path.to_owned(),
+            score,
+        }
+    }
+
+    #[test]
+    fn test_low_discriminative_empty_matches_returns_false() {
+        assert!(!is_low_discriminative(&[], 10));
+    }
+
+    #[test]
+    fn test_low_discriminative_zero_total_docs_returns_false() {
+        let matches = vec![make_match("a.md", 0.5)];
+        assert!(!is_low_discriminative(&matches, 0));
+    }
+
+    #[test]
+    fn test_low_discriminative_high_ratio_low_scores_returns_true() {
+        // 9 matches out of 10 docs = 90% ratio; all scores below 1.0
+        let matches: Vec<Bm25Match> = (0..9)
+            .map(|i| make_match(&format!("{i}.md"), 0.5))
+            .collect();
+        assert!(is_low_discriminative(&matches, 10));
+    }
+
+    #[test]
+    fn test_low_discriminative_low_ratio_returns_false() {
+        // 3 matches out of 10 docs = 30% ratio → not low discriminative
+        let matches: Vec<Bm25Match> = (0..3)
+            .map(|i| make_match(&format!("{i}.md"), 0.5))
+            .collect();
+        assert!(!is_low_discriminative(&matches, 10));
+    }
+
+    #[test]
+    fn test_low_discriminative_high_ratio_high_scores_returns_false() {
+        // 9 matches out of 10 docs = 90% ratio, but top score >= 1.0 → not low discriminative
+        let mut matches: Vec<Bm25Match> = (0..8)
+            .map(|i| make_match(&format!("{i}.md"), 0.5))
+            .collect();
+        matches.push(make_match("high.md", 2.5));
+        assert!(!is_low_discriminative(&matches, 10));
+    }
 }

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -708,6 +708,12 @@ pub fn is_low_discriminative(matches: &[Bm25Match], total_docs: usize) -> bool {
     if total_docs == 0 || matches.is_empty() {
         return false;
     }
+    debug_assert!(
+        matches.len() <= total_docs,
+        "matches ({}) exceeds total_docs ({})",
+        matches.len(),
+        total_docs
+    );
     #[allow(clippy::cast_precision_loss)]
     let match_ratio = matches.len() as f64 / total_docs as f64;
     let max_score = matches.iter().map(|m| m.score).fold(0.0_f64, f64::max);

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -510,6 +510,11 @@ impl Bm25InvertedIndex {
         self.ranked_matches(query, stemmer)
     }
 
+    /// Returns the total number of documents in the index.
+    pub fn doc_count(&self) -> usize {
+        self.doc_paths.len()
+    }
+
     // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
@@ -694,6 +699,19 @@ impl Bm25InvertedIndex {
         }
         false
     }
+}
+
+/// Returns `true` if the BM25 results suggest the query has low discriminative power
+/// (e.g. all terms are very common stop-words). Heuristic: more than 80% of documents
+/// matched and the top score is below 1.0.
+pub fn is_low_discriminative(matches: &[Bm25Match], total_docs: usize) -> bool {
+    if total_docs == 0 || matches.is_empty() {
+        return false;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let match_ratio = matches.len() as f64 / total_docs as f64;
+    let max_score = matches.iter().map(|m| m.score).fold(0.0_f64, f64::max);
+    match_ratio > 0.8 && max_score < 1.0
 }
 
 // ---------------------------------------------------------------------------

--- a/hyalo-knowledgebase/dogfood-results/dogfooding-v0.10.0.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfooding-v0.10.0.md
@@ -73,7 +73,7 @@ Combining `--orphan` and `--dead-end` returns nothing because they're mutually e
 ### UX-3 (LOW): Views can't store BM25 patterns
 
 `views set` accepts all filter flags but not the positional search pattern. A `--pattern` or positional arg would complete the feature:
-```
+```bash
 hyalo views set perf-iterations "performance" --tag iteration
 ```
 
@@ -91,6 +91,7 @@ The Status line in `summary` shows `active (3), completed (184), ...` — alphab
 | `properties` | 15ms | **59x faster** (was 880ms) |
 
 With index:
+
 | Command | Time |
 |---|---|
 | `find "dogfood" --index --limit 1` | 11ms |

--- a/hyalo-knowledgebase/dogfood-results/dogfooding-v0.10.0.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfooding-v0.10.0.md
@@ -1,0 +1,143 @@
+---
+title: "Dogfooding v0.10.0 — Post-BM25, Views, Summary Redesign"
+date: 2026-04-12
+type: research
+status: active
+tags:
+  - dogfooding
+  - performance
+  - bm25
+  - views
+  - summary
+---
+
+# Dogfooding v0.10.0 — Post-BM25, Views, Summary Redesign
+
+Tested on hyalo-knowledgebase (221 files, 102 iterations, 84 backlog items, 26 research docs).
+
+## Overall Verdict
+
+Excellent. No bugs found. All features work correctly. Performance is outstanding. Both previously reported v0.6.0 bugs (title regex on derived titles, text-format backlinks) are confirmed fixed.
+
+## New Feature Assessment
+
+### Summary Redesign (iter-105)
+
+**Verdict: Great.** The compact text output is a massive improvement — fits in ~12 lines and gives a complete vault overview at a glance. Key stats: files, directories (with counts), properties, tags, tasks (done/total), links (total + broken), orphans, dead-ends, status distribution, recent files. Hints point to natural drill-down commands.
+
+**Minor nits:**
+- The "Directories" line lists top-level dirs by count — useful but would be nice to see a percentage or bar
+- "Status" line lists all values sorted alphabetically — might be more useful sorted by count (completed: 184 first, not "active: 3" first)
+
+### BM25 Full-Text Search (iter-101, 101b, 103)
+
+**Verdict: Excellent.** Boolean operators work intuitively:
+
+| Query | Behavior | Works? |
+|---|---|---|
+| `search ranking` | Implicit AND | Yes |
+| `"broken links"` | Phrase match | Yes |
+| `search -vector` | Negation | Yes |
+| `obsidian OR zettelkasten` | Explicit OR | Yes |
+| `dogfood` + `--tag iteration` | BM25 + metadata filter | Yes |
+| `dogfood` + `--view planned` | BM25 + saved view | Yes |
+| Empty `""` | Error with helpful message | Yes |
+| Stopwords only (`the and or`) | Returns 205 matches, very low scores | See UX-1 |
+| Version number `v0.5.0` | Works, finds version mentions | Yes |
+| Stemming (`running` → `run`) | Correctly stems | Yes |
+
+Score ordering is sensible — exact matches and high-density documents rank first.
+
+### Views (iter-94, 96)
+
+**Verdict: Solid.** CRUD works: `views set`, `views list`, `views remove`. Composing `--view` with additional CLI flags (like `--sort`, `--reverse`) works correctly. Unknown view gives a clear error with tip. The pre-configured views (planned, open-tasks, stale-in-progress, etc.) are genuinely useful.
+
+**Gap:** Views cannot save a BM25 search pattern. The `views set` command takes all `find` filter flags but not the positional `PATTERN` argument. This means you can save `--property status=planned --tag iteration` as a view, but not `"search query" --tag iteration`.
+
+### Orphan / Dead-End Filters (iter-105)
+
+**Verdict: Works correctly.** 75 orphans, 72 dead-ends. These are mutually exclusive by definition (orphans have no links in/out; dead-ends have inbound but no outbound), so `--orphan --dead-end` returns 0 results. Not a bug, but could be confusing — see UX-2.
+
+## UX Issues
+
+### UX-1 (LOW): Stopword-only queries return noisy results
+
+`hyalo find "the and or"` returns 205/221 files with scores like 0.16. All search terms are common stopwords, so the results are essentially noise. Consider:
+- Warning when all tokens are stopwords
+- Or returning "No meaningful search terms after stemming" error
+
+### UX-2 (LOW): `--orphan --dead-end` silent empty result
+
+Combining `--orphan` and `--dead-end` returns nothing because they're mutually exclusive by definition. A hint or warning ("orphan and dead-end are disjoint sets — did you mean OR?") would help users who expect union semantics.
+
+### UX-3 (LOW): Views can't store BM25 patterns
+
+`views set` accepts all filter flags but not the positional search pattern. A `--pattern` or positional arg would complete the feature:
+```
+hyalo views set perf-iterations "performance" --tag iteration
+```
+
+### UX-4 (LOW): Summary status sorted alphabetically, not by count
+
+The Status line in `summary` shows `active (3), completed (184), ...` — alphabetical. Sorting by count (completed first) would make the most common statuses scannable faster.
+
+## Performance (hyalo-knowledgebase, 221 files, no index)
+
+| Command | Time | vs v0.6.0 |
+|---|---|---|
+| `find --limit 1` | 17ms | **12x faster** (was 200ms) |
+| `find "dogfood" --limit 1` (BM25) | 51ms | new feature |
+| `summary` | 18ms | **52x faster** (was 940ms) |
+| `properties` | 15ms | **59x faster** (was 880ms) |
+
+With index:
+| Command | Time |
+|---|---|
+| `find "dogfood" --index --limit 1` | 11ms |
+
+**Massive performance improvement** since v0.6.0 — likely due to the unified vault index and scan optimizations. The knowledgebase is small (221 files), but the absolute times are excellent.
+
+## What Works Great
+
+1. **Hints system** — every command outputs contextual, copy-pasteable drill-down commands with descriptions. This is a killer LLM-agent feature.
+2. **BM25 + metadata filter composition** — `find "query" --tag X --property Y=Z` is powerful and natural.
+3. **Error messages** — helpful, with tips pointing to the right command.
+4. **`--count`** — quick way to get totals without parsing JSON.
+5. **`links fix`** dry-run with apply hint — safe default.
+6. **Task read with section scoping** — `task read FILE --section "Quality Gates"` is exactly what an LLM agent needs.
+
+## Previously Reported Bugs — Status
+
+| Bug | Status |
+|---|---|
+| BUG 1: `title~=` doesn't match derived titles | **FIXED** |
+| BUG 2: Text format drops backlinks | **FIXED** |
+| `links fix` false positives for short paths | Still present (5 broken links all map to `iteration-plan` → `iteration-02-links.md`), but reasonable given the fuzzy matching |
+
+## Improvement Ideas (Informed by qmd Gap Analysis)
+
+### High Priority
+
+1. **MCP Server** — Expose hyalo's structured queries as MCP tools. hyalo's metadata filtering + BM25 search + task management would be more powerful than qmd's search-only MCP. Tools: `query` (find), `get` (read), `mutate` (set/remove/append), `status` (summary).
+
+2. **`--explain` flag for BM25** — Show per-result score breakdown (term frequencies, IDF weights). qmd has this and it's useful for tuning queries.
+
+### Medium Priority
+
+3. **Views with BM25 patterns** — Complete the views feature by allowing saved search patterns, not just filter flags.
+
+4. **Summary status sort by count** — Small change, big readability win.
+
+5. **`find --no-links` / `--has-links`** — Complement `--orphan` and `--dead-end` with simpler "has any links" / "has no outgoing links" filters. The current terminology is precise but requires understanding the orphan/dead-end definitions.
+
+6. **`hyalo stats`** — A more detailed version of summary focused on vault health metrics: avg properties per file, property completeness %, tag distribution histogram, link density, task completion rate over time.
+
+### Low Priority
+
+7. **Stopword-only query warning** — Gentle UX improvement for BM25 edge case.
+
+8. **`--orphan --dead-end` hint** — Warn when combining mutually exclusive filters.
+
+9. **Non-markdown file support** — Even basic plaintext indexing for `.txt`, `.yml`, `.toml` files in the vault would be useful. qmd supports code files via tree-sitter, but even without AST parsing, body search over non-markdown would help.
+
+10. **SDK / library crate** — Extract `hyalo-core` as a reusable Rust library for programmatic access. This would enable: custom CLI wrappers, editor plugins, web UIs, and the MCP server as a thin consumer.

--- a/hyalo-knowledgebase/iterations/iteration-106-dogfood-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-106-dogfood-fixes.md
@@ -2,7 +2,7 @@
 title: "Iteration 106 — Dogfood Fixes: Status Sort, Views Pattern, Orphan Warning"
 date: 2026-04-12
 type: iteration
-status: in-progress
+status: completed
 branch: iter-106/dogfood-fixes
 tags:
   - iteration

--- a/hyalo-knowledgebase/iterations/iteration-106-dogfood-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-106-dogfood-fixes.md
@@ -1,0 +1,80 @@
+---
+title: "Iteration 106 — Dogfood Fixes: Status Sort, Views Pattern, Orphan Warning"
+date: 2026-04-12
+type: iteration
+status: in-progress
+branch: iter-106/dogfood-fixes
+tags:
+  - iteration
+  - ux
+  - dogfooding
+  - views
+  - summary
+  - bm25
+---
+
+# Iteration 106 — Dogfood Fixes
+
+## Goal
+
+Fix 4 UX issues found during the v0.10.0 dogfood round.
+
+## Changes
+
+### 1. Summary status sorted by count (not alphabetical)
+
+**File:** `crates/hyalo-cli/src/commands/summary.rs` lines 254-258
+
+The status `BTreeMap` preserves alphabetical order. Sort the resulting `Vec<StatusGroup>` by count descending (ties broken alphabetically) before returning. The text formatter already does `sort_by(-.count)` via jaq — this change makes JSON output match.
+
+### 2. `--orphan --dead-end` warning
+
+**File:** `crates/hyalo-cli/src/dispatch.rs`
+
+Orphans (no links in or out) and dead-ends (inbound but no outbound) are disjoint sets by definition. When both flags are true, emit a stderr warning:
+
+```
+warning: --orphan and --dead-end are mutually exclusive (no file can be both); results will always be empty
+```
+
+### 3. Views store BM25 patterns
+
+**Files:** `crates/hyalo-cli/src/cli/args.rs`, `crates/hyalo-cli/src/commands/views.rs`, `crates/hyalo-cli/src/dispatch.rs`, `crates/hyalo-cli/src/run.rs`
+
+Add `pattern: Option<String>` to `FindFilters`. This lets `views set` save a BM25 pattern and `find --view` recall it. The CLI positional `PATTERN` on `find` overrides the view's pattern (same as other scalar fields). On `views set`, add a positional `PATTERN` arg before `NAME` would conflict with clap, so add it as a second positional after NAME.
+
+### 4. Stopword-only BM25 warning
+
+**File:** `crates/hyalo-core/src/bm25.rs`
+
+After parsing the boolean query, check if all positive clauses have zero tokens (all stripped as noise). If so, emit a warning to stderr:
+
+```
+warning: all search terms are common words with very low discriminative power; results may not be meaningful
+```
+
+This is better than silently returning near-zero-score results for every file.
+
+## Tasks
+
+- [x] Sort status by count descending in summary
+- [x] Add warning for --orphan + --dead-end
+- [x] Add `pattern` field to `FindFilters`
+- [x] Update `views set` to accept pattern
+- [x] Update view merge to handle pattern
+- [x] Update `find --view` dispatch to use view pattern
+- [x] Update views list text output to show pattern
+- [x] Add BM25 low-discriminative-power warning
+- [x] Update e2e tests
+- [x] cargo fmt
+- [x] cargo clippy --workspace --all-targets -- -D warnings
+- [x] cargo test --workspace
+
+## Acceptance Criteria
+
+- [x] `hyalo summary --format json` returns status sorted by count descending
+- [x] `hyalo find --orphan --dead-end` prints a warning to stderr
+- [x] `hyalo views set my-search "performance" --tag iteration` saves the pattern
+- [x] `hyalo find --view my-search` uses the saved BM25 pattern
+- [x] `hyalo find --view my-search "override"` overrides the view's pattern
+- [x] `hyalo find "the and or"` prints a low-discriminative-power warning


### PR DESCRIPTION
## Summary

- **Summary status sort**: Status distribution now sorted by count descending (was alphabetical), so `completed (184)` appears first instead of `active (3)`
- **Views with BM25 patterns**: `views set` now accepts a positional search pattern — `hyalo views set my-view "query" --tag foo` saves the BM25 query, `find --view my-view` recalls it, CLI pattern overrides
- **Orphan + dead-end warning**: Emits a stderr warning when both `--orphan` and `--dead-end` are used together (they're mutually exclusive by definition)
- **Low-discriminative BM25 warning**: Warns when a BM25 query matches >80% of documents with very low scores (e.g., stopword-only queries like `"the and or"`)

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 552 tests pass (7 new)
- [x] Manual verification of all 4 fixes via CLI
- [ ] Copilot review
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save optional BM25 search patterns with views and have view-provided patterns apply when no CLI pattern is given
  * Query-quality diagnostics warn for low-discriminative (too common/stopword) searches

* **Bug Fixes**
  * Summary status groups sorted by count (descending) with stable tie-breaking
  * Mutually exclusive `--orphan` + `--dead-end` now emit a warning

* **Tests**
  * Added e2e and unit tests for view pattern persistence, summary ordering, and query diagnostics

* **Documentation**
  * Added v0.10.0 dogfooding report and iteration notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->