### PR TITLE
iter-110: Default output limits for all list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Most flags have short aliases for quick interactive use:
 | `-s` | `--section` | find, read |
 | `-f` | `--file` | find, read, set, remove, append, task, backlinks, mv |
 | `-g` | `--glob` | find, set, remove, append, properties summary, properties rename, tags summary, tags rename, summary, links fix |
-| `-n` | `--limit` | find, lint |
+| `-n` | `--limit` | find, lint, tags summary, properties summary, backlinks |
 | `-n` | `--recent` | summary |
 | `-l` | `--lines` | read |
 | `-l` | `--line` | task read, task toggle, task set |
@@ -107,15 +107,18 @@ Place a `.hyalo.toml` file in your working directory to set defaults for global 
 
 ```toml
 # .hyalo.toml
-dir = "./my-vault"   # default: "."
-format = "text"      # default: "json"
-hints = false        # default: true (set to false to suppress drill-down hints)
-site_prefix = "docs" # override auto-derived prefix for absolute link resolution
+dir = "./my-vault"     # default: "."
+format = "text"        # default: "json"
+hints = false          # default: true (set to false to suppress drill-down hints)
+site_prefix = "docs"   # override auto-derived prefix for absolute link resolution
+default_limit = 100    # default: 50 (max results for list commands; 0 = unlimited)
 ```
 
 All fields are optional. CLI flags always take precedence over config values. If `.hyalo.toml` is missing, hyalo silently uses built-in defaults; if the file is present but cannot be read or is malformed/invalid, hyalo warns on stderr and falls back to the built-in defaults.
 
 Use `--no-hints` to explicitly disable hints when the config file enables them.
+
+**Default output limits:** List commands (`find`, `lint`, `tags summary`, `properties summary`, `backlinks`) return at most 50 results by default. When results are truncated, the output shows "showing N of M matches" and a hint to get all results. Use `--limit 0` for unlimited output, or set `default_limit` in `.hyalo.toml` to change the project-wide default.
 
 ### Absolute link resolution (site prefix)
 
@@ -347,6 +350,7 @@ Subcommand group for property operations.
 # Aggregate summary of unique property names with inferred types and file counts
 hyalo properties summary
 hyalo properties summary --glob "notes/*.md"
+hyalo properties summary --limit 0              # show all (default: 50)
 
 # Bulk rename a property key across all files
 hyalo properties rename --from old-key --to new-key
@@ -361,6 +365,7 @@ Subcommand group for tag operations.
 # Aggregate summary of unique tags with file counts
 hyalo tags summary
 hyalo tags summary --glob "notes/*.md"
+hyalo tags summary --limit 0                    # show all (default: 50)
 
 # Bulk rename a tag across all files
 hyalo tags rename --from old-tag --to new-tag
@@ -463,6 +468,7 @@ Reverse link lookup — find all files that link to a given file. Scans all `.md
 
 ```sh
 hyalo backlinks --file path/to/note.md
