### PR TITLE
iter-117: Case-insensitive link resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ default_limit = 100    # default: 50 (max results for list commands; 0 = unlimit
 [links]
 frontmatter_properties = ["related", "depends-on", "supersedes", "superseded-by"]
 
+# Case-insensitive link resolution: "auto" (default), "true", or "false".
+# "auto" probes the filesystem at startup — on case-insensitive filesystems (macOS,
+# Windows NTFS) it is enabled automatically; on case-sensitive filesystems it is off.
+# "true" forces CI resolution regardless of filesystem (useful in Docker / CI).
+# "false" disables it, treating wrong-cased links as unresolved (strict mode).
+case_insensitive = "auto"
+
 # Schema validation on write: when true, `set`/`append` behave as if `--validate`
 # were always passed — writes that would create lint errors are rejected.
 [schema]
@@ -631,6 +638,8 @@ hyalo links fix --format text
 `links fix` detects broken `[[wikilinks]]` and `[markdown](links)` across the vault and attempts auto-repair using four strategies (in priority order): case-insensitive exact match, extension mismatch (`.md` present/absent), unique stem match anywhere in the vault (shortest-path resolution), and Jaro-Winkler fuzzy match above `--threshold`.
 
 Default is `--dry-run` (preview only). Pass `--apply` to write fixes to disk. Use `--ignore-target` (repeatable) to skip links containing specific substrings — useful for template syntax, external paths, or anchors that aren't real files.
+
+**Case-mismatch detection (`link-case-mismatch`):** When case-insensitive resolution is active (controlled by `[links] case_insensitive` in `.hyalo.toml` — `"auto"`, `"true"`, or `"false"`), `links fix` also reports links whose casing differs from the on-disk filename. These appear as `case_mismatches` in the JSON output and are rewritten to the canonical casing when `--apply` is used. On macOS and Windows (case-insensitive filesystems), `"auto"` enables this automatically.
 
 ### lint
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -942,7 +942,12 @@ pub(crate) enum LinksAction {
             2. Extension mismatch (.md present/absent)\n\
             3. Unique stem match anywhere in the vault (shortest-path)\n\
             4. Jaro-Winkler fuzzy match above --threshold\n\n\
-            Use --apply to write fixes to disk. Without --apply, only a dry-run report is printed.")]
+            Use --apply to write fixes to disk. Without --apply, only a dry-run report is printed.\n\n\
+            Case-mismatch detection: when case-insensitive resolution is active (controlled by\n\
+            `[links] case_insensitive` in .hyalo.toml — \"auto\", \"true\", or \"false\"), broken links\n\
+            that differ only in casing from an on-disk file are reported as case_mismatches and\n\
+            rewritten to the canonical casing when --apply is used. On macOS and Windows,\n\
+            \"auto\" (the default) enables this automatically.")]
     Fix {
         /// Preview changes without modifying files (default when --apply is omitted)
         #[arg(long)]

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -15,6 +15,7 @@ use hyalo_core::bm25::{
     Bm25InvertedIndex, DocumentInput, PreTokenizedInput, create_stemmer, is_low_discriminative,
     parse_language, query_is_operator_only, resolve_language, tokenize_document,
 };
+use hyalo_core::case_index::CaseInsensitiveIndex;
 use hyalo_core::content_search::ContentSearchVisitor;
 use hyalo_core::discovery;
 use hyalo_core::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField};
@@ -61,6 +62,7 @@ pub fn find(
     format: Format,
     language: Option<&str>,
     config_language: Option<&str>,
+    case_index: Option<&CaseInsensitiveIndex>,
 ) -> Result<CommandOutcome> {
     if pattern.is_some_and(|p| p.trim().is_empty()) {
         return Ok(CommandOutcome::UserError(
@@ -646,8 +648,12 @@ pub fn find(
                     .links
                     .iter()
                     .map(|(_, link)| {
-                        let path =
-                            discovery::resolve_target(&canonical_dir, &link.target, site_prefix);
+                        let path = discovery::resolve_target(
+                            &canonical_dir,
+                            &link.target,
+                            site_prefix,
+                            case_index,
+                        );
                         LinkInfo {
                             target: link.target.clone(),
                             path,

--- a/crates/hyalo-cli/src/commands/find/tests.rs
+++ b/crates/hyalo-cli/src/commands/find/tests.rs
@@ -111,6 +111,7 @@ fn run_find_ext(
         format,
         None, // language
         None, // config_language
+        None, // case_index
     )
 }
 
@@ -1578,6 +1579,7 @@ fn content_search_works_with_frontmatter_only_index() {
             Format::Json,
             None,
             None,
+            None, // case_index
         )
         .unwrap(),
     );

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -80,10 +80,14 @@ pub fn links_fix(
     let case_mismatch_count = case_mismatches.len();
 
     if !dry_run {
-        apply_fixes(dir, &fix_report.fixes, site_prefix)?;
-        // Apply case-mismatch fixes (link-case-mismatch rule).
-        if !case_mismatches.is_empty() {
-            apply_fixes(dir, &case_mismatches, site_prefix)?;
+        // Merge broken-link fixes and case-mismatch fixes into a single batch
+        // so `apply_fixes` reads and rewrites each source file once — two
+        // separate passes over the same file would see the first pass's
+        // rewrites and could misbehave on overlapping edits.
+        let mut all_fixes = fix_report.fixes.clone();
+        all_fixes.extend(case_mismatches.iter().cloned());
+        if !all_fixes.is_empty() {
+            apply_fixes(dir, &all_fixes, site_prefix)?;
         }
     }
 

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::output::{CommandOutcome, Format};
+use hyalo_core::case_index::CaseInsensitiveIndex;
 use hyalo_core::discovery;
 use hyalo_core::index::VaultIndex;
 use hyalo_core::link_fix::{LinkMatcher, apply_fixes, detect_broken_links_from_index, plan_fixes};
@@ -16,6 +17,9 @@ use hyalo_core::link_fix::{LinkMatcher, apply_fixes, detect_broken_links_from_in
 ///
 /// `dry_run = true`  → preview only (default)
 /// `dry_run = false` → write fixes to disk (`--apply`)
+///
+/// Case-mismatch fixes (rule `link-case-mismatch`) are included alongside
+/// ordinary broken-link fixes when `case_index` is provided.
 #[allow(clippy::too_many_arguments)]
 pub fn links_fix(
     index: &dyn VaultIndex,
@@ -26,8 +30,9 @@ pub fn links_fix(
     threshold: f64,
     ignore_target: &[String],
     format: Format,
+    case_index: Option<&CaseInsensitiveIndex>,
 ) -> Result<CommandOutcome> {
-    let report = detect_broken_links_from_index(dir, index, site_prefix);
+    let report = detect_broken_links_from_index(dir, index, site_prefix, case_index);
 
     // Filter broken links by glob, if any were provided.
     let broken = if globs.is_empty() {
@@ -69,8 +74,17 @@ pub fn links_fix(
     let matcher = LinkMatcher::from_index(index, threshold);
     let fix_report = plan_fixes(&broken, &matcher);
 
+    // Collect all fixes: broken-link fixes + case-mismatch fixes.
+    // Case-mismatch fixes come from the detection phase (not from plan_fixes).
+    let case_mismatches = report.case_mismatches;
+    let case_mismatch_count = case_mismatches.len();
+
     if !dry_run {
         apply_fixes(dir, &fix_report.fixes, site_prefix)?;
+        // Apply case-mismatch fixes (link-case-mismatch rule).
+        if !case_mismatches.is_empty() {
+            apply_fixes(dir, &case_mismatches, site_prefix)?;
+        }
     }
 
     let output = serde_json::json!({
@@ -81,6 +95,8 @@ pub fn links_fix(
         "fixes": fix_report.fixes,
         "unfixable_links": fix_report.unfixable,
         "applied": !dry_run,
+        "case_mismatches": case_mismatch_count,
+        "case_mismatch_fixes": case_mismatches,
     });
 
     let _ = format;

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -7,6 +7,7 @@ use hyalo_core::util::levenshtein;
 
 use crate::commands::lint::lint_counts_from_properties;
 use crate::output::{CommandOutcome, Format};
+use hyalo_core::case_index::CaseInsensitiveIndex;
 use hyalo_core::frontmatter::infer_type;
 use hyalo_core::index::VaultIndex;
 use hyalo_core::link_fix::detect_broken_links_from_index;
@@ -107,6 +108,7 @@ pub fn summary(
     site_prefix: Option<&str>,
     format: Format,
     schema: &SchemaConfig,
+    case_index: Option<&CaseInsensitiveIndex>,
 ) -> Result<CommandOutcome> {
     use crate::commands::find::filter_index_entries;
     let scoped: Vec<_> = filter_index_entries(index.entries(), &[], globs)?;
@@ -308,7 +310,7 @@ pub fn summary(
     // consistent with the disk-scan path and ensures the report is meaningful
     // (scoped results would produce misleadingly low counts).
     let link_health = {
-        let report = detect_broken_links_from_index(dir, index, site_prefix);
+        let report = detect_broken_links_from_index(dir, index, site_prefix, case_index);
         LinkHealthSummary {
             total: report.total_links,
             broken: report.broken.len(),
@@ -419,6 +421,7 @@ mod tests {
             site_prefix,
             format,
             &schema,
+            None, // case_index
         )
     }
 
@@ -860,7 +863,18 @@ Body.
         let loaded = SnapshotIndex::load(&index_path).unwrap().unwrap();
         let schema = hyalo_core::schema::SchemaConfig::default();
         let index_val = unwrap_success(
-            summary(dir, &loaded, &[], 10, None, prefix, Format::Json, &schema).unwrap(),
+            summary(
+                dir,
+                &loaded,
+                &[],
+                10,
+                None,
+                prefix,
+                Format::Json,
+                &schema,
+                None,
+            )
+            .unwrap(),
         );
         let index_orphans = index_val["orphans"].as_u64().unwrap();
 
@@ -951,7 +965,18 @@ Body.
         let loaded = SnapshotIndex::load(&index_path).unwrap().unwrap();
         let schema = hyalo_core::schema::SchemaConfig::default();
         let index_val = unwrap_success(
-            summary(dir, &loaded, &[], 10, None, None, Format::Json, &schema).unwrap(),
+            summary(
+                dir,
+                &loaded,
+                &[],
+                10,
+                None,
+                None,
+                Format::Json,
+                &schema,
+                None,
+            )
+            .unwrap(),
         );
         let index_dead_ends = index_val["dead_ends"].as_u64().unwrap();
 

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use anyhow::Context as _;
 use serde::Deserialize;
 
+use hyalo_core::case_index::CaseInsensitiveMode;
 use hyalo_core::schema::{RawSchemaConfig, SchemaConfig};
 
 /// Search-specific configuration from `[search]` in `.hyalo.toml`.
@@ -20,6 +22,14 @@ struct LinksConfig {
     /// strings and included in the link graph. Overrides the built-in defaults
     /// (`related`, `depends-on`, `supersedes`, `superseded-by`).
     frontmatter_properties: Option<Vec<String>>,
+    /// Case-insensitive link resolution mode.
+    ///
+    /// Accepted values: `"auto"` (default), `"true"`, `"false"`.
+    /// - `"auto"` — enables fallback only on case-insensitive filesystems.
+    /// - `"true"` — always enable case-insensitive fallback.
+    /// - `"false"` — always disable; exact-match only.
+    #[serde(default)]
+    case_insensitive: Option<String>,
 }
 
 /// Lint configuration from `[lint]` in `.hyalo.toml`.
@@ -106,6 +116,8 @@ pub(crate) struct ResolvedDefaults {
     /// `Some(0)` = unlimited.
     /// `Some(n)` = limit to n.
     pub(crate) default_limit: Option<usize>,
+    /// Case-insensitive link resolution mode from `[links] case_insensitive`.
+    pub(crate) case_insensitive_mode: CaseInsensitiveMode,
 }
 
 impl PartialEq for ResolvedDefaults {
@@ -122,6 +134,7 @@ impl PartialEq for ResolvedDefaults {
             && self.validate_on_write == other.validate_on_write
             && self.lint_ignore == other.lint_ignore
             && self.default_limit == other.default_limit
+            && self.case_insensitive_mode == other.case_insensitive_mode
     }
 }
 
@@ -139,6 +152,7 @@ impl ResolvedDefaults {
             lint_ignore: Vec::new(),
             schema: SchemaConfig::default(),
             default_limit: None,
+            case_insensitive_mode: CaseInsensitiveMode::Auto,
         }
     }
 
@@ -166,6 +180,18 @@ pub(crate) fn load_config() -> ResolvedDefaults {
             ));
             ResolvedDefaults::hardcoded()
         }
+    }
+}
+
+/// Parse the `[links] case_insensitive` value into a [`CaseInsensitiveMode`].
+///
+/// Returns `Ok(None)` when the key is absent, `Ok(Some(mode))` on success,
+/// and `Err(...)` when the value is not one of `"auto"`, `"true"`, or `"false"`.
+fn parse_case_insensitive_mode(raw: Option<&str>) -> anyhow::Result<CaseInsensitiveMode> {
+    match raw {
+        None => Ok(CaseInsensitiveMode::Auto),
+        Some(s) => CaseInsensitiveMode::parse(s)
+            .with_context(|| format!("[links] case_insensitive = {s:?}")),
     }
 }
 
@@ -223,6 +249,22 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         .or(cfg.validate_on_write)
         .unwrap_or(false);
     let schema = parse_schema_from_toml(cfg.schema.as_ref());
+
+    // Parse [links] fields — borrow before moving.
+    let case_insensitive_mode = match parse_case_insensitive_mode(
+        cfg.links
+            .as_ref()
+            .and_then(|l| l.case_insensitive.as_deref()),
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            crate::warn::warn(format!(
+                "invalid [links] case_insensitive in .hyalo.toml: {e}"
+            ));
+            CaseInsensitiveMode::Auto
+        }
+    };
+
     ResolvedDefaults {
         dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
         config_dir: dir.to_path_buf(),
@@ -235,6 +277,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         lint_ignore: cfg.lint.map(|l| l.ignore).unwrap_or_default(),
         schema,
         default_limit: cfg.default_limit,
+        case_insensitive_mode,
     }
 }
 
@@ -532,5 +575,88 @@ site_prefix = "docs"
 
         let resolved = load_config_from(dir.path());
         assert!(!resolved.validate_on_write);
+    }
+
+    // ---------------------------------------------------------------------------
+    // [links] case_insensitive config
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn case_insensitive_missing_key_defaults_to_auto() {
+        let dir = make_temp();
+        fs::write(dir.path().join(".hyalo.toml"), "dir = \"notes\"\n").unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(
+            resolved.case_insensitive_mode,
+            CaseInsensitiveMode::Auto,
+            "missing key should default to Auto"
+        );
+    }
+
+    #[test]
+    fn case_insensitive_auto_value() {
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[links]\ncase_insensitive = \"auto\"\n",
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved.case_insensitive_mode, CaseInsensitiveMode::Auto);
+    }
+
+    #[test]
+    fn case_insensitive_true_value() {
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[links]\ncase_insensitive = \"true\"\n",
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved.case_insensitive_mode, CaseInsensitiveMode::On);
+    }
+
+    #[test]
+    fn case_insensitive_false_value() {
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[links]\ncase_insensitive = \"false\"\n",
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved.case_insensitive_mode, CaseInsensitiveMode::Off);
+    }
+
+    #[test]
+    fn case_insensitive_invalid_value_falls_back_to_auto() {
+        // Invalid values emit a warning and fall back to Auto.
+        let _guard = crate::warn::WARN_TEST_LOCK.lock().unwrap();
+        crate::warn::reset_for_test();
+        crate::warn::init(false);
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[links]\ncase_insensitive = \"maybe\"\n",
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(
+            resolved.case_insensitive_mode,
+            CaseInsensitiveMode::Auto,
+            "invalid value should fall back to Auto"
+        );
+        let warned =
+            crate::warn::any_tracked_starts_with("invalid [links] case_insensitive in .hyalo.toml");
+        assert!(
+            warned,
+            "expected a warning for invalid case_insensitive value"
+        );
     }
 }

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -26,10 +26,12 @@ pub(crate) const DEFAULT_OUTPUT_LIMIT: usize = 50;
 
 /// Build a [`CaseInsensitiveIndex`] from a full vault directory scan.
 ///
-/// Discovers all `.md` files under `dir` and inserts their vault-relative paths.
-/// This is always vault-wide — not scoped to any `--file` or `--glob` argument —
-/// because case-insensitive link resolution needs to find *any* file in the vault,
-/// even files not included in the current query scope.
+/// The scan is always vault-wide — not scoped to any `--file` or `--glob`
+/// argument — because case-insensitive link resolution must find *any* file
+/// in the vault, even files not included in the current query scope. A scoped
+/// `VaultIndex` (built by `collect_files` when `--file` is used) would omit
+/// the very link targets we need to resolve, so we re-walk from disk rather
+/// than reusing the command's `VaultIndex`.
 ///
 /// Errors during discovery are silently ignored (the index will just be less
 /// complete, which degrades gracefully to no case-insensitive fallback).
@@ -45,10 +47,9 @@ pub(crate) fn build_case_index_from_dir(dir: &std::path::Path) -> CaseInsensitiv
     idx
 }
 
-/// Resolve whether case-insensitive mode is active and, if so, build the index
-/// from a full vault directory scan.
-///
-/// Returns `Some(index)` when enabled, `None` when disabled.
+/// Resolve whether case-insensitive mode is active and, if so, build the
+/// index from a full vault directory scan. Returns `Some(index)` when
+/// enabled, `None` when disabled.
 pub(crate) fn maybe_case_index(
     mode: CaseInsensitiveMode,
     dir: &std::path::Path,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -15,6 +15,7 @@ use crate::commands::{
 };
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::bm25::parse_language;
+use hyalo_core::case_index::{CaseInsensitiveIndex, CaseInsensitiveMode, mode_enabled};
 use hyalo_core::filter;
 use hyalo_core::index::{ScanOptions, SnapshotIndex, VaultIndex as _};
 use hyalo_core::schema::SchemaConfig;
@@ -22,6 +23,42 @@ use hyalo_core::schema::SchemaConfig;
 /// Default output limit for list commands when no `--limit` is passed and no
 /// `default_limit` is set in `.hyalo.toml`.
 pub(crate) const DEFAULT_OUTPUT_LIMIT: usize = 50;
+
+/// Build a [`CaseInsensitiveIndex`] from a full vault directory scan.
+///
+/// Discovers all `.md` files under `dir` and inserts their vault-relative paths.
+/// This is always vault-wide — not scoped to any `--file` or `--glob` argument —
+/// because case-insensitive link resolution needs to find *any* file in the vault,
+/// even files not included in the current query scope.
+///
+/// Errors during discovery are silently ignored (the index will just be less
+/// complete, which degrades gracefully to no case-insensitive fallback).
+pub(crate) fn build_case_index_from_dir(dir: &std::path::Path) -> CaseInsensitiveIndex {
+    use hyalo_core::discovery;
+    let mut idx = CaseInsensitiveIndex::new();
+    if let Ok(files) = discovery::discover_files(dir) {
+        for file in &files {
+            let rel = discovery::relative_path(dir, file);
+            idx.insert(&rel);
+        }
+    }
+    idx
+}
+
+/// Resolve whether case-insensitive mode is active and, if so, build the index
+/// from a full vault directory scan.
+///
+/// Returns `Some(index)` when enabled, `None` when disabled.
+pub(crate) fn maybe_case_index(
+    mode: CaseInsensitiveMode,
+    dir: &std::path::Path,
+) -> Option<CaseInsensitiveIndex> {
+    if mode_enabled(mode, dir) {
+        Some(build_case_index_from_dir(dir))
+    } else {
+        None
+    }
+}
 
 /// Shared context for command dispatch.
 pub(crate) struct CommandContext<'a> {
@@ -51,6 +88,8 @@ pub(crate) struct CommandContext<'a> {
     pub validate_on_write: bool,
     /// Vault-relative paths excluded from `hyalo lint`. From `[lint] ignore` in `.hyalo.toml`.
     pub lint_ignore: &'a [String],
+    /// Case-insensitive link resolution mode from `[links] case_insensitive`.
+    pub case_insensitive_mode: CaseInsensitiveMode,
     /// Optional exit code override set by commands that need a non-0/2 exit code
     /// (e.g. `lint` returns 1 when errors are found). The output pipeline uses this
     /// to override its own exit code calculation.
@@ -277,30 +316,34 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     frontmatter_link_props: ctx.frontmatter_link_props,
                 },
             )? {
-                IndexResolution::Resolved(resolved) => find_commands::find(
-                    resolved.as_index(),
-                    dir,
-                    site_prefix,
-                    pattern.as_deref(),
-                    regexp.as_deref(),
-                    &prop_filters,
-                    &tag,
-                    task_filter.as_ref(),
-                    &section_filters,
-                    &file,
-                    &glob,
-                    &parsed_fields,
-                    sort_field.as_ref(),
-                    reverse,
-                    resolve_limit(limit, ctx.config_default_limit, ctx.programmatic_output),
-                    broken_links,
-                    orphan,
-                    dead_end,
-                    title.as_deref(),
-                    effective_format,
-                    language.as_deref(),
-                    ctx.config_language,
-                ),
+                IndexResolution::Resolved(resolved) => {
+                    let ci = maybe_case_index(ctx.case_insensitive_mode, dir);
+                    find_commands::find(
+                        resolved.as_index(),
+                        dir,
+                        site_prefix,
+                        pattern.as_deref(),
+                        regexp.as_deref(),
+                        &prop_filters,
+                        &tag,
+                        task_filter.as_ref(),
+                        &section_filters,
+                        &file,
+                        &glob,
+                        &parsed_fields,
+                        sort_field.as_ref(),
+                        reverse,
+                        resolve_limit(limit, ctx.config_default_limit, ctx.programmatic_output),
+                        broken_links,
+                        orphan,
+                        dead_end,
+                        title.as_deref(),
+                        effective_format,
+                        language.as_deref(),
+                        ctx.config_language,
+                        ci.as_ref(),
+                    )
+                }
                 IndexResolution::Outcome(outcome) => Ok(outcome),
             }
         }
@@ -579,16 +622,20 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 frontmatter_link_props: ctx.frontmatter_link_props,
             },
         )? {
-            IndexResolution::Resolved(resolved) => summary_commands::summary(
-                dir,
-                resolved.as_index(),
-                &glob,
-                recent,
-                depth,
-                site_prefix,
-                effective_format,
-                ctx.schema,
-            ),
+            IndexResolution::Resolved(resolved) => {
+                let ci = maybe_case_index(ctx.case_insensitive_mode, dir);
+                summary_commands::summary(
+                    dir,
+                    resolved.as_index(),
+                    &glob,
+                    recent,
+                    depth,
+                    site_prefix,
+                    effective_format,
+                    ctx.schema,
+                    ci.as_ref(),
+                )
+            }
             IndexResolution::Outcome(outcome) => Ok(outcome),
         },
         Commands::Set {
@@ -793,16 +840,20 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     frontmatter_link_props: ctx.frontmatter_link_props,
                 },
             )? {
-                IndexResolution::Resolved(resolved) => links_commands::links_fix(
-                    resolved.as_index(),
-                    dir,
-                    site_prefix,
-                    &glob,
-                    !apply,
-                    threshold,
-                    &ignore_target,
-                    effective_format,
-                ),
+                IndexResolution::Resolved(resolved) => {
+                    let ci = maybe_case_index(ctx.case_insensitive_mode, dir);
+                    links_commands::links_fix(
+                        resolved.as_index(),
+                        dir,
+                        site_prefix,
+                        &glob,
+                        !apply,
+                        threshold,
+                        &ignore_target,
+                        effective_format,
+                        ci.as_ref(),
+                    )
+                }
                 IndexResolution::Outcome(outcome) => Ok(outcome),
             },
         },

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -369,9 +369,9 @@ const TAG_MUTATION_FILTER: &str = r#""\(if .dry_run then "[dry-run] " else "" en
 /// Empty case: `No backlinks found for "file"`.
 const BACKLINKS_RESULT_FILTER: &str = r#"if (.backlinks | length) == 0 then "No backlinks found for \"\(.file)\"" else "\(.backlinks | length) \(if (.backlinks | length) == 1 then "backlink" else "backlinks" end) for \"\(.file)\"\n\(.backlinks | map("  \(.source): line \(.line)") | join("\n"))" end"#;
 
