### PR TITLE
iter-113b: Fix config resolution regression for views/types

### DIFF
--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -93,6 +93,14 @@ impl ResolvedDefaults {
             default_limit: None,
         }
     }
+
+    /// Hardcoded defaults with `config_dir` set to the given directory.
+    fn defaults_for(dir: &Path) -> Self {
+        Self {
+            config_dir: dir.to_path_buf(),
+            ..Self::hardcoded()
+        }
+    }
 }
 
 /// Load configuration from `.hyalo.toml` in the current working directory.
@@ -123,15 +131,11 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     let contents = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            let mut defaults = ResolvedDefaults::hardcoded();
-            defaults.config_dir = dir.to_path_buf();
-            return defaults;
+            return ResolvedDefaults::defaults_for(dir);
         }
         Err(e) => {
             crate::warn::warn(format!("could not read .hyalo.toml: {e}"));
-            let mut defaults = ResolvedDefaults::hardcoded();
-            defaults.config_dir = dir.to_path_buf();
-            return defaults;
+            return ResolvedDefaults::defaults_for(dir);
         }
     };
 
@@ -139,9 +143,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         Ok(c) => c,
         Err(e) => {
             crate::warn::warn(format!("malformed .hyalo.toml: {e}"));
-            let mut defaults = ResolvedDefaults::hardcoded();
-            defaults.config_dir = dir.to_path_buf();
-            return defaults;
+            return ResolvedDefaults::defaults_for(dir);
         }
     };
 
@@ -193,9 +195,7 @@ mod tests {
     fn missing_config_returns_defaults() {
         let dir = make_temp();
         let resolved = load_config_from(dir.path());
-        let mut expected = ResolvedDefaults::hardcoded();
-        expected.config_dir = dir.path().to_path_buf();
-        assert_eq!(resolved, expected);
+        assert_eq!(resolved, ResolvedDefaults::defaults_for(dir.path()));
     }
 
     #[test]
@@ -255,9 +255,7 @@ site_prefix = "docs"
         fs::write(dir.path().join(".hyalo.toml"), "this is not { valid toml").unwrap();
 
         let resolved = load_config_from(dir.path());
-        let mut expected = ResolvedDefaults::hardcoded();
-        expected.config_dir = dir.path().to_path_buf();
-        assert_eq!(resolved, expected);
+        assert_eq!(resolved, ResolvedDefaults::defaults_for(dir.path()));
     }
 
     #[test]
@@ -266,9 +264,7 @@ site_prefix = "docs"
         fs::write(dir.path().join(".hyalo.toml"), "unknown_key = \"value\"\n").unwrap();
 
         let resolved = load_config_from(dir.path());
