### PR TITLE
Detect and warn about LLM hyalo misuse (iter-128)

### DIFF
--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 use std::path::Path;
 
 use crate::output::{CommandOutcome, Format};
-use hyalo_core::discovery;
 use hyalo_core::index::VaultIndex;
 use hyalo_core::link_graph::is_self_link;
 
@@ -30,7 +29,7 @@ pub fn backlinks(
     limit: Option<usize>,
 ) -> Result<CommandOutcome> {
     // Resolve the file argument to a relative path (same as in `backlinks`)
-    let (_full_path, rel) = match discovery::resolve_file(dir, file_arg) {
+    let (_full_path, rel) = match crate::commands::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
         Err(e) => {
             return Ok(crate::commands::resolve_error_to_outcome(e, format));

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -24,6 +24,24 @@ pub mod views;
 use crate::output::{CommandOutcome, Format};
 use anyhow::Result;
 use hyalo_core::discovery::{self, FileResolveError};
+
+/// Wrap `discovery::resolve_file` with the LLM-misuse warning.
+///
+/// If `path_arg` is an absolute path that lies inside the canonical vault,
+/// rewrite it to its vault-relative form, emit the misuse warning, and call
+/// `resolve_file` with the rewritten path. Otherwise fall through to
+/// `resolve_file` unchanged — including for absolute paths that resolve
+/// outside the vault, which still hit `OutsideVault`.
+pub fn resolve_file_user(
+    dir: &std::path::Path,
+    path_arg: &str,
+) -> std::result::Result<(std::path::PathBuf, String), FileResolveError> {
+    if let Some(rewritten) = discovery::strip_absolute_vault_prefix(dir, path_arg) {
+        crate::warn::warn_llm_misuse(dir);
+        return discovery::resolve_file(dir, &rewritten);
+    }
+    discovery::resolve_file(dir, path_arg)
+}
 use hyalo_core::index::{ScanOptions, ScannedIndex, ScannedIndexBuild, SnapshotIndex, VaultIndex};
 use std::path::{Path, PathBuf};
 
@@ -54,7 +72,7 @@ pub fn collect_files(
             let mut resolved = Vec::new();
             let mut errors = Vec::new();
             for f in files {
-                match discovery::resolve_file(dir, f) {
+                match resolve_file_user(dir, f) {
                     Ok(r) => resolved.push(r),
                     Err(e) => errors.push((f.clone(), e)),
                 }
@@ -210,7 +228,7 @@ pub fn build_scanned_index(
             let mut resolved = Vec::new();
             let mut first_err = None;
             for f in files_arg {
-                match discovery::resolve_file(dir, f) {
+                match resolve_file_user(dir, f) {
                     Ok(r) => resolved.push(r),
                     Err(e) if first_err.is_none() => first_err = Some(e),
                     Err(_) => {}

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -28,17 +28,25 @@ use hyalo_core::discovery::{self, FileResolveError};
 /// Wrap `discovery::resolve_file` with the LLM-misuse warning.
 ///
 /// If `path_arg` is an absolute path that lies inside the canonical vault,
-/// rewrite it to its vault-relative form, emit the misuse warning, and call
-/// `resolve_file` with the rewritten path. Otherwise fall through to
-/// `resolve_file` unchanged — including for absolute paths that resolve
-/// outside the vault, which still hit `OutsideVault`.
+/// rewrite it to its vault-relative form, call `resolve_file` with the
+/// rewritten path, and emit the misuse warning only when resolution
+/// succeeds. Otherwise fall through to `resolve_file` unchanged — including
+/// for absolute paths that resolve outside the vault, which still hit
+/// `OutsideVault`.
+///
+/// The warning is gated on `Ok` so an absolute path that fails for an
+/// unrelated reason (e.g. NotFound) doesn't bury the actual error under a
+/// stylistic nag.
 pub fn resolve_file_user(
     dir: &std::path::Path,
     path_arg: &str,
 ) -> std::result::Result<(std::path::PathBuf, String), FileResolveError> {
     if let Some(rewritten) = discovery::strip_absolute_vault_prefix(dir, path_arg) {
-        crate::warn::warn_llm_misuse(dir);
-        return discovery::resolve_file(dir, &rewritten);
+        let result = discovery::resolve_file(dir, &rewritten);
+        if result.is_ok() {
+            crate::warn::warn_llm_misuse(dir);
+        }
+        return result;
     }
     discovery::resolve_file(dir, path_arg)
 }

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 
 use crate::commands::mutation;
 use crate::output::{CommandOutcome, Format};
-use hyalo_core::discovery;
 use hyalo_core::index::SnapshotIndex;
 use hyalo_core::link_rewrite::{self, Replacement, RewritePlan};
 
@@ -48,7 +47,7 @@ pub fn mv(
     index_path: Option<&Path>,
 ) -> Result<CommandOutcome> {
     // 1. Validate source exists
-    let (_src_full, old_rel) = match discovery::resolve_file(dir, file_arg) {
+    let (_src_full, old_rel) = match super::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
         Err(e) => return Ok(crate::commands::resolve_error_to_outcome(e, format)),
     };

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -2,7 +2,6 @@
 
 use crate::output::{CommandOutcome, Format, format_error};
 use anyhow::{Context, Result};
-use hyalo_core::discovery;
 use hyalo_core::frontmatter;
 use hyalo_core::heading::{SectionFilter, parse_atx_heading};
 use hyalo_core::scanner;
@@ -187,7 +186,7 @@ pub fn run(
     user_format: Format,
 ) -> Result<CommandOutcome> {
     // Resolve file
-    let (full_path, rel_path) = match discovery::resolve_file(dir, file) {
+    let (full_path, rel_path) = match super::resolve_file_user(dir, file) {
         Ok(r) => r,
         Err(e) => return Ok(super::resolve_error_to_outcome(e, format)),
     };

--- a/crates/hyalo-cli/src/commands/tasks.rs
+++ b/crates/hyalo-cli/src/commands/tasks.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 
 use crate::commands::resolve_error_to_outcome;
 use crate::output::{CommandOutcome, Format};
-use hyalo_core::discovery;
 use hyalo_core::heading::{SectionFilter, parse_atx_heading};
 use hyalo_core::index::{SnapshotIndex, format_modified};
 use hyalo_core::types::{TaskDryRunResult, TaskInfo, TaskReadResult};
@@ -92,7 +91,7 @@ pub fn task_read(
     all: bool,
     format: Format,
 ) -> Result<CommandOutcome> {
-    let (full_path, rel_path) = match discovery::resolve_file(dir, file_arg) {
+    let (full_path, rel_path) = match crate::commands::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
         Err(e) => return Ok(resolve_error_to_outcome(e, format)),
     };
@@ -164,7 +163,7 @@ pub fn task_toggle(
     index_path: Option<&Path>,
     dry_run: bool,
 ) -> Result<CommandOutcome> {
-    let (full_path, rel_path) = match discovery::resolve_file(dir, file_arg) {
+    let (full_path, rel_path) = match crate::commands::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
         Err(e) => return Ok(resolve_error_to_outcome(e, format)),
     };
@@ -283,7 +282,7 @@ pub fn task_set_status(
     index_path: Option<&Path>,
     dry_run: bool,
 ) -> Result<CommandOutcome> {
-    let (full_path, rel_path) = match discovery::resolve_file(dir, file_arg) {
+    let (full_path, rel_path) = match crate::commands::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
         Err(e) => return Ok(resolve_error_to_outcome(e, format)),
     };

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -269,13 +269,6 @@ fn run_inner() -> Result<(), AppError> {
     // covers the common case but this ensures correctness after full parsing).
     crate::warn::init(cli.quiet);
 
-    // LLM-driven shells (Claude Code etc.) often `cd` into the configured
-    // vault dir and pass paths relative to that subdir. The command works,
-    // but the next call from a sibling dir blows up. Walk ancestors looking
-    // for `.hyalo.toml`; if CWD is inside the configured vault, warn once.
-    // Done here, after quiet-flag init, so it fires for every subcommand.
-    crate::warn::warn_if_cwd_in_vault();
-
     // `init` operates on CWD directly and needs no config or format resolution.
     // Dispatch it before the rest of the setup.
     // The global --dir flag is used as the dir value for .hyalo.toml.
@@ -364,6 +357,17 @@ fn run_inner() -> Result<(), AppError> {
             "Error: --dir path '{}' is a file, not a directory. Use --file to target a single file.",
             dir.display()
         )));
+    }
+
+    // LLM-driven shells (Claude Code etc.) often `cd` into the configured
+    // vault dir and pass paths relative to that subdir. The current command
+    // works, but the next call from a sibling dir blows up. If CWD is inside
+    // the configured vault, warn once. Skipped when --dir was passed
+    // explicitly: the user has named the vault directly, so the ancestor
+    // walk would just produce false positives from unrelated `.hyalo.toml`
+    // files. Init/Deinit/Completion early-return above this point.
+    if !dir_from_cli {
+        crate::warn::warn_if_cwd_in_vault();
     }
 
     // Derive site_prefix with tri-state precedence:

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -269,6 +269,13 @@ fn run_inner() -> Result<(), AppError> {
     // covers the common case but this ensures correctness after full parsing).
     crate::warn::init(cli.quiet);
 
+    // LLM-driven shells (Claude Code etc.) often `cd` into the configured
+    // vault dir and pass paths relative to that subdir. The command works,
+    // but the next call from a sibling dir blows up. Walk ancestors looking
+    // for `.hyalo.toml`; if CWD is inside the configured vault, warn once.
+    // Done here, after quiet-flag init, so it fires for every subcommand.
+    crate::warn::warn_if_cwd_in_vault();
+
     // `init` operates on CWD directly and needs no config or format resolution.
     // Dispatch it before the rest of the setup.
     // The global --dir flag is used as the dir value for .hyalo.toml.

--- a/crates/hyalo-cli/src/warn.rs
+++ b/crates/hyalo-cli/src/warn.rs
@@ -215,16 +215,17 @@ pub fn warn_glob_dir_overlap(dir: &std::path::Path, globs: &[String], matched_co
 /// Emit the LLM-misuse warning for a given configured vault `dir`.
 ///
 /// LLM-driven shells (Claude Code etc.) frequently `cd` into the configured
-/// `dir` or pass absolute `--file` paths. Both work badly — `dir` from
-/// `.hyalo.toml` already pins the vault root. This warning teaches them not
-/// to repeat the mistake, while the underlying command still proceeds.
+/// `dir` or pass absolute `--file` paths. Both work badly — the configured
+/// `dir` (whether from `.hyalo.toml` or a `--dir` flag) already pins the
+/// vault root. This warning teaches them not to repeat the mistake, while
+/// the underlying command still proceeds.
 ///
 /// Goes through `warn()`, so it dedupes by message (one print per process)
 /// and respects `--quiet`.
 pub fn warn_llm_misuse(dir: &std::path::Path) {
     let dir_display = dir.display();
     warn(format!(
-        "hyalo is configured with dir = \"{dir_display}\" (from .hyalo.toml).\n  \
+        "hyalo is configured with dir = \"{dir_display}\".\n  \
          Do not cd into \"{dir_display}\" or pass absolute paths to --file.\n  \
          Run hyalo from the project root and pass paths relative to \"{dir_display}\", e.g.\n    \
          hyalo set iterations/iteration-17.md --property status=in-progress"
@@ -262,8 +263,11 @@ pub(crate) fn warn_if_cwd_in_vault_with_cwd(cwd: &std::path::Path) {
         let toml_path = ancestor.join(".hyalo.toml");
         if toml_path.is_file() {
             check_cwd_against_config(&cwd_canonical, ancestor, &toml_path);
-            // Found the closest .hyalo.toml; whether or not it triggered the
-            // warning, stop walking — config-loading uses the closest one.
+            // The closest ancestor `.hyalo.toml` is the project root for this
+            // misuse check; whether or not it triggered the warning, stop
+            // walking. (Note: `config::load_config()` itself only reads CWD's
+            // `.hyalo.toml`, not ancestors — this walk exists specifically to
+            // detect the misuse case where the user `cd`-ed past the config.)
             return;
         }
         current = ancestor.parent();

--- a/crates/hyalo-cli/src/warn.rs
+++ b/crates/hyalo-cli/src/warn.rs
@@ -212,6 +212,96 @@ pub fn warn_glob_dir_overlap(dir: &std::path::Path, globs: &[String], matched_co
     }
 }
 
+/// Emit the LLM-misuse warning for a given configured vault `dir`.
+///
+/// LLM-driven shells (Claude Code etc.) frequently `cd` into the configured
+/// `dir` or pass absolute `--file` paths. Both work badly — `dir` from
+/// `.hyalo.toml` already pins the vault root. This warning teaches them not
+/// to repeat the mistake, while the underlying command still proceeds.
+///
+/// Goes through `warn()`, so it dedupes by message (one print per process)
+/// and respects `--quiet`.
+pub fn warn_llm_misuse(dir: &std::path::Path) {
+    let dir_display = dir.display();
+    warn(format!(
+        "hyalo is configured with dir = \"{dir_display}\" (from .hyalo.toml).\n  \
+         Do not cd into \"{dir_display}\" or pass absolute paths to --file.\n  \
+         Run hyalo from the project root and pass paths relative to \"{dir_display}\", e.g.\n    \
+         hyalo set iterations/iteration-17.md --property status=in-progress"
+    ));
+}
+
+/// If the current working directory lies inside the configured vault dir,
+/// emit the LLM-misuse warning once.
+///
+/// Walks ancestors of CWD looking for `.hyalo.toml`. When the file is found
+/// in a strict ancestor (not CWD itself) and its `dir` value resolves to a
+/// directory that contains CWD, the user has clearly `cd`-ed into the vault
+/// — warn so the LLM stops doing it.
+///
+/// Anything ambiguous (no `.hyalo.toml` in the chain, malformed TOML, vault
+/// that fails to canonicalize) is silently skipped.
+pub fn warn_if_cwd_in_vault() {
+    let Ok(cwd) = std::env::current_dir() else {
+        return;
+    };
+    warn_if_cwd_in_vault_with_cwd(&cwd);
+}
+
+/// Same as [`warn_if_cwd_in_vault`], but with an explicit `cwd` so it can be
+/// exercised in tests without mutating the process working directory.
+pub(crate) fn warn_if_cwd_in_vault_with_cwd(cwd: &std::path::Path) {
+    let Ok(cwd_canonical) = dunce::canonicalize(cwd) else {
+        return;
+    };
+    // Walk strict ancestors looking for `.hyalo.toml`. Skip CWD itself —
+    // when the config lives in CWD, the project root *is* CWD and there's
+    // no "inside the vault" ambiguity to warn about.
+    let mut current: Option<&std::path::Path> = cwd_canonical.parent();
+    while let Some(ancestor) = current {
+        let toml_path = ancestor.join(".hyalo.toml");
+        if toml_path.is_file() {
+            check_cwd_against_config(&cwd_canonical, ancestor, &toml_path);
+            // Found the closest .hyalo.toml; whether or not it triggered the
+            // warning, stop walking — config-loading uses the closest one.
+            return;
+        }
+        current = ancestor.parent();
+    }
+}
+
+/// Read `dir` out of `toml_path` and warn if `cwd_canonical` is inside the
+/// resolved vault. Best-effort: anything malformed is silently skipped.
+fn check_cwd_against_config(
+    cwd_canonical: &std::path::Path,
+    config_dir: &std::path::Path,
+    toml_path: &std::path::Path,
+) {
+    let Ok(text) = std::fs::read_to_string(toml_path) else {
+        return;
+    };
+    let Ok(parsed) = toml::from_str::<toml::Value>(&text) else {
+        return;
+    };
+    let dir_value = parsed.get("dir").and_then(|v| v.as_str()).unwrap_or(".");
+    let dir_path = std::path::Path::new(dir_value);
+    if dir_path
+        .components()
+        .eq(std::path::Path::new(".").components())
+    {
+        // dir = "." — the configured vault *is* the project root, no nested
+        // subdir to be "inside".
+        return;
+    }
+    let vault_path = config_dir.join(dir_path);
+    let Ok(vault_canonical) = dunce::canonicalize(&vault_path) else {
+        return;
+    };
+    if cwd_canonical.starts_with(&vault_canonical) {
+        warn_llm_misuse(dir_path);
+    }
+}
+
 /// Print a summary of suppressed duplicate warnings, if any.
 ///
 /// Should be called just before the process exits. Prints to stderr.
@@ -402,6 +492,128 @@ mod tests {
         init(false);
         let dir = std::path::Path::new("docs");
         warn_glob_dir_overlap(dir, &[], 0);
+        assert_eq!(total_suppressed(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Iteration 128 — LLM-misuse warning
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn llm_misuse_warning_text_references_dir_and_example() {
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let dir = std::path::Path::new("hyalo-knowledgebase");
+        warn_llm_misuse(dir);
+        assert!(any_tracked_starts_with(
+            "hyalo is configured with dir = \"hyalo-knowledgebase\""
+        ));
+    }
+
+    #[test]
+    fn llm_misuse_warning_dedupes_across_calls() {
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let dir = std::path::Path::new("kb");
+        warn_llm_misuse(dir);
+        warn_llm_misuse(dir);
+        warn_llm_misuse(dir);
+        // First print is recorded with suppression count 0; the next two are
+        // suppressed.
+        assert_eq!(total_suppressed(), 2);
+    }
+
+    fn make_project_with_config(dir_value: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".hyalo.toml"),
+            format!("dir = \"{dir_value}\"\n"),
+        )
+        .unwrap();
+        std::fs::create_dir_all(tmp.path().join(dir_value)).unwrap();
+        tmp
+    }
+
+    #[test]
+    fn cwd_in_vault_warns_when_inside_configured_dir() {
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let project = make_project_with_config("kb");
+        let vault = project.path().join("kb");
+        warn_if_cwd_in_vault_with_cwd(&vault);
+        assert!(any_tracked_starts_with(
+            "hyalo is configured with dir = \"kb\""
+        ));
+    }
+
+    #[test]
+    fn cwd_in_vault_warns_when_inside_a_subdir_of_vault() {
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let project = make_project_with_config("kb");
+        let nested = project.path().join("kb/iterations");
+        std::fs::create_dir_all(&nested).unwrap();
+        warn_if_cwd_in_vault_with_cwd(&nested);
+        assert!(any_tracked_starts_with(
+            "hyalo is configured with dir = \"kb\""
+        ));
+    }
+
+    #[test]
+    fn cwd_in_vault_no_warn_when_cwd_equals_config_dir() {
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let project = make_project_with_config("kb");
+        // CWD is the project root (where .hyalo.toml lives) — that's the
+        // intended invocation site, no warning.
+        warn_if_cwd_in_vault_with_cwd(project.path());
+        assert_eq!(total_suppressed(), 0);
+        assert!(!any_tracked_starts_with("hyalo is configured with dir"));
+    }
+
+    #[test]
+    fn cwd_in_vault_no_warn_when_no_config_in_ancestors() {
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let tmp = tempfile::tempdir().unwrap();
+        // No .hyalo.toml anywhere up the chain — silently skip.
+        warn_if_cwd_in_vault_with_cwd(tmp.path());
+        assert_eq!(total_suppressed(), 0);
+        assert!(!any_tracked_starts_with("hyalo is configured with dir"));
+    }
+
+    #[test]
+    fn cwd_in_vault_no_warn_when_dir_is_dot() {
+        // dir = "." means the project root *is* the vault — no nested vault to
+        // be inside, so we never warn.
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".hyalo.toml"), "dir = \".\"\n").unwrap();
+        // Make a nested dir to invoke from.
+        let nested = tmp.path().join("sub");
+        std::fs::create_dir_all(&nested).unwrap();
+        warn_if_cwd_in_vault_with_cwd(&nested);
+        assert_eq!(total_suppressed(), 0);
+    }
+
+    #[test]
+    fn cwd_in_vault_no_warn_when_cwd_is_sibling_of_vault() {
+        let _guard = super::WARN_TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        init(false);
+        let project = make_project_with_config("kb");
+        // CWD is a sibling of the vault, not inside it.
+        let sibling = project.path().join("other");
+        std::fs::create_dir_all(&sibling).unwrap();
+        warn_if_cwd_in_vault_with_cwd(&sibling);
         assert_eq!(total_suppressed(), 0);
     }
 }

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -130,6 +130,35 @@ hyalo find --property status=in-progress --fields tasks \
 
 **Run `hyalo --help` and `hyalo <command> --help` to learn the full API.**
 
+## Always run hyalo from the project root
+
+Hyalo reads `dir` from `.hyalo.toml` at the project root, so it already knows where the
+knowledgebase lives. You never need to `cd` anywhere or use absolute paths — and doing so
+is actively wrong.
+
+- **ALWAYS run hyalo from the project root** (the directory that contains `.hyalo.toml`).
+  Never `cd` into the configured `dir` first.
+- **ALWAYS pass `--file` paths relative to the configured `dir`** (e.g.
+  `iterations/iteration-17.md`). Never pass an absolute path.
+
+Worked example:
+
+```bash
+# ✅ Right (from project root — hyalo resolves the path against `dir`)
+hyalo set iterations/iteration-17.md --property status=in-progress
+
+# ❌ Wrong (cd into the configured dir — hyalo gets confused about the vault root)
+cd hyalo-knowledgebase && hyalo set iterations/iteration-17.md --property status=in-progress
+
+# ❌ Wrong (absolute path — bypasses the configured `dir` entirely)
+hyalo set --file /Users/me/proj/hyalo-knowledgebase/iterations/iteration-17.md --property status=in-progress
+```
+
+Hyalo emits a stderr warning when it detects either anti-pattern (running from inside the
+configured `dir`, or being passed an absolute `--file` path). **Treat that warning as a
+correction signal**: stop, move back to the project root, and rewrite the path as a
+vault-relative one before continuing.
+
 ## Setup (run once per project)
 
 ALWAYS run `which hyalo` as your very first step. Do not skip this.

--- a/crates/hyalo-cli/tests/e2e/llm_misuse.rs
+++ b/crates/hyalo-cli/tests/e2e/llm_misuse.rs
@@ -1,0 +1,187 @@
+//! e2e tests for the LLM-misuse warning (iter-128).
+//!
+//! When an LLM-driven shell `cd`s into the configured `dir` or passes an
+//! absolute `--file` path, hyalo emits a stderr warning that teaches the LLM
+//! to run from the project root with vault-relative paths.
+
+use super::common::{hyalo_no_hints, write_md};
+use tempfile::TempDir;
+
+/// Build a project root with a `.hyalo.toml` that pins `dir = "kb"`, plus a
+/// pre-populated `kb/iterations/iteration-17.md` file.
+fn make_project() -> TempDir {
+    let project = TempDir::new().unwrap();
+    std::fs::write(project.path().join(".hyalo.toml"), "dir = \"kb\"\n").unwrap();
+    write_md(
+        &project.path().join("kb"),
+        "iterations/iteration-17.md",
+        "---\ntitle: Iter 17\ntype: iteration\n---\nBody.\n",
+    );
+    project
+}
+
+#[test]
+fn warns_when_cwd_is_inside_configured_dir() {
+    let project = make_project();
+    let vault = project.path().join("kb");
+
+    let assert = hyalo_no_hints()
+        .current_dir(&vault)
+        .args(["find", "--limit", "1"])
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("hyalo is configured with dir = \"kb\""),
+        "expected misuse warning in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Do not cd into \"kb\""),
+        "expected corrective text in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn no_warning_when_cwd_is_project_root() {
+    let project = make_project();
+
+    let assert = hyalo_no_hints()
+        .current_dir(project.path())
+        .args(["find", "--limit", "1"])
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        !stderr.contains("hyalo is configured with dir"),
+        "expected no misuse warning when run from project root, got: {stderr}"
+    );
+}
+
+#[test]
+fn warns_and_succeeds_when_absolute_file_inside_vault() {
+    let project = make_project();
+    // Canonicalize the project path so the absolute argument exactly matches
+    // the canonical vault prefix (macOS tempdirs go through /private).
+    let canonical_project = dunce::canonicalize(project.path()).unwrap();
+    let abs_file = canonical_project
+        .join("kb/iterations/iteration-17.md")
+        .to_string_lossy()
+        .into_owned();
+
+    let assert = hyalo_no_hints()
+        .current_dir(project.path())
+        .args(["read", "--file", &abs_file])
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("hyalo is configured with dir = \"kb\""),
+        "expected misuse warning when --file is absolute path inside vault, got: {stderr}"
+    );
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("Body."),
+        "expected the file body to be read despite the warning, got: {stdout}"
+    );
+}
+
+#[test]
+fn absolute_file_outside_vault_still_errors() {
+    let project = make_project();
+    // Use a tempdir outside the project as a clearly-out-of-vault path.
+    let outside = TempDir::new().unwrap();
+    write_md(
+        outside.path(),
+        "stray.md",
+        "---\ntitle: Stray\n---\nBody.\n",
+    );
+    let canonical_outside = dunce::canonicalize(outside.path()).unwrap();
+    let abs_file = canonical_outside
+        .join("stray.md")
+        .to_string_lossy()
+        .into_owned();
+
+    let assert = hyalo_no_hints()
+        .current_dir(project.path())
+        .args(["read", "--file", &abs_file])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("outside vault") || stderr.contains("OutsideVault"),
+        "expected outside-vault error for absolute path outside vault, got: {stderr}"
+    );
+    // And the misuse warning must NOT fire — that's reserved for paths that
+    // resolve inside the vault.
+    assert!(
+        !stderr.contains("hyalo is configured with dir"),
+        "misuse warning should not fire for out-of-vault absolute path, got: {stderr}"
+    );
+}
+
+#[test]
+fn warning_fires_only_once_for_multiple_file_args() {
+    let project = make_project();
+    write_md(
+        &project.path().join("kb"),
+        "iterations/iteration-18.md",
+        "---\ntitle: Iter 18\ntype: iteration\n---\nBody 18.\n",
+    );
+
+    let canonical_project = dunce::canonicalize(project.path()).unwrap();
+    let abs_a = canonical_project
+        .join("kb/iterations/iteration-17.md")
+        .to_string_lossy()
+        .into_owned();
+    let abs_b = canonical_project
+        .join("kb/iterations/iteration-18.md")
+        .to_string_lossy()
+        .into_owned();
+
+    // `set` accepts multiple --file flags; both are absolute and inside the vault.
+    let assert = hyalo_no_hints()
+        .current_dir(project.path())
+        .args([
+            "set",
+            "--file",
+            &abs_a,
+            "--file",
+            &abs_b,
+            "--property",
+            "status=in-progress",
+        ])
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    let occurrences = stderr
+        .matches("hyalo is configured with dir = \"kb\"")
+        .count();
+    assert_eq!(
+        occurrences, 1,
+        "warning should be deduplicated; got {occurrences} occurrences:\n{stderr}"
+    );
+}
+
+#[test]
+fn quiet_flag_suppresses_misuse_warning() {
+    let project = make_project();
+    let vault = project.path().join("kb");
+
+    let assert = hyalo_no_hints()
+        .current_dir(&vault)
+        .args(["--quiet", "find", "--limit", "1"])
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        !stderr.contains("hyalo is configured with dir"),
+        "--quiet should suppress the misuse warning, got: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/llm_misuse.rs
+++ b/crates/hyalo-cli/tests/e2e/llm_misuse.rs
@@ -112,8 +112,11 @@ fn absolute_file_outside_vault_still_errors() {
         .failure();
 
     let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    // The canonical Display form of `FileResolveError::OutsideVault` is
+    // "file resolves outside vault boundary: …" — assert against the
+    // user-visible substring, not the variant name.
     assert!(
-        stderr.contains("outside vault") || stderr.contains("OutsideVault"),
+        stderr.contains("outside vault"),
         "expected outside-vault error for absolute path outside vault, got: {stderr}"
     );
     // And the misuse warning must NOT fire — that's reserved for paths that

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -16,6 +16,7 @@ mod init;
 mod jq;
 mod links;
 mod lint;
+mod llm_misuse;
 mod mv;
 mod positional_file;
 mod properties;

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -244,6 +244,34 @@ pub(crate) fn ensure_within_vault(canonical_dir: &Path, full: &Path) -> Result<b
     Ok(canonical_full.starts_with(canonical_dir))
 }
 
+/// If `path_arg` is an absolute path that lies inside the canonical vault `dir`,
+/// return the equivalent vault-relative path. Otherwise return `None`.
+///
+/// Lets the CLI rewrite an absolute `--file` path (which LLM-driven shells
+/// often pass) into the relative form `resolve_file` expects, while keeping
+/// genuinely-out-of-vault absolute paths unchanged so they still hit
+/// `OutsideVault`.
+///
+/// Returns `None` if:
+/// - the input is not absolute (caller can pass it straight through),
+/// - the vault dir cannot be canonicalized,
+/// - the (possibly canonicalized) input does not start with the canonical vault,
+/// - or the path equals the vault dir itself (no remainder).
+#[must_use]
+pub fn strip_absolute_vault_prefix(dir: &Path, path_arg: &str) -> Option<String> {
+    let p = Path::new(path_arg);
+    if !p.is_absolute() {
+        return None;
+    }
+    let canonical_dir = canonicalize_vault_dir(dir).ok()?;
+    // Prefer canonicalized input (resolves symlinks, `..`, etc.); fall back to
+    // the literal path so non-existent files inside the vault still rewrite.
+    let candidate = dunce::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let stripped = candidate.strip_prefix(&canonical_dir).ok()?;
+    let s = stripped.to_string_lossy().replace('\\', "/");
+    if s.is_empty() { None } else { Some(s) }
+}
+
 /// Strip the vault `dir` prefix from a path if present.
 ///
 /// Compares path components so `dir = "docs"` matches the leading `docs/` in
@@ -1508,6 +1536,69 @@ mod tests {
 
         let err = resolve_file(tmp.path(), "/etc/passwd.md").unwrap_err();
         assert!(matches!(err, FileResolveError::OutsideVault { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Iteration 128 — strip_absolute_vault_prefix
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn strip_abs_returns_none_for_relative_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            strip_absolute_vault_prefix(tmp.path(), "notes/foo.md"),
+            None
+        );
+        assert_eq!(strip_absolute_vault_prefix(tmp.path(), "./foo.md"), None);
+    }
+
+    #[test]
+    fn strip_abs_strips_prefix_for_path_inside_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("notes")).unwrap();
+        fs::write(tmp.path().join("notes/foo.md"), "").unwrap();
+
+        let canonical = dunce::canonicalize(tmp.path()).unwrap();
+        let abs = canonical.join("notes/foo.md");
+        let abs_str = abs.to_string_lossy();
+
+        assert_eq!(
+            strip_absolute_vault_prefix(tmp.path(), &abs_str),
+            Some("notes/foo.md".to_owned())
+        );
+    }
+
+    #[test]
+    fn strip_abs_returns_none_for_path_outside_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        // /etc/passwd.md cannot lie inside a tempdir
+        assert_eq!(
+            strip_absolute_vault_prefix(tmp.path(), "/etc/passwd.md"),
+            None
+        );
+    }
+
+    #[test]
+    fn strip_abs_returns_none_for_path_equal_to_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        let canonical = dunce::canonicalize(tmp.path()).unwrap();
+        let abs_str = canonical.to_string_lossy();
+        assert_eq!(strip_absolute_vault_prefix(tmp.path(), &abs_str), None);
+    }
+
+    #[test]
+    fn strip_abs_handles_nonexistent_file_inside_vault() {
+        // A user can pass an absolute path to a file that doesn't exist (yet).
+        // We still want to rewrite it so `resolve_file` can produce the proper
+        // NotFound diagnostic instead of a misleading OutsideVault.
+        let tmp = tempfile::tempdir().unwrap();
+        let canonical = dunce::canonicalize(tmp.path()).unwrap();
+        let abs = canonical.join("missing.md");
+        let abs_str = abs.to_string_lossy();
+        assert_eq!(
+            strip_absolute_vault_prefix(tmp.path(), &abs_str),
+            Some("missing.md".to_owned())
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -268,6 +268,16 @@ pub fn strip_absolute_vault_prefix(dir: &Path, path_arg: &str) -> Option<String>
     // the literal path so non-existent files inside the vault still rewrite.
     let candidate = dunce::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
     let stripped = candidate.strip_prefix(&canonical_dir).ok()?;
+    // Reject leftover parent-traversal segments. When canonicalize falls back
+    // to the literal path, a string like `/vault/../vault/x.md` can survive
+    // strip_prefix with a `..` in the remainder; we must not hand that to
+    // resolve_file as if it were a clean vault-relative path.
+    if stripped
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return None;
+    }
     let s = stripped.to_string_lossy().replace('\\', "/");
     if s.is_empty() { None } else { Some(s) }
 }
@@ -1599,6 +1609,22 @@ mod tests {
             strip_absolute_vault_prefix(tmp.path(), &abs_str),
             Some("missing.md".to_owned())
         );
+    }
+
+    #[test]
+    fn strip_abs_rejects_parent_traversal_in_nonexistent_path() {
+        // When canonicalize falls back to the literal path (because the file
+        // doesn't exist), a `..` segment can survive strip_prefix. We must
+        // refuse to rewrite such paths — handing `../foo.md` to resolve_file
+        // would either error or silently escape the vault.
+        let tmp = tempfile::tempdir().unwrap();
+        let canonical = dunce::canonicalize(tmp.path()).unwrap();
+        // Build something like `<canonical>/sub/../escape.md` where neither
+        // `sub` nor `escape.md` exists, so canonicalize fails and we keep the
+        // literal form with `..` intact.
+        let abs = canonical.join("sub/../escape.md");
+        let abs_str = abs.to_string_lossy();
+        assert_eq!(strip_absolute_vault_prefix(tmp.path(), &abs_str), None);
     }
 
     // -----------------------------------------------------------------------

--- a/hyalo-knowledgebase/iterations/iteration-112-skill-sync-and-limit-bypass.md
+++ b/hyalo-knowledgebase/iterations/iteration-112-skill-sync-and-limit-bypass.md
@@ -1,8 +1,8 @@
 ---
-title: "Iteration 112 — Sync Skills with Recent Features, Bypass Default Limit for --jq/--count"
+title: Iteration 112 — Sync Skills with Recent Features, Bypass Default Limit for --jq/--count
 type: iteration
 date: 2026-04-14
-status: in-progress
+status: completed
 branch: iter-112/skill-sync-and-limit-bypass
 tags:
   - skills
@@ -27,5 +27,5 @@ and `--count` pipelines received only 50 results due to the default limit.
 - [x] Update help texts to document limit bypass behaviour
 - [x] E2e tests for jq/count limit bypass, show alias, schema auto-string
 - [x] Address review: fix help text wording, stale `types create` ref, add tags bypass test
-- [ ] Update README with limit bypass and show alias
-- [ ] Create iteration file
+- [x] Update README with limit bypass and show alias
+- [x] Create iteration file

--- a/hyalo-knowledgebase/iterations/iteration-128-llm-misuse-warning.md
+++ b/hyalo-knowledgebase/iterations/iteration-128-llm-misuse-warning.md
@@ -2,8 +2,12 @@
 title: Iteration 128 — Detect and warn about LLM hyalo misuse
 type: iteration
 date: 2026-05-07
-tags: [ux, llm, dx, validation]
-status: planned
+tags:
+  - ux
+  - llm
+  - dx
+  - validation
+status: in-progress
 branch: iter-128/llm-misuse-warning
 ---
 
@@ -54,26 +58,26 @@ warning: hyalo is configured with dir = "<dir>" (from .hyalo.toml).
 
 ## Tasks
 
-- [ ] Detect absolute `--file` / positional paths in `discovery::resolve_file`; if the canonical path is inside the canonical vault, strip the prefix and continue (instead of returning `OutsideVault`)
-- [ ] Keep `OutsideVault` error when an absolute path canonicalizes outside the vault
-- [ ] Detect when CWD equals or is inside the canonical vault dir, given that `.hyalo.toml` was found in an ancestor of the vault — emit the warning once per invocation
-- [ ] Implement the warning helper that fires at most once per process run (e.g., `OnceCell`-gated emit on stderr)
-- [ ] Wire the trigger into the file-resolution path so absolute-path warnings fire from any subcommand using `--file`
-- [ ] Wire the CWD-in-vault check into CLI startup (after config load) so it fires for every subcommand, not just file-mutating ones
-- [ ] Unit tests: absolute path inside vault → warn + resolve correctly; absolute path outside vault → still errors; CWD inside vault → warn fires; CWD outside vault → no warn; warning fires only once when multiple `--file` args are given
-- [ ] e2e test: invoke a command from inside the configured `dir` and assert the warning appears on stderr with the expected text
-- [ ] e2e test: invoke a command with an absolute `--file` inside the vault from the project root and assert the warning + successful execution
-- [ ] Update CLI help text / README / `.claude/CLAUDE.md` if any guidance contradicts the new behavior
-- [ ] Audit the hyalo skill (`.claude/skills/hyalo/SKILL.md` and the synced copy under `~/.claude/skills/hyalo/`) — add an explicit "always run from the project root, never cd into the configured `dir`, never use absolute `--file` paths" rule with a worked example, so the skill teaches the same lesson the runtime warning does
-- [ ] Dogfood: run hyalo against `hyalo-knowledgebase` and a sibling KB with absolute paths, confirm warnings render readably and don't double-fire
+- [x] Detect absolute `--file` / positional paths in `discovery::resolve_file`; if the canonical path is inside the canonical vault, strip the prefix and continue (instead of returning `OutsideVault`)
+- [x] Keep `OutsideVault` error when an absolute path canonicalizes outside the vault
+- [x] Detect when CWD equals or is inside the canonical vault dir, given that `.hyalo.toml` was found in an ancestor of the vault — emit the warning once per invocation
+- [x] Implement the warning helper that fires at most once per process run (e.g., `OnceCell`-gated emit on stderr)
+- [x] Wire the trigger into the file-resolution path so absolute-path warnings fire from any subcommand using `--file`
+- [x] Wire the CWD-in-vault check into CLI startup (after config load) so it fires for every subcommand, not just file-mutating ones
+- [x] Unit tests: absolute path inside vault → warn + resolve correctly; absolute path outside vault → still errors; CWD inside vault → warn fires; CWD outside vault → no warn; warning fires only once when multiple `--file` args are given
+- [x] e2e test: invoke a command from inside the configured `dir` and assert the warning appears on stderr with the expected text
+- [x] e2e test: invoke a command with an absolute `--file` inside the vault from the project root and assert the warning + successful execution
+- [x] Update CLI help text / README / `.claude/CLAUDE.md` if any guidance contradicts the new behavior
+- [x] Audit the hyalo skill (`.claude/skills/hyalo/SKILL.md` and the synced copy under `~/.claude/skills/hyalo/`) — add an explicit "always run from the project root, never cd into the configured `dir`, never use absolute `--file` paths" rule with a worked example, so the skill teaches the same lesson the runtime warning does
+- [x] Dogfood: run hyalo against `hyalo-knowledgebase` and a sibling KB with absolute paths, confirm warnings render readably and don't double-fire
 
 ## Acceptance Criteria
 
-- [ ] Absolute `--file` path that resolves inside the vault works and emits one warning to stderr
-- [ ] Absolute `--file` path that resolves outside the vault still hard-errors with `OutsideVault`
-- [ ] Running any hyalo subcommand from inside the configured `dir` emits one warning to stderr and otherwise behaves identically
-- [ ] Warning is emitted at most once per process invocation, even with multiple `--file` args or repeated triggers
-- [ ] Warning text references the actual configured `dir` value and gives a concrete corrective example
-- [ ] hyalo skill (project + global copies) explicitly tells the LLM to run from the project root and never cd into `dir` or use absolute paths
-- [ ] All existing tests pass; new unit + e2e tests cover the four cases above
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all clean
+- [x] Absolute `--file` path that resolves inside the vault works and emits one warning to stderr
+- [x] Absolute `--file` path that resolves outside the vault still hard-errors with `OutsideVault`
+- [x] Running any hyalo subcommand from inside the configured `dir` emits one warning to stderr and otherwise behaves identically
+- [x] Warning is emitted at most once per process invocation, even with multiple `--file` args or repeated triggers
+- [x] Warning text references the actual configured `dir` value and gives a concrete corrective example
+- [x] hyalo skill (project + global copies) explicitly tells the LLM to run from the project root and never cd into `dir` or use absolute paths
+- [x] All existing tests pass; new unit + e2e tests cover the four cases above
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all clean

--- a/hyalo-knowledgebase/iterations/iteration-128-llm-misuse-warning.md
+++ b/hyalo-knowledgebase/iterations/iteration-128-llm-misuse-warning.md
@@ -49,8 +49,8 @@ Behavior changes:
 
 Warning text should be short, blunt, and tell the LLM exactly what to do:
 
-```
-warning: hyalo is configured with dir = "<dir>" (from .hyalo.toml).
+```text
+warning: hyalo is configured with dir = "<dir>".
   Do not cd into "<dir>" or pass absolute paths to --file.
   Run hyalo from the project root and pass paths relative to "<dir>", e.g.
     hyalo set iterations/iteration-17.md --property status=in-progress

--- a/hyalo-knowledgebase/iterations/iteration-128-llm-misuse-warning.md
+++ b/hyalo-knowledgebase/iterations/iteration-128-llm-misuse-warning.md
@@ -1,0 +1,79 @@
+---
+title: Iteration 128 — Detect and warn about LLM hyalo misuse
+type: iteration
+date: 2026-05-07
+tags: [ux, llm, dx, validation]
+status: planned
+branch: iter-128/llm-misuse-warning
+---
+
+## Goal
+
+LLM-driven shells (Claude Code, etc.) frequently misuse the hyalo CLI in two
+recurring ways:
+
+1. They pass absolute paths to `--file`, e.g.
+   `hyalo set --file /Users/me/proj/proj-knowledgebase/iter-17.md ...`, and hit
+   the cryptic `file resolves outside vault boundary` error.
+2. They `cd` into the configured knowledgebase directory before invoking
+   hyalo, then pass paths relative to that subdir. This works silently today
+   but reinforces a broken mental model — the next call from a sibling dir
+   blows up.
+
+The configured `dir` in `.hyalo.toml` already pins the vault root, so the
+LLM never needs to navigate into it or pass absolute paths. We should detect
+both anti-patterns and emit a single, prominent stderr warning that corrects
+the LLM's understanding so it stops repeating the mistake.
+
+## Approach
+
+Emit warnings (not errors) to **stderr** so the message reaches both humans
+and LLM-driven shells (Claude Code captures stderr alongside stdout). The
+warning is always on — no suppression knob — and fires at most once per
+invocation regardless of how many `--file` args trigger it.
+
+Behavior changes:
+
+- **Absolute path inside the vault**: warn, strip the canonical vault prefix,
+  proceed with the command. Today this errors out, which is unhelpful when
+  the LLM clearly identified the file it wanted.
+- **Absolute path outside the vault**: keep the existing `OutsideVault`
+  hard error.
+- **CWD == vault dir or inside it** (when `.hyalo.toml` is in an ancestor):
+  warn, proceed normally. The command still works; the warning just teaches
+  the LLM not to `cd` next time.
+
+Warning text should be short, blunt, and tell the LLM exactly what to do:
+
+```
+warning: hyalo is configured with dir = "<dir>" (from .hyalo.toml).
+  Do not cd into "<dir>" or pass absolute paths to --file.
+  Run hyalo from the project root and pass paths relative to "<dir>", e.g.
+    hyalo set iterations/iteration-17.md --property status=in-progress
+```
+
+## Tasks
+
+- [ ] Detect absolute `--file` / positional paths in `discovery::resolve_file`; if the canonical path is inside the canonical vault, strip the prefix and continue (instead of returning `OutsideVault`)
+- [ ] Keep `OutsideVault` error when an absolute path canonicalizes outside the vault
+- [ ] Detect when CWD equals or is inside the canonical vault dir, given that `.hyalo.toml` was found in an ancestor of the vault — emit the warning once per invocation
+- [ ] Implement the warning helper that fires at most once per process run (e.g., `OnceCell`-gated emit on stderr)
+- [ ] Wire the trigger into the file-resolution path so absolute-path warnings fire from any subcommand using `--file`
+- [ ] Wire the CWD-in-vault check into CLI startup (after config load) so it fires for every subcommand, not just file-mutating ones
+- [ ] Unit tests: absolute path inside vault → warn + resolve correctly; absolute path outside vault → still errors; CWD inside vault → warn fires; CWD outside vault → no warn; warning fires only once when multiple `--file` args are given
+- [ ] e2e test: invoke a command from inside the configured `dir` and assert the warning appears on stderr with the expected text
+- [ ] e2e test: invoke a command with an absolute `--file` inside the vault from the project root and assert the warning + successful execution
+- [ ] Update CLI help text / README / `.claude/CLAUDE.md` if any guidance contradicts the new behavior
+- [ ] Audit the hyalo skill (`.claude/skills/hyalo/SKILL.md` and the synced copy under `~/.claude/skills/hyalo/`) — add an explicit "always run from the project root, never cd into the configured `dir`, never use absolute `--file` paths" rule with a worked example, so the skill teaches the same lesson the runtime warning does
+- [ ] Dogfood: run hyalo against `hyalo-knowledgebase` and a sibling KB with absolute paths, confirm warnings render readably and don't double-fire
+
+## Acceptance Criteria
+
+- [ ] Absolute `--file` path that resolves inside the vault works and emits one warning to stderr
+- [ ] Absolute `--file` path that resolves outside the vault still hard-errors with `OutsideVault`
+- [ ] Running any hyalo subcommand from inside the configured `dir` emits one warning to stderr and otherwise behaves identically
+- [ ] Warning is emitted at most once per process invocation, even with multiple `--file` args or repeated triggers
+- [ ] Warning text references the actual configured `dir` value and gives a concrete corrective example
+- [ ] hyalo skill (project + global copies) explicitly tells the LLM to run from the project root and never cd into `dir` or use absolute paths
+- [ ] All existing tests pass; new unit + e2e tests cover the four cases above
+- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all clean


### PR DESCRIPTION
## Summary
- Detects two recurring LLM misuses of the hyalo CLI and emits a single, prominent stderr warning that teaches the LLM the right invocation pattern
- Absolute `--file` paths inside the vault are now rewritten to vault-relative form and the command proceeds (instead of erroring with `outside vault boundary`); absolute paths outside the vault still hard-error with `OutsideVault`
- When CWD lies inside the configured vault dir (with `.hyalo.toml` in an ancestor), warns once per process; skipped when `dir = "."` or no ancestor config exists
- Warning is deduplicated by the existing `warn::warn` machinery and silenced by `--quiet`
- Hyalo skill files (project + global, symlinked) get a new "Always run hyalo from the project root" section with a worked right/wrong example so the skill teaches the same lesson the runtime warning does

## Test plan
- [x] Unit tests in `discovery.rs` cover `strip_absolute_vault_prefix` (relative input, inside-vault, outside-vault, equal-to-vault, nonexistent-but-inside)
- [x] Unit tests in `warn.rs` cover the warning text, deduplication, the four CWD-vs-vault cases (inside, nested-inside, equal, outside, dir=".", sibling) and ancestor-walk fallthrough
- [x] e2e tests (`tests/e2e/llm_misuse.rs`): CWD inside vault warns; project root does not; absolute file inside vault warns and succeeds; absolute file outside vault errors without misuse warning; warning fires only once for multiple `--file` args; `--quiet` suppresses
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all clean
- [x] Dogfooded against this repo's `hyalo-knowledgebase`: warning fires from inside the vault and from a nested subdir, doesn't fire from project root, dedupes across multiple `--file` args, suppressed by `--quiet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM-misuse detection that warns when the CLI runs from inside the configured vault directory or receives absolute file paths via `--file`, with warnings deduplicated per invocation and suppressible via `--quiet`.

* **Documentation**
  * Updated path-handling guidelines with correct and incorrect usage examples.

* **Tests**
  * Added comprehensive test coverage for LLM-misuse warning behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->