+hyalo backlinks --file path/to/note.md --limit 0   # show all (default: 50)
 ```
 
 **JSON output** (default):

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -10,13 +10,8 @@ pub(crate) fn is_false(v: &bool) -> bool {
 }
 
 pub(crate) fn parse_limit(s: &str) -> Result<usize, String> {
-    let n: usize = s
-        .parse()
-        .map_err(|_| format!("'{s}' is not a valid number"))?;
-    if n == 0 {
-        return Err("limit must be at least 1".to_owned());
-    }
-    Ok(n)
+    s.parse()
+        .map_err(|_| format!("'{s}' is not a valid number"))
 }
 
 /// Value parser for `--threshold`: accepts a `f64` in `[0.0, 1.0]`.
@@ -218,7 +213,7 @@ pub(crate) struct FindFilters {
     #[arg(long)]
     #[serde(skip_serializing_if = "is_false")]
     pub reverse: bool,
-    /// Maximum number of results to return (must be at least 1)
+    /// Maximum number of results to return (0 = unlimited)
     #[arg(short = 'n', long, value_parser = parse_limit)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
@@ -462,6 +457,9 @@ pub(crate) enum Commands {
         /// Target file to find backlinks for (relative to --dir) — flag form
         #[arg(short, long, value_name = "FILE", conflicts_with = "file_positional")]
         file: Option<String>,
+        /// Maximum number of backlinks to return (0 = unlimited, default: 50)
+        #[arg(short = 'n', long, value_parser = parse_limit)]
+        limit: Option<usize>,
     },
     /// Move/rename a file and update all inbound and outbound links
     #[command(
@@ -1053,6 +1051,9 @@ pub(crate) enum PropertiesAction {
         /// Glob pattern(s) to select files (repeatable); prefix '!' to negate
         #[arg(short, long)]
         glob: Vec<String>,
+        /// Maximum number of results to return (0 = unlimited, default: 50)
+        #[arg(short = 'n', long, value_parser = parse_limit)]
+        limit: Option<usize>,
     },
     /// Rename a property key across all matched files
     #[command(
@@ -1085,6 +1086,9 @@ pub(crate) enum TagsAction {
         /// Glob pattern(s) to filter which files to scan, relative to --dir (repeatable); prefix '!' to negate
         #[arg(short, long)]
         glob: Vec<String>,
+        /// Maximum number of results to return (0 = unlimited, default: 50)
+        #[arg(short = 'n', long, value_parser = parse_limit)]
+        limit: Option<usize>,
     },
     /// Rename a tag across all matched files
     #[command(long_about = "Rename a tag across all matched files.\n\n\

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -58,11 +58,11 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
     hyalo append -p/--property K=V [-p ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...]
 
   Properties (subcommand group):
-    hyalo properties summary [-g/--glob G]                        Unique property names, types, and file counts (read-only)
+    hyalo properties summary [-g/--glob G] [-n/--limit N]         Unique property names, types, and file counts (read-only)
     hyalo properties rename --from OLD --to NEW [-g/--glob G]     Rename a property key across files (mutates files)
 
   Tags (subcommand group):
-    hyalo tags summary [-g/--glob G]                              Unique tags with file counts (read-only)
+    hyalo tags summary [-g/--glob G] [-n/--limit N]               Unique tags with file counts (read-only)
     hyalo tags rename --from OLD --to NEW [-g/--glob G]           Rename a tag across files (mutates files)
 
   Summary (vault overview, read-only):
@@ -74,7 +74,7 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
     hyalo task set        -f/--file F -l/--line N -s/--status C
 
   Backlinks (reverse link lookup, read-only):
-    hyalo backlinks -f/--file F
+    hyalo backlinks -f/--file F [-n/--limit N]
 
   Links (link operations):
     hyalo links fix [--apply] [--threshold T] [-g/--glob G] [--ignore-target S ...]   Detect and fix broken links (default: dry-run)
@@ -113,6 +113,11 @@ pub(crate) const HELP_LONG: &str = "COMMAND REFERENCE:
     --site-prefix <PREFIX>  Override site prefix for absolute link resolution (auto-derived from --dir)
     --index[=PATH]          Use pre-built snapshot index (default: .hyalo-index in vault dir)
     -q/--quiet              Suppress all warnings to stderr
+
+  Default output limits:
+    List commands (find, lint, tags summary, properties summary, backlinks) return
+    at most 50 results by default. Use --limit 0 for unlimited output.
+    Override the default in .hyalo.toml:  default_limit = 100
 
 COOKBOOK:
   # Discover what metadata exists in a vault

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -21,11 +21,13 @@ struct BacklinkItem {
 ///
 /// `dir` is still needed to resolve the `file_arg` to a vault-relative path via
 /// `discovery::resolve_file`. Link lookup is done against `index.link_graph()`.
+/// `limit` caps how many backlink entries are returned (`None` = no cap).
 pub fn backlinks(
     index: &dyn VaultIndex,
     file_arg: &str,
     dir: &Path,
     format: Format,
+    limit: Option<usize>,
 ) -> Result<CommandOutcome> {
     // Resolve the file argument to a relative path (same as in `backlinks`)
     let (_full_path, rel) = match discovery::resolve_file(dir, file_arg) {
@@ -43,7 +45,8 @@ pub fn backlinks(
         .filter(|e| !is_self_link(e, &rel))
         .collect();
 
-    let items: Vec<BacklinkItem> = entries
+    let total = entries.len() as u64;
+    let mut items: Vec<BacklinkItem> = entries
         .iter()
         .map(|e| BacklinkItem {
             source: e.source.to_string_lossy().replace('\\', "/"),
@@ -53,7 +56,9 @@ pub fn backlinks(
         })
         .collect();
 
-    let total = items.len() as u64;
+    if let Some(n) = limit {
+        items.truncate(n);
+    }
     let result = serde_json::json!({ "file": rel, "backlinks": items });
     Ok(CommandOutcome::success_with_total(
         serde_json::to_string_pretty(&result).context("failed to serialize")?,

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -46,8 +46,10 @@ pub fn backlinks(
         .collect();
 
     let total = entries.len() as u64;
-    let mut items: Vec<BacklinkItem> = entries
+    let take_n = limit.filter(|n| *n > 0).unwrap_or(usize::MAX);
+    let items: Vec<BacklinkItem> = entries
         .iter()
+        .take(take_n)
         .map(|e| BacklinkItem {
             source: e.source.to_string_lossy().replace('\\', "/"),
             line: e.line,
@@ -55,10 +57,6 @@ pub fn backlinks(
             label: e.link.label.clone(),
         })
         .collect();
-
-    if let Some(n) = limit {
-        items.truncate(n);
-    }
     let result = serde_json::json!({ "file": rel, "backlinks": items });
     Ok(CommandOutcome::success_with_total(
         serde_json::to_string_pretty(&result).context("failed to serialize")?,

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -53,7 +53,7 @@ pub fn properties_summary(
     result.sort_by(|a, b| a.name.cmp(&b.name).then(a.prop_type.cmp(&b.prop_type)));
 
     let total = result.len() as u64;
-    if let Some(n) = limit {
+    if let Some(n) = limit.filter(|n| *n > 0) {
         result.truncate(n);
     }
     let _ = format;

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -14,10 +14,12 @@ use serde::Serialize;
 ///
 /// `file_filter` is an optional list of vault-relative paths to include.
 /// When `None` (or an empty slice), all index entries are used.
+/// `limit` caps how many entries are returned (`None` = no cap).
 pub fn properties_summary(
     index: &dyn VaultIndex,
     file_filter: Option<&[String]>,
     format: Format,
+    limit: Option<usize>,
 ) -> Result<CommandOutcome> {
     let mut agg: std::collections::BTreeMap<(String, String), usize> =
         std::collections::BTreeMap::new();
@@ -51,6 +53,9 @@ pub fn properties_summary(
     result.sort_by(|a, b| a.name.cmp(&b.name).then(a.prop_type.cmp(&b.prop_type)));
 
     let total = result.len() as u64;
+    if let Some(n) = limit {
+        result.truncate(n);
+    }
     let _ = format;
     Ok(CommandOutcome::success_with_total(
         serde_json::to_string_pretty(&result).context("failed to serialize")?,
@@ -202,7 +207,7 @@ mod tests {
             },
         )?;
         let file_filter: Option<Vec<String>> = file.map(|f| vec![f.to_owned()]);
-        properties_summary(&build.index, file_filter.as_deref(), format)
+        properties_summary(&build.index, file_filter.as_deref(), format, None)
     }
 
     fn setup_dir() -> tempfile::TempDir {

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -53,10 +53,12 @@ pub fn validate_tag(name: &str) -> Result<(), String> {
 ///
 /// `file_filter` is an optional list of vault-relative paths to include.
 /// When `None` (or an empty slice), all index entries are used.
+/// `limit` caps how many entries are returned (`None` = no cap).
 pub fn tags_summary(
     index: &dyn VaultIndex,
     file_filter: Option<&[String]>,
     format: Format,
+    limit: Option<usize>,
 ) -> Result<CommandOutcome> {
     // Aggregate case-insensitively: use lowercase key, preserve first-seen casing for display
     let mut counts: BTreeMap<String, (String, usize)> = BTreeMap::new();
@@ -78,12 +80,15 @@ pub fn tags_summary(
         }
     }
 
-    let tags: Vec<TagSummaryEntry> = counts
+    let mut tags: Vec<TagSummaryEntry> = counts
         .into_iter()
         .map(|(_, (name, count))| TagSummaryEntry { name, count })
         .collect();
 
     let total = tags.len() as u64;
+    if let Some(n) = limit {
+        tags.truncate(n);
+    }
     let _ = format; // format is applied by the output pipeline
     Ok(CommandOutcome::success_with_total(
         serde_json::to_string_pretty(&tags).context("failed to serialize")?,
@@ -268,7 +273,7 @@ mod tests {
             },
         )?;
         let file_filter: Option<Vec<String>> = file.map(|f| vec![f.to_owned()]);
-        tags_summary(&build.index, file_filter.as_deref(), format)
+        tags_summary(&build.index, file_filter.as_deref(), format, None)
     }
 
     macro_rules! md {

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -86,7 +86,7 @@ pub fn tags_summary(
         .collect();
 
     let total = tags.len() as u64;
-    if let Some(n) = limit {
+    if let Some(n) = limit.filter(|n| *n > 0) {
         tags.truncate(n);
     }
     let _ = format; // format is applied by the output pipeline

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -39,6 +39,8 @@ struct ConfigFile {
     /// the deeply nested schema structure.
     #[serde(default)]
     schema: Option<toml::Value>,
+    /// Default output limit for list commands (0 = unlimited).
+    default_limit: Option<usize>,
 }
 
 /// Resolved configuration with all defaults applied.
@@ -53,6 +55,11 @@ pub(crate) struct ResolvedDefaults {
     pub(crate) search_language: Option<String>,
     /// Parsed schema configuration from `[schema.*]` sections.
     pub(crate) schema: SchemaConfig,
+    /// Default output limit for list commands.
+    /// `None` = use hardcoded default (50).
+    /// `Some(0)` = unlimited.
+    /// `Some(n)` = limit to n.
+    pub(crate) default_limit: Option<usize>,
 }
 
 impl PartialEq for ResolvedDefaults {
@@ -64,6 +71,7 @@ impl PartialEq for ResolvedDefaults {
             && self.hints == other.hints
             && self.site_prefix == other.site_prefix
             && self.search_language == other.search_language
+            && self.default_limit == other.default_limit
     }
 }
 
@@ -76,6 +84,7 @@ impl ResolvedDefaults {
             site_prefix: None,
             search_language: None,
             schema: SchemaConfig::default(),
+            default_limit: None,
         }
     }
 }
@@ -133,6 +142,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         site_prefix: cfg.site_prefix,
         search_language: cfg.search.and_then(|s| s.language),
         schema,
+        default_limit: cfg.default_limit,
     }
 }
 

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -19,6 +19,10 @@ use hyalo_core::filter;
 use hyalo_core::index::{ScanOptions, SnapshotIndex, VaultIndex as _};
 use hyalo_core::schema::SchemaConfig;
 
+/// Default output limit for list commands when no `--limit` is passed and no
+/// `default_limit` is set in `.hyalo.toml`.
+pub(crate) const DEFAULT_OUTPUT_LIMIT: usize = 50;
+
 /// Shared context for command dispatch.
 pub(crate) struct CommandContext<'a> {
     pub dir: &'a Path,
@@ -38,6 +42,31 @@ pub(crate) struct CommandContext<'a> {
     /// (e.g. `lint` returns 1 when errors are found). The output pipeline uses this
     /// to override its own exit code calculation.
     pub exit_code_override: Option<i32>,
+    /// Default output limit from `.hyalo.toml` (`default_limit`).
+    /// `None` = use `DEFAULT_OUTPUT_LIMIT`.
+    /// `Some(0)` = unlimited.
+    /// `Some(n)` = limit to n.
+    pub config_default_limit: Option<usize>,
+}
+
+/// Resolve the effective limit for a list command.
+///
+/// Precedence (highest first):
+/// 1. `cli_limit = Some(n)` — user passed `--limit n` (0 = unlimited → returns `None`)
+/// 2. `config_default` = `Some(n)` from `.hyalo.toml` (0 = unlimited → returns `None`)
+/// 3. `DEFAULT_OUTPUT_LIMIT` — hard-coded fallback
+///
+/// Returns `None` for unlimited, `Some(n)` for an effective cap.
+fn resolve_limit(cli_limit: Option<usize>, config_default: Option<usize>) -> Option<usize> {
+    match cli_limit {
+        Some(0) => None, // explicit --limit 0 = unlimited
+        Some(n) => Some(n),
+        None => match config_default {
+            Some(0) => None, // config default_limit = 0 = unlimited
+            Some(n) => Some(n),
+            None => Some(DEFAULT_OUTPUT_LIMIT),
+        },
+    }
 }
 
 /// Parse `--where-property` filters and validate `--where-tag` names.
@@ -235,7 +264,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     &parsed_fields,
                     sort_field.as_ref(),
                     reverse,
-                    limit,
+                    resolve_limit(limit, ctx.config_default_limit),
                     broken_links,
                     orphan,
                     dead_end,
@@ -269,9 +298,15 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             )
         }
         Commands::Properties { action } => {
-            let action = action.unwrap_or(PropertiesAction::Summary { glob: vec![] });
+            let action = action.unwrap_or(PropertiesAction::Summary {
+                glob: vec![],
+                limit: None,
+            });
             match action {
-                PropertiesAction::Summary { ref glob } => match resolve_index(
+                PropertiesAction::Summary {
+                    ref glob,
+                    limit: cli_limit,
+                } => match resolve_index(
                     snapshot_index.as_ref(),
                     dir,
                     &[],
@@ -298,12 +333,22 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                                 } else {
                                     Some(paths.as_slice())
                                 };
-                                properties::properties_summary(idx, file_filter, effective_format)
+                                properties::properties_summary(
+                                    idx,
+                                    file_filter,
+                                    effective_format,
+                                    resolve_limit(cli_limit, ctx.config_default_limit),
+                                )
                             }
                         }
                     }
                     IndexResolution::Resolved(ResolvedIndex::Scanned(build)) => {
-                        properties::properties_summary(&build.index, None, effective_format)
+                        properties::properties_summary(
+                            &build.index,
+                            None,
+                            effective_format,
+                            resolve_limit(cli_limit, ctx.config_default_limit),
+                        )
                     }
                     IndexResolution::Outcome(outcome) => Ok(outcome),
                 },
@@ -319,9 +364,15 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             }
         }
         Commands::Tags { action } => {
-            let action = action.unwrap_or(TagsAction::Summary { glob: vec![] });
+            let action = action.unwrap_or(TagsAction::Summary {
+                glob: vec![],
+                limit: None,
+            });
             match action {
-                TagsAction::Summary { ref glob } => match resolve_index(
+                TagsAction::Summary {
+                    ref glob,
+                    limit: cli_limit,
+                } => match resolve_index(
                     snapshot_index.as_ref(),
                     dir,
                     &[],
@@ -348,12 +399,22 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                                 } else {
                                     Some(paths.as_slice())
                                 };
-                                tag_commands::tags_summary(idx, file_filter, effective_format)
+                                tag_commands::tags_summary(
+                                    idx,
+                                    file_filter,
+                                    effective_format,
+                                    resolve_limit(cli_limit, ctx.config_default_limit),
+                                )
                             }
                         }
                     }
                     IndexResolution::Resolved(ResolvedIndex::Scanned(build)) => {
-                        tag_commands::tags_summary(&build.index, None, effective_format)
+                        tag_commands::tags_summary(
+                            &build.index,
+                            None,
+                            effective_format,
+                            resolve_limit(cli_limit, ctx.config_default_limit),
+                        )
                     }
                     IndexResolution::Outcome(outcome) => Ok(outcome),
                 },
@@ -581,6 +642,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
         Commands::Backlinks {
             file_positional,
             file,
+            limit: cli_limit,
         } => {
             let file = match resolve_single_file(file_positional, file) {
                 Ok(f) => f,
@@ -600,9 +662,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     default_language: None,
                 },
             )? {
-                IndexResolution::Resolved(resolved) => {
-                    backlinks_commands::backlinks(resolved.as_index(), &file, dir, effective_format)
-                }
+                IndexResolution::Resolved(resolved) => backlinks_commands::backlinks(
+                    resolved.as_index(),
+                    &file,
+                    dir,
+                    effective_format,
+                    resolve_limit(cli_limit, ctx.config_default_limit),
+                ),
                 IndexResolution::Outcome(outcome) => Ok(outcome),
             }
         }
@@ -687,7 +753,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             glob,
             fix,
             dry_run,
-            limit,
+            limit: cli_limit,
         } => {
             // Build the file list. Positional arg is treated as a single --file.
             let mut files_arg: Vec<String> = file;
@@ -711,8 +777,12 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 lint_commands::FixMode::Off
             };
 
-            let (outcome, counts) =
-                lint_commands::lint_files_with_options(&file_pairs, ctx.schema, fix_mode, limit)?;
+            let (outcome, counts) = lint_commands::lint_files_with_options(
+                &file_pairs,
+                ctx.schema,
+                fix_mode,
+                resolve_limit(cli_limit, ctx.config_default_limit),
+            )?;
 
             // Signal exit code 1 when errors remain after fixes (set before returning).
             if counts.errors > 0 {

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -140,25 +140,33 @@ impl HintContext {
 
 /// Generate concrete drill-down hints from a command's JSON output.
 ///
+/// `total` is the real count of items (may exceed the number of items in `data`
+/// when output was truncated by a limit). `None` means the command doesn't
+/// produce a list with a total.
+///
 /// Returns at most [`MAX_HINTS`] [`Hint`]s, each with a human-readable description
 /// and an executable `hyalo` command (`cmd`).
 #[must_use]
-pub fn generate_hints(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+pub fn generate_hints(
+    ctx: &HintContext,
+    data: &serde_json::Value,
+    total: Option<u64>,
+) -> Vec<Hint> {
     let hints = match &ctx.source {
         HintSource::Summary => hints_for_summary(ctx, data),
-        HintSource::PropertiesSummary => hints_for_properties_summary(ctx, data),
-        HintSource::TagsSummary => hints_for_tags_summary(ctx, data),
-        HintSource::Find => hints_for_find(ctx, data),
+        HintSource::PropertiesSummary => hints_for_properties_summary(ctx, data, total),
+        HintSource::TagsSummary => hints_for_tags_summary(ctx, data, total),
+        HintSource::Find => hints_for_find(ctx, data, total),
         HintSource::Set | HintSource::Remove | HintSource::Append => hints_for_mutation(ctx, data),
         HintSource::Read => hints_for_read(ctx, data),
-        HintSource::Backlinks => hints_for_backlinks(ctx, data),
+        HintSource::Backlinks => hints_for_backlinks(ctx, data, total),
         HintSource::Mv => hints_for_mv(ctx, data),
         HintSource::TaskRead => hints_for_task_read(ctx, data),
         HintSource::TaskToggle | HintSource::TaskSetStatus => hints_for_task_mutation(ctx, data),
         HintSource::LinksFix => hints_for_links_fix(ctx, data),
         HintSource::CreateIndex => hints_for_create_index(ctx, data),
         HintSource::DropIndex => hints_for_drop_index(ctx, data),
-        HintSource::Lint => hints_for_lint(ctx, data),
+        HintSource::Lint => hints_for_lint(ctx, data, total),
         HintSource::Types { .. } => hints_for_types(ctx, data),
     };
     hints.into_iter().take(MAX_HINTS).collect()
@@ -530,10 +538,30 @@ fn hints_for_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     hints
 }
 
-fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+fn hints_for_properties_summary(
+    ctx: &HintContext,
+    data: &serde_json::Value,
+    total: Option<u64>,
+) -> Vec<Hint> {
     let Some(arr) = data.as_array() else {
         return vec![];
     };
+
+    let mut hints = Vec::new();
+
+    // When output was truncated by the default limit (not an explicit --limit), suggest
+    // showing all results.
+    if !ctx.has_limit {
+        let shown = arr.len() as u64;
+        if let Some(t) = total
+            && shown < t
+        {
+            hints.push(Hint::new(
+                format!("Show all {t} properties (no limit)"),
+                build_command_with_glob(ctx, &["properties", "--limit", "0"]),
+            ));
+        }
+    }
 
     // Sort by count descending, take top 3.
     let mut entries: Vec<(&str, u64)> = arr
@@ -549,16 +577,17 @@ fn hints_for_properties_summary(ctx: &HintContext, data: &serde_json::Value) -> 
         .collect();
     entries.sort_by(|a, b| b.1.cmp(&a.1));
 
-    entries
-        .into_iter()
-        .take(3)
-        .map(|(name, count)| {
-            Hint::new(
-                format!("Find {count} files with property: {name}"),
-                build_command_with_glob(ctx, &["find", "--property", name]),
-            )
-        })
-        .collect()
+    for (name, count) in entries.into_iter().take(3) {
+        if hints.len() >= MAX_HINTS {
+            break;
+        }
+        hints.push(Hint::new(
+            format!("Find {count} files with property: {name}"),
+            build_command_with_glob(ctx, &["find", "--property", name]),
+        ));
+    }
+
+    hints
 }
 
 /// Slugify a string to the charset valid for view names: `[a-z0-9_-]`.
@@ -662,7 +691,7 @@ fn suggest_save_as_view(ctx: &HintContext) -> Option<Hint> {
     Some(Hint::new("Save this query as a view", cmd))
 }
 
-fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+fn hints_for_find(ctx: &HintContext, data: &serde_json::Value, total: Option<u64>) -> Vec<Hint> {
     // find returns a bare array as the raw command output (the envelope is built later).
     let Some(results) = data.as_array() else {
         return vec![];
@@ -770,6 +799,20 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         ));
     }
 
+    // --- Show-all hint when default limit truncated output ---
+    if !ctx.has_limit
+        && let Some(t) = total
+        && (result_count as u64) < t
+    {
+        let remaining = MAX_HINTS.saturating_sub(hints.len());
+        if remaining > 0 {
+            hints.push(Hint::new(
+                format!("Show all {t} results (no limit)"),
+                build_find_command_preserving_filters(ctx, &["--limit", "0"]),
+            ));
+        }
+    }
+
     // --- Narrowing for many results (>5) ---
     if result_count > 5 {
         // Tag narrowing (skip tags already filtered on).
@@ -862,8 +905,8 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
             }
         }
 
-        // Limit suggestion (only if not already limited).
-        if !ctx.has_limit {
+        // Limit suggestion: suggest --limit 10 when not truncated and no explicit limit.
+        if !ctx.has_limit && total.is_none_or(|t| (result_count as u64) >= t) {
             let remaining = MAX_HINTS.saturating_sub(hints.len());
             if remaining > 0 {
                 hints.push(Hint::new(
@@ -933,11 +976,31 @@ fn hints_for_find(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     hints
 }
 
-fn hints_for_tags_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+fn hints_for_tags_summary(
+    ctx: &HintContext,
+    data: &serde_json::Value,
+    total: Option<u64>,
+) -> Vec<Hint> {
     // tags summary returns a bare array [{name, count}, ...].
     let Some(tags_arr) = data.as_array() else {
         return vec![];
     };
+
+    let mut hints = Vec::new();
+
+    // When output was truncated by the default limit (not an explicit --limit), suggest
+    // showing all results.
+    if !ctx.has_limit {
+        let shown = tags_arr.len() as u64;
+        if let Some(t) = total
+            && shown < t
+        {
+            hints.push(Hint::new(
+                format!("Show all {t} tags (no limit)"),
+                build_command_with_glob(ctx, &["tags", "--limit", "0"]),
+            ));
+        }
+    }
 
     // Sort by count descending, take top 3.
     let mut entries: Vec<(&str, u64)> = tags_arr
@@ -953,16 +1016,17 @@ fn hints_for_tags_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hi
         .collect();
     entries.sort_by(|a, b| b.1.cmp(&a.1));
 
-    entries
-        .into_iter()
-        .take(3)
-        .map(|(name, count)| {
-            Hint::new(
-                format!("Find {count} files tagged: {name}"),
-                build_command_with_glob(ctx, &["find", "--tag", name]),
-            )
-        })
-        .collect()
+    for (name, count) in entries.into_iter().take(3) {
+        if hints.len() >= MAX_HINTS {
+            break;
+        }
+        hints.push(Hint::new(
+            format!("Find {count} files tagged: {name}"),
+            build_command_with_glob(ctx, &["find", "--tag", name]),
+        ));
+    }
+
+    hints
 }
 
 fn hints_for_mutation(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
@@ -1009,8 +1073,30 @@ fn hints_for_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     hints
 }
 
-fn hints_for_backlinks(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+fn hints_for_backlinks(
+    ctx: &HintContext,
+    data: &serde_json::Value,
+    total: Option<u64>,
+) -> Vec<Hint> {
     let mut hints = Vec::new();
+
+    // When output was truncated by the default limit (not an explicit --limit), suggest
+    // showing all results.
+    if !ctx.has_limit {
+        let shown = data
+            .get("backlinks")
+            .and_then(|b| b.as_array())
+            .map_or(0, |a| a.len() as u64);
+        if let Some(t) = total
+            && shown < t
+        {
+            let file = data.get("file").and_then(|f| f.as_str()).unwrap_or("");
+            hints.push(Hint::new(
+                format!("Show all {t} backlinks (no limit)"),
+                build_command_with_file(ctx, &["backlinks", "--limit", "0"], file, &[]),
+            ));
+        }
+    }
 
     let file = data.get("file").and_then(|f| f.as_str());
 
@@ -1031,6 +1117,7 @@ fn hints_for_backlinks(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
             .first()
             .and_then(|b| b.get("source"))
             .and_then(|s| s.as_str())
+        && hints.len() < MAX_HINTS
     {
         hints.push(Hint::new(
             format!("Read linking file: {first_source}"),
@@ -1265,8 +1352,24 @@ fn hints_for_drop_index(ctx: &HintContext, _data: &serde_json::Value) -> Vec<Hin
     )]
 }
 
-fn hints_for_lint(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+fn hints_for_lint(ctx: &HintContext, data: &serde_json::Value, _total: Option<u64>) -> Vec<Hint> {
     let mut hints = Vec::new();
+
+    // When output was truncated by the default limit, suggest showing all.
+    let is_limited = data
+        .get("limited")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if !ctx.has_limit && is_limited {
+        let total_violations = data
+            .get("files_with_issues")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        hints.push(Hint::new(
+            format!("Show all {total_violations} files with issues (no limit)"),
+            build_command_with_glob_and_files(ctx, &["lint", "--limit", "0"]),
+        ));
+    }
 
     // When in dry-run mode and there are pending fixes, suggest applying them.
     let is_dry_run = data
@@ -1501,7 +1604,7 @@ mod tests {
             "tasks": {"total": 0, "done": 0},
             "recent_files": []
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(hints.iter().any(|h| {
             h.cmd == "hyalo properties"
                 || (h.cmd.starts_with("hyalo properties ") && h.cmd.contains("--dir "))
@@ -1525,7 +1628,7 @@ mod tests {
             "tasks": {"total": 10, "done": 3},
             "recent_files": []
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("find")
                 && h.cmd.contains("--task")
@@ -1544,7 +1647,7 @@ mod tests {
             "tasks": {"total": 10, "done": 10},
             "recent_files": []
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(!hints.iter().any(|h| h.cmd.contains("--todo")));
     }
 
@@ -1563,7 +1666,7 @@ mod tests {
             "tasks": {"total": 0, "done": 0},
             "recent_files": []
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         // in-progress should appear before completed
         let in_progress_pos = hints.iter().position(|h| h.cmd.contains("in-progress"));
         let completed_pos = hints.iter().position(|h| h.cmd.contains("completed"));
@@ -1590,7 +1693,7 @@ mod tests {
             "tasks": {"total": 5, "done": 1},
             "recent_files": []
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(hints.len() <= MAX_HINTS);
     }
 
@@ -1605,7 +1708,7 @@ mod tests {
             {"name": "tags", "type": "list", "count": 30},
             {"name": "author", "type": "text", "count": 5}
         ]);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert_eq!(hints.len(), 3);
         assert!(hints[0].cmd.contains("title"));
         assert!(hints[1].cmd.contains("status"));
@@ -1617,7 +1720,7 @@ mod tests {
     #[test]
     fn properties_summary_empty_data() {
         let c = ctx(HintSource::PropertiesSummary);
-        let hints = generate_hints(&c, &json!([]));
+        let hints = generate_hints(&c, &json!([]), None);
         assert!(hints.is_empty());
     }
 
@@ -1625,7 +1728,7 @@ mod tests {
     fn properties_summary_propagates_glob() {
         let c = ctx_with_glob(HintSource::PropertiesSummary, "notes/*.md");
         let data = json!([{"name": "status", "type": "text", "count": 5}]);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(hints[0].cmd.contains("--glob"));
         assert!(hints[0].cmd.contains("notes/*.md"));
     }
@@ -1651,7 +1754,7 @@ mod tests {
     #[test]
     fn find_empty_results_no_hints() {
         let c = ctx(HintSource::Find);
-        let hints = generate_hints(&c, &json!([]));
+        let hints = generate_hints(&c, &json!([]), None);
         assert!(hints.is_empty());
     }
 
@@ -1660,7 +1763,7 @@ mod tests {
         let c = ctx(HintSource::Find);
         let items = vec![make_find_item("notes/alpha.md", None, &[])];
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1688,7 +1791,7 @@ mod tests {
             make_find_item("f.md", Some("completed"), &[]),
         ];
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1710,7 +1813,7 @@ mod tests {
             make_find_item("f.md", Some("completed"), &[]),
         ];
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1732,7 +1835,7 @@ mod tests {
             make_find_item("f.md", Some("planned"), &[]),
         ];
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1754,7 +1857,7 @@ mod tests {
             .map(|i| make_find_item(&format!("{i}.md"), Some("planned"), &["rust", "cli"]))
             .collect();
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(hints.len() <= MAX_HINTS);
     }
 
@@ -1768,7 +1871,7 @@ mod tests {
             .map(|i| make_find_item(&format!("{i}.md"), Some("draft"), &["research"]))
             .collect();
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         let sort_hint = hints.iter().find(|h| h.cmd.contains("--sort"));
         assert!(sort_hint.is_some(), "should include a sort hint: {hints:?}");
         let cmd = &sort_hint.unwrap().cmd;
@@ -1790,7 +1893,7 @@ mod tests {
             .map(|i| make_find_item(&format!("{i}.md"), Some("planned"), &["iteration"]))
             .collect();
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         let limit_hint = hints.iter().find(|h| h.cmd.contains("--limit"));
         assert!(
             limit_hint.is_some(),
@@ -1810,7 +1913,7 @@ mod tests {
         let c = ctx_with_dir(HintSource::TagsSummary, "/vault");
         // tags summary returns a bare array [{name, count}, ...]
         let data = json!([{"name": "rust", "count": 5}]);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(hints[0].cmd.contains("--dir"));
         assert!(hints[0].cmd.contains("/vault"));
     }
@@ -1827,7 +1930,7 @@ mod tests {
             "skipped": [],
             "total": 1
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1846,7 +1949,7 @@ mod tests {
     fn read_hints_suggest_metadata_and_backlinks() {
         let c = ctx(HintSource::Read);
         let data = json!({"file": "notes/alpha.md", "content": "Some content"});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1869,7 +1972,7 @@ mod tests {
             "backlinks": [{"source": "a.md", "line": 5, "target": "target"}],
             "total": 1
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1888,7 +1991,7 @@ mod tests {
     fn create_index_hints_suggest_find_and_drop() {
         let c = ctx(HintSource::CreateIndex);
         let data = json!({"path": ".hyalo-index", "files_indexed": 42, "warnings": 0});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1905,7 +2008,7 @@ mod tests {
     fn drop_index_hints_suggest_create() {
         let c = ctx(HintSource::DropIndex);
         let data = json!({"deleted": ".hyalo-index"});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("create-index")),
             "should suggest create-index: {hints:?}"
@@ -1923,7 +2026,7 @@ mod tests {
             "total_files_updated": 0,
             "total_links_updated": 0
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("mv")
                 && h.cmd.contains("new.md")
@@ -1943,7 +2046,7 @@ mod tests {
             "total_files_updated": 0,
             "total_links_updated": 0
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -1963,7 +2066,7 @@ mod tests {
         let c = ctx(HintSource::TaskRead);
         let data =
             json!({"file": "todo.md", "line": 5, "status": " ", "text": "Fix bug", "done": false});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("task toggle")),
             "should suggest toggling undone task: {hints:?}"
@@ -1975,7 +2078,7 @@ mod tests {
         let c = ctx(HintSource::TaskRead);
         let data =
             json!({"file": "todo.md", "line": 5, "status": "x", "text": "Fix bug", "done": true});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             !hints.iter().any(|h| h.cmd.contains("task toggle")),
             "should not suggest toggling already-done task: {hints:?}"
@@ -1991,7 +2094,7 @@ mod tests {
         let c = ctx(HintSource::TaskToggle);
         let data =
             json!({"file": "todo.md", "line": 5, "status": "x", "text": "Fix bug", "done": true});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("find")
                 && h.cmd.contains("--task")
@@ -2010,7 +2113,7 @@ mod tests {
             "applied": false,
             "fixes": []
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("links fix --apply")),
             "should suggest applying fixes: {hints:?}"
@@ -2029,7 +2132,7 @@ mod tests {
             .map(|i| make_find_item(&format!("{i}.md"), Some("completed"), &[]))
             .collect();
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("summary")),
             "broad query should suggest summary: {hints:?}"
@@ -2044,7 +2147,7 @@ mod tests {
             .map(|i| make_find_item(&format!("{i}.md"), Some("completed"), &["rust"]))
             .collect();
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             !hints.iter().any(|h| h.cmd.contains("summary")),
             "filtered query should not suggest summary: {hints:?}"
@@ -2059,7 +2162,7 @@ mod tests {
             .map(|i| make_find_item(&format!("{i}.md"), Some("planned"), &["rust", "cli"]))
             .collect();
         let data = json!(items);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         // Should NOT suggest narrowing by --tag rust (already filtered).
         // Sort/limit hints may legitimately include --tag rust as a preserved filter,
         // so only check narrowing hints (those whose description starts with "Narrow").
@@ -2087,7 +2190,7 @@ mod tests {
             "tasks": {"total": 0, "done": 0},
             "orphans": 0
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("links fix")),
             "summary with broken links should suggest links fix: {hints:?}"
@@ -2110,7 +2213,7 @@ mod tests {
             "tasks": {"total": 0, "done": 0},
             "orphans": 0
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             !hints.iter().any(|h| h.cmd.contains("links fix")),
             "summary without broken links should not suggest links fix: {hints:?}"
@@ -2133,7 +2236,7 @@ mod tests {
             "modified": "2026-01-01T00:00:00Z"
         });
         let data = json!([item]);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("links fix")),
             "find results with broken links should suggest links fix: {hints:?}"
@@ -2155,7 +2258,7 @@ mod tests {
             "modified": "2026-01-01T00:00:00Z"
         });
         let data = json!([item]);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             !hints.iter().any(|h| h.cmd.contains("links fix")),
             "find results without broken links should not suggest links fix: {hints:?}"
@@ -2171,7 +2274,7 @@ mod tests {
             "files": [{"file": "test.md", "violations": [{"severity": "error", "message": "missing required property"}]}],
             "total": 1,
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(!hints.is_empty());
         assert!(
             hints.iter().any(|h| h.cmd.contains("lint --fix")),
@@ -2189,7 +2292,7 @@ mod tests {
             "fixes": [{"file": "test.md", "actions": [{"kind": "insert-default", "property": "status", "new": "draft"}]}],
             "dry_run": true,
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints
                 .iter()
@@ -2202,7 +2305,7 @@ mod tests {
     fn lint_hints_always_suggest_types_list() {
         let c = ctx(HintSource::Lint);
         let data = json!({"files": [], "total": 0});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("types list")),
             "should always suggest types list: {hints:?}"
@@ -2216,7 +2319,7 @@ mod tests {
             "files": [{"file": "test.md", "violations": [{"severity": "error", "message": "x", "type": "iteration"}]}],
             "total": 5,
         });
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(hints.len() <= MAX_HINTS);
     }
 
@@ -2231,7 +2334,7 @@ mod tests {
             {"type": "iteration", "required": ["title"], "has_filename_template": true, "property_count": 3},
             {"type": "note", "required": [], "has_filename_template": false, "property_count": 1},
         ]);
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("types show")),
             "should suggest types show: {hints:?}"
@@ -2248,7 +2351,7 @@ mod tests {
             subcommand: Some("show".to_owned()),
         });
         let data = json!({"type": "iteration", "required": ["title"], "properties": {}});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("lint")),
             "should suggest lint: {hints:?}"
@@ -2265,7 +2368,7 @@ mod tests {
             subcommand: Some("set".to_owned()),
         });
         let data = json!({"type": "iteration", "action": "updated"});
-        let hints = generate_hints(&c, &data);
+        let hints = generate_hints(&c, &data, None);
         assert!(
             hints.iter().any(|h| h.cmd.contains("types show iteration")),
             "should suggest types show for updated type: {hints:?}"

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -55,7 +55,7 @@ impl OutputPipeline<'_> {
 
                 // Generate hints when a context is available.
                 let hints = if let Some(ctx) = self.hint_ctx {
-                    generate_hints(ctx, &value)
+                    generate_hints(ctx, &value, total)
                 } else {
                     Vec::new()
                 };

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -405,17 +405,19 @@ fn run_inner() -> Result<(), AppError> {
                 Some(ctx)
             }
             Commands::Properties {
-                action: Some(crate::cli::args::PropertiesAction::Summary { glob }),
+                action: Some(crate::cli::args::PropertiesAction::Summary { glob, limit }),
             } => {
                 let mut ctx = HintContext::from_common(HintSource::PropertiesSummary, &common);
                 ctx.glob.clone_from(glob);
+                ctx.has_limit = limit.is_some();
                 Some(ctx)
             }
             Commands::Tags {
-                action: Some(crate::cli::args::TagsAction::Summary { glob }),
+                action: Some(crate::cli::args::TagsAction::Summary { glob, limit }),
             } => {
                 let mut ctx = HintContext::from_common(HintSource::TagsSummary, &common);
                 ctx.glob.clone_from(glob);
+                ctx.has_limit = limit.is_some();
                 Some(ctx)
             }
             Commands::Tags { action: None } => {
@@ -531,11 +533,13 @@ fn run_inner() -> Result<(), AppError> {
             Commands::Backlinks {
                 file_positional,
                 file,
+                limit,
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Backlinks, &common);
                 if let Some(f) = file_positional.as_ref().or(file.as_ref()) {
                     ctx.file_targets = vec![f.clone()];
                 }
+                ctx.has_limit = limit.is_some();
                 Some(ctx)
             }
             Commands::Mv {
@@ -620,11 +624,12 @@ fn run_inner() -> Result<(), AppError> {
                 glob,
                 fix: _,
                 dry_run,
-                limit: _,
+                limit,
             } => {
                 let mut ctx = HintContext::from_common(HintSource::Lint, &common);
                 ctx.glob.clone_from(glob);
                 ctx.dry_run = *dry_run;
+                ctx.has_limit = limit.is_some();
                 let mut targets: Vec<String> = file.clone();
                 if let Some(pos) = file_positional {
                     targets.insert(0, pos.clone());
@@ -712,6 +717,7 @@ fn run_inner() -> Result<(), AppError> {
     };
 
     let config_language_owned = config.search_language.clone();
+    let config_default_limit = config.default_limit;
     let schema = config.schema;
     let mut ctx = CommandContext {
         dir: &dir,
@@ -723,6 +729,7 @@ fn run_inner() -> Result<(), AppError> {
         config_language: config_language_owned.as_deref(),
         schema: &schema,
         exit_code_override: None,
+        config_default_limit,
     };
     let result = dispatch(cli.command, &mut ctx);
     let exit_code_override = ctx.exit_code_override;

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -318,8 +318,24 @@ hyalo backlinks iterations/iteration-37-bulk-mutations.md
 hyalo backlinks iterations/iteration-37-bulk-mutations.md --format json
 ```
 