-        let mut expected = ResolvedDefaults::hardcoded();
-        expected.config_dir = dir.path().to_path_buf();
-        assert_eq!(resolved, expected);
+        assert_eq!(resolved, ResolvedDefaults::defaults_for(dir.path()));
     }
 
     #[test]

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -47,6 +47,10 @@ struct ConfigFile {
 #[derive(Debug)]
 pub(crate) struct ResolvedDefaults {
     pub(crate) dir: PathBuf,
+    /// The directory where `.hyalo.toml` was found.  Views and types are stored
+    /// in this file, so mutations must target `config_dir/.hyalo.toml` — not the
+    /// vault directory (which may be a subdirectory specified via `dir = "…"`).
+    pub(crate) config_dir: PathBuf,
     pub(crate) format: String,
     pub(crate) hints: bool,
     /// Explicit site-prefix override from `.hyalo.toml`, if any.
@@ -67,6 +71,7 @@ impl PartialEq for ResolvedDefaults {
         // SchemaConfig doesn't implement PartialEq, so compare the other fields only.
         // Tests that care about schema equality check it separately.
         self.dir == other.dir
+            && self.config_dir == other.config_dir
             && self.format == other.format
             && self.hints == other.hints
             && self.site_prefix == other.site_prefix
@@ -79,6 +84,7 @@ impl ResolvedDefaults {
     fn hardcoded() -> Self {
         Self {
             dir: PathBuf::from("."),
+            config_dir: PathBuf::from("."),
             format: "json".to_owned(),
             hints: true,
             site_prefix: None,
@@ -117,11 +123,15 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     let contents = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return ResolvedDefaults::hardcoded();
+            let mut defaults = ResolvedDefaults::hardcoded();
+            defaults.config_dir = dir.to_path_buf();
+            return defaults;
         }
         Err(e) => {
             crate::warn::warn(format!("could not read .hyalo.toml: {e}"));
-            return ResolvedDefaults::hardcoded();
+            let mut defaults = ResolvedDefaults::hardcoded();
+            defaults.config_dir = dir.to_path_buf();
+            return defaults;
         }
     };
 
@@ -129,7 +139,9 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         Ok(c) => c,
         Err(e) => {
             crate::warn::warn(format!("malformed .hyalo.toml: {e}"));
-            return ResolvedDefaults::hardcoded();
+            let mut defaults = ResolvedDefaults::hardcoded();
+            defaults.config_dir = dir.to_path_buf();
+            return defaults;
         }
     };
 
@@ -137,6 +149,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     let schema = parse_schema_from_toml(cfg.schema.as_ref());
     ResolvedDefaults {
         dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
+        config_dir: dir.to_path_buf(),
         format: cfg.format.unwrap_or(defaults.format),
         hints: cfg.hints.unwrap_or(defaults.hints),
         site_prefix: cfg.site_prefix,
@@ -180,7 +193,9 @@ mod tests {
     fn missing_config_returns_defaults() {
         let dir = make_temp();
         let resolved = load_config_from(dir.path());
-        assert_eq!(resolved, ResolvedDefaults::hardcoded());
+        let mut expected = ResolvedDefaults::hardcoded();
+        expected.config_dir = dir.path().to_path_buf();
+        assert_eq!(resolved, expected);
     }
 
     #[test]
@@ -240,7 +255,9 @@ site_prefix = "docs"
         fs::write(dir.path().join(".hyalo.toml"), "this is not { valid toml").unwrap();
 
         let resolved = load_config_from(dir.path());
-        assert_eq!(resolved, ResolvedDefaults::hardcoded());
+        let mut expected = ResolvedDefaults::hardcoded();
+        expected.config_dir = dir.path().to_path_buf();
+        assert_eq!(resolved, expected);
     }
 
     #[test]
@@ -249,7 +266,9 @@ site_prefix = "docs"
         fs::write(dir.path().join(".hyalo.toml"), "unknown_key = \"value\"\n").unwrap();
 
         let resolved = load_config_from(dir.path());
-        assert_eq!(resolved, ResolvedDefaults::hardcoded());
+        let mut expected = ResolvedDefaults::hardcoded();
+        expected.config_dir = dir.path().to_path_buf();
+        assert_eq!(resolved, expected);
     }
 
     #[test]
@@ -293,5 +312,20 @@ site_prefix = "docs"
 
         let resolved = load_config_from(dir.path());
         assert_eq!(resolved.search_language, None);
+    }
+
+    #[test]
+    fn config_dir_points_to_toml_location_not_vault_dir() {
+        let dir = make_temp();
+        fs::create_dir_all(dir.path().join("subdir")).unwrap();
+        fs::write(dir.path().join(".hyalo.toml"), "dir = \"subdir\"\n").unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved.dir, PathBuf::from("subdir"));
+        assert_eq!(
+            resolved.config_dir,
+            dir.path().to_path_buf(),
+            "config_dir should be where .hyalo.toml lives, not the vault subdir"
+        );
     }
 }

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -26,6 +26,11 @@ pub(crate) const DEFAULT_OUTPUT_LIMIT: usize = 50;
 /// Shared context for command dispatch.
 pub(crate) struct CommandContext<'a> {
     pub dir: &'a Path,
+    /// The directory where `.hyalo.toml` was loaded from.  This is the
+    /// project root when `dir` comes from `dir = "subdir"` in the config,
+    /// or the `--dir` target when the user passes `--dir` explicitly.
+    /// Views and types are stored in `config_dir/.hyalo.toml`.
+    pub config_dir: &'a Path,
     pub site_prefix: Option<&'a str>,
     /// Internal format — always Json; commands build JSON, pipeline handles conversion.
     pub effective_format: Format,
