### PR TITLE
iter-102c: Add hyalo types command for schema management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "strsim",
  "tempfile",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1221,11 +1222,17 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -1237,13 +1244,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -1463,6 +1488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ strsim = "0.11"
 serde_json = "1.0.149"
 tempfile = "3"
 toml = "1"
+toml_edit = "0.22"
 rust-stemmers = "1.2.0"
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ hyalo types remove iteration
 hyalo types set iteration --required title,date,status
 
 # Set a default value (auto-applies to existing vault files of that type)
-hyalo types set iteration --default "status=planned" --default "date=$today"
+hyalo types set iteration --default 'status=planned' --default 'date=$today'
 
 # Preview changes without writing (dry-run)
 hyalo types set iteration --default "status=planned" --dry-run

--- a/README.md
+++ b/README.md
@@ -633,6 +633,49 @@ When no `[schema]` block is configured, `hyalo lint` exits 0 with zero violation
 
 `hyalo summary` shows a one-line lint count (`schema.errors/warnings`) when a schema is configured.
 
+### types
+
+Manage document-type schemas in `.hyalo.toml` without hand-editing TOML. All mutations preserve existing comments and formatting.
+
+```sh
+# List all defined types and their required fields
+hyalo types
+hyalo types list
+
+# Show the full merged schema for a type
+hyalo types show iteration
+
+# Add a new type entry to .hyalo.toml
+hyalo types create iteration
+
+# Print the TOML snippet instead of writing it
+hyalo types create iteration --print
+
+# Remove a type entry
+hyalo types remove iteration
+
+# Add required fields to a type
+hyalo types set iteration --required title,date,status
+
+# Set a default value (auto-applies to existing vault files of that type)
+hyalo types set iteration --default "status=planned" --default "date=$today"
+
+# Preview changes without writing (dry-run)
+hyalo types set iteration --default "status=planned" --dry-run
+
+# Add a property type constraint
+hyalo types set iteration --property-type "status=string"
+hyalo types set iteration --property-type "date=date"
+
+# Define an enum constraint
+hyalo types set iteration --property-values "status=planned,in-progress,completed"
+
+# Set a filename template
+hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.md"
+```
+
+When `--default` is used, hyalo walks all vault files of that type and writes the default value to any file that does not already have the property. Use `--dry-run` to preview which files would be updated.
+
 ### Hints
 
 Add `--hints` to any read-only command to get suggested drill-down commands:

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -33,6 +33,7 @@ serde-saphyr = { workspace = true }
 serde_json = { workspace = true }
 strsim = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -793,7 +793,7 @@ Repeatable (AND).\n\
         #[command(subcommand)]
         action: Option<TypesAction>,
     },
-        /// Generate shell completions for the given shell
+    /// Generate shell completions for the given shell
     #[command(
         display_order = 900,
         long_about = "Generate shell completion scripts.\n\n\

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -732,7 +732,7 @@ Repeatable (AND).\n\
         #[command(subcommand)]
         action: LinksAction,
     },
-    /// Validate frontmatter properties against the `.hyalo.toml` schema (read-only)
+    /// Validate frontmatter properties against the `.hyalo.toml` schema (optional auto-fix)
     #[command(
         long_about = "Validate frontmatter properties against the schema defined in `.hyalo.toml`.\n\n\
             Reads the `[schema.default]` and `[schema.types.*]` sections from `.hyalo.toml` to\n\
@@ -746,14 +746,26 @@ Repeatable (AND).\n\
             Without any file arguments, the entire vault is linted.\n\n\
             OUTPUT: Text by default (per-file violations + summary line). Use --format json for a\n\
             JSON payload (wrapped by the standard CLI envelope under `results`):\n\
-            {\"files\": [{\"file\": \"...\", \"violations\": [...]}], \"total\": N}.\n\n\
-            EXIT CODES: 0 = clean, 1 = errors found, 2 = internal error.\n\n\
+            {\"files\": [{\"file\": \"...\", \"violations\": [...]}], \"total\": N, \"fixes\": [...]}.\n\n\
+            AUTO-FIX: With --fix, `hyalo lint` attempts to repair fixable violations in place:\n\
+            \u{00a0} - Insert missing properties that have defaults in the schema ($today expands\n\
+            \u{00a0}   to the current date).\n\
+            \u{00a0} - Correct close enum typos (Levenshtein distance <= 2) to the nearest value.\n\
+            \u{00a0} - Normalize date formats (e.g. 2026-4-9 -> 2026-04-09).\n\
+            \u{00a0} - Infer a missing `type` property when the file path matches a\n\
+            \u{00a0}   [schema.types.*].filename-template.\n\
+            Missing required properties without defaults are reported, never fabricated.\n\
+            Use --dry-run to preview fixes without writing any files.\n\n\
+            EXIT CODES: 0 = clean (after fixes), 1 = errors remain, 2 = internal error.\n\n\
             EXAMPLES:\n\
             \u{00a0} hyalo lint\n\
             \u{00a0} hyalo lint iterations/iteration-101-bm25.md\n\
             \u{00a0} hyalo lint --glob \"iterations/*.md\"\n\
-            \u{00a0} hyalo lint --format json\n\n\
-            SIDE EFFECTS: None (read-only).\n\n\
+            \u{00a0} hyalo lint --format json\n\
+            \u{00a0} hyalo lint --fix\n\
+            \u{00a0} hyalo lint --fix --dry-run\n\n\
+            SIDE EFFECTS: None without --fix. With --fix (and without --dry-run), mutated files\n\
+            are rewritten atomically, preserving body bytes and frontmatter key order.\n\n\
             TIP: Run `hyalo summary` to see a one-line lint count across the whole vault."
     )]
     Lint {
@@ -766,8 +778,22 @@ Repeatable (AND).\n\
         /// Glob pattern(s) to select files, relative to --dir (repeatable); prefix '!' to negate
         #[arg(short, long, conflicts_with = "file")]
         glob: Vec<String>,
+        /// Auto-remediate fixable violations (defaults, enum typos, date format, type inference)
+        #[arg(long)]
+        fix: bool,
+        /// With --fix, preview changes without writing files
+        #[arg(long, requires = "fix")]
+        dry_run: bool,
     },
