### PR TITLE
Add --first-only and --exclude-target-glob to links auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ hyalo links fix --apply
 
 # Auto-link unlinked mentions of known page titles
 hyalo links auto --apply
+hyalo links auto --first-only --exclude-target-glob 'templates/*' --apply
 
 # Lint against your schema
 hyalo lint --fix

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1027,6 +1027,10 @@ pub(crate) enum LinksAction {
             3. Frontmatter `aliases` property (list of alternate names)\n\n\
             Exclusion zones: frontmatter, fenced code blocks, inline code,\n\
             existing [[wikilinks]] and [markdown](links), headings, comment fences (%%), self-links.\n\n\
+            Filtering options:\n\
+            --first-only          Only emit the first mention of each target per source file\n\
+            --exclude-title       Exclude specific titles (repeatable, case-insensitive)\n\
+            --exclude-target-glob Exclude target pages by vault-relative path glob (repeatable)\n\n\
             Without --apply, prints a dry-run report. Pass --apply to write changes."
     )]
     Auto {
@@ -1042,6 +1046,12 @@ pub(crate) enum LinksAction {
         /// Titles to exclude from matching (repeatable, case-insensitive)
         #[arg(long)]
         exclude_title: Vec<String>,
+        /// Only emit the first match of each target title per source file
+        #[arg(long)]
+        first_only: bool,
+        /// Exclude target pages whose vault-relative path matches a glob pattern (repeatable)
+        #[arg(long)]
+        exclude_target_glob: Vec<String>,
         /// Restrict to a single file (vault-relative path)
         #[arg(long, conflicts_with = "glob")]
         file: Option<String>,

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -120,6 +120,8 @@ pub fn links_auto(
     apply: bool,
     min_length: usize,
     exclude_titles: &[String],
+    first_only: bool,
+    exclude_target_globs: &[String],
     file_filter: Option<&str>,
     glob_filter: &[String],
     format: Format,
@@ -130,6 +132,8 @@ pub fn links_auto(
         apply,
         min_length,
         exclude_titles,
+        first_only,
+        exclude_target_globs,
         file_filter,
         glob_filter,
     )?;

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -894,6 +894,8 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 apply,
                 min_length,
                 exclude_title,
+                first_only,
+                exclude_target_glob,
                 file,
                 glob,
                 index_flags: _, // consumed in run.rs before dispatch
@@ -918,6 +920,8 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     apply,
                     min_length,
                     &exclude_title,
+                    first_only,
+                    &exclude_target_glob,
                     file.as_deref(),
                     &glob,
                     effective_format,

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -9,6 +9,7 @@ Prefer `hyalo` CLI for operations on files in this directory:
 - **Read frontmatter/metadata**: `hyalo find --file <path>`, `hyalo properties`, `hyalo tags`
 - **Read content/sections**: `hyalo read <path>` or `hyalo read <path> --section "Heading"`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append`
+- **Auto-link**: `hyalo links auto --first-only --exclude-target-glob 'templates/*' --apply`
 - **Move/rename**: `hyalo mv` (rewrites links across the vault)
 
 Fall back to Edit for body prose changes, Write for new files, and Read when

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -1883,3 +1883,314 @@ Sprint Review was also mentioned here.
         "other.md should be excluded by the glob filter, matches: {matches:?}"
     );
 }
+
+#[test]
+fn links_auto_first_only() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "alice.md",
+        md!(r"
+---
+title: Alice
+---
+Alice bio.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+Alice went to the park. Later Alice came back. Then Alice left again.
+"),
+    );
+
+    // Without --first-only: multiple Alice matches in notes.md
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let alice_count = matches
+        .iter()
+        .filter(|m| {
+            m["file"].as_str() == Some("notes.md") && m["link_target"].as_str() == Some("alice")
+        })
+        .count();
+    assert!(
+        alice_count >= 2,
+        "without --first-only, expected multiple Alice matches, got {alice_count}"
+    );
+
+    // With --first-only: at most 1 Alice match per file
+    let results = run_links_auto(tmp.path(), &["--first-only", "--format", "json"]);
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let alice_count = matches
+        .iter()
+        .filter(|m| {
+            m["file"].as_str() == Some("notes.md") && m["link_target"].as_str() == Some("alice")
+        })
+        .count();
+    assert_eq!(
+        alice_count, 1,
+        "with --first-only, expected exactly 1 Alice match, got {alice_count}"
+    );
+}
+
+#[test]
+fn links_auto_first_only_with_apply() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "alice.md",
+        md!(r"
+---
+title: Alice
+---
+Alice bio.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+Alice went to the park. Later Alice came back.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--first-only", "--apply", "--format", "json"]);
+    assert_eq!(
+        results["applied"].as_bool(),
+        Some(true),
+        "should report applied=true"
+    );
+
+    let content = std::fs::read_to_string(tmp.path().join("notes.md")).unwrap();
+    let link_count = content.matches("[[alice").count();
+    assert_eq!(
+        link_count, 1,
+        "with --first-only --apply, only first mention should be linked, content: {content}"
+    );
+}
+
+#[test]
+fn links_auto_exclude_target_glob() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "templates/start.md",
+        md!(r"
+---
+title: Start
+---
+Start template.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "people/alice.md",
+        md!(r"
+---
+title: Alice
+---
+Alice bio.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+We Start with Alice today.
+"),
+    );
+
+    // Without exclusion: both match
+    let results = run_links_auto(tmp.path(), &["--format", "json"]);
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let has_start = matches
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("start"));
+    let has_alice = matches
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("alice"));
+    assert!(has_start, "without exclusion, Start should match");
+    assert!(has_alice, "without exclusion, Alice should match");
+
+    // With --exclude-target-glob: Start should be excluded
+    let results = run_links_auto(
+        tmp.path(),
+        &["--exclude-target-glob", "templates/*", "--format", "json"],
+    );
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let has_start = matches
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("start"));
+    let has_alice = matches
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("alice"));
+    assert!(
+        !has_start,
+        "Start should be excluded by --exclude-target-glob, matches: {matches:?}"
+    );
+    assert!(has_alice, "Alice should still match, matches: {matches:?}");
+}
+
+#[test]
+fn links_auto_exclude_target_glob_multiple() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "templates/start.md",
+        md!(r"
+---
+title: Start
+---
+Start template.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "archive/old-note.md",
+        md!(r"
+---
+title: Old Note
+---
+Old note content.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "people/alice.md",
+        md!(r"
+---
+title: Alice
+---
+Alice bio.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+We Start with Alice and review the Old Note.
+"),
+    );
+
+    let results = run_links_auto(
+        tmp.path(),
+        &[
+            "--exclude-target-glob",
+            "templates/*",
+            "--exclude-target-glob",
+            "archive/*",
+            "--format",
+            "json",
+        ],
+    );
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let targets: Vec<&str> = matches
+        .iter()
+        .filter_map(|m| m["link_target"].as_str())
+        .collect();
+    assert!(
+        !targets.contains(&"start"),
+        "templates/* should be excluded, targets: {targets:?}"
+    );
+    assert!(
+        !targets.contains(&"old-note"),
+        "archive/* should be excluded, targets: {targets:?}"
+    );
+    assert!(
+        targets.contains(&"alice"),
+        "Alice should NOT be excluded, targets: {targets:?}"
+    );
+}
+
+#[test]
+fn links_auto_first_only_and_exclude_target_glob_combined() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "templates/start.md",
+        md!(r"
+---
+title: Start
+---
+Start template.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "alice.md",
+        md!(r"
+---
+title: Alice
+---
+Alice bio.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+Alice went to Start the project. Then Alice returned. We Start again.
+"),
+    );
+
+    let results = run_links_auto(
+        tmp.path(),
+        &[
+            "--first-only",
+            "--exclude-target-glob",
+            "templates/*",
+            "--format",
+            "json",
+        ],
+    );
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+
+    // Start should be fully excluded (--exclude-target-glob)
+    let has_start = matches
+        .iter()
+        .any(|m| m["link_target"].as_str() == Some("start"));
+    assert!(!has_start, "Start should be excluded by glob");
+
+    // Alice should appear exactly once (--first-only)
+    let alice_count = matches
+        .iter()
+        .filter(|m| m["link_target"].as_str() == Some("alice"))
+        .count();
+    assert_eq!(
+        alice_count, 1,
+        "Alice should appear exactly once with --first-only"
+    );
+}

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -10,6 +10,8 @@ use aho_corasick::{AhoCorasick, MatchKind};
 use anyhow::{Context, Result};
 use serde::Serialize;
 
+use globset::{GlobBuilder, GlobSetBuilder};
+
 use crate::discovery::match_globs;
 use crate::fs_util::atomic_write;
 use crate::index::{IndexEntry, VaultIndex};
@@ -81,7 +83,8 @@ fn build_title_inventory(
     entries: &[IndexEntry],
     min_length: usize,
     exclude_titles: &[String],
-) -> (HashMap<String, TitleEntry>, Vec<String>) {
+    exclude_target_globs: &[String],
+) -> Result<(HashMap<String, TitleEntry>, Vec<String>)> {
     let exclude_lower: Vec<String> = exclude_titles
         .iter()
         .map(|s| s.to_ascii_lowercase())
@@ -203,7 +206,24 @@ fn build_title_inventory(
         }
     }
 
-    (title_map, ambiguous)
+    // Apply --exclude-target-glob: remove targets whose source_rel matches any pattern.
+    if !exclude_target_globs.is_empty() {
+        let mut builder = GlobSetBuilder::new();
+        for pat in exclude_target_globs {
+            builder.add(
+                GlobBuilder::new(pat)
+                    .literal_separator(true)
+                    .build()
+                    .context("invalid --exclude-target-glob pattern")?,
+            );
+        }
+        let glob_set = builder
+            .build()
+            .context("failed to build --exclude-target-glob globset")?;
+        title_map.retain(|_, entry| !glob_set.is_match(&entry.source_rel));
+    }
+
+    Ok((title_map, ambiguous))
 }
 
 /// Extract the filename stem from a vault-relative path.
@@ -275,19 +295,23 @@ fn overlaps_any_link(
 ///
 /// When `apply` is true, write the `[[wikilinks]]` into the files.
 /// When false (dry-run), just report what would change.
+#[allow(clippy::too_many_arguments)]
 pub fn auto_link(
     index: &dyn VaultIndex,
     dir: &Path,
     apply: bool,
     min_length: usize,
     exclude_titles: &[String],
+    first_only: bool,
+    exclude_target_globs: &[String],
     file_filter: Option<&str>,
     glob_filter: &[String],
 ) -> Result<AutoLinkReport> {
     let entries = index.entries();
 
     // 1. Build the title inventory.
-    let (title_map, ambiguous_titles) = build_title_inventory(entries, min_length, exclude_titles);
+    let (title_map, ambiguous_titles) =
+        build_title_inventory(entries, min_length, exclude_titles, exclude_target_globs)?;
 
     if title_map.is_empty() {
         return Ok(AutoLinkReport {
@@ -356,6 +380,13 @@ pub fn auto_link(
         let file_matches = scan_file_for_matches(&content, rel_path, &ac, &patterns_sorted);
 
         all_matches.extend(file_matches);
+    }
+
+    // 4b. Apply --first-only: keep only the lowest-offset match per (source_file, target_title).
+    if first_only {
+        use std::collections::HashSet;
+        let mut seen: HashSet<(String, String)> = HashSet::new();
+        all_matches.retain(|m| seen.insert((m.file.clone(), m.link_target.clone())));
     }
 
     // 5. Apply changes if requested.
@@ -631,7 +662,7 @@ mod tests {
                 ),
             ],
         )];
-        let (map, ambiguous) = build_title_inventory(&entries, 2, &[]);
+        let (map, ambiguous) = build_title_inventory(&entries, 2, &[], &[]).unwrap();
         assert!(ambiguous.is_empty());
         // Stem
         assert!(map.contains_key("sprint-planning"), "stem missing");
@@ -657,7 +688,7 @@ mod tests {
                 vec![("title", Value::String("Sprint".to_owned()))],
             ),
         ];
-        let (map, ambiguous) = build_title_inventory(&entries, 3, &[]);
+        let (map, ambiguous) = build_title_inventory(&entries, 3, &[], &[]).unwrap();
         // Both "sprint.md" produce the same stem "sprint" and same title "sprint"
         assert!(
             !map.contains_key("sprint"),
@@ -673,7 +704,7 @@ mod tests {
             vec![("title", Value::String("Go".to_owned()))],
         )];
         // min_length = 3: "go" (len 2) should be filtered
-        let (map, _) = build_title_inventory(&entries, 3, &[]);
+        let (map, _) = build_title_inventory(&entries, 3, &[], &[]).unwrap();
         assert!(!map.contains_key("go"), "short title should be filtered");
     }
 
@@ -683,7 +714,8 @@ mod tests {
             "the.md",
             vec![("title", Value::String("The".to_owned()))],
         )];
-        let (map, _) = build_title_inventory(&entries, 2, &["the".to_owned(), "The".to_owned()]);
+        let (map, _) =
+            build_title_inventory(&entries, 2, &["the".to_owned(), "The".to_owned()], &[]).unwrap();
         assert!(!map.contains_key("the"), "excluded title should not appear");
     }
 
@@ -700,7 +732,18 @@ mod tests {
         write_file(&tmp, "other.md", "Sprinting is fun but Sprint is better.\n");
 
         let index = MockIndex::new(vec![entry, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("other.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("other.md"),
+            &[],
+        )
+        .unwrap();
 
         let matches: Vec<_> = report
             .matches
@@ -729,7 +772,18 @@ mod tests {
         );
 
         let index = MockIndex::new(vec![page, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         // Heading line should be skipped; body line should match.
         assert_eq!(
@@ -753,7 +807,18 @@ mod tests {
         );
 
         let index = MockIndex::new(vec![page, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         // Matches inside fenced code block should be skipped.
         assert!(
@@ -771,7 +836,18 @@ mod tests {
         write_file(&tmp, "notes.md", "Use `target` sparingly.\n");
 
         let index = MockIndex::new(vec![page, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         assert!(
             report.matches.is_empty(),
@@ -792,7 +868,18 @@ mod tests {
         );
 
         let index = MockIndex::new(vec![page, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         assert!(
             report.matches.is_empty(),
@@ -814,7 +901,18 @@ mod tests {
         );
 
         let index = MockIndex::new(vec![page]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("sprint.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("sprint.md"),
+            &[],
+        )
+        .unwrap();
 
         assert!(
             report.matches.is_empty(),
@@ -831,7 +929,18 @@ mod tests {
         write_file(&tmp, "notes.md", "See Target or TARGET or target here.\n");
 
         let index = MockIndex::new(vec![page, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         assert_eq!(report.matches.len(), 3, "all case variants should match");
     }
@@ -854,7 +963,18 @@ mod tests {
         write_file(&tmp, "notes.md", "Sprint Planning kicks off tomorrow.\n");
 
         let index = MockIndex::new(vec![sprint, sp, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         // Should produce exactly one match: "Sprint Planning"
         assert_eq!(report.matches.len(), 1);
@@ -875,7 +995,18 @@ mod tests {
         );
 
         let index = MockIndex::new(vec![page, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         // Frontmatter content should be skipped.
         assert!(
@@ -897,7 +1028,18 @@ mod tests {
         );
 
         let index = MockIndex::new(vec![page, other]);
-        let report = auto_link(&index, tmp.path(), false, 3, &[], Some("notes.md"), &[]).unwrap();
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &[],
+            Some("notes.md"),
+            &[],
+        )
+        .unwrap();
 
         assert!(
             report.matches.is_empty(),
@@ -920,6 +1062,8 @@ mod tests {
             true, // apply
             3,
             &[],
+            false,
+            &[],
             Some("notes.md"),
             &[],
         )
@@ -932,6 +1076,165 @@ mod tests {
         assert!(
             written.contains("[[target]]"),
             "written content should contain wikilink: {written}"
+        );
+    }
+
+    #[test]
+    fn test_first_only_dedup() {
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry("alice.md", vec![("title", Value::String("Alice".into()))]),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(&tmp, "alice.md", "---\ntitle: Alice\n---\nAlice bio.\n");
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nAlice went to the park. Later Alice came back.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        // Without first_only: should get 2 matches for "Alice" in notes.md
+        let report = auto_link(&index, tmp.path(), false, 3, &[], false, &[], None, &[]).unwrap();
+        let alice_matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "alice")
+            .collect();
+        assert_eq!(
+            alice_matches.len(),
+            2,
+            "without first_only, expected 2 Alice matches"
+        );
+
+        // With first_only: should get only 1 match for "Alice" in notes.md
+        let report = auto_link(&index, tmp.path(), false, 3, &[], true, &[], None, &[]).unwrap();
+        let alice_matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "alice")
+            .collect();
+        assert_eq!(
+            alice_matches.len(),
+            1,
+            "with first_only, expected 1 Alice match"
+        );
+    }
+
+    #[test]
+    fn test_exclude_target_glob() {
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry(
+                "templates/start.md",
+                vec![("title", Value::String("Start".into()))],
+            ),
+            make_entry(
+                "people/alice.md",
+                vec![("title", Value::String("Alice".into()))],
+            ),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(
+            &tmp,
+            "templates/start.md",
+            "---\ntitle: Start\n---\nStart template.\n",
+        );
+        write_file(
+            &tmp,
+            "people/alice.md",
+            "---\ntitle: Alice\n---\nAlice bio.\n",
+        );
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nWe Start with Alice today.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        // Without exclusion: both "Start" and "Alice" match in notes.md
+        let report = auto_link(&index, tmp.path(), false, 3, &[], false, &[], None, &[]).unwrap();
+        let has_start = report.matches.iter().any(|m| m.link_target == "start");
+        let has_alice = report.matches.iter().any(|m| m.link_target == "alice");
+        assert!(has_start, "without exclusion, Start should match");
+        assert!(has_alice, "without exclusion, Alice should match");
+
+        // With --exclude-target-glob 'templates/*': "Start" should be excluded
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &["templates/*".to_owned()],
+            None,
+            &[],
+        )
+        .unwrap();
+        let has_start = report.matches.iter().any(|m| m.link_target == "start");
+        let has_alice = report.matches.iter().any(|m| m.link_target == "alice");
+        assert!(!has_start, "with exclusion, Start should NOT match");
+        assert!(has_alice, "with exclusion, Alice should still match");
+    }
+
+    #[test]
+    fn test_exclude_target_glob_multiple() {
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry(
+                "templates/start.md",
+                vec![("title", Value::String("Start".into()))],
+            ),
+            make_entry(
+                "archive/old.md",
+                vec![("title", Value::String("Old".into()))],
+            ),
+            make_entry(
+                "people/alice.md",
+                vec![("title", Value::String("Alice".into()))],
+            ),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(
+            &tmp,
+            "templates/start.md",
+            "---\ntitle: Start\n---\nStart.\n",
+        );
+        write_file(&tmp, "archive/old.md", "---\ntitle: Old\n---\nOld.\n");
+        write_file(&tmp, "people/alice.md", "---\ntitle: Alice\n---\nAlice.\n");
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nStart and Old and Alice today.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            false,
+            3,
+            &[],
+            false,
+            &["templates/*".to_owned(), "archive/*".to_owned()],
+            None,
+            &[],
+        )
+        .unwrap();
+        let targets: Vec<&str> = report
+            .matches
+            .iter()
+            .map(|m| m.link_target.as_str())
+            .collect();
+        assert!(
+            !targets.contains(&"start"),
+            "templates/* should be excluded"
+        );
+        assert!(!targets.contains(&"old"), "archive/* should be excluded");
+        assert!(
+            targets.contains(&"alice"),
+            "people/alice should NOT be excluded"
         );
     }
 }

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -3,7 +3,7 @@
 //!
 //! The public entry point is [`auto_link`].
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use aho_corasick::{AhoCorasick, MatchKind};
@@ -85,6 +85,28 @@ fn build_title_inventory(
     exclude_titles: &[String],
     exclude_target_globs: &[String],
 ) -> Result<(HashMap<String, TitleEntry>, Vec<String>)> {
+    // Build --exclude-target-glob filter up front so excluded entries never
+    // participate in ambiguity detection (fixes false ambiguities when one of
+    // two conflicting pages is glob-excluded).
+    let glob_set = if exclude_target_globs.is_empty() {
+        None
+    } else {
+        let mut builder = GlobSetBuilder::new();
+        for pat in exclude_target_globs {
+            builder.add(
+                GlobBuilder::new(pat)
+                    .literal_separator(true)
+                    .build()
+                    .context("invalid --exclude-target-glob pattern")?,
+            );
+        }
+        Some(
+            builder
+                .build()
+                .context("failed to build --exclude-target-glob globset")?,
+        )
+    };
+
     let exclude_lower: Vec<String> = exclude_titles
         .iter()
         .map(|s| s.to_ascii_lowercase())
@@ -120,6 +142,13 @@ fn build_title_inventory(
 
     for entry in entries {
         let rel = &entry.rel_path;
+
+        // Skip entries whose path matches an --exclude-target-glob pattern.
+        if let Some(ref gs) = glob_set
+            && gs.is_match(rel)
+        {
+            continue;
+        }
 
         // 1. Filename stem.
         let stem = stem_from_rel(rel);
@@ -184,14 +213,14 @@ fn build_title_inventory(
     // example, `projects/apple.md` (title "Apple Inc") and
     // `companies/apple.md` (title "Apple Company") both generate
     // `link_target = "apple"` — emitting `[[apple]]` would be wrong.
-    let mut target_sources: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
+    let mut target_sources: HashMap<String, HashSet<String>> = HashMap::new();
     for entry in title_map.values() {
         target_sources
             .entry(entry.link_target.clone())
             .or_default()
             .insert(entry.source_rel.clone());
     }
-    let ambiguous_targets: std::collections::HashSet<String> = target_sources
+    let ambiguous_targets: HashSet<String> = target_sources
         .into_iter()
         .filter(|(_, sources)| sources.len() > 1)
         .map(|(target, _)| target)
@@ -204,23 +233,6 @@ fn build_title_inventory(
                 ambiguous.push(target.clone());
             }
         }
-    }
-
-    // Apply --exclude-target-glob: remove targets whose source_rel matches any pattern.
-    if !exclude_target_globs.is_empty() {
-        let mut builder = GlobSetBuilder::new();
-        for pat in exclude_target_globs {
-            builder.add(
-                GlobBuilder::new(pat)
-                    .literal_separator(true)
-                    .build()
-                    .context("invalid --exclude-target-glob pattern")?,
-            );
-        }
-        let glob_set = builder
-            .build()
-            .context("failed to build --exclude-target-glob globset")?;
-        title_map.retain(|_, entry| !glob_set.is_match(&entry.source_rel));
     }
 
     Ok((title_map, ambiguous))
@@ -383,10 +395,26 @@ pub fn auto_link(
     }
 
     // 4b. Apply --first-only: keep only the lowest-offset match per (source_file, target_title).
+    //     Two-pass approach: intern strings as integer IDs to avoid cloning per match,
+    //     then filter using the precomputed keep-mask.
     if first_only {
-        use std::collections::HashSet;
-        let mut seen: HashSet<(String, String)> = HashSet::new();
-        all_matches.retain(|m| seen.insert((m.file.clone(), m.link_target.clone())));
+        let mut file_ids: HashMap<&str, usize> = HashMap::new();
+        let mut target_ids: HashMap<&str, usize> = HashMap::new();
+        let mut seen: HashSet<(usize, usize)> = HashSet::new();
+
+        let keep: Vec<bool> = all_matches
+            .iter()
+            .map(|m| {
+                let n = file_ids.len();
+                let fid = *file_ids.entry(&m.file).or_insert(n);
+                let n = target_ids.len();
+                let tid = *target_ids.entry(&m.link_target).or_insert(n);
+                seen.insert((fid, tid))
+            })
+            .collect();
+
+        let mut keep_iter = keep.into_iter();
+        all_matches.retain(|_| keep_iter.next().unwrap_or(false));
     }
 
     // 5. Apply changes if requested.
@@ -1235,6 +1263,45 @@ mod tests {
         assert!(
             targets.contains(&"alice"),
             "people/alice should NOT be excluded"
+        );
+    }
+
+    #[test]
+    fn test_exclude_target_glob_resolves_ambiguity() {
+        // Two pages share the same title "Sprint" — normally ambiguous.
+        // Excluding one via --exclude-target-glob should resolve the ambiguity.
+        let entries = vec![
+            make_entry(
+                "templates/sprint.md",
+                vec![("title", Value::String("Sprint".into()))],
+            ),
+            make_entry(
+                "planning/sprint.md",
+                vec![("title", Value::String("Sprint".into()))],
+            ),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+
+        // Without exclusion: "sprint" is ambiguous.
+        let (map, ambiguous) = build_title_inventory(&entries, 3, &[], &[]).unwrap();
+        assert!(
+            !map.contains_key("sprint"),
+            "without exclusion, sprint should be ambiguous"
+        );
+        assert!(!ambiguous.is_empty());
+
+        // With exclusion: templates/* removed, only planning/sprint.md remains — no ambiguity.
+        let (map, ambiguous) =
+            build_title_inventory(&entries, 3, &[], &["templates/*".to_owned()]).unwrap();
+        assert!(
+            map.contains_key("sprint"),
+            "with templates/* excluded, sprint should be unambiguous and present"
+        );
+        let entry = map.get("sprint").unwrap();
+        assert_eq!(entry.source_rel, "planning/sprint.md");
+        assert!(
+            !ambiguous.iter().any(|a| a.eq_ignore_ascii_case("sprint")),
+            "sprint should not be in the ambiguous list"
         );
     }
 }

--- a/hyalo-knowledgebase/iterations/iteration-124-auto-link-refinements.md
+++ b/hyalo-knowledgebase/iterations/iteration-124-auto-link-refinements.md
@@ -7,7 +7,7 @@ tags:
   - links
   - ux
   - feature
-status: in-progress
+status: completed
 branch: iter-124/auto-link-refinements
 ---
 

--- a/hyalo-knowledgebase/iterations/iteration-124-auto-link-refinements.md
+++ b/hyalo-knowledgebase/iterations/iteration-124-auto-link-refinements.md
@@ -1,0 +1,77 @@
+---
+title: "Iteration 124 — Auto-link refinements: first-only & exclude-target-glob"
+type: iteration
+date: 2026-04-22
+tags:
+  - iteration
+  - links
+  - ux
+  - feature
+status: in-progress
+branch: iter-124/auto-link-refinements
+---
+
+## Goal
+
+Reduce false-positive noise in `hyalo links auto` with two new filtering options discovered during dogfooding on a real KB with 245+ auto-linked mentions.
+
+## Context
+
+Dogfooding iter-123 on a production KB surfaced two categories of noise:
+- **Repetition**: a single page can get 10× `[[Lukas]]` — only the first mention per page matters
+- **Noisy target pages**: entire directories (e.g. `Mail Templates/*`) produce false positives because their titles are common English words ("Start", "Offer", "Retro")
+
+Property-based target filtering (e.g. only link to `type=person` pages) was considered but deferred — `--exclude-title` and `--exclude-target-glob` cover the practical cases. If property filtering is genuinely needed, it'll surface in future dogfooding.
+
+## Design
+
+### `--first-only`
+
+- Boolean flag, default off
+- When set, only emit/apply the **first** match of each target title per source file
+- "First" = lowest byte offset in the source file
+- Applies to both `--dry-run` (default) and `--apply` modes
+
+### `--exclude-target-glob <pattern>`
+
+- Repeatable flag (can pass multiple times)
+- Excludes **target pages** whose relative path matches any of the given glob patterns
+- Example: `--exclude-target-glob 'Mail Templates/*'` removes all pages under that directory from the title inventory
+- Complements existing `--exclude-title` which filters by exact title string
+- Named `--exclude-target-glob` (not `--exclude-glob`) to distinguish from `--glob` which scopes **source** files
+- Glob matching uses the same engine as `--glob` (source scoping) but applied to target candidates
+
+### Implementation approach
+
+Both filters operate on the **title inventory** (built in `build_title_inventory`):
+1. Build the full inventory as today
+2. Apply `--exclude-target-glob` to remove targets by path
+3. Pass the filtered inventory to the matching engine (unchanged)
+4. After matching, if `--first-only`, deduplicate matches per (source_file, target_title) keeping lowest offset
+
+This layered approach keeps the matching engine untouched — all new logic is in inventory filtering and post-match dedup.
+
+## Tasks
+
+- [x] Add `--first-only` boolean flag to CLI and wire to auto-link options struct
+- [x] Implement first-only dedup: after collecting matches per source file, keep only the lowest-offset match per target title
+- [x] Add `--exclude-target-glob` repeatable flag to CLI
+- [x] Implement target inventory filtering by glob pattern in `build_title_inventory`
+- [x] Add unit tests for first-only dedup logic
+- [x] Add unit tests for exclude-target-glob inventory filtering
+- [x] Add e2e tests covering both flags individually and in combination
+- [x] Update `hyalo links auto --help` text with new options and examples
+- [x] Update README.md — ensure the `hyalo links auto` section documents the new flags and includes usage examples
+- [x] Update skill templates (crates/hyalo-cli/templates/rule-knowledgebase.md) — add `hyalo links auto` with key flags to the CLI reference
+- [x] Update knowledgebase docs if any reference auto-link usage
+
+## Acceptance Criteria
+
+- [x] `--first-only` emits at most one link per target title per source file
+- [x] `--exclude-target-glob 'pattern'` removes matching target pages from the inventory
+- [x] Multiple `--exclude-target-glob` flags combine (union of exclusions)
+- [x] Both flags work with both `--dry-run` (default) and `--apply`
+- [x] Both flags compose correctly when used together
+- [x] Help text, README.md, skill templates, and knowledgebase docs all document `hyalo links auto` including the new flags
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [x] `cargo test --workspace -q` passes


### PR DESCRIPTION
## Summary
- Add `--first-only` flag to `hyalo links auto` — emits at most one link per target title per source file, reducing repetitive link noise (e.g. 10× `[[Lukas]]` on one page)
- Add `--exclude-target-glob` repeatable flag — excludes target pages by vault-relative path glob (e.g. `--exclude-target-glob 'Mail Templates/*'` removes noisy common-word titles)
- Both flags compose correctly and work with `--dry-run` (default) and `--apply` modes
- Updated help text, README, and skill template to document the new options

## Test plan
- [x] 3 new unit tests: first-only dedup, single exclude-target-glob, multiple exclude-target-glob patterns
- [x] 5 new e2e tests: first-only dry-run, first-only with apply, exclude-target-glob, multiple globs, both flags combined
- [x] All 17 existing auto-link tests still pass with updated signatures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace -q` — 2002 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --first-only to limit auto-linking to the first mention per target per source file.
  * Added --exclude-target-glob to exclude target pages by vault-relative glob patterns.

* **Behavior**
  * Deduplication ensures at most one match retained per (source file, target) when enabled; excluded globs remove targets from consideration.

* **Tests**
  * Added end-to-end tests covering interactions of the new options.

* **Documentation**
  * Updated README, templates, and spec pages with examples and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->