@@ -894,7 +899,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
         Commands::Views { action } => {
             let action = action.unwrap_or(ViewsAction::List);
             match action {
-                ViewsAction::List => crate::commands::views::list_views(dir),
+                ViewsAction::List => crate::commands::views::list_views(ctx.config_dir),
                 ViewsAction::Set {
                     name,
                     pattern,
@@ -906,9 +911,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                         ));
                     }
                     filters.pattern = pattern;
-                    crate::commands::views::set_view(dir, &name, &filters)
+                    crate::commands::views::set_view(ctx.config_dir, &name, &filters)
                 }
-                ViewsAction::Remove { name } => crate::commands::views::remove_view(dir, &name),
+                ViewsAction::Remove { name } => {
+                    crate::commands::views::remove_view(ctx.config_dir, &name)
+                }
             }
         }
         Commands::Types { action } => {
@@ -919,7 +926,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     Ok(crate::commands::types::show_type(&type_name, ctx.schema))
                 }
                 TypesAction::Remove { type_name } => {
-                    crate::commands::types::remove_type(dir, &type_name)
+                    crate::commands::types::remove_type(ctx.config_dir, &type_name)
                 }
                 TypesAction::Set {
                     type_name,
@@ -930,7 +937,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     filename_template,
                     dry_run,
                 } => crate::commands::types::set_type(
-                    dir,
+                    ctx.config_dir,
                     &type_name,
                     &required,
                     &default,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -235,9 +235,11 @@ fn run_inner() -> Result<(), AppError> {
         let target_config = crate::config::load_config_from(&cli_dir);
         (cli_dir, target_config)
     } else {
-        let config_dir = config.dir.clone();
-        (config_dir, config)
+        let vault_dir = config.dir.clone();
+        (vault_dir, config)
     };
+    // The directory where .hyalo.toml lives. Views/types are stored there.
+    let config_dir = config.config_dir.clone();
 
     // Validate that the resolved dir exists and is a directory (for the
     // non-CLI case where dir comes from .hyalo.toml).
@@ -315,7 +317,7 @@ fn run_inner() -> Result<(), AppError> {
         ..
     } = cli.command
     {
-        let views = crate::commands::views::load_views(&dir);
+        let views = crate::commands::views::load_views(&config_dir);
         match views.get(view_name) {
             Some(base) => {
                 let overlay = std::mem::take(filters);
@@ -723,6 +725,7 @@ fn run_inner() -> Result<(), AppError> {
     let schema = config.schema;
     let mut ctx = CommandContext {
         dir: &dir,
+        config_dir: &config_dir,
         site_prefix,
         effective_format,
         user_format: format,

--- a/crates/hyalo-cli/tests/e2e/views.rs
+++ b/crates/hyalo-cli/tests/e2e/views.rs
@@ -555,3 +555,64 @@ fn views_set_with_bm25_pattern_and_find() {
         "expected relevant.md in results: {results:?}"
     );
 }
+
+/// Regression test: when `.hyalo.toml` in the project root has `dir = "subdir"`,
+/// views must be read from the root config — not from `subdir/.hyalo.toml`.
+#[test]
+fn views_work_when_dir_is_a_subdir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let subdir = tmp.path().join("notes");
+    fs::create_dir_all(&subdir).unwrap();
+    write_md(&subdir, "a.md", "---\nstatus: draft\n---\nhello");
+
+    // Write root .hyalo.toml with dir pointing to subdir
+    fs::write(tmp.path().join(".hyalo.toml"), "dir = \"notes\"\n").unwrap();
+
+    // Set a view (should write to root .hyalo.toml)
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["views", "set", "drafts", "--property", "status=draft"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "views set failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Root config should have the view; subdir should NOT have a .hyalo.toml
+    let root_toml = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        root_toml.contains("[views.drafts]"),
+        "view should be in root .hyalo.toml: {root_toml}"
+    );
+    assert!(
+        !subdir.join(".hyalo.toml").exists(),
+        "subdir should not have its own .hyalo.toml"
+    );
+
+    // List views — should find the view
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["views", "list"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1, "expected 1 view: {json}");
+
+    // find --view should work
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--view", "drafts"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "find --view failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1, "expected 1 result: {results:?}");
+}

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0120-post-iter113.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0120-post-iter113.md
@@ -1,0 +1,139 @@
+---
+title: "Dogfood v0.12.0 — Post Iteration 113 Verification"
+type: research
+date: 2026-04-14
+status: active
+tags:
+  - dogfooding
+  - verification
+  - bug-fix
+related:
+  - "[[dogfood-results/dogfood-v0120-multi-kb]]"
+  - "[[iterations/iteration-113-dogfood-v0120-fixes]]"
+---
+
+# Dogfood v0.12.0 — Post Iteration 113 Verification
+
+Re-ran the scenarios from the [[dogfood-results/dogfood-v0120-multi-kb]] report after iteration 113 merged.
+Binary: `hyalo 0.12.0` installed via `cargo install --path crates/hyalo-cli`.
+
+## Bug Fix Verification
+
+### BUG-1: `--dir` config lookup for `types set` / `views set` — PARTIALLY FIXED
+
+**External KB with `--dir` flag**: FIXED. `types set` and `views set` now correctly write to
+the external KB's `.hyalo.toml` when `--dir` is passed explicitly. `types show` and `views list`
+also read from the correct location.
+
+**REGRESSION: Root config with `dir = "..."` setting**: When the root `.hyalo.toml` has
+`dir = "hyalo-knowledgebase"` and you run `types set` (without `--dir`), the new type is written
+to `hyalo-knowledgebase/.hyalo.toml` instead of the root `.hyalo.toml`. This creates a split
+config: types/views defined in root config become invisible to commands that resolve config to
+the KB subdirectory.
+
+**REGRESSION: `views list` returns empty**: All view commands (`views list`, `views set`,
+`views remove`, `find --view`) are broken for the default case. They resolve config to
+`hyalo-knowledgebase/.hyalo.toml` (which doesn't exist), while views are defined in the root
+`.hyalo.toml`. `types list` still works because schema loading uses a different code path
+(loaded by hyalo-core during vault init, not by CLI commands).
+
+**Root cause**: The BUG-1 fix changed `views.rs` and `types.rs` to use `resolve_toml_path(dir)`
+which joins the KB directory with `.hyalo.toml`. But when `dir` comes from `dir = "hyalo-knowledgebase"`
+in the root config, the config file is the *root* `.hyalo.toml`, not one inside the KB directory.
+The fix should resolve to whichever `.hyalo.toml` was used to *find* the `dir` setting.
+
+### BUG-2: TOML section reordering — FIXED
+
+Added a new type via `types set` to an external KB. The existing sections (article type, views)
+remained in their original order, and the new type was appended after existing types. No
+alphabetical reordering, no escape-style changes. The `toml_edit` migration is working correctly.
+
+### BUG-3: Bare boolean operator warning — FIXED
+
+- `find "and"` → warning: `"and" was interpreted as a boolean operator, leaving an empty query`
+- `find "or"` → same warning with suggestion to use quoted form
+- Both suggest: `To search for the literal word, quote it: '"and"'`
+
+**Edge case**: `find "not"` returns all files without warning. `NOT` alone acts as negation with
+no operand, matching everything. Minor — could warn, but not a blocker.
+
+### BUG-4: `task toggle --all` with deep indentation — FIXED
+
+Tested with checkboxes at 0, 2, 4, 6, 8, 12, and 16-space indentation.
+`task toggle --all --dry-run` found all 7 checkboxes. Previously it missed anything
+beyond a few levels of indentation.
+
+### BUG-5: `create-index --index=PATH` — NOT FIXED
+
+`hyalo create-index --dir /tmp/ext-kb/ --index=/tmp/custom-path` still wrote to
+`/tmp/ext-kb/.hyalo-index` instead of `/tmp/custom-path`. The result JSON confirmed:
+`"path": "/tmp/ext-kb/.hyalo-index"`. The `--index` flag is being ignored.
+
+### BUG-8: `remove --tag` with malformed comma-tags — FIXED
+
+`hyalo remove file.md --tag "cli,ux"` successfully removed the malformed comma-tag.
+Previously this failed with `"invalid character ',' in tag name"`.
+
+## UX Improvement Verification
+
+### UX-2: `lint --type` shortcut — WORKING
+
+`hyalo lint --type iteration` correctly scanned only the 12 iteration-type files
+(matching the `iteration` schema). Previously this flag didn't exist and had to use `--glob`.
+
+### UX-3: Lint detects comma-joined tags — WORKING
+
+`hyalo lint` now warns: `tag "cli,ux,find" appears to be comma-joined -- should be separate list items`.
+Detected all 13 comma-tag files in own KB. `lint --fix --dry-run` shows `split-comma-tags` as
+a fixable action with the proposed split values.
+
+### UX-4: `task toggle --dry-run` — WORKING
+
+`task toggle --all --dry-run` correctly shows what would be toggled without modifying the file.
+
+## Performance
+
+Own KB (236 files, no index):
+- `summary`: 33ms
+- FTS `"snapshot index architecture"`: 55ms
+- Both essentially unchanged from pre-iter-113
+
+## New Issues Found During Verification
+
+### ~~NEW-BUG-1: Config resolution regression (HIGH)~~ — FIXED in iter-113b
+
+`types set` and `views set/list/remove` resolved `.hyalo.toml` to `<dir>/.hyalo.toml` instead of
+using the config file that defined the `dir` setting. Fixed by tracking `config_dir` (where
+`.hyalo.toml` was loaded from) separately from `dir` (the vault directory).
+
+### BUG-5 correction: NOT A BUG
+
+The `create-index` command uses `--output` (`-o`), not `--index`. The `--index` flag is a global
+argument for other commands to *use* a pre-built index. The dogfood report used the wrong flag.
+
+### `find "not"` behavior: BY DESIGN (LOW)
+
+`NOT` is not a keyword operator — negation uses the `-` prefix syntax (e.g., `-foo`). The word
+"not" is treated as a regular search term. There is a test explicitly asserting this behavior.
+
+### Still open from original report
+
+- **BUG-6**: `mv --dry-run` rewrites absolute URL-style links (not addressed in iter-113)
+- **UX-5**: Link resolution case-sensitivity (MDN-specific, not addressed)
+- **UX-6**: Repeated frontmatter warning (not addressed)
+
+## Summary
+
+| Bug | Status | Notes |
+|-----|--------|-------|
+| BUG-1 | Partial fix / regression | `--dir` flag works; `dir=` config setting broken for views |
+| BUG-2 | Fixed | toml_edit preserves order |
+| BUG-3 | Fixed | Warning shown for bare AND/OR |
+| BUG-4 | Fixed | Indentation-agnostic regex |
+| BUG-5 | Not a bug | Flag is `--output`, not `--index` |
+| BUG-8 | Fixed | Comma-tags removable |
+| UX-2 | Working | `lint --type` |
+| UX-3 | Working | Comma-tag detection |
+| UX-4 | Working | `task toggle --dry-run` |
+
+All critical bugs from iter-113 have been addressed in iter-113b.

--- a/hyalo-knowledgebase/iterations/iteration-113-dogfood-v0120-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-113-dogfood-v0120-fixes.md
@@ -2,7 +2,7 @@
 title: Iteration 113 — Dogfood v0.12.0 Fixes
 type: iteration
 date: 2026-04-14
-status: in-progress
+status: completed
 branch: iter-113/dogfood-v0120-fixes
 tags:
   - iteration


### PR DESCRIPTION
## Summary
- Fix regression from iter-113 where views/types commands resolved `.hyalo.toml` to the vault directory instead of the config directory, breaking `views list`, `find --view`, and `types set` when root config has `dir = "subdir"`
- Track `config_dir` (where `.hyalo.toml` was loaded) separately from `dir` (vault directory) in `ResolvedDefaults` and `CommandContext`
- Add dogfood verification results for iter-113 bug fixes
- Correct BUG-5 finding (user error: `--output` not `--index`)

## Test plan
- [x] Unit test: `config_dir_points_to_toml_location_not_vault_dir`
- [x] E2E test: `views_work_when_dir_is_a_subdir` — creates root config with `dir = "notes"`, verifies views set/list/find work against root config
- [x] All 580 existing tests pass
- [x] Manual dogfood: `hyalo views list` returns 7 views, `hyalo find --view stale-in-progress` works, `hyalo types set` writes to root `.hyalo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Views and types now consistently read/write the correct configuration when the project content is in a subdirectory; the configuration file location is tracked separately from the vault/content directory.

* **Tests**
  * Added an end-to-end regression test verifying views work when configuration points to a subdirectory.

* **Documentation**
  * Added a post-iteration verification report and marked the iteration as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->