-Supports `--format text` (default, compact) and `--format json`. Useful for impact analysis
-(what depends on this file?), finding orphan pages, and navigating link structure.
+Supports `--format text` (default, compact), `--format json`, and `--limit N` (default: 50,
+use `--limit 0` for all). Useful for impact analysis (what depends on this file?), finding
+orphan pages, and navigating link structure.
+
+## Default output limits
+
+List commands (`find`, `lint`, `tags summary`, `properties summary`, `backlinks`) return at
+most **50 results** by default to avoid flooding the context window. When results are truncated,
+output shows "showing N of M matches" and a hint to get all results.
+
+- `--limit N` — override the default (e.g. `--limit 20` for fewer, `--limit 200` for more)
+- `--limit 0` — unlimited output (returns everything)
+- `--count` — just get the total count without any results
+
+The default can be changed in `.hyalo.toml`:
+```toml
+default_limit = 100   # 0 = unlimited
+```
 
 ## Snapshot index — ALWAYS create for vaults with 500+ files
 

--- a/crates/hyalo-cli/tests/e2e_config.rs
+++ b/crates/hyalo-cli/tests/e2e_config.rs
@@ -3,6 +3,7 @@ mod common;
 use std::fs;
 
 use common::{hyalo, hyalo_no_hints, write_md};
