### PR TITLE
iter-121: Code review hardening — security fixes, error handling, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   longer appear on `create-index`, `drop-index`, `init`, `completion`,
   `views *`, or `types *`.
 
+- `properties rename` and `tags rename` JSON output now uses `skipped_count`
+  (integer) instead of `skipped` (array). This is a breaking change for
+  consumers that parse the JSON output.
+
 ### Added
 
 - `properties rename --dry-run` and `tags rename --dry-run` — preview which
@@ -40,6 +44,12 @@
 - New lint rule `link-case-mismatch`: warns when a link resolves only via
   case-insensitive fallback, suggesting the canonical-case path.
 - `links fix` now detects and offers to fix case-mismatched links.
+- `task set --dry-run` — preview which tasks would be changed without
+  modifying the file.
+- Security: snapshot index (``.hyalo-index``) now validates entry paths on load
+  — rejects traversal (``..``), absolute paths, and null bytes.
+- Security: snapshot index files larger than 512 MB are rejected to prevent
+  OOM from crafted files.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ hyalo find "retry OR backoff"            # OR: either word matches
 hyalo find "retry -deprecated"           # NOT: exclude "deprecated"
 hyalo find '"retry backoff"'             # Phrase: exact consecutive match
 hyalo find "retry" --tag research        # combine with filters
+hyalo find "retry" --stemmer french      # French Snowball stemmer (full name)
+hyalo find "retry" --stemmer fr          # same, using ISO 639-1 code
+hyalo find "retry" --language de         # German stemmer (--language is an alias for --stemmer)
 
 # Regex content search (case-insensitive by default, unranked)
 hyalo find -e "retry.*backoff"
@@ -296,6 +299,7 @@ hyalo find --glob '!**/draft-*'      # exclude files matching a pattern (glob ne
 # Control returned fields (default: all except properties-typed and backlinks)
 hyalo find --fields properties,tags
 hyalo find --fields sections,tasks,links
+hyalo find --fields outline              # alias for --fields sections
 hyalo find --fields properties-typed     # [{name, type, value}] array instead of {key: value} map
 hyalo find --fields backlinks --file my-note.md    # show who links to this note
 hyalo find --fields properties,backlinks           # combine with other fields
@@ -396,6 +400,7 @@ hyalo properties summary --limit 0              # show all (default: 50)
 # Bulk rename a property key across all files
 hyalo properties rename --from old-key --to new-key
 hyalo properties rename --from old-key --to new-key --glob "notes/*.md"
+hyalo properties rename --from old-key --to new-key --dry-run  # preview without writing
 ```
 
 ### tags
@@ -411,6 +416,7 @@ hyalo tags summary --limit 0                    # show all (default: 50)
 # Bulk rename a tag across all files
 hyalo tags rename --from old-tag --to new-tag
 hyalo tags rename --from old-tag --to new-tag --glob "notes/*.md"
+hyalo tags rename --from old-tag --to new-tag --dry-run  # preview without writing
 ```
 
 ### summary
@@ -517,6 +523,9 @@ hyalo task toggle --file note.md --line 5 --dry-run
 
 # Set custom status on all tasks in a section
 hyalo task set --file note.md --section Tasks --status /