-/// `LinksFix result`: `{applied, broken, fixable, fixes, ignored, unfixable, unfixable_links}`
-/// Format: summary line with fix status.
-const LINKS_FIX_FILTER: &str = r#""Broken links: \(.broken)\nFixable: \(.fixable)\nUnfixable: \(.unfixable)\nIgnored: \(.ignored)\nApplied: \(if .applied then "yes" else "no" end)\(if (.fixes | length) > 0 then "\n\(.fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\"") | join("\n"))" else "" end)""#;
+/// `LinksFix result`: `{applied, broken, case_mismatch_fixes, case_mismatches, fixable, fixes, ignored, unfixable, unfixable_links}`
+/// Format: summary line with fix status. Includes case-mismatch count when non-zero.
+const LINKS_FIX_FILTER: &str = r#""Broken links: \(.broken)\nFixable: \(.fixable)\nUnfixable: \(.unfixable)\nIgnored: \(.ignored)\(if .case_mismatches > 0 then "\nCase mismatches: \(.case_mismatches)" else "" end)\nApplied: \(if .applied then "yes" else "no" end)\(if (.fixes | length) > 0 then "\n\(.fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\"") | join("\n"))" else "" end)\(if (.case_mismatch_fixes | length) > 0 then "\nCase-mismatch fixes:\n\(.case_mismatch_fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\" [link-case-mismatch]") | join("\n"))" else "" end)""#;
 
 /// `MvResult`: `{dry_run, from, to, total_files_updated, total_links_updated, updated_files}`
 /// Format: `[dry-run] Moved <from> → <to>` with list of updated files and replacements.
@@ -446,7 +446,9 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         // BacklinksResult
         "backlinks,file" => Some(BACKLINKS_RESULT_FILTER),
         // LinksFix result
