### PR TITLE
Resolve bare wikilinks by filename stem (Obsidian-style)

### DIFF
--- a/crates/hyalo-core/src/case_index.rs
+++ b/crates/hyalo-core/src/case_index.rs
@@ -73,10 +73,14 @@ impl CaseInsensitiveIndex {
 
         // Also index by filename stem for Obsidian-style bare wikilink resolution.
         let fname = rel_path.rsplit('/').next().unwrap_or(rel_path);
-        let stem = fname
-            .strip_suffix(".md")
-            .or_else(|| fname.strip_suffix(".MD"))
-            .unwrap_or(fname);
+        let stem = if Path::new(fname)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+        {
+            &fname[..fname.len() - 3]
+        } else {
+            fname
+        };
         let stem_key = stem.to_ascii_lowercase();
         let stem_candidates = self.stem_map.entry(stem_key).or_default();
         if !stem_candidates.iter().any(|c| c == rel_path) {

--- a/crates/hyalo-core/src/case_index.rs
+++ b/crates/hyalo-core/src/case_index.rs
@@ -43,10 +43,17 @@ impl CaseInsensitiveMode {
 ///
 /// Used for case-insensitive link resolution: insert all known paths at
 /// index build time, then look up by lowercased target at resolution time.
+///
+/// Also indexes by lowercased filename stem (without `.md` extension and
+/// directory path) for Obsidian-style bare wikilink resolution — e.g.
+/// `[[note]]` resolving to `sub/note.md` when that stem is unique.
 #[derive(Debug, Default, Clone)]
 pub struct CaseInsensitiveIndex {
     /// Map from lowercased path → list of real (original-casing) paths.
     map: HashMap<String, Vec<String>>,
+    /// Map from lowercased filename stem → list of real (original-casing) paths.
+    /// Used for Obsidian-style bare wikilink resolution.
+    stem_map: HashMap<String, Vec<String>>,
 }
 
 impl CaseInsensitiveIndex {
@@ -63,6 +70,18 @@ impl CaseInsensitiveIndex {
         if !candidates.iter().any(|c| c == rel_path) {
             candidates.push(rel_path.to_owned());
         }
+
+        // Also index by filename stem for Obsidian-style bare wikilink resolution.
+        let fname = rel_path.rsplit('/').next().unwrap_or(rel_path);
+        let stem = fname
+            .strip_suffix(".md")
+            .or_else(|| fname.strip_suffix(".MD"))
+            .unwrap_or(fname);
+        let stem_key = stem.to_ascii_lowercase();
+        let stem_candidates = self.stem_map.entry(stem_key).or_default();
+        if !stem_candidates.iter().any(|c| c == rel_path) {
+            stem_candidates.push(rel_path.to_owned());
+        }
     }
 
     /// Look up a relative path (any casing). Returns the canonical real path
@@ -70,6 +89,22 @@ impl CaseInsensitiveIndex {
     pub fn lookup_unique(&self, rel_path: &str) -> Option<&str> {
         let key = rel_path.to_ascii_lowercase();
         let candidates = self.map.get(&key)?;
+        if candidates.len() == 1 {
+            Some(&candidates[0])
+        } else {
+            None
+        }
+    }
+
+    /// Look up a bare filename stem (no directory, no `.md` extension).
+    /// Returns the canonical real path only when exactly one file has that
+    /// stem (unambiguous Obsidian-style resolution).
+    ///
+    /// Example: `lookup_stem("note")` matches `sub/note.md` if it's the only
+    /// file named `note.md` in the vault.
+    pub fn lookup_stem(&self, stem: &str) -> Option<&str> {
+        let key = stem.to_ascii_lowercase();
+        let candidates = self.stem_map.get(&key)?;
         if candidates.len() == 1 {
             Some(&candidates[0])
         } else {
@@ -208,6 +243,34 @@ mod tests {
         assert!(idx.lookup_all("anything.md").is_empty());
         assert!(idx.is_empty());
         assert_eq!(idx.len(), 0);
+    }
+
+    // ---- Stem lookup (Obsidian-style bare wikilink resolution) ----
+
+    #[test]
+    fn lookup_stem_unique() {
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("sub/note.md");
+        idx.insert("other/readme.md");
+        // "note" stem is unique → resolves
+        assert_eq!(idx.lookup_stem("note"), Some("sub/note.md"));
+        // Case-insensitive stem lookup
+        assert_eq!(idx.lookup_stem("NOTE"), Some("sub/note.md"));
+    }
+
+    #[test]
+    fn lookup_stem_ambiguous() {
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("a/note.md");
+        idx.insert("b/note.md");
+        // Two files with same stem → ambiguous → None
+        assert!(idx.lookup_stem("note").is_none());
+    }
+
+    #[test]
+    fn lookup_stem_empty_index() {
+        let idx = CaseInsensitiveIndex::new();
+        assert!(idx.lookup_stem("anything").is_none());
     }
 
     #[test]

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -620,10 +620,14 @@ pub fn resolve_target(
         && let Some(idx) = case_index
     {
         // Try the target as-is (could already be a stem or have .md).
-        let stem = target
-            .strip_suffix(".md")
-            .or_else(|| target.strip_suffix(".MD"))
-            .unwrap_or(&target);
+        let stem = if Path::new(target.as_str())
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+        {
+            &target[..target.len() - 3]
+        } else {
+            &target
+        };
         if let Some(canonical_path) = idx.lookup_stem(stem) {
             let full_resolved = canonical_dir.join(canonical_path);
             if ensure_within_vault(canonical_dir, &full_resolved).unwrap_or(false) {

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -613,6 +613,25 @@ pub fn resolve_target(
         }
     }
 
+    // Obsidian-style bare stem resolution: if the target has no path separator,
+    // look it up by filename stem. Resolves `[[note]]` to `sub/note.md` when
+    // exactly one file in the vault has that stem.
+    if !target.contains('/')
+        && let Some(idx) = case_index
+    {
+        // Try the target as-is (could already be a stem or have .md).
+        let stem = target
+            .strip_suffix(".md")
+            .or_else(|| target.strip_suffix(".MD"))
+            .unwrap_or(&target);
+        if let Some(canonical_path) = idx.lookup_stem(stem) {
+            let full_resolved = canonical_dir.join(canonical_path);
+            if ensure_within_vault(canonical_dir, &full_resolved).unwrap_or(false) {
+                return Some(canonical_path.to_owned());
+            }
+        }
+    }
+
     None
 }
 
@@ -1065,11 +1084,39 @@ mod tests {
     }
 
     #[test]
-    fn resolve_target_bare_stem_does_not_match_subdirectory() {
+    fn resolve_target_bare_stem_without_index_returns_none() {
+        // Without a case/stem index, bare stems can't resolve to subdirectories
+        // (no filesystem scan is performed for stem matching).
         let tmp = tempfile::tempdir().unwrap();
         make_files(tmp.path(), &["sub/other.md"]);
         let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
         assert_eq!(resolve_target(&canonical, "other", None, None), None);
+    }
+
+    #[test]
+    fn resolve_target_bare_stem_with_index_resolves_unique() {
+        // Obsidian-style: [[other]] resolves to sub/other.md when the stem is unique.
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["sub/other.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("sub/other.md");
+        assert_eq!(
+            resolve_target(&canonical, "other", None, Some(&idx)),
+            Some("sub/other.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn resolve_target_bare_stem_ambiguous_returns_none() {
+        // Two files with the same stem → ambiguous → None.
+        let tmp = tempfile::tempdir().unwrap();
+        make_files(tmp.path(), &["a/note.md", "b/note.md"]);
+        let canonical = canonicalize_vault_dir(tmp.path()).unwrap();
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.insert("a/note.md");
+        idx.insert("b/note.md");
+        assert_eq!(resolve_target(&canonical, "note", None, Some(&idx)), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Bare wikilinks like `[[note]]` now resolve to `sub/note.md` when exactly one file in the vault has that filename stem — matching Obsidian's shortest-path resolution
- Extended `CaseInsensitiveIndex` with a `stem_map` that indexes files by lowercased filename stem (without `.md` and directory path)
- Added a final fallback in `resolve_target()` for bare targets (no `/`) that consults the stem index after all existing strategies (exact path, case-insensitive, extension toggle) fail
- Ambiguous stems (multiple files with the same name in different directories) correctly return `None`

## Test plan
- [x] 5 new unit tests: `lookup_stem` (unique, ambiguous, empty index), `resolve_target` with stem index (unique match, ambiguous returns None)
- [x] Manual verification with synthetic vault: `[[html-to-markdown-crates]]` in `research/competitive-landscape.md` resolves to `research/html-to-markdown-crates.md`
- [x] All 638 existing + new tests pass
- [x] Works with both fresh scan and `--index` snapshot paths (same `CaseInsensitiveIndex` is used)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Obsidian-style bare wikilink resolution: users can reference files by filename stem alone when it uniquely matches a single file; ambiguous or missing stems remain unresolved.

* **Tests**
  * Expanded tests covering unique stem resolution, ambiguous stems, and empty/unindexed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->