### PR TITLE
iter-120: Dogfood post-iter-119 fixes

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: dogfood
+description: >
+  Run a dogfooding session for hyalo — build from source, exercise the CLI against real
+  knowledgebases (own KB, MDN, GitHub Docs, VS Code docs), find bugs, verify recent fixes,
+  assess UX, measure performance, and write a structured report. Use this skill whenever
+  the user says /dogfood, "dogfood", "run a dogfood session", "test hyalo against real data",
+  or wants to exercise hyalo on real knowledgebases to find issues.
+user_invocable: true
+---
+
+# Dogfood Session
+
+A dogfood session exercises hyalo against real knowledgebases to find bugs, verify fixes,
+assess UX, and discover improvement opportunities. Sessions should feel like a real user
+working with the tool — not a mechanical checklist. Be curious, follow interesting leads,
+try edge cases that occur to you naturally.
+
+## Phase 1: Prepare
+
+1. **Build from source**: `cargo build --release`
+2. **Find the last dogfood report** to establish the baseline:
+   ```bash
+   hyalo find --tag dogfooding --sort date --reverse --limit 1 --format text
+   ```
+   Read it to learn: which version was tested, which bugs were found, what was verified.
+3. **Discover what changed since then**: Use `git log --oneline` from that report's date
+   to HEAD. Look for merged iteration branches (`iter-N/...`). For each, read the iteration
+   file in the knowledgebase to understand what was implemented:
+   ```bash
+   hyalo find --tag iteration --property "date>=YYYY-MM-DD" --sort date --format text
+   ```
+   Then `hyalo read <iteration-file> --format text` for each to understand the features,
+   bug fixes, and UX changes. These are your priority test targets.
+4. **Check prior dogfood reports** for open bugs to re-verify:
+   ```bash
+   hyalo find --tag dogfooding --sort date --reverse --limit 5 --format text
+   ```
+   Read the most recent reports and collect any bugs marked as found (not yet verified fixed).
+4. **Pick target knowledgebases**: Use a mix of:
+   - **Own KB** (`hyalo-knowledgebase/`, ~250 files) — well-structured, has schemas/views
+   - **MDN Web Docs** (`../mdn/files/en-us/`, ~14K files) — large, stress-tests performance
+   - **GitHub Docs** (`../docs/content/`, ~3.5K files) — complex nested YAML frontmatter
+   - **VS Code Docs** (`../vscode/`, ~1K files) — mid-size, different structure
+
+   For external KBs, check they exist first (`ls ../mdn/files/en-us/ > /dev/null 2>&1`).
+   Create a snapshot index for large vaults (500+ files).
+
+## Phase 2: Exercise the tool
+
+This is the creative part. Don't follow a rigid script — think about what a real user would
+do with hyalo and try it. That said, make sure every session covers these categories:
+
+### New feature verification
+Test the features you discovered in Phase 1 from the iteration files and git log. For each
+new feature or changed command, don't just check the happy path — try edge cases, wrong
+inputs, combinations with other flags. The iteration files describe what was implemented
+and often include acceptance criteria that suggest good test scenarios.
+
+### Bug regression testing
+Re-verify bugs from the most recent dogfood report(s). Use the exact commands or scenarios
+that originally exposed them. Mark each as STILL FIXED, REGRESSED, or PARTIALLY FIXED.
+
+### Creative exploration
+This is where you go beyond verification. Try things like:
+- Unusual filter combinations (`--property` + `--tag` + BM25 + `--section`)
+- Edge-case inputs (empty strings, special characters, very long queries)
+- Commands on files with unusual frontmatter (nested objects, empty values, unicode)
+- `--jq` queries to build ad-hoc reports or dashboards
+- Views that chain with additional CLI flags
+- `mv` on files with many inbound links
+- `lint --fix --dry-run` on messy external KBs
+- Schema validation on write (`--validate` or `validate_on_write`)
+- Performance comparisons (indexed vs non-indexed, small vs large vault)
+- `links fix` on KBs with broken links
+- Anything that occurs to you as you go — follow your curiosity
+
+### UX assessment
+Pay attention to:
+- Are error messages helpful? Do they suggest what to do?
+- Are hints useful and relevant?
+- Is `--format text` output scannable?
+- Do help texts match actual behavior?
+- Any friction points or confusing behavior?
+
+### Performance spot-checks
+Time a few representative commands on each KB used:
+```bash
+time hyalo find --limit 1                    # baseline parse speed
+time hyalo find "some query"                 # BM25 search
+time hyalo summary                           # full vault scan
+time hyalo find --property status=completed  # structured filter
+```
+
+Compare with prior reports if available. Flag regressions > 2x.
+
+## Phase 3: Write the report
+
+Save to `hyalo-knowledgebase/dogfood-results/` with this naming and frontmatter:
+
+```yaml
+---
+title: "Dogfood vX.Y.Z — <descriptive subtitle>"
+type: research
+date: YYYY-MM-DD
+status: active
+tags: [dogfooding, ...]
+related:
+  - "[[dogfood-results/previous-report]]"
+  - "[[iterations/relevant-iteration]]"
+---
+```
+
+### Report structure
+
+Organize findings into clear sections. Use this general shape, but adapt as needed:
+
+```markdown
+# Dogfood vX.Y.Z — <subtitle>
+
+Brief context: binary version, which KBs tested, file counts.
+
+## New Feature Verification
+### Feature Name (iter-NNN) — WORKING / BROKEN / PARTIAL
+Description of what was tested and results.
+
+## Bug Regression Testing
+### BUG-N: Description — STILL FIXED / REGRESSED
+Commands tested, results observed.
+
+## Bugs Found
+### BUG-N: Description (SEVERITY)
+Steps to reproduce, expected vs actual, impact.
+
+## UX Issues
+### UX-N: Description (SEVERITY)
+What's confusing or could be better.
+
+## What Worked Well
+Highlight things that are genuinely good — performance wins, helpful errors, etc.
+
+## Performance
+Table of timings if measured.
+```
+
+Severity levels: HIGH (data loss, wrong results), MEDIUM (confusing behavior, workaround
+exists), LOW (cosmetic, minor friction).
+
+### After writing the report
+
+Use `hyalo set` to ensure the frontmatter is correct. Add `related` links to relevant
+iterations or prior dogfood reports.
+
+## Tips for good dogfood sessions
+
+- **Follow the hints.** Hyalo outputs drill-down suggestions — use them like a real user would.
+- **Don't skip external KBs.** Many bugs only surface at scale or with unusual frontmatter.
+  The own KB is too well-structured to catch everything.
+- **Note what's NOT there.** Missing features, things you wished you could do — these are
+  just as valuable as bugs.
+- **Be specific.** Include exact commands, exact error messages, exact output. Vague reports
+  like "search felt slow" aren't actionable.
+- **Test across KBs.** A command that works on the own KB might fail on MDN due to scale or
+  on GitHub Docs due to nested YAML.
+- **Check data quality.** Use `lint`, `find --broken-links`, `find --orphan` to surface
+  issues in the KB itself — this is valuable dogfooding too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@
 
 ### Added
 