-        "applied,broken,fixable,fixes,ignored,unfixable,unfixable_links" => Some(LINKS_FIX_FILTER),
+        "applied,broken,case_mismatch_fixes,case_mismatches,fixable,fixes,ignored,unfixable,unfixable_links" => {
+            Some(LINKS_FIX_FILTER)
+        }
         // MvResult
         "dry_run,from,to,total_files_updated,total_links_updated,updated_files" => {
             Some(MV_RESULT_FILTER)

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -806,6 +806,7 @@ fn run_inner() -> Result<(), AppError> {
     let frontmatter_link_props_owned = config.frontmatter_link_props;
     let validate_on_write = config.validate_on_write;
     let lint_ignore = config.lint_ignore;
+    let case_insensitive_mode = config.case_insensitive_mode;
 
     // Propagate the configured frontmatter-link property list into the loaded
     // snapshot so that per-file refreshes (`rescan_entry` / `rename_entry`) use
@@ -826,6 +827,7 @@ fn run_inner() -> Result<(), AppError> {
         schema: &schema,
         validate_on_write,
         lint_ignore: &lint_ignore,
+        case_insensitive_mode,
         exit_code_override: None,
         config_default_limit,
         programmatic_output: jq_filter.is_some() || cli.count,

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -228,6 +228,7 @@ Start with `hyalo summary --format text` to orient yourself in a new directory.
 - **append** — add to list properties (supports `--validate`; note: tags are not appendable; use `set --tag` instead)
 - **task** — read, toggle, or set status on checkboxes (supports `--line 5,7`, `--section "Tasks"`, `--all`; `--dry-run` to preview toggles)
 - **mv** — move/rename a file and rewrite all inbound links across the vault (`--dry-run` to preview)
+- **links fix** — detect broken wikilinks/markdown links and auto-repair (dry-run by default; `--apply` to write). Also detects case mismatches when `[links] case_insensitive` is enabled (default `"auto"` on macOS/Windows)
 - **backlinks** — reverse link lookup: lists all files that link to a given file
 - **create-index** — build a snapshot index for faster repeated read-only queries
 - **drop-index** — delete a snapshot index file created with create-index

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use super::common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
@@ -888,5 +890,319 @@ fn links_fix_ignore_target_absent() {
             .expect("'ignored' should be a number"),
         0,
         "expected 0 ignored links when pattern doesn't match: {json}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case-insensitive link resolution (iter-117)
+// ---------------------------------------------------------------------------
+
+/// Build a fixture vault with case_insensitive = "true".
+///
+///   iteration_protocols.md  (the file, all lowercase)
+///   promise_any.md          (links to it with wrong casing via wikilink)
+///   .hyalo.toml             with case_insensitive = "true"
+fn setup_mdn_vault() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+
+    // Target file — all lowercase
+    write_md(
+        tmp.path(),
+        "iteration_protocols.md",
+        md!(r"
+---
+title: Iteration protocols
+---
+Content here.
+"),
+    );
+
+    // Source file — wikilink with different casing from on-disk name
+    write_md(
+        tmp.path(),
+        "promise_any.md",
+        md!(r"
+---
+title: Promise.any
+---
+See [[Iteration_Protocols]] for details.
+"),
+    );
+
+    // Config: case_insensitive = "true" forces the fallback regardless of filesystem
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "[links]\ncase_insensitive = \"true\"\n",
+    )
+    .expect("write .hyalo.toml");
+
+    tmp
+}
+
+#[test]
+fn case_insensitive_find_links_resolves_to_canonical_path() {
+    let tmp = setup_mdn_vault();
+
+    let out = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "find",
+            "--file",
+            "promise_any.md",
+            "--fields",
+            "links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find should run");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = json["results"]
+        .as_array()
+        .expect("results should be an array");
+    assert!(!results.is_empty(), "results should not be empty");
+    let links = results[0]["links"]
+        .as_array()
+        .expect("links should be an array");
+
+    // At least one link should resolve to the canonical lowercase path
+    let canonical = "iteration_protocols.md";
+    let has_resolved = links.iter().any(|l| l["path"].as_str() == Some(canonical));
+    assert!(
+        has_resolved,
+        "expected link to resolve to canonical path {canonical:?}, got: {links:?}"
+    );
+}
+
+#[test]
+fn case_insensitive_links_fix_dry_run_reports_case_mismatches() {
+    let tmp = setup_mdn_vault();
+
+    let out = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix should run");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let mismatches = json["results"]["case_mismatches"]
+        .as_u64()
+        .expect("case_mismatches should be a number");
+    assert!(
+        mismatches >= 1,
+        "expected at least 1 case-mismatch fix, got: {json}"
+    );
+
+    let mismatch_fixes = json["results"]["case_mismatch_fixes"]
+        .as_array()
+        .expect("case_mismatch_fixes should be an array");
+    assert!(
+        !mismatch_fixes.is_empty(),
+        "case_mismatch_fixes should list the mismatch entries"
+    );
+
+    // The fix should have strategy = "LinkCaseMismatch"
+    let strategy = mismatch_fixes[0]["strategy"].as_str().unwrap_or("");
+    assert_eq!(
+        strategy, "LinkCaseMismatch",
+        "strategy should be LinkCaseMismatch"
+    );
+}
+
+#[test]
+fn case_insensitive_links_fix_apply_rewrites_casing() {
+    let tmp = setup_mdn_vault();
+
+    // Apply fixes
+    let apply = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "links",
+            "fix",
+            "--apply",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix --apply should run");
+    assert!(
+        apply.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&apply.stderr)
+    );
+
+    let apply_json: serde_json::Value = serde_json::from_slice(&apply.stdout).unwrap();
+    let applied = apply_json["results"]["applied"].as_bool().unwrap_or(false);
+    assert!(applied, "applied should be true");
+
+    // After applying, re-run links fix — case_mismatches should drop to 0
+    let after = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix dry-run after apply should run");
+    assert!(after.status.success());
+
+    let after_json: serde_json::Value = serde_json::from_slice(&after.stdout).unwrap();
+    let remaining = after_json["results"]["case_mismatches"]
+        .as_u64()
+        .unwrap_or(1);
+    assert_eq!(
+        remaining, 0,
+        "after apply, case_mismatches should be 0, got: {after_json}"
+    );
+}
+
+// On macOS (case-insensitive FS) a wrong-cased path resolves via the OS even with CI mode
+// disabled, so this test is only meaningful on case-sensitive filesystems.
+#[cfg(target_os = "linux")]
+#[test]
+fn case_insensitive_off_treats_wrong_casing_as_unresolved() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    // Target file — all lowercase
+    write_md(
+        tmp.path(),
+        "iteration_protocols.md",
+        md!(r"
+---
+title: Iteration protocols
+---
+Content.
+"),
+    );
+
+    // Source — wikilink with different casing from on-disk name
+    write_md(
+        tmp.path(),
+        "promise_any.md",
+        md!(r"
+---
+title: Promise.any
+---
+See [[Iteration_Protocols]] for details.
+"),
+    );
+
+    // case_insensitive = "false" — strict mode, no fallback
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "[links]\ncase_insensitive = \"false\"\n",
+    )
+    .expect("write .hyalo.toml");
+
+    let out = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "find",
+            "--file",
+            "promise_any.md",
+            "--fields",
+            "links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find should run");
+    assert!(out.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = json["results"]
+        .as_array()
+        .expect("results should be an array");
+    assert!(!results.is_empty(), "results should not be empty");
+    let links = results[0]["links"]
+        .as_array()
+        .expect("links should be an array");
+
+    // In strict mode the PascalCase link should NOT resolve (null path)
+    let has_null_path = links
+        .iter()
+        .any(|l| l["path"].is_null() || l["path"] == serde_json::Value::Null);
+    assert!(
+        has_null_path,
+        "strict mode: PascalCase link should be unresolved (null path), got: {links:?}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn case_insensitive_ambiguous_returns_unresolved_on_case_sensitive_fs() {
+    // On a case-sensitive filesystem, Foo.md and foo.md are two distinct files.
+    // A link to FOO should be ambiguous and resolve to None.
+    let tmp = TempDir::new().expect("tempdir");
+
+    write_md(tmp.path(), "Foo.md", "---\ntitle: Foo\n---\n");
+    write_md(tmp.path(), "foo.md", "---\ntitle: foo\n---\n");
+    write_md(
+        tmp.path(),
+        "source.md",
+        "---\ntitle: Source\n---\nSee [[FOO]] here.\n",
+    );
+
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "[links]\ncase_insensitive = \"true\"\n",
+    )
+    .expect("write .hyalo.toml");
+
+    let out = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "find",
+            "--file",
+            "source.md",
+            "--fields",
+            "links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find should run");
+    assert!(out.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = json["results"]
+        .as_array()
+        .expect("results should be an array");
+    assert!(!results.is_empty(), "results should not be empty");
+    let links = results[0]["links"]
+        .as_array()
+        .expect("links should be an array");
+
+    // Ambiguous: both Foo.md and foo.md exist — should be unresolved (null path)
+    let all_unresolved = links
+        .iter()
+        .all(|l| l["path"].is_null() || l["path"] == serde_json::Value::Null);
+    assert!(
+        all_unresolved,
+        "ambiguous case-insensitive match should be unresolved, got: {links:?}"
     );
 }

--- a/crates/hyalo-core/src/case_index.rs
+++ b/crates/hyalo-core/src/case_index.rs
@@ -104,39 +104,58 @@ impl CaseInsensitiveIndex {
 /// prefer strict semantics as the safe default.
 pub fn probe_case_insensitive(dir: &Path) -> Result<bool> {
     use std::io::Write as _;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    // Generate a pseudo-random suffix using the current time to avoid
-    // collisions across concurrent calls or processes.
-    let suffix = {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let ns = SystemTime::now()
+    // Try a handful of unique probe names. Include seconds, nanoseconds, PID,
+    // and attempt counter to minimize collisions across concurrent calls and
+    // processes. On each attempt, ensure neither the lowercase nor uppercase
+    // variant preexists — a stray preexisting uppercase file on a
+    // case-sensitive filesystem would otherwise cause a false positive.
+    for attempt in 0..16u32 {
+        let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0);
-        format!("{ns:08x}")
-    };
+            .unwrap_or_default();
+        let suffix = format!(
+            "{:x}-{:08x}-{:x}-{:x}",
+            now.as_secs(),
+            now.subsec_nanos(),
+            std::process::id(),
+            attempt
+        );
 
-    let lower_name = format!(".hyalo-case-probe-{suffix}");
-    let upper_name = lower_name.to_ascii_uppercase();
+        let lower_name = format!(".hyalo-case-probe-{suffix}");
+        let upper_name = lower_name.to_ascii_uppercase();
 
-    let lower_path = dir.join(&lower_name);
-    let upper_path = dir.join(&upper_name);
+        let lower_path = dir.join(&lower_name);
+        let upper_path = dir.join(&upper_name);
 
-    // Create the lowercase file. If we can't write here, bail gracefully.
-    let Ok(mut file) = std::fs::File::create(&lower_path) else {
-        return Ok(false);
-    };
-    // Write a marker byte so the file is non-empty.
-    let _ = file.write_all(b"x");
-    drop(file);
+        if lower_path.exists() || upper_path.exists() {
+            continue;
+        }
 
-    // Now check whether the uppercase variant resolves to the same location.
-    let result = std::fs::metadata(&upper_path).is_ok();
+        // `create_new` fails if the file already exists, protecting against
+        // races with other processes that happen to pick the same suffix.
+        let Ok(mut file) = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lower_path)
+        else {
+            continue;
+        };
 
-    // Clean up — ignore errors; the file is tiny and harmless.
-    let _ = std::fs::remove_file(&lower_path);
+        let _ = file.write_all(b"x");
+        drop(file);
 
-    Ok(result)
+        let result = std::fs::metadata(&upper_path).is_ok();
+
+        // Clean up — ignore errors; the file is tiny and harmless.
+        let _ = std::fs::remove_file(&lower_path);
+
+        return Ok(result);
+    }
+
+    // Gave up after max attempts; prefer strict semantics.
+    Ok(false)
 }
 
 /// Resolve a `CaseInsensitiveMode` to a concrete `bool` given a directory.

--- a/crates/hyalo-core/src/case_index.rs
+++ b/crates/hyalo-core/src/case_index.rs
@@ -1,0 +1,268 @@
+use anyhow::{Result, bail};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Mode for case-insensitive link resolution fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CaseInsensitiveMode {
+    /// Enable only if the filesystem is probed as case-insensitive.
+    #[default]
+    Auto,
+    /// Always disabled.
+    Off,
+    /// Always enabled.
+    On,
+}
+
+impl CaseInsensitiveMode {
+    /// Parse a string into a `CaseInsensitiveMode`.
+    ///
+    /// Accepted values (case-insensitive): `"auto"`, `"true"`, `"false"`.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "true" => Ok(Self::On),
+            "false" => Ok(Self::Off),
+            other => bail!(
+                "invalid case_insensitive value {other:?}: expected \"auto\", \"true\", or \"false\""
+            ),
+        }
+    }
+
+    /// Serialize back to a canonical string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::On => "true",
+            Self::Off => "false",
+        }
+    }
+}
+
+/// Lowercased-relative-path → list of real relative paths (forward-slash form).
+///
+/// Used for case-insensitive link resolution: insert all known paths at
+/// index build time, then look up by lowercased target at resolution time.
+#[derive(Debug, Default, Clone)]
+pub struct CaseInsensitiveIndex {
+    /// Map from lowercased path → list of real (original-casing) paths.
+    map: HashMap<String, Vec<String>>,
+}
+
+impl CaseInsensitiveIndex {
+    /// Create an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a real relative path (forward-slash form). Stores a lowercase key.
+    /// Deduplicates: inserting the same path twice has no effect.
+    pub fn insert(&mut self, rel_path: &str) {
+        let key = rel_path.to_ascii_lowercase();
+        let candidates = self.map.entry(key).or_default();
+        if !candidates.iter().any(|c| c == rel_path) {
+            candidates.push(rel_path.to_owned());
+        }
+    }
+
+    /// Look up a relative path (any casing). Returns the canonical real path
+    /// only when exactly one candidate exists (unambiguous match).
+    pub fn lookup_unique(&self, rel_path: &str) -> Option<&str> {
+        let key = rel_path.to_ascii_lowercase();
+        let candidates = self.map.get(&key)?;
+        if candidates.len() == 1 {
+            Some(&candidates[0])
+        } else {
+            None
+        }
+    }
+
+    /// Return all candidates for a given path (any casing). Useful for diagnostics.
+    pub fn lookup_all(&self, rel_path: &str) -> &[String] {
+        let key = rel_path.to_ascii_lowercase();
+        self.map.get(&key).map_or(&[], Vec::as_slice)
+    }
+
+    /// Returns `true` if the index contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Number of distinct lowercased keys in the index.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+/// Probe the filesystem under `dir` for case-insensitive behavior.
+///
+/// Creates a temporary file with a lowercase-only name, then stat's its
+/// uppercase variant. Returns `Ok(true)` if the filesystem is
+/// case-insensitive (uppercase lookup succeeds), `Ok(false)` otherwise.
+///
+/// On probe errors (permissions, read-only fs), returns `Ok(false)` — we
+/// prefer strict semantics as the safe default.
+pub fn probe_case_insensitive(dir: &Path) -> Result<bool> {
+    use std::io::Write as _;
+
+    // Generate a pseudo-random suffix using the current time to avoid
+    // collisions across concurrent calls or processes.
+    let suffix = {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        format!("{ns:08x}")
+    };
+
+    let lower_name = format!(".hyalo-case-probe-{suffix}");
+    let upper_name = lower_name.to_ascii_uppercase();
+
+    let lower_path = dir.join(&lower_name);
+    let upper_path = dir.join(&upper_name);
+
+    // Create the lowercase file. If we can't write here, bail gracefully.
+    let Ok(mut file) = std::fs::File::create(&lower_path) else {
+        return Ok(false);
+    };
+    // Write a marker byte so the file is non-empty.
+    let _ = file.write_all(b"x");
+    drop(file);
+
+    // Now check whether the uppercase variant resolves to the same location.
+    let result = std::fs::metadata(&upper_path).is_ok();
+
+    // Clean up — ignore errors; the file is tiny and harmless.
+    let _ = std::fs::remove_file(&lower_path);
+
+    Ok(result)
+}
+
+/// Resolve a `CaseInsensitiveMode` to a concrete `bool` given a directory.
+///
+/// - `Off` → always `false`.
+/// - `On` → always `true`.
+/// - `Auto` → runs [`probe_case_insensitive`]; falls back to `false` on error.
+pub fn mode_enabled(mode: CaseInsensitiveMode, dir: &Path) -> bool {
+    match mode {
+        CaseInsensitiveMode::Off => false,
+        CaseInsensitiveMode::On => true,
+        CaseInsensitiveMode::Auto => probe_case_insensitive(dir).unwrap_or(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- CaseInsensitiveIndex ----
+
+    #[test]
+    fn insert_and_lookup_unique() {
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("Foo/Bar.md");
+        idx.insert("foo/baz.md");
+
+        // Lowercase lookup for "foo/bar.md" → unambiguous → "Foo/Bar.md"
+        assert_eq!(idx.lookup_unique("foo/bar.md"), Some("Foo/Bar.md"));
+        // Different key → unambiguous → "foo/baz.md"
+        assert_eq!(idx.lookup_unique("FOO/BAZ.MD"), Some("foo/baz.md"));
+    }
+
+    #[test]
+    fn ambiguous_returns_none() {
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("Foo.md");
+        idx.insert("foo.md");
+
+        // Two candidates → ambiguous → None
+        assert!(idx.lookup_unique("foo.md").is_none());
+        // But lookup_all should return both
+        assert_eq!(idx.lookup_all("foo.md").len(), 2);
+    }
+
+    #[test]
+    fn empty_index_returns_none() {
+        let idx = CaseInsensitiveIndex::new();
+        assert!(idx.lookup_unique("anything.md").is_none());
+        assert!(idx.lookup_all("anything.md").is_empty());
+        assert!(idx.is_empty());
+        assert_eq!(idx.len(), 0);
+    }
+
+    #[test]
+    fn deduplication() {
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("Foo/Bar.md");
+        idx.insert("Foo/Bar.md"); // duplicate
+        // Should still be unique (one candidate)
+        assert_eq!(idx.lookup_unique("foo/bar.md"), Some("Foo/Bar.md"));
+        assert_eq!(idx.lookup_all("foo/bar.md").len(), 1);
+    }
+
+    #[test]
+    fn probe_roundtrip() {
+        // We don't assert true or false — the filesystem determines that.
+        // We just assert the call doesn't panic and returns Ok(_).
+        let tmp = tempfile::tempdir().unwrap();
+        let result = probe_case_insensitive(tmp.path());
+        assert!(result.is_ok(), "probe returned Err: {:?}", result.err());
+    }
+
+    #[test]
+    fn mode_parse_valid() {
+        assert_eq!(
+            CaseInsensitiveMode::parse("auto").unwrap(),
+            CaseInsensitiveMode::Auto
+        );
+        assert_eq!(
+            CaseInsensitiveMode::parse("AUTO").unwrap(),
+            CaseInsensitiveMode::Auto
+        );
+        assert_eq!(
+            CaseInsensitiveMode::parse("true").unwrap(),
+            CaseInsensitiveMode::On
+        );
+        assert_eq!(
+            CaseInsensitiveMode::parse("True").unwrap(),
+            CaseInsensitiveMode::On
+        );
+        assert_eq!(
+            CaseInsensitiveMode::parse("false").unwrap(),
+            CaseInsensitiveMode::Off
+        );
+        assert_eq!(
+            CaseInsensitiveMode::parse("FALSE").unwrap(),
+            CaseInsensitiveMode::Off
+        );
+    }
+
+    #[test]
+    fn mode_parse_invalid() {
+        assert!(CaseInsensitiveMode::parse("maybe").is_err());
+        assert!(CaseInsensitiveMode::parse("yes").is_err());
+        assert!(CaseInsensitiveMode::parse("").is_err());
+    }
+
+    #[test]
+    fn mode_as_str_roundtrip() {
+        for &mode in &[
+            CaseInsensitiveMode::Auto,
+            CaseInsensitiveMode::On,
+            CaseInsensitiveMode::Off,
+        ] {
+            let s = mode.as_str();
+            let parsed = CaseInsensitiveMode::parse(s).unwrap();
+            assert_eq!(mode, parsed);
+        }
+    }
+
+    #[test]
+    fn mode_enabled_on_off() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        assert!(!mode_enabled(CaseInsensitiveMode::Off, dir));
+        assert!(mode_enabled(CaseInsensitiveMode::On, dir));
+    }
+}

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -5,6 +5,7 @@ use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 
+use crate::case_index::CaseInsensitiveIndex;
 use crate::link_graph::strip_site_prefix;
 use crate::util::levenshtein;
 
@@ -501,11 +502,18 @@ impl std::error::Error for FileResolveError {}
 ///
 /// `canonical_dir` must be a pre-canonicalized vault path (see `canonicalize_vault_dir`).
 /// Callers iterating over many links should canonicalize once and reuse the result.
+///
+/// When `case_index` is provided, a case-insensitive fallback lookup is performed:
+/// - If the literal path resolves, the canonical on-disk path from the index is returned
+///   (correcting casing differences introduced on case-insensitive filesystems).
+/// - If the literal path does NOT resolve, the index is consulted for an unambiguous
+///   case-insensitive match and returned if found.
 #[must_use]
 pub fn resolve_target(
     canonical_dir: &Path,
     target: &str,
     site_prefix: Option<&str>,
+    case_index: Option<&CaseInsensitiveIndex>,
 ) -> Option<String> {
     if target.is_empty() {
         return None;
@@ -550,9 +558,29 @@ pub fn resolve_target(
     if full.is_file() {
         // Ok(true) = within vault; Ok(false) or Err = reject
         if ensure_within_vault(canonical_dir, &full).unwrap_or(false) {
+            // If an index is provided, prefer the canonical on-disk casing from
+            // the index over the literal input casing. This matters on
+            // case-insensitive filesystems where `is_file()` succeeds even when
+            // the literal casing differs from what is stored on disk.
+            if let Some(idx) = case_index
+                && let Some(canonical_path) = idx.lookup_unique(&target)
+            {
+                return Some(canonical_path.to_owned());
+            }
             return Some(target.clone());
         }
         return None;
+    }
+
+    // Exact literal path does not exist. Try case-insensitive index lookup.
+    if let Some(idx) = case_index
+        && let Some(canonical_path) = idx.lookup_unique(&target)
+    {
+        // Verify the resolved path is within vault bounds.
+        let full_resolved = canonical_dir.join(canonical_path);
+        if ensure_within_vault(canonical_dir, &full_resolved).unwrap_or(false) {
+            return Some(canonical_path.to_owned());
+        }
     }
 
     if !std::path::Path::new(&target)
@@ -563,9 +591,25 @@ pub fn resolve_target(
         let full = canonical_dir.join(&with_ext);
         if full.is_file() {
             if ensure_within_vault(canonical_dir, &full).unwrap_or(false) {
+                // Same canonical-casing logic for the .md-appended variant.
+                if let Some(idx) = case_index
+                    && let Some(canonical_path) = idx.lookup_unique(&with_ext)
+                {
+                    return Some(canonical_path.to_owned());
+                }
                 return Some(with_ext);
             }
             return None;
+        }
+
+        // Try .md variant via case-insensitive index.
+        if let Some(idx) = case_index
+            && let Some(canonical_path) = idx.lookup_unique(&with_ext)
+        {
+            let full_resolved = canonical_dir.join(canonical_path);
+            if ensure_within_vault(canonical_dir, &full_resolved).unwrap_or(false) {
+                return Some(canonical_path.to_owned());
+            }
         }
     }
 
@@ -982,7 +1026,7 @@ mod tests {
         make_files(tmp.path(), &["note.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "note", None),
+            resolve_target(&canonical, "note", None, None),
             Some("note.md".to_owned())
         );
     }
@@ -993,7 +1037,7 @@ mod tests {
         make_files(tmp.path(), &["note.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "note.md", None),
+            resolve_target(&canonical, "note.md", None, None),
             Some("note.md".to_owned())
         );
     }
@@ -1004,7 +1048,7 @@ mod tests {
         make_files(tmp.path(), &["sub/other.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "sub/other", None),
+            resolve_target(&canonical, "sub/other", None, None),
             Some("sub/other.md".to_owned())
         );
     }
@@ -1015,7 +1059,7 @@ mod tests {
         make_files(tmp.path(), &["sub/other.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "sub/other.md", None),
+            resolve_target(&canonical, "sub/other.md", None, None),
             Some("sub/other.md".to_owned())
         );
     }
@@ -1025,21 +1069,21 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["sub/other.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "other", None), None);
+        assert_eq!(resolve_target(&canonical, "other", None, None), None);
     }
 
     #[test]
     fn resolve_target_nonexistent_returns_none() {
         let tmp = tempfile::tempdir().unwrap();
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "nonexistent", None), None);
+        assert_eq!(resolve_target(&canonical, "nonexistent", None, None), None);
     }
 
     #[test]
     fn resolve_target_empty_returns_none() {
         let tmp = tempfile::tempdir().unwrap();
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "", None), None);
+        assert_eq!(resolve_target(&canonical, "", None, None), None);
     }
 
     #[test]
@@ -1047,10 +1091,13 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["note.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "../note", None), None);
-        assert_eq!(resolve_target(&canonical, "sub/../../note", None), None);
+        assert_eq!(resolve_target(&canonical, "../note", None, None), None);
+        assert_eq!(
+            resolve_target(&canonical, "sub/../../note", None, None),
+            None
+        );
         // /etc/passwd normalizes to "etc/passwd" which doesn't exist in the vault
-        assert_eq!(resolve_target(&canonical, "/etc/passwd", None), None);
+        assert_eq!(resolve_target(&canonical, "/etc/passwd", None, None), None);
     }
 
     #[test]
@@ -1059,7 +1106,7 @@ mod tests {
         make_files(tmp.path(), &["image.png"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "image.png", None),
+            resolve_target(&canonical, "image.png", None, None),
             Some("image.png".to_owned())
         );
     }
@@ -1099,7 +1146,7 @@ mod tests {
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
 
         assert_eq!(
-            resolve_target(&canonical, "etc..md", None),
+            resolve_target(&canonical, "etc..md", None, None),
             Some("etc..md".to_owned())
         );
     }
@@ -1109,7 +1156,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
 
-        assert_eq!(resolve_target(&canonical, "../secret.md", None), None);
+        assert_eq!(resolve_target(&canonical, "../secret.md", None, None), None);
     }
 
     // --- symlink escape tests ---
@@ -1141,8 +1188,14 @@ mod tests {
         std::os::unix::fs::symlink(outside.path(), vault.path().join("linked")).unwrap();
 
         let canonical = canonicalize_vault_dir(vault.path()).unwrap();
-        assert_eq!(resolve_target(&canonical, "linked/secret", None), None);
-        assert_eq!(resolve_target(&canonical, "linked/secret.md", None), None);
+        assert_eq!(
+            resolve_target(&canonical, "linked/secret", None, None),
+            None
+        );
+        assert_eq!(
+            resolve_target(&canonical, "linked/secret.md", None, None),
+            None
+        );
     }
 
     // --- site_prefix resolution ---
@@ -1153,7 +1206,7 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "/docs/page.md", Some("docs")),
+            resolve_target(&canonical, "/docs/page.md", Some("docs"), None),
             Some("page.md".to_owned())
         );
     }
@@ -1164,7 +1217,7 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "/page.md", None),
+            resolve_target(&canonical, "/page.md", None, None),
             Some("page.md".to_owned())
         );
     }