+
+# Preview set without writing
+hyalo task set --file note.md --line 5 --status '?' --dry-run
 ```
 
 Tasks are markdown checkboxes (`- [ ]`, `- [x]`, `- [/]`, etc.) in the file body. Checkboxes inside fenced code blocks and `%%comment%%` blocks are ignored. Bulk mutations use a single atomic read-modify-write pass.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ hyalo find '"retry backoff"'             # Phrase: exact consecutive match
 hyalo find "retry" --tag research        # combine with filters
 hyalo find "retry" --stemmer french      # French Snowball stemmer (full name)
 hyalo find "retry" --stemmer fr          # same, using ISO 639-1 code
-hyalo find "retry" --language de         # German stemmer (--language is an alias for --stemmer)
+hyalo find "retry" --language de         # German stemmer (--stemmer is an alias for --language)
 
 # Regex content search (case-insensitive by default, unranked)
 hyalo find -e "retry.*backoff"

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1096,14 +1096,14 @@ pub(crate) enum TaskAction {
         long_about = "Set a custom single-character status on one or more task checkboxes.\n\n\
         INPUT: FILE (positional or --file), --status (single char), and one of: --line (repeatable), --section <heading>, or --all.\n\
         OUTPUT: wrapped in {\"results\": <task>, ...} envelope; single object for one task, array for multiple.\n\
-        SIDE EFFECTS: Modifies the file on disk (rewrites the checkbox character).\n\
+        SIDE EFFECTS: Modifies the file on disk unless --dry-run is passed.\n\
         USE WHEN: You need to set a non-standard status like '?' (question), '-' (cancelled), or '!' (important).\n\n\
         EXAMPLES:\n  \
           hyalo task set note.md --line 5 --status '?'\n  \
           hyalo task set note.md --line 5,7 --status '-'\n  \
           hyalo task set note.md --section Tasks --status '-'\n  \
           hyalo task set note.md --all --status x\n  \
-          hyalo task set --file note.md --line 5 --status '?'"
+          hyalo task set note.md --line 5 --status '?' --dry-run"
     )]
     Set {
         /// File containing the task(s) (relative to --dir) — positional form

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -231,7 +231,7 @@ pub(crate) struct FindFilters {
     #[arg(short, long, conflicts_with = "file")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub glob: Vec<String>,
-    /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections, tasks, links, backlinks, title (default: properties, tags, sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
+    /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections (alias: outline), tasks, links, backlinks, title (default: properties, tags, sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
     #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<String>,
@@ -1124,6 +1124,9 @@ pub(crate) enum TaskAction {
         /// Single character to set as the task status (e.g. '?', '-', '!')
         #[arg(short, long)]
         status: String,
+        /// Preview which tasks would be changed without modifying the file
+        #[arg(long)]
+        dry_run: bool,
         #[command(flatten)]
         index_flags: IndexFlags,
     },

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -70,7 +70,7 @@ pub struct RenamePropertyResult {
     pub to: String,
     pub dry_run: bool,
     pub modified: Vec<String>,
-    pub skipped: Vec<String>,
+    pub skipped_count: usize,
     pub conflicts: Vec<String>,
     pub total: usize,
     pub scanned: usize,
@@ -111,7 +111,7 @@ pub fn properties_rename(
     let scanned = files.len();
 
     let mut modified = Vec::new();
-    let mut skipped = Vec::new();
+    let mut skipped_count: usize = 0;
     let mut conflicts = Vec::new();
     let mut index_dirty = false;
 
@@ -127,7 +127,7 @@ pub fn properties_rename(
 
         // Source key not present -- skip
         let Some(value) = props.shift_remove(from) else {
-            skipped.push(rel_path.clone());
+            skipped_count += 1;
             continue;
         };
 
@@ -161,13 +161,13 @@ pub fn properties_rename(
         idx.save_to(idx_path)?;
     }
 
-    let total = modified.len() + skipped.len() + conflicts.len();
+    let total = modified.len() + skipped_count + conflicts.len();
     let result = RenamePropertyResult {
         from: from.to_owned(),
         to: to.to_owned(),
         dry_run,
         modified,
-        skipped,
+        skipped_count,
         conflicts,
         total,
         scanned,
@@ -328,7 +328,7 @@ title: Note
             panic!("expected success")
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["skipped_count"].as_u64().unwrap(), 1);
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
     }
 

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -107,7 +107,7 @@ pub struct RenameTagResult {
     pub to: String,
     pub dry_run: bool,
     pub modified: Vec<String>,
-    pub skipped: Vec<String>,
+    pub skipped_count: usize,
     pub total: usize,
     pub scanned: usize,
 }
@@ -156,7 +156,7 @@ pub fn tags_rename(
     let scanned = files.len();
 
     let mut modified = Vec::new();
-    let mut skipped = Vec::new();
+    let mut skipped_count: usize = 0;
     let mut index_dirty = false;
 
     for (full_path, rel_path) in &files {
@@ -172,7 +172,7 @@ pub fn tags_rename(
         let tags = extract_tags(&props);
         let has_old = tags.iter().any(|t| t.eq_ignore_ascii_case(from));
         if !has_old {
-            skipped.push(rel_path.clone());
+            skipped_count += 1;
             continue;
         }
 
@@ -228,13 +228,13 @@ pub fn tags_rename(
         idx.save_to(idx_path)?;
     }
 
-    let total = modified.len() + skipped.len();
+    let total = modified.len() + skipped_count;
     let result = RenameTagResult {
         from: from.to_owned(),
         to: to.to_owned(),
         dry_run,
         modified,
-        skipped,
+        skipped_count,
         total,
         scanned,
     };
@@ -587,7 +587,7 @@ tags:
             panic!("expected success")
         };
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(parsed["skipped"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["skipped_count"].as_u64().unwrap(), 1);
         assert_eq!(parsed["modified"].as_array().unwrap().len(), 0);
     }
 

--- a/crates/hyalo-cli/src/commands/tasks.rs
+++ b/crates/hyalo-cli/src/commands/tasks.rs
@@ -281,6 +281,7 @@ pub fn task_set_status(
     format: Format,
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
+    dry_run: bool,
 ) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match discovery::resolve_file(dir, file_arg) {
         Ok(r) => r,
@@ -300,6 +301,43 @@ pub fn task_set_status(
             )));
         }
     };
+
+    if dry_run {
+        let tasks_by_line: std::collections::HashMap<usize, hyalo_core::types::FindTaskInfo> =
+            hyalo_core::tasks::find_task_lines(&full_path)?
+                .into_iter()
+                .map(|t| (t.line, t))
+                .collect();
+        let mut results: Vec<TaskDryRunResult> = Vec::with_capacity(resolved.len());
+        for &line_num in &resolved {
+            match tasks_by_line.get(&line_num) {
+                None => {
+                    let msg = format!("line {line_num} is not a task");
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        format,
+                        &msg,
+                        Some(&rel_path),
+                        None,
+                        None,
+                    )));
+                }
+                Some(info) => {
+                    let new_done = status == 'x' || status == 'X';
+                    results.push(TaskDryRunResult {
+                        file: rel_path.clone(),
+                        line: info.line,
+                        old_status: info.status,
+                        status,
+                        text: info.text.clone(),
+                        done: new_done,
+                    });
+                }
+            }
+        }
+        return Ok(CommandOutcome::success(format_one_or_many(
+            &results, format,
+        )));
+    }
 
     match hyalo_core::tasks::set_tasks_status(&full_path, &resolved, status) {
         Ok(infos) => {
@@ -545,6 +583,7 @@ mod tests {
                 Format::Json,
                 &mut None,
                 None,
+                false,
             )
             .unwrap(),
         );
@@ -571,6 +610,7 @@ mod tests {
                 Format::Json,
                 &mut None,
                 None,
+                false,
             )
             .unwrap(),
         );
@@ -593,8 +633,35 @@ mod tests {
             Format::Json,
             &mut None,
             None,
+            false,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
+    }
+
+    #[test]
+    fn task_set_status_dry_run_does_not_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let original = "- [ ] My task\n";
+        fs::write(tmp.path().join("note.md"), original).unwrap();
+        let out = unwrap_success(
+            task_set_status(
+                tmp.path(),
+                "note.md",
+                &[1],
+                None,
+                false,
+                '?',
+                Format::Json,
+                &mut None,
+                None,
+                true, // dry_run
+            )
+            .unwrap(),
+        );
+        assert!(out.contains("old_status"));
+        assert!(out.contains("\"status\": \"?\"") || out.contains("\"status\":\"?\""));
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert_eq!(content, original, "file was modified during --dry-run");
     }
 }

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -13,7 +13,7 @@ use hyalo_core::discovery;
 use hyalo_core::frontmatter::{read_frontmatter, write_frontmatter};
 use hyalo_core::schema::{SchemaConfig, expand_default};
 
-use crate::output::{CommandOutcome, Format, format_success};
+use crate::output::{CommandOutcome, Format, format_error, format_success};
 
 const TOML_FILENAME: &str = ".hyalo.toml";
 
@@ -49,10 +49,14 @@ pub(crate) fn list_types(schema: &SchemaConfig) -> CommandOutcome {
 // ---------------------------------------------------------------------------
 
 /// `hyalo types show <type>` — full merged schema for a type.
-pub(crate) fn show_type(type_name: &str, schema: &SchemaConfig) -> CommandOutcome {
+pub(crate) fn show_type(type_name: &str, schema: &SchemaConfig, format: Format) -> CommandOutcome {
     if !schema.types.contains_key(type_name) {
-        return CommandOutcome::UserError(format!(
-            "Error: type '{type_name}' not found\n\n  tip: run 'hyalo types list' to see available types"
+        return CommandOutcome::UserError(format_error(
+            format,
+            &format!("type '{type_name}' not found"),
+            None,
+            Some("run 'hyalo types list' to see available types"),
+            None,
         ));
     }
 
@@ -104,19 +108,27 @@ fn constraint_to_json(c: &hyalo_core::schema::PropertyConstraint) -> Value {
 // ---------------------------------------------------------------------------
 
 /// `hyalo types remove <type>` — remove a type entry.
-pub(crate) fn remove_type(dir: &Path, type_name: &str) -> Result<CommandOutcome> {
+pub(crate) fn remove_type(dir: &Path, type_name: &str, format: Format) -> Result<CommandOutcome> {
     let toml_path = resolve_toml_path(dir);
     let mut doc = read_toml_doc(&toml_path)?;
 
     if !toml_type_exists(&doc, type_name) {
-        return Ok(CommandOutcome::UserError(format!(
-            "Error: type '{type_name}' not found\n\n  tip: run 'hyalo types list' to see available types"
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            &format!("type '{type_name}' not found"),
+            None,
+            Some("run 'hyalo types list' to see available types"),
+            None,
         )));
     }
 
     {
-        let schema = doc["schema"].as_table_mut().expect("schema is a table");
-        let types = schema["types"].as_table_mut().expect("types is a table");
+        let schema = doc["schema"]
+            .as_table_mut()
+            .context("malformed .hyalo.toml: schema is not a table")?;
+        let types = schema["types"]
+            .as_table_mut()
+            .context("malformed .hyalo.toml: schema.types is not a table")?;
         types.remove(type_name);
     }
 
@@ -177,10 +189,13 @@ pub(crate) fn set_type(
     property_values_args: &[String],
     filename_template: Option<&str>,
     dry_run: bool,
+    format: Format,
 ) -> Result<CommandOutcome> {
     // Validate type name before anything else.
     if let Err(msg) = validate_type_name(type_name) {
-        return Ok(CommandOutcome::UserError(format!("Error: {msg}")));
+        return Ok(CommandOutcome::UserError(format_error(
+            format, &msg, None, None, None,
+        )));
     }
 
     // Require at least one mutation flag.
@@ -190,11 +205,13 @@ pub(crate) fn set_type(
         && property_values_args.is_empty()
         && filename_template.is_none()
     {
-        return Ok(CommandOutcome::UserError(
-            "Error: no mutation flags provided — specify at least one of: \
-             --required, --default, --property-type, --property-values, --filename-template"
-                .to_owned(),
-        ));
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            "no mutation flags provided — specify at least one of:              --required, --default, --property-type, --property-values, --filename-template",
+            None,
+            None,
+            None,
+        )));
     }
 
     // Parse --required: each arg may be comma-separated.
@@ -212,7 +229,11 @@ pub(crate) fn set_type(
             Ok((k, v)) => {
                 defaults_map.insert(k.to_owned(), v.to_owned());
             }
-            Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+            Err(e) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format, &e, None, None, None,
+                )));
+            }
         }
     }
 
@@ -224,9 +245,17 @@ pub(crate) fn set_type(
                 Ok(pt) => {
                     prop_type_map.insert(k.to_owned(), pt);
                 }
-                Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+                Err(e) => {
+                    return Ok(CommandOutcome::UserError(format_error(
+                        format, &e, None, None, None,
+                    )));
+                }
             },
-            Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+            Err(e) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format, &e, None, None, None,
+                )));
+            }
         }
     }
 
@@ -240,13 +269,23 @@ pub(crate) fn set_type(
                 // `""` value, which would make lint/fix output confusing.
                 let vals: Vec<String> = v.split(',').map(|s| s.trim().to_owned()).collect();
                 if vals.iter().any(String::is_empty) {
-                    return Ok(CommandOutcome::UserError(format!(
-                        "Error: invalid --property-values argument '{arg}': enum values cannot be empty"
+                    return Ok(CommandOutcome::UserError(format_error(
+                        format,
+                        &format!(
+                            "invalid --property-values argument '{arg}': enum values cannot be empty"
+                        ),
+                        None,
+                        None,
+                        None,
                     )));
                 }
                 prop_values_map.insert(k.to_owned(), vals);
             }
-            Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+            Err(e) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format, &e, None, None, None,
+                )));
+            }
         }
     }
 
@@ -266,10 +305,18 @@ pub(crate) fn set_type(
                     toml_changes.push("enable validate_on_write (new schema)".to_owned());
                 }
             }
-            Err(msg) => return Ok(CommandOutcome::UserError(format!("Error: {msg}"))),
+            Err(msg) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format, &msg, None, None, None,
+                )));
+            }
         }
-        let schema = doc["schema"].as_table_mut().expect("schema is a table");
-        let types = schema["types"].as_table_mut().expect("types is a table");
+        let schema = doc["schema"]
+            .as_table_mut()
+            .context("malformed .hyalo.toml: schema is not a table")?;
+        let types = schema["types"]
+            .as_table_mut()
+            .context("malformed .hyalo.toml: schema.types is not a table")?;
         let mut type_table = toml_edit::Table::new();
         type_table.insert(
             "required",
@@ -290,7 +337,7 @@ pub(crate) fn set_type(
             }
         }
         if !dry_run {
-            set_required_array(&mut doc, type_name, &new_required);
+            set_required_array(&mut doc, type_name, &new_required)?;
         }
     }
 
@@ -298,7 +345,7 @@ pub(crate) fn set_type(
     if let Some(tmpl) = filename_template {
         toml_changes.push(format!("set filename-template: {tmpl}"));
         if !dry_run {
-            set_string_field(&mut doc, type_name, "filename-template", tmpl);
+            set_string_field(&mut doc, type_name, "filename-template", tmpl)?;
         }
     }
 
@@ -315,7 +362,7 @@ pub(crate) fn set_type(
     for (k, v) in &defaults_map {
         toml_changes.push(format!("set default: {k} = {v}"));
         if !dry_run {
-            set_default_field(&mut doc, type_name, k, v);
+            set_default_field(&mut doc, type_name, k, v)?;
         }
     }
 
@@ -326,7 +373,7 @@ pub(crate) fn set_type(
             vals.join(", ")
         ));
         if !dry_run {
-            set_property_enum(&mut doc, type_name, k, vals);
+            set_property_enum(&mut doc, type_name, k, vals)?;
         }
         // Remove from prop_type_map so it isn't also applied below.
         prop_type_map.remove(k.as_str());
@@ -336,7 +383,7 @@ pub(crate) fn set_type(
     for (k, pt) in &prop_type_map {
         toml_changes.push(format!("set property {k}: type={pt}"));
         if !dry_run {
-            set_property_type_field(&mut doc, type_name, k, pt);
+            set_property_type_field(&mut doc, type_name, k, pt)?;
         }
     }
 
@@ -368,7 +415,7 @@ pub(crate) fn set_type(
         if !already_has {
             toml_changes.push(format!("auto-add property {f}: type=string"));
             if !dry_run {
-                set_property_type_field(&mut doc, type_name, f, "string");
+                set_property_type_field(&mut doc, type_name, f, "string")?;
             }
         }
     }
@@ -571,24 +618,37 @@ fn ensure_schema_types_table(doc: &mut toml_edit::DocumentMut) -> Result<bool, S
 }
 
 /// Ensure `[schema.types.<name>.defaults]` table exists.
-fn ensure_defaults_table(doc: &mut toml_edit::DocumentMut, type_name: &str) {
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
-    let types = schema["types"].as_table_mut().expect("types is a table");
+fn ensure_defaults_table(doc: &mut toml_edit::DocumentMut, type_name: &str) -> Result<()> {
+    let schema = doc["schema"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema is not a table")?;
+    let types = schema["types"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema.types is not a table")?;
     let type_table = types[type_name]
         .as_table_mut()
-        .expect("type entry is a table");
+        .context("malformed .hyalo.toml: type entry is not a table")?;
     if !type_table.contains_key("defaults") {
         type_table.insert("defaults", toml_edit::Item::Table(toml_edit::Table::new()));
     }
+    Ok(())
 }
 
 /// Ensure `[schema.types.<name>.properties.<prop>]` table exists.
-fn ensure_property_table(doc: &mut toml_edit::DocumentMut, type_name: &str, prop: &str) {
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
-    let types = schema["types"].as_table_mut().expect("types is a table");
+fn ensure_property_table(
+    doc: &mut toml_edit::DocumentMut,
+    type_name: &str,
+    prop: &str,
+) -> Result<()> {
+    let schema = doc["schema"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema is not a table")?;
+    let types = schema["types"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema.types is not a table")?;
     let type_table = types[type_name]
         .as_table_mut()
-        .expect("type entry is a table");
+        .context("malformed .hyalo.toml: type entry is not a table")?;
     if !type_table.contains_key("properties") {
         type_table.insert(
             "properties",
@@ -597,10 +657,11 @@ fn ensure_property_table(doc: &mut toml_edit::DocumentMut, type_name: &str, prop
     }
     let props = type_table["properties"]
         .as_table_mut()
-        .expect("properties is a table");
+        .context("malformed .hyalo.toml: properties section is not a table")?;
     if !props.contains_key(prop) {
         props.insert(prop, toml_edit::Item::Table(toml_edit::Table::new()));
     }
+    Ok(())
 }
 
 /// Get the current `required` array for a type.
@@ -622,41 +683,70 @@ fn get_required_array(doc: &toml_edit::DocumentMut, type_name: &str) -> Vec<Stri
 }
 
 /// Set the `required` array for a type.
-fn set_required_array(doc: &mut toml_edit::DocumentMut, type_name: &str, fields: &[String]) {
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
-    let types = schema["types"].as_table_mut().expect("types is a table");
+fn set_required_array(
+    doc: &mut toml_edit::DocumentMut,
+    type_name: &str,
+    fields: &[String],
+) -> Result<()> {
+    let schema = doc["schema"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema is not a table")?;
+    let types = schema["types"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema.types is not a table")?;
     let type_table = types[type_name]
         .as_table_mut()
-        .expect("type entry is a table");
+        .context("malformed .hyalo.toml: type entry is not a table")?;
     let mut arr = toml_edit::Array::new();
     for f in fields {
         arr.push(f.as_str());
     }
     type_table["required"] = toml_edit::Item::Value(toml_edit::Value::Array(arr));
+    Ok(())
 }
 
 /// Set a string field at `[schema.types.<name>.<key>]`.
-fn set_string_field(doc: &mut toml_edit::DocumentMut, type_name: &str, key: &str, value: &str) {
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
-    let types = schema["types"].as_table_mut().expect("types is a table");
+fn set_string_field(
+    doc: &mut toml_edit::DocumentMut,
+    type_name: &str,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    let schema = doc["schema"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema is not a table")?;
+    let types = schema["types"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema.types is not a table")?;
     let type_table = types[type_name]
         .as_table_mut()
-        .expect("type entry is a table");
+        .context("malformed .hyalo.toml: type entry is not a table")?;
     type_table[key] = toml_edit::value(value);
+    Ok(())
 }
 
 /// Set `[schema.types.<name>.defaults.<key>] = value`.
-fn set_default_field(doc: &mut toml_edit::DocumentMut, type_name: &str, key: &str, value: &str) {
-    ensure_defaults_table(doc, type_name);
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
-    let types = schema["types"].as_table_mut().expect("types is a table");
+fn set_default_field(
+    doc: &mut toml_edit::DocumentMut,
+    type_name: &str,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    ensure_defaults_table(doc, type_name)?;
+    let schema = doc["schema"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema is not a table")?;
+    let types = schema["types"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema.types is not a table")?;
     let type_table = types[type_name]
         .as_table_mut()
-        .expect("type entry is a table");
+        .context("malformed .hyalo.toml: type entry is not a table")?;
     let defaults = type_table["defaults"]
         .as_table_mut()
-        .expect("defaults is a table");
+        .context("malformed .hyalo.toml: defaults section is not a table")?;
     defaults[key] = toml_edit::value(value);
+    Ok(())
 }
 
 /// Set a simple (non-enum) property constraint: `type = "<pt>"`.
@@ -665,20 +755,27 @@ fn set_property_type_field(
     type_name: &str,
     prop: &str,
     pt: &str,
-) {
-    ensure_property_table(doc, type_name, prop);
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
-    let types = schema["types"].as_table_mut().expect("types is a table");
+) -> Result<()> {
+    ensure_property_table(doc, type_name, prop)?;
+    let schema = doc["schema"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema is not a table")?;
+    let types = schema["types"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema.types is not a table")?;
     let type_table = types[type_name]
         .as_table_mut()
-        .expect("type entry is a table");
+        .context("malformed .hyalo.toml: type entry is not a table")?;
     let props = type_table["properties"]
         .as_table_mut()
-        .expect("properties is a table");
-    let prop_table = props[prop].as_table_mut().expect("property is a table");
+        .context("malformed .hyalo.toml: properties section is not a table")?;
+    let prop_table = props[prop]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: property entry is not a table")?;
     prop_table["type"] = toml_edit::value(pt);
     // Remove values key if switching away from enum.
     prop_table.remove("values");
+    Ok(())
 }
 
 /// Set an enum property constraint.
@@ -687,23 +784,30 @@ fn set_property_enum(
     type_name: &str,
     prop: &str,
     values: &[String],
-) {
-    ensure_property_table(doc, type_name, prop);
-    let schema = doc["schema"].as_table_mut().expect("schema is a table");
-    let types = schema["types"].as_table_mut().expect("types is a table");
+) -> Result<()> {
+    ensure_property_table(doc, type_name, prop)?;
+    let schema = doc["schema"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema is not a table")?;
+    let types = schema["types"]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: schema.types is not a table")?;
     let type_table = types[type_name]
         .as_table_mut()
-        .expect("type entry is a table");
+        .context("malformed .hyalo.toml: type entry is not a table")?;
     let props = type_table["properties"]
         .as_table_mut()
-        .expect("properties is a table");
-    let prop_table = props[prop].as_table_mut().expect("property is a table");
+        .context("malformed .hyalo.toml: properties section is not a table")?;
+    let prop_table = props[prop]
+        .as_table_mut()
+        .context("malformed .hyalo.toml: property entry is not a table")?;
     prop_table["type"] = toml_edit::value("enum");
     let mut arr = toml_edit::Array::new();
     for v in values {
         arr.push(v.as_str());
     }
     prop_table["values"] = toml_edit::Item::Value(toml_edit::Value::Array(arr));
+    Ok(())
 }
 
 /// Coerce a raw default string to the JSON type implied by the property's
@@ -861,14 +965,14 @@ mod tests {
     #[test]
     fn show_type_not_found() {
         let schema = SchemaConfig::default();
-        let outcome = show_type("nonexistent", &schema);
+        let outcome = show_type("nonexistent", &schema, Format::Json);
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
     }
 
     #[test]
     fn show_type_found() {
         let schema = make_schema_with_type("note", &["title"]);
-        let outcome = show_type("note", &schema);
+        let outcome = show_type("note", &schema, Format::Json);
         match outcome {
             CommandOutcome::Success { output, .. } => {
                 let v: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -893,7 +997,7 @@ mod tests {
                 values: vec!["draft".to_owned(), "published".to_owned()],
             },
         );
-        let outcome = show_type("note", &schema);
+        let outcome = show_type("note", &schema, Format::Json);
         match outcome {
             CommandOutcome::Success { output, .. } => {
                 let v: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -984,6 +1088,7 @@ mod tests {
             &[],
             None,
             false,
+            Format::Json,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::Success { .. }));
@@ -1010,11 +1115,12 @@ mod tests {
             &[],
             None,
             false,
+            Format::Json,
         )
         .unwrap();
 
         // Now remove it — should succeed and update the same file.
-        let outcome = remove_type(dir, "note").unwrap();
+        let outcome = remove_type(dir, "note", Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::Success { .. }));
 
         let toml_path = dir.join(".hyalo.toml");
@@ -1022,6 +1128,59 @@ mod tests {
         assert!(
             !contents.contains("[schema.types.note]"),
             "type 'note' should have been removed"
+        );
+    }
+
+    // --- malformed .hyalo.toml error handling (no panics) ---
+
+    #[test]
+    fn remove_type_malformed_toml_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        // schema is a string instead of a table — should error, not panic
+        std::fs::write(tmp.path().join(".hyalo.toml"), "schema = \"not-a-table\"\n").unwrap();
+        let result = remove_type(tmp.path(), "iteration", Format::Json);
+        // Should succeed with UserError or Err, but NOT panic
+        match result {
+            Ok(CommandOutcome::UserError(msg)) => {
+                assert!(
+                    msg.contains("not found") || msg.contains("malformed"),
+                    "unexpected error: {msg}"
+                );
+            }
+            Err(e) => {
+                let msg = format!("{e:#}");
+                assert!(
+                    msg.contains("malformed") || msg.contains("not a table"),
+                    "unexpected error: {msg}"
+                );
+            }
+            other => panic!("expected error for malformed TOML, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_type_malformed_schema_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".hyalo.toml"),
+            "[schema]\ntypes = \"not-a-table\"\n",
+        )
+        .unwrap();
+        let result = set_type(
+            tmp.path(),
+            "iteration",
+            &["title".to_owned()],
+            &[],
+            &[],
+            &[],
+            None,
+            false,
+            Format::Json,
+        );
+        // Should return an error about malformed TOML, not panic
+        assert!(
+            result.is_err() || matches!(result, Ok(CommandOutcome::UserError(_))),
+            "expected error for malformed TOML"
         );
     }
 }

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -207,7 +207,7 @@ pub(crate) fn set_type(
     {
         return Ok(CommandOutcome::UserError(format_error(
             format,
-            "no mutation flags provided — specify at least one of:              --required, --default, --property-type, --property-values, --filename-template",
+            "no mutation flags provided — specify at least one of: --required, --default, --property-type, --property-values, --filename-template",
             None,
             None,
             None,

--- a/crates/hyalo-cli/src/commands/views.rs
+++ b/crates/hyalo-cli/src/commands/views.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 use crate::cli::args::FindFilters;
-use crate::output::CommandOutcome;
+use crate::output::{CommandOutcome, Format, format_error};
 
 const TOML_FILENAME: &str = ".hyalo.toml";
 
@@ -51,7 +51,7 @@ pub(crate) fn load_views(dir: &Path) -> HashMap<String, FindFilters> {
 }
 
 /// List all saved views.
-pub(crate) fn list_views(dir: &Path) -> Result<CommandOutcome> {
+pub(crate) fn list_views(dir: &Path, _format: Format) -> Result<CommandOutcome> {
     let views = load_views(dir);
     let mut items: Vec<serde_json::Value> = Vec::new();
     let mut sorted_keys: Vec<&String> = views.keys().collect();
@@ -71,16 +71,26 @@ pub(crate) fn list_views(dir: &Path) -> Result<CommandOutcome> {
 }
 
 /// Save a view to `.hyalo.toml` within `dir`.
-pub(crate) fn set_view(dir: &Path, name: &str, filters: &FindFilters) -> Result<CommandOutcome> {
+pub(crate) fn set_view(
+    dir: &Path,
+    name: &str,
+    filters: &FindFilters,
+    format: Format,
+) -> Result<CommandOutcome> {
     // Validate name: alphanumeric, hyphens, and underscores only (TOML bare-key safe)
     if name.is_empty()
         || !name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
     {
-        return Ok(CommandOutcome::UserError(format!(
-            "Error: invalid view name '{name}': must be non-empty and contain only \
-             alphanumeric characters, hyphens, or underscores"
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            &format!(
+                "invalid view name '{name}': must be non-empty and contain only alphanumeric characters, hyphens, or underscores"
+            ),
+            None,
+            None,
+            None,
         )));
     }
 
@@ -90,9 +100,13 @@ pub(crate) fn set_view(dir: &Path, name: &str, filters: &FindFilters) -> Result<
     let default_value = toml::Value::try_from(FindFilters::default())
         .context("failed to serialize default filters")?;
     if filters_value == default_value {
-        return Ok(CommandOutcome::UserError(
-            "Error: no filters specified — a view must contain at least one filter".to_owned(),
-        ));
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            "no filters specified — a view must contain at least one filter",
+            None,
+            None,
+            None,
+        )));
     }
 
     let toml_path = resolve_toml_path(dir);
@@ -106,9 +120,13 @@ pub(crate) fn set_view(dir: &Path, name: &str, filters: &FindFilters) -> Result<
         unreachable!()
     };
     let Some(views_table) = views_item.as_table_mut() else {
-        return Ok(CommandOutcome::UserError(
-            "Error: 'views' in .hyalo.toml is not a table — check your config file".to_owned(),
-        ));
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            "'views' in .hyalo.toml is not a table — check your config file",
+            None,
+            None,
+            None,
+        )));
     };
 
     // Convert filters to a toml_edit table via text round-trip
@@ -126,19 +144,27 @@ pub(crate) fn set_view(dir: &Path, name: &str, filters: &FindFilters) -> Result<
 }
 
 /// Remove a view from `.hyalo.toml` within `dir`.
-pub(crate) fn remove_view(dir: &Path, name: &str) -> Result<CommandOutcome> {
+pub(crate) fn remove_view(dir: &Path, name: &str, format: Format) -> Result<CommandOutcome> {
     let toml_path = resolve_toml_path(dir);
     let mut doc = read_toml_doc(&toml_path)?;
 
     let Some(views_table) = doc.get_mut("views").and_then(|v| v.as_table_mut()) else {
-        return Ok(CommandOutcome::UserError(format!(
-            "Error: view '{name}' not found\n\n  tip: run 'hyalo views list' to see available views"
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            &format!("view '{name}' not found"),
+            None,
+            Some("run 'hyalo views list' to see available views"),
+            None,
         )));
     };
 
     if views_table.remove(name).is_none() {
-        return Ok(CommandOutcome::UserError(format!(
-            "Error: view '{name}' not found\n\n  tip: run 'hyalo views list' to see available views"
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            &format!("view '{name}' not found"),
+            None,
+            Some("run 'hyalo views list' to see available views"),
+            None,
         )));
     }
 
@@ -204,7 +230,7 @@ mod tests {
         let dir = tmp.path();
         let filters = make_tag_filters("iteration");
 
-        let outcome = set_view(dir, "my-view", &filters).unwrap();
+        let outcome = set_view(dir, "my-view", &filters, Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::Success { .. }));
 
         // Config must be written inside the temp dir, not CWD.
@@ -223,7 +249,7 @@ mod tests {
         let dir = tmp.path();
         let filters = make_tag_filters("iteration");
 
-        set_view(dir, "iter-view", &filters).unwrap();
+        set_view(dir, "iter-view", &filters, Format::Json).unwrap();
 
         let views = load_views(dir);
         assert!(
@@ -238,8 +264,8 @@ mod tests {
         let dir = tmp.path();
         let filters = make_tag_filters("done");
 
-        set_view(dir, "done-view", &filters).unwrap();
-        let outcome = remove_view(dir, "done-view").unwrap();
+        set_view(dir, "done-view", &filters, Format::Json).unwrap();
+        let outcome = remove_view(dir, "done-view", Format::Json).unwrap();
         assert!(matches!(outcome, CommandOutcome::Success { .. }));
 
         let views = load_views(dir);
@@ -284,7 +310,7 @@ mod tests {
         std::fs::write(dir.join(".hyalo.toml"), original).unwrap();
 
         let filters = make_tag_filters("iteration");
-        set_view(dir, "iter", &filters).unwrap();
+        set_view(dir, "iter", &filters, Format::Json).unwrap();
 
         let result = std::fs::read_to_string(dir.join(".hyalo.toml")).unwrap();
         // Existing sections should still appear in order

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -593,6 +593,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 section,
                 all,
                 status,
+                dry_run,
                 index_flags: _, // consumed in run.rs before dispatch
             } => {
                 let file = match resolve_single_file(file_positional, file) {
@@ -624,6 +625,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     effective_format,
                     snapshot_index,
                     index_path,
+                    dry_run,
                 )
             }
         },
@@ -1072,7 +1074,9 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
         Commands::Views { action } => {
             let action = action.unwrap_or(ViewsAction::List);
             match action {
-                ViewsAction::List => crate::commands::views::list_views(ctx.config_dir),
+                ViewsAction::List => {
+                    crate::commands::views::list_views(ctx.config_dir, effective_format)
+                }
                 ViewsAction::Set {
                     name,
                     pattern,
@@ -1084,10 +1088,15 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                         ));
                     }
                     filters.pattern = pattern;
-                    crate::commands::views::set_view(ctx.config_dir, &name, &filters)
+                    crate::commands::views::set_view(
+                        ctx.config_dir,
+                        &name,
+                        &filters,
+                        effective_format,
+                    )
                 }
                 ViewsAction::Remove { name } => {
-                    crate::commands::views::remove_view(ctx.config_dir, &name)
+                    crate::commands::views::remove_view(ctx.config_dir, &name, effective_format)
                 }
             }
         }
@@ -1095,12 +1104,16 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let action = action.unwrap_or(TypesAction::List);
             match action {
                 TypesAction::List => Ok(crate::commands::types::list_types(ctx.schema)),
-                TypesAction::Show { type_name } => {
-                    Ok(crate::commands::types::show_type(&type_name, ctx.schema))
-                }
-                TypesAction::Remove { type_name } => {
-                    crate::commands::types::remove_type(ctx.config_dir, &type_name)
-                }
+                TypesAction::Show { type_name } => Ok(crate::commands::types::show_type(
+                    &type_name,
+                    ctx.schema,
+                    effective_format,
+                )),
+                TypesAction::Remove { type_name } => crate::commands::types::remove_type(
+                    ctx.config_dir,
+                    &type_name,
+                    effective_format,
+                ),
                 TypesAction::Set {
                     type_name,
                     required,
@@ -1118,6 +1131,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     &property_values,
                     filename_template.as_deref(),
                     dry_run,
+                    effective_format,
                 ),
             }
         }

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -49,7 +49,8 @@ hyalo find "rust OR golang -obsolete"    # Mixed: either rust or golang, not obs
 For literal pattern matching (not stemmed), use regex: `hyalo find -e "exact_string"`.
 
 Stemmer language: `--stemmer french` (or the older `--language french`) selects the French
-Snowball stemmer for BM25 tokenization. This is *not* markdown code-block language filtering.
+Snowball stemmer for BM25 tokenization. Accepts full names (english, german, french, …) or
+ISO 639-1 codes (en, de, fr, …). This is *not* markdown code-block language filtering.
 Per-file override via frontmatter `language: french`. Config default via
 `[search] language = "french"` in `.hyalo.toml`.
 
@@ -88,7 +89,7 @@ hyalo find --sort backlinks_count --reverse        # most-linked files first
 ```
 
 The `--fields` flag controls which data is returned. Available fields: `properties`,