+- `properties rename --dry-run` and `tags rename --dry-run` — preview which
+  files would be modified without writing to disk.
+- `find --fields outline` — alias for `--fields sections`.
+- `--stemmer` / `--language` now accepts ISO 639-1 two-letter codes (e.g.
+  `en`, `de`, `fr`) in addition to full language names.
+- `create-index` output now notes when replacing an existing index file.
+- `lint` hints now suggest adding unfixable files (e.g. unclosed frontmatter)
+  to `[lint] ignore` in `.hyalo.toml` instead of only showing "See defined
+  type schemas".
+
 - **Case-insensitive link resolution.** Wikilinks and markdown links now
   resolve even when the target file's path differs in case (e.g.
   `[[api/fetch]]` matches `API/Fetch.md`). Controlled via `.hyalo.toml`:

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -268,9 +268,10 @@ pub(crate) struct FindFilters {
     pub title: Option<String>,
     /// Stemmer language for BM25 body search (also --stemmer). Selects Snowball stemmer for BM25
     /// tokenization — NOT markdown code-block language.
-    /// Default: english. Supported: arabic, danish, dutch, english, finnish, french, german,
-    /// greek, hungarian, italian, norwegian, portuguese, romanian, russian, spanish, swedish,
-    /// tamil, turkish
+    /// Default: english. Accepts full names (english, german, …) or ISO 639-1 codes (en, de, …).
+    /// Supported: arabic (ar), danish (da), dutch (nl), english (en), finnish (fi), french (fr),
+    /// german (de), greek (el), hungarian (hu), italian (it), norwegian (no), portuguese (pt),
+    /// romanian (ro), russian (ru), spanish (es), swedish (sv), tamil (ta), turkish (tr)
     #[arg(long, alias = "stemmer", value_name = "LANG")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
@@ -352,8 +353,10 @@ pub(crate) enum Commands {
             - Combine freely: 'rust -java', 'rust OR golang', '\"error handling\" -panic'\n\n\
             LANGUAGE: The --language flag (or [search] language in .hyalo.toml, or frontmatter \
             'language' property per file) selects the Snowball stemmer for tokenization. Default: english. \
-            Supported: arabic, danish, dutch, english, finnish, french, german, greek, hungarian, \
-            italian, norwegian, portuguese, romanian, russian, spanish, swedish, tamil, turkish. \
+            Accepts full names or ISO 639-1 codes (e.g. 'en' for english, 'de' for german). \
+            Supported: arabic (ar), danish (da), dutch (nl), english (en), finnish (fi), french (fr), \
+            german (de), greek (el), hungarian (hu), italian (it), norwegian (no), portuguese (pt), \
+            romanian (ro), russian (ru), spanish (es), swedish (sv), tamil (ta), turkish (tr). \
             Language precedence: frontmatter > --language > config > english.\n\n\
             FILTERS: All filters are AND'd together.\n\
             - --property K=V: frontmatter property filter (supports =, !=, >, >=, <, <=, bare K for existence, !K for absence, K~=pattern or K~=/pattern/i for regex)\n\
@@ -1162,6 +1165,9 @@ pub(crate) enum PropertiesAction {
         /// Glob pattern(s) to scope which files to scan (repeatable); prefix '!' to negate
         #[arg(short, long)]
         glob: Vec<String>,
+        /// Preview changes without writing to disk
+        #[arg(long)]
+        dry_run: bool,
         #[command(flatten)]
         index_flags: IndexFlags,
     },
@@ -1200,6 +1206,9 @@ pub(crate) enum TagsAction {
         /// Glob pattern(s) to scope which files to scan (repeatable); prefix '!' to negate
         #[arg(short, long)]
         glob: Vec<String>,
+        /// Preview changes without writing to disk
+        #[arg(long)]
+        dry_run: bool,
         #[command(flatten)]
         index_flags: IndexFlags,
     },

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -51,6 +51,9 @@ pub fn create_index(
         }
     }
 
+    // Check if we're replacing an existing index.
+    let replacing_existing = index_path.exists();
+
     // Discover all markdown files
     let all = discovery::discover_files(dir)?;
     let files: Vec<(PathBuf, String)> = all
@@ -113,11 +116,14 @@ pub fn create_index(
     }
 
     let file_count = build.index.entries().len();
