### PR TITLE
iter-114b: sync README and skill templates with iter-114 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ hyalo lint --limit 10
 hyalo lint --type iteration
 ```
 
-Lint also warns about comma-joined tags (e.g. `"cli,ux"` instead of separate list items); `--fix` splits them automatically. Lint additionally validates `[views.*]` in `.hyalo.toml` — views whose only narrowing key is `fields` (which picks output columns, not matches) are flagged so you can add an actual filter like `orphan = true` or `tags = [...]`.
+Lint also warns about comma-joined tags (e.g. `"cli,ux"` instead of separate list items); `--fix` splits them automatically. Lint additionally validates `[views.*]` in `.hyalo.toml` — views whose only narrowing key is `fields` (which picks output columns, not matches) are flagged so you can add an actual filter like `orphan = true` or `tag = [...]` (saved views store tags under the `tag` key, not `tags`).
 
 **Exit codes:** 0 = clean, 1 = errors found, 2 = internal error.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ default_limit = 100    # default: 50 (max results for list commands; 0 = unlimit
 
 All fields are optional. CLI flags always take precedence over config values. If `.hyalo.toml` is missing, hyalo silently uses built-in defaults; if the file is present but cannot be read or is malformed/invalid, hyalo warns on stderr and falls back to the built-in defaults.
 
+**Nested config shadowing:** If the root `.hyalo.toml` has `dir` pointing at a subdirectory that itself contains a `.hyalo.toml`, the nested config is silently shadowed — only the root config applies. Hyalo emits a warning on stderr (`ignoring nested config <path>/.hyalo.toml (shadowed by <root>/.hyalo.toml)`). Either merge the settings into the root config or remove the nested file. Suppress the warning with `--quiet`.
+
 Use `--no-hints` to explicitly disable hints when the config file enables them.
 
 **Default output limits:** List commands (`find`, `lint`, `tags summary`, `properties summary`, `backlinks`) return at most 50 results by default. When results are truncated, the output shows "showing N of M matches" and a hint to get all results. Use `--limit 0` for unlimited output, or set `default_limit` in `.hyalo.toml` to change the project-wide default. The default limit is **not applied** when `--jq` or `--count` is used — programmatic pipelines always receive complete results.
@@ -301,7 +303,7 @@ hyalo find --view recent-todos --tag rust   # extend the view with additional fi
 |------------|----------|
 | Vec fields (`--property`, `--tag`, `--section`, `--file`, `--glob`) | Extended — extra filters are ANDed on top of the view |
 | Option fields (`--sort`, `--limit`, `--regexp`, `--title`, `--task`, `--fields`) | Override — CLI value takes precedence over the view |
-| Bool fields (`--broken-links`, `--reverse`) | OR'd — enabled if either the view or the CLI sets them |
+| Bool fields (`--broken-links`, `--orphan`, `--dead-end`, `--reverse`) | OR'd — enabled if either the view or the CLI sets them |
 
 **Storage:** Views are persisted as TOML tables in `.hyalo.toml` under `[views.<name>]`:
 
@@ -315,7 +317,15 @@ task = "todo"
 sort = "modified"
 reverse = true
 limit = 20
+
+[views.orphans]
+orphan = true
+
+[views.dead-ends]
+dead_end = true
 ```
+
+`hyalo lint` flags views whose only narrowing key is `fields` (which controls display, not filtering) — add an explicit filter like `orphan = true` or `dead_end = true` to silence the warning.
 
 ### read
 