-`properties-typed`, `tags`, `sections`, `tasks`, `links`, `backlinks`, `title`. Default fields are
+`properties-typed`, `tags`, `sections` (alias: `outline`), `tasks`, `links`, `backlinks`, `title`. Default fields are
 `properties`, `tags`, `sections`, `links`. Opt-in fields: `tasks`, `properties-typed`,
 `backlinks`, `title`. Use `--fields all` or `--fields tasks` to include them. `properties-typed`
 returns a `[{name, type, value}]` array instead of a `{key: value}` map; `backlinks` requires

--- a/crates/hyalo-cli/tests/e2e/properties.rs
+++ b/crates/hyalo-cli/tests/e2e/properties.rs
@@ -388,7 +388,7 @@ fn properties_rename_basic() {
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["results"]["modified"].as_array().unwrap().len(), 2);
-    assert_eq!(json["results"]["skipped"].as_array().unwrap().len(), 1);
+    assert_eq!(json["results"]["skipped_count"].as_u64().unwrap(), 1);
 
     let a = fs::read_to_string(tmp.path().join("a.md")).unwrap();
     assert!(a.contains("Keywords:"));

--- a/crates/hyalo-cli/tests/e2e/tags.rs
+++ b/crates/hyalo-cli/tests/e2e/tags.rs
@@ -610,7 +610,7 @@ fn tags_rename_basic() {
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["results"]["modified"].as_array().unwrap().len(), 2);
-    assert_eq!(json["results"]["skipped"].as_array().unwrap().len(), 1);
+    assert_eq!(json["results"]["skipped_count"].as_u64().unwrap(), 1);
 
     let a = std::fs::read_to_string(tmp.path().join("a.md")).unwrap();
     assert!(a.contains("filters"));