+use serde_json::Value;
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -256,5 +257,212 @@ fn cli_hints_false_overrides_config() {
     assert!(
         hints.is_empty(),
         "hints should be empty when --no-hints overrides config; got: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// default_limit config key
+// ---------------------------------------------------------------------------
+
+/// Write N minimal markdown files named "file-N.md" with a single tag.
+fn write_many_notes(dir: &std::path::Path, count: usize) {
+    for i in 0..count {
+        write_md(
+            dir,
+            &format!("file-{i:03}.md"),
+            &format!("---\ntitle: Note {i}\ntags:\n  - testtag\n---\n"),
+        );
+    }
+}
+
+#[test]
+fn default_limit_applies_to_find() {
+    let tmp = TempDir::new().unwrap();
+    // Write 60 files — more than the hardcoded default of 50.
+    write_many_notes(tmp.path(), 60);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    // Default limit is 50; only 50 results should be shown.
+    assert_eq!(
+        results.len(),
+        50,
+        "expected default limit of 50 results, got {}",
+        results.len()
+    );
+    // Total should report all 60.
+    assert_eq!(json["total"], 60);
+}
+
+#[test]
+fn default_limit_bypassed_with_limit_zero() {
+    let tmp = TempDir::new().unwrap();
+    write_many_notes(tmp.path(), 60);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--limit", "0"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        60,
+        "--limit 0 should return all results, got {}",
+        results.len()
+    );
+}
+
+#[test]
+fn config_default_limit_overrides_hardcoded_default() {
+    let tmp = TempDir::new().unwrap();
+    // Set default_limit = 5 in config.
+    fs::write(tmp.path().join(".hyalo.toml"), "default_limit = 5\n").unwrap();
+    write_many_notes(tmp.path(), 20);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        5,
+        "config default_limit=5 should cap results to 5, got {}",
+        results.len()
+    );
+    assert_eq!(json["total"], 20);
+}
+
+#[test]
+fn config_default_limit_zero_means_unlimited() {
+    let tmp = TempDir::new().unwrap();
+    // default_limit = 0 means unlimited.
+    fs::write(tmp.path().join(".hyalo.toml"), "default_limit = 0\n").unwrap();
+    write_many_notes(tmp.path(), 60);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        60,
+        "default_limit=0 in config should return all results, got {}",
+        results.len()
+    );
+}
+
+#[test]
+fn cli_limit_overrides_config_default_limit() {
+    let tmp = TempDir::new().unwrap();
+    // Config sets limit to 5 but CLI passes --limit 3.
+    fs::write(tmp.path().join(".hyalo.toml"), "default_limit = 5\n").unwrap();
+    write_many_notes(tmp.path(), 20);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--limit", "3"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        3,
+        "explicit --limit 3 should override config default_limit=5, got {}",
+        results.len()
+    );
+}
+
+#[test]
+fn default_limit_applies_to_tags_summary() {
+    let tmp = TempDir::new().unwrap();
+    // Write files with many unique tags (more than 50).
+    for i in 0..60usize {
+        write_md(
+            tmp.path(),
+            &format!("file-{i:03}.md"),
+            &format!("---\ntitle: Note {i}\ntags:\n  - tag-{i:03}\n---\n"),
+        );
+    }
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["tags"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        50,
+        "tags summary should default-limit to 50, got {}",
+        results.len()
+    );
+    assert_eq!(json["total"], 60);
+}
+
+#[test]
+fn default_limit_applies_to_properties_summary() {
+    let tmp = TempDir::new().unwrap();
+    // Write files with many unique property keys (more than 50).
+    for i in 0..60usize {
+        write_md(
+            tmp.path(),
+            &format!("file-{i:03}.md"),
+            &format!("---\ntitle: Note {i}\nprop_{i:03}: value\n---\n"),
+        );
+    }
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["properties"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        50,
+        "properties summary should default-limit to 50, got {}",
+        results.len()
+    );
+    // 60 unique props + 60 "title" entries = 61 unique property names total
+    assert!(
+        json["total"].as_u64().unwrap() > 50,
+        "total should exceed 50"
     );
 }