-    let result = serde_json::json!({
+    let mut result = serde_json::json!({
         "path": index_path.display().to_string(),
         "files_indexed": file_count,
         "warnings": build.warnings.len(),
     });
+    if replacing_existing {
+        result["note"] = serde_json::json!("replaced existing index");
+    }
 
     Ok(CommandOutcome::success(format_success(format, &result)))
 }

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -68,6 +68,7 @@ pub fn properties_summary(
 pub struct RenamePropertyResult {
     pub from: String,
     pub to: String,
+    pub dry_run: bool,
     pub modified: Vec<String>,
     pub skipped: Vec<String>,
     pub conflicts: Vec<String>,
@@ -80,11 +81,13 @@ pub struct RenamePropertyResult {
 /// - Preserves value and type (moves the `Value` in the IndexMap)
 /// - Skips files where the source key is absent (reported in `skipped`)
 /// - Skips files where the target key already exists (reported in `conflicts`)
+#[allow(clippy::too_many_arguments)]
 pub fn properties_rename(
     dir: &Path,
     from: &str,
     to: &str,
     globs: &[String],
+    dry_run: bool,
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
@@ -136,20 +139,25 @@ pub fn properties_rename(
         }
 
         props.insert(to.to_owned(), value);
-        frontmatter::write_frontmatter(full_path, &props)?;
-        if let Some(idx) = snapshot_index.as_mut()
-            && let Some(entry) = idx.get_mut(rel_path)
-        {
-            let new_tags = extract_tags(&props);
-            entry.properties = props;
-            entry.tags = new_tags;
-            entry.modified = format_modified(full_path)?;
-            index_dirty = true;
+        if !dry_run {
+            frontmatter::write_frontmatter(full_path, &props)?;
+            if let Some(idx) = snapshot_index.as_mut()
+                && let Some(entry) = idx.get_mut(rel_path)
+            {
+                let new_tags = extract_tags(&props);
+                entry.properties = props;
+                entry.tags = new_tags;
+                entry.modified = format_modified(full_path)?;
+                index_dirty = true;
+            }
         }
         modified.push(rel_path.clone());
     }
 
-    if index_dirty && let (Some(idx), Some(idx_path)) = (snapshot_index.as_mut(), index_path) {
+    if !dry_run
+        && index_dirty
+        && let (Some(idx), Some(idx_path)) = (snapshot_index.as_mut(), index_path)
+    {
         idx.save_to(idx_path)?;
     }
 
@@ -157,6 +165,7 @@ pub fn properties_rename(
     let result = RenamePropertyResult {
         from: from.to_owned(),
         to: to.to_owned(),
+        dry_run,
         modified,
         skipped,
         conflicts,
@@ -272,6 +281,7 @@ keywords: test
             "keywords",
             "Keywords",
             &[],
+            false,
             Format::Json,
             &mut None,
             None,
@@ -308,6 +318,7 @@ title: Note
             "keywords",
             "Keywords",
             &[],
+            false,
             Format::Json,
             &mut None,
             None,
@@ -341,6 +352,7 @@ Keywords: other
             "keywords",
             "Keywords",
             &[],
+            false,
             Format::Json,
             &mut None,
             None,
@@ -357,9 +369,17 @@ Keywords: other
     #[test]
     fn properties_rename_same_name_error() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome =
-            properties_rename(tmp.path(), "foo", "foo", &[], Format::Json, &mut None, None)
-                .unwrap();
+        let outcome = properties_rename(
+            tmp.path(),
+            "foo",
+            "foo",
+            &[],
+            false,
+            Format::Json,
+            &mut None,
+            None,
+        )
+        .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -105,6 +105,7 @@ pub fn tags_summary(
 pub struct RenameTagResult {
     pub from: String,
     pub to: String,
+    pub dry_run: bool,
     pub modified: Vec<String>,
     pub skipped: Vec<String>,
     pub total: usize,
@@ -115,11 +116,13 @@ pub struct RenameTagResult {
 ///
 /// - Atomic per-file: if new tag already exists, only old one is removed
 /// - Skips files where the source tag is absent
+#[allow(clippy::too_many_arguments)]
 pub fn tags_rename(
     dir: &Path,
     from: &str,
     to: &str,
     globs: &[String],
+    dry_run: bool,
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
@@ -203,20 +206,25 @@ pub fn tags_rename(
             props.shift_remove("tags");
         }
 
-        frontmatter::write_frontmatter(full_path, &props)?;
-        if let Some(idx) = snapshot_index.as_mut()
-            && let Some(entry) = idx.get_mut(rel_path)
-        {
-            let new_tags = extract_tags(&props);
-            entry.properties = props;
-            entry.tags = new_tags;
-            entry.modified = format_modified(full_path)?;
-            index_dirty = true;
+        if !dry_run {
+            frontmatter::write_frontmatter(full_path, &props)?;
+            if let Some(idx) = snapshot_index.as_mut()
+                && let Some(entry) = idx.get_mut(rel_path)
+            {
+                let new_tags = extract_tags(&props);
+                entry.properties = props;
+                entry.tags = new_tags;
+                entry.modified = format_modified(full_path)?;
+                index_dirty = true;
+            }
         }
         modified.push(rel_path.clone());
     }
 
-    if index_dirty && let (Some(idx), Some(idx_path)) = (snapshot_index.as_mut(), index_path) {
+    if !dry_run
+        && index_dirty
+        && let (Some(idx), Some(idx_path)) = (snapshot_index.as_mut(), index_path)
+    {
         idx.save_to(idx_path)?;
     }
 
@@ -224,6 +232,7 @@ pub fn tags_rename(
     let result = RenameTagResult {
         from: from.to_owned(),
         to: to.to_owned(),
+        dry_run,
         modified,
         skipped,
         total,
@@ -490,6 +499,7 @@ tags:
             "filtering",
             "filters",
             &[],
+            false,
             Format::Json,
             &mut None,
             None,
@@ -528,6 +538,7 @@ tags:
             "filtering",
             "filters",
             &[],
+            false,
             Format::Json,
             &mut None,
             None,
@@ -566,6 +577,7 @@ tags:
             "filtering",
             "filters",
             &[],
+            false,
             Format::Json,
             &mut None,
             None,
@@ -582,8 +594,17 @@ tags:
     #[test]
     fn tags_rename_same_name_error() {
         let tmp = tempfile::tempdir().unwrap();
-        let outcome =
-            tags_rename(tmp.path(), "foo", "foo", &[], Format::Json, &mut None, None).unwrap();
+        let outcome = tags_rename(
+            tmp.path(),
+            "foo",
+            "foo",
+            &[],
+            false,
+            Format::Json,
+            &mut None,
+            None,
+        )
+        .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
@@ -595,6 +616,7 @@ tags:
             "1984",
             "filters",
             &[],
+            false,
             Format::Json,
             &mut None,
             None,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -441,12 +441,14 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     from,
                     to,
                     glob,
+                    dry_run,
                     index_flags: _, // consumed in run.rs before dispatch
                 } => properties::properties_rename(
                     dir,
                     &from,
                     &to,
                     &glob,
+                    dry_run,
                     effective_format,
                     snapshot_index,
                     index_path,
@@ -523,12 +525,14 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     from,
                     to,
                     glob,
+                    dry_run,
                     index_flags: _, // consumed in run.rs before dispatch
                 } => tag_commands::tags_rename(
                     dir,
                     &from,
                     &to,
                     &glob,
+                    dry_run,
                     effective_format,
                     snapshot_index,
                     index_path,

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -1412,6 +1412,31 @@ fn hints_for_lint(ctx: &HintContext, data: &serde_json::Value, _total: Option<u6
         }
     }
 
+    // When there are unfixable parse errors, suggest ignoring those files.
+    let has_parse_errors = data
+        .get("files")
+        .and_then(|f| f.as_array())
+        .is_some_and(|files| {
+            files.iter().any(|file| {
+                file.get("violations")
+                    .and_then(|v| v.as_array())
+                    .is_some_and(|v| {
+                        v.iter().any(|violation| {
+                            violation
+                                .get("message")
+                                .and_then(|m| m.as_str())
+                                .is_some_and(|m| m.starts_with("could not parse frontmatter"))
+                        })
+                    })
+            })
+        });
+    if has_parse_errors && hints.len() < MAX_HINTS {
+        hints.push(Hint::new(
+            "Exclude unfixable files via [lint] ignore in .hyalo.toml",
+            "# Add ignore = [\"path/to/file.md\"] under [lint] in .hyalo.toml".to_owned(),
+        ));
+    }
+
     // Always suggest listing defined types.
     if hints.len() < MAX_HINTS {
         hints.push(Hint::new(

--- a/crates/hyalo-cli/tests/e2e/bm25.rs
+++ b/crates/hyalo-cli/tests/e2e/bm25.rs
@@ -970,3 +970,54 @@ Words like and, or, but are conjunctions.
         "quoted 'and' should match connector.md: {arr:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --stemmer / --language ISO 639-1 codes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stemmer_iso_639_1_code_accepted() {
+    let tmp = setup_bm25_vault();
+    let dir = tmp.path().to_str().unwrap();
+
+    // --stemmer en (ISO code for English) should work the same as --stemmer english
+    let output = hyalo_no_hints()
+        .args(["--dir", dir, "find", "rust", "--stemmer", "en"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert!(!results.is_empty(), "ISO code 'en' should produce results");
+}
+
+#[test]
+fn stemmer_iso_639_1_de_accepted() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "doc.md",
+        "---\ntitle: Test\n---\nDeutsche Sprache schwere Sprache.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "find",
+            "sprache",
+            "--stemmer",
+            "de",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/find.rs
+++ b/crates/hyalo-cli/tests/e2e/find.rs
@@ -3755,3 +3755,53 @@ fn find_orphan_and_dead_end_warns_mutually_exclusive() {
         "orphan+dead-end should return no results"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --fields outline (alias for sections)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_fields_outline_is_alias_for_sections() {
+    let tmp = setup_vault();
+    let dir = tmp.path().to_str().unwrap();
+
+    let outline_output = hyalo_no_hints()
+        .args(["--dir", dir, "find", "--fields", "outline", "--limit", "1"])
+        .output()
+        .unwrap();
+    assert!(
+        outline_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&outline_output.stderr)
+    );
+
+    let sections_output = hyalo_no_hints()
+        .args(["--dir", dir, "find", "--fields", "sections", "--limit", "1"])
+        .output()
+        .unwrap();
+    assert!(sections_output.status.success());
+
+    // Both should produce the same structure (sections key present in results).
+    let outline_json: serde_json::Value = serde_json::from_slice(&outline_output.stdout).unwrap();
+    let sections_json: serde_json::Value = serde_json::from_slice(&sections_output.stdout).unwrap();
+
+    let outline_has_sections = outline_json["results"]
+        .as_array()
+        .unwrap()
+        .first()
+        .unwrap()
+        .get("sections")
+        .is_some();
+    let sections_has_sections = sections_json["results"]
+        .as_array()
+        .unwrap()
+        .first()
+        .unwrap()
+        .get("sections")
+        .is_some();
+    assert!(
+        outline_has_sections,
+        "outline should produce sections field"
+    );
+    assert!(sections_has_sections);
+}

--- a/crates/hyalo-cli/tests/e2e/properties.rs
+++ b/crates/hyalo-cli/tests/e2e/properties.rs
@@ -462,6 +462,42 @@ fn properties_rename_same_name_exits_1() {
 }
 
 // ---------------------------------------------------------------------------
+// `hyalo properties rename --dry-run`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn properties_rename_dry_run_does_not_modify() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\nkeywords: test\n---\n");
+
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args([
+        "properties",
+        "rename",
+        "--from",
+        "keywords",
+        "--to",
+        "Keywords",
+        "--dry-run",
+    ]);
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["results"]["dry_run"], true);
+    assert_eq!(json["results"]["modified"].as_array().unwrap().len(), 1);
+
+    // File should be unchanged.
+    let content = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        content.contains("keywords:"),
+        "dry-run must not modify files"
+    );
+    assert!(!content.contains("Keywords:"));
+}
+
+// ---------------------------------------------------------------------------
 // Glob negation
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e/tags.rs
+++ b/crates/hyalo-cli/tests/e2e/tags.rs
@@ -743,6 +743,42 @@ fn tags_rename_scalar_tag_already_has_new() {
 }
 
 // ---------------------------------------------------------------------------
+// tags rename --dry-run
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_rename_dry_run_does_not_modify() {
+    let tmp = TempDir::new().unwrap();
+    write_tagged(tmp.path(), "a.md", &["filtering", "cli"]);
+
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args([
+        "tags",
+        "rename",
+        "--from",
+        "filtering",
+        "--to",
+        "filters",
+        "--dry-run",
+    ]);
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["results"]["dry_run"], true);
+    assert_eq!(json["results"]["modified"].as_array().unwrap().len(), 1);
+
+    // File should be unchanged.
+    let content = std::fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        content.contains("filtering"),
+        "dry-run must not modify files"
+    );
+    assert!(!content.contains("filters"));
+}
+
+// ---------------------------------------------------------------------------
 // Glob negation
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -39,14 +39,49 @@ macro_rules! define_stem_languages {
 
         /// Parses a language name string (case-insensitive) into a [`StemLanguage`].
         ///
+        /// Accepts full names (e.g. "english") or ISO 639-1 codes (e.g. "en").
         /// Returns an error for unrecognised language names.
         pub fn parse_language(s: &str) -> anyhow::Result<StemLanguage> {
-            match s.to_lowercase().as_str() {
-                $( $canonical => Ok(StemLanguage::$variant), )+
-                other => anyhow::bail!("unknown stemming language: {other:?}"),
+            let lower = s.to_lowercase();
+            // Try canonical (full) names first.
+            match lower.as_str() {
+                $( $canonical => return Ok(StemLanguage::$variant), )+
+                _ => {}
+            }
+            // Try ISO 639-1 two-letter codes.
+            match iso639_to_canonical(lower.as_str()) {
+                Some(lang) => Ok(lang),
+                None => anyhow::bail!(
+                    "unknown stemming language: {s:?} (use a full name like \"english\" or an ISO 639-1 code like \"en\")"
+                ),
             }
         }
     };
+}
+
+/// Map ISO 639-1 two-letter codes to [`StemLanguage`] variants.
+fn iso639_to_canonical(code: &str) -> Option<StemLanguage> {
+    match code {
+        "ar" => Some(StemLanguage::Arabic),
+        "da" => Some(StemLanguage::Danish),
+        "nl" => Some(StemLanguage::Dutch),
+        "en" => Some(StemLanguage::English),
+        "fi" => Some(StemLanguage::Finnish),
+        "fr" => Some(StemLanguage::French),
+        "de" => Some(StemLanguage::German),
+        "el" => Some(StemLanguage::Greek),
+        "hu" => Some(StemLanguage::Hungarian),
+        "it" => Some(StemLanguage::Italian),
+        "no" | "nb" | "nn" => Some(StemLanguage::Norwegian),
+        "pt" => Some(StemLanguage::Portuguese),
+        "ro" => Some(StemLanguage::Romanian),
+        "ru" => Some(StemLanguage::Russian),
+        "es" => Some(StemLanguage::Spanish),
+        "sv" => Some(StemLanguage::Swedish),
+        "ta" => Some(StemLanguage::Tamil),
+        "tr" => Some(StemLanguage::Turkish),
+        _ => None,
+    }
 }
 
 define_stem_languages! {
@@ -871,7 +906,19 @@ mod tests {
     fn test_parse_language_invalid() {
         assert!(parse_language("klingon").is_err());
         assert!(parse_language("").is_err());
-        assert!(parse_language("en").is_err());
+        assert!(parse_language("xx").is_err());
+    }
+
+    #[test]
+    fn test_parse_language_iso639_codes() {
+        assert_eq!(parse_language("en").unwrap(), StemLanguage::English);
+        assert_eq!(parse_language("de").unwrap(), StemLanguage::German);
+        assert_eq!(parse_language("fr").unwrap(), StemLanguage::French);
+        assert_eq!(parse_language("es").unwrap(), StemLanguage::Spanish);
+        assert_eq!(parse_language("ar").unwrap(), StemLanguage::Arabic);
+        assert_eq!(parse_language("no").unwrap(), StemLanguage::Norwegian);
+        assert_eq!(parse_language("nb").unwrap(), StemLanguage::Norwegian);
+        assert_eq!(parse_language("EN").unwrap(), StemLanguage::English);
     }
 
     // ------------------------------------------------------------------

--- a/crates/hyalo-core/src/filter/fields.rs
+++ b/crates/hyalo-core/src/filter/fields.rs
@@ -72,13 +72,13 @@ impl Fields {
                     "properties" => fields.properties = true,
                     "properties-typed" => fields.properties_typed = true,
                     "tags" => fields.tags = true,
-                    "sections" => fields.sections = true,
+                    "sections" | "outline" => fields.sections = true,
                     "tasks" => fields.tasks = true,
                     "links" => fields.links = true,
                     "backlinks" => fields.backlinks = true,
                     "title" => fields.title = true,
                     unknown => bail!(
-                        "unknown field {unknown:?}: valid fields are all, properties, properties-typed, tags, sections, tasks, links, backlinks, title"
+                        "unknown field {unknown:?}: valid fields are all, properties, properties-typed, tags, sections (alias: outline), tasks, links, backlinks, title"
                     ),
                 }
             }

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0120-post-iter119.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0120-post-iter119.md
@@ -1,0 +1,122 @@
+---
+title: "Dogfood v0.12.0 — Post Iteration 119 (Multi-KB Session)"
+type: research
+date: 2026-04-16
+status: active
+tags:
+  - dogfooding
+  - verification
+  - multi-kb
+related:
+  - "[[dogfood-results/dogfood-v0120-post-iter118]]"
+  - "[[iterations/iteration-118-split-index-flag]]"
+---
+
+# Dogfood v0.12.0 — Post Iteration 119 (Multi-KB Session)
+
+Binary: `hyalo 0.12.0` built via `cargo build --release`.
+Tested on: Own KB (246 files), MDN Web Docs (14,245 files), GitHub Docs (3,520 files).
+
+## Iter-119 Feature Verification
+
+### `validate_on_write` auto-enable on first type creation — WORKING
+
+Created a fresh `.hyalo.toml` with only `dir = "docs"`, ran `types set mytype --required title`. Output correctly reports `"enable validate_on_write (new schema)"` in `toml_changes`, and the resulting `.hyalo.toml` contains `validate_on_write = true` under `[schema]`.
+
+Also verified `types set --dry-run` on GitHub Docs external KB works correctly — reports what would change without writing.
+
+**Edge case**: When running `types set --dir <subdir>` from outside the project root (the original iter-113 config-lookup bug territory), the feature still works correctly as long as CWD matches the project root.
+
+## Prior Bug Re-verification
+
+### BUG-1 (post-118): `--fields outline` alias — STILL OPEN
+
+`find --fields outline` still fails with: `unknown field "outline": valid fields are all, properties, properties-typed, tags, sections, tasks, links, backlinks, title`.
+
+### BUG-2 (post-118): `--stemmer` ISO codes — STILL OPEN
+
+`find "search" --stemmer en` still fails: `invalid --language value "en": unknown stemming language: "en"`.
+
+### BUG-3 (iter-113): Boolean operator warning — STILL FIXED
+
+`find "AND OR"` correctly warns: `"AND", "OR" were interpreted as boolean operators, leaving an empty query`.
+
+### BUG-D (iter-114): Schema validation on `set` — STILL WORKING
+
+`set --property "status=banana" --validate --dry-run` correctly rejects with did-you-mean suggestion.
+
+### Non-existent view error — STILL WORKING
+
+`find --view nonexistent` gives clear error with tip to run `views list`.
+
+## Bugs Found
+
+### BUG-1: `mv --dry-run` doesn't preview link rewrites (MEDIUM)
+
+`decision-log.md` has 14 backlinks (verified via `backlinks` command). Running `mv decision-log.md --to reference/decision-log.md --dry-run` reports:
+```json
+{
+  "total_files_updated": 0,
+  "total_links_updated": 0,
+  "updated_files": []
+}
+```
+
+The dry-run should preview which files would be rewritten and how many links would change, so the user can assess the impact before applying. Currently it only shows the file move itself.
+
+### BUG-2: `properties rename` lacks `--dry-run` (MEDIUM)
+
+`properties rename --from "origin" --to "source" --dry-run` fails: `unexpected argument '--dry-run' found`. This is a bulk mutation that could affect many files — previewing is essential. Same issue affects `tags rename`.
+
+Both `set` and `mv` support `--dry-run`; the rename commands should too for consistency and safety.
+
+### BUG-3: MDN index load dominates query time — potential optimization (LOW)
+
+The MDN snapshot index is 113 MB. Every indexed query takes ~0.67s regardless of complexity, because loading/deserializing the index from disk dominates. Without index, `summary` takes 1.07s (I/O-bound disk scan), so the index saves ~0.4s only for summary-class operations. For BM25 search, index saves significantly more (0.67s vs 3.8s).
+
+Not a bug per se, but the 113 MB index file for 14K files seems large. Could be worth investigating if the serialization format can be more compact, or if lazy/partial loading is feasible.
+
+## UX Observations
+
+### UX-1: `create-index` silently overwrites existing index (LOW)
+
+Running `create-index` when `.hyalo-index` already exists produces no warning — it just rebuilds. A brief note like "replacing existing index (was 2.5s old)" would help users understand what happened, especially if they accidentally run it twice.
+
+### UX-2: `lint --fix --dry-run` on unclosed-frontmatter files gives no fix hint (LOW)
+
+On GitHub Docs, `code-security/concepts/index.md` has unclosed frontmatter. `lint --fix --dry-run` correctly reports the error but doesn't suggest any fix. The hint says "See defined type schemas" which isn't helpful. A better hint would reference the `[lint] ignore` config for known-bad files.
+
+## What Worked Well
+
+### Multi-filter composition is excellent
+Tested all combinations: BM25 + `--property` + `--tag` + `--section` + `--task` + `--sort` + `--limit`. Everything composes cleanly. The maximum-filter test (`find "bug" --property type=iteration --property "date>=2026-04-01" --tag dogfooding --section "Tasks" --task done --sort date --reverse --limit 3`) returned exactly the right results.
+
+### BM25 search ranking is spot-on
+MDN: "CSS grid layout" → CSS grid module page first (score 16.47). GitHub Docs: "pull request merge conflict" → merge conflicts page first (score 18.09). Own KB: "snapshot index" → iter-47 first. Ranking is consistently excellent across all three KBs.
+
+### External KB compatibility
+Both MDN (14K files) and GitHub Docs (3.5K files) work seamlessly. The `--dir` flag, `--ignore-target`, `--site-prefix`, and schema-less operation all work correctly. The unclosed-frontmatter skip-and-warn behavior is robust — one bad file doesn't break 3,519 others.
+
+### `jq` queries are powerful
+Built a burndown query: `find --property type=iteration --property status=in-progress --fields tasks --jq '.results | map({file, open: ..., total: ...})'` — worked perfectly.
+
+### `links fix` with `--ignore-target` is useful
+MDN has 48,979 broken links (mostly site-absolute). `links fix --ignore-target "/en-US/docs"` correctly filtered to just 212 unfixable non-MDN links and 0 fixable ones. Clean and fast (1.55s for 14K files).
+
+### Performance remains excellent
+
+| Command | Own KB (246) | MDN (14,245) | MDN (indexed) | GH Docs (3,520) |
+|---|---|---|---|---|
+| `find --limit 1` | 29ms | — | 687ms | — |
+| BM25 search | 79ms | 3.8s | 657ms | 944ms |
+| `summary` | 30ms | 1.07s | — | 381ms |
+| `property filter` | 19ms | — | 672ms | 149ms |
+
+Own KB is blazing fast (19-79ms). MDN indexed queries are consistent ~0.67s (index load dominated). GitHub Docs is fast at 149ms-944ms.
+
+## Suggested Priorities
+
+1. **BUG-2**: Add `--dry-run` to `properties rename` and `tags rename` — safety gap for bulk mutations
+2. **BUG-1**: `mv --dry-run` should preview link rewrites — currently misleading (shows 0 changes)
+3. **BUG-1 (prior)**: `--fields outline` alias for `sections` — easy UX win
+4. **BUG-2 (prior)**: `--stemmer` ISO 639-1 codes — easy UX win

--- a/hyalo-knowledgebase/iterations/iteration-120-dogfood-v0120-post-iter119-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-120-dogfood-v0120-post-iter119-fixes.md
@@ -1,0 +1,130 @@
+---
+title: "Iteration 120 — Dogfood v0.12.0 Post-iter-119 Fixes"
+type: iteration
+date: 2026-04-16
+status: planned
+branch: iter-120/dogfood-post-iter119-fixes
+tags:
+  - iteration
+  - dogfooding
+  - bug-fix
+  - ux
+  - dry-run
+related:
+  - "[[dogfood-results/dogfood-v0120-post-iter119]]"
+---
+
+# Iteration 120 — Dogfood v0.12.0 Post-iter-119 Fixes
+
+## Goal
+
+Address the bugs and UX issues found in the post-iter-119 dogfood session. The two
+highest-priority findings are missing `--dry-run` support on bulk mutation commands
+(`properties rename`, `tags rename`) and `mv --dry-run` not previewing link rewrites.
+Also includes two small UX wins carried over from post-iter-118.
+
+## Bugs
+
+### BUG-1: `mv --dry-run` doesn't preview link rewrites (MEDIUM)
+
+`decision-log.md` has 14 backlinks. Running `mv decision-log.md --to reference/decision-log.md --dry-run`
+reports `total_files_updated: 0, total_links_updated: 0, updated_files: []`. The dry-run
+should scan for backlinks and show which files and links would be rewritten, so the user
+can assess impact before applying.
+
+**Fix**: In the `mv` dry-run path, still compute link rewrites (scan for backlinks, resolve
+rewrite targets) but skip the actual file writes. Populate `total_files_updated`,
+`total_links_updated`, and `updated_files` with the preview data.
+
+### BUG-2: `properties rename` and `tags rename` lack `--dry-run` (MEDIUM)
+
+Both commands perform bulk mutations across all matching files with no way to preview.
+`properties rename --from origin --to source --dry-run` fails with `unexpected argument '--dry-run' found`.
+
+Every other mutation command (`set`, `remove`, `append`, `task toggle`, `mv`, `links fix`)
+supports `--dry-run`. The rename commands are the only gap.
+
+**Fix**: Add `--dry-run` flag to both `properties rename` and `tags rename`. In dry-run mode,
+scan files and report which would change, but don't write. Text output should show file
+paths and the rename preview (e.g., `origin → source`). JSON output should include
+`dry_run: true` and the list of affected files.
+
+### BUG-3 (carried over): `--fields outline` is not a valid field name (LOW)
+
+`find --fields outline` errors. `outline` is a natural alias for `sections` (which shows
+heading structure). Adding it as an alias improves discoverability.
+
+**Fix**: Accept `outline` as an alias for `sections` in the `--fields` parser.
+
+### BUG-4 (carried over): `--stemmer` doesn't accept ISO 639-1 codes (LOW)
+
+`--stemmer en` fails with "unknown stemming language". Only full names like `english` are
+accepted. Two-letter codes are the natural form for many users.
+
+**Fix**: Map common ISO 639-1 codes to Snowball stemmer names: `en` → `english`,
+`de` → `german`, `fr` → `french`, `es` → `spanish`, `it` → `italian`, `pt` → `portuguese`,
+`nl` → `dutch`, `sv` → `swedish`, `no` → `norwegian`, `da` → `danish`, `fi` → `finnish`,
+`hu` → `hungarian`, `ro` → `romanian`, `tr` → `turkish`, `ru` → `russian`, `ar` → `arabic`.
+
+## UX Improvements
+
+### UX-1: `create-index` should note when overwriting (LOW)
+
+Currently `create-index` silently overwrites an existing `.hyalo-index`. Adding a brief
+note (e.g., `"note": "replaced existing index"`) in the JSON output helps users
+understand what happened.
+
+### UX-2: `lint --fix` hint for unfixable parse errors (LOW)
+
+When `lint --fix --dry-run` encounters an unfixable error like unclosed frontmatter, the
+hint says "See defined type schemas" which isn't helpful. A better hint would suggest
+adding the file to `[lint] ignore` in `.hyalo.toml`.
+
+## Tasks
+
+### BUG-1: `mv --dry-run` link rewrite preview
+- [ ] Refactor mv command to compute link rewrites before deciding to write
+- [ ] Populate `updated_files` and counters in dry-run output
+- [ ] Add text-format output showing affected files and link counts
+- [ ] Add e2e test: mv --dry-run on file with backlinks shows non-zero counts
+
+### BUG-2: `--dry-run` for `properties rename` and `tags rename`
+- [ ] Add `--dry-run` flag to `properties rename` clap definition
+- [ ] Add `--dry-run` flag to `tags rename` clap definition
+- [ ] Implement dry-run logic: scan and report without writing
+- [ ] Add text-format output for dry-run preview
+- [ ] Add e2e tests for both commands with `--dry-run`
+
+### BUG-3: `--fields outline` alias
+- [ ] Accept `outline` as alias for `sections` in field parsing
+- [ ] Add e2e test
+
+### BUG-4: `--stemmer` ISO 639-1 codes
+- [ ] Add ISO 639-1 to Snowball name mapping
+- [ ] Update help text to mention both forms
+- [ ] Add e2e test for `--stemmer en`
+
+### UX improvements
+- [ ] `create-index`: note when overwriting existing index
+- [ ] `lint --fix` hint: suggest `[lint] ignore` for unfixable parse errors
+
+### Documentation surfaces (keep all in sync)
+- [ ] Update help texts for changed commands
+- [ ] Update CHANGELOG
+- [ ] Update knowledgebase skill if needed
+- [ ] Update README if needed
+
+### Quality gates
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace -q`
+
+## Acceptance Criteria
+
+- [ ] `mv --dry-run` on a file with backlinks shows non-zero `total_files_updated` and `total_links_updated`
+- [ ] `properties rename --dry-run` previews affected files without writing
+- [ ] `tags rename --dry-run` previews affected files without writing
+- [ ] `find --fields outline` works as alias for `--fields sections`
+- [ ] `find --stemmer en` works (maps to English stemmer)
+- [ ] `create-index` output notes when replacing existing index
+- [ ] All existing tests still pass

--- a/hyalo-knowledgebase/iterations/iteration-120-dogfood-v0120-post-iter119-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-120-dogfood-v0120-post-iter119-fixes.md
@@ -1,8 +1,8 @@
 ---
-title: "Iteration 120 — Dogfood v0.12.0 Post-iter-119 Fixes"
+title: Iteration 120 — Dogfood v0.12.0 Post-iter-119 Fixes
 type: iteration
 date: 2026-04-16
-status: planned
+status: in-progress
 branch: iter-120/dogfood-post-iter119-fixes
 tags:
   - iteration
@@ -82,49 +82,48 @@ adding the file to `[lint] ignore` in `.hyalo.toml`.
 
 ## Tasks
 
-### BUG-1: `mv --dry-run` link rewrite preview
-- [ ] Refactor mv command to compute link rewrites before deciding to write
-- [ ] Populate `updated_files` and counters in dry-run output
-- [ ] Add text-format output showing affected files and link counts
-- [ ] Add e2e test: mv --dry-run on file with backlinks shows non-zero counts
+### BUG-1: `mv --dry-run` link rewrite preview — NOT A BUG
+Bare wikilinks (e.g. `[[decision-log]]`) are intentionally not rewritten by
+`mv` — they use name-based resolution and remain valid after a move. The
+dry-run correctly shows 0 rewrites. No code change needed.
 
 ### BUG-2: `--dry-run` for `properties rename` and `tags rename`
-- [ ] Add `--dry-run` flag to `properties rename` clap definition
-- [ ] Add `--dry-run` flag to `tags rename` clap definition
-- [ ] Implement dry-run logic: scan and report without writing
-- [ ] Add text-format output for dry-run preview
-- [ ] Add e2e tests for both commands with `--dry-run`
+- [x] Add `--dry-run` flag to `properties rename` clap definition
+- [x] Add `--dry-run` flag to `tags rename` clap definition
+- [x] Implement dry-run logic: scan and report without writing
+- [x] Add text-format output for dry-run preview
+- [x] Add e2e tests for both commands with `--dry-run`
 
 ### BUG-3: `--fields outline` alias
-- [ ] Accept `outline` as alias for `sections` in field parsing
-- [ ] Add e2e test
+- [x] Accept `outline` as alias for `sections` in field parsing
+- [x] Add e2e test
 
 ### BUG-4: `--stemmer` ISO 639-1 codes
-- [ ] Add ISO 639-1 to Snowball name mapping
-- [ ] Update help text to mention both forms
-- [ ] Add e2e test for `--stemmer en`
+- [x] Add ISO 639-1 to Snowball name mapping
+- [x] Update help text to mention both forms
+- [x] Add e2e test for `--stemmer en`
 
 ### UX improvements
-- [ ] `create-index`: note when overwriting existing index
-- [ ] `lint --fix` hint: suggest `[lint] ignore` for unfixable parse errors
+- [x] `create-index`: note when overwriting existing index
+- [x] `lint --fix` hint: suggest `[lint] ignore` for unfixable parse errors
 
 ### Documentation surfaces (keep all in sync)
-- [ ] Update help texts for changed commands
-- [ ] Update CHANGELOG
-- [ ] Update knowledgebase skill if needed
-- [ ] Update README if needed
+- [x] Update help texts for changed commands
+- [x] Update CHANGELOG
+- [x] Update knowledgebase skill if needed (no changes needed)
+- [x] Update README if needed (no changes needed)
 
 ### Quality gates
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace -q`
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace -q`
 
 ## Acceptance Criteria
 
-- [ ] `mv --dry-run` on a file with backlinks shows non-zero `total_files_updated` and `total_links_updated`
-- [ ] `properties rename --dry-run` previews affected files without writing
-- [ ] `tags rename --dry-run` previews affected files without writing
-- [ ] `find --fields outline` works as alias for `--fields sections`
-- [ ] `find --stemmer en` works (maps to English stemmer)
-- [ ] `create-index` output notes when replacing existing index
-- [ ] All existing tests still pass
+- [x] ~~`mv --dry-run`~~: NOT A BUG — bare wikilinks are intentionally skipped
+- [x] `properties rename --dry-run` previews affected files without writing
+- [x] `tags rename --dry-run` previews affected files without writing
+- [x] `find --fields outline` works as alias for `--fields sections`
+- [x] `find --stemmer en` works (maps to English stemmer)
+- [x] `create-index` output notes when replacing existing index
+- [x] All existing tests still pass


### PR DESCRIPTION
## Summary
- Add `--dry-run` to `properties rename` and `tags rename` — the last mutation commands missing preview support
- Add `outline` as alias for `sections` in `find --fields`
- Add ISO 639-1 two-letter codes to `--stemmer`/`--language` (e.g. `en`, `de`, `fr`)
- `create-index` output notes when replacing an existing index file
- `lint` hints now suggest `[lint] ignore` for unfixable parse errors (e.g. unclosed frontmatter)
- BUG-1 (`mv --dry-run` showing 0 rewrites) confirmed working as designed: bare wikilinks use name-based resolution and are intentionally not rewritten

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace -q` — 1944 tests pass (6 new)
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--dry-run` flag to `properties rename` and `tags rename` for preview-only operations
  * Added `--fields outline` as an alias for `--fields sections` in find command
  * Extended `--stemmer` and `--language` to accept ISO 639-1 two-letter codes (e.g., "en", "de")
  * Added explicit notification when `create-index` replaces an existing index

* **Improvements**
  * Lint hints now recommend adding unfixable files to `[lint] ignore` configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->