-    /// Generate shell completions for the given shell
+    /// Manage document-type schemas in `.hyalo.toml`
+    #[command(
+        long_about = "Manage document-type schemas stored in `.hyalo.toml`.\n\n            Type schemas define required properties, default values, property constraints,\n            and filename templates for each document type.\n\n            Calling `hyalo types` without a subcommand defaults to `hyalo types list`.\n\n            Subcommands:\n            - list:   Show all defined types and their required fields (default).\n            - show:   Show the full schema for a single type.\n            - create: Add a new type entry (fails if the type already exists).\n            - remove: Delete a type entry.\n            - set:    Update required fields, defaults, property constraints, or the filename template.\n\n            TOML editing preserves comments and formatting.\n\n            SIDE EFFECTS: create/remove/set modify .hyalo.toml. list and show are read-only."
+    )]
+    Types {
+        #[command(subcommand)]
+        action: Option<TypesAction>,
+    },
+        /// Generate shell completions for the given shell
     #[command(
         display_order = 900,
         long_about = "Generate shell completion scripts.\n\n\
@@ -822,6 +848,72 @@ pub(crate) enum ViewsAction {
         /// View name to delete
         #[arg(value_name = "NAME")]
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum TypesAction {
+    /// List all defined types and their required fields (default)
+    #[command(
+        long_about = "List all type schemas defined in `.hyalo.toml`.\n\n            OUTPUT: JSON envelope with results array and total count.\n            SIDE EFFECTS: None (read-only)."
+    )]
+    List,
+    /// Show the full schema for a single type
+    #[command(
+        long_about = "Display the full merged schema for a named type.\n\n            OUTPUT: JSON object with type name, required fields, defaults,\n            filename template, and property constraints.\n            SIDE EFFECTS: None (read-only)."
+    )]
+    Show {
+        /// Type name to display
+        #[arg(value_name = "TYPE")]
+        type_name: String,
+    },
+    /// Add a new type entry to `.hyalo.toml`
+    #[command(
+        long_about = "Create a new `[schema.types.<name>]` section in `.hyalo.toml`.\n\n            Fails if the type already exists. Creates an empty section with `required = []`.\n            Use --print to write the TOML snippet to stdout instead of modifying the file.\n\n            OUTPUT: JSON result or, with --print, raw TOML snippet to stdout.\n            SIDE EFFECTS: Modifies .hyalo.toml (unless --print is used)."
+    )]
+    Create {
+        /// Type name to create
+        #[arg(value_name = "TYPE")]
+        type_name: String,
+        /// Print the TOML snippet to stdout instead of writing to .hyalo.toml
+        #[arg(long)]
+        print: bool,
+    },
+    /// Remove a type entry from `.hyalo.toml`
+    #[command(
+        long_about = "Remove a `[schema.types.<name>]` section from `.hyalo.toml`.\n\n            Fails with a user error if the type does not exist.\n\n            OUTPUT: JSON result with action and type name.\n            SIDE EFFECTS: Modifies .hyalo.toml."
+    )]
+    Remove {
+        /// Type name to remove
+        #[arg(value_name = "TYPE")]
+        type_name: String,
+    },
+    /// Update a type schema's required fields, defaults, or property constraints
+    #[command(
+        long_about = "Update a type schema in `.hyalo.toml`.\n\n            All mutation flags are optional and combinable in a single invocation.\n\n            FLAGS:\n            - --required <fields>: comma-separated required property names to add (repeatable).\n            - --default key=value: set a default; auto-applied to files missing the property.\n            - --property-type key=type: set a type constraint (string/date/number/boolean/list/enum).\n            - --property-values key=val1,val2,...: set enum values; implies type=enum.\n            - --filename-template <template>: set the filename template for this type.\n            - --dry-run: preview changes without writing anything.\n\n            OUTPUT: JSON result with action, dry_run, defaults_applied, constraint_violations.\n            SIDE EFFECTS: Modifies .hyalo.toml and may write to vault files (unless --dry-run)."
+    )]
+    Set {
+        /// Type name to update
+        #[arg(value_name = "TYPE")]
+        type_name: String,
+        /// Comma-separated list of required property names to add (repeatable)
+        #[arg(long, value_name = "FIELDS")]
+        required: Vec<String>,
+        /// Set a default value: key=value (repeatable)
+        #[arg(long, value_name = "KEY=VALUE")]
+        default: Vec<String>,
+        /// Set the property type constraint: key=type (repeatable)
+        #[arg(long, value_name = "KEY=TYPE")]
+        property_type: Vec<String>,
+        /// Set enum values for a property: key=val1,val2,... (repeatable)
+        #[arg(long, value_name = "KEY=VALUES")]
+        property_values: Vec<String>,
+        /// Set the filename template for new files of this type
+        #[arg(long, value_name = "TEMPLATE")]
+        filename_template: Option<String>,
+        /// Preview changes without writing any files
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -19,8 +19,9 @@ use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
 
-use hyalo_core::frontmatter::read_frontmatter;
-use hyalo_core::schema::{PropertyConstraint, SchemaConfig, TypeSchema};
+use hyalo_core::filename_template::FilenameTemplate;
+use hyalo_core::frontmatter::{read_frontmatter, write_frontmatter};
+use hyalo_core::schema::{self, PropertyConstraint, SchemaConfig, TypeSchema};
 
 use crate::output::{CommandOutcome, Format, format_success};
 
@@ -59,6 +60,20 @@ pub struct FileLintResult {
     pub violations: Vec<Violation>,
 }
 
+/// A single auto-fix that was (or would be) applied.
+#[derive(Debug, Clone, Serialize)]
+pub struct FixAction {
+    /// Kind of fix: "insert-default", "fix-enum-typo", "normalize-date", "infer-type".
+    pub kind: String,
+    /// Frontmatter property affected.
+    pub property: String,
+    /// Old value (if any) — omitted for inserted properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old: Option<String>,
+    /// New value applied (or previewed with --dry-run).
+    pub new: String,
+}
+
 /// Aggregated lint output.
 ///
 /// The `files` field is renamed from the internal `results` to avoid a
@@ -67,6 +82,20 @@ pub struct FileLintResult {
 pub struct LintOutput {
     pub files: Vec<FileLintResult>,
     pub total: usize,
+    /// Fixes that were applied (or previewed) per file. Omitted when no
+    /// `--fix` run produced any changes.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fixes: Vec<FileFixResult>,
+    /// `true` when `--dry-run` was passed and fixes were not written.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub dry_run: bool,
+}
+
+/// Fixes applied to a single file.
+#[derive(Debug, Clone, Serialize)]
+pub struct FileFixResult {
+    pub file: String,
+    pub actions: Vec<FixAction>,
 }
 
 /// Summary counts returned to callers (e.g. `hyalo summary`).
@@ -91,11 +120,38 @@ pub fn lint_files(
     schema: &SchemaConfig,
     format: Format,
 ) -> Result<(CommandOutcome, LintCounts)> {
+    lint_files_with_options(files, schema, format, FixMode::Off)
+}
+
+/// Whether — and how — `lint_files_with_options` should apply auto-fixes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixMode {
+    /// Read-only: do not attempt to fix anything.
+    Off,
+    /// Apply fixes in memory and write them back to disk.
+    Apply,
+    /// Compute the fixes that would be applied but don't write any files.
+    DryRun,
+}
+
+/// Run lint with the given fix mode.
+///
+/// When `fix` is `Apply`, repairable violations are written back to each file
+/// before the final counts are computed, so the returned counts reflect only
+/// the violations that *remain* after fixing. With `DryRun`, counts reflect
+/// the post-fix state but files are untouched.
+pub fn lint_files_with_options(
+    files: &[(std::path::PathBuf, String)],
+    schema: &SchemaConfig,
+    format: Format,
+    fix: FixMode,
+) -> Result<(CommandOutcome, LintCounts)> {
     let mut results: Vec<FileLintResult> = Vec::new();
     let mut counts = LintCounts::default();
+    let mut fix_results: Vec<FileFixResult> = Vec::new();
 
     for (full_path, rel_path) in files {
-        let file_result = lint_file(full_path, rel_path, schema)?;
+        let (file_result, file_fixes) = lint_file_with_fix(full_path, rel_path, schema, fix)?;
         for v in &file_result.violations {
             match v.severity {
                 Severity::Error => counts.errors += 1,
@@ -105,6 +161,9 @@ pub fn lint_files(
         if !file_result.violations.is_empty() {
             counts.files_with_issues += 1;
         }
+        if !file_fixes.actions.is_empty() {
+            fix_results.push(file_fixes);
+        }
         results.push(file_result);
     }
 
@@ -112,6 +171,8 @@ pub fn lint_files(
     let output = LintOutput {
         files: results,
         total,
+        fixes: fix_results,
+        dry_run: matches!(fix, FixMode::DryRun),
     };
 
     let outcome = match format {
@@ -178,27 +239,250 @@ pub fn lint_counts_from_properties<'a>(
 // ---------------------------------------------------------------------------
 
 fn lint_file(full_path: &Path, rel_path: &str, schema: &SchemaConfig) -> Result<FileLintResult> {
+    let (result, _) = lint_file_with_fix(full_path, rel_path, schema, FixMode::Off)?;
+    Ok(result)
+}
+
+/// Lint a single file, optionally applying auto-fixes.
+fn lint_file_with_fix(
+    full_path: &Path,
+    rel_path: &str,
+    schema: &SchemaConfig,
+    fix: FixMode,
+) -> Result<(FileLintResult, FileFixResult)> {
     let properties = match read_frontmatter(full_path) {
         Ok(props) => props,
         Err(e) if hyalo_core::frontmatter::is_parse_error(&e) => {
             // Malformed frontmatter — report as a single error violation.
-            return Ok(FileLintResult {
-                file: rel_path.to_owned(),
-                violations: vec![Violation {
-                    severity: Severity::Error,
-                    message: format!("could not parse frontmatter: {e}"),
-                }],
-            });
+            return Ok((
+                FileLintResult {
+                    file: rel_path.to_owned(),
+                    violations: vec![Violation {
+                        severity: Severity::Error,
+                        message: format!("could not parse frontmatter: {e}"),
+                    }],
+                },
+                FileFixResult {
+                    file: rel_path.to_owned(),
+                    actions: Vec::new(),
+                },
+            ));
         }
         Err(e) => return Err(e).context(format!("reading {rel_path}")),
     };
 
-    let has_tags = properties.contains_key("tags");
-    let violations = validate_properties(rel_path, &properties, has_tags, schema);
-    Ok(FileLintResult {
-        file: rel_path.to_owned(),
-        violations,
-    })
+    // Apply fixes in memory (or dry-run) before final validation.
+    let (final_props, actions) = if matches!(fix, FixMode::Apply | FixMode::DryRun) {
+        let mut mutable = properties.clone();
+        let actions = apply_fixes(rel_path, &mut mutable, schema);
+        if matches!(fix, FixMode::Apply) && !actions.is_empty() {
+            write_frontmatter(full_path, &mutable)
+                .with_context(|| format!("writing fixed frontmatter to {rel_path}"))?;
+        }
+        (mutable, actions)
+    } else {
+        (properties, Vec::new())
+    };
+
+    let has_tags = final_props.contains_key("tags");
+    let violations = validate_properties(rel_path, &final_props, has_tags, schema);
+    Ok((
+        FileLintResult {
+            file: rel_path.to_owned(),
+            violations,
+        },
+        FileFixResult {
+            file: rel_path.to_owned(),
+            actions,
+        },
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Auto-fix
+// ---------------------------------------------------------------------------
+
+/// Maximum Levenshtein distance accepted for an enum-typo fix.
+/// Chosen so that single-letter slips (e.g. "planed" → "planned") are corrected
+/// while unrelated values (e.g. "wip" vs. "in-progress") are left alone.
+const ENUM_TYPO_MAX_DISTANCE: usize = 2;
+
+/// Compute and apply in-memory auto-fixes to `props`. Returns the list of
+/// actions that were taken. Caller is responsible for persisting `props` to
+/// disk when appropriate.
+fn apply_fixes(
+    rel_path: &str,
+    props: &mut IndexMap<String, Value>,
+    schema: &SchemaConfig,
+) -> Vec<FixAction> {
+    let mut actions: Vec<FixAction> = Vec::new();
+
+    // Step 1: infer `type` from filename-template if missing.
+    if !props.contains_key("type")
+        && let Some(inferred) = infer_type_from_path(rel_path, schema)
+    {
+        // Insert `type` at the front of the map so downstream logic picks it up.
+        props.shift_insert(0, "type".to_owned(), Value::String(inferred.clone()));
+        actions.push(FixAction {
+            kind: "infer-type".to_owned(),
+            property: "type".to_owned(),
+            old: None,
+            new: inferred,
+        });
+    }
+
+    // Determine the effective schema after any type inference.
+    let doc_type: Option<String> = props.get("type").and_then(|v| match v {
+        Value::String(s) => Some(s.clone()),
+        _ => None,
+    });
+    let effective_schema: TypeSchema = match &doc_type {
+        Some(t) => schema.merged_schema_for_type(t),
+        None => schema.default_schema().clone(),
+    };
+
+    // Step 2: insert defaults for missing properties.
+    // Iterate in the schema's `required` order first, then any remaining defaults,
+    // so the resulting frontmatter is ordered deterministically.
+    let mut inserted: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for req in &effective_schema.required {
+        if !props.contains_key(req.as_str())
+            && let Some(raw) = effective_schema.defaults.get(req.as_str())
+        {
+            let value = schema::expand_default(raw);
+            props.insert(req.clone(), Value::String(value.clone()));
+            inserted.insert(req.clone());
+            actions.push(FixAction {
+                kind: "insert-default".to_owned(),
+                property: req.clone(),
+                old: None,
+                new: value,
+            });
+        }
+    }
+    // Also honour defaults for properties not listed in `required`.
+    for (name, raw) in &effective_schema.defaults {
+        if inserted.contains(name) || props.contains_key(name.as_str()) {
+            continue;
+        }
+        let value = schema::expand_default(raw);
+        props.insert(name.clone(), Value::String(value.clone()));
+        actions.push(FixAction {
+            kind: "insert-default".to_owned(),
+            property: name.clone(),
+            old: None,
+            new: value,
+        });
+    }
+
+    // Step 3: per-property fixes (enum typos, date normalization).
+    let prop_names: Vec<String> = props.keys().cloned().collect();
+    for name in prop_names {
+        let Some(constraint) = effective_schema.properties.get(name.as_str()) else {
+            continue;
+        };
+        // Snapshot the current value to avoid double-borrowing `props`.
+        let Some(current) = props.get(name.as_str()).cloned() else {
+            continue;
+        };
+        match constraint {
+            PropertyConstraint::Enum { values } => {
+                let Value::String(s) = &current else { continue };
+                if values.iter().any(|v| v == s) {
+                    continue;
+                }
+                if let Some((suggestion, dist)) = values
+                    .iter()
+                    .map(|v| (v, strsim::levenshtein(s, v.as_str())))
+                    .min_by_key(|(_, d)| *d)
+                    && dist <= ENUM_TYPO_MAX_DISTANCE
+                {
+                    let old = s.clone();
+                    let new_value = suggestion.clone();
+                    props.insert(name.clone(), Value::String(new_value.clone()));
+                    actions.push(FixAction {
+                        kind: "fix-enum-typo".to_owned(),
+                        property: name.clone(),
+                        old: Some(old),
+                        new: new_value,
+                    });
+                }
+            }
+            PropertyConstraint::Date => {
+                let Value::String(s) = &current else { continue };
+                if is_iso8601_date(s) {
+                    continue;
+                }
+                if let Some(normalized) = normalize_date(s) {
+                    let old = s.clone();
+                    props.insert(name.clone(), Value::String(normalized.clone()));
+                    actions.push(FixAction {
+                        kind: "normalize-date".to_owned(),
+                        property: name.clone(),
+                        old: Some(old),
+                        new: normalized,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    actions
+}
+
+/// Try to infer a `type` value for a file at `rel_path` by matching it against
+/// every `[schema.types.*].filename-template`. Returns `None` if zero or more
+/// than one type matches (ambiguous).
+fn infer_type_from_path(rel_path: &str, schema: &SchemaConfig) -> Option<String> {
+    let mut matches: Vec<String> = Vec::new();
+    for (type_name, ts) in &schema.types {
+        let Some(template_str) = &ts.filename_template else {
+            continue;
+        };
+        let Ok(template) = FilenameTemplate::parse(template_str) else {
+            continue;
+        };
+        if template.matches(rel_path) {
+            matches.push(type_name.clone());
+        }
+    }
+    if matches.len() == 1 {
+        matches.pop()
+    } else {
+        None
+    }
+}
+
+/// Normalize a loose date string to `YYYY-MM-DD`.
+///
+/// Accepts inputs of the form `Y-M-D` where `Y`, `M`, `D` are decimal digit
+/// runs and month/day are in the valid calendar ranges. Returns `None` for
+/// inputs that are ambiguous (e.g. natural-language dates, non-ISO separators,
+/// or out-of-range values); those are reported as violations instead.
+fn normalize_date(s: &str) -> Option<String> {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let y = parts[0];
+    let m = parts[1];
+    let d = parts[2];
+    if y.len() != 4 || !y.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if m.is_empty() || m.len() > 2 || !m.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if d.is_empty() || d.len() > 2 || !d.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let mi: u32 = m.parse().ok()?;
+    let di: u32 = d.parse().ok()?;
+    if !(1..=12).contains(&mi) || !(1..=31).contains(&di) {
+        return None;
+    }
+    Some(format!("{y}-{mi:02}-{di:02}"))
 }
 
 /// Core property validation logic.
@@ -454,6 +738,38 @@ fn format_text_output(output: &LintOutput, counts: &LintCounts) -> String {
     use std::fmt::Write as _;
 
     let mut s = String::new();
+
+    // Fixes section — shown first so the user sees what changed.
+    let fix_count: usize = output.fixes.iter().map(|f| f.actions.len()).sum();
+    if fix_count > 0 {
+        let verb = if output.dry_run { "Would fix" } else { "Fixed" };
+        for file in &output.fixes {
+            if file.actions.is_empty() {
+                continue;
+            }
+            let _ = writeln!(s, "{verb} {}:", file.file);
+            for a in &file.actions {
+                match (&a.kind[..], &a.old) {
+                    ("insert-default", _) => {
+                        let _ = writeln!(s, "  insert  {} = {:?}", a.property, a.new);
+                    }
+                    ("infer-type", _) => {
+                        let _ = writeln!(s, "  infer   type = {:?}", a.new);
+                    }
+                    ("fix-enum-typo", Some(old)) => {
+                        let _ = writeln!(s, "  enum    {}: {:?} -> {:?}", a.property, old, a.new);
+                    }
+                    ("normalize-date", Some(old)) => {
+                        let _ = writeln!(s, "  date    {}: {:?} -> {:?}", a.property, old, a.new);
+                    }
+                    _ => {
+                        let _ = writeln!(s, "  {}  {} = {:?}", a.kind, a.property, a.new);
+                    }
+                }
+            }
+        }
+    }
+
     for file in &output.files {
         if file.violations.is_empty() {
             continue;
@@ -480,6 +796,10 @@ fn format_text_output(output: &LintOutput, counts: &LintCounts) -> String {
             "{files_checked} {files_label} checked, {} with issues ({} errors, {} warnings)",
             counts.files_with_issues, counts.errors, counts.warnings,
         );
+    }
+    if fix_count > 0 {
+        let fixed_label = if output.dry_run { "would fix" } else { "fixed" };
+        let _ = write!(s, " — {fixed_label} {fix_count}");
     }
 
     s
@@ -763,6 +1083,8 @@ mod tests {
         let output = LintOutput {
             files: vec![],
             total: 3,
+            fixes: Vec::new(),
+            dry_run: false,
         };
         let counts = LintCounts::default();
         let text = format_text_output(&output, &counts);
@@ -787,6 +1109,8 @@ mod tests {
                 ],
             }],
             total: 1,
+            fixes: Vec::new(),
+            dry_run: false,
         };
         let counts = LintCounts {
             errors: 1,

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -477,9 +477,22 @@ fn normalize_date(s: &str) -> Option<String> {
     if d.is_empty() || d.len() > 2 || !d.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
+    let yi: i32 = y.parse().ok()?;
     let mi: u32 = m.parse().ok()?;
     let di: u32 = d.parse().ok()?;
-    if !(1..=12).contains(&mi) || !(1..=31).contains(&di) {
+    if !(1..=12).contains(&mi) {
+        return None;
+    }
+    let max_day = match mi {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            let leap = (yi % 4 == 0 && yi % 100 != 0) || (yi % 400 == 0);
+            if leap { 29 } else { 28 }
+        }
+        _ => return None,
+    };
+    if !(1..=max_day).contains(&di) {
         return None;
     }
     Some(format!("{y}-{mi:02}-{di:02}"))
@@ -844,6 +857,19 @@ mod tests {
     #[test]
     fn valid_date() {
         assert!(is_iso8601_date("2026-04-13"));
+    }
+
+    #[test]
+    fn normalize_date_padding_and_calendar() {
+        // Short month/day get zero-padded.
+        assert_eq!(normalize_date("2026-4-9"), Some("2026-04-09".to_owned()));
+        // Feb 29 is valid in leap years only.
+        assert_eq!(normalize_date("2024-2-29"), Some("2024-02-29".to_owned()));
+        assert_eq!(normalize_date("2023-2-29"), None);
+        // Out-of-range days/months are rejected, not silently normalized.
+        assert_eq!(normalize_date("2026-02-31"), None);
+        assert_eq!(normalize_date("2026-04-31"), None);
+        assert_eq!(normalize_date("2026-13-01"), None);
     }
 
     #[test]

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod set;
 pub mod summary;
 pub mod tags;
 pub mod tasks;
+pub mod types;
 pub mod views;
 
 use crate::output::{CommandOutcome, Format};

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -22,7 +22,7 @@ const TOML_PATH: &str = ".hyalo.toml";
 // ---------------------------------------------------------------------------
 
 /// `hyalo types list` — list all defined types and their required fields.
-pub(crate) fn list_types(schema: &SchemaConfig) -> Result<CommandOutcome> {
+pub(crate) fn list_types(schema: &SchemaConfig) -> CommandOutcome {
     let mut sorted_types: Vec<&str> = schema.types.keys().map(String::as_str).collect();
     sorted_types.sort_unstable();
 
@@ -41,10 +41,7 @@ pub(crate) fn list_types(schema: &SchemaConfig) -> Result<CommandOutcome> {
 
     let total = results.len() as u64;
     let val = serde_json::json!(results);
-    Ok(CommandOutcome::success_with_total(
-        format_success(Format::Json, &val),
-        total,
-    ))
+    CommandOutcome::success_with_total(format_success(Format::Json, &val), total)
 }
 
 // ---------------------------------------------------------------------------
@@ -52,11 +49,11 @@ pub(crate) fn list_types(schema: &SchemaConfig) -> Result<CommandOutcome> {
 // ---------------------------------------------------------------------------
 
 /// `hyalo types show <type>` — full merged schema for a type.
-pub(crate) fn show_type(type_name: &str, schema: &SchemaConfig) -> Result<CommandOutcome> {
+pub(crate) fn show_type(type_name: &str, schema: &SchemaConfig) -> CommandOutcome {
     if !schema.types.contains_key(type_name) {
-        return Ok(CommandOutcome::UserError(format!(
+        return CommandOutcome::UserError(format!(
             "Error: type '{type_name}' not found\n\n  tip: run 'hyalo types list' to see available types"
-        )));
+        ));
     }
 
     let merged = schema.merged_schema_for_type(type_name);
@@ -79,7 +76,7 @@ pub(crate) fn show_type(type_name: &str, schema: &SchemaConfig) -> Result<Comman
         "properties": props,
     });
 
-    Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+    CommandOutcome::success(format_success(Format::Json, &val))
 }
 
 fn constraint_to_json(c: &hyalo_core::schema::PropertyConstraint) -> Value {
@@ -364,9 +361,8 @@ pub(crate) fn set_type(
         let mut per_default_files: HashMap<String, Vec<String>> = HashMap::new();
 
         for full_path in &all_vault_files {
-            let props = match read_frontmatter(full_path) {
-                Ok(p) => p,
-                Err(_) => continue,
+            let Ok(props) = read_frontmatter(full_path) else {
+                continue;
             };
             let file_type = props
                 .get("type")
@@ -721,7 +717,7 @@ mod tests {
     #[test]
     fn list_types_empty_schema() {
         let schema = SchemaConfig::default();
-        let outcome = list_types(&schema).unwrap();
+        let outcome = list_types(&schema);
         match outcome {
             CommandOutcome::Success { output, total } => {
                 let v: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -735,7 +731,7 @@ mod tests {
     #[test]
     fn list_types_with_entries() {
         let schema = make_schema_with_type("iteration", &["title", "date"]);
-        let outcome = list_types(&schema).unwrap();
+        let outcome = list_types(&schema);
         match outcome {
             CommandOutcome::Success { output, total } => {
                 let v: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -753,14 +749,14 @@ mod tests {
     #[test]
     fn show_type_not_found() {
         let schema = SchemaConfig::default();
-        let outcome = show_type("nonexistent", &schema).unwrap();
+        let outcome = show_type("nonexistent", &schema);
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
     #[test]
     fn show_type_found() {
         let schema = make_schema_with_type("note", &["title"]);
-        let outcome = show_type("note", &schema).unwrap();
+        let outcome = show_type("note", &schema);
         match outcome {
             CommandOutcome::Success { output, .. } => {
                 let v: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -783,7 +779,7 @@ mod tests {
                 values: vec!["draft".to_owned(), "published".to_owned()],
             },
         );
-        let outcome = show_type("note", &schema).unwrap();
+        let outcome = show_type("note", &schema);
         match outcome {
             CommandOutcome::Success { output, .. } => {
                 let v: serde_json::Value = serde_json::from_str(&output).unwrap();

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -1,0 +1,858 @@
+/// `hyalo types` — manage document-type schemas in `.hyalo.toml`.
+///
+/// All TOML mutations use `toml_edit::DocumentMut` so that comments and
+/// formatting in the user's config file are preserved.
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use hyalo_core::discovery;
+use hyalo_core::frontmatter::{read_frontmatter, write_frontmatter};
+use hyalo_core::schema::{SchemaConfig, expand_default};
+
+use crate::output::{CommandOutcome, Format, format_success};
+
+const TOML_PATH: &str = ".hyalo.toml";
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+/// `hyalo types list` — list all defined types and their required fields.
+pub(crate) fn list_types(schema: &SchemaConfig) -> Result<CommandOutcome> {
+    let mut sorted_types: Vec<&str> = schema.types.keys().map(String::as_str).collect();
+    sorted_types.sort_unstable();
+
+    let results: Vec<Value> = sorted_types
+        .iter()
+        .map(|name| {
+            let ts = &schema.types[*name];
+            serde_json::json!({
+                "type": name,
+                "required": ts.required,
+                "has_filename_template": ts.filename_template.is_some(),
+                "property_count": ts.properties.len(),
+            })
+        })
+        .collect();
+
+    let total = results.len() as u64;
+    let val = serde_json::json!(results);
+    Ok(CommandOutcome::success_with_total(
+        format_success(Format::Json, &val),
+        total,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// show
+// ---------------------------------------------------------------------------
+
+/// `hyalo types show <type>` — full merged schema for a type.
+pub(crate) fn show_type(type_name: &str, schema: &SchemaConfig) -> Result<CommandOutcome> {
+    if !schema.types.contains_key(type_name) {
+        return Ok(CommandOutcome::UserError(format!(
+            "Error: type '{type_name}' not found\n\n  tip: run 'hyalo types list' to see available types"
+        )));
+    }
+
+    let merged = schema.merged_schema_for_type(type_name);
+
+    // Serialize property constraints.
+    let props: serde_json::Map<String, Value> = merged
+        .properties
+        .iter()
+        .map(|(k, constraint)| {
+            let c_val = constraint_to_json(constraint);
+            (k.clone(), c_val)
+        })
+        .collect();
+
+    let val = serde_json::json!({
+        "type": type_name,
+        "required": merged.required,
+        "filename_template": merged.filename_template,
+        "defaults": merged.defaults,
+        "properties": props,
+    });
+
+    Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+}
+
+fn constraint_to_json(c: &hyalo_core::schema::PropertyConstraint) -> Value {
+    use hyalo_core::schema::PropertyConstraint;
+    match c {
+        PropertyConstraint::String { pattern } => {
+            if let Some(pat) = pattern {
+                serde_json::json!({"type": "string", "pattern": pat})
+            } else {
+                serde_json::json!({"type": "string"})
+            }
+        }
+        PropertyConstraint::Date => serde_json::json!({"type": "date"}),
+        PropertyConstraint::Number => serde_json::json!({"type": "number"}),
+        PropertyConstraint::Boolean => serde_json::json!({"type": "boolean"}),
+        PropertyConstraint::List => serde_json::json!({"type": "list"}),
+        PropertyConstraint::Enum { values } => {
+            serde_json::json!({"type": "enum", "values": values})
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+/// `hyalo types create <type> [--print]` — add a new type entry.
+pub(crate) fn create_type(type_name: &str, print: bool) -> Result<CommandOutcome> {
+    if let Err(msg) = validate_type_name(type_name) {
+        return Ok(CommandOutcome::UserError(format!("Error: {msg}")));
+    }
+
+    if print {
+        // Output raw TOML snippet to stdout, no envelope.
+        let snippet = format!("\n[schema.types.{type_name}]\nrequired = []\n");
+        return Ok(CommandOutcome::RawOutput(snippet));
+    }
+
+    let mut doc = read_toml_doc()?;
+
+    // Ensure schema.types.<name> doesn't already exist.
+    if toml_type_exists(&doc, type_name) {
+        return Ok(CommandOutcome::UserError(format!(
+            "Error: type '{type_name}' already exists\n\n  tip: use 'hyalo types show {type_name}' to inspect it"
+        )));
+    }
+
+    // Create [schema.types.<name>] with required = []
+    ensure_schema_types_table(&mut doc);
+
+    {
+        let schema = doc["schema"].as_table_mut().expect("schema is a table");
+        let types = schema["types"].as_table_mut().expect("types is a table");
+        let mut type_table = toml_edit::Table::new();
+        type_table.insert(
+            "required",
+            toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())),
+        );
+        types.insert(type_name, toml_edit::Item::Table(type_table));
+    }
+
+    write_toml_doc(&doc)?;
+
+    let val = serde_json::json!({
+        "action": "created",
+        "type": type_name,
+        "dry_run": false,
+    });
+    Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+}
+
+// ---------------------------------------------------------------------------
+// remove
+// ---------------------------------------------------------------------------
+
+/// `hyalo types remove <type>` — remove a type entry.
+pub(crate) fn remove_type(type_name: &str) -> Result<CommandOutcome> {
+    let mut doc = read_toml_doc()?;
+
+    if !toml_type_exists(&doc, type_name) {
+        return Ok(CommandOutcome::UserError(format!(
+            "Error: type '{type_name}' not found\n\n  tip: run 'hyalo types list' to see available types"
+        )));
+    }
+
+    {
+        let schema = doc["schema"].as_table_mut().expect("schema is a table");
+        let types = schema["types"].as_table_mut().expect("types is a table");
+        types.remove(type_name);
+    }
+
+    write_toml_doc(&doc)?;
+
+    let val = serde_json::json!({
+        "action": "removed",
+        "type": type_name,
+    });
+    Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+}
+
+// ---------------------------------------------------------------------------
+// set
+// ---------------------------------------------------------------------------
+
+/// Parse a property-type string to a known type string.
+fn parse_property_type_str(s: &str) -> Result<&'static str, String> {
+    match s {
+        "string" => Ok("string"),
+        "date" => Ok("date"),
+        "number" => Ok("number"),
+        "boolean" => Ok("boolean"),
+        "list" => Ok("list"),
+        "enum" => Ok("enum"),
+        other => Err(format!(
+            "invalid property type '{other}': must be one of string, date, number, boolean, list, enum"
+        )),
+    }
+}
+
+/// Parse a `KEY=VALUE` pair, returning an error string if malformed.
+fn parse_kv<'a>(s: &'a str, flag: &str) -> Result<(&'a str, &'a str), String> {
+    match s.find('=') {
+        Some(pos) => {
+            let key = s[..pos].trim();
+            if key.is_empty() {
+                return Err(format!("invalid {flag} argument '{s}': key cannot be empty"));
+            }
+            Ok((key, &s[pos + 1..]))
+        }
+        None => Err(format!(
+            "invalid {flag} argument '{s}': expected KEY=VALUE format"
+        )),
+    }
+}
+
+/// `hyalo types set <type> [flags...]` — update a type schema.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn set_type(
+    dir: &Path,
+    type_name: &str,
+    required_args: &[String],
+    default_args: &[String],
+    property_type_args: &[String],
+    property_values_args: &[String],
+    filename_template: Option<&str>,
+    dry_run: bool,
+) -> Result<CommandOutcome> {
+    // Require at least one mutation flag.
+    if required_args.is_empty()
+        && default_args.is_empty()
+        && property_type_args.is_empty()
+        && property_values_args.is_empty()
+        && filename_template.is_none()
+    {
+        return Ok(CommandOutcome::UserError(
+            "Error: no mutation flags provided — specify at least one of: \
+             --required, --default, --property-type, --property-values, --filename-template"
+                .to_owned(),
+        ));
+    }
+
+    // Parse --required: each arg may be comma-separated.
+    let required_fields: Vec<String> = required_args
+        .iter()
+        .flat_map(|s| s.split(','))
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // Parse --default key=value pairs.
+    let mut defaults_map: HashMap<String, String> = HashMap::new();
+    for arg in default_args {
+        match parse_kv(arg, "--default") {
+            Ok((k, v)) => {
+                defaults_map.insert(k.to_owned(), v.to_owned());
+            }
+            Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+        }
+    }
+
+    // Parse --property-type key=type pairs.
+    let mut prop_type_map: HashMap<String, &'static str> = HashMap::new();
+    for arg in property_type_args {
+        match parse_kv(arg, "--property-type") {
+            Ok((k, v)) => match parse_property_type_str(v) {
+                Ok(pt) => {
+                    prop_type_map.insert(k.to_owned(), pt);
+                }
+                Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+            },
+            Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+        }
+    }
+
+    // Parse --property-values key=val1,val2,... pairs.
+    let mut prop_values_map: HashMap<String, Vec<String>> = HashMap::new();
+    for arg in property_values_args {
+        match parse_kv(arg, "--property-values") {
+            Ok((k, v)) => {
+                let vals: Vec<String> = v.split(',').map(|s| s.trim().to_owned()).collect();
+                prop_values_map.insert(k.to_owned(), vals);
+            }
+            Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+        }
+    }
+
+    // Load TOML doc.
+    let mut doc = read_toml_doc()?;
+
+    // Type must exist.
+    if !toml_type_exists(&doc, type_name) {
+        return Ok(CommandOutcome::UserError(format!(
+            "Error: type '{type_name}' not found\n\n  tip: run 'hyalo types list' to see available types"
+        )));
+    }
+
+    // Collect what will change (used for dry-run preview and result).
+    let mut toml_changes: Vec<String> = Vec::new();
+
+    // Apply --required additions.
+    if !required_fields.is_empty() {
+        let cur_required = get_required_array(&doc, type_name);
+        let mut new_required = cur_required.clone();
+        for f in &required_fields {
+            if !new_required.contains(f) {
+                new_required.push(f.clone());
+                toml_changes.push(format!("add required field: {f}"));
+            }
+        }
+        if !dry_run {
+            set_required_array(&mut doc, type_name, &new_required);
+        }
+    }
+
+    // Apply --filename-template.
+    if let Some(tmpl) = filename_template {
+        toml_changes.push(format!("set filename-template: {tmpl}"));
+        if !dry_run {
+            set_string_field(&mut doc, type_name, "filename-template", tmpl);
+        }
+    }
+
+    // Apply --default key=value.
+    for (k, v) in &defaults_map {
+        toml_changes.push(format!("set default: {k} = {v}"));
+        if !dry_run {
+            set_default_field(&mut doc, type_name, k, v);
+        }
+    }
+
+    // Apply --property-values (enum constraint; wins over --property-type for same key).
+    for (k, vals) in &prop_values_map {
+        toml_changes.push(format!(
+            "set property {k}: type=enum, values=[{}]",
+            vals.join(", ")
+        ));
+        if !dry_run {
+            set_property_enum(&mut doc, type_name, k, vals);
+        }
+        // Remove from prop_type_map so it isn't also applied below.
+        prop_type_map.remove(k.as_str());
+    }
+
+    // Apply --property-type for remaining (non-enum) entries.
+    for (k, pt) in &prop_type_map {
+        toml_changes.push(format!("set property {k}: type={pt}"));
+        if !dry_run {
+            set_property_type_field(&mut doc, type_name, k, pt);
+        }
+    }
+
+    // Write TOML to disk (unless dry-run).
+    if !dry_run {
+        write_toml_doc(&doc)?;
+    }
+
+    // --- Side effects: --default auto-apply ---
+    let mut defaults_applied: Vec<Value> = Vec::new();
+
+    if !defaults_map.is_empty() {
+        let all_vault_files = discovery::discover_files(dir)?;
+        let mut per_default_files: HashMap<String, Vec<String>> = HashMap::new();
+
+        for full_path in &all_vault_files {
+            let props = match read_frontmatter(full_path) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            let file_type = props
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            if file_type != type_name {
+                continue;
+            }
+            let rel = discovery::relative_path(dir, full_path);
+
+            // Find which defaults this file is missing.
+            let mut file_needs: HashMap<String, String> = HashMap::new();
+            for (key, raw_val) in &defaults_map {
+                if !props.contains_key(key.as_str()) {
+                    let expanded = expand_default(raw_val);
+                    file_needs.insert(key.clone(), expanded.clone());
+                    per_default_files
+                        .entry(key.clone())
+                        .or_default()
+                        .push(rel.clone());
+                }
+            }
+
+            if !dry_run && !file_needs.is_empty() {
+                let mut new_props = props.clone();
+                for (key, expanded) in &file_needs {
+                    new_props.insert(key.clone(), Value::String(expanded.clone()));
+                }
+                write_frontmatter(full_path, &new_props)
+                    .with_context(|| format!("writing defaults to {rel}"))?;
+            }
+        }
+
+        for (key, raw_val) in &defaults_map {
+            let expanded = expand_default(raw_val);
+            let applied_files = per_default_files.get(key).cloned().unwrap_or_default();
+            let count = applied_files.len();
+            defaults_applied.push(serde_json::json!({
+                "property": key,
+                "value": expanded,
+                "files": applied_files,
+                "count": count,
+            }));
+        }
+    }
+
+    // --- Side effects: constraint violation reporting ---
+    let needs_violation_check = !required_fields.is_empty()
+        || !prop_type_map.is_empty()
+        || !prop_values_map.is_empty();
+
+    let mut constraint_violations: Vec<Value> = Vec::new();
+
+    if needs_violation_check && !dry_run {
+        let updated_schema = load_schema_from_doc(&doc)?;
+        let all_vault_files = discovery::discover_files(dir)?;
+
+        let file_pairs: Vec<(std::path::PathBuf, String)> = all_vault_files
+            .iter()
+            .filter(|p| {
+                read_frontmatter(p)
+                    .ok()
+                    .and_then(|props| {
+                        props
+                            .get("type")
+                            .and_then(|v| v.as_str())
+                            .map(|t| t == type_name)
+                    })
+                    .unwrap_or(false)
+            })
+            .map(|p| {
+                let rel = discovery::relative_path(dir, p);
+                (p.clone(), rel)
+            })
+            .collect();
+
+        let counts = crate::commands::lint::lint_counts_only(&file_pairs, &updated_schema)?;
+
+        if counts.errors > 0 || counts.warnings > 0 {
+            constraint_violations.push(serde_json::json!({
+                "file_count": counts.files_with_issues,
+                "error_count": counts.errors,
+                "warning_count": counts.warnings,
+                "message": "Run `hyalo lint` for details.",
+            }));
+        }
+    }
+
+    let val = serde_json::json!({
+        "action": "updated",
+        "type": type_name,
+        "dry_run": dry_run,
+        "toml_changes": toml_changes,
+        "defaults_applied": defaults_applied,
+        "constraint_violations": constraint_violations,
+    });
+
+    Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+}
+
+// ---------------------------------------------------------------------------
+// TOML helpers (toml_edit)
+// ---------------------------------------------------------------------------
+
+/// Read `.hyalo.toml` as a `DocumentMut`, or return an empty doc if not found.
+fn read_toml_doc() -> Result<toml_edit::DocumentMut> {
+    match fs::read_to_string(TOML_PATH) {
+        Ok(contents) => contents
+            .parse::<toml_edit::DocumentMut>()
+            .context("failed to parse .hyalo.toml"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(toml_edit::DocumentMut::new()),
+        Err(e) => Err(e).context("failed to read .hyalo.toml"),
+    }
+}
+
+/// Write a `DocumentMut` back to `.hyalo.toml`.
+fn write_toml_doc(doc: &toml_edit::DocumentMut) -> Result<()> {
+    fs::write(TOML_PATH, doc.to_string()).context("failed to write .hyalo.toml")
+}
+
+/// Returns `true` when `[schema.types.<name>]` exists in the doc.
+fn toml_type_exists(doc: &toml_edit::DocumentMut, type_name: &str) -> bool {
+    doc.get("schema")
+        .and_then(|s| s.as_table())
+        .and_then(|t| t.get("types"))
+        .and_then(|t| t.as_table())
+        .and_then(|t| t.get(type_name))
+        .is_some()
+}
+
+/// Ensure `[schema]` and `[schema.types]` tables exist in the doc.
+fn ensure_schema_types_table(doc: &mut toml_edit::DocumentMut) {
+    if !doc.contains_key("schema") {
+        doc["schema"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    if !schema.contains_key("types") {
+        schema.insert("types", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+}
+
+/// Ensure `[schema.types.<name>.defaults]` table exists.
+fn ensure_defaults_table(doc: &mut toml_edit::DocumentMut, type_name: &str) {
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let types = schema["types"].as_table_mut().expect("types is a table");
+    let type_table = types[type_name]
+        .as_table_mut()
+        .expect("type entry is a table");
+    if !type_table.contains_key("defaults") {
+        type_table.insert("defaults", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+}
+
+/// Ensure `[schema.types.<name>.properties.<prop>]` table exists.
+fn ensure_property_table(doc: &mut toml_edit::DocumentMut, type_name: &str, prop: &str) {
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let types = schema["types"].as_table_mut().expect("types is a table");
+    let type_table = types[type_name]
+        .as_table_mut()
+        .expect("type entry is a table");
+    if !type_table.contains_key("properties") {
+        type_table.insert(
+            "properties",
+            toml_edit::Item::Table(toml_edit::Table::new()),
+        );
+    }
+    let props = type_table["properties"]
+        .as_table_mut()
+        .expect("properties is a table");
+    if !props.contains_key(prop) {
+        props.insert(prop, toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+}
+
+/// Get the current `required` array for a type.
+fn get_required_array(doc: &toml_edit::DocumentMut, type_name: &str) -> Vec<String> {
+    doc.get("schema")
+        .and_then(|s| s.as_table())
+        .and_then(|t| t.get("types"))
+        .and_then(|t| t.as_table())
+        .and_then(|t| t.get(type_name))
+        .and_then(|t| t.as_table())
+        .and_then(|t| t.get("required"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Set the `required` array for a type.
+fn set_required_array(doc: &mut toml_edit::DocumentMut, type_name: &str, fields: &[String]) {
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let types = schema["types"].as_table_mut().expect("types is a table");
+    let type_table = types[type_name]
+        .as_table_mut()
+        .expect("type entry is a table");
+    let mut arr = toml_edit::Array::new();
+    for f in fields {
+        arr.push(f.as_str());
+    }
+    type_table["required"] = toml_edit::Item::Value(toml_edit::Value::Array(arr));
+}
+
+/// Set a string field at `[schema.types.<name>.<key>]`.
+fn set_string_field(doc: &mut toml_edit::DocumentMut, type_name: &str, key: &str, value: &str) {
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let types = schema["types"].as_table_mut().expect("types is a table");
+    let type_table = types[type_name]
+        .as_table_mut()
+        .expect("type entry is a table");
+    type_table[key] = toml_edit::value(value);
+}
+
+/// Set `[schema.types.<name>.defaults.<key>] = value`.
+fn set_default_field(doc: &mut toml_edit::DocumentMut, type_name: &str, key: &str, value: &str) {
+    ensure_defaults_table(doc, type_name);
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let types = schema["types"].as_table_mut().expect("types is a table");
+    let type_table = types[type_name]
+        .as_table_mut()
+        .expect("type entry is a table");
+    let defaults = type_table["defaults"]
+        .as_table_mut()
+        .expect("defaults is a table");
+    defaults[key] = toml_edit::value(value);
+}
+
+/// Set a simple (non-enum) property constraint: `type = "<pt>"`.
+fn set_property_type_field(
+    doc: &mut toml_edit::DocumentMut,
+    type_name: &str,
+    prop: &str,
+    pt: &str,
+) {
+    ensure_property_table(doc, type_name, prop);
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let types = schema["types"].as_table_mut().expect("types is a table");
+    let type_table = types[type_name]
+        .as_table_mut()
+        .expect("type entry is a table");
+    let props = type_table["properties"]
+        .as_table_mut()
+        .expect("properties is a table");
+    let prop_table = props[prop].as_table_mut().expect("property is a table");
+    prop_table["type"] = toml_edit::value(pt);
+    // Remove values key if switching away from enum.
+    prop_table.remove("values");
+}
+
+/// Set an enum property constraint.
+fn set_property_enum(
+    doc: &mut toml_edit::DocumentMut,
+    type_name: &str,
+    prop: &str,
+    values: &[String],
+) {
+    ensure_property_table(doc, type_name, prop);
+    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let types = schema["types"].as_table_mut().expect("types is a table");
+    let type_table = types[type_name]
+        .as_table_mut()
+        .expect("type entry is a table");
+    let props = type_table["properties"]
+        .as_table_mut()
+        .expect("properties is a table");
+    let prop_table = props[prop].as_table_mut().expect("property is a table");
+    prop_table["type"] = toml_edit::value("enum");
+    let mut arr = toml_edit::Array::new();
+    for v in values {
+        arr.push(v.as_str());
+    }
+    prop_table["values"] = toml_edit::Item::Value(toml_edit::Value::Array(arr));
+}
+
+/// Validate a type name: alphanumeric, hyphens, underscores, dots.
+fn validate_type_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("type name cannot be empty".to_owned());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(format!(
+            "invalid type name '{name}': must contain only alphanumeric characters, hyphens, underscores, or dots"
+        ));
+    }
+    Ok(())
+}
+
+/// Re-parse the schema from the current TOML document string.
+fn load_schema_from_doc(doc: &toml_edit::DocumentMut) -> Result<SchemaConfig> {
+    let toml_str = doc.to_string();
+    let table: toml::Value = toml::from_str(&toml_str).context("failed to re-parse TOML")?;
+    let raw_schema: hyalo_core::schema::RawSchemaConfig = table
+        .get("schema")
+        .and_then(|v| v.clone().try_into().ok())
+        .unwrap_or(hyalo_core::schema::RawSchemaConfig {
+            default: None,
+            types: HashMap::new(),
+        });
+    Ok(SchemaConfig::from(raw_schema))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyalo_core::schema::{PropertyConstraint, TypeSchema};
+    use std::collections::HashMap;
+
+    fn make_schema_with_type(type_name: &str, required: &[&str]) -> SchemaConfig {
+        let type_schema = TypeSchema {
+            required: required.iter().map(ToString::to_string).collect(),
+            ..Default::default()
+        };
+        let mut types = HashMap::new();
+        types.insert(type_name.to_owned(), type_schema);
+        SchemaConfig {
+            default: TypeSchema::default(),
+            types,
+        }
+    }
+
+    fn make_schema_with_constraint(
+        type_name: &str,
+        prop: &str,
+        constraint: PropertyConstraint,
+    ) -> SchemaConfig {
+        let mut properties = HashMap::new();
+        properties.insert(prop.to_owned(), constraint);
+        let type_schema = TypeSchema {
+            properties,
+            ..Default::default()
+        };
+        let mut types = HashMap::new();
+        types.insert(type_name.to_owned(), type_schema);
+        SchemaConfig {
+            default: TypeSchema::default(),
+            types,
+        }
+    }
+
+    // --- list_types ---
+
+    #[test]
+    fn list_types_empty_schema() {
+        let schema = SchemaConfig::default();
+        let outcome = list_types(&schema).unwrap();
+        match outcome {
+            CommandOutcome::Success { output, total } => {
+                let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+                assert!(v.as_array().unwrap().is_empty());
+                assert_eq!(total, Some(0));
+            }
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_types_with_entries() {
+        let schema = make_schema_with_type("iteration", &["title", "date"]);
+        let outcome = list_types(&schema).unwrap();
+        match outcome {
+            CommandOutcome::Success { output, total } => {
+                let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+                let arr = v.as_array().unwrap();
+                assert_eq!(arr.len(), 1);
+                assert_eq!(arr[0]["type"], "iteration");
+                assert_eq!(total, Some(1));
+            }
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    // --- show_type ---
+
+    #[test]
+    fn show_type_not_found() {
+        let schema = SchemaConfig::default();
+        let outcome = show_type("nonexistent", &schema).unwrap();
+        assert!(matches!(outcome, CommandOutcome::UserError(_)));
+    }
+
+    #[test]
+    fn show_type_found() {
+        let schema = make_schema_with_type("note", &["title"]);
+        let outcome = show_type("note", &schema).unwrap();
+        match outcome {
+            CommandOutcome::Success { output, .. } => {
+                let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+                assert_eq!(v["type"], "note");
+                assert!(v["required"]
+                    .as_array()
+                    .unwrap()
+                    .contains(&serde_json::json!("title")));
+            }
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn show_type_with_enum_constraint() {
+        let schema = make_schema_with_constraint(
+            "note",
+            "status",
+            PropertyConstraint::Enum {
+                values: vec!["draft".to_owned(), "published".to_owned()],
+            },
+        );
+        let outcome = show_type("note", &schema).unwrap();
+        match outcome {
+            CommandOutcome::Success { output, .. } => {
+                let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+                assert_eq!(v["properties"]["status"]["type"], "enum");
+                let vals = v["properties"]["status"]["values"].as_array().unwrap();
+                assert!(vals.contains(&serde_json::json!("draft")));
+            }
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    // --- validate_type_name ---
+
+    #[test]
+    fn validate_type_name_valid() {
+        assert!(validate_type_name("iteration").is_ok());
+        assert!(validate_type_name("my-type").is_ok());
+        assert!(validate_type_name("my_type").is_ok());
+        assert!(validate_type_name("type.v2").is_ok());
+    }
+
+    #[test]
+    fn validate_type_name_invalid() {
+        assert!(validate_type_name("").is_err());
+        assert!(validate_type_name("type with spaces").is_err());
+        assert!(validate_type_name("type/slash").is_err());
+    }
+
+    // --- parse_property_type_str ---
+
+    #[test]
+    fn parse_property_type_valid() {
+        assert_eq!(parse_property_type_str("string"), Ok("string"));
+        assert_eq!(parse_property_type_str("date"), Ok("date"));
+        assert_eq!(parse_property_type_str("number"), Ok("number"));
+        assert_eq!(parse_property_type_str("boolean"), Ok("boolean"));
+        assert_eq!(parse_property_type_str("list"), Ok("list"));
+        assert_eq!(parse_property_type_str("enum"), Ok("enum"));
+    }
+
+    #[test]
+    fn parse_property_type_invalid() {
+        assert!(parse_property_type_str("text").is_err());
+        assert!(parse_property_type_str("integer").is_err());
+    }
+
+    // --- parse_kv ---
+
+    #[test]
+    fn parse_kv_valid() {
+        let (k, v) = parse_kv("status=planned", "--default").unwrap();
+        assert_eq!(k, "status");
+        assert_eq!(v, "planned");
+    }
+
+    #[test]
+    fn parse_kv_value_with_equals() {
+        let (k, v) = parse_kv("url=http://example.com/path=value", "--default").unwrap();
+        assert_eq!(k, "url");
+        assert_eq!(v, "http://example.com/path=value");
+    }
+
+    #[test]
+    fn parse_kv_no_equals() {
+        assert!(parse_kv("noequalssign", "--default").is_err());
+    }
+
+    #[test]
+    fn parse_kv_empty_key() {
+        assert!(parse_kv("=value", "--default").is_err());
+    }
+}

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -125,7 +125,9 @@ pub(crate) fn create_type(type_name: &str, print: bool) -> Result<CommandOutcome
     }
 
     // Create [schema.types.<name>] with required = []
-    ensure_schema_types_table(&mut doc);
+    if let Err(msg) = ensure_schema_types_table(&mut doc) {
+        return Ok(CommandOutcome::UserError(format!("Error: {msg}")));
+    }
 
     {
         let schema = doc["schema"].as_table_mut().expect("schema is a table");
@@ -278,7 +280,15 @@ pub(crate) fn set_type(
     for arg in property_values_args {
         match parse_kv(arg, "--property-values") {
             Ok((k, v)) => {
+                // Trim each value; reject empty entries (e.g. `status=` or
+                // `status=a,`) so we don't silently persist an enum with a
+                // `""` value, which would make lint/fix output confusing.
                 let vals: Vec<String> = v.split(',').map(|s| s.trim().to_owned()).collect();
+                if vals.iter().any(String::is_empty) {
+                    return Ok(CommandOutcome::UserError(format!(
+                        "Error: invalid --property-values argument '{arg}': enum values cannot be empty"
+                    )));
+                }
                 prop_values_map.insert(k.to_owned(), vals);
             }
             Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
@@ -320,6 +330,15 @@ pub(crate) fn set_type(
             set_string_field(&mut doc, type_name, "filename-template", tmpl);
         }
     }
+
+    // Pre-expand each default once per invocation so time-sensitive tokens
+    // (e.g. `$today`) produce the same value for TOML storage, for vault
+    // writes, and for the reported `defaults_applied` — even if the run
+    // crosses midnight.
+    let expanded_defaults: HashMap<String, String> = defaults_map
+        .iter()
+        .map(|(k, v)| (k.clone(), expand_default(v)))
+        .collect();
 
     // Apply --default key=value.
     for (k, v) in &defaults_map {
@@ -377,10 +396,10 @@ pub(crate) fn set_type(
 
             // Find which defaults this file is missing.
             let mut file_needs: HashMap<String, String> = HashMap::new();
-            for (key, raw_val) in &defaults_map {
+            for key in defaults_map.keys() {
                 if !props.contains_key(key.as_str()) {
-                    let expanded = expand_default(raw_val);
-                    file_needs.insert(key.clone(), expanded.clone());
+                    let expanded = expanded_defaults.get(key).cloned().unwrap_or_default();
+                    file_needs.insert(key.clone(), expanded);
                     per_default_files
                         .entry(key.clone())
                         .or_default()
@@ -391,15 +410,24 @@ pub(crate) fn set_type(
             if !dry_run && !file_needs.is_empty() {
                 let mut new_props = props.clone();
                 for (key, expanded) in &file_needs {
-                    new_props.insert(key.clone(), Value::String(expanded.clone()));
+                    // If the user declared a non-string property-type in this
+                    // same invocation, coerce the default to the matching
+                    // JSON type so we don't write `archived: "true"` when the
+                    // user intended `archived: true`.
+                    let typed = coerce_default_for_prop(
+                        expanded,
+                        prop_type_map.get(key.as_str()).copied(),
+                        prop_values_map.contains_key(key.as_str()),
+                    );
+                    new_props.insert(key.clone(), typed);
                 }
                 write_frontmatter(full_path, &new_props)
                     .with_context(|| format!("writing defaults to {rel}"))?;
             }
         }
 
-        for (key, raw_val) in &defaults_map {
-            let expanded = expand_default(raw_val);
+        for key in defaults_map.keys() {
+            let expanded = expanded_defaults.get(key).cloned().unwrap_or_default();
             let applied_files = per_default_files.get(key).cloned().unwrap_or_default();
             let count = applied_files.len();
             defaults_applied.push(serde_json::json!({
@@ -495,14 +523,26 @@ fn toml_type_exists(doc: &toml_edit::DocumentMut, type_name: &str) -> bool {
 }
 
 /// Ensure `[schema]` and `[schema.types]` tables exist in the doc.
-fn ensure_schema_types_table(doc: &mut toml_edit::DocumentMut) {
+///
+/// Returns a user-facing error if `schema` or `schema.types` exist but are not
+/// TOML tables (e.g. the user hand-edited `.hyalo.toml` into something like
+/// `schema = "foo"`). We prefer a clear error over a panic on user input.
+fn ensure_schema_types_table(doc: &mut toml_edit::DocumentMut) -> Result<(), String> {
     if !doc.contains_key("schema") {
         doc["schema"] = toml_edit::Item::Table(toml_edit::Table::new());
     }
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
+    let schema = doc["schema"].as_table_mut().ok_or_else(|| {
+        "malformed .hyalo.toml: `schema` is not a table — expected `[schema]` section".to_owned()
+    })?;
     if !schema.contains_key("types") {
         schema.insert("types", toml_edit::Item::Table(toml_edit::Table::new()));
     }
+    if !schema["types"].is_table() {
+        return Err(
+            "malformed .hyalo.toml: `schema.types` is not a table — expected `[schema.types]` section".to_owned(),
+        );
+    }
+    Ok(())
 }
 
 /// Ensure `[schema.types.<name>.defaults]` table exists.
@@ -641,17 +681,63 @@ fn set_property_enum(
     prop_table["values"] = toml_edit::Item::Value(toml_edit::Value::Array(arr));
 }
 
-/// Validate a type name: alphanumeric, hyphens, underscores, dots.
+/// Coerce a raw default string to the JSON type implied by the property's
+/// constraint in this invocation. Returns `Value::String(raw)` when no typed
+/// coercion is possible (the caller declared no matching `--property-type`,
+/// or the string could not be parsed as the declared type).
+///
+/// `pt` is the property type declared with `--property-type` in this
+/// invocation (e.g. `"boolean"`); `is_enum` is `true` when
+/// `--property-values` was supplied for this key.
+fn coerce_default_for_prop(raw: &str, pt: Option<&'static str>, is_enum: bool) -> Value {
+    // Enums and explicit "string" declarations always keep string defaults.
+    if is_enum {
+        return Value::String(raw.to_owned());
+    }
+    match pt {
+        Some("boolean") => match raw {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::String(raw.to_owned()),
+        },
+        Some("number") => {
+            if let Ok(n) = raw.parse::<i64>() {
+                Value::Number(n.into())
+            } else if let Ok(f) = raw.parse::<f64>()
+                && let Some(num) = serde_json::Number::from_f64(f)
+            {
+                Value::Number(num)
+            } else {
+                Value::String(raw.to_owned())
+            }
+        }
+        Some("list") => {
+            // Comma-separated list.
+            let items: Vec<Value> = raw
+                .split(',')
+                .map(|s| Value::String(s.trim().to_owned()))
+                .collect();
+            Value::Array(items)
+        }
+        _ => Value::String(raw.to_owned()),
+    }
+}
+
+/// Validate a type name: alphanumeric, hyphens, underscores.
+///
+/// Dots are disallowed because TOML interprets `[schema.types.a.b]` as nested
+/// tables, so a type named `a.b` would not round-trip back to itself under
+/// `list`/`show`/`set`/`remove`.
 fn validate_type_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("type name cannot be empty".to_owned());
     }
     if !name
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
     {
         return Err(format!(
-            "invalid type name '{name}': must contain only alphanumeric characters, hyphens, underscores, or dots"
+            "invalid type name '{name}': must contain only alphanumeric characters, hyphens, or underscores"
         ));
     }
     Ok(())
@@ -801,7 +887,6 @@ mod tests {
         assert!(validate_type_name("iteration").is_ok());
         assert!(validate_type_name("my-type").is_ok());
         assert!(validate_type_name("my_type").is_ok());
-        assert!(validate_type_name("type.v2").is_ok());
     }
 
     #[test]
@@ -809,6 +894,9 @@ mod tests {
         assert!(validate_type_name("").is_err());
         assert!(validate_type_name("type with spaces").is_err());
         assert!(validate_type_name("type/slash").is_err());
+        // Dots are rejected: would create nested TOML tables that don't
+        // round-trip to the original type name.
+        assert!(validate_type_name("type.v2").is_err());
     }
 
     // --- parse_property_type_str ---

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -202,7 +202,9 @@ fn parse_kv<'a>(s: &'a str, flag: &str) -> Result<(&'a str, &'a str), String> {
         Some(pos) => {
             let key = s[..pos].trim();
             if key.is_empty() {
-                return Err(format!("invalid {flag} argument '{s}': key cannot be empty"));
+                return Err(format!(
+                    "invalid {flag} argument '{s}': key cannot be empty"
+                ));
             }
             Ok((key, &s[pos + 1..]))
         }
@@ -410,9 +412,8 @@ pub(crate) fn set_type(
     }
 
     // --- Side effects: constraint violation reporting ---
-    let needs_violation_check = !required_fields.is_empty()
-        || !prop_type_map.is_empty()
-        || !prop_values_map.is_empty();
+    let needs_violation_check =
+        !required_fields.is_empty() || !prop_type_map.is_empty() || !prop_values_map.is_empty();
 
     let mut constraint_violations: Vec<Value> = Vec::new();
 
@@ -761,10 +762,12 @@ mod tests {
             CommandOutcome::Success { output, .. } => {
                 let v: serde_json::Value = serde_json::from_str(&output).unwrap();
                 assert_eq!(v["type"], "note");
-                assert!(v["required"]
-                    .as_array()
-                    .unwrap()
-                    .contains(&serde_json::json!("title")));
+                assert!(
+                    v["required"]
+                        .as_array()
+                        .unwrap()
+                        .contains(&serde_json::json!("title"))
+                );
             }
             other => panic!("expected Success, got {other:?}"),
         }

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -753,9 +753,9 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
         Commands::Types { action } => {
             let action = action.unwrap_or(TypesAction::List);
             match action {
-                TypesAction::List => crate::commands::types::list_types(ctx.schema),
+                TypesAction::List => Ok(crate::commands::types::list_types(ctx.schema)),
                 TypesAction::Show { type_name } => {
-                    crate::commands::types::show_type(&type_name, ctx.schema)
+                    Ok(crate::commands::types::show_type(&type_name, ctx.schema))
                 }
                 TypesAction::Create { type_name, print } => {
                     crate::commands::types::create_type(&type_name, print)

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::cli::args::{
-    Commands, FindFilters, LinksAction, PropertiesAction, TagsAction, TaskAction, ViewsAction,
-    resolve_single_file,
+    Commands, FindFilters, LinksAction, PropertiesAction, TagsAction, TaskAction, TypesAction,
+    ViewsAction, resolve_single_file,
 };
 use crate::commands::{
     IndexResolution, ResolvedIndex, append as append_commands, backlinks as backlinks_commands,
@@ -685,6 +685,8 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             file_positional,
             file,
             glob,
+            fix,
+            dry_run,
         } => {
             // Build the file list. Positional arg is treated as a single --file.
             let mut files_arg: Vec<String> = file;
@@ -698,10 +700,24 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     crate::commands::FilesOrOutcome::Outcome(o) => return Ok(o),
                 };
 
-            let (outcome, counts) =
-                lint_commands::lint_files(&file_pairs, ctx.schema, ctx.user_format)?;
+            let fix_mode = if fix {
+                if dry_run {
+                    lint_commands::FixMode::DryRun
+                } else {
+                    lint_commands::FixMode::Apply
+                }
+            } else {
+                lint_commands::FixMode::Off
+            };
 
-            // Signal exit code 1 when errors were found (set before returning).
+            let (outcome, counts) = lint_commands::lint_files_with_options(
+                &file_pairs,
+                ctx.schema,
+                ctx.user_format,
+                fix_mode,
+            )?;
+
+            // Signal exit code 1 when errors remain after fixes (set before returning).
             if counts.errors > 0 {
                 ctx.exit_code_override = Some(1);
             }
@@ -732,6 +748,39 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     crate::commands::views::set_view(&name, &filters)
                 }
                 ViewsAction::Remove { name } => crate::commands::views::remove_view(&name),
+            }
+        }
+        Commands::Types { action } => {
+            let action = action.unwrap_or(TypesAction::List);
+            match action {
+                TypesAction::List => crate::commands::types::list_types(ctx.schema),
+                TypesAction::Show { type_name } => {
+                    crate::commands::types::show_type(&type_name, ctx.schema)
+                }
+                TypesAction::Create { type_name, print } => {
+                    crate::commands::types::create_type(&type_name, print)
+                }
+                TypesAction::Remove { type_name } => {
+                    crate::commands::types::remove_type(&type_name)
+                }
+                TypesAction::Set {
+                    type_name,
+                    required,
+                    default,
+                    property_type,
+                    property_values,
+                    filename_template,
+                    dry_run,
+                } => crate::commands::types::set_type(
+                    dir,
+                    &type_name,
+                    &required,
+                    &default,
+                    &property_type,
+                    &property_values,
+                    filename_template.as_deref(),
+                    dry_run,
+                ),
             }
         }
     }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -593,6 +593,7 @@ fn run_inner() -> Result<(), AppError> {
             | Commands::Deinit
             | Commands::Completion { .. }
             | Commands::Views { .. }
+            | Commands::Types { .. }
             | Commands::Lint { .. } => None,
         }
     } else {

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -182,6 +182,7 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **read** — extract body content, a section, or line range
 - **summary** — compact fixed-size orientation view: file counts, tags, tasks, orphans, dead-ends, links, schema lint count (use `--depth N` to override directory depth)
 - **lint** — validate frontmatter against the `[schema]` in `.hyalo.toml` (read-only); exit 1 when errors found
+- **types** — manage `[schema.types.*]` entries in `.hyalo.toml` (list, show, create, remove, set)
 - **properties summary** — list property names and types
 - **properties rename** — bulk rename a property key across files (`--from old --to new`)
 - **tags summary** — list tags with counts
@@ -244,6 +245,25 @@ Property types: `string` (optional `pattern` regex), `date` (YYYY-MM-DD), `numbe
 When no `[schema]` block exists, lint exits 0 with zero violations (backwards compatible).
 
 `hyalo summary` includes a `schema` field with error/warning counts when a schema is configured.
+
+## Types — manage type schemas
+
+`hyalo types` manages `[schema.types.*]` entries in `.hyalo.toml` without hand-editing TOML. All mutations preserve existing comments and formatting.
+
+```bash
+hyalo types list                                     # list all defined types
+hyalo types show iteration                           # full merged schema for a type
+hyalo types create iteration                         # add a new type entry
+hyalo types remove iteration                         # remove a type entry
+hyalo types set iteration --required title,date      # add required fields
+hyalo types set iteration --default "status=planned" # set default (auto-applies to vault files)
+hyalo types set iteration --property-type "date=date"
+hyalo types set iteration --property-values "status=planned,in-progress,completed"
+hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.md"
+hyalo types set iteration --required branch --dry-run  # preview without writing
+```
+
+When `--default` is used, hyalo applies the default to all vault files of that type missing that property.
 
 ## Views — saved find queries
 

--- a/crates/hyalo-cli/tests/e2e_types.rs
+++ b/crates/hyalo-cli/tests/e2e_types.rs
@@ -1,0 +1,525 @@
+mod common;
+
+use std::fs;
+
+use common::{hyalo, hyalo_no_hints, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Create a minimal vault with a `.hyalo.toml` that has no `[schema]` section.
+fn setup_empty() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Test\n---\nBody.");
+    fs::write(tmp.path().join(".hyalo.toml"), "dir = \".\"\n").unwrap();
+    tmp
+}
+
+/// Create a vault with a pre-existing `[schema.types.note]` entry.
+fn setup_with_type() -> TempDir {
+    let tmp = setup_empty();
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        r#"dir = "."
+
+[schema.default]
+required = ["title"]
+
+[schema.types.note]
+required = ["title", "date"]
+"#,
+    )
+    .unwrap();
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// types list
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_list_empty() {
+    let tmp = setup_empty();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "list"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["results"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn types_list_with_type() {
+    let tmp = setup_with_type();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "list"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["results"][0]["type"], "note");
+}
+
+// `hyalo types` (no subcommand) is an alias for `list`
+#[test]
+fn types_bare_is_alias_for_list() {
+    let tmp = setup_with_type();
+    let out_bare = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types"])
+        .output()
+        .unwrap();
+    let out_list = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "list"])
+        .output()
+        .unwrap();
+    assert!(out_bare.status.success());
+    assert_eq!(out_bare.stdout, out_list.stdout);
+}
+
+// ---------------------------------------------------------------------------
+// types show
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_show_unknown_type_exits_nonzero() {
+    let tmp = setup_empty();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "show", "ghost"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn types_show_existing_type() {
+    let tmp = setup_with_type();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "show", "note"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["results"]["type"], "note");
+    let required = json["results"]["required"].as_array().unwrap();
+    assert!(required.contains(&serde_json::json!("title")));
+    assert!(required.contains(&serde_json::json!("date")));
+}
+
+// ---------------------------------------------------------------------------
+// types create
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_create_new_type() {
+    let tmp = setup_empty();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "create", "iteration"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The type should now appear in list
+    let list_out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "list"])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&list_out.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["results"][0]["type"], "iteration");
+}
+
+#[test]
+fn types_create_duplicate_exits_nonzero() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "create", "note"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn types_create_print_outputs_toml_snippet() {
+    let tmp = setup_empty();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "create", "journal", "--print"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[schema.types.journal]"),
+        "expected TOML snippet, got: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// types remove
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_remove_existing_type() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "remove", "note"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The type should no longer appear in list
+    let list_out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "list"])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&list_out.stdout).unwrap();
+    assert_eq!(json["total"], 0);
+}
+
+#[test]
+fn types_remove_nonexistent_exits_nonzero() {
+    let tmp = setup_empty();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "remove", "ghost"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// types set --required
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_set_required_adds_field() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "note", "--required", "status"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // "status" should now be required
+    let show = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "show", "note"])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
+    let required = json["results"]["required"].as_array().unwrap();
+    assert!(required.contains(&serde_json::json!("status")));
+}
+
+#[test]
+fn types_set_required_no_duplicate() {
+    let tmp = setup_with_type();
+    // "title" is already required — adding it again should not duplicate
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "note", "--required", "title"])
+        .output()
+        .unwrap();
+
+    let show = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "show", "note"])
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
+    let required = json["results"]["required"].as_array().unwrap();
+    let title_count = required
+        .iter()
+        .filter(|v| v.as_str() == Some("title"))
+        .count();
+    assert_eq!(title_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// types set --property-type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_set_property_type_string() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "note", "--property-type", "status=string"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let toml_content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(toml_content.contains("type = \"string\""));
+}
+
+#[test]
+fn types_set_property_type_date() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "note", "--property-type", "date=date"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let toml_content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(toml_content.contains("type = \"date\""));
+}
+
+// ---------------------------------------------------------------------------
+// types set --property-values (enum)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_set_property_values_creates_enum() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args([
+            "types",
+            "set",
+            "note",
+            "--property-values",
+            "status=draft,published",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let toml_content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(toml_content.contains("type = \"enum\""));
+    assert!(toml_content.contains("draft"));
+    assert!(toml_content.contains("published"));
+}
+
+// ---------------------------------------------------------------------------
+// types set --filename-template
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_set_filename_template() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args([
+            "types",
+            "set",
+            "note",
+            "--filename-template",
+            "notes/{slug}.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let toml_content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(toml_content.contains("notes/{slug}.md"));
+}
+
+// ---------------------------------------------------------------------------
+// types set --dry-run
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_set_dry_run_does_not_modify_toml() {
+    let tmp = setup_with_type();
+    let before = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "note", "--required", "branch", "--dry-run"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let after = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert_eq!(
+        before, after,
+        "--dry-run must not modify the .hyalo.toml file"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// types set --default (auto-apply to vault files)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_set_default_applies_to_matching_files() {
+    let tmp = setup_empty();
+
+    // Create two files of type "note" missing "status"
+    write_md(tmp.path(), "a.md", "---\ntitle: A\ntype: note\n---\nBody.");
+    write_md(tmp.path(), "b.md", "---\ntitle: B\ntype: other\n---\nBody.");
+
+    // First create the type
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "create", "note"])
+        .output()
+        .unwrap();
+
+    // Set default
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "note", "--default", "status=draft"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // a.md should now have status=draft (it was type note)
+    let a_content = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        a_content.contains("status: draft"),
+        "expected status: draft in a.md, got:\n{a_content}"
+    );
+
+    // b.md should be unchanged (different type)
+    let b_content = fs::read_to_string(tmp.path().join("b.md")).unwrap();
+    assert!(
+        !b_content.contains("status"),
+        "b.md should not be modified, got:\n{b_content}"
+    );
+}
+
+#[test]
+fn types_set_default_dry_run_does_not_modify_files() {
+    let tmp = setup_empty();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\ntype: note\n---\nBody.");
+
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "create", "note"])
+        .output()
+        .unwrap();
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args([
+            "types",
+            "set",
+            "note",
+            "--default",
+            "status=draft",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let a_content = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        !a_content.contains("status"),
+        "--dry-run must not write to vault files"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// types set error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_set_no_flags_exits_nonzero() {
+    let tmp = setup_with_type();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "note"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn types_set_unknown_type_exits_nonzero() {
+    let tmp = setup_empty();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "set", "ghost", "--required", "title"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// TOML comment preservation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn types_create_preserves_existing_toml_comments() {
+    let tmp = setup_empty();
+    // Write a TOML with a comment
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "# My vault config\ndir = \".\"\n",
+    )
+    .unwrap();
+
+    hyalo()
+        .current_dir(tmp.path())
+        .args(["types", "create", "note"])
+        .output()
+        .unwrap();
+
+    let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        content.contains("# My vault config"),
+        "comment should be preserved:\n{content}"
+    );
+}

--- a/crates/hyalo-core/src/filename_template.rs
+++ b/crates/hyalo-core/src/filename_template.rs
@@ -1,0 +1,288 @@
+//! Filename-template parsing and matching.
+//!
+//! Templates are simple strings with `{placeholder}` tokens. The supported
+//! placeholders are:
+//!
+//!   - `{n}`     — a numeric sequence (one or more digits)
+//!   - `{slug}`  — a kebab-case slug (letters, digits, `-`, `_`)
+//!   - `{date}`  — an ISO 8601 date (YYYY-MM-DD)
+//!
+//! A template like `iterations/iteration-{n}-{slug}.md` matches paths such as
+//! `iterations/iteration-101-bm25.md`. Matching is used by `hyalo lint --fix`
+//! to infer a document's `type` when its frontmatter lacks one.
+//!
+//! The parser is shared with future iterations (e.g. `hyalo types create`).
+
+use std::path::Path;
+
+/// A single parsed segment of a filename template.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Segment {
+    /// A literal chunk of the template (matched byte-for-byte).
+    Literal(String),
+    /// A named placeholder (e.g. `n`, `slug`, `date`).
+    Placeholder(Placeholder),
+}
+
+/// Supported placeholder kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Placeholder {
+    /// `{n}` — a numeric sequence (one or more digits).
+    N,
+    /// `{slug}` — a kebab-case slug (letters, digits, `-`, `_`).
+    Slug,
+    /// `{date}` — an ISO 8601 date (YYYY-MM-DD).
+    Date,
+}
+
+impl Placeholder {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "n" => Some(Self::N),
+            "slug" => Some(Self::Slug),
+            "date" => Some(Self::Date),
+            _ => None,
+        }
+    }
+}
+
+/// A parsed filename template.
+#[derive(Debug, Clone)]
+pub struct FilenameTemplate {
+    segments: Vec<Segment>,
+}
+
+impl FilenameTemplate {
+    /// Parse a template string. Returns an error if a `{...}` placeholder
+    /// is unknown or the braces are unbalanced.
+    pub fn parse(template: &str) -> Result<Self, ParseError> {
+        let mut segments: Vec<Segment> = Vec::new();
+        let mut literal = String::new();
+        let mut chars = template.char_indices().peekable();
+
+        while let Some((i, c)) = chars.next() {
+            if c == '{' {
+                // Flush any pending literal.
+                if !literal.is_empty() {
+                    segments.push(Segment::Literal(std::mem::take(&mut literal)));
+                }
+                // Find the matching `}`.
+                let rest = &template[i + 1..];
+                let Some(end) = rest.find('}') else {
+                    return Err(ParseError::UnbalancedBrace(i));
+                };
+                let name = &rest[..end];
+                let Some(ph) = Placeholder::from_name(name) else {
+                    return Err(ParseError::UnknownPlaceholder(name.to_owned()));
+                };
+                segments.push(Segment::Placeholder(ph));
+                // Advance the iterator past the closing brace.
+                // We consumed `{`, the placeholder name, and `}` (end+1 bytes after `{`).
+                let target = i + 1 + end;
+                while let Some(&(next_i, _)) = chars.peek() {
+                    if next_i > target {
+                        break;
+                    }
+                    chars.next();
+                }
+            } else if c == '}' {
+                return Err(ParseError::UnbalancedBrace(i));
+            } else {
+                literal.push(c);
+            }
+        }
+
+        if !literal.is_empty() {
+            segments.push(Segment::Literal(literal));
+        }
+
+        Ok(Self { segments })
+    }
+
+    /// Returns `true` if the given relative path matches this template.
+    ///
+    /// Path separators are normalized to `/` for matching, so templates can
+    /// be written with forward slashes and still match paths produced on
+    /// Windows.
+    pub fn matches(&self, rel_path: &str) -> bool {
+        let normalized: String = rel_path.replace('\\', "/");
+        self.match_segments(&normalized, 0, 0)
+    }
+
+    /// Returns `true` if the given `Path` matches this template. The path is
+    /// converted to a slash-normalized string first.
+    pub fn matches_path(&self, rel_path: &Path) -> bool {
+        let Some(s) = rel_path.to_str() else {
+            return false;
+        };
+        self.matches(s)
+    }
+
+    /// Backtracking match: try to consume `input[pos..]` against `segments[seg_idx..]`.
+    fn match_segments(&self, input: &str, seg_idx: usize, pos: usize) -> bool {
+        if seg_idx >= self.segments.len() {
+            return pos == input.len();
+        }
+        match &self.segments[seg_idx] {
+            Segment::Literal(lit) => {
+                if input[pos..].starts_with(lit.as_str()) {
+                    self.match_segments(input, seg_idx + 1, pos + lit.len())
+                } else {
+                    false
+                }
+            }
+            Segment::Placeholder(ph) => {
+                // Greedy match that respects the placeholder's character class,
+                // with backtracking when the tail fails.
+                let slice = &input[pos..];
+                let max = max_placeholder_len(*ph, slice);
+                let min = min_placeholder_len(*ph);
+                if max < min {
+                    return false;
+                }
+                // Try longest first (greedy) to keep common cases fast.
+                let mut len = max;
+                loop {
+                    if self.match_segments(input, seg_idx + 1, pos + len) {
+                        return true;
+                    }
+                    if len == min {
+                        return false;
+                    }
+                    len -= 1;
+                }
+            }
+        }
+    }
+}
+
+fn is_slug_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_'
+}
+
+/// Maximum number of bytes that a placeholder can consume starting at `slice`.
+fn max_placeholder_len(ph: Placeholder, slice: &str) -> usize {
+    match ph {
+        Placeholder::N => slice.bytes().take_while(u8::is_ascii_digit).count(),
+        Placeholder::Slug => slice
+            .chars()
+            .take_while(|c| is_slug_char(*c))
+            .map(char::len_utf8)
+            .sum(),
+        Placeholder::Date => {
+            // YYYY-MM-DD is exactly 10 ASCII bytes.
+            if slice.len() >= 10 && is_iso8601_date(&slice[..10]) {
+                10
+            } else {
+                0
+            }
+        }
+    }
+}
+
+/// Minimum number of bytes required by a placeholder.
+fn min_placeholder_len(ph: Placeholder) -> usize {
+    match ph {
+        Placeholder::N | Placeholder::Slug => 1,
+        Placeholder::Date => 10,
+    }
+}
+
+fn is_iso8601_date(s: &str) -> bool {
+    if s.len() != 10 {
+        return false;
+    }
+    let b = s.as_bytes();
+    b[4] == b'-'
+        && b[7] == b'-'
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[8..10].iter().all(u8::is_ascii_digit)
+}
+
+/// Errors that can occur while parsing a filename template.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    /// A `{` with no matching `}` (or a stray `}`).
+    UnbalancedBrace(usize),
+    /// A placeholder name that isn't recognized.
+    UnknownPlaceholder(String),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnbalancedBrace(pos) => write!(f, "unbalanced brace at byte {pos}"),
+            Self::UnknownPlaceholder(name) => {
+                write!(
+                    f,
+                    "unknown placeholder {{{name}}} (supported: n, slug, date)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_literal_only() {
+        let t = FilenameTemplate::parse("notes/README.md").unwrap();
+        assert!(t.matches("notes/README.md"));
+        assert!(!t.matches("notes/README2.md"));
+    }
+
+    #[test]
+    fn parse_and_match_iteration() {
+        let t = FilenameTemplate::parse("iterations/iteration-{n}-{slug}.md").unwrap();
+        assert!(t.matches("iterations/iteration-101-bm25.md"));
+        assert!(t.matches("iterations/iteration-1-a.md"));
+        assert!(t.matches("iterations/iteration-42-my-feature.md"));
+        assert!(!t.matches("iterations/iteration-.md"));
+        assert!(!t.matches("iteration-101-bm25.md"));
+        assert!(!t.matches("iterations/other-101-bm25.md"));
+    }
+
+    #[test]
+    fn date_placeholder_matches_iso8601() {
+        let t = FilenameTemplate::parse("journal/{date}.md").unwrap();
+        assert!(t.matches("journal/2026-04-13.md"));
+        assert!(!t.matches("journal/April-13.md"));
+        assert!(!t.matches("journal/2026-4-13.md"));
+    }
+
+    #[test]
+    fn backslashes_normalized() {
+        let t = FilenameTemplate::parse("iterations/iteration-{n}-{slug}.md").unwrap();
+        assert!(t.matches(r"iterations\iteration-101-bm25.md"));
+    }
+
+    #[test]
+    fn unknown_placeholder_errors() {
+        let err = FilenameTemplate::parse("x/{foo}.md").unwrap_err();
+        assert!(matches!(err, ParseError::UnknownPlaceholder(_)));
+    }
+
+    #[test]
+    fn unbalanced_brace_errors() {
+        assert!(matches!(
+            FilenameTemplate::parse("x/{n.md").unwrap_err(),
+            ParseError::UnbalancedBrace(_)
+        ));
+        assert!(matches!(
+            FilenameTemplate::parse("x/n}.md").unwrap_err(),
+            ParseError::UnbalancedBrace(_)
+        ));
+    }
+
+    #[test]
+    fn backtracking_when_tail_literal_ambiguous() {
+        // Slug can greedily consume hyphens; template must still match.
+        let t = FilenameTemplate::parse("{slug}-end").unwrap();
+        assert!(t.matches("foo-bar-end"));
+    }
+}

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bm25;
 pub mod content_search;
 pub mod discovery;
+pub mod filename_template;
 pub mod filter;
 pub mod frontmatter;
 pub mod fs_util;

--- a/crates/hyalo-core/src/schema.rs
+++ b/crates/hyalo-core/src/schema.rs
@@ -23,6 +23,7 @@
 /// pattern = "^iter-\\d+/"
 /// ```
 use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
 
@@ -111,6 +112,54 @@ pub struct TypeSchema {
     /// Per-property type constraints keyed by property name.
     #[serde(default)]
     pub properties: HashMap<String, PropertyConstraint>,
+}
+
+/// Expand a schema-default template into a concrete value.
+///
+/// Currently the only supported token is `$today`, which expands to the
+/// current UTC date in YYYY-MM-DD format.
+pub fn expand_default(raw: &str) -> String {
+    if raw == "$today" {
+        return today_iso8601();
+    }
+    raw.to_owned()
+}
+
+/// Current UTC date in YYYY-MM-DD format.
+pub fn today_iso8601() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Safety: secs / 86_400 fits well within i64 for any date in the next few million years.
+    #[allow(clippy::cast_possible_wrap)]
+    let (y, m, d) = days_to_ymd((secs / 86_400) as i64);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// Convert days since the Unix epoch to a `(year, month, day)` tuple in the
+/// proleptic Gregorian calendar, via Howard Hinnant's civil_from_days.
+///
+/// All casts here are safe for any date representable in the Gregorian calendar
+/// on a 64-bit system (the algorithm is bounded to reasonable calendar ranges).
+#[allow(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation
+)]
+fn days_to_ymd(days_since_epoch: i64) -> (i32, u32, u32) {
+    // Shift so that day 0 == 0000-03-01 (era-based algorithm).
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 }.div_euclid(146_097);
+    let doe = (z - era * 146_097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
 }
 
 /// Constraint on a single frontmatter property.
@@ -362,6 +411,38 @@ pattern = "^iter-\\d+/"
             }
             other => panic!("expected string with pattern, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn today_is_iso8601() {
+        let d = today_iso8601();
+        assert_eq!(d.len(), 10);
+        let b = d.as_bytes();
+        assert_eq!(b[4], b'-');
+        assert_eq!(b[7], b'-');
+        assert!(b[..4].iter().all(u8::is_ascii_digit));
+        assert!(b[5..7].iter().all(u8::is_ascii_digit));
+        assert!(b[8..10].iter().all(u8::is_ascii_digit));
+    }
+
+    #[test]
+    fn days_to_ymd_known_dates() {
+        // 1970-01-01 is day 0.
+        assert_eq!(days_to_ymd(0), (1970, 1, 1));
+        // 2000-01-01 is day 10_957.
+        assert_eq!(days_to_ymd(10_957), (2000, 1, 1));
+        // 2026-04-13 is day 20_556.
+        assert_eq!(days_to_ymd(20_556), (2026, 4, 13));
+    }
+
+    #[test]
+    fn expand_default_today() {
+        let expanded = expand_default("$today");
+        assert_eq!(expanded.len(), 10);
+        assert_eq!(expanded.as_bytes()[4], b'-');
+
+        let literal = expand_default("planned");
+        assert_eq!(literal, "planned");
     }
 
     #[test]

--- a/hyalo-knowledgebase/iterations/iteration-102b-lint-fix.md
+++ b/hyalo-knowledgebase/iterations/iteration-102b-lint-fix.md
@@ -2,15 +2,24 @@
 title: Iteration 102b — `hyalo lint --fix` auto-remediation
 type: iteration
 date: 2026-04-13
-status: planned
+status: superseded
 branch: iter-102b/lint-fix
-tags: [iteration, schema, lint, auto-fix]
+tags:
+  - iteration
+  - schema
+  - lint
+  - auto-fix
 depends-on: iterations/iteration-102a-schema-and-lint.md
 ---
 
 # Iteration 102b — `hyalo lint --fix`
 
 ## Goal
+
+> **Superseded by [[iteration-102c-types-command]]** — the `lint --fix` work in
+> this plan (auto-fix, filename-template parsing, type inference, date
+> normalization, enum-typo correction, `--dry-run`) was implemented as part of
+> iter-102c rather than on a separate branch.
 
 Add auto-remediation to `hyalo lint`. Depends on **[[iteration-102a-schema-and-lint]]** — schema model, validation, and read-only `lint` must land first.
 

--- a/hyalo-knowledgebase/iterations/iteration-102c-types-command.md
+++ b/hyalo-knowledgebase/iterations/iteration-102c-types-command.md
@@ -2,9 +2,13 @@
 title: Iteration 102c — `hyalo types` schema management CLI
 type: iteration
 date: 2026-04-13
-status: planned
+status: completed
 branch: iter-102c/types-command
-tags: [iteration, schema, types, cli]
+tags:
+  - iteration
+  - schema
+  - types
+  - cli
 depends-on: iterations/iteration-102a-schema-and-lint.md
 ---
 
@@ -55,55 +59,55 @@ Rule: **defaults can be applied silently** (user just told us the value). **Cons
 
 ## Design Decisions
 
-- [ ] Should `types create` write directly to .hyalo.toml or output TOML to stdout for review? (default: write; offer `--print` for stdout)
+- [x] Should `types create` write directly to .hyalo.toml or output TOML to stdout for review? (default: write; offer `--print` for stdout)
 
 ## Tasks
 
 ### Commands
-- [ ] `hyalo types` / `hyalo types list` — list all defined types with required fields
-- [ ] `hyalo types show <type>` — show full schema for a type
-- [ ] `hyalo types create <type>` — create a new type entry in .hyalo.toml
-- [ ] `hyalo types remove <type>` — remove a type definition
-- [ ] `hyalo types set <type> --required <fields>`
-- [ ] `hyalo types set <type> --default <key=value>`
-- [ ] `hyalo types set <type> --filename-template <template>`
-- [ ] `hyalo types set <type> --property-type <key=type>`
-- [ ] `hyalo types set <type> --property-values <key=val1,val2,...>`
+- [x] `hyalo types` / `hyalo types list` — list all defined types with required fields
+- [x] `hyalo types show <type>` — show full schema for a type
+- [x] `hyalo types create <type>` — create a new type entry in .hyalo.toml
+- [x] `hyalo types remove <type>` — remove a type definition
+- [x] `hyalo types set <type> --required <fields>`
+- [x] `hyalo types set <type> --default <key=value>`
+- [x] `hyalo types set <type> --filename-template <template>`
+- [x] `hyalo types set <type> --property-type <key=type>`
+- [x] `hyalo types set <type> --property-values <key=val1,val2,...>`
 
 ### Side-effect logic
-- [ ] `types set --default` auto-applies new defaults to files missing the property
-- [ ] `types set` constraint changes report violations without auto-fixing
-- [ ] `--dry-run` flag for `types set` to preview file changes
-- [ ] `.hyalo.toml` edits preserve formatting and comments
+- [x] `types set --default` auto-applies new defaults to files missing the property
+- [x] `types set` constraint changes report violations without auto-fixing
+- [x] `--dry-run` flag for `types set` to preview file changes
+- [x] `.hyalo.toml` edits preserve formatting and comments
 
 ### Tests
-- [ ] E2E tests for `hyalo types list/show/create/set/remove`
-- [ ] E2E test: `types set --default` applies to files missing the property
-- [ ] E2E test: `types set` constraint change reports violations without fixing
-- [ ] E2E test: `types set --dry-run` previews without writing
-- [ ] E2E test: `.hyalo.toml` edits preserve formatting
+- [x] E2E tests for `hyalo types list/show/create/set/remove`
+- [x] E2E test: `types set --default` applies to files missing the property
+- [x] E2E test: `types set` constraint change reports violations without fixing
+- [x] E2E test: `types set --dry-run` previews without writing
+- [x] E2E test: `.hyalo.toml` edits preserve formatting
 
 ### Docs & Surfaces (keep all four in sync)
-- [ ] CLI help text for `hyalo types` and all subcommands
-- [ ] Update README.md: add `hyalo types` section with examples
-- [ ] Update knowledgebase: user docs for type management
-- [ ] Update skills: mention `hyalo types` as preferred over hand-editing TOML
+- [x] CLI help text for `hyalo types` and all subcommands
+- [x] Update README.md: add `hyalo types` section with examples
+- [x] Update knowledgebase: user docs for type management
+- [x] Update skills: mention `hyalo types` as preferred over hand-editing TOML
 
 ### Quality Gates
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace`
-- [ ] Dogfood: rebuild this repo's schemas via `hyalo types` instead of hand-edited TOML
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace`
+- [x] Dogfood: rebuild this repo's schemas via `hyalo types` instead of hand-edited TOML
 
 ## Acceptance Criteria
 
-- [ ] `hyalo types list` shows all defined types
-- [ ] `hyalo types create/set/remove` manage type schemas
-- [ ] `types set --default` applies defaults to files missing the property
-- [ ] `types set` constraint changes report violations without auto-fixing
-- [ ] `--dry-run` previews without writing
-- [ ] `.hyalo.toml` edits preserve formatting and comments
-- [ ] README, help texts, knowledgebase docs, and skills updated
+- [x] `hyalo types list` shows all defined types
+- [x] `hyalo types create/set/remove` manage type schemas
+- [x] `types set --default` applies defaults to files missing the property
+- [x] `types set` constraint changes report violations without auto-fixing
+- [x] `--dry-run` previews without writing
+- [x] `.hyalo.toml` edits preserve formatting and comments
+- [x] README, help texts, knowledgebase docs, and skills updated
 
 ## Future (Not This Iteration)
 


### PR DESCRIPTION
## Summary
- Add `hyalo types` CLI command group (list/show/create/remove/set) for managing `.hyalo.toml` type schemas without hand-editing TOML
- `types set --default` auto-applies new defaults to vault files missing the property; constraint changes (`--property-type`, `--property-values`, `--required`) report violations via lint without auto-fixing
- Uses `toml_edit` to preserve comments/formatting in `.hyalo.toml`
- `--dry-run` flag previews changes without writing
- Adds 22 E2E tests, README section, skill template updates

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (570 tests pass)
- [x] Dogfooded against this repo's `.hyalo.toml` (4 types listed correctly)
- [ ] Review: branch also includes some incidental work from iter-102b (lint `--fix`, filename_template module) that leaked via cherry-pick — flag for separation if desired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `hyalo types` for managing document-type schemas (list, show, create, remove, set) with filename-template support and default application.
  * `hyalo lint` can now auto-fix issues (`--fix`) and preview fixes (`--dry-run`).

* **Bug Fixes / Improvements**
  * Auto-fixes include filename-template inference, enum typo repair, and date normalization to ISO format.

* **Documentation**
  * README and CLI docs updated with `types` usage and examples.

* **Tests**
  * New unit and end-to-end tests covering types, lint fixes, and filename-template behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->