--- a/crates/hyalo-cli/tests/e2e_find.rs
+++ b/crates/hyalo-cli/tests/e2e_find.rs
@@ -2590,21 +2590,20 @@ fn find_single_glob_backward_compat() {
 }
 
 // ---------------------------------------------------------------------------
-// --limit 0 = rejected by clap
+// --limit 0 = unlimited (no cap)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn find_limit_zero_is_rejected() {
+fn find_limit_zero_is_unlimited() {
     let tmp = setup_vault();
-    let (status, _json, stderr) = find_json(&tmp, &["--limit", "0"]);
+    let (status, json, _stderr) = find_json(&tmp, &["--limit", "0"]);
     assert!(
-        !status.success(),
-        "--limit 0 should fail but exited successfully"
+        status.success(),
+        "--limit 0 should succeed (unlimited), but failed"
     );
-    assert!(
-        stderr.contains("invalid value '0' for '--limit"),
-        "expected clap error about invalid value, got: {stderr}"
-    );
+    // Should return all results with no truncation.
+    let results = json["results"].as_array().unwrap();
+    assert!(!results.is_empty(), "expected results with --limit 0");
 }
 
 // ---------------------------------------------------------------------------
@@ -3114,11 +3113,11 @@ title: B
 }
 
 // ---------------------------------------------------------------------------
