### PR TITLE
Add `hyalo links auto` — auto-link unlinked page-title mentions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
 name = "hyalo-core"
 version = "0.13.2"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "criterion",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1"
 rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }
 serde-saphyr = "0.0.23"
+aho-corasick = "1"
 strsim = "0.11"
 serde_json = "1.0.149"
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ hyalo mv --file old/path.md --to archive/path.md
 # Detect and fix broken links
 hyalo links fix --apply
 
+# Auto-link unlinked mentions of known page titles
+hyalo links auto --apply
+
 # Lint against your schema
 hyalo lint --fix
 ```

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1018,6 +1018,39 @@ pub(crate) enum LinksAction {
         #[command(flatten)]
         index_flags: IndexFlags,
     },
+    /// Auto-link unlinked mentions of known page titles
+    #[command(
+        long_about = "Scan body text for unlinked mentions of known page titles and convert them to [[wikilinks]].\n\n\
+            Title sources (in priority order):\n\
+            1. Filename stems (without .md)\n\
+            2. Frontmatter `title` property\n\
+            3. Frontmatter `aliases` property (list of alternate names)\n\n\
+            Exclusion zones: frontmatter, fenced code blocks, inline code,\n\
+            existing [[wikilinks]] and [markdown](links), headings, self-links.\n\n\
+            Without --apply, prints a dry-run report. Pass --apply to write changes."
+    )]
+    Auto {
+        /// Preview changes without modifying files (default when --apply is omitted)
+        #[arg(long)]
+        dry_run: bool,
+        /// Apply changes to files on disk
+        #[arg(long, conflicts_with = "dry_run")]
+        apply: bool,
+        /// Minimum title length to consider (skip short common words)
+        #[arg(long, default_value = "3")]
+        min_length: usize,
+        /// Titles to exclude from matching (repeatable, case-insensitive)
+        #[arg(long)]
+        exclude_title: Vec<String>,
+        /// Restrict to a single file
+        #[arg(long)]
+        file: Option<String>,
+        /// Glob pattern(s) to filter which files to scan (repeatable); prefix '!' to negate
+        #[arg(short, long)]
+        glob: Vec<String>,
+        #[command(flatten)]
+        index_flags: IndexFlags,
+    },
 }
 
 #[derive(Subcommand)]

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1026,7 +1026,7 @@ pub(crate) enum LinksAction {
             2. Frontmatter `title` property\n\
             3. Frontmatter `aliases` property (list of alternate names)\n\n\
             Exclusion zones: frontmatter, fenced code blocks, inline code,\n\
-            existing [[wikilinks]] and [markdown](links), headings, self-links.\n\n\
+            existing [[wikilinks]] and [markdown](links), headings, comment fences (%%), self-links.\n\n\
             Without --apply, prints a dry-run report. Pass --apply to write changes."
     )]
     Auto {
@@ -1042,11 +1042,11 @@ pub(crate) enum LinksAction {
         /// Titles to exclude from matching (repeatable, case-insensitive)
         #[arg(long)]
         exclude_title: Vec<String>,
-        /// Restrict to a single file
-        #[arg(long)]
+        /// Restrict to a single file (vault-relative path)
+        #[arg(long, conflicts_with = "glob")]
         file: Option<String>,
         /// Glob pattern(s) to filter which files to scan (repeatable); prefix '!' to negate
-        #[arg(short, long)]
+        #[arg(short, long, conflicts_with = "file")]
         glob: Vec<String>,
         #[command(flatten)]
         index_flags: IndexFlags,

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -109,4 +109,43 @@ pub fn links_fix(
     ))
 }
 
+/// Run `hyalo links auto` using a pre-built index.
+///
+/// `apply = false` → preview only (default)
+/// `apply = true`  → write `[[wikilinks]]` to disk
+#[allow(clippy::too_many_arguments)]
+pub fn links_auto(
+    index: &dyn VaultIndex,
+    dir: &Path,
+    apply: bool,
+    min_length: usize,
+    exclude_titles: &[String],
+    file_filter: Option<&str>,
+    glob_filter: &[String],
+    format: Format,
+) -> Result<CommandOutcome> {
+    let report = hyalo_core::auto_link::auto_link(
+        index,
+        dir,
+        apply,
+        min_length,
+        exclude_titles,
+        file_filter,
+        glob_filter,
+    )?;
+
+    let output = serde_json::json!({
+        "scanned": report.scanned,
+        "total": report.total,
+        "matches": report.matches,
+        "ambiguous_titles": report.ambiguous_titles,
+        "applied": report.applied,
+    });
+
+    let _ = format;
+    Ok(CommandOutcome::success(
+        serde_json::to_string_pretty(&output).context("failed to serialize")?,
+    ))
+}
+
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -889,6 +889,41 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 }
                 IndexResolution::Outcome(outcome) => Ok(outcome),
             },
+            LinksAction::Auto {
+                dry_run: _,
+                apply,
+                min_length,
+                exclude_title,
+                file,
+                glob,
+                index_flags: _, // consumed in run.rs before dispatch
+            } => match resolve_index(
+                snapshot_index.as_ref(),
+                dir,
+                &[],
+                &[],
+                effective_format,
+                site_prefix,
+                true,
+                &ScanOptions {
+                    scan_body: false,
+                    bm25_tokenize: false,
+                    default_language: None,
+                    frontmatter_link_props: ctx.frontmatter_link_props,
+                },
+            )? {
+                IndexResolution::Resolved(resolved) => links_commands::links_auto(
+                    resolved.as_index(),
+                    dir,
+                    apply,
+                    min_length,
+                    &exclude_title,
+                    file.as_deref(),
+                    &glob,
+                    effective_format,
+                ),
+                IndexResolution::Outcome(outcome) => Ok(outcome),
+            },
         },
         Commands::Lint {
             file_positional,

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -88,6 +88,10 @@ pub struct HintContext {
     pub dry_run: bool,
     // Index context
     pub index_path: Option<String>,
+    // Links-auto context (for replaying the exact preview scope in hints)
+    pub auto_link_file: Option<String>,
+    pub auto_link_min_length: Option<usize>,
+    pub auto_link_exclude_titles: Vec<String>,
 }
 
 /// Common global flags captured once per command dispatch and threaded into
@@ -126,6 +130,9 @@ impl HintContext {
             task_selector: None,
             dry_run: false,
             index_path: None,
+            auto_link_file: None,
+            auto_link_min_length: None,
+            auto_link_exclude_titles: vec![],
         }
     }
 
@@ -1332,9 +1339,30 @@ fn hints_for_links_auto(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint
         .unwrap_or(0);
 
     if is_dry_run && total > 0 {
+        // Rebuild the exact command from the preview, preserving all
+        // scope-narrowing flags so the apply doesn't widen the mutation set.
+        let mut args: Vec<&str> = vec!["links", "auto", "--apply"];
+        let min_str;
+        if let Some(ml) = ctx.auto_link_min_length
+            && ml != 3
+        {
+            args.push("--min-length");
+            min_str = ml.to_string();
+            args.push(&min_str);
+        }
+        let cmd = build_command_with_glob(ctx, &args);
+        // Append --file and --exclude-title after the builder (they are not
+        // glob-related and aren't handled by build_command_with_glob).
+        let mut parts = vec![cmd];
+        if let Some(ref f) = ctx.auto_link_file {
+            parts.push(format!("--file {}", shell_quote(f)));
+        }
+        for et in &ctx.auto_link_exclude_titles {
+            parts.push(format!("--exclude-title {}", shell_quote(et)));
+        }
         hints.push(Hint::new(
             format!("Apply {total} auto-links"),
-            build_command_with_glob(ctx, &["links", "auto", "--apply"]),
+            parts.join(" "),
         ));
     }
 

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -43,6 +43,7 @@ pub enum HintSource {
     TaskToggle,
     TaskSetStatus,
     LinksFix,
+    LinksAuto,
     CreateIndex,
     DropIndex,
     Lint,
@@ -168,6 +169,7 @@ pub fn generate_hints(
         HintSource::TaskRead => hints_for_task_read(ctx, data),
         HintSource::TaskToggle | HintSource::TaskSetStatus => hints_for_task_mutation(ctx, data),
         HintSource::LinksFix => hints_for_links_fix(ctx, data),
+        HintSource::LinksAuto => hints_for_links_auto(ctx, data),
         HintSource::CreateIndex => hints_for_create_index(ctx, data),
         HintSource::DropIndex => hints_for_drop_index(ctx, data),
         HintSource::Lint => hints_for_lint(ctx, data, total),
@@ -1311,6 +1313,28 @@ fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
         hints.push(Hint::new(
             "List files with remaining broken links",
             build_command_with_glob(ctx, &["find", "--broken-links"]),
+        ));
+    }
+
+    hints
+}
+
+fn hints_for_links_auto(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let is_dry_run = !data
+        .get("applied")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let total = data
+        .get("total")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    if is_dry_run && total > 0 {
+        hints.push(Hint::new(
+            format!("Apply {total} auto-links"),
+            build_command_with_glob(ctx, &["links", "auto", "--apply"]),
         ));
     }
 

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -388,7 +388,7 @@ const LINKS_FIX_FILTER: &str = r#""Broken links: \(.broken)\nFixable: \(.fixable
 
 /// `LinksAuto result`: `{ambiguous_titles, applied, matches, scanned, total}`
 /// Format: summary line + per-match details.
-const LINKS_AUTO_FILTER: &str = r#""\(.total) unlinked mention\(if .total == 1 then "" else "s" end) found in \(.scanned) file\(if .scanned == 1 then "" else "s" end)\(if (.ambiguous_titles | length) > 0 then " (\(.ambiguous_titles | length) ambiguous title\(if (.ambiguous_titles | length) == 1 then "" else "s" end) skipped)" else "" end)\nApplied: \(if .applied then "yes" else "no" end)\(if (.matches | length) > 0 then "\n\(.matches | map("  \(.file):\(.line)    \"\(.matched_text)\" → [[\(.link_target)]]") | join("\n"))" else "" end)""#;
+const LINKS_AUTO_FILTER: &str = r#""\(.total) unlinked mention\(if .total == 1 then "" else "s" end) found in \(.matches | map(.file) | unique | length) file\(if (.matches | map(.file) | unique | length) == 1 then "" else "s" end) (\(.scanned) scanned)\(if (.ambiguous_titles | length) > 0 then " (\(.ambiguous_titles | length) ambiguous title\(if (.ambiguous_titles | length) == 1 then "" else "s" end) skipped)" else "" end)\nApplied: \(if .applied then "yes" else "no" end)\(if (.matches | length) > 0 then "\n\(.matches | map("  \(.file):\(.line)    \"\(.matched_text)\" → [[\(.link_target)]]") | join("\n"))" else "" end)""#;
 
 /// `MvResult`: `{dry_run, from, to, total_files_updated, total_links_updated, updated_files}`
 /// Format: `[dry-run] Moved <from> → <to>` with list of updated files and replacements.

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -386,6 +386,10 @@ const BACKLINKS_RESULT_FILTER: &str = r#"if (.backlinks | length) == 0 then "No 
 /// Format: summary line with fix status. Includes case-mismatch count when non-zero.
 const LINKS_FIX_FILTER: &str = r#""Broken links: \(.broken)\nFixable: \(.fixable)\nUnfixable: \(.unfixable)\nIgnored: \(.ignored)\(if .case_mismatches > 0 then "\nCase mismatches: \(.case_mismatches)" else "" end)\nApplied: \(if .applied then "yes" else "no" end)\(if (.fixes | length) > 0 then "\n\(.fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\"") | join("\n"))" else "" end)\(if (.case_mismatch_fixes | length) > 0 then "\nCase-mismatch fixes:\n\(.case_mismatch_fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\" [link-case-mismatch]") | join("\n"))" else "" end)""#;
 
+/// `LinksAuto result`: `{ambiguous_titles, applied, matches, scanned, total}`
+/// Format: summary line + per-match details.
+const LINKS_AUTO_FILTER: &str = r#""\(.total) unlinked mention\(if .total == 1 then "" else "s" end) found in \(.scanned) file\(if .scanned == 1 then "" else "s" end)\(if (.ambiguous_titles | length) > 0 then " (\(.ambiguous_titles | length) ambiguous title\(if (.ambiguous_titles | length) == 1 then "" else "s" end) skipped)" else "" end)\nApplied: \(if .applied then "yes" else "no" end)\(if (.matches | length) > 0 then "\n\(.matches | map("  \(.file):\(.line)    \"\(.matched_text)\" → [[\(.link_target)]]") | join("\n"))" else "" end)""#;
+
 /// `MvResult`: `{dry_run, from, to, total_files_updated, total_links_updated, updated_files}`
 /// Format: `[dry-run] Moved <from> → <to>` with list of updated files and replacements.
 const MV_RESULT_FILTER: &str = r#""\(if .dry_run then "[dry-run] " else "" end)Moved \(.from) → \(.to)\(.updated_files | if length > 0 then "\n" + (map("  \(.file): " + (.replacements | map(.old_text + " → " + .new_text) | join(", "))) | join("\n")) else "" end)""#;
@@ -462,6 +466,8 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         "applied,broken,case_mismatch_fixes,case_mismatches,fixable,fixes,ignored,unfixable,unfixable_links" => {
             Some(LINKS_FIX_FILTER)
         }
+        // LinksAuto result
+        "ambiguous_titles,applied,matches,scanned,total" => Some(LINKS_AUTO_FILTER),
         // MvResult
         "dry_run,from,to,total_files_updated,total_links_updated,updated_files" => {
             Some(MV_RESULT_FILTER)

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -48,7 +48,9 @@ fn effective_index_path_for(
             None => None,
         },
         Commands::Links { action } => match action {
-            LinksAction::Fix { index_flags, .. } => Some(index_flags),
+            LinksAction::Fix { index_flags, .. } | LinksAction::Auto { index_flags, .. } => {
+                Some(index_flags)
+            }
         },
         Commands::Task { action } => match action {
             TaskAction::Read { index_flags, .. }
@@ -712,6 +714,12 @@ fn run_inner() -> Result<(), AppError> {
             Commands::Links { action } => match action {
                 crate::cli::args::LinksAction::Fix { apply, glob, .. } => {
                     let mut ctx = HintContext::from_common(HintSource::LinksFix, &common);
+                    ctx.glob.clone_from(glob);
+                    ctx.dry_run = !apply;
+                    Some(ctx)
+                }
+                crate::cli::args::LinksAction::Auto { apply, glob, .. } => {
+                    let mut ctx = HintContext::from_common(HintSource::LinksAuto, &common);
                     ctx.glob.clone_from(glob);
                     ctx.dry_run = !apply;
                     Some(ctx)

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -718,10 +718,20 @@ fn run_inner() -> Result<(), AppError> {
                     ctx.dry_run = !apply;
                     Some(ctx)
                 }
-                crate::cli::args::LinksAction::Auto { apply, glob, .. } => {
+                crate::cli::args::LinksAction::Auto {
+                    apply,
+                    glob,
+                    file,
+                    min_length,
+                    exclude_title,
+                    ..
+                } => {
                     let mut ctx = HintContext::from_common(HintSource::LinksAuto, &common);
                     ctx.glob.clone_from(glob);
                     ctx.dry_run = !apply;
+                    ctx.auto_link_file.clone_from(file);
+                    ctx.auto_link_min_length = Some(*min_length);
+                    ctx.auto_link_exclude_titles.clone_from(exclude_title);
                     Some(ctx)
                 }
             },

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -1206,3 +1206,680 @@ fn case_insensitive_ambiguous_returns_unresolved_on_case_sensitive_fs() {
         "ambiguous case-insensitive match should be unresolved, got: {links:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// links auto
+// ---------------------------------------------------------------------------
+
+/// Run `hyalo links auto` against `dir` with the given extra args, parse the
+/// JSON envelope and return the `results` object.
+fn run_links_auto(dir: &std::path::Path, extra_args: &[&str]) -> serde_json::Value {
+    let mut cmd = hyalo_no_hints();
+    cmd.args([
+        "--dir",
+        dir.to_str().expect("temp path should be valid UTF-8"),
+    ])
+    .args(["links", "auto"])
+    .args(extra_args);
+    let output = cmd.output().expect("hyalo links auto should run");
+    assert!(
+        output.status.success(),
+        "links auto exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    json["results"].clone()
+}
+
+#[test]
+fn links_auto_dry_run_finds_mentions() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint-review.md",
+        md!(r"
+---
+title: Sprint Review
+---
+Sprint review process description.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "meetings.md",
+        md!(r"
+---
+title: Meetings
+---
+We held a Sprint Review last week.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+
+    let total = results["total"]
+        .as_u64()
+        .expect("results.total should be a number");
+    assert!(
+        total >= 1,
+        "expected at least 1 unlinked mention, got {total}"
+    );
+
+    let applied = results["applied"]
+        .as_bool()
+        .expect("results.applied should be a bool");
+    assert!(!applied, "dry-run should report applied=false");
+
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let has_meetings_match = matches.iter().any(|m| {
+        m["file"].as_str() == Some("meetings.md")
+            && m["link_target"].as_str() == Some("sprint-review")
+    });
+    assert!(
+        has_meetings_match,
+        "expected a match in meetings.md with link_target=sprint-review, matches: {matches:?}"
+    );
+}
+
+#[test]
+fn links_auto_apply_writes_wikilinks() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint-review.md",
+        md!(r"
+---
+title: Sprint Review
+---
+Sprint review process description.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "meetings.md",
+        md!(r"
+---
+title: Meetings
+---
+We held a Sprint Review last week.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--apply", "--format", "json"]);
+
+    let applied = results["applied"]
+        .as_bool()
+        .expect("results.applied should be a bool");
+    assert!(applied, "links auto --apply should report applied=true");
+
+    let total = results["total"]
+        .as_u64()
+        .expect("results.total should be a number");
+    assert!(total >= 1, "expected at least 1 applied replacement");
+
+    let meetings_content = fs::read_to_string(tmp.path().join("meetings.md"))
+        .expect("meetings.md should be readable after apply");
+    assert!(
+        meetings_content.contains("[[sprint-review]]"),
+        "meetings.md should contain [[sprint-review]] after apply, got:\n{meetings_content}"
+    );
+    // The bare mention on that line should have been replaced — it must not
+    // appear as plain text followed by a non-bracket character.
+    let bare_mention_still_present = meetings_content
+        .lines()
+        .any(|l| l.contains("Sprint Review") && !l.contains("[[sprint-review]]"));
+    assert!(
+        !bare_mention_still_present,
+        "bare 'Sprint Review' (outside brackets) should be gone after apply, got:\n{meetings_content}"
+    );
+}
+
+#[test]
+fn links_auto_skips_existing_links() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint-review.md",
+        md!(r"
+---
+title: Sprint Review
+---
+Sprint review process description.
+"),
+    );
+    // One already-linked mention and one bare mention on a different line.
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+See [[sprint-review]] here.
+Sprint Review on Friday.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let notes_matches: Vec<_> = matches
+        .iter()
+        .filter(|m| m["file"].as_str() == Some("notes.md"))
+        .collect();
+    assert_eq!(
+        notes_matches.len(),
+        1,
+        "only the unlinked mention on the second line should match, got: {notes_matches:?}"
+    );
+}
+
+#[test]
+fn links_auto_skips_code_blocks() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "config.md",
+        md!(r"
+---
+title: Config
+---
+Configuration reference.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "docs.md",
+        md!(r"
+---
+title: Docs
+---
+```
+Config details go here
+```
+See Config for more information.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+
+    // Only the mention outside the code block should match.
+    let docs_matches: Vec<_> = matches
+        .iter()
+        .filter(|m| m["file"].as_str() == Some("docs.md"))
+        .collect();
+
+    // Line numbers inside the fenced block should not appear.
+    let has_code_block_match = docs_matches.iter().any(|m| {
+        // Lines 4 and 5 (1-based) are inside the fence; line 7 is outside.
+        m["line"].as_u64().is_some_and(|l| (4..=5).contains(&l))
+    });
+    assert!(
+        !has_code_block_match,
+        "matches inside code block should be skipped, docs matches: {docs_matches:?}"
+    );
+
+    // There should be exactly one match: the outside mention.
+    assert_eq!(
+        docs_matches.len(),
+        1,
+        "only the mention outside the code block should match, got: {docs_matches:?}"
+    );
+}
+
+#[test]
+fn links_auto_skips_headings() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "alpha.md",
+        md!(r"
+---
+title: Alpha
+---
+Alpha documentation.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "page.md",
+        md!(r"
+---
+title: Page
+---
+# Alpha Section
+Alpha is great.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+
+    let page_matches: Vec<_> = matches
+        .iter()
+        .filter(|m| m["file"].as_str() == Some("page.md"))
+        .collect();
+
+    // The heading line (# Alpha Section) should be skipped; only the body
+    // line "Alpha is great." should produce a match.
+    assert_eq!(
+        page_matches.len(),
+        1,
+        "only the body-text mention should match (not the heading), got: {page_matches:?}"
+    );
+    // The match must be on the body line (line 5, "Alpha is great.") and NOT
+    // on the heading line (line 4, "# Alpha Section").
+    let match_line = page_matches[0]["line"]
+        .as_u64()
+        .expect("match.line should be a number");
+    assert!(
+        match_line > 4,
+        "match should be on the body line after the heading, got line {match_line}"
+    );
+}
+
+#[test]
+fn links_auto_skips_self_links() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint-review.md",
+        md!(r"
+---
+title: Sprint Review
+---
+This Sprint Review process is important.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+
+    let total = results["total"]
+        .as_u64()
+        .expect("results.total should be a number");
+    assert_eq!(
+        total, 0,
+        "a file should not generate a self-link, got total={total}"
+    );
+}
+
+#[test]
+fn links_auto_min_length_filter() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+Single character title.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "beta.md",
+        md!(r"
+---
+title: Beta
+---
+Beta documentation.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "page.md",
+        md!(r"
+---
+title: Page
+---
+A and Beta are both mentioned here.
+"),
+    );
+
+    // With default --min-length 3, only "Beta" (len 4) should match.
+    let results_default = run_links_auto(tmp.path(), &["--format", "json"]);
+    let matches_default = results_default["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let page_default: Vec<_> = matches_default
+        .iter()
+        .filter(|m| m["file"].as_str() == Some("page.md"))
+        .collect();
+    let has_beta_default = page_default
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("beta"));
+    let has_a_default = page_default
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("a"));
+    assert!(
+        has_beta_default,
+        "Beta should match with default min-length, matches: {page_default:?}"
+    );
+    assert!(
+        !has_a_default,
+        "single-char title 'A' should be filtered by default min-length=3, matches: {page_default:?}"
+    );
+
+    // With --min-length 1, "A" should also match.
+    let results_min1 = run_links_auto(tmp.path(), &["--min-length", "1", "--format", "json"]);
+    let matches_min1 = results_min1["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let page_min1: Vec<_> = matches_min1
+        .iter()
+        .filter(|m| m["file"].as_str() == Some("page.md"))
+        .collect();
+    let has_a_min1 = page_min1
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("a"));
+    assert!(
+        has_a_min1,
+        "single-char title 'A' should match with --min-length 1, matches: {page_min1:?}"
+    );
+}
+
+#[test]
+fn links_auto_exclude_title() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint-review.md",
+        md!(r"
+---
+title: Sprint Review
+---
+Sprint review process.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "daily.md",
+        md!(r"
+---
+title: Daily
+---
+Daily standup notes.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "page.md",
+        md!(r"
+---
+title: Page
+---
+Sprint Review and Daily are both mentioned.
+"),
+    );
+
+    let results = run_links_auto(
+        tmp.path(),
+        &["--exclude-title", "Sprint Review", "--format", "json"],
+    );
+
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let has_sprint_review = matches
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("sprint-review"));
+    let has_daily = matches
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("daily"));
+
+    assert!(
+        !has_sprint_review,
+        "Sprint Review should be excluded via --exclude-title, matches: {matches:?}"
+    );
+    assert!(
+        has_daily,
+        "Daily should still match (not excluded), matches: {matches:?}"
+    );
+}
+
+#[test]
+fn links_auto_text_format() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint-review.md",
+        md!(r"
+---
+title: Sprint Review
+---
+Sprint review process.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+Sprint Review happened last week.
+"),
+    );
+
+    let mut cmd = hyalo_no_hints();
+    cmd.args([
+        "--dir",
+        tmp.path()
+            .to_str()
+            .expect("temp path should be valid UTF-8"),
+        "links",
+        "auto",
+        "--format",
+        "text",
+    ]);
+    let output = cmd
+        .output()
+        .expect("hyalo links auto --format text should run");
+    assert!(
+        output.status.success(),
+        "links auto --format text exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let text = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+
+    assert!(
+        text.to_lowercase().contains("unlinked mention"),
+        "text output should contain 'unlinked mention', got:\n{text}"
+    );
+    assert!(
+        text.contains("Applied: no"),
+        "dry-run text output should contain 'Applied: no', got:\n{text}"
+    );
+    assert!(
+        text.contains('\u{2192}'),
+        "text output should contain the → arrow in match lines, got:\n{text}"
+    );
+}
+
+#[test]
+fn links_auto_ambiguous_titles_skipped() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    // Two files with the same title — the title is ambiguous.
+    write_md(
+        tmp.path(),
+        "alpha.md",
+        md!(r"
+---
+title: Common Title
+---
+First file.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "beta.md",
+        md!(r"
+---
+title: Common Title
+---
+Second file.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "page.md",
+        md!(r"
+---
+title: Page
+---
+See Common Title here.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+
+    let total = results["total"]
+        .as_u64()
+        .expect("results.total should be a number");
+    assert_eq!(
+        total, 0,
+        "ambiguous title should produce no matches, got total={total}"
+    );
+
+    let ambiguous = results["ambiguous_titles"]
+        .as_array()
+        .expect("results.ambiguous_titles should be an array");
+    assert!(
+        !ambiguous.is_empty(),
+        "ambiguous_titles should be non-empty when two files share the same title"
+    );
+}
+
+#[test]
+fn links_auto_word_boundaries() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint.md",
+        md!(r"
+---
+title: Sprint
+---
+Sprint documentation.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "page.md",
+        md!(r"
+---
+title: Page
+---
+Sprinting fast. Sprint starts Monday.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let page_matches: Vec<_> = matches
+        .iter()
+        .filter(|m| m["file"].as_str() == Some("page.md"))
+        .collect();
+
+    // Only the standalone "Sprint" word should match, not "Sprint" inside "Sprinting".
+    assert_eq!(
+        page_matches.len(),
+        1,
+        "only standalone 'Sprint' should match (not inside 'Sprinting'), got: {page_matches:?}"
+    );
+    let matched_text = page_matches[0]["matched_text"]
+        .as_str()
+        .expect("match.matched_text should be a string");
+    assert_eq!(
+        matched_text.to_ascii_lowercase(),
+        "sprint",
+        "matched text should be 'sprint', got: {matched_text}"
+    );
+}
+
+#[test]
+fn links_auto_glob_filter() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sprint-review.md",
+        md!(r"
+---
+title: Sprint Review
+---
+Sprint review process.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "meetings/weekly.md",
+        md!(r"
+---
+title: Weekly Meeting
+---
+We covered Sprint Review in this session.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "other.md",
+        md!(r"
+---
+title: Other
+---
+Sprint Review was also mentioned here.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--glob", "meetings/*", "--format", "json"]);
+
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+
+    // Only meetings/weekly.md should appear in the matches.
+    let has_weekly = matches
+        .iter()
+        .any(|m| m["file"].as_str() == Some("meetings/weekly.md"));
+    let has_other = matches
+        .iter()
+        .any(|m| m["file"].as_str() == Some("other.md"));
+
+    assert!(
+        has_weekly,
+        "meetings/weekly.md should have matches when glob=meetings/*, matches: {matches:?}"
+    );
+    assert!(
+        !has_other,
+        "other.md should be excluded by the glob filter, matches: {matches:?}"
+    );
+}

--- a/crates/hyalo-core/Cargo.toml
+++ b/crates/hyalo-core/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["parser-implementations"]
 workspace = true
 
 [dependencies]
+aho-corasick = { workspace = true }
 anyhow = { workspace = true }
 dunce = { workspace = true }
 globset = { workspace = true }

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -1,0 +1,892 @@
+//! Auto-link: scan markdown body text for unlinked mentions of known page
+//! titles and propose (or apply) `[[wikilink]]` replacements.
+//!
+//! The public entry point is [`auto_link`].
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use aho_corasick::{AhoCorasick, MatchKind};
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::discovery::match_globs;
+use crate::fs_util::atomic_write;
+use crate::index::{IndexEntry, VaultIndex};
+use crate::links::extract_link_spans_with_original;
+use crate::scanner::{FenceTracker, is_comment_fence, strip_inline_code, strip_inline_comments};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A single proposed auto-link replacement.
+#[derive(Debug, Clone, Serialize)]
+pub struct AutoLinkMatch {
+    /// Vault-relative path of the file containing the unlinked mention.
+    pub file: String,
+    /// 1-based line number.
+    pub line: usize,
+    /// Column offset (0-based byte offset within the line).
+    pub col: usize,
+    /// The matched text as it appears in the file.
+    pub matched_text: String,
+    /// The wikilink target (file stem or title) to link to.
+    pub link_target: String,
+}
+
+/// Result of the auto-link scan.
+#[derive(Debug, Serialize)]
+pub struct AutoLinkReport {
+    /// Number of files scanned.
+    pub scanned: usize,
+    /// Total number of proposed auto-link replacements.
+    pub total: usize,
+    /// The proposed replacements, grouped or flat.
+    pub matches: Vec<AutoLinkMatch>,
+    /// Titles that were skipped due to ambiguity (multiple files share the
+    /// same title).
+    pub ambiguous_titles: Vec<String>,
+    /// Whether changes were applied to disk.
+    pub applied: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/// One entry in the title inventory: maps a lowercased title to the
+/// wikilink target and the source file (to detect self-links).
+#[derive(Debug)]
+struct TitleEntry {
+    /// The wikilink target: the filename stem (without `.md`, without dir).
+    link_target: String,
+    /// The source file's vault-relative path (to detect self-links).
+    source_rel: String,
+}
+
+// ---------------------------------------------------------------------------
+// Title inventory builder
+// ---------------------------------------------------------------------------
+
+/// Build a title inventory from index entries.
+///
+/// Returns `(title_to_target map, ambiguous_titles list)`.
+/// `title_to_target` maps `lowercased_title` → `TitleEntry`.
+/// When two different files produce the same lowercased title the entry is
+/// removed and the title is placed in `ambiguous_titles`.
+fn build_title_inventory(
+    entries: &[IndexEntry],
+    min_length: usize,
+    exclude_titles: &[String],
+) -> (HashMap<String, TitleEntry>, Vec<String>) {
+    let exclude_lower: Vec<String> = exclude_titles
+        .iter()
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+
+    // Track ambiguity: a title key that maps to `None` was seen from 2+ different source files.
+    let mut map: HashMap<String, Option<TitleEntry>> = HashMap::new();
+    let mut ambiguous: Vec<String> = Vec::new();
+
+    let mut try_insert = |title: &str, entry: TitleEntry| {
+        if title.len() < min_length {
+            return;
+        }
+        let key = title.to_ascii_lowercase();
+        if exclude_lower.contains(&key) {
+            return;
+        }
+        match map.get(&key) {
+            None => {
+                map.insert(key, Some(entry));
+            }
+            Some(Some(existing)) if existing.source_rel != entry.source_rel => {
+                // Conflict: two different files produce the same lowercased title.
+                ambiguous.push(title.to_owned());
+                map.insert(key, None);
+            }
+            Some(_) => {
+                // Same source file — keep whichever was first (stem usually wins,
+                // but the order of iteration doesn't matter for correctness).
+            }
+        }
+    };
+
+    for entry in entries {
+        let rel = &entry.rel_path;
+
+        // 1. Filename stem.
+        let stem = stem_from_rel(rel);
+        try_insert(
+            stem,
+            TitleEntry {
+                link_target: stem.to_owned(),
+                source_rel: rel.clone(),
+            },
+        );
+
+        // 2. Frontmatter `title` property.
+        if let Some(title_val) = entry.properties.get("title")
+            && let Some(title_str) = title_val.as_str()
+        {
+            let title_str = title_str.trim();
+            if !title_str.is_empty() {
+                try_insert(
+                    title_str,
+                    TitleEntry {
+                        link_target: stem.to_owned(),
+                        source_rel: rel.clone(),
+                    },
+                );
+            }
+        }
+
+        // 3. Frontmatter `aliases` property (list of alternate names).
+        if let Some(aliases_val) = entry.properties.get("aliases") {
+            let aliases: Vec<&str> = if let Some(arr) = aliases_val.as_array() {
+                arr.iter().filter_map(|v| v.as_str()).collect()
+            } else if let Some(s) = aliases_val.as_str() {
+                // YAML scalar: treat as a single alias.
+                vec![s]
+            } else {
+                vec![]
+            };
+
+            for alias in aliases {
+                let alias = alias.trim();
+                if !alias.is_empty() {
+                    try_insert(
+                        alias,
+                        TitleEntry {
+                            link_target: stem.to_owned(),
+                            source_rel: rel.clone(),
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    // Flatten: keep only unambiguous entries.
+    let title_map: HashMap<String, TitleEntry> = map
+        .into_iter()
+        .filter_map(|(k, v)| v.map(|entry| (k, entry)))
+        .collect();
+
+    (title_map, ambiguous)
+}
+
+/// Extract the filename stem from a vault-relative path.
+///
+/// `"notes/sprint-planning.md"` → `"sprint-planning"`.
+fn stem_from_rel(rel: &str) -> &str {
+    let fname = rel.rsplit('/').next().unwrap_or(rel);
+    if fname.len() > 3
+        && fname
+            .as_bytes()
+            .get(fname.len() - 3..)
+            .is_some_and(|s| s.eq_ignore_ascii_case(b".md"))
+    {
+        &fname[..fname.len() - 3]
+    } else {
+        fname
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Word boundary helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the byte at position `idx` in `s` is NOT an
+/// alphanumeric ASCII character or underscore.
+///
+/// If `idx` is out of bounds (i.e. at the start/end of the string), that
+/// boundary is considered to be a word boundary (returns `true`).
+fn is_word_boundary_byte(s: &str, idx: usize) -> bool {
+    match s.as_bytes().get(idx) {
+        None => true,
+        Some(&b) => !b.is_ascii_alphanumeric() && b != b'_',
+    }
+}
+
+/// Verify that a match at `[start, end)` in `line` sits on word boundaries.
+fn has_word_boundaries(line: &str, start: usize, end: usize) -> bool {
+    // The byte before `start` (if any).
+    let before_ok = if start == 0 {
+        true
+    } else {
+        is_word_boundary_byte(line, start - 1)
+    };
+    // The byte at `end` (first byte after the match).
+    let after_ok = is_word_boundary_byte(line, end);
+    before_ok && after_ok
+}
+
+// ---------------------------------------------------------------------------
+// Scanning helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `[match_start, match_end)` overlaps any link span in `spans`.
+fn overlaps_any_link(
+    spans: &[crate::links::LinkSpan],
+    match_start: usize,
+    match_end: usize,
+) -> bool {
+    spans
+        .iter()
+        .any(|s| match_start < s.full_end && match_end > s.full_start)
+}
+
+// ---------------------------------------------------------------------------
+// Main public function
+// ---------------------------------------------------------------------------
+
+/// Scan the vault for unlinked mentions of known page titles.
+///
+/// When `apply` is true, write the `[[wikilinks]]` into the files.
+/// When false (dry-run), just report what would change.
+pub fn auto_link(
+    index: &dyn VaultIndex,
+    dir: &Path,
+    apply: bool,
+    min_length: usize,
+    exclude_titles: &[String],
+    file_filter: Option<&str>,
+    glob_filter: &[String],
+) -> Result<AutoLinkReport> {
+    let entries = index.entries();
+
+    // 1. Build the title inventory.
+    let (title_map, ambiguous_titles) = build_title_inventory(entries, min_length, exclude_titles);
+
+    if title_map.is_empty() {
+        return Ok(AutoLinkReport {
+            scanned: 0,
+            total: 0,
+            matches: Vec::new(),
+            ambiguous_titles,
+            applied: false,
+        });
+    }
+
+    // 2. Build the Aho-Corasick automaton.
+    //    We need to keep track of which pattern index maps to which TitleEntry.
+    //    Sort for determinism.
+    let mut patterns_sorted: Vec<(&str, &TitleEntry)> =
+        title_map.iter().map(|(k, v)| (k.as_str(), v)).collect();
+    patterns_sorted.sort_by_key(|(k, _)| *k);
+
+    let ac = AhoCorasick::builder()
+        .match_kind(MatchKind::LeftmostLongest)
+        .ascii_case_insensitive(true)
+        .build(patterns_sorted.iter().map(|(k, _)| k))
+        .context("failed to build Aho-Corasick automaton")?;
+
+    // 3. Determine which files to scan (respecting file_filter and glob_filter).
+    let all_paths: Vec<PathBuf> = entries.iter().map(|e| dir.join(&e.rel_path)).collect();
+
+    let paths_to_scan: Vec<(PathBuf, String)> = if !glob_filter.is_empty() {
+        match_globs(dir, &all_paths, glob_filter)?
+    } else if let Some(filter) = file_filter {
+        let filter_lower = filter.to_ascii_lowercase();
+        entries
+            .iter()
+            .filter(|e| e.rel_path.to_ascii_lowercase().contains(&filter_lower))
+            .map(|e| (dir.join(&e.rel_path), e.rel_path.clone()))
+            .collect()
+    } else {
+        entries
+            .iter()
+            .map(|e| (dir.join(&e.rel_path), e.rel_path.clone()))
+            .collect()
+    };
+
+    // 4. Scan each file.
+    let mut all_matches: Vec<AutoLinkMatch> = Vec::new();
+    let scanned = paths_to_scan.len();
+
+    for (abs_path, rel_path) in &paths_to_scan {
+        let content = std::fs::read_to_string(abs_path)
+            .with_context(|| format!("failed to read {}", abs_path.display()))?;
+
+        let file_matches = scan_file_for_matches(&content, rel_path, &ac, &patterns_sorted);
+
+        all_matches.extend(file_matches);
+    }
+
+    // 5. Apply changes if requested.
+    if apply {
+        apply_matches(dir, &all_matches)?;
+    }
+
+    let total = all_matches.len();
+    Ok(AutoLinkReport {
+        scanned,
+        total,
+        matches: all_matches,
+        ambiguous_titles,
+        applied: apply,
+    })
+}
+
+/// Scan a single file's content for unlinked title mentions, returning all
+/// proposed [`AutoLinkMatch`] values.
+fn scan_file_for_matches(
+    content: &str,
+    rel_path: &str,
+    ac: &AhoCorasick,
+    patterns_sorted: &[(&str, &TitleEntry)],
+) -> Vec<AutoLinkMatch> {
+    let mut results = Vec::new();
+
+    let mut fence = FenceTracker::new();
+    let mut in_comment_fence = false;
+    let mut in_frontmatter = false;
+    let mut frontmatter_done = false;
+    let mut line_num = 0usize;
+
+    for line in content.split('\n') {
+        line_num += 1;
+
+        // ---- Frontmatter handling ----
+        if !frontmatter_done {
+            if line_num == 1 && line.trim() == "---" {
+                in_frontmatter = true;
+                continue;
+            }
+            if in_frontmatter {
+                if line.trim() == "---" {
+                    in_frontmatter = false;
+                    frontmatter_done = true;
+                }
+                continue;
+            }
+            // No frontmatter block; mark done.
+            frontmatter_done = true;
+        }
+
+        // ---- Comment fence (Obsidian %% blocks) ----
+        if is_comment_fence(line) {
+            in_comment_fence = !in_comment_fence;
+            continue;
+        }
+        if in_comment_fence {
+            continue;
+        }
+
+        // ---- Fenced code block ----
+        if fence.process_line(line) {
+            continue;
+        }
+
+        // ---- Skip heading lines ----
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+
+        // ---- Strip inline code and inline comments ----
+        let stripped_code = strip_inline_code(line);
+        let cleaned = strip_inline_comments(stripped_code.as_ref());
+        let cleaned_str: &str = cleaned.as_ref();
+
+        // ---- Extract existing link spans to avoid overlapping them ----
+        let link_spans = extract_link_spans_with_original(cleaned_str, line);
+
+        // ---- Run Aho-Corasick on the cleaned line ----
+        for mat in ac.find_iter(cleaned_str) {
+            let start = mat.start();
+            let end = mat.end();
+            let pat_idx = mat.pattern().as_usize();
+            let (_, entry) = patterns_sorted[pat_idx];
+
+            // Self-link check: skip if the match belongs to the current file.
+            if entry.source_rel == rel_path {
+                continue;
+            }
+
+            // Word boundary check.
+            if !has_word_boundaries(cleaned_str, start, end) {
+                continue;
+            }
+
+            // Existing link overlap check.
+            if overlaps_any_link(&link_spans, start, end) {
+                continue;
+            }
+
+            // Use original line text for the matched_text (preserves casing).
+            let matched_text = line.get(start..end).unwrap_or(&cleaned_str[start..end]);
+
+            results.push(AutoLinkMatch {
+                file: rel_path.to_owned(),
+                line: line_num,
+                col: start,
+                matched_text: matched_text.to_owned(),
+                link_target: entry.link_target.clone(),
+            });
+        }
+    }
+
+    results
+}
+
+// ---------------------------------------------------------------------------
+// Apply changes
+// ---------------------------------------------------------------------------
+
+/// Apply a batch of matches to the vault by rewriting files atomically.
+///
+/// For each file with matches, reads the content, applies all replacements
+/// from end to start (to preserve byte offsets), then writes back.
+fn apply_matches(dir: &Path, matches: &[AutoLinkMatch]) -> Result<()> {
+    // Group matches by file.
+    let mut by_file: HashMap<&str, Vec<&AutoLinkMatch>> = HashMap::new();
+    for m in matches {
+        by_file.entry(&m.file).or_default().push(m);
+    }
+
+    for (rel_path, file_matches) in by_file {
+        let abs_path = dir.join(rel_path);
+        let content = std::fs::read_to_string(&abs_path)
+            .with_context(|| format!("failed to read {} for apply", abs_path.display()))?;
+
+        // Build per-line replacements: (line_idx (0-based), col, matched_text, link_target).
+        // We need to apply them from last to first within each line (and last to first line).
+        // Sort descending by (line, col).
+        let mut sorted_matches: Vec<&AutoLinkMatch> = file_matches;
+        sorted_matches.sort_by(|a, b| b.line.cmp(&a.line).then(b.col.cmp(&a.col)));
+
+        // Work on a per-line basis. We need to reconstruct the full content after edits.
+        // Split lines while preserving line endings.
+        let mut lines: Vec<String> = split_lines_preserving_endings(&content);
+
+        for m in sorted_matches {
+            let line_idx = m.line.saturating_sub(1);
+            if let Some(line) = lines.get_mut(line_idx) {
+                let start = m.col;
+                let end = start + m.matched_text.len();
+                if end <= line.len() && line.get(start..end) == Some(&m.matched_text) {
+                    let replacement = format!("[[{}]]", m.link_target);
+                    line.replace_range(start..end, &replacement);
+                }
+            }
+        }
+
+        let new_content = lines.concat();
+        atomic_write(&abs_path, new_content.as_bytes())
+            .with_context(|| format!("failed to write {}", abs_path.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Split content into lines while preserving line endings (`\n` or `\r\n`).
+///
+/// This allows `concat()` of the result to reconstruct the original content
+/// byte-for-byte (modulo applied replacements).
+fn split_lines_preserving_endings(content: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut remaining = content;
+    while let Some(pos) = remaining.find('\n') {
+        // Include the `\n` (and possible preceding `\r`) in the line string.
+        lines.push(remaining[..=pos].to_owned());
+        remaining = &remaining[pos + 1..];
+    }
+    if !remaining.is_empty() {
+        lines.push(remaining.to_owned());
+    }
+    lines
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::{IndexEntry, VaultIndex};
+    use crate::link_graph::LinkGraph;
+    use indexmap::IndexMap;
+    use serde_json::Value;
+    use tempfile::TempDir;
+
+    // ---- Mock VaultIndex ----
+
+    struct MockIndex {
+        entries: Vec<IndexEntry>,
+        graph: LinkGraph,
+    }
+
+    impl MockIndex {
+        fn new(entries: Vec<IndexEntry>) -> Self {
+            Self {
+                entries,
+                graph: LinkGraph::default(),
+            }
+        }
+    }
+
+    impl VaultIndex for MockIndex {
+        fn entries(&self) -> &[IndexEntry] {
+            &self.entries
+        }
+
+        fn get(&self, rel_path: &str) -> Option<&IndexEntry> {
+            self.entries.iter().find(|e| e.rel_path == rel_path)
+        }
+
+        fn link_graph(&self) -> &LinkGraph {
+            &self.graph
+        }
+    }
+
+    // ---- Builder helpers ----
+
+    fn make_entry(rel_path: &str, props: Vec<(&str, Value)>) -> IndexEntry {
+        let mut properties = IndexMap::new();
+        for (k, v) in props {
+            properties.insert(k.to_owned(), v);
+        }
+        IndexEntry {
+            rel_path: rel_path.to_owned(),
+            modified: String::new(),
+            properties,
+            tags: Vec::new(),
+            sections: Vec::new(),
+            tasks: Vec::new(),
+            links: Vec::new(),
+            bm25_tokens: None,
+            bm25_language: None,
+        }
+    }
+
+    /// Write a file to a temp dir and return its abs path.
+    fn write_file(dir: &TempDir, rel: &str, content: &str) -> PathBuf {
+        let path = dir.path().join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    // ---- Tests ----
+
+    #[test]
+    fn test_title_inventory_basic() {
+        let entries = vec![make_entry(
+            "sprint-planning.md",
+            vec![
+                ("title", Value::String("Sprint Planning".to_owned())),
+                (
+                    "aliases",
+                    Value::Array(vec![Value::String("SP".to_owned())]),
+                ),
+            ],
+        )];
+        let (map, ambiguous) = build_title_inventory(&entries, 2, &[]);
+        assert!(ambiguous.is_empty());
+        // Stem
+        assert!(map.contains_key("sprint-planning"), "stem missing");
+        // Title
+        assert!(map.contains_key("sprint planning"), "title missing");
+        // Alias "SP" (len 2 >= min_length 2)
+        assert!(map.contains_key("sp"), "alias missing");
+
+        let title_entry = map.get("sprint planning").unwrap();
+        assert_eq!(title_entry.link_target, "sprint-planning");
+        assert_eq!(title_entry.source_rel, "sprint-planning.md");
+    }
+
+    #[test]
+    fn test_title_inventory_ambiguous() {
+        let entries = vec![
+            make_entry(
+                "planning/sprint.md",
+                vec![("title", Value::String("Sprint".to_owned()))],
+            ),
+            make_entry(
+                "notes/sprint.md",
+                vec![("title", Value::String("Sprint".to_owned()))],
+            ),
+        ];
+        let (map, ambiguous) = build_title_inventory(&entries, 3, &[]);
+        // Both "sprint.md" produce the same stem "sprint" and same title "sprint"
+        assert!(
+            !map.contains_key("sprint"),
+            "ambiguous title should be absent from map"
+        );
+        assert!(!ambiguous.is_empty(), "should have ambiguous entries");
+    }
+
+    #[test]
+    fn test_title_inventory_min_length() {
+        let entries = vec![make_entry(
+            "go.md",
+            vec![("title", Value::String("Go".to_owned()))],
+        )];
+        // min_length = 3: "go" (len 2) should be filtered
+        let (map, _) = build_title_inventory(&entries, 3, &[]);
+        assert!(!map.contains_key("go"), "short title should be filtered");
+    }
+
+    #[test]
+    fn test_title_inventory_exclude() {
+        let entries = vec![make_entry(
+            "the.md",
+            vec![("title", Value::String("The".to_owned()))],
+        )];
+        let (map, _) = build_title_inventory(&entries, 2, &["the".to_owned(), "The".to_owned()]);
+        assert!(!map.contains_key("the"), "excluded title should not appear");
+    }
+
+    #[test]
+    fn test_word_boundary() {
+        // "Sprint" should not match inside "Sprinting"
+        let entry = make_entry(
+            "sprint.md",
+            vec![("title", Value::String("Sprint".to_owned()))],
+        );
+        let other = make_entry("other.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "sprint.md", "---\ntitle: Sprint\n---\n");
+        write_file(&tmp, "other.md", "Sprinting is fun but Sprint is better.\n");
+
+        let index = MockIndex::new(vec![entry, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("other.md"), &[]).unwrap();
+
+        let matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.matched_text == "Sprint")
+            .collect();
+        // "Sprint" at the beginning of "Sprinting" should NOT match (no word boundary after)
+        // "Sprint" as standalone word SHOULD match
+        assert_eq!(matches.len(), 1, "only standalone 'Sprint' should match");
+        assert_eq!(matches[0].matched_text, "Sprint");
+    }
+
+    #[test]
+    fn test_skip_headings() {
+        let page = make_entry(
+            "sprint-planning.md",
+            vec![("title", Value::String("Sprint Planning".to_owned()))],
+        );
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "sprint-planning.md", "# Sprint Planning\n");
+        write_file(
+            &tmp,
+            "notes.md",
+            "## Sprint Planning\n\nSee Sprint Planning for details.\n",
+        );
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        // Heading line should be skipped; body line should match.
+        assert_eq!(
+            report.matches.len(),
+            1,
+            "only the body mention should match"
+        );
+        assert_eq!(report.matches[0].line, 3);
+    }
+
+    #[test]
+    fn test_skip_code_blocks() {
+        let page = make_entry("target.md", vec![]);
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "target.md", "");
+        write_file(
+            &tmp,
+            "notes.md",
+            "```\ntarget text mentioning target\n```\n",
+        );
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        // Matches inside fenced code block should be skipped.
+        assert!(
+            report.matches.is_empty(),
+            "code block content should not match"
+        );
+    }
+
+    #[test]
+    fn test_skip_inline_code() {
+        let page = make_entry("target.md", vec![]);
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "target.md", "");
+        write_file(&tmp, "notes.md", "Use `target` sparingly.\n");
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        assert!(
+            report.matches.is_empty(),
+            "inline code span should not match"
+        );
+    }
+
+    #[test]
+    fn test_skip_existing_links() {
+        let page = make_entry("target.md", vec![]);
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "target.md", "");
+        write_file(
+            &tmp,
+            "notes.md",
+            "See [[target]] and [target](target.md) for details.\n",
+        );
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        assert!(
+            report.matches.is_empty(),
+            "matches overlapping existing links should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_skip_self_links() {
+        let page = make_entry(
+            "sprint.md",
+            vec![("title", Value::String("Sprint".to_owned()))],
+        );
+        let tmp = TempDir::new().unwrap();
+        write_file(
+            &tmp,
+            "sprint.md",
+            "---\ntitle: Sprint\n---\n\nThis is the Sprint page.\n",
+        );
+
+        let index = MockIndex::new(vec![page]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("sprint.md"), &[]).unwrap();
+
+        assert!(
+            report.matches.is_empty(),
+            "self-links (file's own title in its own body) should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let page = make_entry("target.md", vec![]);
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "target.md", "");
+        write_file(&tmp, "notes.md", "See Target or TARGET or target here.\n");
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        assert_eq!(report.matches.len(), 3, "all case variants should match");
+    }
+
+    #[test]
+    fn test_longest_match() {
+        // "Sprint Planning" should win over "Sprint" when both are in inventory.
+        let sprint = make_entry(
+            "sprint.md",
+            vec![("title", Value::String("Sprint".to_owned()))],
+        );
+        let sp = make_entry(
+            "sprint-planning.md",
+            vec![("title", Value::String("Sprint Planning".to_owned()))],
+        );
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "sprint.md", "");
+        write_file(&tmp, "sprint-planning.md", "");
+        write_file(&tmp, "notes.md", "Sprint Planning kicks off tomorrow.\n");
+
+        let index = MockIndex::new(vec![sprint, sp, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        // Should produce exactly one match: "Sprint Planning"
+        assert_eq!(report.matches.len(), 1);
+        assert_eq!(report.matches[0].matched_text, "Sprint Planning");
+        assert_eq!(report.matches[0].link_target, "sprint-planning");
+    }
+
+    #[test]
+    fn test_skip_frontmatter() {
+        let page = make_entry("target.md", vec![]);
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "target.md", "");
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: target mentions\n---\n\nNo mention in body.\n",
+        );
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        // Frontmatter content should be skipped.
+        assert!(
+            report.matches.is_empty(),
+            "frontmatter mentions should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_skip_comment_fences() {
+        let page = make_entry("target.md", vec![]);
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "target.md", "");
+        write_file(
+            &tmp,
+            "notes.md",
+            "%%\ntarget is mentioned here inside comment\n%%\n",
+        );
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+
+        assert!(
+            report.matches.is_empty(),
+            "comment fence blocks should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_apply_writes_wikilinks() {
+        let page = make_entry("target.md", vec![]);
+        let other = make_entry("notes.md", vec![]);
+        let tmp = TempDir::new().unwrap();
+        write_file(&tmp, "target.md", "");
+        write_file(&tmp, "notes.md", "See target for details.\n");
+
+        let index = MockIndex::new(vec![page, other]);
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            true, // apply
+            3,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(report.matches.len(), 1);
+        assert!(report.applied);
+
+        let written = std::fs::read_to_string(tmp.path().join("notes.md")).unwrap();
+        assert!(
+            written.contains("[[target]]"),
+            "written content should contain wikilink: {written}"
+        );
+    }
+}

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -14,7 +14,9 @@ use crate::discovery::match_globs;
 use crate::fs_util::atomic_write;
 use crate::index::{IndexEntry, VaultIndex};
 use crate::links::extract_link_spans_with_original;
-use crate::scanner::{FenceTracker, is_comment_fence, strip_inline_code, strip_inline_comments};
+use crate::scanner::{
+    FenceTracker, MAX_FILE_SIZE, is_comment_fence, strip_inline_code, strip_inline_comments,
+};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -169,10 +171,37 @@ fn build_title_inventory(
     }
 
     // Flatten: keep only unambiguous entries.
-    let title_map: HashMap<String, TitleEntry> = map
+    let mut title_map: HashMap<String, TitleEntry> = map
         .into_iter()
         .filter_map(|(k, v)| v.map(|entry| (k, entry)))
         .collect();
+
+    // Second pass: a `link_target` (stem) that maps to 2+ different source
+    // files is ambiguous even when the *title keys* are distinct.  For
+    // example, `projects/apple.md` (title "Apple Inc") and
+    // `companies/apple.md` (title "Apple Company") both generate
+    // `link_target = "apple"` — emitting `[[apple]]` would be wrong.
+    let mut target_sources: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
+    for entry in title_map.values() {
+        target_sources
+            .entry(entry.link_target.clone())
+            .or_default()
+            .insert(entry.source_rel.clone());
+    }
+    let ambiguous_targets: std::collections::HashSet<String> = target_sources
+        .into_iter()
+        .filter(|(_, sources)| sources.len() > 1)
+        .map(|(target, _)| target)
+        .collect();
+
+    if !ambiguous_targets.is_empty() {
+        title_map.retain(|_, entry| !ambiguous_targets.contains(&entry.link_target));
+        for target in &ambiguous_targets {
+            if !ambiguous.iter().any(|a| a.eq_ignore_ascii_case(target)) {
+                ambiguous.push(target.clone());
+            }
+        }
+    }
 
     (title_map, ambiguous)
 }
@@ -289,10 +318,11 @@ pub fn auto_link(
     let paths_to_scan: Vec<(PathBuf, String)> = if !glob_filter.is_empty() {
         match_globs(dir, &all_paths, glob_filter)?
     } else if let Some(filter) = file_filter {
-        let filter_lower = filter.to_ascii_lowercase();
+        // Exact vault-relative path match (normalise separators for Windows).
+        let normalised = filter.replace('\\', "/");
         entries
             .iter()
-            .filter(|e| e.rel_path.to_ascii_lowercase().contains(&filter_lower))
+            .filter(|e| e.rel_path == normalised)
             .map(|e| (dir.join(&e.rel_path), e.rel_path.clone()))
             .collect()
     } else {
@@ -307,6 +337,19 @@ pub fn auto_link(
     let scanned = paths_to_scan.len();
 
     for (abs_path, rel_path) in &paths_to_scan {
+        // Enforce the same size cap used elsewhere (scanner, link_fix, etc.).
+        if let Ok(meta) = std::fs::metadata(abs_path)
+            && meta.len() > MAX_FILE_SIZE
+        {
+            eprintln!(
+                "warning: skipping {} ({} MiB exceeds {} MiB limit)",
+                abs_path.display(),
+                meta.len() / (1024 * 1024),
+                MAX_FILE_SIZE / (1024 * 1024),
+            );
+            continue;
+        }
+
         let content = std::fs::read_to_string(abs_path)
             .with_context(|| format!("failed to read {}", abs_path.display()))?;
 
@@ -366,17 +409,19 @@ fn scan_file_for_matches(
             frontmatter_done = true;
         }
 
+        // ---- Fenced code block ----
+        if fence.process_line(line) {
+            continue;
+        }
+
         // ---- Comment fence (Obsidian %% blocks) ----
-        if is_comment_fence(line) {
+        // Must come after code-fence check: a `%%` inside a fenced code block
+        // is literal text, not an Obsidian comment delimiter.
+        if !fence.in_fence() && is_comment_fence(line) {
             in_comment_fence = !in_comment_fence;
             continue;
         }
         if in_comment_fence {
-            continue;
-        }
-
-        // ---- Fenced code block ----
-        if fence.process_line(line) {
             continue;
         }
 

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auto_link;
 pub mod bm25;
 pub mod case_index;
 pub mod content_search;

--- a/hyalo-knowledgebase/iterations/iteration-123-auto-link.md
+++ b/hyalo-knowledgebase/iterations/iteration-123-auto-link.md
@@ -79,7 +79,7 @@ hyalo links auto --apply            # write changes
 hyalo links auto --file note.md     # single file
 hyalo links auto --glob 'Common/*'  # scope to specific files
 hyalo links auto --min-length 4     # skip short titles (default: 3)
-hyalo links auto --exclude-title "Common,Mail"  # manually exclude noisy titles
+hyalo links auto --exclude-title Common --exclude-title Mail  # manually exclude noisy titles
 hyalo links auto --format text      # human-readable output
 ```
 