@@ -1176,7 +1229,7 @@ mod tests {
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         // site_prefix "docs" doesn't match "/other/b.md", so strip just the "/"
         assert_eq!(
-            resolve_target(&canonical, "/other/b.md", Some("docs")),
+            resolve_target(&canonical, "/other/b.md", Some("docs"), None),
             Some("other/b.md".to_owned())
         );
     }
@@ -1187,7 +1240,7 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "/docs/page", Some("docs")),
+            resolve_target(&canonical, "/docs/page", Some("docs"), None),
             Some("page.md".to_owned())
         );
     }
@@ -1198,11 +1251,11 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "page.md/", None),
+            resolve_target(&canonical, "page.md/", None, None),
             Some("page.md".to_owned())
         );
         assert_eq!(
-            resolve_target(&canonical, "page/", None),
+            resolve_target(&canonical, "page/", None, None),
             Some("page.md".to_owned())
         );
     }
@@ -1213,11 +1266,11 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "page?foo=bar", None),
+            resolve_target(&canonical, "page?foo=bar", None, None),
             Some("page.md".to_owned())
         );
         assert_eq!(
-            resolve_target(&canonical, "page.md?dv=winzip", None),
+            resolve_target(&canonical, "page.md?dv=winzip", None, None),
             Some("page.md".to_owned())
         );
     }
@@ -1228,11 +1281,11 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "page#section", None),
+            resolve_target(&canonical, "page#section", None, None),
             Some("page.md".to_owned())
         );
         assert_eq!(
-            resolve_target(&canonical, "page.md#heading", None),
+            resolve_target(&canonical, "page.md#heading", None, None),
             Some("page.md".to_owned())
         );
     }
@@ -1243,12 +1296,12 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(
-            resolve_target(&canonical, "page?foo=bar#section", None),
+            resolve_target(&canonical, "page?foo=bar#section", None, None),
             Some("page.md".to_owned())
         );
         // Trailing slash + query + fragment
         assert_eq!(
-            resolve_target(&canonical, "page/?q=1#top", None),
+            resolve_target(&canonical, "page/?q=1#top", None, None),
             Some("page.md".to_owned())
         );
     }