-// Bug 5 — --limit 0 must be rejected
+// --limit 0 = unlimited (no cap) — previously rejected, now allowed
 // ---------------------------------------------------------------------------
 
 #[test]
-fn find_limit_zero_rejected() {
+fn find_limit_zero_unlimited() {
     let dir = tempfile::tempdir().unwrap();
     write_md(
         dir.path(),
@@ -3142,15 +3141,14 @@ title: A
         .unwrap();
 
     assert!(
-        !output.status.success(),
-        "expected failure for --limit 0; exit code: {:?}",
+        output.status.success(),
+        "--limit 0 should succeed (unlimited); exit code: {:?}",
         output.status.code()
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("limit must be at least 1"),
-        "expected 'limit must be at least 1' in stderr; got: {stderr}"
-    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1, "expected 1 result with --limit 0");
 }
 
 // ---------------------------------------------------------------------------

--- a/hyalo-knowledgebase/iterations/iteration-110-default-output-limits.md
+++ b/hyalo-knowledgebase/iterations/iteration-110-default-output-limits.md
@@ -1,10 +1,15 @@
 ---
-title: "Default output limits for all list commands"
+title: Default output limits for all list commands
 type: iteration
 date: 2026-04-14
-status: planned
+status: in-progress
 branch: iter-110/default-output-limits
-tags: [cli, ux, llm, performance, dogfooding]
+tags:
+  - cli
+  - ux
+  - llm
+  - performance
+  - dogfooding
 ---
 
 # iter-110: Default output limits for all list commands
@@ -31,12 +36,12 @@ Large knowledgebases can produce output that busts an LLM's context window. Comm
 
 ## Tasks
 
-- [ ] Change `parse_limit` to accept 0 as "unlimited"
-- [ ] Add default limit to `find` (e.g. 50)
-- [ ] Add `--limit` to `lint` with default (e.g. 50)
-- [ ] Add `--limit` to `tags summary` with default
-- [ ] Add `--limit` to `properties summary` with default
-- [ ] Add `--limit` to `backlinks` with default
-- [ ] Support `default_limit` in `.hyalo.toml`
-- [ ] Ensure "showing N of M" message works consistently across all commands
-- [ ] Update e2e tests
+- [x] Change `parse_limit` to accept 0 as "unlimited"
+- [x] Add default limit to `find` (e.g. 50)
+- [x] Add `--limit` to `lint` with default (e.g. 50)
+- [x] Add `--limit` to `tags summary` with default
+- [x] Add `--limit` to `properties summary` with default
+- [x] Add `--limit` to `backlinks` with default
+- [x] Support `default_limit` in `.hyalo.toml`
+- [x] Ensure "showing N of M" message works consistently across all commands
+- [x] Update e2e tests


### PR DESCRIPTION
## Summary
- List commands (`find`, `lint`, `tags summary`, `properties summary`, `backlinks`) now return at most **50 results** by default to prevent LLM context window overflow
- `--limit 0` means unlimited (previously rejected); `--limit` flag added to `tags summary`, `properties summary`, and `backlinks`
- New `default_limit` config key in `.hyalo.toml` overrides the built-in default (e.g. `default_limit = 100`)
- Truncated output shows "showing N of M matches" and hints `--limit 0` to get all results
- Updated README, `--help` text, and skill-hyalo template to document the new behavior

## Test plan
- [x] `cargo fmt` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace -q` — 572 tests pass
- [x] Dogfood: `hyalo find --format text` shows "showing 50 of 233 matches" with `--limit 0` hint
- [x] Dogfood: `hyalo find --limit 0 --format text` returns all 233 results
- [x] Dogfood: `hyalo tags summary`, `hyalo properties summary` work with new `--limit` flag
- [x] 8 new e2e tests for default limit behavior, config override, and `--limit 0` bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--limit/-n` to `tags summary`, `properties summary`, and `backlinks`; `--limit 0` means unlimited.
  * Introduced `default_limit` in `.hyalo.toml` to set a project-wide default for list commands.

* **Behavior**
  * List commands default to showing up to 50 results and indicate truncation with “showing N of M matches”.
  * Hints now offer a “show all … (no limit)” suggestion when output is truncated.

* **Documentation**
  * Help text, README, and examples updated for `--limit` and `default_limit`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->