### PR TITLE
iter-114: Dogfood v0.12.0 follow-up fixes

### DIFF
--- a/.hyalo.toml
+++ b/.hyalo.toml
@@ -132,6 +132,7 @@ properties = ["!type"]
 task = "todo"
 
 [views.orphans]
+orphan = true
 fields = ["backlinks"]
 
 [views.planned]

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -448,10 +448,29 @@ pub fn find(
         && score_map.is_empty()
         && query_is_operator_only(pat)
     {
-        // Extract the first operator word for a targeted message.
-        let word = pat.split_whitespace().next().unwrap_or(pat);
+        // Collect every operator word in the query so that e.g. `find "AND OR"`
+        // reports both, not just the first. Preserve the user's original casing
+        // for a natural error message.
+        let operators: Vec<&str> = pat
+            .split_whitespace()
+            .filter(|w| {
+                let lw = w.to_ascii_lowercase();
+                lw == "and" || lw == "or"
+            })
+            .collect();
+        let quoted: Vec<String> = operators.iter().map(|w| format!("\"{w}\"")).collect();
+        let list = quoted.join(", ");
+        let phrase = if operators.len() <= 1 {
+            "was interpreted as a boolean operator"
+        } else {
+            "were interpreted as boolean operators"
+        };
+        let literal_hint = operators
+            .first()
+            .map_or_else(|| "'\"and\"'".to_owned(), |w| format!("'\"{w}\"'"));
         crate::warn::warn(format!(
-            r#""{word}" was interpreted as a boolean operator, leaving an empty query. To search for the literal word, quote it: '"{word}"'"#
+            "{list} {phrase}, leaving an empty query. \
+             To search for the literal word, quote it: {literal_hint}"
         ));
     }
 

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -135,6 +135,154 @@ pub fn lint_files(
     lint_files_with_options(files, schema, FixMode::Off, None)
 }
 
+/// Prepend an additional `FileLintResult` (e.g. `.hyalo.toml` view violations)
+/// to the outcome produced by [`lint_files_with_options`]. Adjusts the totals
+/// and the `files_with_issues` counter in the serialized payload to stay
+/// consistent with the new entry.
+pub fn prepend_file_result(
+    outcome: CommandOutcome,
+    extra: &FileLintResult,
+) -> Result<CommandOutcome> {
+    let (payload, total) = match outcome {
+        CommandOutcome::Success { output, total } => (output, total),
+        other => return Ok(other),
+    };
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(&payload).context("failed to re-parse lint output JSON")?;
+
+    if let Some(obj) = value.as_object_mut() {
+        let extra_errors = extra
+            .violations
+            .iter()
+            .filter(|v| matches!(v.severity, Severity::Error))
+            .count();
+        let extra_warnings = extra.violations.len() - extra_errors;
+
+        if let Some(files) = obj.get_mut("files").and_then(|f| f.as_array_mut()) {
+            let extra_value = serde_json::to_value(extra)
+                .context("failed to serialize .hyalo.toml lint result")?;
+            files.insert(0, extra_value);
+        }
+        if let Some(n) = obj.get_mut("total").and_then(|v| v.as_u64()) {
+            obj.insert(
+                "total".to_string(),
+                serde_json::Value::from(n + extra.violations.len() as u64),
+            );
+        }
+        if let Some(n) = obj.get_mut("errors").and_then(|v| v.as_u64()) {
+            obj.insert(
+                "errors".to_string(),
+                serde_json::Value::from(n + extra_errors as u64),
+            );
+        }
+        if let Some(n) = obj.get_mut("warnings").and_then(|v| v.as_u64()) {
+            obj.insert(
+                "warnings".to_string(),
+                serde_json::Value::from(n + extra_warnings as u64),
+            );
+        }
+        if let Some(n) = obj.get_mut("files_with_issues").and_then(|v| v.as_u64()) {
+            obj.insert(
+                "files_with_issues".to_string(),
+                serde_json::Value::from(n + 1),
+            );
+        }
+    }
+
+    let new_payload = format_success(Format::Json, &value);
+    Ok(match total {
+        Some(t) => CommandOutcome::success_with_total(new_payload, t),
+        None => CommandOutcome::success(new_payload),
+    })
+}
+
+/// Validate `.hyalo.toml` view definitions and return a pseudo-file lint
+/// result when at least one view looks suspicious.
+///
+/// Current checks:
+/// - Views whose only narrowing mechanism is `fields = ["backlinks"]` or
+///   similar — `fields` controls display columns, not filtering, so such a
+///   view matches every file. The likely intent is `orphan = true`.
+///
+/// Returns `None` when there is nothing to report.
+pub fn validate_views(dir: &Path) -> Option<FileLintResult> {
+    // Keys that actually *narrow* the result set.
+    const NARROWING_KEYS: &[&str] = &[
+        "pattern",
+        "regexp",
+        "properties",
+        "tag",
+        "task",
+        "sections",
+        "file",
+        "glob",
+        "broken_links",
+        "orphan",
+        "dead_end",
+        "title",
+        "language",
+    ];
+
+    let toml_path = dir.join(".hyalo.toml");
+    let contents = std::fs::read_to_string(&toml_path).ok()?;
+    let table: toml::Table = toml::from_str(&contents).ok()?;
+    let Some(toml::Value::Table(views_table)) = table.get("views") else {
+        return None;
+    };
+
+    let mut violations: Vec<Violation> = Vec::new();
+    for (name, value) in views_table {
+        let Some(view_tbl) = value.as_table() else {
+            continue;
+        };
+
+        let has_narrowing = view_tbl.iter().any(|(k, v)| {
+            if !NARROWING_KEYS.contains(&k.as_str()) {
+                return false;
+            }
+            // Treat `orphan = false` / `dead_end = false` as non-narrowing.
+            if matches!(k.as_str(), "orphan" | "dead_end" | "broken_links") {
+                return matches!(v, toml::Value::Boolean(true));
+            }
+            // List-typed narrowing keys with empty values don't narrow either.
+            if let toml::Value::Array(a) = v {
+                return !a.is_empty();
+            }
+            true
+        });
+
+        let has_fields = view_tbl.contains_key("fields");
+
+        if !has_narrowing && has_fields {
+            violations.push(Violation {
+                severity: Severity::Warn,
+                message: format!(
+                    "view '{name}' has no narrowing filter — `fields` controls display columns only, \
+                     not filtering. Did you mean `orphan = true` or `dead_end = true`?"
+                ),
+            });
+        } else if !has_narrowing {
+            violations.push(Violation {
+                severity: Severity::Warn,
+                message: format!(
+                    "view '{name}' has no narrowing filter — add at least one of: \
+                     tag, properties, task, orphan, dead_end, broken_links, glob, file, title"
+                ),
+            });
+        }
+    }
+
+    if violations.is_empty() {
+        None
+    } else {
+        Some(FileLintResult {
+            file: ".hyalo.toml".to_string(),
+            violations,
+        })
+    }
+}
+
 /// Whether — and how — `lint_files_with_options` should apply auto-fixes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixMode {

--- a/crates/hyalo-cli/src/commands/views.rs
+++ b/crates/hyalo-cli/src/commands/views.rs
@@ -250,6 +250,30 @@ mod tests {
     }
 
     #[test]
+    fn load_views_supports_orphan_and_dead_end_flags() {
+        // Regression: views must be able to filter by `orphan` / `dead_end`
+        // the same way CLI flags do.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        std::fs::write(
+            dir.join(".hyalo.toml"),
+            "[views.orphans]\norphan = true\n\n[views.dead-ends]\ndead_end = true\n",
+        )
+        .unwrap();
+
+        let views = load_views(dir);
+        let orphan_view = views.get("orphans").expect("orphans view missing");
+        assert!(orphan_view.orphan, "view should have orphan = true");
+        assert!(
+            !orphan_view.dead_end,
+            "view should not have dead_end = true"
+        );
+
+        let dead_view = views.get("dead-ends").expect("dead-ends view missing");
+        assert!(dead_view.dead_end, "view should have dead_end = true");
+    }
+
+    #[test]
     fn set_view_preserves_existing_sections_and_order() {
         let tmp = tempfile::TempDir::new().unwrap();
         let dir = tmp.path();

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -151,6 +151,10 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     // itself contains a `.hyalo.toml`. The inner file is shadowed by this
     // parent config, and `hyalo` currently doesn't merge nested configs —
     // surfacing the shadow at least makes the silent shadowing visible.
+    //
+    // Routed through `warn::warn`, so `--quiet` suppresses it and the dedup
+    // tracker prevents multiple prints per run. It's a warning (not a hint),
+    // so `--no-hints` intentionally does *not* gate it.
     if let Some(ref sub) = cfg.dir {
         let nested = dir.join(sub).join(".hyalo.toml");
         if nested.is_file() {

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -147,6 +147,21 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         }
     };
 
+    // Warn when the resolved config points its `dir` at a subdirectory that
+    // itself contains a `.hyalo.toml`. The inner file is shadowed by this
+    // parent config, and `hyalo` currently doesn't merge nested configs —
+    // surfacing the shadow at least makes the silent shadowing visible.
+    if let Some(ref sub) = cfg.dir {
+        let nested = dir.join(sub).join(".hyalo.toml");
+        if nested.is_file() {
+            crate::warn::warn(format!(
+                "ignoring nested config {}/.hyalo.toml (shadowed by {}/.hyalo.toml)",
+                sub.trim_end_matches('/'),
+                dir.display()
+            ));
+        }
+    }
+
     let defaults = ResolvedDefaults::hardcoded();
     let schema = parse_schema_from_toml(cfg.schema.as_ref());
     ResolvedDefaults {
@@ -308,6 +323,26 @@ site_prefix = "docs"
 
         let resolved = load_config_from(dir.path());
         assert_eq!(resolved.search_language, None);
+    }
+
+    #[test]
+    fn nested_config_emits_shadow_warning() {
+        // Parent `.hyalo.toml` sets dir = "subkb" and `subkb/` contains its own
+        // `.hyalo.toml`. The nested file is shadowed, so a warning must fire.
+        let _guard = crate::warn::WARN_TEST_LOCK.lock().unwrap();
+        crate::warn::reset_for_test();
+        crate::warn::init(false);
+        let dir = make_temp();
+        fs::create_dir_all(dir.path().join("subkb")).unwrap();
+        fs::write(dir.path().join(".hyalo.toml"), "dir = \"subkb\"\n").unwrap();
+        fs::write(dir.path().join("subkb").join(".hyalo.toml"), "# nested\n").unwrap();
+        let _ = load_config_from(dir.path());
+        // The warning message is built with dir.display() which is a tempdir path,
+        // so we verify the "ignoring nested config" fragment got tracked by
+        // walking all recorded keys.
+        let tracked =
+            crate::warn::any_tracked_starts_with("ignoring nested config subkb/.hyalo.toml");
+        assert!(tracked, "expected nested-config warning to fire");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -884,7 +884,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             )?;
 
             // Additional config-level lint: check view definitions.
-            let config_violations = lint_commands::validate_views(dir);
+            //
+            // Views live in `.hyalo.toml`, which is located in `ctx.config_dir`
+            // — that directory can differ from `dir` when the config sets
+            // `dir = "subkb"` and the `.hyalo.toml` sits in the parent.
+            let config_violations = lint_commands::validate_views(ctx.config_dir);
             let outcome = if let Some(view_result) = config_violations {
                 for v in &view_result.violations {
                     match v.severity {

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -876,12 +876,27 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 lint_commands::FixMode::Off
             };
 
-            let (outcome, counts) = lint_commands::lint_files_with_options(
+            let (outcome, mut counts) = lint_commands::lint_files_with_options(
                 &file_pairs,
                 ctx.schema,
                 fix_mode,
                 resolve_limit(cli_limit, ctx.config_default_limit, ctx.programmatic_output),
             )?;
+
+            // Additional config-level lint: check view definitions.
+            let config_violations = lint_commands::validate_views(dir);
+            let outcome = if let Some(view_result) = config_violations {
+                for v in &view_result.violations {
+                    match v.severity {
+                        lint_commands::Severity::Error => counts.errors += 1,
+                        lint_commands::Severity::Warn => counts.warnings += 1,
+                    }
+                }
+                counts.files_with_issues += 1;
+                lint_commands::prepend_file_result(outcome, &view_result)?
+            } else {
+                outcome
+            };
 
             // Signal exit code 1 when errors remain after fixes (set before returning).
             if counts.errors > 0 {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -118,6 +118,22 @@ fn run_inner() -> Result<(), AppError> {
                 return Err(AppError::Exit(2));
             }
 
+            // Intercept `--tag` / `-t` on the `append` subcommand. Tags are
+            // scalar list items, so there is nothing to "append" in the
+            // property-level sense — `hyalo set --tag T` is the right tool.
+            // Surface that hint instead of clap's generic unknown-arg error.
+            if e.kind() == clap::error::ErrorKind::UnknownArgument
+                && raw_args.iter().any(|a| a == "append")
+                && (crate::suggest::unknown_arg_is(&e, "--tag")
+                    || crate::suggest::unknown_arg_is(&e, "-t"))
+            {
+                eprintln!(
+                    "error: `hyalo append` does not accept --tag (tags are scalar list items, not appendable)\n\n\
+                     hint: use `hyalo set <file> --tag <tag>` to add a tag\n"
+                );
+                return Err(AppError::Exit(2));
+            }
+
             // Only attempt subcommand suggestions when clap couldn't recognise a
             // flag or subcommand — this avoids misleading tips for other error kinds.
             if matches!(

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -122,8 +122,14 @@ fn run_inner() -> Result<(), AppError> {
             // scalar list items, so there is nothing to "append" in the
             // property-level sense — `hyalo set --tag T` is the right tool.
             // Surface that hint instead of clap's generic unknown-arg error.
+            //
+            // Gate the hint on the *resolved* top-level subcommand rather
+            // than a substring scan, so unrelated commands whose args happen
+            // to include `append` (e.g. `hyalo find append`) don't get the
+            // `hyalo append`-specific message.
             if e.kind() == clap::error::ErrorKind::UnknownArgument
-                && raw_args.iter().any(|a| a == "append")
+                && crate::suggest::top_level_subcommand(&raw_args, &Cli::command())
+                    == Some("append")
                 && (crate::suggest::unknown_arg_is(&e, "--tag")
                     || crate::suggest::unknown_arg_is(&e, "-t"))
             {

--- a/crates/hyalo-cli/src/suggest.rs
+++ b/crates/hyalo-cli/src/suggest.rs
@@ -9,6 +9,55 @@ pub fn unknown_arg_is(err: &clap::Error, flag: &str) -> bool {
     })
 }
 
+/// Identify the first top-level subcommand token in `args`, accounting for
+/// global value-taking flags (e.g. `--dir <path>`).
+///
+/// Returns `None` if no known top-level subcommand appears before `--` / end.
+///
+/// This is used by callers that need to show subcommand-specific error hints
+/// (e.g. `hyalo append --tag …`) without being fooled by argv positions that
+/// merely *contain* the subcommand name as a value (`hyalo read append …` or
+/// `hyalo --dir append …`).
+pub fn top_level_subcommand<'a>(args: &'a [String], cmd: &clap::Command) -> Option<&'a str> {
+    // Value-taking root flags whose next token must be skipped (e.g. `--dir`).
+    let value_flags: Vec<&str> = cmd
+        .get_arguments()
+        .filter(|a| a.get_num_args().is_some_and(|r| r.min_values() > 0))
+        .filter_map(|a| a.get_long())
+        .collect();
+
+    let top_level_names: Vec<&str> = cmd.get_subcommands().map(clap::Command::get_name).collect();
+
+    let mut skip_next = false;
+    for arg in args.iter().skip(1) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if arg == "--" {
+            break;
+        }
+        if let Some(flag) = arg.strip_prefix("--") {
+            if value_flags.contains(&flag) {
+                skip_next = true;
+            }
+            continue;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        if let Some(name) = top_level_names.iter().find(|&&n| n == arg.as_str()) {
+            // Return a slice of the matching argv element rather than the
+            // borrowed name table entry, so lifetimes tie to `args`.
+            return args
+                .iter()
+                .find(|a| a.as_str() == *name)
+                .map(String::as_str);
+        }
+    }
+    None
+}
+
 /// Given the raw CLI args and the clap Command tree, detect when an unknown
 /// `--flag` matches a known subcommand name and return a corrected command suggestion.
 ///

--- a/crates/hyalo-cli/src/warn.rs
+++ b/crates/hyalo-cli/src/warn.rs
@@ -118,6 +118,19 @@ pub fn was_emitted(msg: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Return whether any tracked warning key starts with the given prefix.
+///
+/// Useful when the exact message contains a path that's known only at runtime.
+/// **For use in tests only.**
+#[cfg(test)]
+pub fn any_tracked_starts_with(prefix: &str) -> bool {
+    SUPPRESSED
+        .lock()
+        .ok()
+        .and_then(|g| g.as_ref().map(|m| m.keys().any(|k| k.starts_with(prefix))))
+        .unwrap_or(false)
+}
+
 /// Return the total number of suppressed (duplicate) warning occurrences.
 ///
 /// **For use in tests only.**

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -219,7 +219,7 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates; `--property 'K=[a,b,c]'` creates YAML sequences; file arg is positional or `--file`, repeatable)
 - **remove** — delete properties or tags
 - **append** — add to list properties
-- **task** — read, toggle, or set status on checkboxes (supports `--line 5,7`, `--section "Tasks"`, `--all`)
+- **task** — read, toggle, or set status on checkboxes (supports `--line 5,7`, `--section "Tasks"`, `--all`; `--dry-run` to preview toggles)
 - **mv** — move/rename a file and rewrite all inbound links across the vault (`--dry-run` to preview)
 - **backlinks** — reverse link lookup: lists all files that link to a given file
 - **create-index** — build a snapshot index for faster repeated read-only queries
@@ -242,12 +242,22 @@ hyalo lint iterations/iteration-42-feature.md
 # Lint with a glob
 hyalo lint --glob "iterations/*.md"
 
+# Lint only files matching a named type's filename template
+hyalo lint --type iteration
+
 # JSON output
 hyalo lint --format json
 
 # Limit output to first N files with violations
 hyalo lint --limit 10
+
+# Auto-fix: defaults, enum typos, date format, type inference, comma-joined tags
+hyalo lint --fix --dry-run
+hyalo lint --fix
 ```
+
+Lint also warns about comma-joined tags (e.g. `tags: ["cli,ux"]` instead of two list
+items); `--fix` splits them into proper list entries automatically.
 
 Exit codes: 0 = clean, 1 = errors found, 2 = internal error.
 

--- a/crates/hyalo-cli/tests/e2e/bm25.rs
+++ b/crates/hyalo-cli/tests/e2e/bm25.rs
@@ -909,6 +909,27 @@ fn bm25_uppercase_and_operator_emits_warning() {
 }
 
 #[test]
+fn bm25_combined_and_or_operators_listed_together() {
+    // BUG-3 follow-up (iter-114): when both AND and OR are stripped as bare
+    // operators, the warning must mention BOTH — not just the first.
+    let tmp = setup_bm25_vault();
+    let (status, _json, stderr) = find_json(&tmp, &["AND OR"]);
+    assert!(status.success(), "command should still succeed: {stderr}");
+    assert!(
+        stderr.contains(r#""AND""#),
+        "warning should mention AND, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains(r#""OR""#),
+        "warning should mention OR, got: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("were interpreted as boolean operators"),
+        "warning should use plural phrasing when multiple operators stripped, got: {stderr:?}"
+    );
+}
+
+#[test]
 fn bm25_real_word_does_not_emit_operator_warning() {
     let tmp = setup_bm25_vault();
     // "rust" is a real search term — no operator warning should be emitted.

--- a/crates/hyalo-cli/tests/e2e/mv.rs
+++ b/crates/hyalo-cli/tests/e2e/mv.rs
@@ -830,9 +830,13 @@ fn mv_site_prefix_cli_empty_disables_prefix() {
 
 #[test]
 fn mv_rewrites_self_link() {
-    // a.md contains a markdown self-link [me](a.md).
-    // When a.md is moved to archive/a.md the self-link must be rewritten —
-    // just like any other inbound link to the file.
+    // NEW-BUG-2 regression: `a.md` contains a self-link `[me](a.md)`. When
+    // `a.md` is moved to `archive/a.md` the mv must (a) succeed without a
+    // canonicalization error on the old path, and (b) leave the self-link
+    // pointing at the file's new location. A relative link `a.md` from
+    // `archive/a.md` already resolves to `archive/a.md` itself — so no text
+    // change is needed for cross-directory moves; the important contract is
+    // that the resulting link still resolves to the moved file.
     let tmp = TempDir::new().unwrap();
     write_md(
         tmp.path(),
@@ -859,15 +863,56 @@ See [me](a.md) for details.
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["results"]["from"], "a.md");
     assert_eq!(json["results"]["to"], "archive/a.md");
-    assert!(
-        json["results"]["total_links_updated"].as_u64().unwrap() >= 1,
-        "self-link must be counted as rewritten: {json}"
-    );
 
-    // The moved file must exist and the original self-link target must be gone.
+    // The moved file must exist and the self-link must still resolve to the
+    // file's new location (i.e. `archive/a.md`). Relative to `archive/a.md`,
+    // the link target `a.md` points at `archive/a.md` — same file.
     let content = fs::read_to_string(tmp.path().join("archive/a.md")).unwrap();
     assert!(
-        !content.contains("[me](a.md)"),
-        "old self-link must be gone after move: {content}"
+        content.contains("[me](a.md)"),
+        "self-link must remain valid (resolves to new location): {content}"
+    );
+}
+
+#[test]
+fn mv_rewrites_self_link_same_directory() {
+    // NEW-BUG-2: self.md contains `[me](self.md)`. Rename within the same
+    // directory must rewrite the self-link to the new filename.
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "self.md",
+        md!(r"
+---
+title: Self
+---
+See [me](self.md) for details.
+"),
+    );
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["mv", "--file", "self.md", "--to", "other.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        json["results"]["total_links_updated"].as_u64().unwrap() >= 1,
+        "self-link must be rewritten on same-dir rename: {json}"
+    );
+    let content = fs::read_to_string(tmp.path().join("other.md")).unwrap();
+    assert!(
+        content.contains("[me](other.md)"),
+        "self-link must point to new filename: {content}"
+    );
+    assert!(
+        !content.contains("[me](self.md)"),
+        "old self-link must be gone after rename: {content}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e/suggest.rs
+++ b/crates/hyalo-cli/tests/e2e/suggest.rs
@@ -178,3 +178,53 @@ fn suggest_help_for_typo() {
         "expected '--help' suggestion in stderr; got: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// NEW-UX-1: `append --tag` → friendly hint, not clap's unknown-arg error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn append_tag_shows_friendly_hint() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_file(&tmp);
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["append", "tasks.md", "--tag", "foo"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`hyalo append` does not accept --tag"),
+        "expected friendly hint in stderr; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("hyalo set"),
+        "expected `hyalo set` recommendation in stderr; got: {stderr}"
+    );
+}
+
+#[test]
+fn append_tag_hint_only_fires_for_real_append_subcommand() {
+    // CodeRabbit review finding: the hint previously matched any argv element
+    // equal to "append", so commands like `hyalo find append --tag foo` also
+    // got the `hyalo append`-specific message. Gate on the resolved top-level
+    // subcommand instead.
+    let tmp = tempfile::tempdir().unwrap();
+    setup_file(&tmp);
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "append", "--tag", "foo"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("`hyalo append` does not accept --tag"),
+        "append-specific hint must not fire when subcommand is `find`; got: {stderr}"
+    );
+}

--- a/crates/hyalo-core/src/fs_util.rs
+++ b/crates/hyalo-core/src/fs_util.rs
@@ -10,10 +10,18 @@ use tempfile::NamedTempFile;
 /// then renames it into place. This ensures that a crash mid-write never leaves
 /// a truncated or corrupted file — the original is either fully replaced or
 /// left untouched.
+///
+/// When `path` already exists, the original file's permissions are preserved.
+/// `NamedTempFile` defaults to mode `0600`, so without this step rewrites
+/// would silently tighten file permissions on every mutation.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     let parent = path
         .parent()
         .context("cannot determine parent directory for atomic write")?;
+
+    // Capture existing permissions (if any) before the rename so we can restore
+    // them on the new file — otherwise `NamedTempFile`'s default `0600` wins.
+    let existing_perms = std::fs::metadata(path).ok().map(|m| m.permissions());
 
     let mut tmp = NamedTempFile::new_in(parent)
         .with_context(|| format!("failed to create temp file in {}", parent.display()))?;
@@ -21,8 +29,23 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     tmp.write_all(data)
         .with_context(|| format!("failed to write temp file for {}", path.display()))?;
 
+    if let Some(perms) = existing_perms.clone() {
+        std::fs::set_permissions(tmp.path(), perms).with_context(|| {
+            format!(
+                "failed to restore permissions on temp file for {}",
+                path.display()
+            )
+        })?;
+    }
+
     tmp.persist(path)
         .with_context(|| format!("failed to persist temp file to {}", path.display()))?;
+
+    // On some platforms `persist` can reset the mode; re-apply for safety.
+    if let Some(perms) = existing_perms {
+        std::fs::set_permissions(path, perms)
+            .with_context(|| format!("failed to restore permissions on {}", path.display()))?;
+    }
 
     Ok(())
 }
@@ -46,6 +69,45 @@ mod tests {
         std::fs::write(&target, "old content").unwrap();
         atomic_write(&target, b"new content").unwrap();
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "new content");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_preserves_existing_mode_0644() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("mode-0644.txt");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        atomic_write(&target, b"new content").unwrap();
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o644, "mode should be preserved across rewrite");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_preserves_existing_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("mode-0600.txt");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
+        atomic_write(&target, b"new content").unwrap();
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "tight mode should be preserved across rewrite");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_new_file_uses_platform_default() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("brand-new.txt");
+        atomic_write(&target, b"data").unwrap();
+        // For a brand-new file we don't enforce a specific mode — just make sure the
+        // file was created. Platform umask governs the exact bits.
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert!(mode != 0, "mode should be non-zero: {mode:o}");
     }
 
     #[test]

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -179,6 +179,18 @@ pub fn plan_mv(
     Ok(plans.into_values().collect())
 }
 
+/// Split a markdown-link target into its path portion and any trailing
+/// `#fragment`. Returns `(path, fragment_including_hash)`.
+///
+/// For `"peer.md#intro"` this returns `("peer.md", "#intro")`; for a target
+/// without a fragment the second element is `""`.
+fn split_target_fragment(target: &str) -> (&str, &str) {
+    match target.find('#') {
+        Some(idx) => (&target[..idx], &target[idx..]),
+        None => (target, ""),
+    }
+}
+
 /// Decide whether a markdown-link target should be considered for rewriting
 /// when a file moves.
 ///
@@ -187,24 +199,47 @@ pub fn plan_mv(
 /// - Site-absolute paths (start with `/`) — these are left untouched so that
 ///   downstream site renderers can resolve them from their own root.
 /// - URL schemes (`http://`, `mailto:`, …) and fragment-only refs (`#anchor`).
+///   Windows drive-letter paths like `C:\notes\x.md` are **not** treated as
+///   URL schemes.
 /// - Bare tokens with no `.md` suffix *and* no path separator — these look
 ///   like Obsidian wikilink labels or plain anchor text rather than file
 ///   paths.
+///
+/// Any trailing `#fragment` on the target is ignored when classifying — the
+/// file portion is what matters. So `peer.md#intro` is still treated as an
+/// `.md` link, and `#anchor` alone is still a pure fragment.
 ///
 /// Inbound rewriting already narrows by string-equality against the moved
 /// file's rel/stem, so this extra guard mostly protects outbound rewriting
 /// from blindly rebasing non-filesystem references.
 fn should_rewrite_outbound_target(target: &str) -> bool {
-    if target.is_empty() {
+    if target.is_empty() || target.starts_with('#') {
         return false;
     }
-    if target.starts_with('/') || target.starts_with('#') {
+    let (path_part, _) = split_target_fragment(target);
+    if path_part.is_empty() {
+        return false;
+    }
+    if path_part.starts_with('/') {
         return false;
     }
     // URL schemes: `http://`, `https://`, `mailto:`, `tel:`, …
-    if let Some(colon) = target.find(':') {
-        let scheme = &target[..colon];
-        if !scheme.is_empty()
+    //
+    // Exclude Windows drive-letter paths (single ASCII letter followed by `:`
+    // and a path separator) — they are filesystem paths, not URLs.
+    if let Some(colon) = path_part.find(':') {
+        let scheme = &path_part[..colon];
+        let is_drive_letter = colon == 1
+            && scheme
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic())
+            && path_part
+                .as_bytes()
+                .get(colon + 1)
+                .is_some_and(|b| *b == b'/' || *b == b'\\');
+        if !is_drive_letter
+            && !scheme.is_empty()
             && scheme
                 .chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
@@ -213,8 +248,8 @@ fn should_rewrite_outbound_target(target: &str) -> bool {
         }
     }
     // Bare token with no `.md` suffix and no path separator: treat as label.
-    let has_path_sep = target.contains('/') || target.contains('\\');
-    let is_md = std::path::Path::new(target)
+    let has_path_sep = path_part.contains('/') || path_part.contains('\\');
+    let is_md = std::path::Path::new(path_part)
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
     if !has_path_sep && !is_md {
@@ -465,8 +500,13 @@ fn plan_outbound_rewrites(
                 continue;
             }
 
+            // Strip any trailing `#fragment` for resolution / comparison, then
+            // re-attach it to the rewritten path so anchored file links keep
+            // their anchor.
+            let (target_path, target_fragment) = split_target_fragment(&span.link.target);
+
             // Resolve target relative to the OLD location's directory.
-            let resolved = normalize_target(Path::new(old_rel), &span.link.target);
+            let resolved = normalize_target(Path::new(old_rel), target_path);
 
             // Self-links: the file moves to `new_rel`, so the link should
             // continue to refer to the file at its new location.
@@ -481,8 +521,13 @@ fn plan_outbound_rewrites(
                 resolved
             };
 
-            // Compute new relative path from the NEW location.
-            let new_target = relative_path_between(new_rel, &target_after_move);
+            // Compute new relative path from the NEW location, then re-attach
+            // any fragment that was stripped above.
+            let new_target = format!(
+                "{}{}",
+                relative_path_between(new_rel, &target_after_move),
+                target_fragment
+            );
 
             // Original target as written in the file.
             let original_target = &line[span.target_start..span.target_end];
@@ -1119,6 +1164,67 @@ mod tests {
         assert!(should_rewrite_outbound_target("sub/x.md"));
         assert!(should_rewrite_outbound_target("x.md"));
         assert!(should_rewrite_outbound_target("sub/label"));
+        // Fragments: classify by the path portion, not the whole target.
+        assert!(
+            should_rewrite_outbound_target("x.md#intro"),
+            "anchored .md link should be rewritable"
+        );
+        assert!(
+            should_rewrite_outbound_target("sub/x.md#section-1"),
+            "anchored nested .md link should be rewritable"
+        );
+        assert!(
+            !should_rewrite_outbound_target("#anchor-with-dashes"),
+            "fragment-only target must still be skipped"
+        );
+        // Windows drive-letter paths are filesystem paths, not URL schemes.
+        assert!(
+            should_rewrite_outbound_target("C:/notes/x.md"),
+            "Windows drive-letter forward-slash path should be rewritable"
+        );
+        assert!(
+            should_rewrite_outbound_target("C:\\notes\\x.md"),
+            "Windows drive-letter backslash path should be rewritable"
+        );
+    }
+
+    #[test]
+    fn plan_mv_outbound_rewrites_anchored_self_link() {
+        // NEW-BUG-2 follow-up: self-links with fragments must still be rewritten
+        // to point at the file's new location while preserving the anchor.
+        let vault = create_vault(&[("self.md", "Jump to [intro](self.md#intro) in this file.\n")]);
+        let plans = plan_mv(vault.path(), "self.md", "other.md", None).unwrap();
+        assert_eq!(plans.len(), 1);
+        let plan = &plans[0];
+        assert_eq!(plan.rel_path, "other.md");
+        assert_eq!(plan.replacements.len(), 1);
+        assert_eq!(plan.replacements[0].old_text, "[intro](self.md#intro)");
+        assert_eq!(plan.replacements[0].new_text, "[intro](other.md#intro)");
+    }
+
+    #[test]
+    fn plan_mv_outbound_rewrites_anchored_relative_link_on_dir_change() {
+        // Anchored relative links must be rebased when the directory changes.
+        // `sub/a.md` moves to `a.md`; the link `peer.md#heading` should become
+        // `sub/peer.md#heading` from the new location.
+        let vault = create_vault(&[
+            ("sub/a.md", "See [peer](peer.md#heading).\n"),
+            ("sub/peer.md", "peer\n"),
+        ]);
+        let plans = plan_mv(vault.path(), "sub/a.md", "a.md", None).unwrap();
+        let moved_plan = plans
+            .iter()
+            .find(|p| p.rel_path == "a.md")
+            .expect("expected rewrite plan");
+        assert_eq!(moved_plan.replacements.len(), 1);
+        assert_eq!(
+            moved_plan.replacements[0].old_text,
+            "[peer](peer.md#heading)"
+        );
+        assert_eq!(
+            moved_plan.replacements[0].new_text,
+            "[peer](sub/peer.md#heading)"
+        );
     }
 
     #[test]

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -87,9 +87,19 @@ pub fn plan_mv(
     let dir_changed = old_dir != new_dir;
 
     // Step 2: gather inbound backlinks, grouped by source file.
+    //
+    // Skip self-links here — links that point from the moved file to itself
+    // are handled as outbound rewrites. Leaving them in the inbound set would
+    // produce a plan whose `path` still refers to `old_rel`, which no longer
+    // exists on disk after `fs::rename` (NEW-BUG-2).
     let backlinks = graph.backlinks(old_rel);
+    let old_rel_norm = old_rel.replace('\\', "/");
     let mut by_source: HashMap<PathBuf, Vec<_>> = HashMap::new();
     for entry in backlinks {
+        let source_norm = entry.source.to_string_lossy().replace('\\', "/");
+        if source_norm == old_rel_norm {
+            continue;
+        }
         by_source
             .entry(entry.source.clone())
             .or_default()
@@ -129,46 +139,88 @@ pub fn plan_mv(
         }
     }
 
-    // Step 4: plan outbound link updates for the moved file itself,
-    // but only when its directory context changes.
-    if dir_changed {
-        let old_abs = dir.join(old_rel);
-        let content = std::fs::read_to_string(&old_abs)
-            .with_context(|| format!("reading {}", old_abs.display()))?;
+    // Step 4: plan outbound link updates for the moved file itself.
+    //
+    // Always run — the moved file may contain self-links that need rewriting
+    // even when its directory didn't change (NEW-BUG-2). When the directory
+    // does change, relative links to other files are also rebased here.
+    let old_abs = dir.join(old_rel);
+    let content = std::fs::read_to_string(&old_abs)
+        .with_context(|| format!("reading {}", old_abs.display()))?;
 
-        let outbound_replacements = plan_outbound_rewrites(&content, old_rel, new_rel);
+    let outbound_replacements = plan_outbound_rewrites(&content, old_rel, new_rel, dir_changed);
 
-        if !outbound_replacements.is_empty() {
-            let moved_key = PathBuf::from(old_rel.replace('\\', "/"));
-            // The path targets the NEW location — after fs::rename, that's
-            // where the file lives and where the rewritten content must be
-            // written by execute_plans.
-            let new_abs = dir.join(new_rel);
+    if !outbound_replacements.is_empty() {
+        let moved_key = PathBuf::from(old_rel.replace('\\', "/"));
+        // The path targets the NEW location — after fs::rename, that's where
+        // the file lives and where the rewritten content must be written by
+        // execute_plans.
+        let new_abs = dir.join(new_rel);
 
-            if let Some(existing) = plans.get_mut(&moved_key) {
-                // The moved file already has an inbound plan; merge.
-                // Update path to point to the new location and re-apply
-                // all replacements (inbound + outbound) together.
-                existing.path = new_abs;
-                existing.rel_path = new_rel.to_string();
-                existing.replacements.extend(outbound_replacements);
-                existing.rewritten_content = apply_replacements(&content, &existing.replacements);
-            } else {
-                let rewritten_content = apply_replacements(&content, &outbound_replacements);
-                plans.insert(
-                    moved_key,
-                    RewritePlan {
-                        path: new_abs,
-                        rel_path: new_rel.to_string(),
-                        replacements: outbound_replacements,
-                        rewritten_content,
-                    },
-                );
-            }
+        if let Some(existing) = plans.get_mut(&moved_key) {
+            existing.path = new_abs;
+            existing.rel_path = new_rel.to_string();
+            existing.replacements.extend(outbound_replacements);
+            existing.rewritten_content = apply_replacements(&content, &existing.replacements);
+        } else {
+            let rewritten_content = apply_replacements(&content, &outbound_replacements);
+            plans.insert(
+                moved_key,
+                RewritePlan {
+                    path: new_abs,
+                    rel_path: new_rel.to_string(),
+                    replacements: outbound_replacements,
+                    rewritten_content,
+                },
+            );
         }
     }
 
     Ok(plans.into_values().collect())
+}
+
+/// Decide whether a markdown-link target should be considered for rewriting
+/// when a file moves.
+///
+/// Returns `false` (skip) for link targets that clearly do **not** point at a
+/// vault markdown file:
+/// - Site-absolute paths (start with `/`) — these are left untouched so that
+///   downstream site renderers can resolve them from their own root.
+/// - URL schemes (`http://`, `mailto:`, …) and fragment-only refs (`#anchor`).
+/// - Bare tokens with no `.md` suffix *and* no path separator — these look
+///   like Obsidian wikilink labels or plain anchor text rather than file
+///   paths.
+///
+/// Inbound rewriting already narrows by string-equality against the moved
+/// file's rel/stem, so this extra guard mostly protects outbound rewriting
+/// from blindly rebasing non-filesystem references.
+fn should_rewrite_outbound_target(target: &str) -> bool {
+    if target.is_empty() {
+        return false;
+    }
+    if target.starts_with('/') || target.starts_with('#') {
+        return false;
+    }
+    // URL schemes: `http://`, `https://`, `mailto:`, `tel:`, …
+    if let Some(colon) = target.find(':') {
+        let scheme = &target[..colon];
+        if !scheme.is_empty()
+            && scheme
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
+        {
+            return false;
+        }
+    }
+    // Bare token with no `.md` suffix and no path separator: treat as label.
+    let has_path_sep = target.contains('/') || target.contains('\\');
+    let is_md = std::path::Path::new(target)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+    if !has_path_sep && !is_md {
+        return false;
+    }
+    true
 }
 
 /// Execute rewrite plans: write each plan's `rewritten_content` back to disk.
@@ -346,7 +398,16 @@ fn plan_inbound_rewrites(
 /// file moves to `new_rel`.
 ///
 /// Wikilinks are vault-relative and never change.
-fn plan_outbound_rewrites(content: &str, old_rel: &str, new_rel: &str) -> Vec<Replacement> {
+///
+/// `dir_changed` indicates whether the move crosses directory boundaries.
+/// When `false`, only self-links (pointing at `old_rel` itself) need updating;
+/// all other relative links remain valid.
+fn plan_outbound_rewrites(
+    content: &str,
+    old_rel: &str,
+    new_rel: &str,
+    dir_changed: bool,
+) -> Vec<Replacement> {
     let mut replacements = Vec::new();
     let mut fence = FenceTracker::new();
     let mut in_comment_fence = false;
@@ -398,11 +459,30 @@ fn plan_outbound_rewrites(content: &str, old_rel: &str, new_rel: &str) -> Vec<Re
                 continue;
             }
 
+            // Skip targets that aren't vault markdown paths (site-absolute,
+            // URL schemes, bare labels). See `should_rewrite_outbound_target`.
+            if !should_rewrite_outbound_target(&span.link.target) {
+                continue;
+            }
+
             // Resolve target relative to the OLD location's directory.
             let resolved = normalize_target(Path::new(old_rel), &span.link.target);
 
+            // Self-links: the file moves to `new_rel`, so the link should
+            // continue to refer to the file at its new location.
+            let target_after_move = if resolved == old_rel {
+                new_rel.to_string()
+            } else {
+                // When the directory hasn't changed, relative links to other
+                // files in the same directory are still valid — skip them.
+                if !dir_changed {
+                    continue;
+                }
+                resolved
+            };
+
             // Compute new relative path from the NEW location.
-            let new_target = relative_path_between(new_rel, &resolved);
+            let new_target = relative_path_between(new_rel, &target_after_move);
 
             // Original target as written in the file.
             let original_target = &line[span.target_start..span.target_end];
@@ -904,6 +984,141 @@ mod tests {
             plans[0].replacements[0].new_text,
             "[settings](/docs/config/settings)"
         );
+    }
+
+    // ---- Self-link tests (NEW-BUG-2) ----
+
+    #[test]
+    fn plan_mv_self_link_same_directory() {
+        // `self.md` contains a markdown link to itself. Moving it to `other.md`
+        // in the same directory must (1) succeed, (2) produce a plan whose path
+        // points to the NEW location, and (3) rewrite the self-link.
+        let vault = create_vault(&[("self.md", "A link to [me](self.md).\n")]);
+        let plans = plan_mv(vault.path(), "self.md", "other.md", None).unwrap();
+        assert_eq!(plans.len(), 1);
+        let plan = &plans[0];
+        assert_eq!(plan.rel_path, "other.md");
+        assert_eq!(plan.path, vault.path().join("other.md"));
+        assert_eq!(plan.replacements.len(), 1);
+        assert_eq!(plan.replacements[0].old_text, "[me](self.md)");
+        assert_eq!(plan.replacements[0].new_text, "[me](other.md)");
+    }
+
+    #[test]
+    fn execute_plans_self_link_same_directory_e2e() {
+        // Full mv flow: rename + rewrite without canonicalization error.
+        let vault = create_vault(&[("self.md", "A link to [me](self.md).\n")]);
+        let plans = plan_mv(vault.path(), "self.md", "other.md", None).unwrap();
+        fs::rename(vault.path().join("self.md"), vault.path().join("other.md")).unwrap();
+        execute_plans(vault.path(), &plans).unwrap();
+        let content = fs::read_to_string(vault.path().join("other.md")).unwrap();
+        assert!(content.contains("[me](other.md)"), "got: {content:?}");
+        assert!(!content.contains("self.md"));
+    }
+
+    // ---- Outbound skip-rule tests (BUG-6) ----
+
+    #[test]
+    fn plan_mv_outbound_skips_site_absolute_links() {
+        // Site-absolute links (/…) must NOT be rewritten when the moved file's
+        // directory changes.
+        let vault = create_vault(&[
+            (
+                "games/anatomy/index.md",
+                "See [MDN](/en-US/docs/Web/API/Web_Workers).\n",
+            ),
+            ("games/anatomy-renamed/.gitkeep", ""),
+        ]);
+        let plans = plan_mv(
+            vault.path(),
+            "games/anatomy/index.md",
+            "games/anatomy-renamed/index.md",
+            None,
+        )
+        .unwrap();
+        let moved_plan = plans
+            .iter()
+            .find(|p| p.rel_path == "games/anatomy-renamed/index.md");
+        assert!(
+            moved_plan.is_none(),
+            "site-absolute link must not trigger a rewrite: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn plan_mv_outbound_skips_url_schemes() {
+        let vault = create_vault(&[(
+            "sub/note.md",
+            "See [link](https://example.com/x) and [mail](mailto:a@b.c).\n",
+        )]);
+        let plans = plan_mv(vault.path(), "sub/note.md", "archive/note.md", None).unwrap();
+        let moved_plan = plans.iter().find(|p| p.rel_path == "archive/note.md");
+        assert!(
+            moved_plan.is_none(),
+            "URL-scheme links must not be rewritten: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn plan_mv_outbound_skips_fragment_only() {
+        let vault = create_vault(&[("sub/note.md", "Jump to [top](#top).\n")]);
+        let plans = plan_mv(vault.path(), "sub/note.md", "archive/note.md", None).unwrap();
+        let moved_plan = plans.iter().find(|p| p.rel_path == "archive/note.md");
+        assert!(
+            moved_plan.is_none(),
+            "fragment-only links must not be rewritten: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn plan_mv_outbound_skips_bare_token_without_md_extension() {
+        // `[obsidian](Note One)` — no `.md`, no path separator. Must be left
+        // alone (treated as a label / Obsidian-style reference).
+        let vault = create_vault(&[("sub/note.md", "See [obsidian](Note One) here.\n")]);
+        let plans = plan_mv(vault.path(), "sub/note.md", "archive/note.md", None).unwrap();
+        let moved_plan = plans.iter().find(|p| p.rel_path == "archive/note.md");
+        assert!(
+            moved_plan.is_none(),
+            "bare non-md link must not be rewritten: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn plan_mv_outbound_rewrites_genuine_relative_link() {
+        // Regression: genuine relative links that would resolve differently
+        // after the move are rebased. Here `sub/a.md` moves to `a.md` at the
+        // root; the link `peer.md` (previously sub/peer.md) must be rewritten
+        // to `sub/peer.md` from the new location.
+        let vault = create_vault(&[
+            ("sub/a.md", "See [peer](peer.md).\n"),
+            ("sub/peer.md", "peer\n"),
+        ]);
+        let plans = plan_mv(vault.path(), "sub/a.md", "a.md", None).unwrap();
+        let moved_plan = plans
+            .iter()
+            .find(|p| p.rel_path == "a.md")
+            .expect("expected rewrite plan");
+        assert_eq!(moved_plan.replacements.len(), 1);
+        assert_eq!(moved_plan.replacements[0].old_text, "[peer](peer.md)");
+        assert_eq!(moved_plan.replacements[0].new_text, "[peer](sub/peer.md)");
+    }
+
+    #[test]
+    fn should_rewrite_outbound_target_rules() {
+        assert!(!should_rewrite_outbound_target(""));
+        assert!(!should_rewrite_outbound_target("/en-US/docs/x"));
+        assert!(!should_rewrite_outbound_target("/page.md"));
+        assert!(!should_rewrite_outbound_target("#anchor"));
+        assert!(!should_rewrite_outbound_target("https://a.b/c"));
+        assert!(!should_rewrite_outbound_target("mailto:a@b.c"));
+        assert!(!should_rewrite_outbound_target("tel:+1"));
+        assert!(!should_rewrite_outbound_target("Note One"));
+        assert!(!should_rewrite_outbound_target("plain-label"));
+        // Rewritable:
+        assert!(should_rewrite_outbound_target("../notes/x.md"));
+        assert!(should_rewrite_outbound_target("sub/x.md"));
+        assert!(should_rewrite_outbound_target("x.md"));
+        assert!(should_rewrite_outbound_target("sub/label"));
     }
 
     #[test]

--- a/hyalo-knowledgebase/backlog/done/bare-subcommand-defaults.md
+++ b/hyalo-knowledgebase/backlog/done/bare-subcommand-defaults.md
@@ -6,7 +6,8 @@ origin: dogfooding v0.4.1
 priority: low
 status: completed
 tags:
-  - cli,ux
+  - cli
+  - ux
 ---
 
 `hyalo tags` and `hyalo properties` exit with code 2 (usage error) instead of defaulting to the `summary` subcommand. This is a friction point — `hyalo tags` is the intuitive first thing to try.

--- a/hyalo-knowledgebase/backlog/done/empty-body-pattern-matches-all.md
+++ b/hyalo-knowledgebase/backlog/done/empty-body-pattern-matches-all.md
@@ -6,7 +6,9 @@ origin: dogfooding v0.4.1 on GitHub Docs
 priority: low
 status: completed
 tags:
-  - cli,find,validation
+  - cli
+  - find
+  - validation
 ---
 
 `hyalo find ""` returns all 3520 files because empty string is a substring of everything. This is technically correct but surprising — no warning is emitted.

--- a/hyalo-knowledgebase/backlog/done/fields-all-keyword.md
+++ b/hyalo-knowledgebase/backlog/done/fields-all-keyword.md
@@ -6,7 +6,9 @@ status: completed
 priority: low
 origin: dogfooding v0.4.2 on docs/content
 tags:
-  - cli,find,ux
+  - cli
+  - find
+  - ux
 ---
 
 `hyalo find --fields all` returns `unknown field "all"`. The help text says "default: all except properties-typed and backlinks", implying `all` should be a valid keyword.

--- a/hyalo-knowledgebase/backlog/done/fields-title-shorthand.md
+++ b/hyalo-knowledgebase/backlog/done/fields-title-shorthand.md
@@ -6,7 +6,9 @@ status: completed
 priority: low
 origin: dogfooding v0.4.2 on docs/content
 tags:
-  - cli,find,ux
+  - cli
+  - find
+  - ux
 ---
 
 `title` is the most commonly wanted field when browsing files, but `--fields title` is not supported. Users must use `--fields properties` which returns the entire property bag.

--- a/hyalo-knowledgebase/backlog/done/filter-typo-suggestion.md
+++ b/hyalo-knowledgebase/backlog/done/filter-typo-suggestion.md
@@ -6,7 +6,9 @@ status: completed
 priority: low
 origin: dogfooding v0.4.2 on docs/content
 tags:
-  - cli,ux,error-handling
+  - cli
+  - ux
+  - error-handling
 ---
 
 When a user types `--filter` (which doesn't exist), clap suggests `--file` as the closest match. Since the user almost certainly meant `--property`, the error message is misleading.

--- a/hyalo-knowledgebase/backlog/done/index-orphan-count-discrepancy.md
+++ b/hyalo-knowledgebase/backlog/done/index-orphan-count-discrepancy.md
@@ -6,7 +6,8 @@ status: completed
 priority: critical
 origin: dogfooding v0.4.2 on vscode-docs/docs
 tags:
-  - index,bug
+  - index
+  - bug
 ---
 
 `hyalo summary` reports **48 orphans** from disk scan but only **25 orphans** from the snapshot index on vscode-docs/docs (339 files). 23 files silently disappear from the orphan list when using `--index`.

--- a/hyalo-knowledgebase/backlog/done/limit-zero-means-unlimited.md
+++ b/hyalo-knowledgebase/backlog/done/limit-zero-means-unlimited.md
@@ -6,7 +6,8 @@ origin: dogfooding v0.4.1 + v0.4.2
 priority: medium
 status: completed
 tags:
-  - cli,validation
+  - cli
+  - validation
 ---
 
 `hyalo find --limit 0` returns ALL files (330,981 lines of JSON on docs/content). It behaves as if `--limit` were omitted entirely — `0` is treated as "no limit".

--- a/hyalo-knowledgebase/backlog/done/query-string-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/done/query-string-link-resolution.md
@@ -6,7 +6,8 @@ origin: dogfooding v0.4.1 on VS Code Docs (setup/windows.md links to /docs/?dv=w
 priority: low
 status: completed
 tags:
-  - links,bug-fix
+  - links
+  - bug-fix
 ---
 
 Link `/docs/?dv=winzip` is not resolved because the `?dv=winzip` query string is included in the path lookup. Similarly, `#fragment` anchors should be stripped.

--- a/hyalo-knowledgebase/backlog/done/quiet-flag-warning-dedup.md
+++ b/hyalo-knowledgebase/backlog/done/quiet-flag-warning-dedup.md
@@ -6,7 +6,8 @@ status: completed
 priority: low
 origin: dogfooding v0.4.2 on docs/content
 tags:
-  - cli,ux
+  - cli
+  - ux
 ---
 
 The warning `skipping code-security/concepts/index.md: unclosed frontmatter` appears on every full-scan command. When running multiple commands in sequence (common in batch/scripting), this adds noise.

--- a/hyalo-knowledgebase/backlog/done/repeatable-glob-flag.md
+++ b/hyalo-knowledgebase/backlog/done/repeatable-glob-flag.md
@@ -6,7 +6,8 @@ origin: dogfooding v0.4.0 (ISSUE-7) and v0.4.1 confirmed
 priority: medium
 status: completed
 tags:
-  - cli,filtering
+  - cli
+  - filtering
 ---
 
 `--glob` cannot be passed multiple times. Users want `--glob 'rest/**' --glob '!rest/**/index.md'` to include + exclude in one call. Currently errors with "cannot be used multiple times".

--- a/hyalo-knowledgebase/backlog/done/sort-by-backlinks-count.md
+++ b/hyalo-knowledgebase/backlog/done/sort-by-backlinks-count.md
@@ -6,7 +6,9 @@ origin: dogfooding v0.4.1 on GitHub Docs and VS Code Docs
 priority: medium
 status: completed
 tags:
-  - find,links,sorting
+  - find
+  - links
+  - sorting
 ---
 
 `find --sort backlinks_count` errors with "unknown sort field". Only `file` and `modified` are valid. This makes it impossible to natively find the most-linked-to files — users must pipe through jq.

--- a/hyalo-knowledgebase/backlog/done/sort-by-property-value.md
+++ b/hyalo-knowledgebase/backlog/done/sort-by-property-value.md
@@ -6,7 +6,9 @@ status: completed
 priority: medium
 origin: dogfooding v0.4.2 on docs/content and vscode-docs/docs
 tags:
-  - find,sorting,ux
+  - find
+  - sorting
+  - ux
 ---
 
 Currently `--sort` only accepts `file`, `modified`, `backlinks_count`, `links_count`. Users naturally expect `--sort title` and `--sort date` (or any frontmatter property).

--- a/hyalo-knowledgebase/backlog/done/trailing-slash-link-resolution.md
+++ b/hyalo-knowledgebase/backlog/done/trailing-slash-link-resolution.md
@@ -8,7 +8,8 @@ origin: >-
 priority: low
 status: completed
 tags:
-  - links,bug-fix
+  - links
+  - bug-fix
 ---
 
 Link `/docs/debugtest/debugging.md/` (with trailing `/`) fails to resolve even though `debugtest/debugging.md` exists. The trailing slash should be stripped before resolution.

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0120-followup-iter113b.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0120-followup-iter113b.md
@@ -1,0 +1,222 @@
+---
+title: "Dogfood v0.12.0 — Follow-up After Iter-113/113b/113c"
+type: research
+date: 2026-04-15
+status: active
+tags:
+  - dogfooding
+  - verification
+  - bug-fix
+  - permissions
+  - views
+  - mv
+related:
+  - "[[dogfood-results/dogfood-v0120-post-iter113]]"
+  - "[[dogfood-results/dogfood-v0120-multi-kb]]"
+  - "[[iterations/iteration-113-dogfood-v0120-fixes]]"
+---
+
+# Dogfood v0.12.0 — Follow-up After Iter-113/113b/113c
+
+Re-ran scenarios from [[dogfood-results/dogfood-v0120-post-iter113]] against the current tip of `main`
+(`target/release/hyalo 0.12.0`, built with `cargo build --release`). Covered both the own KB and a
+synthetic multi-KB setup under `/tmp/dogfood-v0120-iter113b/` with:
+
+- `ext-kb/` — flat external KB (`dir = "."`)
+- `root-kb/` with root `.hyalo.toml` having `dir = "subkb"` and schema/views defined at the root level
+- `root-kb/subkb/.hyalo.toml` — a second config inside the vault directory
+
+## Bug Fix Verification
+
+### BUG-1: `--dir` + `dir=` config resolution — FIXED
+
+Root `.hyalo.toml`:
+
+```toml
+dir = "subkb"
+[schema.types.article]
+required = ["title", "date"]
+[views.recent]
+properties = ["status=active"]
+```
+
+- `hyalo views list` shows `recent`
+- `hyalo types list` shows `article`
+- `hyalo find --view recent` returns `subkb/a1.md`, `subkb/a2.md`
+- `hyalo types set recipe --required title,date` appends to **root** `.hyalo.toml` (not `subkb/.hyalo.toml`)
+- `hyalo --dir subkb types set …` writes to `subkb/.hyalo.toml`
+
+The iter-113b fix (tracking `config_dir` separately from `dir`) is working correctly in both directions.
+
+### BUG-2: TOML section ordering — FIXED
+
+`types set` / `types remove` preserve existing key order and only mutate the touched sections. No alphabetical reshuffle, no escape-style churn.
+
+### BUG-3: Bare boolean operator warning — PARTIAL
+
+- `find "and"` / `find "or"` / `find "AND"` → warning with `"and" was interpreted as a boolean operator …`
+- `find "AND OR"` → warns about `"AND"` only; `OR` is silently swallowed after `AND` short-circuits. Minor.
+- `find "not"` / `find "NOT"` → no warning (by design; `NOT` is not an operator in this parser).
+
+### BUG-4: `task toggle --all` deep indentation — FIXED
+
+Exercised 0/2/4/6/8/12/16-space indent plus a tab-indented checkbox. All 8 detected and toggled.
+
+### BUG-5: `create-index --output PATH` — WORKING (with vault guard)
+
+`create-index --output /tmp/custom-index` is rejected with:
+```
+Error: output path is outside the vault boundary
+  hint: use --allow-outside-vault to override
+```
+That hint is discoverable and safer than the previous silent fallback. Fine as-is.
+
+### BUG-8: `remove --tag` with comma tags — FIXED
+
+`hyalo remove tasks.md --tag "foo,bar"` reports `foo,bar: 0/1 modified` (or removes it if present) without rejecting the name.
+
+`append --property tags=` (empty RHS) now errors cleanly:
+```
+Error: append --property tags= requires a non-empty tag value
+  hint: example: hyalo append --property tags=my-tag --file note.md
+```
+
+### UX-2 / UX-3 / UX-4 — STILL WORKING
+
+- `lint --type iteration` scans only iteration files.
+- `lint` flags 13 comma-joined tags in `backlog/done/`. `lint --fix --dry-run` reports `split-comma-tags` for each.
+- `task toggle --dry-run` shows planned changes without modifying the file.
+
+## New Issues
+
+### NEW-BUG-1: File permissions dropped on rewrite (HIGH)
+
+Any command that rewrites frontmatter or body (`hyalo set`, `hyalo task toggle`, `hyalo mv` *when link rewriting fires*) produces a file with mode `0600` regardless of the source mode. `hyalo mv` without link rewrites preserves the original mode.
+
+Reproduction with default `umask 022` on macOS:
+
+```
+$ ls -l perms-test.md
+-rw-r--r--  1 james  wheel  108 perms-test.md
+$ hyalo set perms-test.md --property status=planned
+$ ls -l perms-test.md
+-rw-------  1 james  wheel  111 perms-test.md
+```
+
+Implication: dogfooding against a git-checked-out vault changes `git status` to show mode-only diffs on any mutated file (`100644 → 100600`), and in a multi-user vault this locks out other readers. Likely cause is `tempfile::NamedTempFile` defaulting to `0600` followed by `persist()` without restoring the original mode.
+
+Suggested fix: before atomic replace, `fs::set_permissions(tmp, original_metadata.permissions())`.
+
+### NEW-BUG-2: `mv` with self-referencing link fails after the move succeeds (MEDIUM)
+
+A file containing a markdown link to itself (`[label](same-file.md)`) is moved correctly, but `hyalo mv` then errors:
+
+```
+Error: could not verify ./perms-test4.md is within vault
+  cause: failed to canonicalize path: ./perms-test4.md
+```
+
+The rename already happened, and the renamed file is present; but the exit code is non-zero and the link inside the new file is not rewritten. Atomicity is broken — the user sees both "success move" output and a follow-up error. Likely the link-rewriter canonicalizes the old path (now missing) after renaming.
+
+### NEW-BUG-3: `views "orphans"` view cannot actually filter orphans (MEDIUM, UX)
+
+Own KB defines:
+```toml
+[views.orphans]
+fields = ["backlinks"]
+```
+But `fields` only controls display columns. `find --view orphans --count` returns **237** (all files), while `find --orphan --count` returns **83**. There is no view-level `orphan = true` / `dead_end = true` option. Either:
+
+1. Teach views about `orphan` / `dead-end` filters (preferred).
+2. Have `hyalo init` or `lint` flag misconfigured views whose filters could never narrow the set.
+
+Workaround today: drop the view and use the `--orphan` flag directly.
+
+### NEW-BUG-4: Nested `.hyalo.toml` silently ignored (LOW)
+
+With the layout:
+```
+root-kb/.hyalo.toml      # dir = "subkb", declares type "article"
+root-kb/subkb/.hyalo.toml   # declares type "chapter"
+```
+`hyalo types list` (from `root-kb/`) lists only `article`. `chapter` is invisible. No warning or hint that a second `.hyalo.toml` was skipped.
+
+Expected: either merge (like nested git configs) or warn that `subkb/.hyalo.toml` is shadowed. Today it is silent.
+
+### NEW-BUG-5: Prior dogfood's "FIXED during this session" was never committed (LOW, data-quality)
+
+[[dogfood-results/dogfood-v0120-multi-kb]] line 144 says the 10 comma-joined tags in `backlog/done/` were *fixed* during the previous session. They weren't: `hyalo lint` still reports all 13 files (the count even grew). Either run `hyalo lint --fix` or update the prior report.
+
+`priority` still has mixed types (6 number / 84 text) as noted previously.
+
+### NEW-UX-1: `append --tag` gives a clap error, not a hint (LOW)
+
+`hyalo append note.md --tag foo` yields:
+```
+error: unexpected argument '--tag' found
+  tip: to pass '--tag' as a value, use '-- --tag'
+```
+The `append --help` text does say "Note: --tag is not available on append … Use `hyalo set --tag T`". A nicer error would surface that hint directly instead of clap's generic message.
+
+## Still Open From Prior Reports
+
+### BUG-6: `mv --dry-run` rewrites absolute URL-style links — STILL BROKEN
+
+```
+$ hyalo mv games/anatomy/index.md --to games/anatomy-renamed/index.md --dry-run
+[dry-run] Moved games/anatomy/index.md → games/anatomy-renamed/index.md
+  games/anatomy-renamed/index.md: [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
+    → [Web Workers](../../en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
+```
+
+Absolute URL-style links (those starting with `/`) should be treated as site-absolute and left alone. Obsidian-style bare labels (`[obsidian](Note One)` with no `.md` extension and spaces) are *also* rewritten into relative paths, which is likely wrong too — these are either Obsidian wikilink-ish references or plain anchor text and should not become filesystem paths.
+
+### UX-5 / UX-6 — NOT ADDRESSED
+
+- Link resolution is still case-sensitive (MDN-specific; no `--case-insensitive` option).
+- Unclosed-frontmatter files warn on *every* command invocation (`summary`, `find`, etc.). Confirmed with a synthetic `broken-fm.md`: every command prints `warning: skipping broken-fm.md: unclosed frontmatter`. Would still benefit from a per-file suppression or `.hyalo-ignore`-style list.
+
+## Performance (Own KB, 237 files)
+
+| Scenario              | Time       |
+|-----------------------|-----------|
+| `summary` (text)      | ~25 ms     |
+| FTS `"snapshot index architecture"` | ~55 ms |
+| FTS `"bm25 ranking"` (no index) | ~60 ms |
+| `create-index`        | ~45 ms     |
+| FTS with index        | ~55 ms (too small to see speedup) |
+
+No regressions vs. iter-113. KB is too small to exercise the index code path meaningfully; MDN/GH-docs would be needed for that.
+
+## Summary
+
+| Bug / Issue | Status | Notes |
+|-----|--------|-------|
+| BUG-1 | Fixed | Root-config `dir=` + explicit `--dir` both route correctly |
+| BUG-2 | Fixed | toml_edit preserves order |
+| BUG-3 | Fixed (minor gap) | `AND OR` only warns about the first operator |
+| BUG-4 | Fixed | 16-space & tab indent work |
+| BUG-5 | Working (vault-guarded) | Use `--allow-outside-vault` to override |
+| BUG-6 | **Open** | `/` URL-style + obsidian-style links still rewritten |
+| BUG-8 | Fixed | Comma-tags removable |
+| UX-2 | Working | `lint --type` |
+| UX-3 | Working | Comma-tag detection |
+| UX-4 | Working | `task toggle --dry-run` |
+| UX-5 | **Open** | Link case-sensitivity |
+| UX-6 | **Open** | Repeated frontmatter warnings |
+| NEW-BUG-1 | **Open (HIGH)** | Set/task-toggle/mv-with-rewrite drop mode to 0600 |
+| NEW-BUG-2 | **Open (MEDIUM)** | `mv` errors after move when file links to itself |
+| NEW-BUG-3 | **Open (MEDIUM)** | Views can't express orphan/dead-end filters |
+| NEW-BUG-4 | **Open (LOW)** | Nested `.hyalo.toml` silently shadowed |
+| NEW-BUG-5 | **Open (LOW)** | Own KB still has 13 comma-joined tags (prior report claim was wrong) |
+| NEW-UX-1 | **Open (LOW)** | `append --tag` shows clap error instead of "use `set --tag`" hint |
+
+## Suggested Iteration Priority
+
+1. **HIGH**: Preserve file mode across atomic rewrites (NEW-BUG-1) — silent permission tightening is a data/ops hazard.
+2. **MEDIUM**: Fix `mv` rewriter to handle self-referencing links (NEW-BUG-2) and leave `/`-prefixed + bare Obsidian links alone (BUG-6).
+3. **MEDIUM**: Extend views schema with `orphan` / `dead_end` (NEW-BUG-3).
+4. **LOW**: Warn when a nested `.hyalo.toml` is shadowed (NEW-BUG-4).
+5. **LOW**: Improve `append --tag` error to point at `set --tag` (NEW-UX-1).
+6. **LOW / housekeeping**: Run `hyalo lint --fix` on own KB to finally clean the comma-joined tags (NEW-BUG-5).
+7. **LOW**: Suppress repeated frontmatter warnings (UX-6).

--- a/hyalo-knowledgebase/iterations/iteration-114-dogfood-v0120-followup-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-114-dogfood-v0120-followup-fixes.md
@@ -1,0 +1,225 @@
+---
+title: Iteration 114 — Dogfood v0.12.0 Follow-up Fixes
+type: iteration
+date: 2026-04-15
+status: completed
+branch: iter-114/dogfood-v0120-followup-fixes
+tags:
+  - dogfooding
+  - bug-fix
+  - permissions
+  - mv
+  - views
+  - links
+related:
+  - "[[dogfood-results/dogfood-v0120-followup-iter113b]]"
+  - "[[iterations/iteration-113-dogfood-v0120-fixes]]"
+---
+
+# Iteration 114 — Dogfood v0.12.0 Follow-up Fixes
+
+## Goal
+
+Fix the bugs and UX issues that remained open or were newly discovered in the v0.12.0 follow-up
+dogfood session after iter-113/113b/113c landed. See [[dogfood-results/dogfood-v0120-followup-iter113b]]
+for the full report.
+
+Scope: data-safety (file permissions), link-rewriting correctness (`mv`), view expressiveness
+(orphans/dead-ends), config-layering transparency, and a handful of CLI-UX polish items.
+
+## Bugs
+
+### NEW-BUG-1: File permissions dropped to 0600 on rewrite (HIGH)
+
+Any command that rewrites a file — `hyalo set`, `hyalo task toggle`, and `hyalo mv` when it rewrites
+links inside the moved file — replaces the file with one whose mode is `0600`, regardless of the
+original mode. `hyalo mv` without link rewrites preserves the mode, which pinpoints the atomic-replace
+path.
+
+Reproduction (macOS, `umask 022`):
+```
+$ ls -l perms.md
+-rw-r--r--  … perms.md
+$ hyalo set perms.md --property status=planned
+$ ls -l perms.md
+-rw-------  … perms.md
+```
+
+Likely cause: the temporary file created by `tempfile::NamedTempFile` (or equivalent) defaults to
+`0600`; `persist()` renames it over the target without copying the original mode.
+
+**Fix**: Before the atomic replace, `fs::set_permissions(tmp, original_metadata.permissions())`
+(and fall back to `umask`-derived default if the original metadata can't be read — e.g. a brand-new
+file). Ensure tests cover both existing and newly-created target paths.
+
+### NEW-BUG-2: `mv` with self-referencing link errors after move (MEDIUM)
+
+A file containing a markdown link to itself (`[label](self.md)`) is moved, but `hyalo mv` then
+errors:
+
+```
+Error: could not verify ./self.md is within vault
+  cause: failed to canonicalize path: ./self.md
+```
+
+Exit code is non-zero, but the rename already happened. The self-link inside the new file is not
+rewritten.
+
+**Fix**: When rewriting links inside the *moved* file, resolve link targets against the new path
+(`--to`), not the source path. Add an e2e test that moves a file containing a link to itself and
+asserts that (a) exit code is 0, (b) the link in the new file points at the new location.
+
+### NEW-BUG-3: Views cannot filter by `orphan` / `dead-end` (MEDIUM)
+
+Views today only support `properties`, `tags`, `task`, and `fields`. Defining `[views.orphans]` with
+`fields = ["backlinks"]` merely adds a display column — it does not restrict the result set. In the
+own KB, `find --view orphans --count` returns 237 (every file) while `find --orphan --count` returns 83.
+
+**Fix**: Extend the view schema with optional `orphan = true` / `dead_end = true` booleans that map
+onto the same filters exposed by `find --orphan` / `find --dead-end`. Update the view validator so
+`hyalo lint` can flag legacy view definitions that look orphan-ish but don't filter.
+
+### BUG-6 (still open): `mv` rewrites `/`-prefixed and bare wiki-style links (MEDIUM)
+
+Carried over from [[dogfood-results/dogfood-v0120-multi-kb]]. Reproduced again:
+
+```
+hyalo mv games/anatomy/index.md --to games/anatomy-renamed/index.md --dry-run
+  [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
+    → [Web Workers](../../en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
+  [obsidian](Note One)
+    → [obsidian](../Note One)
+```
+
+- Links starting with `/` are site-absolute and must be left untouched.
+- Tokens with no `.md` extension and no path separator (e.g. `Note One`) are almost always labels,
+  Obsidian-style wikilinks, or external refs — not file paths — and should not be rewritten.
+
+**Fix**: In the link-rewriter, skip any target that (a) starts with `/`, (b) starts with a URL scheme
+(`http://`, `https://`, `mailto:`, `tel:`, `#`), or (c) has no `.md` suffix *and* contains no path
+separator. Preserve behaviour for genuine relative/absolute filesystem paths.
+
+### NEW-BUG-4: Nested `.hyalo.toml` silently shadowed (LOW)
+
+With:
+```
+root/.hyalo.toml        # dir = "subkb", declares type "article"
+root/subkb/.hyalo.toml  # declares type "chapter"
+```
+Running `hyalo types list` from `root/` shows only `article`. The nested `subkb/.hyalo.toml` is
+silently ignored.
+
+**Fix**: When config resolution selects a parent `.hyalo.toml` whose `dir` points at a directory
+containing another `.hyalo.toml`, emit a single one-line warning:
+
+```
+warning: ignoring nested config subkb/.hyalo.toml (shadowed by root config)
+```
+
+Do not try to merge — keep semantics simple, just make the shadowing visible. Suppress behind
+`--no-hints` / `quiet = true`.
+
+### NEW-UX-1: `append --tag` shows clap error instead of hint (LOW)
+
+```
+$ hyalo append note.md --tag foo
+error: unexpected argument '--tag' found
+  tip: to pass '--tag' as a value, use '-- --tag'
+```
+
+The `append` help text already explains that `--tag` is not available on append and suggests
+`hyalo set --tag T`, but the CLI error does not surface this.
+
+**Fix**: Add a custom clap error handler (or a pre-parse check) for `append` that, when `--tag` is
+seen, emits:
+
+```
+error: `hyalo append` does not accept --tag (tags are scalar list items, not appendable)
+  hint: use `hyalo set <file> --tag <tag>` to add a tag
+```
+
+### BUG-3 minor gap: `AND OR` only warns about the first operator (LOW)
+
+`find "AND OR"` warns about `AND` but silently swallows `OR`. Low impact; the user still sees a
+warning and fixes the query.
+
+**Fix**: Rework the bare-operator check to concatenate every stripped operator into the warning
+message, e.g. `"AND", "OR" were interpreted as boolean operators …`.
+
+## UX / Housekeeping
+
+### UX-5 (still open): Link resolution is case-sensitive
+
+Not addressed in this iteration. Leave as a follow-up — MDN-specific, orthogonal to the fixes above.
+
+### UX-6 (still open): Repeated unclosed-frontmatter warnings
+
+Not addressed in this iteration. The warning is correct but noisy. A future iteration should add an
+ignore-list mechanism (e.g. `[scanner] ignore = ["path/to/broken.md"]` in `.hyalo.toml`).
+
+### Data-quality: NEW-BUG-5 — unfixed comma-joined tags in own KB
+
+[[dogfood-results/dogfood-v0120-multi-kb]] claimed "FIXED during this session" for 13 comma-joined
+tags in `backlog/done/`. They are still present. Run `hyalo lint --fix` on the own KB as part of
+this iteration and update the prior report's claim.
+
+## Tasks
+
+### NEW-BUG-1: preserve file mode on atomic rewrite
+- [x] Locate the atomic-replace helper (hyalo-io or equivalent) used by `set`, `task toggle`, and `mv`'s body rewriter
+- [x] Before rename/persist, copy the source file's permissions onto the temp file
+- [x] If the target is brand-new (no prior file), leave the temp file with the platform default derived from `umask`
+- [x] Unit test: write two files with modes 0644 and 0600; mutate both; assert modes are preserved
+- [x] e2e test: `hyalo set file.md --property status=x` on a 0644 file → still 0644
+- [x] e2e test: `hyalo task toggle file.md --all` preserves mode
+- [x] e2e test: `hyalo mv a.md --to b.md` with link rewrite preserves mode of the new file
+
+### NEW-BUG-2: mv-with-self-link should not error after move
+- [x] Reproduce in an integration test: create `self.md` containing `[me](self.md)`; `hyalo mv self.md --to other.md`
+- [x] Fix the link-rewriter so it canonicalises against the destination path, not the source, after the rename
+- [x] Assert exit code 0 and that `other.md` contains `[me](other.md)`
+
+### NEW-BUG-3: view filters for orphan / dead-end
+- [x] Add `orphan: Option<bool>` and `dead_end: Option<bool>` to the view schema (TOML + struct)
+- [x] Thread them into the same filter pipeline as `find --orphan` / `--dead-end`
+- [x] `hyalo lint` flags views that use `fields = ["backlinks"]` as their only narrowing mechanism (likely intended to be `orphan = true`)
+- [x] Update own KB `.hyalo.toml`: `[views.orphans] orphan = true` (remove the misleading `fields` line)
+- [x] e2e test: a view with `orphan = true` returns the same count as `find --orphan`
+
+### BUG-6: skip site-absolute and non-md link rewrites
+- [x] In the link rewriter, add a `should_rewrite(target: &str) -> bool` helper with the rules above
+- [x] Skip `/…`, URL schemes, `#…`, `mailto:…`, `tel:…`
+- [x] Skip bare tokens with no `.md` suffix and no `/`
+- [x] Add test cases for each skip rule (MDN-style, Obsidian-style, fragment-only)
+- [x] Regression test: genuine relative link `../notes/x.md` still gets rewritten
+
+### NEW-BUG-4: warn on shadowed nested config
+- [x] When config resolution settles on a config whose `dir` points at a subdirectory containing its own `.hyalo.toml`, emit a one-line warning
+- [x] Respect `--no-hints` / global quiet flags
+- [x] e2e test: create `root/.hyalo.toml (dir=subkb)` + `root/subkb/.hyalo.toml`; assert warning is emitted once
+
+### NEW-UX-1: friendly error for `append --tag`
+- [x] Intercept `--tag` in the `append` subcommand's argument parsing
+- [x] Emit the hint shown above instead of the generic clap error
+- [x] e2e test: `hyalo append file.md --tag foo` exits non-zero with the new message
+
+### BUG-3 follow-up: aggregate operator warning
+- [x] Collect all stripped bare operators into the warning message
+- [x] e2e test: `find "AND OR"` warns about both
+
+### Data quality
+- [x] Run `hyalo lint --fix` to split the 13 comma-joined tags in `backlog/done/`
+- [x] Update [[dogfood-results/dogfood-v0120-multi-kb]] — remove the inaccurate "FIXED during this session" claim (or mark it fixed in iter-114)
+
+### Quality gate
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace -q`
+- [x] Rebuild release binary and re-run a focused dogfood pass against the own KB + the `/tmp` multi-KB fixture
+- [x] Update CLAUDE.md / skill templates if any flag surface changes
+
+## Deferred to a Later Iteration
+
+- UX-5: Case-insensitive link resolution (MDN-specific; probably needs a `--case-insensitive` flag or `.hyalo.toml` option).
+- UX-6: Per-file ignore list for unclosed-frontmatter warnings.
+- Consider extending `find` so bare-token queries can opt in to case-insensitive regex without slash-form (`--property 'title~=dogfood' --ci`).


### PR DESCRIPTION
## Summary
- **NEW-BUG-1 (file mode)**: `hyalo set`, `task toggle`, and `mv` now preserve the target file's permissions across atomic rewrites (no more 0644 → 0600 drops).
- **NEW-BUG-2 (mv self-link)**: `mv` no longer errors on files containing a self-link; link-rewriter planning targets the destination path and handles self-links correctly for both same-dir renames (rewritten to new name) and cross-dir moves (left as-is — still resolves to the moved file).
- **NEW-BUG-3 (views orphan/dead-end)**: view TOML accepts `orphan = true` / `dead_end = true` — same filter path as `find --orphan`. `hyalo lint` now flags views whose only narrowing key is `fields` (which controls display, not filtering).
- **BUG-6 (link-rewrite skip rules)**: `mv`'s outbound rewriter now skips site-absolute (`/…`), URL-scheme (`http://`, `mailto:`, `tel:`), fragment-only (`#…`), and bare non-md token targets.
- **NEW-BUG-4 (nested config)**: warn when `.hyalo.toml`'s `dir` points at a subdirectory that itself contains a `.hyalo.toml` (silent shadowing).
- **NEW-UX-1 (append --tag)**: `hyalo append --tag foo` shows a friendly hint pointing to `hyalo set --tag`, not a raw clap error.
- **BUG-3 follow-up**: bare-operator warning lists ALL stripped operators (e.g. `find "AND OR"` mentions both `AND` and `OR`).
- **Data quality**: ran `hyalo lint --fix` on own KB to split 13 comma-joined tag lists in `backlog/done/`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo test --workspace -q` (all 1400+ tests pass)
- [x] Dogfood: `hyalo append foo.md --tag bar` → friendly hint ✓
- [x] Dogfood: `hyalo find "AND OR"` → warns about both operators ✓
- [x] Dogfood: nested config → shadow warning emitted ✓
- [x] Dogfood: `find --view orphans` matches `find --orphan` count (83=83) ✓
- [x] New unit tests for `atomic_write` permission preservation (0644, 0600, new file)
- [x] New unit tests for `should_rewrite_outbound_target` (absolute, URL, fragment, bare-token, genuine relative)
- [x] New e2e tests: mv self-link (same-dir rewrites, cross-dir valid), append --tag hint, nested config shadow, aggregate AND/OR warning, orphan/dead_end view deserialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orphan view support in configuration and new view-validation warnings.
  * Search warnings now list all boolean operators when applicable.
  * Improved link-rewrite behavior for self-links and non-file targets.
  * Preserves file permissions during atomic rewrites.

* **Bug Fixes**
  * Warns on shadowed nested configurations.
  * Fixes self-link rewriting after moves and adds a friendlier hint for unsupported append flags.

* **Documentation**
  * Updated CLI docs, examples, and dogfood follow-up notes.

* **Tests**
  * Added e2e and unit tests for operator warnings, mv/link behavior, and permission preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->