### PR TITLE
iter-102a: Schema data model and `hyalo lint` (read-only)

### DIFF
--- a/.hyalo.toml
+++ b/.hyalo.toml
@@ -1,5 +1,98 @@
 dir = "hyalo-knowledgebase"
 
+[schema.default]
+required = ["title", "type"]
+
+[schema.types.iteration]
+required = ["title", "type", "date", "status", "branch", "tags"]
+filename-template = "iterations/iteration-{n}-{slug}.md"
+
+[schema.types.iteration.defaults]
+status = "planned"
+date = "$today"
+type = "iteration"
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed", "superseded", "shelved", "deferred"]
+
+[schema.types.iteration.properties.branch]
+type = "string"
+pattern = "^iter-\\d+[a-z]*/"
+
+[schema.types.iteration.properties.date]
+type = "date"
+
+[schema.types.iteration.properties.tags]
+type = "list"
+
+[schema.types.iteration.properties.priority]
+type = "number"
+
+[schema.types.iteration.properties.related]
+type = "list"
+
+[schema.types.iteration.properties.supersedes]
+type = "string"
+
+[schema.types.iteration.properties.superseded-by]
+type = "string"
+
+[schema.types.iteration.properties.depends-on]
+type = "string"
+
+[schema.types.research]
+required = ["title", "type", "date", "status"]
+
+[schema.types.research.properties.date]
+type = "date"
+
+[schema.types.research.properties.status]
+type = "enum"
+values = ["active", "archived", "reference", "completed", "superseded"]
+
+[schema.types.research.properties.related]
+type = "list"
+
+[schema.types.research.properties.supersedes]
+type = "string"
+
+[schema.types.research.properties.source]
+type = "string"
+
+[schema.types.research.properties.origin]
+type = "string"
+
+[schema.types.backlog]
+required = ["title", "type", "date", "status", "priority"]
+
+[schema.types.backlog.properties.date]
+type = "date"
+
+[schema.types.backlog.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed", "superseded", "wont-do", "deferred", "shelved", "not-a-bug"]
+
+[schema.types.backlog.properties.priority]
+type = "enum"
+values = ["low", "medium", "high", "critical"]
+
+[schema.types.backlog.properties.origin]
+type = "string"
+
+[schema.types.backlog.properties.blocked-by]
+type = "string"
+
+[schema.types.docs]
+required = ["title", "type", "date", "status"]
+
+[schema.types.docs.properties.date]
+type = "date"
+
+[schema.types.docs.properties.status]
+type = "enum"
+values = ["active", "archived", "draft"]
+
 [views.completed-with-todos]
 fields = ["tasks"]
 properties = ["status=completed"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "serde_json",
  "strsim",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -571,6 +571,68 @@ hyalo links fix --format text
 
 Default is `--dry-run` (preview only). Pass `--apply` to write fixes to disk. Use `--ignore-target` (repeatable) to skip links containing specific substrings — useful for template syntax, external paths, or anchors that aren't real files.
 
+### lint
+
+Validate frontmatter properties against the schema defined in `.hyalo.toml` (read-only).
+
+```sh
+# Lint the whole vault
+hyalo lint
+
+# Lint a single file
+hyalo lint iterations/iteration-101-bm25.md
+
+# Lint with a glob
+hyalo lint --glob "iterations/*.md"
+
+# JSON output
+hyalo lint --format json
+```
+
+**Exit codes:** 0 = clean, 1 = errors found, 2 = internal error.
+
+Define a schema in `.hyalo.toml`:
+
+```toml
+[schema.default]
+required = ["title"]
+
+[schema.types.iteration]
+required = ["title", "date", "status", "branch", "tags"]
+filename-template = "iterations/iteration-{n}-{slug}.md"
+
+[schema.types.iteration.defaults]
+status = "planned"
+date = "$today"
+type = "iteration"
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed", "superseded", "shelved", "deferred"]
+
+[schema.types.iteration.properties.branch]
+type = "string"
+pattern = "^iter-\\d+/"
+
+[schema.types.iteration.properties.date]
+type = "date"
+
+[schema.types.iteration.properties.tags]
+type = "list"
+```
+
+**Property types:** `string` (with optional `pattern` regex), `date` (YYYY-MM-DD), `number`, `boolean`, `list`, `enum` (with `values`).
+
+**Severity levels:**
+- `error` — schema violation (missing required, wrong type, invalid enum value, pattern mismatch)
+- `warn` — soft issue (no `type` property, no `tags`, property not in schema)
+
+**Schema merging:** `schema.default` is the baseline. Type-specific `required` extends (not replaces) default required. Type-specific `properties` override defaults for the same property name.
+
+When no `[schema]` block is configured, `hyalo lint` exits 0 with zero violations (backwards compatible).
+
+`hyalo summary` shows a one-line lint count (`schema.errors/warnings`) when a schema is configured.
+
 ### Hints
 
 Add `--hints` to any read-only command to get suggested drill-down commands:

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -745,7 +745,8 @@ Repeatable (AND).\n\
             INPUT: Optional FILE (positional or --file) or --glob to narrow scope.\n\
             Without any file arguments, the entire vault is linted.\n\n\
             OUTPUT: Text by default (per-file violations + summary line). Use --format json for a\n\
-            JSON envelope: {{\"results\": [{{\"file\": \"...\", \"violations\": [...]}}], \"total\": N}}.\n\n\
+            JSON payload (wrapped by the standard CLI envelope under `results`):\n\
+            {\"files\": [{\"file\": \"...\", \"violations\": [...]}], \"total\": N}.\n\n\
             EXIT CODES: 0 = clean, 1 = errors found, 2 = internal error.\n\n\
             EXAMPLES:\n\
             \u{00a0} hyalo lint\n\

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -732,6 +732,40 @@ Repeatable (AND).\n\
         #[command(subcommand)]
         action: LinksAction,
     },
+    /// Validate frontmatter properties against the `.hyalo.toml` schema (read-only)
+    #[command(
+        long_about = "Validate frontmatter properties against the schema defined in `.hyalo.toml`.\n\n\
+            Reads the `[schema.default]` and `[schema.types.*]` sections from `.hyalo.toml` to\n\
+            determine which properties are required, what types they should be, and which enum\n\
+            values are allowed. Reports violations at two severity levels:\n\n\
+            - error: schema violation (missing required property, wrong type, invalid enum value,\n\
+                     pattern mismatch)\n\
+            - warn:  soft issue (no 'type' property, no 'tags', property not declared in schema)\n\n\
+            When no `[schema]` section exists in `.hyalo.toml`, lint exits 0 with zero violations.\n\n\
+            INPUT: Optional FILE (positional or --file) or --glob to narrow scope.\n\
+            Without any file arguments, the entire vault is linted.\n\n\
+            OUTPUT: Text by default (per-file violations + summary line). Use --format json for a\n\
+            JSON envelope: {{\"results\": [{{\"file\": \"...\", \"violations\": [...]}}], \"total\": N}}.\n\n\
+            EXIT CODES: 0 = clean, 1 = errors found, 2 = internal error.\n\n\
+            EXAMPLES:\n\
+            \u{00a0} hyalo lint\n\
+            \u{00a0} hyalo lint iterations/iteration-101-bm25.md\n\
+            \u{00a0} hyalo lint --glob \"iterations/*.md\"\n\
+            \u{00a0} hyalo lint --format json\n\n\
+            SIDE EFFECTS: None (read-only).\n\n\
+            TIP: Run `hyalo summary` to see a one-line lint count across the whole vault."
+    )]
+    Lint {
+        /// Target file (relative to --dir) — positional form
+        #[arg(value_name = "FILE", conflicts_with_all = ["file", "glob"])]
+        file_positional: Option<String>,
+        /// Target file(s) (repeatable). Mutually exclusive with --glob
+        #[arg(short, long, conflicts_with = "glob")]
+        file: Vec<String>,
+        /// Glob pattern(s) to select files, relative to --dir (repeatable); prefix '!' to negate
+        #[arg(short, long, conflicts_with = "file")]
+        glob: Vec<String>,
+    },
     /// Generate shell completions for the given shell
     #[command(
         display_order = 900,

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -10,6 +10,7 @@
 ///     not declared in schema)
 ///
 /// Exit code: 0 = clean, 1 = errors found, 2 = internal error.
+use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -59,9 +60,12 @@ pub struct FileLintResult {
 }
 
 /// Aggregated lint output.
+///
+/// The `files` field is renamed from the internal `results` to avoid a
+/// confusing `results.results` nesting once the CLI envelope wraps the payload.
 #[derive(Debug, Serialize)]
 pub struct LintOutput {
-    pub results: Vec<FileLintResult>,
+    pub files: Vec<FileLintResult>,
     pub total: usize,
 }
 
@@ -105,7 +109,10 @@ pub fn lint_files(
     }
 
     let total = files.len();
-    let output = LintOutput { results, total };
+    let output = LintOutput {
+        files: results,
+        total,
+    };
 
     let outcome = match format {
         Format::Json => {
@@ -207,13 +214,26 @@ fn validate_properties(
     let mut violations: Vec<Violation> = Vec::new();
 
     // Determine the document type.
-    let doc_type: Option<String> = properties.get("type").and_then(|v| match v {
+    let type_value = properties.get("type");
+    let doc_type: Option<String> = type_value.and_then(|v| match v {
         Value::String(s) => Some(s.clone()),
         _ => None,
     });
 
+    // If `type` is present but not a string, report an error. A non-string `type`
+    // still satisfies a bare `required = ["type"]` check, so without this error
+    // invalid type values would slip through silently.
+    if let Some(v) = type_value
+        && doc_type.is_none()
+    {
+        violations.push(Violation {
+            severity: Severity::Error,
+            message: format!("property \"type\" expected string, got {v}"),
+        });
+    }
+
     // Warn when no `type` property is present.
-    if doc_type.is_none() && !schema.is_empty() {
+    if type_value.is_none() && !schema.is_empty() {
         violations.push(Violation {
             severity: Severity::Warn,
             message: "no 'type' property — validating against default schema only".to_owned(),
@@ -248,24 +268,36 @@ fn validate_properties(
         });
     }
 
+    // Build a per-call regex cache so the same pattern isn't recompiled across
+    // properties (this matters in `hyalo summary`, which runs lint over the full
+    // index).
+    let mut regex_cache: HashMap<String, Result<Regex, String>> = HashMap::new();
+
     // Type-specific property constraint validation.
     for (name, value) in properties {
+        // `tags` is validated against its declared constraint if present, but we
+        // never emit an "undeclared property" warning for it (it has its own
+        // "no tags defined" warning above).
         if name == "tags" {
-            continue; // tags handled separately
+            if let Some(constraint) = effective_schema.properties.get(name.as_str())
+                && let Some(v) = validate_constraint(name, value, constraint, &mut regex_cache)
+            {
+                violations.push(v);
+            }
+            continue;
         }
         // Never warn about "type" (type discriminator) or properties listed in `required`
         // — they're implicitly accepted even if not in the `properties` map.
-        let implicitly_accepted =
-            name == "type" || effective_schema.required.contains(&name.clone());
+        let implicitly_accepted = name == "type" || effective_schema.required.contains(name);
 
         if let Some(constraint) = effective_schema.properties.get(name.as_str()) {
-            if let Some(v) = validate_constraint(name, value, constraint) {
+            if let Some(v) = validate_constraint(name, value, constraint, &mut regex_cache) {
                 violations.push(v);
             }
         } else if !effective_schema.properties.is_empty() && !implicitly_accepted {
-            // Property not declared in schema — warn if the schema has any constraints.
-            // We only warn when the schema is non-trivial (has some declared properties)
-            // to avoid noisy warnings on minimal schemas that only specify `required`.
+            // Property not declared in schema — warn only when the schema declares
+            // some properties. Schemas that only specify `required` remain
+            // intentionally permissive about extra fields.
             violations.push(Violation {
                 severity: Severity::Warn,
                 message: format!("property \"{name}\" is not declared in schema"),
@@ -284,12 +316,22 @@ fn validate_constraint(
     name: &str,
     value: &Value,
     constraint: &PropertyConstraint,
+    regex_cache: &mut HashMap<String, Result<Regex, String>>,
 ) -> Option<Violation> {
     match constraint {
         PropertyConstraint::String { pattern } => {
-            let s = value_as_str(value)?;
+            let Some(s) = value_as_str(value) else {
+                return Some(Violation {
+                    severity: Severity::Error,
+                    message: format!("property \"{name}\" expected string, got {value}"),
+                });
+            };
             if let Some(pat) = pattern {
-                match Regex::new(pat) {
+                // Compile (or look up) the regex once per pattern per call.
+                let entry = regex_cache
+                    .entry(pat.clone())
+                    .or_insert_with(|| Regex::new(pat).map_err(|e| e.to_string()));
+                match entry {
                     Ok(re) => {
                         if !re.is_match(s) {
                             return Some(Violation {
@@ -412,7 +454,7 @@ fn format_text_output(output: &LintOutput, counts: &LintCounts) -> String {
     use std::fmt::Write as _;
 
     let mut s = String::new();
-    for file in &output.results {
+    for file in &output.files {
         if file.violations.is_empty() {
             continue;
         }
@@ -429,12 +471,13 @@ fn format_text_output(output: &LintOutput, counts: &LintCounts) -> String {
 
     // Summary line.
     let files_checked = output.total;
+    let files_label = if files_checked == 1 { "file" } else { "files" };
     if counts.errors == 0 && counts.warnings == 0 {
-        let _ = write!(s, "{files_checked} files checked, no issues");
+        let _ = write!(s, "{files_checked} {files_label} checked, no issues");
     } else {
         let _ = write!(
             s,
-            "{files_checked} files checked, {} with issues ({} errors, {} warnings)",
+            "{files_checked} {files_label} checked, {} with issues ({} errors, {} warnings)",
             counts.files_with_issues, counts.errors, counts.warnings,
         );
     }
@@ -490,11 +533,17 @@ mod tests {
         assert!(!is_iso8601_date("2026/04/13"));
     }
 
+    // Test helper: wraps `validate_constraint` with a throwaway regex cache.
+    fn vc(name: &str, value: &Value, c: &PropertyConstraint) -> Option<Violation> {
+        let mut cache = HashMap::new();
+        validate_constraint(name, value, c, &mut cache)
+    }
+
     // --- validate_constraint ---
 
     #[test]
     fn date_constraint_valid() {
-        let v = validate_constraint(
+        let v = vc(
             "date",
             &Value::String("2026-04-13".into()),
             &PropertyConstraint::Date,
@@ -504,7 +553,7 @@ mod tests {
 
     #[test]
     fn date_constraint_invalid() {
-        let v = validate_constraint(
+        let v = vc(
             "date",
             &Value::String("April 13".into()),
             &PropertyConstraint::Date,
@@ -520,7 +569,7 @@ mod tests {
 
     #[test]
     fn enum_constraint_valid() {
-        let v = validate_constraint(
+        let v = vc(
             "status",
             &Value::String("planned".into()),
             &PropertyConstraint::Enum {
@@ -532,7 +581,7 @@ mod tests {
 
     #[test]
     fn enum_constraint_invalid_with_suggestion() {
-        let v = validate_constraint(
+        let v = vc(
             "status",
             &Value::String("planed".into()),
             &PropertyConstraint::Enum {
@@ -546,7 +595,7 @@ mod tests {
 
     #[test]
     fn number_constraint_valid() {
-        let v = validate_constraint(
+        let v = vc(
             "priority",
             &Value::Number(5.into()),
             &PropertyConstraint::Number,
@@ -556,7 +605,7 @@ mod tests {
 
     #[test]
     fn number_constraint_invalid() {
-        let v = validate_constraint(
+        let v = vc(
             "priority",
             &Value::String("five".into()),
             &PropertyConstraint::Number,
@@ -572,13 +621,13 @@ mod tests {
 
     #[test]
     fn boolean_constraint_valid() {
-        let v = validate_constraint("draft", &Value::Bool(true), &PropertyConstraint::Boolean);
+        let v = vc("draft", &Value::Bool(true), &PropertyConstraint::Boolean);
         assert!(v.is_none());
     }
 
     #[test]
     fn boolean_constraint_invalid() {
-        let v = validate_constraint(
+        let v = vc(
             "draft",
             &Value::String("yes".into()),
             &PropertyConstraint::Boolean,
@@ -594,13 +643,13 @@ mod tests {
 
     #[test]
     fn list_constraint_valid() {
-        let v = validate_constraint("tags", &Value::Array(vec![]), &PropertyConstraint::List);
+        let v = vc("tags", &Value::Array(vec![]), &PropertyConstraint::List);
         assert!(v.is_none());
     }
 
     #[test]
     fn list_constraint_invalid() {
-        let v = validate_constraint(
+        let v = vc(
             "tags",
             &Value::String("rust".into()),
             &PropertyConstraint::List,
@@ -616,7 +665,7 @@ mod tests {
 
     #[test]
     fn string_pattern_constraint_valid() {
-        let v = validate_constraint(
+        let v = vc(
             "branch",
             &Value::String("iter-42/my-feature".into()),
             &PropertyConstraint::String {
@@ -628,7 +677,7 @@ mod tests {
 
     #[test]
     fn string_pattern_constraint_invalid() {
-        let v = validate_constraint(
+        let v = vc(
             "branch",
             &Value::String("feature/my-branch".into()),
             &PropertyConstraint::String {
@@ -712,7 +761,7 @@ mod tests {
     #[test]
     fn format_text_output_clean() {
         let output = LintOutput {
-            results: vec![],
+            files: vec![],
             total: 3,
         };
         let counts = LintCounts::default();
@@ -724,7 +773,7 @@ mod tests {
     #[test]
     fn format_text_output_with_violations() {
         let output = LintOutput {
-            results: vec![FileLintResult {
+            files: vec![FileLintResult {
                 file: "note.md".to_owned(),
                 violations: vec![
                     Violation {
@@ -748,6 +797,6 @@ mod tests {
         assert!(text.contains("note.md:"));
         assert!(text.contains("error"));
         assert!(text.contains("warn"));
-        assert!(text.contains("1 files checked, 1 with issues"));
+        assert!(text.contains("1 file checked, 1 with issues"));
     }
 }

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -1,0 +1,753 @@
+/// `hyalo lint` — validate frontmatter properties against the `.hyalo.toml` schema.
+///
+/// Reads each file's frontmatter, applies the type-specific schema (or the
+/// default schema if `type` is absent), and reports violations at two severity
+/// levels:
+///
+///   - **error**  — schema violation (missing required field, wrong value type,
+///     invalid enum value, failed pattern match)
+///   - **warn**   — soft issue (no `type` property, no `tags` property, property
+///     not declared in schema)
+///
+/// Exit code: 0 = clean, 1 = errors found, 2 = internal error.
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use indexmap::IndexMap;
+use regex::Regex;
+use serde::Serialize;
+use serde_json::Value;
+
+use hyalo_core::frontmatter::read_frontmatter;
+use hyalo_core::schema::{PropertyConstraint, SchemaConfig, TypeSchema};
+
+use crate::output::{CommandOutcome, Format, format_success};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Severity of a single lint violation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Error,
+    Warn,
+}
+
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Error => f.write_str("error"),
+            Self::Warn => f.write_str("warn"),
+        }
+    }
+}
+
+/// A single lint violation found in a file.
+#[derive(Debug, Clone, Serialize)]
+pub struct Violation {
+    pub severity: Severity,
+    pub message: String,
+}
+
+/// Lint results for a single file.
+#[derive(Debug, Serialize)]
+pub struct FileLintResult {
+    pub file: String,
+    pub violations: Vec<Violation>,
+}
+
+/// Aggregated lint output.
+#[derive(Debug, Serialize)]
+pub struct LintOutput {
+    pub results: Vec<FileLintResult>,
+    pub total: usize,
+}
+
+/// Summary counts returned to callers (e.g. `hyalo summary`).
+#[derive(Debug, Clone, Default)]
+pub struct LintCounts {
+    pub errors: usize,
+    pub warnings: usize,
+    /// Number of files with at least one violation.
+    pub files_with_issues: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Run `hyalo lint` against a list of `(full_path, rel_path)` file pairs.
+///
+/// Returns the formatted output and the set of counts; the caller is
+/// responsible for translating counts into an exit code.
+pub fn lint_files(
+    files: &[(std::path::PathBuf, String)],
+    schema: &SchemaConfig,
+    format: Format,
+) -> Result<(CommandOutcome, LintCounts)> {
+    let mut results: Vec<FileLintResult> = Vec::new();
+    let mut counts = LintCounts::default();
+
+    for (full_path, rel_path) in files {
+        let file_result = lint_file(full_path, rel_path, schema)?;
+        for v in &file_result.violations {
+            match v.severity {
+                Severity::Error => counts.errors += 1,
+                Severity::Warn => counts.warnings += 1,
+            }
+        }
+        if !file_result.violations.is_empty() {
+            counts.files_with_issues += 1;
+        }
+        results.push(file_result);
+    }
+
+    let total = files.len();
+    let output = LintOutput { results, total };
+
+    let outcome = match format {
+        Format::Json => {
+            let val = serde_json::to_value(&output).context("failed to serialize lint output")?;
+            CommandOutcome::success(format_success(Format::Json, &val))
+        }
+        Format::Text => {
+            let text = format_text_output(&output, &counts);
+            CommandOutcome::RawOutput(text)
+        }
+    };
+
+    Ok((outcome, counts))
+}
+
+/// Compute lint counts for `hyalo summary` without formatting output.
+pub fn lint_counts_only(
+    files: &[(std::path::PathBuf, String)],
+    schema: &SchemaConfig,
+) -> Result<LintCounts> {
+    let mut counts = LintCounts::default();
+    for (full_path, rel_path) in files {
+        let file_result = lint_file(full_path, rel_path, schema)?;
+        for v in &file_result.violations {
+            match v.severity {
+                Severity::Error => counts.errors += 1,
+                Severity::Warn => counts.warnings += 1,
+            }
+        }
+        if !file_result.violations.is_empty() {
+            counts.files_with_issues += 1;
+        }
+    }
+    Ok(counts)
+}
+
+/// Compute lint counts from pre-indexed `IndexEntry` properties.
+///
+/// Used by `hyalo summary` to avoid re-reading files from disk.
+/// The `index_entries` iterator yields `(rel_path, properties, has_tags)` tuples.
+pub fn lint_counts_from_properties<'a>(
+    entries: impl Iterator<Item = (&'a str, &'a IndexMap<String, Value>, bool)>,
+    schema: &SchemaConfig,
+) -> LintCounts {
+    let mut counts = LintCounts::default();
+    for (rel_path, properties, has_tags) in entries {
+        let violations = validate_properties(rel_path, properties, has_tags, schema);
+        for v in &violations {
+            match v.severity {
+                Severity::Error => counts.errors += 1,
+                Severity::Warn => counts.warnings += 1,
+            }
+        }
+        if !violations.is_empty() {
+            counts.files_with_issues += 1;
+        }
+    }
+    counts
+}
+
+// ---------------------------------------------------------------------------
+// Per-file validation
+// ---------------------------------------------------------------------------
+
+fn lint_file(full_path: &Path, rel_path: &str, schema: &SchemaConfig) -> Result<FileLintResult> {
+    let properties = match read_frontmatter(full_path) {
+        Ok(props) => props,
+        Err(e) if hyalo_core::frontmatter::is_parse_error(&e) => {
+            // Malformed frontmatter — report as a single error violation.
+            return Ok(FileLintResult {
+                file: rel_path.to_owned(),
+                violations: vec![Violation {
+                    severity: Severity::Error,
+                    message: format!("could not parse frontmatter: {e}"),
+                }],
+            });
+        }
+        Err(e) => return Err(e).context(format!("reading {rel_path}")),
+    };
+
+    let has_tags = properties.contains_key("tags");
+    let violations = validate_properties(rel_path, &properties, has_tags, schema);
+    Ok(FileLintResult {
+        file: rel_path.to_owned(),
+        violations,
+    })
+}
+
+/// Core property validation logic.
+///
+/// Separated so it can be used both by the disk-reading path (`lint_file`) and
+/// the index-based path (`lint_counts_from_properties`).
+fn validate_properties(
+    _rel_path: &str,
+    properties: &IndexMap<String, Value>,
+    has_tags: bool,
+    schema: &SchemaConfig,
+) -> Vec<Violation> {
+    let mut violations: Vec<Violation> = Vec::new();
+
+    // Determine the document type.
+    let doc_type: Option<String> = properties.get("type").and_then(|v| match v {
+        Value::String(s) => Some(s.clone()),
+        _ => None,
+    });
+
+    // Warn when no `type` property is present.
+    if doc_type.is_none() && !schema.is_empty() {
+        violations.push(Violation {
+            severity: Severity::Warn,
+            message: "no 'type' property — validating against default schema only".to_owned(),
+        });
+    }
+
+    // Determine the effective schema for this file.
+    let effective_schema: TypeSchema = match &doc_type {
+        Some(t) => schema.merged_schema_for_type(t),
+        None => schema.default_schema().clone(),
+    };
+
+    // Check required properties.
+    for req in &effective_schema.required {
+        if !properties.contains_key(req.as_str()) {
+            let type_hint = doc_type
+                .as_deref()
+                .map(|t| format!(" (type: {t})"))
+                .unwrap_or_default();
+            violations.push(Violation {
+                severity: Severity::Error,
+                message: format!("missing required property \"{req}\"{type_hint}"),
+            });
+        }
+    }
+
+    // Warn when no `tags` property is present and the schema has at least one type defined.
+    if !has_tags && !schema.types.is_empty() {
+        violations.push(Violation {
+            severity: Severity::Warn,
+            message: "no tags defined".to_owned(),
+        });
+    }
+
+    // Type-specific property constraint validation.
+    for (name, value) in properties {
+        if name == "tags" {
+            continue; // tags handled separately
+        }
+        // Never warn about "type" (type discriminator) or properties listed in `required`
+        // — they're implicitly accepted even if not in the `properties` map.
+        let implicitly_accepted =
+            name == "type" || effective_schema.required.contains(&name.clone());
+
+        if let Some(constraint) = effective_schema.properties.get(name.as_str()) {
+            if let Some(v) = validate_constraint(name, value, constraint) {
+                violations.push(v);
+            }
+        } else if !effective_schema.properties.is_empty() && !implicitly_accepted {
+            // Property not declared in schema — warn if the schema has any constraints.
+            // We only warn when the schema is non-trivial (has some declared properties)
+            // to avoid noisy warnings on minimal schemas that only specify `required`.
+            violations.push(Violation {
+                severity: Severity::Warn,
+                message: format!("property \"{name}\" is not declared in schema"),
+            });
+        }
+    }
+
+    violations
+}
+
+// ---------------------------------------------------------------------------
+// Constraint validators
+// ---------------------------------------------------------------------------
+
+fn validate_constraint(
+    name: &str,
+    value: &Value,
+    constraint: &PropertyConstraint,
+) -> Option<Violation> {
+    match constraint {
+        PropertyConstraint::String { pattern } => {
+            let s = value_as_str(value)?;
+            if let Some(pat) = pattern {
+                match Regex::new(pat) {
+                    Ok(re) => {
+                        if !re.is_match(s) {
+                            return Some(Violation {
+                                severity: Severity::Error,
+                                message: format!(
+                                    "property \"{name}\" value {s:?} does not match pattern {pat:?}"
+                                ),
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        return Some(Violation {
+                            severity: Severity::Error,
+                            message: format!("property \"{name}\": invalid pattern {pat:?}: {e}"),
+                        });
+                    }
+                }
+            }
+            None
+        }
+        PropertyConstraint::Date => {
+            let Some(s) = value_as_str(value) else {
+                return Some(Violation {
+                    severity: Severity::Error,
+                    message: format!("property \"{name}\" expected date (YYYY-MM-DD), got {value}"),
+                });
+            };
+            if !is_iso8601_date(s) {
+                return Some(Violation {
+                    severity: Severity::Error,
+                    message: format!("property \"{name}\" expected date (YYYY-MM-DD), got \"{s}\""),
+                });
+            }
+            None
+        }
+        PropertyConstraint::Number => {
+            if !matches!(value, Value::Number(_)) {
+                return Some(Violation {
+                    severity: Severity::Error,
+                    message: format!("property \"{name}\" expected number, got {value}"),
+                });
+            }
+            None
+        }
+        PropertyConstraint::Boolean => {
+            if !matches!(value, Value::Bool(_)) {
+                return Some(Violation {
+                    severity: Severity::Error,
+                    message: format!("property \"{name}\" expected boolean, got {value}"),
+                });
+            }
+            None
+        }
+        PropertyConstraint::List => {
+            if !matches!(value, Value::Array(_)) {
+                return Some(Violation {
+                    severity: Severity::Error,
+                    message: format!("property \"{name}\" expected list, got {value}"),
+                });
+            }
+            None
+        }
+        PropertyConstraint::Enum { values } => {
+            let Some(s) = value_as_str(value) else {
+                return Some(Violation {
+                    severity: Severity::Error,
+                    message: format!(
+                        "property \"{name}\" expected one of [{}], got {value}",
+                        values.join(", ")
+                    ),
+                });
+            };
+            if values.contains(&s.to_owned()) {
+                return None;
+            }
+            // Find nearest suggestion via Levenshtein.
+            let suggestion = values
+                .iter()
+                .min_by_key(|v| strsim::levenshtein(s, v.as_str()))
+                .map(|v| format!(" (did you mean \"{v}\"?)"))
+                .unwrap_or_default();
+            Some(Violation {
+                severity: Severity::Error,
+                message: format!(
+                    "property \"{name}\" value \"{s}\" not in [{}]{suggestion}",
+                    values.join(", ")
+                ),
+            })
+        }
+    }
+}
+
+/// Extract a `&str` from a `Value::String`, or `None` for other variants.
+fn value_as_str(v: &Value) -> Option<&str> {
+    if let Value::String(s) = v {
+        Some(s.as_str())
+    } else {
+        None
+    }
+}
+
+/// Returns `true` for YYYY-MM-DD formatted dates.
+fn is_iso8601_date(s: &str) -> bool {
+    if s.len() != 10 {
+        return false;
+    }
+    let b = s.as_bytes();
+    b[4] == b'-'
+        && b[7] == b'-'
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[8..10].iter().all(u8::is_ascii_digit)
+}
+
+// ---------------------------------------------------------------------------
+// Text formatter
+// ---------------------------------------------------------------------------
+
+fn format_text_output(output: &LintOutput, counts: &LintCounts) -> String {
+    use std::fmt::Write as _;
+
+    let mut s = String::new();
+    for file in &output.results {
+        if file.violations.is_empty() {
+            continue;
+        }
+        let _ = writeln!(s, "{}:", file.file);
+        for v in &file.violations {
+            let pad = if v.severity == Severity::Error {
+                "error"
+            } else {
+                "warn "
+            };
+            let _ = writeln!(s, "  {pad}  {}", v.message);
+        }
+    }
+
+    // Summary line.
+    let files_checked = output.total;
+    if counts.errors == 0 && counts.warnings == 0 {
+        let _ = write!(s, "{files_checked} files checked, no issues");
+    } else {
+        let _ = write!(
+            s,
+            "{files_checked} files checked, {} with issues ({} errors, {} warnings)",
+            counts.files_with_issues, counts.errors, counts.warnings,
+        );
+    }
+
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyalo_core::schema::{PropertyConstraint, SchemaConfig, TypeSchema};
+    use std::collections::HashMap;
+
+    fn make_schema(
+        default_required: &[&str],
+        type_name: &str,
+        type_required: &[&str],
+        type_properties: HashMap<&str, PropertyConstraint>,
+    ) -> SchemaConfig {
+        let default = TypeSchema {
+            required: default_required.iter().map(ToString::to_string).collect(),
+            ..Default::default()
+        };
+        let mut props: HashMap<String, PropertyConstraint> = HashMap::new();
+        for (k, v) in type_properties {
+            props.insert(k.to_owned(), v);
+        }
+        let type_schema = TypeSchema {
+            required: type_required.iter().map(ToString::to_string).collect(),
+            properties: props,
+            ..Default::default()
+        };
+        let mut types = HashMap::new();
+        types.insert(type_name.to_owned(), type_schema);
+        SchemaConfig { default, types }
+    }
+
+    // --- is_iso8601_date ---
+
+    #[test]
+    fn valid_date() {
+        assert!(is_iso8601_date("2026-04-13"));
+    }
+
+    #[test]
+    fn invalid_date_format() {
+        assert!(!is_iso8601_date("April 13"));
+        assert!(!is_iso8601_date("13-04-2026"));
+        assert!(!is_iso8601_date("2026/04/13"));
+    }
+
+    // --- validate_constraint ---
+
+    #[test]
+    fn date_constraint_valid() {
+        let v = validate_constraint(
+            "date",
+            &Value::String("2026-04-13".into()),
+            &PropertyConstraint::Date,
+        );
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn date_constraint_invalid() {
+        let v = validate_constraint(
+            "date",
+            &Value::String("April 13".into()),
+            &PropertyConstraint::Date,
+        );
+        assert!(matches!(
+            v,
+            Some(Violation {
+                severity: Severity::Error,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn enum_constraint_valid() {
+        let v = validate_constraint(
+            "status",
+            &Value::String("planned".into()),
+            &PropertyConstraint::Enum {
+                values: vec!["planned".into(), "done".into()],
+            },
+        );
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn enum_constraint_invalid_with_suggestion() {
+        let v = validate_constraint(
+            "status",
+            &Value::String("planed".into()),
+            &PropertyConstraint::Enum {
+                values: vec!["planned".into(), "done".into()],
+            },
+        );
+        let viol = v.expect("expected violation");
+        assert_eq!(viol.severity, Severity::Error);
+        assert!(viol.message.contains("did you mean \"planned\""));
+    }
+
+    #[test]
+    fn number_constraint_valid() {
+        let v = validate_constraint(
+            "priority",
+            &Value::Number(5.into()),
+            &PropertyConstraint::Number,
+        );
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn number_constraint_invalid() {
+        let v = validate_constraint(
+            "priority",
+            &Value::String("five".into()),
+            &PropertyConstraint::Number,
+        );
+        assert!(matches!(
+            v,
+            Some(Violation {
+                severity: Severity::Error,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn boolean_constraint_valid() {
+        let v = validate_constraint("draft", &Value::Bool(true), &PropertyConstraint::Boolean);
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn boolean_constraint_invalid() {
+        let v = validate_constraint(
+            "draft",
+            &Value::String("yes".into()),
+            &PropertyConstraint::Boolean,
+        );
+        assert!(matches!(
+            v,
+            Some(Violation {
+                severity: Severity::Error,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn list_constraint_valid() {
+        let v = validate_constraint("tags", &Value::Array(vec![]), &PropertyConstraint::List);
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn list_constraint_invalid() {
+        let v = validate_constraint(
+            "tags",
+            &Value::String("rust".into()),
+            &PropertyConstraint::List,
+        );
+        assert!(matches!(
+            v,
+            Some(Violation {
+                severity: Severity::Error,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn string_pattern_constraint_valid() {
+        let v = validate_constraint(
+            "branch",
+            &Value::String("iter-42/my-feature".into()),
+            &PropertyConstraint::String {
+                pattern: Some(r"^iter-\d+/".into()),
+            },
+        );
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn string_pattern_constraint_invalid() {
+        let v = validate_constraint(
+            "branch",
+            &Value::String("feature/my-branch".into()),
+            &PropertyConstraint::String {
+                pattern: Some(r"^iter-\d+/".into()),
+            },
+        );
+        assert!(matches!(
+            v,
+            Some(Violation {
+                severity: Severity::Error,
+                ..
+            })
+        ));
+    }
+
+    // --- lint_file via a temp file ---
+
+    #[test]
+    fn lint_file_missing_required() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "---\ntitle: Hello\n---\nBody\n").unwrap();
+
+        let schema = make_schema(&["title", "date"], "note", &[], HashMap::new());
+        let result = lint_file(&path, "note.md", &schema).unwrap();
+        // date is in default required, but only "title" is present.
+        // No type -> warn about no type. date missing -> error.
+        assert!(
+            result
+                .violations
+                .iter()
+                .any(|v| v.severity == Severity::Error
+                    && v.message.contains("missing required property \"date\""))
+        );
+    }
+
+    #[test]
+    fn lint_file_no_type_warn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "---\ntitle: Hello\n---\nBody\n").unwrap();
+
+        let schema = make_schema(&["title"], "note", &[], HashMap::new());
+        let result = lint_file(&path, "note.md", &schema).unwrap();
+        assert!(
+            result
+                .violations
+                .iter()
+                .any(|v| v.severity == Severity::Warn && v.message.contains("no 'type' property"))
+        );
+    }
+
+    #[test]
+    fn lint_file_no_violations_clean_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: Hello\ntype: note\ntags:\n  - rust\n---\nBody\n",
+        )
+        .unwrap();
+
+        let schema = make_schema(&["title"], "note", &[], HashMap::new());
+        let result = lint_file(&path, "note.md", &schema).unwrap();
+        assert!(result.violations.is_empty());
+    }
+
+    #[test]
+    fn lint_no_schema_no_violations() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "---\ntitle: Hello\n---\nBody\n").unwrap();
+
+        let schema = SchemaConfig::default();
+        let files = vec![(path, "note.md".to_owned())];
+        let (_, counts) = lint_files(&files, &schema, Format::Text).unwrap();
+        assert_eq!(counts.errors, 0);
+        assert_eq!(counts.warnings, 0);
+    }
+
+    #[test]
+    fn format_text_output_clean() {
+        let output = LintOutput {
+            results: vec![],
+            total: 3,
+        };
+        let counts = LintCounts::default();
+        let text = format_text_output(&output, &counts);
+        assert!(text.contains("3 files checked"));
+        assert!(text.contains("no issues"));
+    }
+
+    #[test]
+    fn format_text_output_with_violations() {
+        let output = LintOutput {
+            results: vec![FileLintResult {
+                file: "note.md".to_owned(),
+                violations: vec![
+                    Violation {
+                        severity: Severity::Error,
+                        message: "missing required property \"date\"".to_owned(),
+                    },
+                    Violation {
+                        severity: Severity::Warn,
+                        message: "no tags defined".to_owned(),
+                    },
+                ],
+            }],
+            total: 1,
+        };
+        let counts = LintCounts {
+            errors: 1,
+            warnings: 1,
+            files_with_issues: 1,
+        };
+        let text = format_text_output(&output, &counts);
+        assert!(text.contains("note.md:"));
+        assert!(text.contains("error"));
+        assert!(text.contains("warn"));
+        assert!(text.contains("1 files checked, 1 with issues"));
+    }
+}

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod drop_index;
 pub mod find;
 pub mod init;
 pub mod links;
+pub mod lint;
 pub(crate) mod mutation;
 pub mod mv;
 pub mod properties;

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -5,13 +5,15 @@ use std::path::Path;
 
 use hyalo_core::util::levenshtein;
 
+use crate::commands::lint::lint_counts_from_properties;
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::frontmatter::infer_type;
 use hyalo_core::index::VaultIndex;
 use hyalo_core::link_fix::detect_broken_links_from_index;
+use hyalo_core::schema::SchemaConfig;
 use hyalo_core::types::{
-    DirectoryCount, FileCounts, LinkHealthSummary, PropertySummaryEntry, RecentFile, StatusGroup,
-    TagSummary, TagSummaryEntry, TaskCount, VaultSummary,
+    DirectoryCount, FileCounts, LinkHealthSummary, LintSummary, PropertySummaryEntry, RecentFile,
+    StatusGroup, TagSummary, TagSummaryEntry, TaskCount, VaultSummary,
 };
 
 // ---------------------------------------------------------------------------
@@ -95,6 +97,7 @@ fn warn_inconsistent_properties(string_prop_values: &BTreeMap<String, BTreeMap<S
 ///
 /// `globs` optionally narrows which entries are included (same semantics as the
 /// `--glob` flag on the `summary` command).
+#[allow(clippy::too_many_arguments)]
 pub fn summary(
     dir: &Path,
     index: &dyn VaultIndex,
@@ -103,6 +106,7 @@ pub fn summary(
     depth: Option<usize>,
     site_prefix: Option<&str>,
     format: Format,
+    schema: &SchemaConfig,
 ) -> Result<CommandOutcome> {
     use crate::commands::find::filter_index_entries;
     let scoped: Vec<_> = filter_index_entries(index.entries(), &[], globs)?;
@@ -311,6 +315,22 @@ pub fn summary(
         }
     };
 
+    // Compute schema lint counts from index data (no disk re-read needed).
+    let lint_summary: Option<LintSummary> = if schema.is_empty() {
+        None
+    } else {
+        let lint_entries = entries.iter().map(|e| {
+            let has_tags = e.properties.contains_key("tags") || !e.tags.is_empty();
+            (e.rel_path.as_str(), &e.properties, has_tags)
+        });
+        let counts = lint_counts_from_properties(lint_entries, schema);
+        Some(LintSummary {
+            errors: counts.errors,
+            warnings: counts.warnings,
+            files_with_issues: counts.files_with_issues,
+        })
+    };
+
     let vault_summary = VaultSummary {
         files: file_counts,
         orphans,
@@ -321,6 +341,7 @@ pub fn summary(
         status,
         tasks,
         recent_files,
+        schema: lint_summary,
     };
 
     let json_value = serde_json::to_value(&vault_summary).context("failed to serialize summary")?;
@@ -387,7 +408,17 @@ mod tests {
                 default_language: None,
             },
         )?;
-        summary(dir, &build.index, globs, recent, depth, site_prefix, format)
+        let schema = hyalo_core::schema::SchemaConfig::default();
+        summary(
+            dir,
+            &build.index,
+            globs,
+            recent,
+            depth,
+            site_prefix,
+            format,
+            &schema,
+        )
     }
 
     macro_rules! md {
@@ -825,8 +856,10 @@ Body.
         )
         .unwrap();
         let loaded = SnapshotIndex::load(&index_path).unwrap().unwrap();
-        let index_val =
-            unwrap_success(summary(dir, &loaded, &[], 10, None, prefix, Format::Json).unwrap());
+        let schema = hyalo_core::schema::SchemaConfig::default();
+        let index_val = unwrap_success(
+            summary(dir, &loaded, &[], 10, None, prefix, Format::Json, &schema).unwrap(),
+        );
         let index_orphans = index_val["orphans"].as_u64().unwrap();
 
         assert_eq!(
@@ -913,8 +946,10 @@ Body.
         )
         .unwrap();
         let loaded = SnapshotIndex::load(&index_path).unwrap().unwrap();
-        let index_val =
-            unwrap_success(summary(dir, &loaded, &[], 10, None, None, Format::Json).unwrap());
+        let schema = hyalo_core::schema::SchemaConfig::default();
+        let index_val = unwrap_success(
+            summary(dir, &loaded, &[], 10, None, None, Format::Json, &schema).unwrap(),
+        );
         let index_dead_ends = index_val["dead_ends"].as_u64().unwrap();
 
         assert_eq!(

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+use hyalo_core::schema::{RawSchemaConfig, SchemaConfig};
+
 /// Search-specific configuration from `[search]` in `.hyalo.toml`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -32,10 +34,15 @@ struct ConfigFile {
     views: Option<HashMap<String, toml::Value>>,
     /// Search configuration (BM25 stemming language, etc.)
     search: Option<SearchConfig>,
+    /// Schema configuration for document type validation.
+    /// Stored as raw TOML value to avoid `deny_unknown_fields` issues with
+    /// the deeply nested schema structure.
+    #[serde(default)]
+    schema: Option<toml::Value>,
 }
 
 /// Resolved configuration with all defaults applied.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub(crate) struct ResolvedDefaults {
     pub(crate) dir: PathBuf,
     pub(crate) format: String,
@@ -44,6 +51,20 @@ pub(crate) struct ResolvedDefaults {
     pub(crate) site_prefix: Option<String>,
     /// Default stemming language for BM25 search from `[search] language` in `.hyalo.toml`.
     pub(crate) search_language: Option<String>,
+    /// Parsed schema configuration from `[schema.*]` sections.
+    pub(crate) schema: SchemaConfig,
+}
+
+impl PartialEq for ResolvedDefaults {
+    fn eq(&self, other: &Self) -> bool {
+        // SchemaConfig doesn't implement PartialEq, so compare the other fields only.
+        // Tests that care about schema equality check it separately.
+        self.dir == other.dir
+            && self.format == other.format
+            && self.hints == other.hints
+            && self.site_prefix == other.site_prefix
+            && self.search_language == other.search_language
+    }
 }
 
 impl ResolvedDefaults {
@@ -54,6 +75,7 @@ impl ResolvedDefaults {
             hints: true,
             site_prefix: None,
             search_language: None,
+            schema: SchemaConfig::default(),
         }
     }
 }
@@ -103,12 +125,32 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     };
 
     let defaults = ResolvedDefaults::hardcoded();
+    let schema = parse_schema_from_toml(cfg.schema.as_ref());
     ResolvedDefaults {
         dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
         format: cfg.format.unwrap_or(defaults.format),
         hints: cfg.hints.unwrap_or(defaults.hints),
         site_prefix: cfg.site_prefix,
         search_language: cfg.search.and_then(|s| s.language),
+        schema,
+    }
+}
+
+/// Parse a `SchemaConfig` from the raw `[schema]` TOML value.
+///
+/// On malformed schema TOML, emits a warning and returns an empty schema
+/// (no validation), consistent with how malformed `.hyalo.toml` is handled
+/// throughout the rest of the config loading pipeline.
+fn parse_schema_from_toml(raw: Option<&toml::Value>) -> SchemaConfig {
+    let Some(val) = raw else {
+        return SchemaConfig::default();
+    };
+    match val.clone().try_into::<RawSchemaConfig>() {
+        Ok(raw_cfg) => SchemaConfig::from(raw_cfg),
+        Err(e) => {
+            crate::warn::warn(format!("malformed [schema] in .hyalo.toml: {e}"));
+            SchemaConfig::default()
+        }
     }
 }
 

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -9,14 +9,15 @@ use crate::cli::args::{
 use crate::commands::{
     IndexResolution, ResolvedIndex, append as append_commands, backlinks as backlinks_commands,
     create_index as create_index_commands, drop_index as drop_index_commands,
-    find as find_commands, links as links_commands, mv as mv_commands, properties,
-    read as read_commands, remove as remove_commands, resolve_index, set as set_commands,
-    summary as summary_commands, tags as tag_commands, tasks as task_commands,
+    find as find_commands, links as links_commands, lint as lint_commands, mv as mv_commands,
+    properties, read as read_commands, remove as remove_commands, resolve_index,
+    set as set_commands, summary as summary_commands, tags as tag_commands, tasks as task_commands,
 };
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::bm25::parse_language;
 use hyalo_core::filter;
 use hyalo_core::index::{ScanOptions, SnapshotIndex, VaultIndex as _};
+use hyalo_core::schema::SchemaConfig;
 
 /// Shared context for command dispatch.
 pub(crate) struct CommandContext<'a> {
@@ -31,6 +32,12 @@ pub(crate) struct CommandContext<'a> {
     pub index_path: Option<&'a Path>,
     /// Default stemming language from `[search] language` in `.hyalo.toml`.
     pub config_language: Option<&'a str>,
+    /// Parsed schema configuration from `[schema.*]` sections in `.hyalo.toml`.
+    pub schema: &'a SchemaConfig,
+    /// Optional exit code override set by commands that need a non-0/2 exit code
+    /// (e.g. `lint` returns 1 when errors are found). The output pipeline uses this
+    /// to override its own exit code calculation.
+    pub exit_code_override: Option<i32>,
 }
 
 /// Parse `--where-property` filters and validate `--where-tag` names.
@@ -470,6 +477,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 depth,
                 site_prefix,
                 effective_format,
+                ctx.schema,
             ),
             IndexResolution::Outcome(outcome) => Ok(outcome),
         },
@@ -673,6 +681,33 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 IndexResolution::Outcome(outcome) => Ok(outcome),
             },
         },
+        Commands::Lint {
+            file_positional,
+            file,
+            glob,
+        } => {
+            // Build the file list. Positional arg is treated as a single --file.
+            let mut files_arg: Vec<String> = file;
+            if let Some(pos) = file_positional {
+                files_arg.insert(0, pos);
+            }
+
+            let file_pairs =
+                match crate::commands::collect_files(dir, &files_arg, &glob, ctx.user_format)? {
+                    crate::commands::FilesOrOutcome::Files(f) => f,
+                    crate::commands::FilesOrOutcome::Outcome(o) => return Ok(o),
+                };
+
+            let (outcome, counts) =
+                lint_commands::lint_files(&file_pairs, ctx.schema, ctx.user_format)?;
+
+            // Signal exit code 1 when errors were found (set before returning).
+            if counts.errors > 0 {
+                ctx.exit_code_override = Some(1);
+            }
+
+            Ok(outcome)
+        }
         // `Init`, `Deinit`, and `Completion` are handled as early returns before dispatch is called.
         Commands::Init { .. } => unreachable!("Init is dispatched before this match reached"),
         Commands::Deinit => unreachable!("Deinit is dispatched before this match reached"),

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -592,7 +592,8 @@ fn run_inner() -> Result<(), AppError> {
             | Commands::Init { .. }
             | Commands::Deinit
             | Commands::Completion { .. }
-            | Commands::Views { .. } => None,
+            | Commands::Views { .. }
+            | Commands::Lint { .. } => None,
         }
     } else {
         None
@@ -617,6 +618,7 @@ fn run_inner() -> Result<(), AppError> {
             | Commands::DropIndex { .. }
             | Commands::Read { .. }
             | Commands::Views { .. }
+            | Commands::Lint { .. }
     );
     let mut snapshot_index: Option<SnapshotIndex> = if uses_index {
         if let Some(ref index_path) = cli.index {
@@ -653,6 +655,7 @@ fn run_inner() -> Result<(), AppError> {
     };
 
     let config_language_owned = config.search_language.clone();
+    let schema = config.schema;
     let mut ctx = CommandContext {
         dir: &dir,
         site_prefix,
@@ -661,8 +664,11 @@ fn run_inner() -> Result<(), AppError> {
         snapshot_index: &mut snapshot_index,
         index_path: cli.index.as_deref(),
         config_language: config_language_owned.as_deref(),
+        schema: &schema,
+        exit_code_override: None,
     };
     let result = dispatch(cli.command, &mut ctx);
+    let exit_code_override = ctx.exit_code_override;
 
     let pipeline = OutputPipeline {
         user_format: format,
@@ -671,9 +677,11 @@ fn run_inner() -> Result<(), AppError> {
         count: cli.count,
     };
     let code = pipeline.finalize(result);
-    if code == 0 {
+    // Commands like `lint` may override the exit code even on success output.
+    let final_code = exit_code_override.unwrap_or(code);
+    if final_code == 0 {
         Ok(())
     } else {
-        Err(AppError::Exit(code))
+        Err(AppError::Exit(final_code))
     }
 }

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -180,7 +180,8 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 
 - **find** — BM25 ranked full-text search (AND, OR, phrase, negation) or regex; filter by property, tag, task status
 - **read** — extract body content, a section, or line range
-- **summary** — compact fixed-size orientation view: file counts, tags, tasks, orphans, dead-ends, links (use `--depth N` to override directory depth)
+- **summary** — compact fixed-size orientation view: file counts, tags, tasks, orphans, dead-ends, links, schema lint count (use `--depth N` to override directory depth)
+- **lint** — validate frontmatter against the `[schema]` in `.hyalo.toml` (read-only); exit 1 when errors found
 - **properties summary** — list property names and types
 - **properties rename** — bulk rename a property key across files (`--from old --to new`)
 - **tags summary** — list tags with counts
@@ -196,6 +197,53 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **views list** — show all saved views and their filters
 - **views set** — save a find query as a named view (`hyalo views set todo --task todo`)
 - **views remove** — delete a saved view
+
+## Schema & Lint
+
+Hyalo supports optional frontmatter schema validation. Define schemas in `.hyalo.toml` under `[schema.*]` sections, then run `hyalo lint` to validate files.
+
+```bash
+# Lint the whole vault
+hyalo lint
+
+# Lint a single file
+hyalo lint iterations/iteration-42-feature.md
+
+# Lint with a glob
+hyalo lint --glob "iterations/*.md"
+
+# JSON output
+hyalo lint --format json
+```
+
+Exit codes: 0 = clean, 1 = errors found, 2 = internal error.
+
+**Schema format:**
+
+```toml
+[schema.default]
+required = ["title"]
+
+[schema.types.iteration]
+required = ["title", "date", "status", "branch", "tags"]
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed", "superseded"]
+
+[schema.types.iteration.properties.date]
+type = "date"
+
+[schema.types.iteration.properties.branch]
+type = "string"
+pattern = "^iter-\\d+/"
+```
+
+Property types: `string` (optional `pattern` regex), `date` (YYYY-MM-DD), `number`, `boolean`, `list`, `enum` (with `values`).
+
+When no `[schema]` block exists, lint exits 0 with zero violations (backwards compatible).
+
+`hyalo summary` includes a `schema` field with error/warning counts when a schema is configured.
 
 ## Views — saved find queries
 

--- a/crates/hyalo-cli/tests/e2e_lint.rs
+++ b/crates/hyalo-cli/tests/e2e_lint.rs
@@ -1,0 +1,468 @@
+mod common;
+
+use common::{hyalo_no_hints, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write a `.hyalo.toml` with a `[schema]` block into `dir`.
+fn write_schema_toml(dir: &std::path::Path, content: &str) {
+    std::fs::write(dir.join(".hyalo.toml"), content).unwrap();
+}
+
+/// Set up a minimal vault for lint tests.
+fn setup_vault_with_schema() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+
+    // Write schema
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+
+[schema.default]
+required = ["title"]
+
+[schema.types.note]
+required = ["title", "date"]
+
+[schema.types.note.properties.date]
+type = "date"
+
+[schema.types.note.properties.status]
+type = "enum"
+values = ["draft", "published"]
+"#,
+    );
+
+    // Clean file
+    write_md(
+        tmp.path(),
+        "clean.md",
+        md!(r"
+---
+title: Clean Note
+type: note
+date: 2026-04-13
+tags:
+  - test
+---
+Body.
+"),
+    );
+
+    // File missing required property
+    write_md(
+        tmp.path(),
+        "missing_date.md",
+        md!(r"
+---
+title: Missing Date
+type: note
+tags:
+  - test
+---
+Body.
+"),
+    );
+
+    // File with invalid enum value
+    write_md(
+        tmp.path(),
+        "bad_status.md",
+        md!(r"
+---
+title: Bad Status
+type: note
+date: 2026-04-13
+status: wip
+tags:
+  - test
+---
+Body.
+"),
+    );
+
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// Basic lint tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lint_no_schema_exits_zero() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: Hello\n---\nBody\n");
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint"])
+        .assert()
+        .success()
+        .code(0);
+}
+
+#[test]
+fn lint_clean_vault_exits_zero() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        "dir = \".\"\n[schema.default]\nrequired = [\"title\"]\n",
+    );
+    write_md(
+        tmp.path(),
+        "clean.md",
+        "---\ntitle: Hello\ntype: note\ntags:\n  - test\n---\nBody\n",
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint"])
+        .assert()
+        .success()
+        .code(0);
+}
+
+#[test]
+fn lint_exits_one_when_errors_found() {
+    let tmp = setup_vault_with_schema();
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint"])
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn lint_text_output_shows_missing_required() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "missing_date.md"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        stdout.contains("missing_date.md"),
+        "expected filename in output"
+    );
+    assert!(
+        stdout.contains("missing required property"),
+        "expected error message"
+    );
+    assert!(stdout.contains("date"), "expected property name");
+}
+
+#[test]
+fn lint_text_output_shows_enum_violation() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "bad_status.md"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(stdout.contains("bad_status.md"), "expected filename");
+    assert!(stdout.contains("wip"), "expected bad value in output");
+    assert!(stdout.contains("not in"), "expected enum violation message");
+}
+
+#[test]
+fn lint_suggests_nearest_enum_value() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+[schema.types.note.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed"]
+"#,
+    );
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\ntype: note\nstatus: planed\ntags:\n  - test\n---\nBody\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "a.md"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        stdout.contains("planned"),
+        "expected suggestion 'planned' for misspelling 'planed'"
+    );
+}
+
+#[test]
+fn lint_single_file_positional() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "text", "clean.md"])
+        .output()
+        .unwrap();
+
+    let exit = output.status.code().unwrap();
+    assert_eq!(exit, 0, "clean file should exit 0");
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        stdout.contains("no issues"),
+        "expected no issues message: {stdout}"
+    );
+}
+
+#[test]
+fn lint_single_file_flag() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--file", "clean.md"])
+        .output()
+        .unwrap();
+
+    let exit = output.status.code().unwrap();
+    assert_eq!(exit, 0, "clean file should exit 0");
+}
+
+#[test]
+fn lint_glob_flag() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--glob", "*.md"])
+        .output()
+        .unwrap();
+
+    // vault has errors so exit 1
+    let exit = output.status.code().unwrap();
+    assert_eq!(exit, 1, "glob over errored vault should exit 1");
+}
+
+#[test]
+fn lint_json_output() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json", "missing_date.md"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let val: serde_json::Value = serde_json::from_str(stdout)
+        .unwrap_or_else(|e| panic!("expected JSON output, got: {stdout}\nerr: {e}"));
+
+    // The pipeline wraps the lint output in the standard envelope:
+    // {"results": {"results": [...], "total": N}, "hints": [...]}
+    let inner = &val["results"];
+    assert!(inner.is_object(), "expected results object in envelope");
+    assert!(inner["results"].is_array(), "expected inner results array");
+    assert!(inner["total"].is_number(), "expected total field");
+
+    let results = inner["results"].as_array().unwrap();
+    assert!(!results.is_empty());
+    let first = &results[0];
+    assert!(first["file"].is_string(), "expected file field");
+    assert!(first["violations"].is_array(), "expected violations array");
+
+    let violations = first["violations"].as_array().unwrap();
+    assert!(!violations.is_empty(), "expected at least one violation");
+    let v = &violations[0];
+    assert!(v["severity"].is_string(), "expected severity field");
+    assert!(v["message"].is_string(), "expected message field");
+}
+
+#[test]
+fn lint_no_type_property_warn() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+[schema.default]
+required = ["title"]
+
+[schema.types.note]
+required = ["title"]
+"#,
+    );
+    write_md(tmp.path(), "a.md", "---\ntitle: Hello\n---\nBody\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "a.md"])
+        .output()
+        .unwrap();
+
+    // Has warnings but no errors -> exit 0
+    let exit = output.status.code().unwrap();
+    assert_eq!(exit, 0, "warnings only should exit 0");
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        stdout.contains("no 'type' property") || stdout.contains("warn"),
+        "expected warning about missing type"
+    );
+}
+
+#[test]
+fn lint_unknown_type_uses_default_schema() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+[schema.default]
+required = ["title"]
+
+[schema.types.note]
+required = ["title", "date"]
+"#,
+    );
+    // File with type "unknown" — should only validate against default (title required)
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: Hello\ntype: unknown\ntags:\n  - test\n---\nBody\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "a.md"])
+        .output()
+        .unwrap();
+
+    // "date" is only required for type "note", not for "unknown"
+    // So this should pass with exit 0 (title is present)
+    let exit = output.status.code().unwrap();
+    assert_eq!(exit, 0, "unknown type should validate against default only");
+}
+
+#[test]
+fn lint_date_format_error() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+[schema.types.note.properties.date]
+type = "date"
+"#,
+    );
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\ntype: note\ndate: April 9\ntags:\n  - test\n---\nBody\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "a.md"])
+        .output()
+        .unwrap();
+
+    let exit = output.status.code().unwrap();
+    assert_eq!(exit, 1, "invalid date format should produce error");
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        stdout.contains("expected date"),
+        "expected date error message in output"
+    );
+}
+
+#[test]
+fn lint_string_pattern_error() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+[schema.types.note.properties.branch]
+type = "string"
+pattern = "^iter-\\d+/"
+"#,
+    );
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\ntype: note\nbranch: feature/foo\ntags:\n  - test\n---\nBody\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "a.md"])
+        .output()
+        .unwrap();
+
+    let exit = output.status.code().unwrap();
+    assert_eq!(exit, 1, "pattern mismatch should produce error");
+}
+
+// ---------------------------------------------------------------------------
+// Summary integration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_shows_lint_count_when_schema_configured() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["--format", "json", "summary"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let val: serde_json::Value =
+        serde_json::from_str(stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
+
+    // When a schema is configured, results.schema should be present
+    let schema_field = &val["results"]["schema"];
+    assert!(
+        !schema_field.is_null(),
+        "expected schema field in summary when schema is configured"
+    );
+    assert!(
+        schema_field["errors"].is_number(),
+        "expected errors count in schema summary"
+    );
+    assert!(
+        schema_field["warnings"].is_number(),
+        "expected warnings count in schema summary"
+    );
+    assert!(
+        schema_field["files_with_issues"].is_number(),
+        "expected files_with_issues in schema summary"
+    );
+}
+
+#[test]
+fn summary_no_schema_field_without_config() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: Hello\n---\nBody\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["--format", "json", "summary"])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let val: serde_json::Value =
+        serde_json::from_str(stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
+
+    // No schema configured → schema field should be absent (null in JSON)
+    assert!(
+        val["results"]["schema"].is_null(),
+        "schema field should be absent when no schema is configured"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e_lint.rs
+++ b/crates/hyalo-cli/tests/e2e_lint.rs
@@ -267,15 +267,15 @@ fn lint_json_output() {
         .unwrap_or_else(|e| panic!("expected JSON output, got: {stdout}\nerr: {e}"));
 
     // The pipeline wraps the lint output in the standard envelope:
-    // {"results": {"results": [...], "total": N}, "hints": [...]}
+    // {"results": {"files": [...], "total": N}, "hints": [...]}
     let inner = &val["results"];
     assert!(inner.is_object(), "expected results object in envelope");
-    assert!(inner["results"].is_array(), "expected inner results array");
+    assert!(inner["files"].is_array(), "expected files array");
     assert!(inner["total"].is_number(), "expected total field");
 
-    let results = inner["results"].as_array().unwrap();
-    assert!(!results.is_empty());
-    let first = &results[0];
+    let files = inner["files"].as_array().unwrap();
+    assert!(!files.is_empty());
+    let first = &files[0];
     assert!(first["file"].is_string(), "expected file field");
     assert!(first["violations"].is_array(), "expected violations array");
 

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -28,6 +28,7 @@ serde-saphyr = { workspace = true }
 serde_json = { workspace = true }
 strsim = { workspace = true }
 tempfile = { workspace = true }
+toml = { workspace = true }
 rust-stemmers = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod link_graph;
 pub mod link_rewrite;
 pub mod links;
 pub mod scanner;
+pub mod schema;
 pub mod tasks;
 pub mod types;
 pub mod util;

--- a/crates/hyalo-core/src/schema.rs
+++ b/crates/hyalo-core/src/schema.rs
@@ -1,0 +1,391 @@
+/// Schema data model for document type validation.
+///
+/// Parsed from `[schema.*]` sections in `.hyalo.toml`:
+///
+/// ```toml
+/// [schema.default]
+/// required = ["title"]
+///
+/// [schema.types.iteration]
+/// required = ["title", "date", "status", "branch", "tags"]
+/// filename-template = "iterations/iteration-{n}-{slug}.md"
+///
+/// [schema.types.iteration.defaults]
+/// status = "planned"
+/// date = "$today"
+///
+/// [schema.types.iteration.properties.status]
+/// type = "enum"
+/// values = ["planned", "in-progress", "completed"]
+///
+/// [schema.types.iteration.properties.branch]
+/// type = "string"
+/// pattern = "^iter-\\d+/"
+/// ```
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// The fully-resolved schema configuration for a vault.
+///
+/// Constructed from the `[schema]` section of `.hyalo.toml`.  When the
+/// section is absent, `SchemaConfig::default()` (which has no types and no
+/// required properties) represents "no validation".
+#[derive(Debug, Clone, Default)]
+pub struct SchemaConfig {
+    /// Global defaults applied to every file, regardless of type.
+    pub default: TypeSchema,
+    /// Per-type schemas, keyed by the value of the `type` frontmatter property.
+    pub types: HashMap<String, TypeSchema>,
+}
+
+impl SchemaConfig {
+    /// Returns `true` when no schema configuration was provided at all.
+    ///
+    /// When this returns `true`, `hyalo lint` produces zero violations and
+    /// exits 0 immediately.
+    pub fn is_empty(&self) -> bool {
+        self.default.required.is_empty()
+            && self.default.properties.is_empty()
+            && self.types.is_empty()
+    }
+
+    /// Merge the default schema with a named type schema.
+    ///
+    /// - `required` lists are combined (type extends default, no duplicates).
+    /// - `properties` are merged: type-specific constraints override defaults
+    ///   for the same property name; defaults fill in any gaps.
+    /// - `filename_template` and `defaults` come from the type schema only.
+    pub fn merged_schema_for_type(&self, type_name: &str) -> TypeSchema {
+        let type_schema = self.types.get(type_name);
+        let mut required: Vec<String> = self.default.required.clone();
+        // Extend with type-specific required fields, deduplicated.
+        if let Some(ts) = type_schema {
+            for r in &ts.required {
+                if !required.contains(r) {
+                    required.push(r.clone());
+                }
+            }
+        }
+
+        // Merge properties: defaults first, then type overrides.
+        let mut properties = self.default.properties.clone();
+        if let Some(ts) = type_schema {
+            for (k, v) in &ts.properties {
+                properties.insert(k.clone(), v.clone());
+            }
+        }
+
+        TypeSchema {
+            required,
+            filename_template: type_schema.and_then(|ts| ts.filename_template.clone()),
+            defaults: type_schema
+                .map(|ts| ts.defaults.clone())
+                .unwrap_or_default(),
+            properties,
+        }
+    }
+
+    /// Returns the default-only schema (used for files without a `type` property).
+    pub fn default_schema(&self) -> &TypeSchema {
+        &self.default
+    }
+}
+
+/// Schema definition for a single document type (or the global default).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TypeSchema {
+    /// Property keys that must be present in every file of this type.
+    #[serde(default)]
+    pub required: Vec<String>,
+
+    /// Optional filename template for new files of this type.
+    /// Tokens: `{n}` (sequence number), `{slug}` (title-derived slug).
+    #[serde(rename = "filename-template")]
+    pub filename_template: Option<String>,
+
+    /// Default values used when creating new files; `$today` expands to YYYY-MM-DD.
+    #[serde(default)]
+    pub defaults: HashMap<String, String>,
+
+    /// Per-property type constraints keyed by property name.
+    #[serde(default)]
+    pub properties: HashMap<String, PropertyConstraint>,
+}
+
+/// Constraint on a single frontmatter property.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PropertyConstraint {
+    /// Any string value; optional regex pattern validation.
+    String {
+        /// Optional regex that the value must match.
+        pattern: Option<String>,
+    },
+    /// ISO 8601 date (YYYY-MM-DD).
+    Date,
+    /// Integer or floating-point number.
+    Number,
+    /// Boolean (`true` / `false`).
+    Boolean,
+    /// YAML sequence / list.
+    List,
+    /// String restricted to one of the given `values`.
+    Enum {
+        /// Valid values for this enum property.
+        values: Vec<String>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Raw TOML deserialization helpers
+// ---------------------------------------------------------------------------
+
+/// Raw TOML shape for a single `[schema.types.<name>]` block.
+/// Intentionally lenient (`serde(default)`) so partial configs are valid.
+#[derive(Debug, Deserialize)]
+pub struct RawTypeSchema {
+    #[serde(default)]
+    pub required: Vec<String>,
+    #[serde(rename = "filename-template")]
+    pub filename_template: Option<String>,
+    #[serde(default)]
+    pub defaults: HashMap<String, String>,
+    #[serde(default)]
+    pub properties: HashMap<String, PropertyConstraint>,
+}
+
+impl From<RawTypeSchema> for TypeSchema {
+    fn from(raw: RawTypeSchema) -> Self {
+        Self {
+            required: raw.required,
+            filename_template: raw.filename_template,
+            defaults: raw.defaults,
+            properties: raw.properties,
+        }
+    }
+}
+
+/// Raw TOML shape for the entire `[schema]` section.
+#[derive(Debug, Deserialize)]
+pub struct RawSchemaConfig {
+    #[serde(default)]
+    pub default: Option<RawTypeSchema>,
+    #[serde(default)]
+    pub types: HashMap<String, RawTypeSchema>,
+}
+
+impl From<RawSchemaConfig> for SchemaConfig {
+    fn from(raw: RawSchemaConfig) -> Self {
+        Self {
+            default: raw.default.map(TypeSchema::from).unwrap_or_default(),
+            types: raw
+                .types
+                .into_iter()
+                .map(|(k, v)| (k, TypeSchema::from(v)))
+                .collect(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_schema_is_empty() {
+        let cfg = SchemaConfig::default();
+        assert!(cfg.is_empty());
+    }
+
+    #[test]
+    fn parse_default_required() {
+        let toml = r#"
+[schema.default]
+required = ["title"]
+"#;
+        // Parse directly as a full TOML document
+        let raw: toml::Value = toml::from_str(toml).expect("valid toml");
+        let raw_schema: RawSchemaConfig = raw
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .unwrap_or_else(|| RawSchemaConfig {
+                default: None,
+                types: HashMap::new(),
+            });
+        let cfg = SchemaConfig::from(raw_schema);
+        assert_eq!(cfg.default.required, vec!["title".to_owned()]);
+        assert!(!cfg.is_empty());
+    }
+
+    #[test]
+    fn parse_type_schema() {
+        let toml = r#"
+[schema.default]
+required = ["title"]
+
+[schema.types.iteration]
+required = ["title", "date", "status"]
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed"]
+
+[schema.types.iteration.properties.date]
+type = "date"
+"#;
+        let raw: toml::Value = toml::from_str(toml).expect("valid toml");
+        let raw_schema: RawSchemaConfig = raw
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .unwrap_or_else(|| RawSchemaConfig {
+                default: None,
+                types: HashMap::new(),
+            });
+        let cfg = SchemaConfig::from(raw_schema);
+
+        assert!(cfg.types.contains_key("iteration"));
+        let iter = &cfg.types["iteration"];
+        assert_eq!(iter.required, vec!["title", "date", "status"]);
+        assert!(matches!(
+            iter.properties.get("date"),
+            Some(PropertyConstraint::Date)
+        ));
+        match iter.properties.get("status") {
+            Some(PropertyConstraint::Enum { values }) => {
+                assert!(values.contains(&"planned".to_owned()));
+            }
+            _ => panic!("expected enum constraint"),
+        }
+    }
+
+    #[test]
+    fn merged_schema_extends_required() {
+        let toml = r#"
+[schema.default]
+required = ["title"]
+
+[schema.types.iteration]
+required = ["date", "status"]
+"#;
+        let raw: toml::Value = toml::from_str(toml).expect("valid toml");
+        let raw_schema: RawSchemaConfig = raw
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .unwrap_or_else(|| RawSchemaConfig {
+                default: None,
+                types: HashMap::new(),
+            });
+        let cfg = SchemaConfig::from(raw_schema);
+
+        let merged = cfg.merged_schema_for_type("iteration");
+        // "title" from default + "date", "status" from type
+        assert!(merged.required.contains(&"title".to_owned()));
+        assert!(merged.required.contains(&"date".to_owned()));
+        assert!(merged.required.contains(&"status".to_owned()));
+        assert_eq!(merged.required.len(), 3);
+    }
+
+    #[test]
+    fn merged_schema_type_override_default_property() {
+        let toml = r#"
+[schema.default.properties.status]
+type = "string"
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "completed"]
+"#;
+        let raw: toml::Value = toml::from_str(toml).expect("valid toml");
+        let raw_schema: RawSchemaConfig = raw
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .unwrap_or_else(|| RawSchemaConfig {
+                default: None,
+                types: HashMap::new(),
+            });
+        let cfg = SchemaConfig::from(raw_schema);
+
+        let merged = cfg.merged_schema_for_type("iteration");
+        match merged.properties.get("status") {
+            Some(PropertyConstraint::Enum { values }) => {
+                assert_eq!(values.len(), 2);
+            }
+            other => panic!("expected enum, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merged_schema_for_unknown_type_uses_default() {
+        let toml = r#"
+[schema.default]
+required = ["title"]
+"#;
+        let raw: toml::Value = toml::from_str(toml).expect("valid toml");
+        let raw_schema: RawSchemaConfig = raw
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .unwrap_or_else(|| RawSchemaConfig {
+                default: None,
+                types: HashMap::new(),
+            });
+        let cfg = SchemaConfig::from(raw_schema);
+
+        let merged = cfg.merged_schema_for_type("nonexistent");
+        assert_eq!(merged.required, vec!["title".to_owned()]);
+    }
+
+    #[test]
+    fn parse_string_pattern_constraint() {
+        let toml = r#"
+[schema.types.iteration.properties.branch]
+type = "string"
+pattern = "^iter-\\d+/"
+"#;
+        let raw: toml::Value = toml::from_str(toml).expect("valid toml");
+        let raw_schema: RawSchemaConfig = raw
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .unwrap_or_else(|| RawSchemaConfig {
+                default: None,
+                types: HashMap::new(),
+            });
+        let cfg = SchemaConfig::from(raw_schema);
+
+        match cfg.types["iteration"].properties.get("branch") {
+            Some(PropertyConstraint::String { pattern: Some(p) }) => {
+                assert_eq!(p, "^iter-\\d+/");
+            }
+            other => panic!("expected string with pattern, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_no_duplicates_in_merged_required() {
+        let toml = r#"
+[schema.default]
+required = ["title"]
+
+[schema.types.note]
+required = ["title", "date"]
+"#;
+        let raw: toml::Value = toml::from_str(toml).expect("valid toml");
+        let raw_schema: RawSchemaConfig = raw
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .unwrap_or_else(|| RawSchemaConfig {
+                default: None,
+                types: HashMap::new(),
+            });
+        let cfg = SchemaConfig::from(raw_schema);
+
+        let merged = cfg.merged_schema_for_type("note");
+        // "title" must appear exactly once (no duplicate from both default and type)
+        assert_eq!(merged.required.iter().filter(|r| *r == "title").count(), 1);
+        assert_eq!(merged.required.len(), 2);
+    }
+}

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -125,6 +125,14 @@ pub struct TaskReadResult {
 // Summary types
 // ---------------------------------------------------------------------------
 
+/// Lint violation counts for the vault summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct LintSummary {
+    pub errors: usize,
+    pub warnings: usize,
+    pub files_with_issues: usize,
+}
+
 /// High-level vault summary.
 #[derive(Debug, Clone, Serialize)]
 pub struct VaultSummary {
@@ -137,6 +145,9 @@ pub struct VaultSummary {
     pub status: Vec<StatusGroup>,
     pub tasks: TaskCount,
     pub recent_files: Vec<RecentFile>,
+    /// Schema lint counts — `None` when no `[schema]` block is configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<LintSummary>,
 }
 
 /// Vault-wide link health: total links and broken count.

--- a/hyalo-knowledgebase/backlog/done/index-server-raii.md
+++ b/hyalo-knowledgebase/backlog/done/index-server-raii.md
@@ -7,6 +7,7 @@ tags:
   - index
   - daemon
 status: wont-do
+priority: medium
 ---
 
 # RAII Index Server with File Watcher

--- a/hyalo-knowledgebase/backlog/property-regex-yaml-lists.md
+++ b/hyalo-knowledgebase/backlog/property-regex-yaml-lists.md
@@ -8,6 +8,7 @@ tags:
   - dogfooding
 status: planned
 date: 2026-03-30
+priority: medium
 ---
 
 ## Problem

--- a/hyalo-knowledgebase/docs/schema-and-lint.md
+++ b/hyalo-knowledgebase/docs/schema-and-lint.md
@@ -1,0 +1,124 @@
+---
+title: Schema & Lint — Document Type Validation
+type: docs
+date: 2026-04-14
+status: active
+tags:
+  - docs
+  - schema
+  - lint
+  - validation
+---
+
+# Schema & Lint — Document Type Validation
+
+Hyalo supports optional schema validation for frontmatter properties. Define a schema in `.hyalo.toml` under `[schema.*]` sections, then run `hyalo lint` to validate all files.
+
+## Configuring a Schema
+
+```toml
+# .hyalo.toml
+
+[schema.default]
+required = ["title"]
+
+[schema.types.iteration]
+required = ["title", "date", "status", "branch", "tags"]
+filename-template = "iterations/iteration-{n}-{slug}.md"
+
+[schema.types.iteration.defaults]
+status = "planned"
+date = "$today"
+type = "iteration"
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed", "superseded", "shelved", "deferred"]
+
+[schema.types.iteration.properties.branch]
+type = "string"
+pattern = "^iter-\\d+/"
+
+[schema.types.iteration.properties.date]
+type = "date"
+
+[schema.types.iteration.properties.tags]
+type = "list"
+```
+
+### Property Types
+
+| Type      | Validates |
+|-----------|-----------|
+| `string`  | Any string; optional `pattern` (regex) |
+| `date`    | ISO 8601 date (YYYY-MM-DD) |
+| `number`  | Integer or float |
+| `boolean` | true/false |
+| `list`    | YAML sequence |
+| `enum`    | String matching one of `values` |
+
+### Schema Merging
+
+`schema.default` applies to every file regardless of type.
+
+- `required`: type-specific list **extends** the default (additive, no duplicates)
+- `properties`: type-specific constraints **override** defaults for the same property name; other defaults fill in gaps
+
+Files without a `type` property are validated against `schema.default` only.
+
+## Running `hyalo lint`
+
+```sh
+# Lint the whole vault
+hyalo lint
+
+# Lint a single file
+hyalo lint iterations/iteration-101-bm25.md
+
+# Lint with a glob
+hyalo lint --glob "iterations/*.md"
+
+# JSON output
+hyalo lint --format json
+```
+
+**Exit codes:** `0` = clean, `1` = errors found, `2` = internal error.
+
+### Output (text)
+
+```
+iterations/iteration-101-bm25.md:
+  error  missing required property "foo" (type: iteration)
+  warn   status "planed" not in [planned, in-progress, completed, ...] (did you mean "planned"?)
+
+research/karpathy-llm-wiki.md:
+  error  property "date" expected date (YYYY-MM-DD), got "April 9"
+  warn   no tags defined
+
+3 files checked, 2 with issues (2 errors, 2 warnings)
+```
+
+### Severity Levels
+
+- **error** — schema violation (missing required property, wrong value type, invalid enum value, pattern mismatch)
+- **warn** — soft issue (no `type` property, no `tags`, property not declared in schema)
+
+## Summary Integration
+
+When a schema is configured, `hyalo summary` includes a one-line lint count in the `schema` field of the JSON output:
+
+```json
+{
+  "results": {
+    "files": { "total": 42, ... },
+    "schema": { "errors": 3, "warnings": 7, "files_with_issues": 5 },
+    ...
+  }
+}
+```
+
+Run `hyalo lint` to see the full violation report.
+
+## Backwards Compatibility
+
+Vaults without a `[schema]` block in `.hyalo.toml` are fully supported: `hyalo lint` exits 0 with zero violations, and `hyalo summary` omits the `schema` field.

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v080-views.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v080-views.md
@@ -2,7 +2,11 @@
 title: "Dogfood v0.8.0: Views Feature"
 date: 2026-04-03
 origin: dogfood session 2026-04-03
-tags: [dogfooding, views]
+tags:
+  - dogfooding
+  - views
+type: research
+status: archived
 ---
 
 # Dogfood v0.8.0 — Views Feature

--- a/hyalo-knowledgebase/dogfood-results/hyalo-run.md
+++ b/hyalo-knowledgebase/dogfood-results/hyalo-run.md
@@ -1,3 +1,11 @@
+---
+title: Hyalo Dogfood Run — MDN Docs Maintenance
+type: research
+date: 2026-03-30
+status: archived
+tags:
+  - dogfooding
+---
 # Hyalo Dogfood Run — MDN Docs Maintenance
 
 **Date:** 2026-03-30

--- a/hyalo-knowledgebase/dogfood-results/hyalo-run2.md
+++ b/hyalo-knowledgebase/dogfood-results/hyalo-run2.md
@@ -1,3 +1,11 @@
+---
+title: Hyalo Dogfood Run 2 — MDN Maintenance Tasks
+type: research
+date: 2026-03-30
+status: archived
+tags:
+  - dogfooding
+---
 # Hyalo Dogfood Run 2 — MDN Maintenance Tasks
 
 Date: 2026-03-30

--- a/hyalo-knowledgebase/dogfood-results/hyalo-run3.md
+++ b/hyalo-knowledgebase/dogfood-results/hyalo-run3.md
@@ -1,3 +1,11 @@
+---
+title: Hyalo Dogfood Run 3 — MDN Maintenance Use Cases
+type: research
+date: 2026-03-30
+status: archived
+tags:
+  - dogfooding
+---
 # Hyalo Dogfood Run 3 — MDN Maintenance Use Cases
 
 **Date:** 2026-03-30

--- a/hyalo-knowledgebase/dogfood-results/hyalo-run4.md
+++ b/hyalo-knowledgebase/dogfood-results/hyalo-run4.md
@@ -1,3 +1,11 @@
+---
+title: Hyalo Dogfood Run 4 — MDN Maintenance Tasks
+type: research
+date: 2026-03-30
+status: archived
+tags:
+  - dogfooding
+---
 # Hyalo Dogfood Run 4 — MDN Maintenance Tasks
 
 Date: 2026-03-30

--- a/hyalo-knowledgebase/dogfood-results/hyalo-run5.md
+++ b/hyalo-knowledgebase/dogfood-results/hyalo-run5.md
@@ -1,3 +1,11 @@
+---
+title: Hyalo Dogfood Run 5 — MDN Maintenance Tasks
+type: research
+date: 2026-03-30
+status: archived
+tags:
+  - dogfooding
+---
 # Hyalo Dogfood Run 5 — MDN Maintenance Tasks
 Date: 2026-03-31
 Vault: 14,245 files (MDN en-us docs)

--- a/hyalo-knowledgebase/dogfood-results/hyalo-run5.md
+++ b/hyalo-knowledgebase/dogfood-results/hyalo-run5.md
@@ -1,7 +1,7 @@
 ---
 title: Hyalo Dogfood Run 5 — MDN Maintenance Tasks
 type: research
-date: 2026-03-30
+date: 2026-03-31
 status: archived
 tags:
   - dogfooding

--- a/hyalo-knowledgebase/dogfood-results/normal-run.md
+++ b/hyalo-knowledgebase/dogfood-results/normal-run.md
@@ -1,3 +1,11 @@
+---
+title: Normal Run (built-in tools only)
+type: research
+date: 2026-03-30
+status: archived
+tags:
+  - dogfooding
+---
 # Normal Run (built-in tools only)
 Date: 2026-03-30
 

--- a/hyalo-knowledgebase/iterations/done/iteration-102-frontmatter-types-schema.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-102-frontmatter-types-schema.md
@@ -1,10 +1,19 @@
 ---
-title: "Iteration 102 — Frontmatter Types, Schema & Lint"
+title: Iteration 102 — Frontmatter Types, Schema & Lint
 type: iteration
 date: 2026-04-09
-status: planned
+status: superseded
 branch: iter-102/frontmatter-types-schema
-tags: [iteration, schema, types, validation, lint, toml]
+tags:
+  - iteration
+  - schema
+  - types
+  - validation
+  - lint
+  - toml
+superseded-by: >-
+  iterations/iteration-102a-schema-and-lint.md,
+  iterations/iteration-102b-lint-fix.md, iterations/iteration-102c-types-command.md
 ---
 
 # Iteration 102 — Frontmatter Types, Schema & Lint
@@ -246,3 +255,13 @@ Use `--dry-run` to preview what would change without writing anything.
 - Skill-driven migration when a type schema changes (bulk fix when schema evolves)
 - Cross-file validation (e.g. unique titles, no duplicate branches)
 - Lint checks beyond schema: orphan pages, broken links (currently in `summary` and `links fix`)
+- Bulk renumber / shift of sequenced files (e.g. iterations) — `hyalo renumber iterations/iteration-4-*.md --shift +1` or similar:
+  - Use case: iterations 4, 5, 6 are planned; a new ad-hoc iteration needs slot 4, so shift existing 4/5/6 → 5/6/7
+  - Leverages this iteration's filename templates (`iteration-{n}-{slug}.md`) + property types (`n: integer`) to know which field drives the number and how the filename is derived
+  - Updates frontmatter (e.g. a numeric property) AND renames the file, rewriting backlinks via the existing `hyalo mv` machinery
+  - Could generalize beyond iterations to any type with an ordinal field + filename template (episodes, ADRs, RFCs)
+- Markdown body linting (MD001–MD054-style rules) via an existing Rust crate:
+  - [`rumdl`](https://crates.io/crates/rumdl) — actively maintained pure-Rust `markdownlint` drop-in with library API; best candidate for integration
+  - [`mado`](https://crates.io/crates/mado) — alternative markdownlint-compatible Rust linter
+  - [`comrak`](https://crates.io/crates/comrak) / [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark) — parsers to build custom rules (e.g. wikilink validation, frontmatter-aware checks) if generic rule sets don't fit
+  - Would extend `hyalo lint` beyond frontmatter/schema into prose-level checks (heading levels, list style, trailing whitespace, etc.)

--- a/hyalo-knowledgebase/iterations/done/iteration-32-claude-code-skill-init-command.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-32-claude-code-skill-init-command.md
@@ -1,5 +1,5 @@
 ---
-branch: worktree-sunny-gliding-glade
+branch: iter-32/claude-code-skill-init-command
 date: 2026-03-23
 status: completed
 tags:

--- a/hyalo-knowledgebase/iterations/iteration-102a-schema-and-lint.md
+++ b/hyalo-knowledgebase/iterations/iteration-102a-schema-and-lint.md
@@ -1,0 +1,165 @@
+---
+title: Iteration 102a — Schema Data Model & `hyalo lint` (read-only)
+type: iteration
+date: 2026-04-13
+status: planned
+branch: iter-102a/schema-and-lint
+tags: [iteration, schema, types, validation, lint, toml]
+supersedes: iterations/iteration-102-frontmatter-types-schema.md
+---
+
+# Iteration 102a — Schema Data Model & `hyalo lint` (read-only)
+
+## Goal
+
+Introduce first-class document types with schema definitions in `.hyalo.toml`, and a read-only `hyalo lint` command that validates files against their schema.
+
+This is the **foundation** of the original iteration 102. It ships validation without `--fix` and without a `hyalo types` CLI — users author schemas by hand in `.hyalo.toml`. Follow-up iterations 102b (`lint --fix`) and 102c (`hyalo types` CLI) build on this.
+
+## Background
+
+Inspired by the LLM Wiki pattern ([[research/karpathy-llm-wiki]]): different document types (iteration, research, backlog, entity) need different frontmatter structures. Conventions are currently enforced only by CLAUDE.md instructions — no machine-readable schema, no validation.
+
+## Schema Format in .hyalo.toml
+
+```toml
+[schema.default]
+required = ["title"]
+
+[schema.types.iteration]
+required = ["title", "date", "status", "branch", "tags"]
+filename-template = "iterations/iteration-{n}-{slug}.md"
+
+[schema.types.iteration.defaults]
+status = "planned"
+date = "$today"
+type = "iteration"
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed", "superseded", "shelved", "deferred"]
+
+[schema.types.iteration.properties.branch]
+type = "string"
+pattern = "^iter-\\d+/"
+
+[schema.types.iteration.properties.date]
+type = "date"
+
+[schema.types.iteration.properties.tags]
+type = "list"
+```
+
+### Schema Merging
+
+Type schemas merge with `schema.default`. Type-specific `required` **extends** (does not replace) default required. Type-specific property constraints override default ones for the same property name.
+
+### Property Types
+
+| Type | Validates |
+|------|-----------|
+| `string` | Any string; optional `pattern` (regex) |
+| `date` | ISO 8601 date (YYYY-MM-DD) |
+| `number` | Integer or float |
+| `boolean` | true/false |
+| `list` | YAML list |
+| `enum` | String matching one of `values` |
+
+## `hyalo lint` Command (read-only)
+
+```bash
+hyalo lint                                     # whole vault
+hyalo lint iterations/iteration-101-bm25.md    # single file
+hyalo lint --glob "iterations/*.md"            # glob
+hyalo lint --format json                       # JSON envelope
+```
+
+### Output
+
+```
+iterations/iteration-101-bm25-ranked-search.md:
+  error: missing required property "foo" (type: iteration)
+  warn:  status "planed" not in [planned, in-progress, completed, ...]
+
+research/karpathy-llm-wiki.md:
+  error: property "date" expected date, got "April 9"
+  warn:  no tags defined
+
+3 files checked, 2 with issues (2 errors, 2 warnings)
+```
+
+JSON output follows the standard envelope: `{"results": [{"file": "...", "violations": [...]}], "total": N}`.
+
+### Severity Levels
+
+- **error** — schema violation (missing required, wrong type, invalid enum value)
+- **warn** — soft issue (no tags, no type property, property not in schema)
+
+### Interaction with `summary`
+
+`summary` gets a one-line lint count (e.g. `Schema: 5 errors, 3 warnings in 4 files`) with a hint to run `hyalo lint` for details. No flag needed — always reports when a schema exists.
+
+## Design Decisions
+
+- [ ] `schema.default.required` is additive with type-specific `required` (decided: additive)
+- [ ] Unknown properties (not in schema) → warning or silently allowed? (default: warning)
+- [ ] Files with no `type` → validate against `schema.default` only
+- [ ] Lint exit codes: 0 = clean, 1 = errors found, 2 = internal error
+
+## Tasks
+
+### Schema Data Model
+- [ ] Define Rust types for schema config (SchemaConfig, TypeSchema, PropertyConstraint)
+- [ ] Parse `[schema.*]` sections from .hyalo.toml
+- [ ] Implement schema merging (default + type-specific)
+- [ ] Handle missing/empty schema gracefully (no schema = no validation)
+
+### `hyalo lint` Command
+- [ ] Implement validation: required properties check
+- [ ] Implement validation: enum values check (with Levenshtein suggestion via strsim)
+- [ ] Implement validation: date format check
+- [ ] Implement validation: string pattern (regex) check
+- [ ] Implement validation: type checks (list, number, boolean)
+- [ ] Support positional file arg, `--file`, and `--glob`
+- [ ] JSON and text output formats
+- [ ] Exit code 1 when errors found
+- [ ] Add lint violation count to `hyalo summary` output
+
+### Tests
+- [ ] Unit tests for schema parsing from TOML
+- [ ] Unit tests for schema merging
+- [ ] Unit tests for each validation type
+- [ ] E2E tests for `hyalo lint` (whole vault, single file, glob)
+- [ ] E2E tests: lint summary count in `hyalo summary`
+- [ ] E2E test: file with no type validates against default only
+- [ ] E2E test: file with unknown type validates against default only
+- [ ] E2E test: vault with no schema runs lint with zero violations
+
+### Docs & Surfaces (keep all four in sync)
+- [ ] CLI help text for `hyalo lint` (`--help`)
+- [ ] Update README.md: add `hyalo lint` section + `[schema]` config example
+- [ ] Update knowledgebase: document schema format + lint in user docs
+- [ ] Update skills: `.claude/skills/hyalo` and symlinked `crates/*/templates/` — mention lint + schema authoring
+- [ ] Dogfood: hand-author `[schema]` in this repo's `.hyalo.toml` for iteration/research/backlog types
+
+### Quality Gates
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+
+## Acceptance Criteria
+
+- [ ] Types defined in `.hyalo.toml` under `[schema.types.<name>]`
+- [ ] `hyalo lint` reports per-file violations with error/warn severity
+- [ ] `hyalo lint` supports positional file, `--file`, `--glob`
+- [ ] `hyalo lint` returns exit 1 when errors found
+- [ ] `hyalo summary` shows one-line lint violation count
+- [ ] Files without a `type` property validate against `schema.default` only
+- [ ] No new external dependencies (TOML + strsim already in tree)
+- [ ] Backwards compatible: vaults without `[schema]` work unchanged
+- [ ] README, help texts, knowledgebase docs, and skills updated
+
+## Follow-up iterations
+
+- **[[iteration-102b-lint-fix]]** — `hyalo lint --fix` auto-remediation
+- **[[iteration-102c-types-command]]** — `hyalo types` CLI for schema management

--- a/hyalo-knowledgebase/iterations/iteration-102a-schema-and-lint.md
+++ b/hyalo-knowledgebase/iterations/iteration-102a-schema-and-lint.md
@@ -94,7 +94,7 @@ research/karpathy-llm-wiki.md:
 3 files checked, 2 with issues (2 errors, 2 warnings)
 ```
 
-JSON output follows the standard envelope: `{"results": [{"file": "...", "violations": [...]}], "total": N}`.
+JSON output is wrapped by the standard CLI envelope. The lint payload uses `files` (not `results`) to avoid a confusing `results.results` nesting: `{"results": {"files": [{"file": "...", "violations": [...]}], "total": N}, "hints": [...]}`.
 
 ### Severity Levels
 

--- a/hyalo-knowledgebase/iterations/iteration-102a-schema-and-lint.md
+++ b/hyalo-knowledgebase/iterations/iteration-102a-schema-and-lint.md
@@ -2,9 +2,15 @@
 title: Iteration 102a — Schema Data Model & `hyalo lint` (read-only)
 type: iteration
 date: 2026-04-13
-status: planned
+status: completed
 branch: iter-102a/schema-and-lint
-tags: [iteration, schema, types, validation, lint, toml]
+tags:
+  - iteration
+  - schema
+  - types
+  - validation
+  - lint
+  - toml
 supersedes: iterations/iteration-102-frontmatter-types-schema.md
 ---
 
@@ -101,63 +107,63 @@ JSON output follows the standard envelope: `{"results": [{"file": "...", "violat
 
 ## Design Decisions
 
-- [ ] `schema.default.required` is additive with type-specific `required` (decided: additive)
-- [ ] Unknown properties (not in schema) → warning or silently allowed? (default: warning)
-- [ ] Files with no `type` → validate against `schema.default` only
-- [ ] Lint exit codes: 0 = clean, 1 = errors found, 2 = internal error
+- [x] `schema.default.required` is additive with type-specific `required` (decided: additive)
+- [x] Unknown properties (not in schema) → warning or silently allowed? (default: warning)
+- [x] Files with no `type` → validate against `schema.default` only
+- [x] Lint exit codes: 0 = clean, 1 = errors found, 2 = internal error
 
 ## Tasks
 
 ### Schema Data Model
-- [ ] Define Rust types for schema config (SchemaConfig, TypeSchema, PropertyConstraint)
-- [ ] Parse `[schema.*]` sections from .hyalo.toml
-- [ ] Implement schema merging (default + type-specific)
-- [ ] Handle missing/empty schema gracefully (no schema = no validation)
+- [x] Define Rust types for schema config (SchemaConfig, TypeSchema, PropertyConstraint)
+- [x] Parse `[schema.*]` sections from .hyalo.toml
+- [x] Implement schema merging (default + type-specific)
+- [x] Handle missing/empty schema gracefully (no schema = no validation)
 
 ### `hyalo lint` Command
-- [ ] Implement validation: required properties check
-- [ ] Implement validation: enum values check (with Levenshtein suggestion via strsim)
-- [ ] Implement validation: date format check
-- [ ] Implement validation: string pattern (regex) check
-- [ ] Implement validation: type checks (list, number, boolean)
-- [ ] Support positional file arg, `--file`, and `--glob`
-- [ ] JSON and text output formats
-- [ ] Exit code 1 when errors found
-- [ ] Add lint violation count to `hyalo summary` output
+- [x] Implement validation: required properties check
+- [x] Implement validation: enum values check (with Levenshtein suggestion via strsim)
+- [x] Implement validation: date format check
+- [x] Implement validation: string pattern (regex) check
+- [x] Implement validation: type checks (list, number, boolean)
+- [x] Support positional file arg, `--file`, and `--glob`
+- [x] JSON and text output formats
+- [x] Exit code 1 when errors found
+- [x] Add lint violation count to `hyalo summary` output
 
 ### Tests
-- [ ] Unit tests for schema parsing from TOML
-- [ ] Unit tests for schema merging
-- [ ] Unit tests for each validation type
-- [ ] E2E tests for `hyalo lint` (whole vault, single file, glob)
-- [ ] E2E tests: lint summary count in `hyalo summary`
-- [ ] E2E test: file with no type validates against default only
-- [ ] E2E test: file with unknown type validates against default only
-- [ ] E2E test: vault with no schema runs lint with zero violations
+- [x] Unit tests for schema parsing from TOML
+- [x] Unit tests for schema merging
+- [x] Unit tests for each validation type
+- [x] E2E tests for `hyalo lint` (whole vault, single file, glob)
+- [x] E2E tests: lint summary count in `hyalo summary`
+- [x] E2E test: file with no type validates against default only
+- [x] E2E test: file with unknown type validates against default only
+- [x] E2E test: vault with no schema runs lint with zero violations
 
 ### Docs & Surfaces (keep all four in sync)
-- [ ] CLI help text for `hyalo lint` (`--help`)
-- [ ] Update README.md: add `hyalo lint` section + `[schema]` config example
-- [ ] Update knowledgebase: document schema format + lint in user docs
-- [ ] Update skills: `.claude/skills/hyalo` and symlinked `crates/*/templates/` — mention lint + schema authoring
-- [ ] Dogfood: hand-author `[schema]` in this repo's `.hyalo.toml` for iteration/research/backlog types
+- [x] CLI help text for `hyalo lint` (`--help`)
+- [x] Update README.md: add `hyalo lint` section + `[schema]` config example
+- [x] Update knowledgebase: document schema format + lint in user docs
+- [x] Update skills: `.claude/skills/hyalo` and symlinked `crates/*/templates/` — mention lint + schema authoring
+- [x] Dogfood: hand-author `[schema]` in this repo's `.hyalo.toml` for iteration/research/backlog types
 
 ### Quality Gates
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`
 
 ## Acceptance Criteria
 
-- [ ] Types defined in `.hyalo.toml` under `[schema.types.<name>]`
-- [ ] `hyalo lint` reports per-file violations with error/warn severity
-- [ ] `hyalo lint` supports positional file, `--file`, `--glob`
-- [ ] `hyalo lint` returns exit 1 when errors found
-- [ ] `hyalo summary` shows one-line lint violation count
-- [ ] Files without a `type` property validate against `schema.default` only
-- [ ] No new external dependencies (TOML + strsim already in tree)
-- [ ] Backwards compatible: vaults without `[schema]` work unchanged
-- [ ] README, help texts, knowledgebase docs, and skills updated
+- [x] Types defined in `.hyalo.toml` under `[schema.types.<name>]`
+- [x] `hyalo lint` reports per-file violations with error/warn severity
+- [x] `hyalo lint` supports positional file, `--file`, `--glob`
+- [x] `hyalo lint` returns exit 1 when errors found
+- [x] `hyalo summary` shows one-line lint violation count
+- [x] Files without a `type` property validate against `schema.default` only
+- [x] No new external dependencies (TOML + strsim already in tree)
+- [x] Backwards compatible: vaults without `[schema]` work unchanged
+- [x] README, help texts, knowledgebase docs, and skills updated
 
 ## Follow-up iterations
 

--- a/hyalo-knowledgebase/iterations/iteration-102b-lint-fix.md
+++ b/hyalo-knowledgebase/iterations/iteration-102b-lint-fix.md
@@ -1,0 +1,76 @@
+---
+title: Iteration 102b — `hyalo lint --fix` auto-remediation
+type: iteration
+date: 2026-04-13
+status: planned
+branch: iter-102b/lint-fix
+tags: [iteration, schema, lint, auto-fix]
+depends-on: iterations/iteration-102a-schema-and-lint.md
+---
+
+# Iteration 102b — `hyalo lint --fix`
+
+## Goal
+
+Add auto-remediation to `hyalo lint`. Depends on **[[iteration-102a-schema-and-lint]]** — schema model, validation, and read-only `lint` must land first.
+
+## `--fix` Auto-Fixes
+
+| Fixable | How |
+|---------|-----|
+| Missing property with a default in schema | Insert the default |
+| Close enum typo ("planed" → "planned") | Levenshtein via `strsim` (already a dep) |
+| Missing `type` when file path matches a `filename-template` | Infer type from path |
+| Normalizable date ("2026-4-9" → "2026-04-09") | Normalize format |
+
+**Not fixable by `--fix`:** missing required properties without defaults — report only. The LLM/skill decides what value to use.
+
+```bash
+hyalo lint --fix
+hyalo lint --fix iterations/iteration-101-bm25.md
+hyalo lint --fix --glob "iterations/*.md"
+hyalo lint --fix --dry-run     # preview without writing
+```
+
+## Tasks
+
+### Implementation
+- [ ] Implement `--fix`: insert defaults for missing properties with schema defaults
+- [ ] Implement `--fix`: correct close enum typos (Levenshtein threshold tuning)
+- [ ] Implement `--fix`: infer `type` from filename-template match
+- [ ] Implement `--fix`: normalize date formats to ISO 8601
+- [ ] Add `--dry-run` to preview fixes without writing
+- [ ] Ensure fixes preserve frontmatter key ordering and comments
+
+### Filename-template parsing
+- [ ] Parse `{slug}`, `{n}`, `{date}` placeholders
+- [ ] Match file paths against templates for type inference
+- [ ] Shared module — reused by 102c for `types create/set`
+
+### Tests
+- [ ] Unit tests for each fix action in isolation
+- [ ] Unit tests for filename-template matching
+- [ ] E2E tests for `hyalo lint --fix` on each fix category
+- [ ] E2E test: `--dry-run` does not modify files
+- [ ] E2E test: `--fix` is idempotent (second run is a no-op)
+- [ ] E2E test: `--fix` preserves frontmatter formatting
+
+### Docs & Surfaces (keep all four in sync)
+- [ ] Update `hyalo lint --help`: document `--fix`, `--dry-run`
+- [ ] Update README.md: add `--fix` examples
+- [ ] Update knowledgebase user docs
+- [ ] Update skills: mention `lint --fix` as remediation path
+
+### Quality Gates
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] Dogfood: run `hyalo lint --fix` on this repo's knowledgebase
+
+## Acceptance Criteria
+
+- [ ] `hyalo lint --fix` auto-fixes: defaults, enum typos, date normalization, type inference
+- [ ] `--dry-run` previews without writing
+- [ ] Missing required properties without defaults are reported, not fabricated
+- [ ] Fixes preserve frontmatter key ordering and formatting
+- [ ] README, help texts, knowledgebase docs, and skills updated

--- a/hyalo-knowledgebase/iterations/iteration-102c-types-command.md
+++ b/hyalo-knowledgebase/iterations/iteration-102c-types-command.md
@@ -1,0 +1,122 @@
+---
+title: Iteration 102c — `hyalo types` schema management CLI
+type: iteration
+date: 2026-04-13
+status: planned
+branch: iter-102c/types-command
+tags: [iteration, schema, types, cli]
+depends-on: iterations/iteration-102a-schema-and-lint.md
+---
+
+# Iteration 102c — `hyalo types` command
+
+## Goal
+
+Add a `hyalo types` CLI for managing type schemas in `.hyalo.toml` without hand-editing TOML. Depends on **[[iteration-102a-schema-and-lint]]** for the schema data model. Independent of 102b (can ship in parallel).
+
+## CLI Surface
+
+```bash
+hyalo types                            # alias for: hyalo types list
+hyalo types list                       # list all defined types + required fields
+hyalo types show iteration             # full schema for a type
+hyalo types create <type>              # add a new type entry
+hyalo types remove <type>              # remove a type entry
+hyalo types set <type> --required <fields>
+hyalo types set <type> --default <key=value>
+hyalo types set <type> --filename-template <template>
+hyalo types set <type> --property-type <key=type>
+hyalo types set <type> --property-values <key=val1,val2,...>
+hyalo types set <type> ... --dry-run   # preview file changes
+```
+
+## `types set` Side Effects
+
+When `types set` modifies the schema, it immediately applies **safe** fixes to matching files.
+
+**Defaults → auto-apply to files missing the property:**
+```
+hyalo types set iteration --default status=planned
+→ Updates .hyalo.toml
+→ Sets status=planned on all type:iteration files missing `status`
+→ "Updated .hyalo.toml. Set status=planned on 3 files missing the property."
+```
+
+**Constraint changes → report violations only:**
+```
+hyalo types set iteration --property-values 'status=planned,active,completed'
+→ Updates .hyalo.toml
+→ "Found 2 iteration files with status values not in the new set. Run `hyalo lint` for details."
+```
+
+Rule: **defaults can be applied silently** (user just told us the value). **Constraint violations need judgment** — just report, let the user or LLM remediate via `lint --fix` (if 102b is merged) or manual edits.
+
+`--dry-run` previews what would change without writing.
+
+## Design Decisions
+
+- [ ] Should `types create` write directly to .hyalo.toml or output TOML to stdout for review? (default: write; offer `--print` for stdout)
+
+## Tasks
+
+### Commands
+- [ ] `hyalo types` / `hyalo types list` — list all defined types with required fields
+- [ ] `hyalo types show <type>` — show full schema for a type
+- [ ] `hyalo types create <type>` — create a new type entry in .hyalo.toml
+- [ ] `hyalo types remove <type>` — remove a type definition
+- [ ] `hyalo types set <type> --required <fields>`
+- [ ] `hyalo types set <type> --default <key=value>`
+- [ ] `hyalo types set <type> --filename-template <template>`
+- [ ] `hyalo types set <type> --property-type <key=type>`
+- [ ] `hyalo types set <type> --property-values <key=val1,val2,...>`
+
+### Side-effect logic
+- [ ] `types set --default` auto-applies new defaults to files missing the property
+- [ ] `types set` constraint changes report violations without auto-fixing
+- [ ] `--dry-run` flag for `types set` to preview file changes
+- [ ] `.hyalo.toml` edits preserve formatting and comments
+
+### Tests
+- [ ] E2E tests for `hyalo types list/show/create/set/remove`
+- [ ] E2E test: `types set --default` applies to files missing the property
+- [ ] E2E test: `types set` constraint change reports violations without fixing
+- [ ] E2E test: `types set --dry-run` previews without writing
+- [ ] E2E test: `.hyalo.toml` edits preserve formatting
+
+### Docs & Surfaces (keep all four in sync)
+- [ ] CLI help text for `hyalo types` and all subcommands
+- [ ] Update README.md: add `hyalo types` section with examples
+- [ ] Update knowledgebase: user docs for type management
+- [ ] Update skills: mention `hyalo types` as preferred over hand-editing TOML
+
+### Quality Gates
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] Dogfood: rebuild this repo's schemas via `hyalo types` instead of hand-edited TOML
+
+## Acceptance Criteria
+
+- [ ] `hyalo types list` shows all defined types
+- [ ] `hyalo types create/set/remove` manage type schemas
+- [ ] `types set --default` applies defaults to files missing the property
+- [ ] `types set` constraint changes report violations without auto-fixing
+- [ ] `--dry-run` previews without writing
+- [ ] `.hyalo.toml` edits preserve formatting and comments
+- [ ] README, help texts, knowledgebase docs, and skills updated
+
+## Future (Not This Iteration)
+
+- `hyalo create --type iteration --title "BM25 search"` — create files from type templates with defaults
+- Skill-driven migration when a type schema changes (bulk fix when schema evolves)
+- Cross-file validation (e.g. unique titles, no duplicate branches)
+- Lint checks beyond schema: orphan pages, broken links (currently in `summary` and `links fix`)
+- Bulk renumber / shift of sequenced files (e.g. iterations) — `hyalo renumber iterations/iteration-4-*.md --shift +1` or similar:
+  - Use case: iterations 4, 5, 6 are planned; a new ad-hoc iteration needs slot 4, so shift existing 4/5/6 → 5/6/7
+  - Leverages filename templates (`iteration-{n}-{slug}.md`) + property types (`n: integer`) to know which field drives the number and how the filename is derived
+  - Updates frontmatter AND renames the file, rewriting backlinks via `hyalo mv`
+  - Could generalize beyond iterations to any type with an ordinal field + filename template (episodes, ADRs, RFCs)
+- Markdown body linting (MD001–MD054-style rules) via an existing Rust crate:
+  - [`rumdl`](https://crates.io/crates/rumdl) — actively maintained pure-Rust `markdownlint` drop-in with library API
+  - [`mado`](https://crates.io/crates/mado) — alternative markdownlint-compatible Rust linter
+  - [`comrak`](https://crates.io/crates/comrak) / [`pulldown-cmark`](https://crates.io/crates/pulldown-cmark) — parsers to build custom rules

--- a/hyalo-knowledgebase/research/benchmark-iter101-bm25.md
+++ b/hyalo-knowledgebase/research/benchmark-iter101-bm25.md
@@ -9,6 +9,7 @@ tags:
   - benchmarking
 related:
   - "[[iterations/iteration-101-bm25-ranked-search]]"
+status: archived
 ---
 
 # Benchmark: Iteration 101 — BM25 Ranked Search


### PR DESCRIPTION
## Summary
- Introduces first-class frontmatter schemas defined in `.hyalo.toml` under `[schema.default]` and `[schema.types.<name>]`, with per-property constraints (string/date/number/boolean/list/enum, optional regex pattern).
- Adds a read-only `hyalo lint` command (positional file, `--file`, `--glob`, `--format text|json`) that validates files against their declared type, reports per-file error/warn violations, and exits 1 when errors are found.
- `hyalo summary` now reports schema violation counts when a schema is configured.
- Dogfooded: repo's own `.hyalo.toml` now defines `iteration`, `research`, `backlog`, and `docs` schemas; knowledgebase content fixed to pass lint cleanly.
- Docs/skills/README/help text all updated; foundation for follow-up iter-102b (`--fix`) and iter-102c (`hyalo types`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (560+ tests, all green)
- [x] Manual dogfood: `hyalo lint` on this repo reports 0 errors
- [x] `hyalo summary` shows schema counts
- [ ] Reviewer: sanity-check schema TOML syntax in README example
- [ ] Reviewer: verify backwards compatibility (vaults without `[schema]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional frontmatter schema in .hyalo.toml (per-type required fields, defaults, filename templates, property constraints).
  * New hyalo lint command: vault/file/glob/positional targeting, text & --format json output, explicit exit codes (0 clean, 1 violations, 2 internal), and enum suggestion hints.
  * hyalo summary now reports schema error/warning counts when a schema is configured.

* **Documentation**
  * Added docs and README guidance for schema format, lint usage, outputs, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->