@@ -437,6 +447,8 @@ hyalo append --property tags=serde --glob "crates/*.md"
 hyalo append --property aliases=old-name --where-tag renamed --glob '**/*.md'
 ```
 
+`append` does not support `--tag` — tags aren't appendable via `append`. Use `hyalo set --tag <name>` to add a tag instead; running `hyalo append --tag …` prints a hint pointing to `set --tag`.
+
 ### task
 
 Read, toggle, or set the status of task checkboxes. Supports three mutually exclusive selectors: `--line` (single, comma-separated, or repeatable), `--section`, and `--all`.
@@ -553,6 +565,14 @@ Use `--dry-run` to preview which files and links would change without modifying 
 
 Root-absolute links (e.g. `/docs/guides/setup.md`) are also rewritten during a move. Hyalo uses the site prefix to map these to vault-relative paths. If `mv` reports 0 links updated but you expect absolute links to be rewritten, check your `--site-prefix` setting (see [Absolute link resolution](#absolute-link-resolution-site-prefix)).
 
+**Targets that are not rewritten** when `mv` updates outbound links inside the moved file:
+- Site-absolute links starting with `/` (resolved via site prefix instead)
+- URL-scheme links (`http://`, `https://`, `mailto:`, `tel:`, …)
+- Fragment-only links (`#heading`)
+- Bare non-md tokens with no path separator (e.g. Obsidian-style `[[Topic]]`)
+
+File permissions are preserved across all atomic rewrites (`set`, `task toggle`, `mv`, `lint --fix`) — files keep their existing mode (e.g. `0644`) rather than dropping to `0600`.
+
 ### links
 
 Subcommand group for link operations.
@@ -605,7 +625,7 @@ hyalo lint --limit 10
 hyalo lint --type iteration
 ```
 
-Lint also warns about comma-joined tags (e.g. `"cli,ux"` instead of separate list items); `--fix` splits them automatically.
+Lint also warns about comma-joined tags (e.g. `"cli,ux"` instead of separate list items); `--fix` splits them automatically. Lint additionally validates `[views.*]` in `.hyalo.toml` — views whose only narrowing key is `fields` (which picks output columns, not matches) are flagged so you can add an actual filter like `orphan = true` or `tags = [...]`.
 
 **Exit codes:** 0 = clean, 1 = errors found, 2 = internal error.
 

--- a/crates/hyalo-cli/templates/skill-hyalo-tidy.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-tidy.md
@@ -136,6 +136,11 @@ report the suggestion in Phase 5.
 
 If lint reports fixable violations, note the counts for Phase 4.
 
+Lint also validates `[views.*]` in `.hyalo.toml`. A view whose only narrowing key is
+`fields` (display columns, not a filter) is surfaced as a warning — suggest adding an
+explicit filter like `orphan = true`, `dead_end = true`, or `tags = [...]` when you see
+one in Phase 5.
+
 ### Broken links
 ```bash
 # Dry-run shows broken links with proposed fixes and confidence scores

--- a/crates/hyalo-cli/templates/skill-hyalo-tidy.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-tidy.md
@@ -47,7 +47,7 @@ hyalo create-index
 hyalo views set stale-in-progress --property status=in-progress --fields tasks
 hyalo views set missing-status --property '!status'
 hyalo views set missing-type --property '!type'
-hyalo views set orphans --fields backlinks
+hyalo views set orphans --orphan --fields backlinks
 hyalo views set completed-with-todos --property status=completed --task todo --fields tasks
 ```
 
@@ -138,7 +138,7 @@ If lint reports fixable violations, note the counts for Phase 4.
 
 Lint also validates `[views.*]` in `.hyalo.toml`. A view whose only narrowing key is
 `fields` (display columns, not a filter) is surfaced as a warning — suggest adding an
-explicit filter like `orphan = true`, `dead_end = true`, or `tags = [...]` when you see
+explicit filter like `orphan = true`, `dead_end = true`, or `tag = [...]` when you see
 one in Phase 5.
 
 ### Broken links

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -165,6 +165,11 @@ hyalo mv backlog/my-item.md --to backlog/done/my-item.md
 hyalo mv old-path.md --to new-path.md --dry-run
 ```
 
+`hyalo mv` rewrites relative `.md` paths only. It leaves untouched: site-absolute links
+(`/docs/...`, handled separately via site prefix), URL-scheme links (`http://`, `mailto:`),
+fragment-only links (`#section`), and bare non-`.md` wiki tokens. File permissions (e.g.
+`0644`) are preserved through all atomic rewrites.
+
 ## Absolute link resolution (site prefix)
 
 Documentation sites often use root-absolute links like `/docs/guides/setup.md`. Hyalo resolves
@@ -218,7 +223,7 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **tags rename** — bulk rename a tag across files (`--from old --to new`)
 - **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates; `--property 'K=[a,b,c]'` creates YAML sequences; file arg is positional or `--file`, repeatable)
 - **remove** — delete properties or tags