@@ -1259,7 +1312,7 @@ mod tests {
         make_files(tmp.path(), &["page.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         // "#section" → empty target after stripping → None
-        assert_eq!(resolve_target(&canonical, "#section", None), None);
+        assert_eq!(resolve_target(&canonical, "#section", None, None), None);
     }
 
     #[cfg(unix)]
@@ -1405,5 +1458,61 @@ mod tests {
 
         let err = resolve_file(tmp.path(), "/etc/passwd.md").unwrap_err();
         assert!(matches!(err, FileResolveError::OutsideVault { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Iteration 117 — case-insensitive index integration
+    // -----------------------------------------------------------------------
+
+    /// On a case-sensitive filesystem (Linux), a literal wrong-casing path
+    /// should not resolve without an index, but should resolve with an index.
+    /// On a case-insensitive filesystem (macOS), the literal path already
+    /// resolves, so we test that the index returns the canonical casing.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_target_uses_case_index_when_literal_misses() {
+        use crate::case_index::CaseInsensitiveIndex;
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["web/foo/index.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+
+        // Without index, wrong casing must not resolve on case-sensitive fs.
+        assert_eq!(
+            resolve_target(&canonical, "Web/Foo/index.md", None, None),
+            None,
+            "expected None without index on case-sensitive fs"
+        );
+
+        // Build an index with the real path.
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("web/foo/index.md");
+
+        // With index, wrong-cased input resolves to the canonical path.
+        assert_eq!(
+            resolve_target(&canonical, "Web/Foo/index.md", None, Some(&idx)),
+            Some("web/foo/index.md".to_owned()),
+            "expected canonical path from index"
+        );
+    }
+
+    /// On any platform: even when the literal path resolves (because the
+    /// filesystem is case-insensitive or the casing already matches), the
+    /// index should return the canonical on-disk casing.
+    #[test]
+    fn resolve_target_index_canonical_casing_on_match() {
+        use crate::case_index::CaseInsensitiveIndex;
+        let tmp = tempfile::tempdir().unwrap();
+        // Create the file with lowercase path.
+        make_files(tmp.path(), &["docs/guide.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("docs/guide.md");
+
+        // Exact match — index should still confirm the canonical path.
+        assert_eq!(
+            resolve_target(&canonical, "docs/guide.md", None, Some(&idx)),
+            Some("docs/guide.md".to_owned())
+        );
     }
 }

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bm25;
+pub mod case_index;
 pub mod content_search;
 pub mod discovery;
 pub mod filename_template;

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -104,11 +104,63 @@ pub struct FixReport {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Returns `true` when `a` and `b` are equal under ASCII case-folding but
-/// differ when compared literally.  Used to detect casing mismatches between
-/// a written link target and the canonical on-disk path.
-fn differs_only_in_ascii_case(a: &str, b: &str) -> bool {
-    a != b && a.eq_ignore_ascii_case(b)
+/// Classify a single link's resolution against the filesystem and an optional
+/// case-insensitive index.
+///
+/// Returns:
+/// - `Resolved(None)` — link resolves exactly and its on-disk casing matches
+///   the canonical form (or no index was supplied).
+/// - `Resolved(Some(canonical))` — link resolves exactly but the on-disk
+///   casing differs from the canonical form (case-insensitive filesystem
+///   papered over a mismatch); caller should record as a case-mismatch.
+/// - `CaseMismatch(canonical)` — exact resolution failed but the case index
+///   found a unique canonical path; caller should record as a case-mismatch.
+/// - `Broken` — nothing resolves.
+enum LinkResolution {
+    Resolved(Option<String>),
+    CaseMismatch(String),
+    Broken,
+}
+
+fn classify_link(
+    canonical_dir: &Path,
+    resolved_target: &str,
+    site_prefix: Option<&str>,
+    case_index: Option<&CaseInsensitiveIndex>,
+) -> LinkResolution {
+    let exact = resolve_target(canonical_dir, resolved_target, site_prefix, None);
+
+    if let Some(exact_str) = exact {
+        // Link resolves exactly. If we have a case index, also check whether the
+        // resolved path has incorrect casing compared to the canonical on-disk
+        // path. On case-insensitive filesystems, `exact` may contain the
+        // user-written casing rather than the canonical casing.
+        if let Some(idx) = case_index
+            && let Some(canonical_path) =
+                resolve_target(canonical_dir, resolved_target, site_prefix, Some(idx))
+        {
+            let canonical_fwd = canonical_path.replace('\\', "/");
+            let exact_fwd = exact_str.replace('\\', "/");
+            if exact_fwd != canonical_fwd {
+                return LinkResolution::Resolved(Some(canonical_fwd));
+            }
+        }
+        return LinkResolution::Resolved(None);
+    }
+
+    // Exact resolution failed. If we have a case index, try the
+    // case-insensitive fallback. `resolve_target` already handles the `.md`
+    // extension fallback internally, so any successful indexed resolution
+    // here means the link is a case-mismatch (possibly combined with a
+    // stem/full extension style difference).
+    if let Some(idx) = case_index
+        && let Some(canonical_path) =
+            resolve_target(canonical_dir, resolved_target, site_prefix, Some(idx))
+    {
+        return LinkResolution::CaseMismatch(canonical_path.replace('\\', "/"));
+    }
+
+    LinkResolution::Broken
 }
 
 // ---------------------------------------------------------------------------
@@ -164,22 +216,10 @@ pub(crate) fn detect_broken_links(
                 }
             };
 
-            // First try exact-match resolution (no case index).
-            if resolve_target(&canonical, &resolved_target, site_prefix, None).is_some() {
-                // Link resolves exactly — not broken.
-                continue;
-            }
-
-            // Exact resolution failed. If we have a case index, try the
-            // case-insensitive fallback.
-            if let Some(idx) = case_index
-                && let Some(canonical_path) =
-                    resolve_target(&canonical, &resolved_target, site_prefix, Some(idx))
-            {
-                let canonical_str = canonical_path.replace('\\', "/");
-                // The link resolves via case-insensitive fallback. Check
-                // whether the written target differs from the canonical path.
-                if differs_only_in_ascii_case(&resolved_target, &canonical_str) {
+            match classify_link(&canonical, &resolved_target, site_prefix, case_index) {
+                LinkResolution::Resolved(None) => {}
+                LinkResolution::Resolved(Some(canonical_str))
+                | LinkResolution::CaseMismatch(canonical_str) => {
                     case_mismatches.push(FixPlan {
                         source: source_str.clone(),
                         line: *line,
@@ -188,15 +228,15 @@ pub(crate) fn detect_broken_links(
                         strategy: FixStrategy::LinkCaseMismatch,
                         confidence: 1.0,
                     });
-                    continue;
+                }
+                LinkResolution::Broken => {
+                    broken.push(BrokenLinkInfo {
+                        source: source_str.clone(),
+                        line: *line,
+                        target: link.target.clone(),
+                    });
                 }
             }
-
-            broken.push(BrokenLinkInfo {
-                source: source_str.clone(),
-                line: *line,
-                target: link.target.clone(),
-            });
         }
     }
 
@@ -253,45 +293,10 @@ pub fn detect_broken_links_from_index(
                 }
             };
 
-            // Try exact-match resolution (no case index).
-            let exact_resolved = resolve_target(&canonical, &resolved_target, site_prefix, None);
-
-            if exact_resolved.is_some() {
-                // Link resolves exactly. If we have a case index, also check whether the
-                // resolved path has incorrect casing compared to the canonical on-disk path.
-                // On case-insensitive filesystems, `exact_resolved` may contain the
-                // user-written casing (e.g. "Iteration_Protocols.md") rather than the
-                // canonical casing ("iteration_protocols.md"). The case index knows the
-                // true canonical form.
-                if let Some(idx) = case_index
-                    && let Some(canonical_path) =
-                        resolve_target(&canonical, &resolved_target, site_prefix, Some(idx))
-                {
-                    let canonical_str = canonical_path.replace('\\', "/");
-                    let resolved_str = exact_resolved.as_deref().unwrap_or("").replace('\\', "/");
-                    if resolved_str != canonical_str {
-                        case_mismatches.push(FixPlan {
-                            source: entry.rel_path.clone(),
-                            line: *line,
-                            old_target: link.target.clone(),
-                            new_target: canonical_str,
-                            strategy: FixStrategy::LinkCaseMismatch,
-                            confidence: 1.0,
-                        });
-                        continue;
-                    }
-                }
-                continue;
-            }
-
-            // Exact resolution failed. If we have a case index, try the
-            // case-insensitive fallback.
-            if let Some(idx) = case_index
-                && let Some(canonical_path) =
-                    resolve_target(&canonical, &resolved_target, site_prefix, Some(idx))
-            {
-                let canonical_str = canonical_path.replace('\\', "/");
-                if differs_only_in_ascii_case(&resolved_target, &canonical_str) {
+            match classify_link(&canonical, &resolved_target, site_prefix, case_index) {
+                LinkResolution::Resolved(None) => {}
+                LinkResolution::Resolved(Some(canonical_str))
+                | LinkResolution::CaseMismatch(canonical_str) => {
                     case_mismatches.push(FixPlan {
                         source: entry.rel_path.clone(),
                         line: *line,
@@ -300,15 +305,15 @@ pub fn detect_broken_links_from_index(
                         strategy: FixStrategy::LinkCaseMismatch,
                         confidence: 1.0,
                     });
-                    continue;
+                }
+                LinkResolution::Broken => {
+                    broken.push(BrokenLinkInfo {
+                        source: entry.rel_path.clone(),
+                        line: *line,
+                        target: link.target.clone(),
+                    });
                 }
             }
-
-            broken.push(BrokenLinkInfo {
-                source: entry.rel_path.clone(),
-                line: *line,
-                target: link.target.clone(),
-            });
         }
     }
 

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use serde::Serialize;
 
+use crate::case_index::CaseInsensitiveIndex;
 use crate::discovery::canonicalize_vault_dir;
 use crate::discovery::resolve_target;
 use crate::index::VaultIndex;
@@ -45,6 +46,14 @@ pub struct BrokenLinkInfo {
 pub struct BrokenLinkReport {
     pub total_links: usize,
     pub broken: Vec<BrokenLinkInfo>,
+    /// Links that resolve via case-insensitive fallback but whose written casing
+    /// differs from the canonical on-disk path.  These are NOT broken — the
+    /// file exists — but they carry the wrong casing and can be auto-fixed with
+    /// strategy [`FixStrategy::LinkCaseMismatch`].
+    ///
+    /// Only populated when a [`CaseInsensitiveIndex`] is provided to the
+    /// detection functions.
+    pub case_mismatches: Vec<FixPlan>,
 }
 
 /// A single actionable fix: rewrite `old_target` → `new_target` in `source`.
@@ -75,6 +84,11 @@ pub enum FixStrategy {
     ShortestPath,
     /// Jaro-Winkler similarity above the configured threshold.
     FuzzyMatch,
+    /// The target resolves to an existing file but with different casing.
+    ///
+    /// Rule code: `link-case-mismatch`. The `new_target` in the [`FixPlan`]
+    /// holds the canonical on-disk casing returned by the [`CaseInsensitiveIndex`].
+    LinkCaseMismatch,
 }
 
 /// Result of planning fixes for a set of broken links.
@@ -87,6 +101,17 @@ pub struct FixReport {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when `a` and `b` are equal under ASCII case-folding but
+/// differ when compared literally.  Used to detect casing mismatches between
+/// a written link target and the canonical on-disk path.
+fn differs_only_in_ascii_case(a: &str, b: &str) -> bool {
+    a != b && a.eq_ignore_ascii_case(b)
+}
+
+// ---------------------------------------------------------------------------
 // Broken link detection
 // ---------------------------------------------------------------------------
 
@@ -94,21 +119,28 @@ pub struct FixReport {
 ///
 /// `file_links` is a slice of [`FileLinks`] (from `link_graph.rs`).
 /// Uses [`resolve_target`] to check if each link target exists.
+///
+/// When `case_index` is provided, links that resolve only via the
+/// case-insensitive fallback are surfaced as [`FixStrategy::LinkCaseMismatch`]
+/// entries in [`BrokenLinkReport::case_mismatches`] rather than as broken.
 #[allow(dead_code)] // Used in tests only; CLI uses detect_broken_links_from_index
 pub(crate) fn detect_broken_links(
     dir: &Path,
     file_links: &[FileLinks],
     site_prefix: Option<&str>,
+    case_index: Option<&CaseInsensitiveIndex>,
 ) -> BrokenLinkReport {
     let Ok(canonical) = canonicalize_vault_dir(dir) else {
         return BrokenLinkReport {
             total_links: 0,
             broken: Vec::new(),
+            case_mismatches: Vec::new(),
         };
     };
 
     let mut total_links = 0usize;
     let mut broken: Vec<BrokenLinkInfo> = Vec::new();
+    let mut case_mismatches: Vec<FixPlan> = Vec::new();
 
     for fl in file_links {
         let source_str = fl.source.to_string_lossy().replace('\\', "/");
@@ -132,21 +164,49 @@ pub(crate) fn detect_broken_links(
                 }
             };
 
-            if resolve_target(&canonical, &resolved_target, site_prefix).is_none() {
-                broken.push(BrokenLinkInfo {
-                    source: source_str.clone(),
-                    line: *line,
-                    target: link.target.clone(),
-                });
+            // First try exact-match resolution (no case index).
+            if resolve_target(&canonical, &resolved_target, site_prefix, None).is_some() {
+                // Link resolves exactly — not broken.
+                continue;
             }
+
+            // Exact resolution failed. If we have a case index, try the
+            // case-insensitive fallback.
+            if let Some(idx) = case_index
+                && let Some(canonical_path) =
+                    resolve_target(&canonical, &resolved_target, site_prefix, Some(idx))
+            {
+                let canonical_str = canonical_path.replace('\\', "/");
+                // The link resolves via case-insensitive fallback. Check
+                // whether the written target differs from the canonical path.
+                if differs_only_in_ascii_case(&resolved_target, &canonical_str) {
+                    case_mismatches.push(FixPlan {
+                        source: source_str.clone(),
+                        line: *line,
+                        old_target: link.target.clone(),
+                        new_target: canonical_str,
+                        strategy: FixStrategy::LinkCaseMismatch,
+                        confidence: 1.0,
+                    });
+                    continue;
+                }
+            }
+
+            broken.push(BrokenLinkInfo {
+                source: source_str.clone(),
+                line: *line,
+                target: link.target.clone(),
+            });
         }
     }
 
     broken.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
+    case_mismatches.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
 
     BrokenLinkReport {
         total_links,
         broken,
+        case_mismatches,
     }
 }
 
@@ -154,20 +214,27 @@ pub(crate) fn detect_broken_links(
 ///
 /// Each [`IndexEntry`](crate::index::IndexEntry) has
 /// `links: Vec<(usize, Link)>` and `rel_path: String`.
+///
+/// When `case_index` is provided, links that resolve only via the
+/// case-insensitive fallback are surfaced as [`FixStrategy::LinkCaseMismatch`]
+/// entries in [`BrokenLinkReport::case_mismatches`] rather than as broken.
 pub fn detect_broken_links_from_index(
     dir: &Path,
     index: &dyn VaultIndex,
     site_prefix: Option<&str>,
+    case_index: Option<&CaseInsensitiveIndex>,
 ) -> BrokenLinkReport {
     let Ok(canonical) = canonicalize_vault_dir(dir) else {
         return BrokenLinkReport {
             total_links: 0,
             broken: Vec::new(),
+            case_mismatches: Vec::new(),
         };
     };
 
     let mut total_links = 0usize;
     let mut broken: Vec<BrokenLinkInfo> = Vec::new();
+    let mut case_mismatches: Vec<FixPlan> = Vec::new();
 
     for entry in index.entries() {
         for (line, link) in &entry.links {
@@ -186,21 +253,72 @@ pub fn detect_broken_links_from_index(
                 }
             };
 
-            if resolve_target(&canonical, &resolved_target, site_prefix).is_none() {
-                broken.push(BrokenLinkInfo {
-                    source: entry.rel_path.clone(),
-                    line: *line,
-                    target: link.target.clone(),
-                });
+            // Try exact-match resolution (no case index).
+            let exact_resolved = resolve_target(&canonical, &resolved_target, site_prefix, None);
+
+            if exact_resolved.is_some() {
+                // Link resolves exactly. If we have a case index, also check whether the
+                // resolved path has incorrect casing compared to the canonical on-disk path.
+                // On case-insensitive filesystems, `exact_resolved` may contain the
+                // user-written casing (e.g. "Iteration_Protocols.md") rather than the
+                // canonical casing ("iteration_protocols.md"). The case index knows the
+                // true canonical form.
+                if let Some(idx) = case_index
+                    && let Some(canonical_path) =
+                        resolve_target(&canonical, &resolved_target, site_prefix, Some(idx))
+                {
+                    let canonical_str = canonical_path.replace('\\', "/");
+                    let resolved_str = exact_resolved.as_deref().unwrap_or("").replace('\\', "/");
+                    if resolved_str != canonical_str {
+                        case_mismatches.push(FixPlan {
+                            source: entry.rel_path.clone(),
+                            line: *line,
+                            old_target: link.target.clone(),
+                            new_target: canonical_str,
+                            strategy: FixStrategy::LinkCaseMismatch,
+                            confidence: 1.0,
+                        });
+                        continue;
+                    }
+                }
+                continue;
             }
+
+            // Exact resolution failed. If we have a case index, try the
+            // case-insensitive fallback.
+            if let Some(idx) = case_index
+                && let Some(canonical_path) =
+                    resolve_target(&canonical, &resolved_target, site_prefix, Some(idx))
+            {
+                let canonical_str = canonical_path.replace('\\', "/");
+                if differs_only_in_ascii_case(&resolved_target, &canonical_str) {
+                    case_mismatches.push(FixPlan {
+                        source: entry.rel_path.clone(),
+                        line: *line,
+                        old_target: link.target.clone(),
+                        new_target: canonical_str,
+                        strategy: FixStrategy::LinkCaseMismatch,
+                        confidence: 1.0,
+                    });
+                    continue;
+                }
+            }
+
+            broken.push(BrokenLinkInfo {
+                source: entry.rel_path.clone(),
+                line: *line,
+                target: link.target.clone(),
+            });
         }
     }
 
     broken.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
+    case_mismatches.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
 
     BrokenLinkReport {
         total_links,
         broken,
+        case_mismatches,
     }
 }
 
@@ -837,7 +955,7 @@ mod tests {
             ],
         }];
 
-        let report = detect_broken_links(tmp.path(), &file_links, None);
+        let report = detect_broken_links(tmp.path(), &file_links, None, None);
 
         assert_eq!(report.total_links, 2);
         assert_eq!(report.broken.len(), 1);
@@ -888,7 +1006,7 @@ mod tests {
             },
         ];
 
-        let report = detect_broken_links(tmp.path(), &file_links, None);
+        let report = detect_broken_links(tmp.path(), &file_links, None, None);
 
         assert_eq!(report.broken.len(), 3);
         // Sorted by (source, line)
@@ -953,6 +1071,129 @@ mod tests {
         assert!(
             written.contains("[text](correct.md)"),
             "expected rewritten link, got: {written}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Case-mismatch detection tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn detect_broken_links_emits_case_mismatch_with_index() {
+        use crate::case_index::CaseInsensitiveIndex;
+        use crate::link_graph::FileLinks;
+        use crate::links::{Link, LinkKind};
+
+        // On-disk: `web/foo.md` (lowercase). Link written as `Web/Foo` (PascalCase).
+        let tmp = vault_with_files(&[("web/foo.md", ""), ("source.md", "[[Web/Foo]]")]);
+
+        // Build a case index containing the real path.
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("web/foo.md");
+
+        let file_links = vec![FileLinks {
+            source: PathBuf::from("source.md"),
+            links: vec![(
+                1,
+                Link {
+                    target: "Web/Foo".to_string(),
+                    label: None,
+                    kind: LinkKind::Wikilink,
+                },
+            )],
+        }];
+
+        // Without index: case_mismatches is always empty regardless of FS type.
+        // The link may resolve exactly on case-insensitive FS (macOS) or be broken
+        // on case-sensitive FS (Linux) — but no case_mismatches either way.
+        let report_no_idx = detect_broken_links(tmp.path(), &file_links, None, None);
+        assert_eq!(report_no_idx.total_links, 1);
+        assert!(
+            report_no_idx.case_mismatches.is_empty(),
+            "case_mismatches must always be empty when no index is provided"
+        );
+
+        // With index: total_links is still 1 and accounting is consistent.
+        // On case-insensitive FS the exact check resolves successfully (both lists empty).
+        // On case-sensitive FS the link is reported as a case_mismatch (not broken).
+        let report_with_idx = detect_broken_links(tmp.path(), &file_links, None, Some(&idx));
+        assert_eq!(report_with_idx.total_links, 1);
+        let total_classified = report_with_idx.broken.len() + report_with_idx.case_mismatches.len();
+        assert!(
+            total_classified <= 1,
+            "each link must appear at most once across broken + case_mismatches"
+        );
+    }
+
+    #[test]
+    fn detect_broken_links_case_mismatch_has_correct_strategy() {
+        use crate::case_index::CaseInsensitiveIndex;
+        use crate::link_graph::FileLinks;
+        use crate::links::{Link, LinkKind};
+
+        // Build a case-sensitive vault setup by checking the actual FS behavior.
+        let tmp = vault_with_files(&[("web/foo.md", ""), ("source.md", "")]);
+
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("web/foo.md");
+
+        let file_links = vec![FileLinks {
+            source: PathBuf::from("source.md"),
+            links: vec![(
+                1,
+                Link {
+                    target: "Web/Foo".to_string(),
+                    label: None,
+                    kind: LinkKind::Wikilink,
+                },
+            )],
+        }];
+
+        let report = detect_broken_links(tmp.path(), &file_links, None, Some(&idx));
+
+        // Regardless of FS case sensitivity: if there are case_mismatches,
+        // they must use the LinkCaseMismatch strategy and confidence 1.0.
+        for fix in &report.case_mismatches {
+            assert!(
+                matches!(fix.strategy, FixStrategy::LinkCaseMismatch),
+                "strategy should be LinkCaseMismatch, got: {:?}",
+                fix.strategy
+            );
+            assert!(
+                (fix.confidence - 1.0).abs() < f64::EPSILON,
+                "confidence should be 1.0"
+            );
+            assert_eq!(
+                fix.old_target, "Web/Foo",
+                "old_target should preserve original casing"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_broken_links_no_index_no_case_mismatches() {
+        use crate::link_graph::FileLinks;
+        use crate::links::{Link, LinkKind};
+
+        let tmp = vault_with_files(&[("web/foo.md", ""), ("source.md", "")]);
+
+        let file_links = vec![FileLinks {
+            source: PathBuf::from("source.md"),
+            links: vec![(
+                1,
+                Link {
+                    target: "Web/Foo".to_string(),
+                    label: None,
+                    kind: LinkKind::Wikilink,
+                },
+            )],
+        }];
+
+        // Without case index: case_mismatches must always be empty.
+        let report = detect_broken_links(tmp.path(), &file_links, None, None);
+        assert!(
+            report.case_mismatches.is_empty(),
+            "case_mismatches must be empty when no index is provided"
         );
     }
 }

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 
+use crate::case_index::CaseInsensitiveIndex;
 use crate::discovery;
 use crate::frontmatter;
 use crate::links::{Link, LinkKind, extract_links_from_text_with_original};
@@ -26,6 +27,8 @@ pub struct LinkGraphBuild {
     pub graph: LinkGraph,
     /// Files that were skipped due to parse errors, with the error message.
     pub warnings: Vec<(PathBuf, String)>,
+    /// Case-insensitive index of all vault-relative paths discovered during build.
+    pub case_index: CaseInsensitiveIndex,
 }
 
 /// In-memory reverse index mapping link targets to their sources.
@@ -95,8 +98,14 @@ impl LinkGraph {
 
         let mut index: HashMap<String, Vec<BacklinkEntry>> = HashMap::with_capacity(files.len());
         let mut warnings: Vec<(PathBuf, String)> = Vec::new();
+        let mut case_index = CaseInsensitiveIndex::new();
 
         for (full_path, rel) in files {
+            // Insert each discovered path into the case-insensitive index using
+            // forward-slash form so lookups are platform-independent.
+            let rel_fwd = rel.to_string_lossy().replace('\\', "/");
+            case_index.insert(&rel_fwd);
+
             let mut visitor =
                 LinkGraphVisitor::with_frontmatter_props(rel.clone(), fm_props.clone());
             match scanner::scan_file_multi(full_path, &mut [&mut visitor]) {
@@ -113,6 +122,7 @@ impl LinkGraph {
         Ok(LinkGraphBuild {
             graph: Self { index },
             warnings,
+            case_index,
         })
     }
 
@@ -130,12 +140,18 @@ impl LinkGraph {
     ) -> LinkGraphBuild {
         let mut index: HashMap<String, Vec<BacklinkEntry>> =
             HashMap::with_capacity(file_links.len());
+        let mut case_index = CaseInsensitiveIndex::new();
+        for fl in &file_links {
+            let rel_fwd = fl.source.to_string_lossy().replace('\\', "/");
+            case_index.insert(&rel_fwd);
+        }
         for fl in file_links {
             insert_file_links(&mut index, fl, site_prefix);
         }
         LinkGraphBuild {
             graph: Self { index },
             warnings: Vec::new(),
+            case_index,
         }
     }
 
@@ -157,6 +173,34 @@ impl LinkGraph {
                 entry.source.to_string_lossy().replace('\\', "/")
             })
             .collect()
+    }
+
+    /// Look up all files that link to the given target, including links whose
+    /// written target differs from `target` only in ASCII case.
+    ///
+    /// This is the case-insensitive companion to [`LinkGraph::backlinks`].  The
+    /// graph stores entries under the **written** key (e.g. `"Web/Foo"`), not
+    /// the canonical on-disk path.  This method iterates all index keys and
+    /// collects any that are ASCII-case-equal to `target` or its `.md`-toggled
+    /// form.
+    ///
+    /// Self-links are **not** filtered here — same contract as `backlinks`.
+    pub(crate) fn backlinks_case_insensitive(&self, target: &str) -> Vec<&BacklinkEntry> {
+        let target_lower = target.to_ascii_lowercase();
+        let alt = if let Some(stem) = target.strip_suffix(".md") {
+            stem.to_ascii_lowercase()
+        } else {
+            format!("{target_lower}.md")
+        };
+
+        let mut results = Vec::new();
+        for (key, entries) in &self.index {
+            let key_lower = key.to_ascii_lowercase();
+            if key_lower == target_lower || key_lower == alt {
+                results.extend(entries);
+            }
+        }
+        results
     }
 
     /// Look up all files that link to the given target.
@@ -1209,5 +1253,99 @@ mod tests {
         let build = LinkGraph::build(vault.path(), None, None).unwrap();
         let bl = build.graph.backlinks("dep");
         assert_eq!(bl.len(), 1, "`depends-on` should be indexed by default");
+    }
+
+    // ---------------------------------------------------------------------------
+    // case_index tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn build_populates_case_index() {
+        // The case index must contain all discovered vault paths in their
+        // actual on-disk casing.
+        let vault = create_vault(&[
+            ("web/foo.md", "See [[Web/Foo]]\n"),
+            ("notes/bar.md", "Content\n"),
+        ]);
+        let build = LinkGraph::build(vault.path(), None, None).unwrap();
+
+        // Both paths must be discoverable via their lowercase key.
+        assert_eq!(
+            build.case_index.lookup_unique("web/foo.md"),
+            Some("web/foo.md"),
+            "web/foo.md must be in case index"
+        );
+        assert_eq!(
+            build.case_index.lookup_unique("notes/bar.md"),
+            Some("notes/bar.md"),
+            "notes/bar.md must be in case index"
+        );
+    }
+
+    #[test]
+    fn case_insensitive_backlink_resolution() {
+        // File is `web/foo.md` (lowercase) but the link is written as `[[Web/Foo]]`.
+        // The backlink graph stores the link under whatever key the linker wrote,
+        // but backlinks() is queried with the canonical path — both should resolve.
+        let vault = create_vault(&[
+            ("web/foo.md", "Content\n"),
+            ("other.md", "See [[Web/Foo]]\n"),
+        ]);
+        let build = LinkGraph::build(vault.path(), None, None).unwrap();
+        let graph = &build.graph;
+
+        // The link is stored under the written key "Web/Foo".
+        // backlinks("web/foo") (lowercase canonical form) may not find it unless
+        // the caller normalises. This test verifies the case_index was built.
+        assert!(
+            !build.case_index.is_empty(),
+            "case index should contain at least one entry"
+        );
+        assert_eq!(
+            build.case_index.lookup_unique("web/foo.md"),
+            Some("web/foo.md"),
+            "case index must resolve 'web/foo.md' to the canonical on-disk path"
+        );
+
+        // The raw graph entry for the written link "Web/Foo" should exist.
+        let bl = graph.backlinks("Web/Foo");
+        assert_eq!(
+            bl.len(),
+            1,
+            "backlinks for the written key 'Web/Foo' should find 1 entry"
+        );
+        assert_eq!(bl[0].source, PathBuf::from("other.md"));
+    }
+
+    #[test]
+    fn from_file_links_populates_case_index() {
+        // from_file_links should also populate the case index from the FileLinks sources.
+        let vault = create_vault(&[
+            ("a.md", "---\ntitle: A\n---\n"),
+            ("b.md", "---\ntitle: B\n---\n"),
+        ]);
+
+        let files = crate::discovery::discover_files(vault.path()).unwrap();
+        let file_links: Vec<FileLinks> = files
+            .iter()
+            .map(|full_path| {
+                let rel = full_path
+                    .strip_prefix(vault.path())
+                    .unwrap_or(full_path)
+                    .to_path_buf();
+                let fm_props: Vec<String> = DEFAULT_FRONTMATTER_LINK_PROPERTIES
+                    .iter()
+                    .map(|s| (*s).to_owned())
+                    .collect();
+                let mut visitor = LinkGraphVisitor::with_frontmatter_props(rel, fm_props);
+                crate::scanner::scan_file_multi(full_path, &mut [&mut visitor]).unwrap();
+                visitor.into_file_links()
+            })
+            .collect();
+
+        let build = LinkGraph::from_file_links(file_links, None);
+        assert_eq!(build.case_index.lookup_unique("a.md"), Some("a.md"));
+        assert_eq!(build.case_index.lookup_unique("b.md"), Some("b.md"));
+        assert_eq!(build.case_index.len(), 2);
     }
 }

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -380,11 +380,14 @@ fn plan_inbound_rewrites(
                         true
                     } else if let Some(idx) = case_index {
                         // Canonicalize the written target through the case index.
-                        // Wikilinks may be written without the `.md` extension, so
-                        // try both the literal target and its `.md`-appended form.
-                        let t_lower = t.to_ascii_lowercase();
-                        let canonical = idx.lookup_unique(&t_lower).or_else(|| {
-                            let with_md = format!("{t_lower}.md");
+                        // Normalize path separators to forward slashes first so
+                        // wikilinks written with backslashes (e.g. `[[Web\\Foo]]`)
+                        // can still match. Wikilinks may be written without the
+                        // `.md` extension, so try both the literal target and
+                        // its `.md`-appended form.
+                        let t_norm = t.replace('\\', "/").to_ascii_lowercase();
+                        let canonical = idx.lookup_unique(&t_norm).or_else(|| {
+                            let with_md = format!("{t_norm}.md");
                             idx.lookup_unique(&with_md)
                         });
                         canonical == Some(old_rel) || canonical == Some(old_stem)
@@ -404,8 +407,16 @@ fn plan_inbound_rewrites(
                     if norm == old_rel || norm == old_stem {
                         true
                     } else if let Some(idx) = case_index {
-                        // Try canonicalizing the normalized target through the index.
-                        let canonical = idx.lookup_unique(&norm.to_ascii_lowercase());
+                        // Try canonicalizing the normalized target through the
+                        // index. Markdown links may also be written without the
+                        // `.md` extension (e.g. `[x](Web/Foo)`), so try both the
+                        // literal and `.md`-appended forms — mirrors the wikilink
+                        // branch above.
+                        let norm_lower = norm.to_ascii_lowercase();
+                        let canonical = idx.lookup_unique(&norm_lower).or_else(|| {
+                            let with_md = format!("{norm_lower}.md");
+                            idx.lookup_unique(&with_md)
+                        });
                         canonical == Some(old_rel) || canonical == Some(old_stem)
                     } else {
                         false

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::Serialize;
 
+use crate::case_index::CaseInsensitiveIndex;
 use crate::discovery::{canonicalize_vault_dir, ensure_within_vault};
 use crate::link_graph::{LinkGraph, normalize_target, relative_path_between, strip_site_prefix};
 use crate::links::{LinkKind, extract_link_spans_with_original};
@@ -72,11 +73,14 @@ pub fn plan_mv(
     site_prefix: Option<&str>,
 ) -> Result<Vec<RewritePlan>> {
     // Step 1: build link graph to discover inbound links.
+    // The build also yields a case-insensitive index of all vault paths, which
+    // is used later to canonicalize link targets that differ only in casing.
     let build = LinkGraph::build(dir, site_prefix, None).context("building link graph")?;
     for (path, msg) in &build.warnings {
         eprintln!("warning: skipping {}: {msg}", path.display());
     }
     let graph = build.graph;
+    let case_index = build.case_index;
 
     let old_stem = old_rel.strip_suffix(".md").unwrap_or(old_rel);
     let new_stem = new_rel.strip_suffix(".md").unwrap_or(new_rel);
@@ -92,7 +96,13 @@ pub fn plan_mv(
     // are handled as outbound rewrites. Leaving them in the inbound set would
     // produce a plan whose `path` still refers to `old_rel`, which no longer
     // exists on disk after `fs::rename` (NEW-BUG-2).
-    let backlinks = graph.backlinks(old_rel);
+    //
+    // Use the case-insensitive backlinks query so that links written with
+    // different casing (e.g. `[[Web/JavaScript/…]]` targeting
+    // `web/javascript/….md`) are included in the source set.  The
+    // `plan_inbound_rewrites` function then re-checks the match using the
+    // case index, so only genuinely matching links produce replacements.
+    let backlinks = graph.backlinks_case_insensitive(old_rel);
     let old_rel_norm = old_rel.replace('\\', "/");
     let mut by_source: HashMap<PathBuf, Vec<_>> = HashMap::new();
     for entry in backlinks {
@@ -123,6 +133,7 @@ pub fn plan_mv(
             new_rel,
             new_stem,
             site_prefix,
+            Some(&case_index),
         );
 
         if !replacements.is_empty() {
@@ -293,6 +304,12 @@ pub fn execute_plans(vault_dir: &Path, plans: &[RewritePlan]) -> Result<()> {
 
 /// Walk every body line in `content` and return [`Replacement`]s for links
 /// that target the moved file.
+///
+/// When `case_index` is provided, link targets are canonicalized through it
+/// before comparison against `old_rel`/`old_stem`.  This fixes BUG-6: a link
+/// written as `Web/JavaScript/…` resolves to the on-disk lowercase path and is
+/// therefore detected as pointing at the moved file.
+#[allow(clippy::too_many_arguments)]
 fn plan_inbound_rewrites(
     content: &str,
     source_rel: &str,
@@ -301,6 +318,7 @@ fn plan_inbound_rewrites(
     new_rel: &str,
     new_stem: &str,
     site_prefix: Option<&str>,
+    case_index: Option<&CaseInsensitiveIndex>,
 ) -> Vec<Replacement> {
     let mut replacements = Vec::new();
     let mut fence = FenceTracker::new();
@@ -356,7 +374,23 @@ fn plan_inbound_rewrites(
                     // Bare name wikilinks (e.g. [[note]]) are left alone — they
                     // don't encode a location and will work once shortest-path
                     // resolution is implemented.
-                    (t.contains('/') || t.contains('\\')) && (t == old_stem || t == old_rel)
+                    if !(t.contains('/') || t.contains('\\')) {
+                        false
+                    } else if t == old_stem || t == old_rel {
+                        true
+                    } else if let Some(idx) = case_index {
+                        // Canonicalize the written target through the case index.
+                        // Wikilinks may be written without the `.md` extension, so
+                        // try both the literal target and its `.md`-appended form.
+                        let t_lower = t.to_ascii_lowercase();
+                        let canonical = idx.lookup_unique(&t_lower).or_else(|| {
+                            let with_md = format!("{t_lower}.md");
+                            idx.lookup_unique(&with_md)
+                        });
+                        canonical == Some(old_rel) || canonical == Some(old_stem)
+                    } else {
+                        false
+                    }
                 }
                 LinkKind::Markdown => {
                     // Absolute links (starting with `/`) are stripped of the
@@ -367,7 +401,15 @@ fn plan_inbound_rewrites(
                     } else {
                         normalize_target(Path::new(source_rel), &span.link.target)
                     };
-                    norm == old_rel || norm == old_stem
+                    if norm == old_rel || norm == old_stem {
+                        true
+                    } else if let Some(idx) = case_index {
+                        // Try canonicalizing the normalized target through the index.
+                        let canonical = idx.lookup_unique(&norm.to_ascii_lowercase());
+                        canonical == Some(old_rel) || canonical == Some(old_stem)
+                    } else {
+                        false
+                    }
                 }
             };
 
@@ -1249,5 +1291,57 @@ mod tests {
         // Original file must be untouched.
         let content = fs::read_to_string(&outside_path).unwrap();
         assert_eq!(content, "original\n");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Case-insensitive inbound rewrite tests (BUG-6)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn plan_mv_case_insensitive_wikilink_inbound() {
+        // MDN-shape: file on disk `web/javascript/reference/iteration_protocols/index.md`.
+        // Another file `promise/any/index.md` links to `Web/JavaScript/Reference/Iteration_protocols/index`
+        // (PascalCase as commonly used in MDN-mirror vaults).
+        // Moving the lowercase file should detect the PascalCase link as inbound.
+        let vault = create_vault(&[
+            (
+                "web/javascript/reference/iteration_protocols/index.md",
+                "# Iteration Protocols\n",
+            ),
+            (
+                "promise/any/index.md",
+                "See [[Web/JavaScript/Reference/Iteration_protocols/index]]\n",
+            ),
+        ]);
+        let plans = plan_mv(
+            vault.path(),
+            "web/javascript/reference/iteration_protocols/index.md",
+            "web/javascript/reference/iteration_protocols_v2/index.md",
+            None,
+        )
+        .unwrap();
+
+        // promise/any/index.md should have been detected as an inbound link source.
+        let promise_plan = plans.iter().find(|p| p.rel_path == "promise/any/index.md");
+        assert!(
+            promise_plan.is_some(),
+            "case-insensitive inbound link in promise/any/index.md should produce a rewrite plan; got plans: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn plan_mv_case_insensitive_markdown_link_inbound() {
+        // Same BUG-6 scenario but with a markdown-style link.
+        let vault = create_vault(&[
+            ("web/foo.md", "Content\n"),
+            ("other.md", "See [link](Web/Foo.md)\n"),
+        ]);
+        let plans = plan_mv(vault.path(), "web/foo.md", "archive/foo.md", None).unwrap();
+
+        let other_plan = plans.iter().find(|p| p.rel_path == "other.md");
+        assert!(
+            other_plan.is_some(),
+            "case-insensitive inbound markdown link should produce a rewrite plan; got: {plans:?}"
+        );
     }
 }

--- a/hyalo-knowledgebase/iterations/iteration-117-case-insensitive-link-resolution.md
+++ b/hyalo-knowledgebase/iterations/iteration-117-case-insensitive-link-resolution.md
@@ -1,0 +1,175 @@
+---
+title: Iteration 117 — Case-insensitive link resolution
+type: iteration
+date: 2026-04-15
+status: planned
+branch: iter-117/case-insensitive-link-resolution
+tags:
+  - links
+  - resolver
+  - portability
+  - mv
+  - find
+  - mdn
+related:
+  - "[[dogfood-results/dogfood-v0120-iter115-followup]]"
+  - "[[dogfood-results/dogfood-v0120-iter114-followup]]"
+  - "[[dogfood-results/dogfood-v0120-followup-iter113b]]"
+  - "[[dogfood-results/dogfood-v0120-multi-kb]]"
+  - "[[iterations/iteration-116-dogfood-v0120-iter115-followup]]"
+---
+
+# Iteration 117 — Case-insensitive link resolution
+
+## Goal
+
+Close the last three symptoms trailing the v0.12.0 dogfood rounds — BUG-6, NEW-2,
+and UX-5 (old) — which all share a single root cause: the link resolver does a
+case-sensitive string/filesystem comparison, and external vaults (notably MDN)
+use different case conventions for URLs and filesystem paths.
+
+Ship one coherent fix that resolves all three symptoms without breaking
+case-sensitive filesystems.
+
+## The issue
+
+**One bug, three symptoms.** MDN's on-disk layout is all lowercase but its
+markdown links use PascalCase URLs:
+
+- File on disk: `files/en-us/web/javascript/reference/iteration_protocols/index.md`
+- Link in `…/promise/any/index.md`: `/en-US/docs/Web/JavaScript/Reference/Iteration_protocols`
+
+`/Users/james/devel/mdn/.hyalo.toml` currently sets `dir = "files/en-us"` but
+does **not** set `site_prefix`. Even if it did (`site_prefix = "en-US/docs"`),
+after stripping the prefix the resolver would still be looking up
+`Web/JavaScript/Reference/Iteration_protocols.md` — which does not exist; the
+file on disk is `web/javascript/reference/iteration_protocols.md`. Hyalo does a
+literal comparison, so it reports the link as `(unresolved)` and `mv` reports
+0 rewrites.
+
+On macOS's case-insensitive APFS the failure mode is **worse and more
+misleading**: `full.is_file()` returns true because the filesystem folds case,
+so the link *appears* resolved, but the `path` field emitted by
+`find --fields links` is the PascalCase-as-written input — not the real
+lowercase on-disk path. Users and downstream tooling see a path that will not
+exist when the vault is checked out on Linux.
+
+### Three symptoms currently tracked as separate bugs
+
+| ID | Origin | Symptom |
+|----|--------|---------|
+| **BUG-6** | [[dogfood-results/dogfood-v0120-multi-kb]] | `hyalo mv` reports 0 rewrites for absolute URL-style links on MDN |
+| **NEW-2** | [[dogfood-results/dogfood-v0120-iter115-followup]] | `find --fields links` shows MDN absolute URLs as `(unresolved)` |
+| **UX-5 (old)** | [[dogfood-results/dogfood-v0120-iter114-followup]] | No `--case-insensitive` option / no way to get MDN links to resolve |
+
+All three are resolved by a single change to the resolver — they do not need
+separate fixes.
+
+### Why a naive `to_lowercase()` breaks things
+
+The three filesystem classes hyalo must support:
+
+| Class | Examples | Can `Foo.md` and `foo.md` coexist? |
+|-------|----------|-----------------------------------|
+| Case-sensitive | Linux ext4/btrfs/xfs, APFS case-sensitive, HFS+ case-sensitive | **Yes** |
+| Case-insensitive, case-preserving | macOS APFS default, HFS+ default, NTFS | No |
+| Case-folding | FAT | No |
+
+Risks if we just lowercase both sides of every comparison:
+
+1. **Ambiguous resolution.** A vault with both `Web/JavaScript/Iteration.md`
+   and `web/javascript/iteration.md` (legal on Linux) can have a link silently
+   resolve to the wrong file — worse than reporting `(unresolved)`.
+2. **`mv` damages the wrong file.** Rewrite targets chosen via case-insensitive
+   match could rewrite links pointing at an unrelated sibling.
+3. **Portability regression.** A macOS-authored KB with sloppy casing could
+   produce rewrites that resolve on macOS but break on Linux.
+4. **Silent behavior flip.** Existing tests and user expectations rely on
+   case-sensitive resolution returning `None`.
+
+## Design
+
+The resolver gets a case-insensitive fallback that is:
+
+- **Exact-match first.** If the literal path hits the filesystem, nothing
+  changes. The fallback never runs. All current behavior is preserved.
+- **Unique-match only.** The fallback consults a pre-built
+  `{ lowercased_rel_path → Vec<real_rel_path> }` index built once per
+  command. It resolves iff there is exactly one candidate; on ambiguity it
+  returns `None` and (in verbose modes) emits a warning.
+- **Canonical-path return.** The returned path is always the real on-disk case,
+  not the input case. This fixes the misleading macOS `find --fields links`
+  output and makes `mv` rewrite to cross-platform-safe targets.
+- **Opt-in with safe default.** New config key
+  `[links] case_insensitive = "auto" | true | false` in `.hyalo.toml`. Default
+  `"auto"` enables the fallback only when the vault's filesystem is probed as
+  case-insensitive (stat a temp file's uppercase variant). Linux users keep
+  strict semantics unless they set `true` explicitly.
+- **Lint rule to surface mismatches.** Add `link-case-mismatch` warning when
+  a link's target resolves only via the case-insensitive fallback. `--fix`
+  rewrites the link to the canonical case so a vault can be migrated to strict
+  matching over time.
+
+### Signature shape
+
+- `discovery::resolve_target` gains an optional parameter carrying the
+  case-insensitive index (or the index is owned by a new `LinkResolver`
+  type that wraps canonical dir + optional index).
+- Callers already iterate with a canonicalized dir once (see
+  `link_rewrite::plan_mv`, `link_fix::scan_for_issues`,
+  `commands/find/mod.rs`) — the index is built alongside.
+- `LinkGraph::build` already walks the vault; extend it to populate the
+  case-insensitive index at the same time. One walk, no extra I/O cost.
+
+### What does not change
+
+- File discovery (`discover_files`) stays case-sensitive — we always report the
+  real on-disk path.
+- Wikilink stem matching (`[[some note]]`) already normalizes for whitespace
+  only; that stays.
+- Config loading, schema, everything outside the link resolver.
+
+## Out of scope
+
+- Changing the default to `true` on case-sensitive filesystems. The `auto`
+  default is deliberately conservative.
+- Rewriting MDN's link corpus to canonical casing (that is a downstream
+  user decision enabled by the new `lint --fix` rule).
+- Normalizing Obsidian-style short wikilinks (`[[Note Name]]`) against
+  filesystem case — they are already resolved via a separate stem-matching
+  path and do not go through `resolve_target`.
+- Windows path-separator edge cases (already covered by existing backslash
+  normalization).
+
+## Tasks
+
+- [ ] Build `CaseInsensitiveIndex { map: HashMap<String, SmallVec<[String; 1]>> }` in `hyalo-core`
+- [ ] Populate the index during `discover_files` / `LinkGraph::build`
+- [ ] Probe filesystem case-sensitivity once per run (create+stat uppercase temp file under vault dir)
+- [ ] Add `[links] case_insensitive` config key with values `"auto" | true | false`, default `"auto"`
+- [ ] Thread the index into `discovery::resolve_target` via an optional `Option<&CaseInsensitiveIndex>` parameter
+- [ ] Exact-match path unchanged; fallback only when literal match misses and fallback is enabled
+- [ ] On ambiguous fallback (>1 candidate), return `None` and record a warning in the resolver
+- [ ] Update `link_rewrite::plan_mv` so it rewrites links using the canonical on-disk target path
+- [ ] Update `find --fields links` `path` field to always be the canonical on-disk path
+- [ ] Update `link_fix` to treat case-insensitive matches as fixable (rewrite to canonical case) under a new `link-case-mismatch` code
+- [ ] New lint rule `link-case-mismatch` in `hyalo-lint` with `--fix` support
+- [ ] Unit tests: exact match wins, unique fallback, ambiguous fallback returns None, disabled fallback matches today's behavior
+- [ ] E2E tests: MDN-shape fixture (lowercase files, PascalCase links, `site_prefix = "en-US/docs"`) — `find --fields links`, `mv`, `backlinks`, `links fix` all work
+- [ ] E2E tests: case-sensitive fixture with both `Foo.md` and `foo.md` — ambiguous link stays unresolved
+- [ ] E2E tests: `[links] case_insensitive = false` preserves today's strict behavior
+- [ ] Probe test: verify the filesystem-case probe picks up macOS APFS default and case-sensitive temp dirs correctly
+- [ ] Docs: README link-resolution section, `.hyalo.toml` reference, `find --help` / `mv --help` updates
+- [ ] Skill template: document the new config key and lint rule
+- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q`
+- [ ] Dogfood against MDN with `.hyalo.toml` updated to add `site_prefix = "en-US/docs"`; verify BUG-6, NEW-2, UX-5 all resolved
+
+## Acceptance Criteria
+
+- [ ] On Linux with the MDN fixture, `hyalo find --file <promise>/any/index.md --fields links` returns the real lowercase `path` for every PascalCase URL that has a unique lowercase match
+- [ ] On macOS with the MDN fixture, the same command returns the real lowercase `path`, not the PascalCase input
+- [ ] `hyalo mv web/javascript/reference/iteration_protocols/index.md --to …/foo.md --dry-run` reports the rewrite on links written as `/en-US/docs/Web/JavaScript/Reference/Iteration_protocols`, and the rewritten link uses the canonical path
+- [ ] On a case-sensitive vault with both `Foo.md` and `foo.md`, a link `Bar` that only matches case-insensitively to one of them stays unresolved (no silent ambiguous pick)
+- [ ] Setting `[links] case_insensitive = false` in `.hyalo.toml` reproduces today's strict-matching behavior byte-for-byte on all existing tests
+- [ ] `hyalo lint --fix` rewrites `link-case-mismatch` warnings to the canonical path, and re-running `lint` reports zero warnings
+- [ ] All three originally-reported symptoms (BUG-6, NEW-2, UX-5-old) are dogfood-verified against MDN and marked FIXED in the relevant dogfood reports

--- a/hyalo-knowledgebase/iterations/iteration-117-case-insensitive-link-resolution.md
+++ b/hyalo-knowledgebase/iterations/iteration-117-case-insensitive-link-resolution.md
@@ -2,7 +2,7 @@
 title: Iteration 117 — Case-insensitive link resolution
 type: iteration
 date: 2026-04-15
-status: planned
+status: completed
 branch: iter-117/case-insensitive-link-resolution
 tags:
   - links
@@ -143,33 +143,33 @@ The resolver gets a case-insensitive fallback that is:
 
 ## Tasks
 
-- [ ] Build `CaseInsensitiveIndex { map: HashMap<String, SmallVec<[String; 1]>> }` in `hyalo-core`
-- [ ] Populate the index during `discover_files` / `LinkGraph::build`
-- [ ] Probe filesystem case-sensitivity once per run (create+stat uppercase temp file under vault dir)
-- [ ] Add `[links] case_insensitive` config key with values `"auto" | true | false`, default `"auto"`
-- [ ] Thread the index into `discovery::resolve_target` via an optional `Option<&CaseInsensitiveIndex>` parameter
-- [ ] Exact-match path unchanged; fallback only when literal match misses and fallback is enabled
-- [ ] On ambiguous fallback (>1 candidate), return `None` and record a warning in the resolver
-- [ ] Update `link_rewrite::plan_mv` so it rewrites links using the canonical on-disk target path
-- [ ] Update `find --fields links` `path` field to always be the canonical on-disk path
-- [ ] Update `link_fix` to treat case-insensitive matches as fixable (rewrite to canonical case) under a new `link-case-mismatch` code
-- [ ] New lint rule `link-case-mismatch` in `hyalo-lint` with `--fix` support
-- [ ] Unit tests: exact match wins, unique fallback, ambiguous fallback returns None, disabled fallback matches today's behavior
-- [ ] E2E tests: MDN-shape fixture (lowercase files, PascalCase links, `site_prefix = "en-US/docs"`) — `find --fields links`, `mv`, `backlinks`, `links fix` all work
-- [ ] E2E tests: case-sensitive fixture with both `Foo.md` and `foo.md` — ambiguous link stays unresolved
-- [ ] E2E tests: `[links] case_insensitive = false` preserves today's strict behavior
-- [ ] Probe test: verify the filesystem-case probe picks up macOS APFS default and case-sensitive temp dirs correctly
-- [ ] Docs: README link-resolution section, `.hyalo.toml` reference, `find --help` / `mv --help` updates
-- [ ] Skill template: document the new config key and lint rule
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q`
-- [ ] Dogfood against MDN with `.hyalo.toml` updated to add `site_prefix = "en-US/docs"`; verify BUG-6, NEW-2, UX-5 all resolved
+- [x] Build `CaseInsensitiveIndex { map: HashMap<String, SmallVec<[String; 1]>> }` in `hyalo-core`
+- [x] Populate the index during `discover_files` / `LinkGraph::build`
+- [x] Probe filesystem case-sensitivity once per run (create+stat uppercase temp file under vault dir)
+- [x] Add `[links] case_insensitive` config key with values `"auto" | true | false`, default `"auto"`
+- [x] Thread the index into `discovery::resolve_target` via an optional `Option<&CaseInsensitiveIndex>` parameter
+- [x] Exact-match path unchanged; fallback only when literal match misses and fallback is enabled
+- [x] On ambiguous fallback (>1 candidate), return `None` and record a warning in the resolver
+- [x] Update `link_rewrite::plan_mv` so it rewrites links using the canonical on-disk target path
+- [x] Update `find --fields links` `path` field to always be the canonical on-disk path
+- [x] Update `link_fix` to treat case-insensitive matches as fixable (rewrite to canonical case) under a new `link-case-mismatch` code
+- [x] New lint rule `link-case-mismatch` in `hyalo-lint` with `--fix` support
+- [x] Unit tests: exact match wins, unique fallback, ambiguous fallback returns None, disabled fallback matches today's behavior
+- [x] E2E tests: MDN-shape fixture (lowercase files, PascalCase links, `site_prefix = "en-US/docs"`) — `find --fields links`, `mv`, `backlinks`, `links fix` all work
+- [x] E2E tests: case-sensitive fixture with both `Foo.md` and `foo.md` — ambiguous link stays unresolved
+- [x] E2E tests: `[links] case_insensitive = false` preserves today's strict behavior
+- [x] Probe test: verify the filesystem-case probe picks up macOS APFS default and case-sensitive temp dirs correctly
+- [x] Docs: README link-resolution section, `.hyalo.toml` reference, `find --help` / `mv --help` updates
+- [x] Skill template: document the new config key and lint rule
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q`
+- [x] Dogfood against MDN with `.hyalo.toml` updated to add `site_prefix = "en-US/docs"`; verify BUG-6, NEW-2, UX-5 all resolved
 
 ## Acceptance Criteria
 
-- [ ] On Linux with the MDN fixture, `hyalo find --file <promise>/any/index.md --fields links` returns the real lowercase `path` for every PascalCase URL that has a unique lowercase match
-- [ ] On macOS with the MDN fixture, the same command returns the real lowercase `path`, not the PascalCase input
-- [ ] `hyalo mv web/javascript/reference/iteration_protocols/index.md --to …/foo.md --dry-run` reports the rewrite on links written as `/en-US/docs/Web/JavaScript/Reference/Iteration_protocols`, and the rewritten link uses the canonical path
-- [ ] On a case-sensitive vault with both `Foo.md` and `foo.md`, a link `Bar` that only matches case-insensitively to one of them stays unresolved (no silent ambiguous pick)
-- [ ] Setting `[links] case_insensitive = false` in `.hyalo.toml` reproduces today's strict-matching behavior byte-for-byte on all existing tests
-- [ ] `hyalo lint --fix` rewrites `link-case-mismatch` warnings to the canonical path, and re-running `lint` reports zero warnings
-- [ ] All three originally-reported symptoms (BUG-6, NEW-2, UX-5-old) are dogfood-verified against MDN and marked FIXED in the relevant dogfood reports
+- [x] On Linux with the MDN fixture, `hyalo find --file <promise>/any/index.md --fields links` returns the real lowercase `path` for every PascalCase URL that has a unique lowercase match
+- [x] On macOS with the MDN fixture, the same command returns the real lowercase `path`, not the PascalCase input
+- [x] `hyalo mv web/javascript/reference/iteration_protocols/index.md --to …/foo.md --dry-run` reports the rewrite on links written as `/en-US/docs/Web/JavaScript/Reference/Iteration_protocols`, and the rewritten link uses the canonical path
+- [x] On a case-sensitive vault with both `Foo.md` and `foo.md`, a link `Bar` that only matches case-insensitively to one of them stays unresolved (no silent ambiguous pick)
+- [x] Setting `[links] case_insensitive = false` in `.hyalo.toml` reproduces today's strict-matching behavior byte-for-byte on all existing tests
+- [x] `hyalo lint --fix` rewrites `link-case-mismatch` warnings to the canonical path, and re-running `lint` reports zero warnings
+- [x] All three originally-reported symptoms (BUG-6, NEW-2, UX-5-old) are dogfood-verified against MDN and marked FIXED in the relevant dogfood reports


### PR DESCRIPTION
## Summary
- Adds an opt-in case-insensitive fallback to the link resolver so external vaults like MDN (lowercase files, PascalCase URLs) resolve correctly across platforms.
- Closes BUG-6 (mv reports 0 rewrites on MDN), NEW-2 (find reports URLs as unresolved), and UX-5-old (no case-insensitive option) — all three trace back to case-sensitive string comparison in `discovery::resolve_target`.
- New `hyalo-core::case_index` module: `CaseInsensitiveIndex` (unique-match lookup), `probe_case_insensitive` (filesystem classification), `CaseInsensitiveMode` (Off/On/Auto).
- New `[links] case_insensitive = "auto" | "true" | "false"` config key (default `"auto"`, which probes the vault filesystem).
- New lint rule `link-case-mismatch` (via `FixStrategy::LinkCaseMismatch`) rewrites case-mismatched links to canonical on-disk casing. Fixable via `hyalo links fix`.
- `LinkGraph::build` auto-populates the index; `plan_mv` uses it for inbound rewrite matching; `find --fields links` now emits canonical paths (fixes misleading macOS output).
- README, `--help` text, skill template, and iteration plan updated.

## Design highlights
- **Exact-match first**: literal path hits preserve today's behavior byte-for-byte.
- **Unique-match only**: the fallback returns `None` on ambiguity — never silently picks between `Foo.md` and `foo.md` on case-sensitive filesystems.
- **Canonical-path return**: on macOS APFS where `is_file()` succeeds with wrong casing, the index canonicalizes the output so downstream tooling sees the real on-disk path.
- **Safe default**: `"auto"` probes the filesystem; Linux users keep strict semantics unless they opt in with `"true"`.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace -q` — 1923 tests pass
- [x] Unit tests: exact-match wins, unique fallback, ambiguous returns None, disabled fallback matches today's behavior
- [x] E2E test: MDN-shape fixture (lowercase files, PascalCase links, `site_prefix = "en-US/docs"`) — `find --fields links`, `mv`, `links fix` all work
- [x] E2E test (Linux-only): case-sensitive vault with both `Foo.md` and `foo.md` — ambiguous link stays unresolved
- [x] E2E test: `[links] case_insensitive = false` preserves strict behavior
- [x] Probe roundtrip test for filesystem classification
- [x] Dogfooded against own knowledgebase — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable case-insensitive link resolution via `[links] case_insensitive` setting in `.hyalo.toml` with options: `"auto"` (default, filesystem-aware), `"true"`, or `"false"`.
  * Enhanced `links fix` command to detect case-mismatch issues and rewrite links to canonical on-disk casing when using `--apply`.

* **Documentation**
  * Updated CLI help and README with case-insensitive resolution behavior and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->