--- a/crates/hyalo-cli/tests/e2e/task.rs
+++ b/crates/hyalo-cli/tests/e2e/task.rs
@@ -1057,3 +1057,40 @@ fn task_toggle_dry_run_text_uses_arrow_format() {
         "missing arrow format for complete->incomplete:\n{stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// task set --dry-run
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_set_status_dry_run_does_not_modify_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_task_file(&tmp);
+
+    let original = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args([
+        "task",
+        "set",
+        "--file",
+        "tasks.md",
+        "--line",
+        &LINE_INCOMPLETE.to_string(),
+        "--status",
+        "?",
+        "--dry-run",
+    ]);
+    let output = cmd.output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let result = &json["results"];
+    assert_eq!(result["old_status"], " ");
+    assert_eq!(result["status"], "?");
+
+    let after = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+    assert_eq!(original, after, "file was modified during --dry-run");
+}

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -467,6 +467,40 @@ impl SnapshotIndex {
     fn load_inner(bytes: &[u8], warn: bool) -> Option<Self> {
         match rmp_serde::from_slice::<SnapshotData>(bytes) {
             Ok(data) => {
+                // SEC-1: Validate every rel_path before trusting snapshot data.
+                // Reject the entire snapshot if any path is unsafe — a crafted
+                // snapshot with path-traversal entries could escape the vault.
+                for entry in &data.entries {
+                    let rel_path = &entry.rel_path;
+                    if rel_path.contains('\0') {
+                        if warn {
+                            eprintln!(
+                                "warning: index file contains unsafe path '{rel_path}'; falling back to disk scan"
+                            );
+                        }
+                        return None;
+                    }
+                    if std::path::Path::new(rel_path.as_str()).is_absolute() {
+                        if warn {
+                            eprintln!(
+                                "warning: index file contains unsafe path '{rel_path}'; falling back to disk scan"
+                            );
+                        }
+                        return None;
+                    }
+                    if std::path::Path::new(rel_path.as_str())
+                        .components()
+                        .any(|c| matches!(c, std::path::Component::ParentDir))
+                    {
+                        if warn {
+                            eprintln!(
+                                "warning: index file contains unsafe path '{rel_path}'; falling back to disk scan"
+                            );
+                        }
+                        return None;
+                    }
+                }
+
                 // Entries are stored in sorted order (ScannedIndex::build sorts
                 // before saving).  Re-sort here to guarantee the invariant even
                 // if an older snapshot was created without sorting.
@@ -506,8 +540,9 @@ impl SnapshotIndex {
     /// fall back to a disk scan. A warning is printed to stderr in this case.
     /// Returns `Err` only for hard I/O failures.
     pub fn load(path: &Path) -> Result<Option<Self>> {
-        let bytes = std::fs::read(path)
-            .with_context(|| format!("failed to read index file: {}", path.display()))?;
+        let Some(bytes) = read_index_bytes(path, true)? else {
+            return Ok(None);
+        };
         Ok(Self::load_inner(&bytes, true))
     }
 
@@ -515,8 +550,9 @@ impl SnapshotIndex {
     /// incompatibility warning.  Used by `find_stale_indexes` which expects to
     /// silently skip files that cannot be deserialized.
     fn load_silent(path: &Path) -> Result<Option<Self>> {
-        let bytes = std::fs::read(path)
-            .with_context(|| format!("failed to read index file: {}", path.display()))?;
+        let Some(bytes) = read_index_bytes(path, false)? else {
+            return Ok(None);
+        };
         Ok(Self::load_inner(&bytes, false))
     }
 
@@ -560,6 +596,37 @@ impl SnapshotIndex {
             self.header.pid,
         )
     }
+}
+
+/// Maximum index file size accepted by [`read_index_bytes`].
+///
+/// Files larger than this are almost certainly corrupt or crafted to trigger an
+/// OOM condition during deserialization.  512 MiB is a generous upper bound for
+/// even the largest real-world knowledgebases.
+const MAX_INDEX_FILE_SIZE: u64 = 512 * 1024 * 1024;
+
+/// Read the raw bytes of an index file, enforcing the size limit.
+///
+/// Returns `Ok(Some(bytes))` when the file is within [`MAX_INDEX_FILE_SIZE`].
+/// Returns `Ok(None)` when the file exceeds the limit (a warning is printed
+/// when `warn` is `true`).
+/// Returns `Err` for hard I/O failures.
+fn read_index_bytes(path: &Path, warn: bool) -> Result<Option<Vec<u8>>> {
+    let meta = std::fs::metadata(path)
+        .with_context(|| format!("failed to stat index file: {}", path.display()))?;
+    if meta.len() > MAX_INDEX_FILE_SIZE {
+        if warn {
+            eprintln!(
+                "warning: index file is too large ({} bytes, limit {}); falling back to disk scan",
+                meta.len(),
+                MAX_INDEX_FILE_SIZE
+            );
+        }
+        return Ok(None);
+    }
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed to read index file: {}", path.display()))?;
+    Ok(Some(bytes))
 }
 
 /// Shared serialization logic for saving a snapshot index to disk.
@@ -658,6 +725,13 @@ fn is_pid_alive(pid: u32) -> bool {
         // targeting a real process and blocking stale-index cleanup.  Treat
         // any out-of-range PID as "not alive" so the stale index is removed.
         if pid > i32::MAX as u32 {
+            return false;
+        }
+
+        // pid 0 means "my own process group" for kill(), not a specific process.
+        // A crafted snapshot with pid=0 would always pass the liveness check,
+        // preventing stale-index cleanup.
+        if pid == 0 {
             return false;
         }
 
@@ -1358,5 +1432,82 @@ Content.
         // Link graph is empty
         assert!(idx.link_graph().backlinks("a").is_empty());
         assert!(idx.link_graph().backlinks("b").is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Security tests
+    // -------------------------------------------------------------------------
+
+    fn make_snapshot_bytes(rel_path: &str) -> Vec<u8> {
+        let data = SnapshotData {
+            header: SnapshotHeader {
+                vault_dir: "/tmp/vault".to_owned(),
+                site_prefix: None,
+                created_at: 0,
+                pid: std::process::id(),
+            },
+            entries: vec![IndexEntry {
+                rel_path: rel_path.to_owned(),
+                modified: "2024-01-01T00:00:00Z".to_owned(),
+                properties: IndexMap::default(),
+                tags: vec![],
+                sections: vec![],
+                tasks: vec![],
+                links: vec![],
+                bm25_tokens: None,
+                bm25_language: None,
+            }],
+            graph: LinkGraph::default(),
+            bm25_index: None,
+        };
+        rmp_serde::to_vec_named(&data).unwrap()
+    }
+
+    #[test]
+    fn load_inner_rejects_parent_traversal() {
+        let bytes = make_snapshot_bytes("../../escape.md");
+        assert!(
+            SnapshotIndex::load_inner(&bytes, false).is_none(),
+            "snapshot with '..' path components must be rejected"
+        );
+    }
+
+    #[test]
+    fn load_inner_rejects_absolute_path() {
+        let bytes = make_snapshot_bytes("/etc/passwd");
+        assert!(
+            SnapshotIndex::load_inner(&bytes, false).is_none(),
+            "snapshot with absolute rel_path must be rejected"
+        );
+    }
+
+    #[test]
+    fn load_inner_rejects_null_byte() {
+        let bytes = make_snapshot_bytes("foo\0bar.md");
+        assert!(
+            SnapshotIndex::load_inner(&bytes, false).is_none(),
+            "snapshot with null-byte path must be rejected"
+        );
+    }
+
+    #[test]
+    fn is_pid_alive_zero_returns_false() {
+        assert!(
+            !is_pid_alive(0),
+            "pid 0 must not be treated as an alive process"
+        );
+    }
+
+    #[test]
+    fn load_rejects_oversized_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("big.hyalo-index");
+        let f = std::fs::File::create(&path).unwrap();
+        f.set_len(MAX_INDEX_FILE_SIZE + 1).unwrap();
+        let result = SnapshotIndex::load(&path).unwrap();
+        assert!(
+            result.is_none(),
+            "oversized index file must return Ok(None)"
+        );
     }
 }

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -748,6 +748,14 @@ impl VaultIndex for SnapshotIndex {
 /// existence). On all other platforms we conservatively assume the PID is
 /// alive so that we never falsely claim a running process is stale.
 fn is_pid_alive(pid: u32) -> bool {
+    // pid 0 means "my own process group" for kill() on Unix, not a specific
+    // process.  A crafted snapshot with pid=0 would always pass the liveness
+    // check, preventing stale-index cleanup.  Guard before platform-specific
+    // blocks so it applies on all targets.
+    if pid == 0 {
+        return false;
+    }
+
     #[cfg(unix)]
     {
         // A tampered snapshot could carry a PID that exceeds `i32::MAX`.  On
@@ -755,13 +763,6 @@ fn is_pid_alive(pid: u32) -> bool {
         // targeting a real process and blocking stale-index cleanup.  Treat
         // any out-of-range PID as "not alive" so the stale index is removed.
         if pid > i32::MAX as u32 {
-            return false;
-        }
-
-        // pid 0 means "my own process group" for kill(), not a specific process.
-        // A crafted snapshot with pid=0 would always pass the liveness check,
-        // preventing stale-index cleanup.
-        if pid == 0 {
             return false;
         }
 

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -467,6 +467,21 @@ impl SnapshotIndex {
     fn load_inner(bytes: &[u8], warn: bool) -> Option<Self> {
         match rmp_serde::from_slice::<SnapshotData>(bytes) {
             Ok(data) => {
+                // SEC-2 (defense-in-depth): reject snapshots with an implausible
+                // number of entries — a crafted MessagePack header claiming millions
+                // of entries can trigger large allocations even with file-size caps.
+                const MAX_ENTRIES: usize = 5_000_000;
+                if data.entries.len() > MAX_ENTRIES {
+                    if warn {
+                        eprintln!(
+                            "warning: index file contains {} entries (limit {}); falling back to disk scan",
+                            data.entries.len(),
+                            MAX_ENTRIES
+                        );
+                    }
+                    return None;
+                }
+
                 // SEC-1: Validate every rel_path before trusting snapshot data.
                 // Reject the entire snapshot if any path is unsafe — a crafted
                 // snapshot with path-traversal entries could escape the vault.
@@ -490,7 +505,12 @@ impl SnapshotIndex {
                     }
                     if std::path::Path::new(rel_path.as_str())
                         .components()
-                        .any(|c| matches!(c, std::path::Component::ParentDir))
+                        .any(|c| {
+                            matches!(
+                                c,
+                                std::path::Component::ParentDir | std::path::Component::Prefix(_)
+                            )
+                        })
                     {
                         if warn {
                             eprintln!(
@@ -612,7 +632,12 @@ const MAX_INDEX_FILE_SIZE: u64 = 512 * 1024 * 1024;
 /// when `warn` is `true`).
 /// Returns `Err` for hard I/O failures.
 fn read_index_bytes(path: &Path, warn: bool) -> Result<Option<Vec<u8>>> {
-    let meta = std::fs::metadata(path)
+    use std::io::Read as _;
+
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open index file: {}", path.display()))?;
+    let meta = file
+        .metadata()
         .with_context(|| format!("failed to stat index file: {}", path.display()))?;
     if meta.len() > MAX_INDEX_FILE_SIZE {
         if warn {
@@ -624,7 +649,12 @@ fn read_index_bytes(path: &Path, warn: bool) -> Result<Option<Vec<u8>>> {
         }
         return Ok(None);
     }
-    let bytes = std::fs::read(path)
+    // Size was already checked against MAX_INDEX_FILE_SIZE (512 MiB) which
+    // fits in usize on all supported targets (32-bit and above).
+    #[allow(clippy::cast_possible_truncation)]
+    let mut bytes = Vec::with_capacity(meta.len() as usize);
+    file.take(MAX_INDEX_FILE_SIZE + 1)
+        .read_to_end(&mut bytes)
         .with_context(|| format!("failed to read index file: {}", path.display()))?;
     Ok(Some(bytes))
 }

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0120-post-iter120.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0120-post-iter120.md
@@ -1,0 +1,119 @@
+---
+title: "Dogfood v0.12.0 — Post Iteration 120 (Feature Verification + Multi-KB)"
+type: research
+date: 2026-04-16
+status: active
+tags: [dogfooding, verification, multi-kb]
+related:
+  - "[[dogfood-results/dogfood-v0120-post-iter119]]"
+  - "[[iterations/iteration-120-dogfood-v0120-post-iter119-fixes]]"
+---
+
+# Dogfood v0.12.0 — Post Iteration 120
+
+Binary: `hyalo 0.12.0` (built from source, main branch post-iter-120 merge).
+KBs tested: Own KB (248 files), MDN Web Docs (14,245 files, indexed), GitHub Docs (3,520 files).
+
+## Iter-120 Feature Verification
+
+### `--fields outline` alias — WORKING
+
+`find --fields outline` produces identical output to `--fields sections`. Tested standalone and combined with other fields on both own KB and GitHub Docs (3,520 files).
+
+### `--stemmer` ISO 639-1 codes — WORKING
+
+- `--stemmer en` → accepted (English stemmer)
+- `--stemmer de` → accepted (German stemmer)
+- `--stemmer fr` → accepted (French stemmer, tested on MDN with indexed search)
+- `--stemmer EN` → accepted (case-insensitive)
+- `--stemmer xx` → clear error: `unknown stemming language "xx"`
+
+### `properties rename --dry-run` — WORKING
+
+Tested on own KB (248 files, 248 modified) and GitHub Docs (3,521 scanned, 7 modified for `heroImage → hero_image`). Shows `dry_run: true`, file list, and no files are actually changed. JSON output is clean. Text output shows the skipped list which is verbose on large KBs (see UX-1 below).
+
+### `tags rename --dry-run` — WORKING
+
+Tested on own KB (91 modified, 157 skipped for tag rename). Correctly shows `dry_run: true` and affected files without writing.
+
+### `create-index` overwrite note — WORKING
+
+First `create-index` has no note. Second run includes `"note": "replaced existing index"` in JSON output.
+
+### Lint parse error hint — WORKING
+
+On GitHub Docs, `lint` correctly detects the unclosed frontmatter in `code-security/concepts/index.md` and the hint shows an executable command: `hyalo lint --limit 0 --dir ../docs/content/ --format json`. This is the iter-120 fix — previously it showed a non-executable comment.
+
+## Bug Regression Testing
+
+### BUG-1 (prior): `mv --dry-run` link rewrites — NOT A BUG (confirmed)
+
+Confirmed again: bare wikilinks (`[[name]]`) are intentionally skipped by `plan_mv` because they use name-based resolution. The dry-run correctly reports 0 rewrites when all links are bare.
+
+### BUG-3 (prior): MDN index load dominates query time — UNCHANGED
+
+MDN indexed query: ~0.67s (index deserialization dominated). Unindexed BM25: ~3.86s. The index still provides ~6x speedup for search. The 113 MB index file size is unchanged.
+
+### Boolean operator warning — STILL FIXED
+
+`find "TODO AND FIXME"` returns results without spurious warnings.
+
+### Non-existent view error — STILL WORKING
+
+`find --view nonexistent` gives clear error with `tip: run 'hyalo views list'`.
+
+### Schema validation on `set` — STILL WORKING
+
+`set --property "status=banana" --validate --dry-run` correctly rejects with did-you-mean suggestion.
+
+## Bugs Found
+
+No new bugs found in this session.
+
+## UX Issues
+
+### UX-1: `properties rename --dry-run` text output includes full skipped list (LOW)
+
+When running `properties rename --from heroImage --to hero_image --dry-run --dir ../docs/content/`, the text output includes every single skipped file (3,514 files) which makes the output enormous and hard to scan. The useful information (7 modified files) is buried at the top.
+
+The JSON output has the same issue — the `skipped` array contains all 3,514 non-matching files. For a bulk operation, the user cares about what WILL change, not what won't. Consider:
+- Omitting the skipped list from text output entirely
+- Truncating to a count in JSON (e.g., `"skipped_count": 3514`)
+- Or adding `--verbose` to opt-in to the full list
+
+### UX-2: `stale-in-progress` view found genuinely stale iteration (data quality note)
+
+The `stale-in-progress` view correctly identified `iteration-112` with 2 unchecked tasks ("Update README with limit bypass and show alias" and "Create iteration file"). This is a data quality finding, not a tool bug — but it demonstrates the view's value for housekeeping.
+
+## What Worked Well
+
+### All iter-120 features work correctly across all KBs
+Every feature verified on both own KB and external KBs (MDN 14K files, GitHub Docs 3.5K files). No cross-KB compatibility issues.
+
+### BM25 ranking remains excellent
+- MDN: "CSS grid layout" → CSS grid module page first (score 16.73)
+- GitHub Docs: "pull request merge conflict" → merge conflicts page first (score 18.09)
+- Own KB: "snapshot index" → iter-47 first (score 5.39)
+
+### Error messages are clear and actionable
+- Empty string search: `body pattern must not be empty; omit the pattern to match all files`
+- Unknown stemmer: `unknown stemming language "xx"` with suggestion
+- Unknown view: clear error + tip to run `views list`
+- Schema validation: rejects invalid values with did-you-mean
+
+### Views are a powerful housekeeping tool
+7 views defined, all working. `stale-in-progress` found a genuinely stale iteration. `completed-with-todos` and `orphans` work for vault hygiene.
+
+### External KB handling is robust
+GitHub Docs' unclosed frontmatter file is cleanly skipped with a warning, not crashing 3,520 other files. MDN's 14,245 files work seamlessly with the snapshot index.
+
+## Performance
+
+| Command | Own KB (248) | Own KB (indexed) | MDN (14,245) | MDN (indexed) | GH Docs (3,520) |
+|---|---|---|---|---|---|
+| `find --limit 1` | 20ms | 19ms | — | — | — |
+| BM25 search | 68ms | 19ms | 3.86s | 666ms | 944ms |
+| `summary` | 31ms | — | 1.27s | — | 366ms |
+| `property filter` | 21ms | — | — | — | — |
+
+No regressions compared to the prior dogfood report. The own KB indexed search (19ms) is notably faster than unindexed (68ms) — a ~3.5x speedup even on a small vault.

--- a/hyalo-knowledgebase/iterations/iteration-121-review-hardening.md
+++ b/hyalo-knowledgebase/iterations/iteration-121-review-hardening.md
@@ -1,0 +1,128 @@
+---
+title: Iteration 121 — Code Review Hardening
+type: iteration
+date: 2026-04-16
+status: completed
+branch: iter-121/review-hardening
+tags:
+  - iteration
+  - security
+  - code-quality
+  - ux
+  - docs
+related:
+  - "[[dogfood-results/dogfood-v0120-post-iter120]]"
+---
+
+# Iteration 121 — Code Review Hardening
+
+## Goal
+
+Address findings from the deep code review (post-iter-120 dogfood session):
+two MEDIUM security issues in snapshot index handling, one missing `--dry-run`
+flag, production `.expect()` cleanup, inconsistent error formatting, and
+documentation gaps.
+
+## Security Fixes
+
+### SEC-1: Index `rel_path` traversal validation (MEDIUM)
+
+Deserialized `IndexEntry::rel_path` values from `.hyalo-index` are accepted
+verbatim. A crafted index with `rel_path = "../../etc/cron.d/malicious"` causes
+`dir.join(rel_path)` to escape the vault when mutation commands trigger
+`rescan_entry`.
+
+**Fix**: In `SnapshotIndex::load_inner`, validate every `entry.rel_path` after
+deserialization — reject (warn + fall back to disk scan) if any path has `..`
+components, is absolute, or contains null bytes. Reuse `has_parent_traversal`
+from `discovery.rs`.
+
+- [x] Add `rel_path` validation in `load_inner` (`crates/hyalo-core/src/index.rs`)
+- [x] Reject entire snapshot with warning if any path fails
+- [x] Add unit test with crafted index containing traversal path
+- [x] Add e2e test: index with `../../escape.md` entry is rejected
+
+### SEC-2: Index deserialization OOM from crafted `.hyalo-index` (MEDIUM)
+
+`rmp_serde::from_slice` applies no allocation limits. A crafted file with a
+MessagePack array header claiming millions of entries triggers OOM.
+
+**Fix**: Cap file size before reading. Check `metadata().len()` and reject files
+above a reasonable limit (e.g. 512 MB) with a clear error.
+
+- [x] Add file size check before `std::fs::read` in `SnapshotIndex::load`
+- [x] Add test with oversized file size metadata
+
+### SEC-3: `is_pid_alive` does not guard `pid == 0` (LOW)
+
+A crafted snapshot with `pid = 0` causes `kill(0, 0)` which checks the process
+group, not a specific process — always returns alive, preventing stale index
+cleanup.
+
+- [x] Add `pid == 0` guard in `is_pid_alive` (`crates/hyalo-core/src/index.rs`)
+
+## Code Quality
+
+### CQ-1: `task set` missing `--dry-run`
+
+Only mutation command without `--dry-run`. `task toggle` has it; `task set`
+(same kind of write) does not.
+
+- [x] Add `--dry-run` flag to `TaskAction::Set` in `args.rs`
+- [x] Thread through dispatch and `task_set` implementation
+- [x] Add e2e test for `task set --dry-run`
+
+### CQ-2: `types.rs` `.expect()` in production (~30 instances)
+
+TOML table access uses `.expect("schema is a table")` after `toml_type_exists`
+guard. Safe by invariant but panics on hand-edited `.hyalo.toml` with wrong
+structure.
+
+- [x] Replace `.expect()` calls with `.context()` + `?` returning user error
+- [x] Add test: malformed `.hyalo.toml` (e.g. `schema = "string"`) gives error not panic
+
+### CQ-3: `types.rs`/`views.rs` bypass `format_error()` (~12 instances)
+
+Use raw `format!("Error: ...")` instead of `format_error()`, so errors don't
+respect `--format text` vs JSON.
+
+- [x] Add `format: Format` parameter to `views.rs` functions
+- [x] Replace `format!("Error: ...")` with `format_error()` in types.rs and views.rs
+- [x] Verify with `--format text` that errors render correctly
+
+## Documentation
+
+### DOC-1: Update `--fields` help text to mention `outline` alias
+
+- [x] Add `(alias: outline)` next to `sections` in help text (`args.rs:234`)
+
+### DOC-2: Update README
+
+- [x] Add `--stemmer`/`--language` section with ISO 639-1 examples
+- [x] Add `--dry-run` examples for `properties rename` and `tags rename`
+- [x] Mention `outline` alias in `--fields` examples
+
+### DOC-3: Update CHANGELOG
+
+- [x] Add `skipped` → `skipped_count` breaking change for `properties rename` and `tags rename` JSON output
+
+### DOC-4: Update skill template
+
+- [x] Mention ISO 639-1 codes in `skill-hyalo.md` `--stemmer` section
+
+## Quality Gates
+
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace -q`
+
+## Acceptance Criteria
+
+- [x] Crafted `.hyalo-index` with traversal `rel_path` is rejected with warning
+- [x] Crafted `.hyalo-index` over 512 MB is rejected
+- [x] `task set --dry-run` previews without writing
+- [x] `types remove` on malformed `.hyalo.toml` returns error, not panic
+- [x] `views list --format text` errors are format-aware
+- [x] README documents `--stemmer`, `--dry-run` for rename, `outline` alias
+- [x] CHANGELOG documents `skipped_count` breaking change
+- [x] All existing tests still pass


### PR DESCRIPTION
## Summary

- **Security:** Snapshot index (`.hyalo-index`) now validates entry paths on load — rejects path traversal (`..`), absolute paths, and null bytes (SEC-1). Files over 512 MB are rejected to prevent OOM (SEC-2). `pid=0` guard prevents stale-index persistence (SEC-3).
- **Code quality:** `task set --dry-run` added (CQ-1). ~30 `.expect()` calls in `types.rs` replaced with `anyhow::Context` error handling so malformed `.hyalo.toml` returns a user error instead of panicking (CQ-2). Raw `format!("Error: ...")` in `types.rs` and `views.rs` replaced with `format_error()` for format-aware output (CQ-3).
- **Documentation:** README updated with `--stemmer` ISO 639-1 examples, `outline` alias for `--fields sections`, `--dry-run` examples for `properties rename`/`tags rename`/`task set`. CHANGELOG documents `skipped_count` breaking change. Skill template updated with ISO 639-1 codes and `outline` alias.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace -q` — 631 unit tests pass
- [x] e2e tests — 835 tests pass
- [x] New unit tests: traversal/absolute/null-byte path rejection, oversized file rejection, pid==0, `task set --dry-run`, malformed `.hyalo.toml` error handling
- [ ] Manual: `hyalo task set note.md --line 1 --status '?' --dry-run` previews without writing
- [ ] Manual: `hyalo types remove iteration` on malformed `.hyalo.toml` returns error, not panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` preview for task set and documented dry-run previews for rename commands
  * Added `--fields outline` as an alias for `sections`
  * `find` now accepts ISO 639-1 language codes for stemmer selection

* **Bug Fixes**
  * Snapshot index rejects unsafe entry paths and oversized index files
  * Hard crashes on malformed config files replaced with user-facing errors

* **Breaking Changes**
  * `properties rename` and `tags rename` JSON now report `skipped_count` (integer) instead of `skipped` (array)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->