-- **append** — add to list properties
+- **append** — add to list properties (note: tags are not appendable; use `set --tag` instead)
 - **task** — read, toggle, or set status on checkboxes (supports `--line 5,7`, `--section "Tasks"`, `--all`; `--dry-run` to preview toggles)
 - **mv** — move/rename a file and rewrite all inbound links across the vault (`--dry-run` to preview)
 - **backlinks** — reverse link lookup: lists all files that link to a given file
@@ -258,6 +263,10 @@ hyalo lint --fix
 
 Lint also warns about comma-joined tags (e.g. `tags: ["cli,ux"]` instead of two list
 items); `--fix` splits them into proper list entries automatically.
+
+Lint additionally validates saved views in `.hyalo.toml`: if a `[views.*]` entry only
+sets `fields` (which controls output columns, not which files match), lint flags it so
+you can add a real filter like `orphan = true` or `tags = [...]`.
 
 Exit codes: 0 = clean, 1 = errors found, 2 = internal error.
 
@@ -322,6 +331,8 @@ hyalo views list --format text
 ```bash
 hyalo views set stale-iterations --property type=iteration --property status=in-progress
 hyalo views set perf-research "performance" --tag research   # BM25 pattern + filter
+hyalo views set orphans --orphan                             # files with no inbound/outbound links
+hyalo views set dead-ends --dead-end                         # files with inbound but no outbound links
 hyalo find --view stale-iterations                    # reuse later
 hyalo find --view stale-iterations --limit 5          # compose with overrides
 ```

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -266,7 +266,8 @@ items); `--fix` splits them into proper list entries automatically.
 
 Lint additionally validates saved views in `.hyalo.toml`: if a `[views.*]` entry only
 sets `fields` (which controls output columns, not which files match), lint flags it so
-you can add a real filter like `orphan = true` or `tags = [...]`.
+you can add a real filter like `orphan = true` or `tag = [...]` (saved views
+store tags under the `tag` key).
 
 Exit codes: 0 = clean, 1 = errors found, 2 = internal error.
 


### PR DESCRIPTION
## Summary

Follow-up to #130 (iter-114). Syncs user-facing docs with the new behavior that iter-114 introduced so the README and bundled skill templates match what the CLI actually does.

- **Views** — README now lists `--orphan` / `--dead-end` as merge-OR bool fields and shows `[views.orphans]` / `[views.dead-ends]` TOML examples. Skill template gains matching `views set --orphan` / `--dead-end` examples.
- **Lint** — README and both skill templates mention the new `[views.*]` validation (views whose only narrowing key is `fields` are flagged).
- **Config** — README documents the "nested `.hyalo.toml` shadowed" stderr warning (exact message: `ignoring nested config <path>/.hyalo.toml (shadowed by <root>/.hyalo.toml)`) and that `--quiet` silences it.
- **mv** — README and skill template document the rewrite skip rules (site-absolute `/`, URL schemes, fragment-only, bare non-md wiki tokens) and note the file-mode preservation guarantee.
- **append** — README and skill template call out that `--tag` is not supported on `append`; users should `set --tag` instead. Matches the new friendly clap-error hint.

No code changes.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace -q` — 592 passed, 0 failed
- [x] Verified `hyalo views set --help` exposes `--orphan` / `--dead-end` so the example is accurate
- [x] Verified shadow-warning wording against `crates/hyalo-cli/src/config.rs:162`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified nested config behavior with a stderr warning (suppressible via --quiet) when a nested root-config’s own config is ignored.
  * Documented OR-ed view flags to include --orphan and --dead-end alongside existing flags.
  * Added persisted-view examples for orphans and dead-ends and clarified saved-view TOML uses key `tag` (not `tags`).
  * Noted `hyalo append` won’t accept --tag and now prints a hint to use `hyalo set --tag`.
  * Expanded `hyalo mv` link-rewriting scope and listed link targets left untouched.
  * Added lint guidance: views with only `fields` produce a warning; lint validates `[views.*]`.
  * Documented that file permissions are preserved across atomic rewrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->