@@ -107,7 +107,7 @@ BM25/FTS index: tokenizes and stems, so "running" matches "run". Wrong for auto-
 - [x] Implement ambiguity detection (skip titles shared by multiple files)
 - [x] Implement dry-run output (JSON envelope + text format)
 - [x] Implement `--apply` mode with atomic read-modify-write
-- [x] Add `--min-length`, `--exclude-title`, `--glob`, `--case-sensitive` flags
+- [x] Add `--min-length`, `--exclude-title`, `--glob` flags
 - [x] Wire up as `hyalo links auto` subcommand
 - [x] Add unit tests for matching edge cases (word boundaries, overlaps, self-links, ambiguity)
 - [x] Add e2e tests

--- a/hyalo-knowledgebase/iterations/iteration-123-auto-link.md
+++ b/hyalo-knowledgebase/iterations/iteration-123-auto-link.md
@@ -1,0 +1,126 @@
+---
+title: Iteration 123 — Auto-link unlinked mentions
+type: iteration
+date: 2026-04-17
+status: in-progress
+tags:
+  - iteration
+  - links
+  - ux
+  - feature
+branch: iter-123/auto-link
+---
+
+## Goal
+
+Add `hyalo links auto` — scan body text for unlinked mentions of known page titles and convert them to `[[wikilinks]]`. This turns a multi-hour manual linking task into a one-liner, leveraging hyalo's knowledge of the file graph.
+
+Motivated by real dogfooding: a `/hyalo-tidy` session on a work vault required manually reading every file to find linkable mentions. See [[promotion-plan]] for the broader context of making hyalo useful for real-world KB maintenance.
+
+## Design
+
+### Title inventory
+
+Build a lookup of linkable targets from three sources:
+1. Filename stems (without `.md` and directory path)
+2. Frontmatter `title` property
+3. Frontmatter `aliases` property (list of alternate names)
+
+Skip titles shorter than a configurable minimum (default: 3 characters) to avoid false positives on short common words like "CI", "API", "US".
+
+### Matching engine
+
+Use [Aho-Corasick](https://docs.rs/aho-corasick) multi-pattern matching for O(file_size) scanning regardless of pattern count. The `aho-corasick` crate is already a transitive dependency via `regex`.
+
+Build the automaton **once** from the full title inventory, then reuse it for every file. Construction is O(total title characters) and takes single-digit milliseconds even for 10K+ titles. Do not rebuild per file.
+
+- Case-insensitive matching by default
+- Word-boundary constraints (don't match "Sprint" inside "Sprinting")
+- Longest-match-first to prefer "Sprint Planning" over "Sprint"
+
+### Exclusion zones
+
+Skip matches inside:
+- Frontmatter (already handled by scanner)
+- Fenced code blocks and inline code
+- Existing `[[wikilinks]]` and `[markdown](links)`
+- Headings (auto-linking a heading looks wrong)
+- The file's own title (no self-links)
+
+The scanner infrastructure already handles most of these exclusion zones.
+
+### Ambiguity handling
+
+- If multiple files share the same title/stem, skip that title (no silent wrong linking)
+- If a match overlaps with an existing link's text, skip it
+- Prefer exact-case matches over case-insensitive ones
+
+### Output
+
+Follow existing patterns: JSON envelope by default, `--format text` for human-readable, `--dry-run` as default (safe).
+
+```
+$ hyalo links auto --format text
+12 unlinked mentions found in 8 files:
+
+  Meetings/2026-04-15.md:7    "Sprint Review" → [[Sprint Review]]
+  Meetings/2026-04-15.md:12   "Bilas" → [[Bilas]]
+  Common/onboarding.md:3      "Mail Templates" → [[Mail Templates]]
+  ...
+
+Pass --apply to write changes.
+```
+
+### CLI interface
+
+```sh
+hyalo links auto --dry-run          # preview (default)
+hyalo links auto --apply            # write changes
+hyalo links auto --file note.md     # single file
+hyalo links auto --glob 'Common/*'  # scope to specific files
+hyalo links auto --min-length 4     # skip short titles (default: 3)
+hyalo links auto --exclude-title "Common,Mail"  # manually exclude noisy titles
+hyalo links auto --format text      # human-readable output
+```
+
+### How existing infrastructure helps
+
+| Component | Role |
+|-----------|------|
+| `CaseInsensitiveIndex` + `stem_map` | Title inventory from filenames |
+| `discovery::discover_files` | File enumeration |
+| `scanner::scan_file_multi` | Body text with exclusion zones |
+| `links::extract_links_from_text` | Detect already-linked regions |
+| `link_graph` | Know what's already linked |
+| Snapshot index | Provide title list without re-scanning (marginal benefit since body I/O dominates) |
+
+### What does NOT help
+
+BM25/FTS index: tokenizes and stems, so "running" matches "run". Wrong for auto-linking where exact surface-form matching is needed.
+
+## Tasks
+
+- [x] Add `aho-corasick` as a direct workspace dependency
+- [x] Implement title inventory builder (stems + frontmatter title + aliases)
+- [x] Implement body text scanner with exclusion zones (reuse scanner infrastructure)
+- [x] Implement Aho-Corasick matching with word-boundary constraints
+- [x] Implement ambiguity detection (skip titles shared by multiple files)
+- [x] Implement dry-run output (JSON envelope + text format)
+- [x] Implement `--apply` mode with atomic read-modify-write
+- [x] Add `--min-length`, `--exclude-title`, `--glob`, `--case-sensitive` flags
+- [x] Wire up as `hyalo links auto` subcommand
+- [x] Add unit tests for matching edge cases (word boundaries, overlaps, self-links, ambiguity)
+- [x] Add e2e tests
+- [x] Update skill templates and README if needed
+
+## Acceptance Criteria
+
+- [x] `hyalo links auto --dry-run` finds unlinked mentions and shows proposed changes
+- [x] `hyalo links auto --apply` writes correct `[[wikilinks]]` without breaking existing links
+- [x] Self-links are excluded
+- [x] Ambiguous titles (shared by multiple files) are skipped
+- [x] Matches inside code blocks, existing links, and headings are skipped
+- [x] Word boundaries are respected (no partial-word matches)
+- [x] `--min-length` filters short titles
+- [x] Works with `--index` for the title inventory phase
+- [x] All quality gates pass


### PR DESCRIPTION
## Summary

- Add `hyalo links auto` subcommand that scans markdown body text for unlinked mentions of known page titles (filename stems, frontmatter `title`, frontmatter `aliases`) and converts them to `[[wikilinks]]`
- Uses Aho-Corasick multi-pattern matching for O(file_size) scanning regardless of pattern count, with word-boundary constraints and longest-match-first semantics
- Respects exclusion zones: frontmatter, fenced code blocks, inline code, existing links, headings, comment fences, and self-links; ambiguous titles (shared by multiple files) are skipped
- Supports `--apply`/`--dry-run`, `--min-length`, `--exclude-title`, `--glob`, `--file`, and `--format text/json`

## Test plan

- [x] 14 unit tests covering title inventory, word boundaries, exclusion zones, ambiguity, case-insensitivity, longest-match, apply mode
- [x] 12 e2e tests covering dry-run, apply, existing-link skip, code-block skip, heading skip, self-link skip, min-length filter, exclude-title, text format, ambiguous titles, word boundaries, glob filter
- [x] Dogfooded on own knowledgebase: 129 unlinked mentions found across 254 files
- [x] All quality gates pass (fmt, clippy, 1501 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `hyalo links auto` to detect unlinked page-title mentions and propose or apply wikilinks; supports `--min-length`, `--exclude-title`, `--file`/`--glob`, dry-run by default and `--apply` to write changes

* **Output**
  * New JSON/text result shape summarizing scanned/matched/ambiguous counts and per-match details

* **Documentation**
  * Quick start updated with the new auto-link step

* **Tests**
  * End-to-end tests covering dry-run, apply, filtering, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->