### PR TITLE
Fix spurious nested-config warning when dir = "."

### DIFF
--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -231,7 +231,13 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     // so `--no-hints` intentionally does *not* gate it.
     if let Some(ref sub) = cfg.dir {
         let nested = dir.join(sub).join(".hyalo.toml");
-        if nested.is_file() {
+        // Skip warning when dir points back at itself (e.g. dir = ".") —
+        // the nested path resolves to the same file as the root config.
+        let is_self = nested
+            .canonicalize()
+            .and_then(|n| dir.join(".hyalo.toml").canonicalize().map(|r| n == r))
+            .unwrap_or(false);
+        if !is_self && nested.is_file() {
             crate::warn::warn(format!(
                 "ignoring nested config {}/.hyalo.toml (shadowed by {}/.hyalo.toml)",
                 sub.trim_end_matches('/'),
@@ -455,6 +461,20 @@ site_prefix = "docs"
         let tracked =
             crate::warn::any_tracked_starts_with("ignoring nested config subkb/.hyalo.toml");
         assert!(tracked, "expected nested-config warning to fire");
+    }
+
+    #[test]
+    fn nested_config_dir_dot_no_warning() {
+        // When dir = ".", the nested path resolves to the same .hyalo.toml —
+        // this should NOT trigger a shadow warning.
+        let _guard = crate::warn::WARN_TEST_LOCK.lock().unwrap();
+        crate::warn::reset_for_test();
+        crate::warn::init(false);
+        let dir = make_temp();
+        fs::write(dir.path().join(".hyalo.toml"), "dir = \".\"\n").unwrap();
+        let _ = load_config_from(dir.path());
+        let tracked = crate::warn::any_tracked_starts_with("ignoring nested config");
+        assert!(!tracked, "dir = '.' should not trigger nested-config warning");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -231,18 +231,20 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     // so `--no-hints` intentionally does *not* gate it.
     if let Some(ref sub) = cfg.dir {
         let nested = dir.join(sub).join(".hyalo.toml");
-        // Skip warning when dir points back at itself (e.g. dir = ".") —
-        // the nested path resolves to the same file as the root config.
-        let is_self = nested
-            .canonicalize()
-            .and_then(|n| dir.join(".hyalo.toml").canonicalize().map(|r| n == r))
-            .unwrap_or(false);
-        if !is_self && nested.is_file() {
-            crate::warn::warn(format!(
-                "ignoring nested config {}/.hyalo.toml (shadowed by {}/.hyalo.toml)",
-                sub.trim_end_matches('/'),
-                dir.display()
-            ));
+        if nested.is_file() {
+            // Skip warning when dir points back at itself (e.g. dir = ".") —
+            // the nested path resolves to the same file as the root config.
+            let is_self = nested
+                .canonicalize()
+                .and_then(|n| dir.join(".hyalo.toml").canonicalize().map(|r| n == r))
+                .unwrap_or(false);
+            if !is_self {
+                crate::warn::warn(format!(
+                    "ignoring nested config {}/.hyalo.toml (shadowed by {}/.hyalo.toml)",
+                    sub.trim_end_matches('/'),
+                    dir.display()
+                ));
+            }
         }
     }
 
@@ -474,7 +476,10 @@ site_prefix = "docs"
         fs::write(dir.path().join(".hyalo.toml"), "dir = \".\"\n").unwrap();
         let _ = load_config_from(dir.path());
         let tracked = crate::warn::any_tracked_starts_with("ignoring nested config");
-        assert!(!tracked, "dir = '.' should not trigger nested-config warning");
+        assert!(
+            !tracked,
+            "dir = '.' should not trigger nested-config warning"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- When `.hyalo.toml` has `dir = "."`, hyalo incorrectly warned about a "nested config being shadowed" — the nested path resolved to the same file as the root config
- Now compares canonical paths to detect self-references and skips the warning

## Test plan
- [x] New unit test `nested_config_dir_dot_no_warning` verifies no warning fires for `dir = "."`
- [x] Existing test `nested_config_emits_shadow_warning` still passes (genuine nested configs still warn)
- [x] All tests pass, clippy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed spurious nested-configuration warnings when a nested config path resolves to the same file as the root configuration.
* **Tests**
  * Added a test ensuring no nested-config warning is emitted for a dot (".") directory reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->