### PR TITLE
Tighten link correctness, add lint --strict, TTY-aware --format (iter-129)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- hyalo:start -->
 Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations.
-Examples: `hyalo find --property status=planned --format text`, `hyalo find "search text"`, `hyalo lint`, `hyalo types list`.
-Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.
+Examples: `hyalo find --property status=planned`, `hyalo find "search text"`, `hyalo lint` (add `--strict` to fail on missing-type / undeclared-property warnings), `hyalo types list`.
+Run `hyalo --help` for usage. Output format auto-detects (text on terminals, json when piped); pass `--format text`/`--format json` to override.
 <!-- hyalo:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,13 @@ After an iteration or before starting one, build hyalo with "cargo build --relea
 Then use target/release/hyalo to work with the documentation in `./hyalo-knowledgebase/` to dogfood what you did. Mention issues you have using it, propose features you'd like to have.
 
 **Always use hyalo for knowledgebase interactions — never use Edit/Read/Grep directly:**
-- **Search/filter**: `hyalo find --property status=planned --tag iteration --format text`
-- **Body search**: `hyalo find "broken links" --format text` or regex: `hyalo find -e 'TODO|FIXME' --format text`
-- **Title regex**: `hyalo find --property 'title~=link' --format text`
+- **Search/filter**: `hyalo find --property status=planned --tag iteration`
+- **Body search**: `hyalo find "broken links"` or regex: `hyalo find -e 'TODO|FIXME'`
+- **Title regex**: `hyalo find --property 'title~=link'`
 - **Overview**: `hyalo summary`, `hyalo properties`, `hyalo tags`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append` (e.g., `hyalo set iterations/iteration-16-robustness.md --property status=completed`)
 - **Toggle tasks**: `hyalo task toggle <path> --all` (whole file), `--section "Tasks"` (by heading), `--line 5,7,9` (specific lines)
-- **Lint frontmatter + markdown body**: `hyalo lint`, `hyalo lint --rule MD013 --detailed`, `hyalo lint --rule-prefix HYALO`, `hyalo lint --fix --dry-run`, `hyalo lint --fix`, `hyalo lint --fix-rule HYALO001`
+- **Lint frontmatter + markdown body**: `hyalo lint`, `hyalo lint --rule MD013 --detailed`, `hyalo lint --rule-prefix HYALO`, `hyalo lint --strict` (promotes missing-type and undeclared-property warnings to errors), `hyalo lint --fix --dry-run`, `hyalo lint --fix`, `hyalo lint --fix-rule HYALO001`
 - **Manage lint rules**: `hyalo lint-rules list`, `hyalo lint-rules show MD013`, `hyalo lint-rules set MD013 --enabled false`, `hyalo lint-rules set MD013 --severity error`, `hyalo lint-rules remove MD013`
 - **Manage schemas**: `hyalo types list`, `hyalo types show <name>`, `hyalo types set <name> --required title,date`
 - Only fall back to Edit for body content changes (markdown prose) that hyalo can't handle

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Hyalo is the tooling layer that makes this practical. An LLM agent can use `hyal
 ### Why hyalo?
 
 - **Fast.** Parallel scanning, streaming I/O, optional snapshot index. Handles 10,000+ file vaults in under a second.
-- **Structured output.** JSON by default with built-in `--jq` support. Easy to pipe into scripts, CI, or AI agents.
+- **Structured output.** TTY-aware: compact `text` for terminals, `json` when piped — with built-in `--jq` support. Easy to pipe into scripts, CI, or AI agents.
 - **AI-agent friendly.** Designed as a tool for [Claude Code](https://claude.ai/claude-code) and other LLM coding agents. One command sets up the integration: `hyalo init --claude`.
 - **Safe mutations.** Dry-run mode on all write operations. Preview before committing changes.
 - **Cross-platform.** Works on macOS, Linux, and Windows. No runtime dependencies.
@@ -39,8 +39,8 @@ Hyalo is the tooling layer that makes this practical. An LLM agent can use `hyal
 # Omit --dir if the project root itself is the knowledgebase.
 hyalo init --dir docs
 
-# Get a bird's-eye view
-hyalo summary --format text
+# Get a bird's-eye view (output format auto-detected: text on terminals, json when piped)
+hyalo summary
 
 # Full-text search (BM25 ranked, with boolean operators)
 hyalo find "retry backoff"
@@ -77,6 +77,7 @@ hyalo links auto --file notes/todo.md --apply   # single-file mode
 hyalo lint                              # full vault, summary mode
 hyalo lint --rule MD013 --detailed      # drill into a single rule
 hyalo lint --rule-prefix HYALO          # only HYALO native rules
+hyalo lint --strict                     # promote missing-type and undeclared-property warnings to errors
 hyalo lint --fix --dry-run              # preview autofixes
 hyalo lint --fix                        # apply autofixes
 hyalo lint --fix-rule HYALO001          # only autofix one rule
@@ -149,7 +150,7 @@ Pre-built binaries for Linux (x86_64, ARM64, glibc and musl), macOS (Apple Silic
 
 ```toml
 dir = "./my-vault"        # vault directory (default: ".")
-format = "text"           # output format: "json" (default) or "text"
+format = "text"           # output format: "json" or "text" (default: TTY-aware — text on terminals, json when piped)
 hints = false             # drill-down command hints (default: true)
 default_limit = 100       # max results for list commands (default: 50; 0 = unlimited)
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -106,20 +106,21 @@ pub(crate) fn resolve_single_file(
         If a file path starts with the --dir prefix, it is stripped automatically \
         (e.g. --file docs/note.md resolves to note.md when --dir is docs). \
         Globs use standard syntax: '**/*.md' matches recursively, 'notes/*.md' matches one level.\n\n\
-        OUTPUT: Returns JSON by default (--format json). All JSON is wrapped in a consistent envelope:\n\
+        OUTPUT: Default format is \"text\" when stdout is a terminal, \"json\" when piped. \
+        All JSON is wrapped in a consistent envelope:\n\
         \u{00a0} {\"results\": <payload>, \"total\": N, \"hints\": [...]}\n\
         total is present for list commands (find, tags, properties, backlinks). \
         hints is always present (empty [] when --no-hints). \
         --jq operates on the full envelope, e.g. --jq '.results[].file' or --jq '.total'.\n\
         --count prints just the total as a bare integer (shortcut for --jq '.total').\n\
-        Use --format text for human-readable output. \
+        Use --format text for human-readable output, --format json for machine-readable output. \
         Successful output goes to stdout; errors go to stderr with exit code 1 (user error) or 2 (internal error).\n\n\
         ABSOLUTE LINKS: Links like `/docs/page.md` are resolved by stripping a site prefix. \
         By default the prefix is auto-derived from --dir's last path component (e.g. --dir ../my-site/docs → prefix \"docs\"). \
         Override with --site-prefix <PREFIX>, or --site-prefix \"\" to disable. Also settable in .hyalo.toml.\n\n\
         CONFIG: Place a .hyalo.toml in the working directory to set defaults:\n\
         \u{00a0} dir = \"vault/\"        # default --dir\n\
-        \u{00a0} format = \"text\"       # default --format (CLI default is json)\n\
+        \u{00a0} format = \"text\"       # pin format regardless of TTY detection\n\
         \u{00a0} hints = false          # disable hints (CLI default is on)\n\
         \u{00a0} site_prefix = \"docs\"  # override auto-derived site prefix for absolute links\n\
         CLI flags always take precedence.\n\n\
@@ -132,7 +133,8 @@ pub(crate) struct Cli {
     pub dir: Option<PathBuf>,
 
     /// Output format: "json" or "text".
-    /// Default: "json" (Override via .hyalo.toml)
+    /// Default: "text" when stdout is a terminal, "json" when piped.
+    /// Override for a session via .hyalo.toml: format = "text"
     #[arg(long, global = true)]
     pub format: Option<Format>,
 
@@ -886,6 +888,12 @@ Repeatable (AND).\n\
         /// Only autofix the specified rule(s) — repeatable
         #[arg(long, value_name = "RULE_ID", requires = "fix")]
         fix_rule: Vec<String>,
+        /// Promote schema warnings to errors for "no 'type' property" and
+        /// "undeclared property in frontmatter", causing lint to exit non-zero
+        /// when those issues are found.
+        /// Overrides `[lint] strict` in `.hyalo.toml` for this invocation.
+        #[arg(long)]
+        strict: bool,
         #[command(flatten)]
         index_flags: IndexFlags,
     },

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -21,7 +21,8 @@ use hyalo_core::discovery;
 use hyalo_core::filter::{self, Fields, FindTaskFilter, PropertyFilter, SortField};
 use hyalo_core::heading::{SectionFilter, SectionRange, build_section_scope, in_scope};
 use hyalo_core::index::VaultIndex;
-use hyalo_core::link_graph::is_self_link;
+use hyalo_core::link_graph::{is_self_link, normalize_target};
+use hyalo_core::links::LinkKind;
 use hyalo_core::types::{
     BacklinkInfo, ContentMatch, FileObject, FindTaskInfo, LinkInfo, OutlineSection, PropertyInfo,
 };
@@ -648,9 +649,46 @@ pub fn find(
                     .links
                     .iter()
                     .map(|(_, link)| {
+                        // Markdown links stored in the index carry the raw
+                        // (unresolved) target as written in the file.  Resolve
+                        // them against the source file's directory before
+                        // calling `resolve_target`, which rejects `..` components
+                        // for security reasons.  Wikilinks remain vault-relative.
+                        let resolved = match link.kind {
+                            LinkKind::Wikilink => link.target.clone(),
+                            LinkKind::Markdown => {
+                                if link.target.starts_with('/') {
+                                    link.target.clone()
+                                } else if link.target.contains('/') || link.target.contains('\\') {
+                                    normalize_target(
+                                        std::path::Path::new(&entry.rel_path),
+                                        &link.target,
+                                    )
+                                } else {
+                                    // Bare basename: try source-relative first so
+                                    // same-folder links resolve correctly.
+                                    let src_rel = normalize_target(
+                                        std::path::Path::new(&entry.rel_path),
+                                        &link.target,
+                                    );
+                                    if discovery::resolve_target(
+                                        &canonical_dir,
+                                        &src_rel,
+                                        site_prefix,
+                                        case_index,
+                                    )
+                                    .is_some()
+                                    {
+                                        src_rel
+                                    } else {
+                                        link.target.clone()
+                                    }
+                                }
+                            }
+                        };
                         let path = discovery::resolve_target(
                             &canonical_dir,
-                            &link.target,
+                            &resolved,
                             site_prefix,
                             case_index,
                         );

--- a/crates/hyalo-cli/src/commands/find/tests.rs
+++ b/crates/hyalo-cli/src/commands/find/tests.rs
@@ -1736,3 +1736,80 @@ fn find_orphan_composes_with_sort_and_limit() {
     let files: Vec<&str> = arr.iter().map(|v| v["file"].as_str().unwrap()).collect();
     assert_eq!(files, vec!["a.md", "b.md"], "sorted by file, limited to 2");
 }
+
+// --- Finding 2: `../` relative markdown links resolve correctly ---
+
+/// `a/foo.md` links to `[x](../sibling/y.md)` and `sibling/y.md` exists.
+/// The `links.path` field must be populated (not `null`/unresolved).
+#[test]
+fn relative_dotdot_link_resolves_in_find() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create a/foo.md with a ../sibling/y.md link.
+    fs::create_dir_all(tmp.path().join("a")).unwrap();
+    fs::create_dir_all(tmp.path().join("sibling")).unwrap();
+    fs::write(
+        tmp.path().join("a/foo.md"),
+        md!(r"
+---
+title: Foo
+---
+See [x](../sibling/y.md) for details.
+"),
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("sibling/y.md"),
+        md!(r"
+---
+title: Y
+---
+# Y
+"),
+    )
+    .unwrap();
+
+    let fields = Fields {
+        links: true,
+        ..Default::default()
+    };
+
+    let out = unwrap_success(
+        run_find(
+            tmp.path(),
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            None,
+            &[],
+            &["a/foo.md".to_string()],
+            &[],
+            &fields,
+            None,
+            false,
+            None,
+            false,
+            None,
+            Format::Json,
+        )
+        .unwrap(),
+    );
+
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&out).unwrap();
+    assert_eq!(arr.len(), 1, "should find a/foo.md");
+    let links = arr[0]["links"].as_array().expect("links field present");
+    assert_eq!(links.len(), 1, "one link");
+    let path_val = &links[0]["path"];
+    assert!(
+        !path_val.is_null(),
+        "../sibling/y.md link should resolve; got path={path_val}"
+    );
+    // The resolved path should be the vault-relative form.
+    let path_str = path_val.as_str().expect("path is string");
+    assert_eq!(
+        path_str, "sibling/y.md",
+        "resolved path should be vault-relative sibling/y.md"
+    );
+}

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -47,11 +47,34 @@ impl std::fmt::Display for Severity {
     }
 }
 
+/// Stable identifier for schema warnings that strict mode promotes to errors.
+///
+/// Strict-mode promotion matches on these constants rather than the
+/// user-facing `message`, so reworded messages don't silently disable
+/// the promotion logic.
+pub const VIOLATION_KIND_MISSING_TYPE: &str = "schema/missing-type";
+pub const VIOLATION_KIND_UNDECLARED_PROPERTY: &str = "schema/undeclared-property";
+
 /// A single lint violation found in a file.
 #[derive(Debug, Clone, Serialize)]
 pub struct Violation {
     pub severity: Severity,
     pub message: String,
+    /// Stable kind identifier for programmatic dispatch (e.g. strict-mode
+    /// promotion in `lint_file`). `None` for ad-hoc violations that don't
+    /// need to be matched programmatically.
+    #[serde(skip)]
+    pub kind: Option<&'static str>,
+}
+
+impl Default for Violation {
+    fn default() -> Self {
+        Self {
+            severity: Severity::Warn,
+            message: String::new(),
+            kind: None,
+        }
+    }
 }
 
 /// Lint results for a single file.
@@ -264,6 +287,7 @@ pub fn validate_views(dir: &Path) -> Option<FileLintResult> {
         if !has_narrowing && has_fields {
             violations.push(Violation {
                 severity: Severity::Warn,
+                kind: None,
                 message: format!(
                     "view '{name}' has no narrowing filter — `fields` controls display columns only, \
                      not filtering. Did you mean `orphan = true` or `dead_end = true`?"
@@ -272,6 +296,7 @@ pub fn validate_views(dir: &Path) -> Option<FileLintResult> {
         } else if !has_narrowing {
             violations.push(Violation {
                 severity: Severity::Warn,
+                kind: None,
                 message: format!(
                     "view '{name}' has no narrowing filter — add at least one of: \
                      tag, properties, task, orphan, dead_end, broken_links, glob, file, title"
@@ -451,6 +476,7 @@ fn lint_file_with_fix(
                     file: rel_path.to_owned(),
                     violations: vec![Violation {
                         severity: Severity::Error,
+                        kind: None,
                         message: format!("{}: {e}", crate::hints::PARSE_ERROR_PREFIX),
                     }],
                 },
@@ -756,6 +782,7 @@ fn validate_properties(
     {
         violations.push(Violation {
             severity: Severity::Error,
+            kind: None,
             message: format!("property \"type\" expected string, got {v}"),
         });
     }
@@ -764,6 +791,7 @@ fn validate_properties(
     if type_value.is_none() && !schema.is_empty() {
         violations.push(Violation {
             severity: Severity::Warn,
+            kind: Some(VIOLATION_KIND_MISSING_TYPE),
             message: "no 'type' property — validating against default schema only".to_owned(),
         });
     }
@@ -783,6 +811,7 @@ fn validate_properties(
                 .unwrap_or_default();
             violations.push(Violation {
                 severity: Severity::Error,
+                kind: None,
                 message: format!("missing required property \"{req}\"{type_hint}"),
             });
         }
@@ -792,6 +821,7 @@ fn validate_properties(
     if !has_tags && !schema.types.is_empty() {
         violations.push(Violation {
             severity: Severity::Warn,
+            kind: None,
             message: "no tags defined".to_owned(),
         });
     }
@@ -820,6 +850,7 @@ fn validate_properties(
                     {
                         violations.push(Violation {
                             severity: Severity::Warn,
+                            kind: None,
                             message: format!(
                                 "tag \"{tag}\" appears to be comma-joined -- should be separate list items"
                             ),
@@ -843,6 +874,7 @@ fn validate_properties(
             // intentionally permissive about extra fields.
             violations.push(Violation {
                 severity: Severity::Warn,
+                kind: Some(VIOLATION_KIND_UNDECLARED_PROPERTY),
                 message: format!("property \"{name}\" is not declared in schema"),
             });
         }
@@ -866,6 +898,7 @@ fn validate_constraint(
             let Some(s) = value_as_str(value) else {
                 return Some(Violation {
                     severity: Severity::Error,
+                    kind: None,
                     message: format!("property \"{name}\" expected string, got {value}"),
                 });
             };
@@ -879,6 +912,7 @@ fn validate_constraint(
                         if !re.is_match(s) {
                             return Some(Violation {
                                 severity: Severity::Error,
+                                kind: None,
                                 message: format!(
                                     "property \"{name}\" value {s:?} does not match pattern {pat:?}"
                                 ),
@@ -888,6 +922,7 @@ fn validate_constraint(
                     Err(e) => {
                         return Some(Violation {
                             severity: Severity::Error,
+                            kind: None,
                             message: format!("property \"{name}\": invalid pattern {pat:?}: {e}"),
                         });
                     }
@@ -899,12 +934,14 @@ fn validate_constraint(
             let Some(s) = value_as_str(value) else {
                 return Some(Violation {
                     severity: Severity::Error,
+                    kind: None,
                     message: format!("property \"{name}\" expected date (YYYY-MM-DD), got {value}"),
                 });
             };
             if !is_iso8601_date(s) {
                 return Some(Violation {
                     severity: Severity::Error,
+                    kind: None,
                     message: format!("property \"{name}\" expected date (YYYY-MM-DD), got \"{s}\""),
                 });
             }
@@ -914,6 +951,7 @@ fn validate_constraint(
             if !matches!(value, Value::Number(_)) {
                 return Some(Violation {
                     severity: Severity::Error,
+                    kind: None,
                     message: format!("property \"{name}\" expected number, got {value}"),
                 });
             }
@@ -923,6 +961,7 @@ fn validate_constraint(
             if !matches!(value, Value::Bool(_)) {
                 return Some(Violation {
                     severity: Severity::Error,
+                    kind: None,
                     message: format!("property \"{name}\" expected boolean, got {value}"),
                 });
             }
@@ -932,6 +971,7 @@ fn validate_constraint(
             if !matches!(value, Value::Array(_)) {
                 return Some(Violation {
                     severity: Severity::Error,
+                    kind: None,
                     message: format!("property \"{name}\" expected list, got {value}"),
                 });
             }
@@ -941,6 +981,7 @@ fn validate_constraint(
             let Some(s) = value_as_str(value) else {
                 return Some(Violation {
                     severity: Severity::Error,
+                    kind: None,
                     message: format!(
                         "property \"{name}\" expected one of [{}], got {value}",
                         values.join(", ")
@@ -958,6 +999,7 @@ fn validate_constraint(
                 .unwrap_or_default();
             Some(Violation {
                 severity: Severity::Error,
+                kind: None,
                 message: format!(
                     "property \"{name}\" value \"{s}\" not in [{}]{suggestion}",
                     values.join(", ")
@@ -1677,14 +1719,15 @@ fn lint_one_file_extended(
         let fm_violations = validate_properties(rel_path, &properties, has_tags, schema);
         for v in fm_violations {
             // In strict mode, promote the two targeted schema warnings to errors.
-            let effective_severity = if strict && v.severity == Severity::Warn {
-                let is_missing_type = v.message.contains("no 'type' property");
-                let is_undeclared = v.message.contains("is not declared in schema");
-                if is_missing_type || is_undeclared {
-                    Severity::Error
-                } else {
-                    v.severity
-                }
+            // Match on the stable `kind` identifier rather than message text so
+            // future message rewordings don't silently disable promotion.
+            let effective_severity = if strict
+                && v.severity == Severity::Warn
+                && matches!(
+                    v.kind,
+                    Some(VIOLATION_KIND_MISSING_TYPE | VIOLATION_KIND_UNDECLARED_PROPERTY)
+                ) {
+                Severity::Error
             } else {
                 v.severity
             };

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -1112,6 +1112,9 @@ pub struct ExtLintOptions<'a> {
     pub snapshot_index: &'a mut Option<hyalo_core::index::SnapshotIndex>,
     pub index_path: Option<&'a Path>,
     pub vault_dir: &'a Path,
+    /// When `true`, promote "no 'type' property" and "undeclared property in
+    /// frontmatter" from `Severity::Warn` to `Severity::Error`.
+    pub strict: bool,
 }
 
 /// Run the extended lint (frontmatter + body) and return the new output shape.
@@ -1140,6 +1143,8 @@ pub fn lint_files_extended(
     // Determine if schema has `status: completed` in any type.
     let schema_has_completed = schema_has_completed_status(schema);
 
+    let strict = opts.strict;
+
     // Process files in parallel. Each worker lints one file.
     let per_file: Vec<Result<PerFileLintResult>> = files
         .par_iter()
@@ -1155,6 +1160,7 @@ pub fn lint_files_extended(
                 opts.fix,
                 opts.fix_rules,
                 opts.max_per_rule,
+                strict,
             )
         })
         .collect();
@@ -1617,6 +1623,7 @@ fn lint_one_file_extended(
     fix: FixMode,
     fix_rules: &[String],
     max_per_rule: usize,
+    strict: bool,
 ) -> Result<PerFileLintResult> {
     // Read the file content once.
     let content =
@@ -1669,7 +1676,19 @@ fn lint_one_file_extended(
         let has_tags = properties.contains_key("tags");
         let fm_violations = validate_properties(rel_path, &properties, has_tags, schema);
         for v in fm_violations {
-            let sev = match v.severity {
+            // In strict mode, promote the two targeted schema warnings to errors.
+            let effective_severity = if strict && v.severity == Severity::Warn {
+                let is_missing_type = v.message.contains("no 'type' property");
+                let is_undeclared = v.message.contains("is not declared in schema");
+                if is_missing_type || is_undeclared {
+                    Severity::Error
+                } else {
+                    v.severity
+                }
+            } else {
+                v.severity
+            };
+            let sev = match effective_severity {
                 Severity::Error => "error",
                 Severity::Warn => "warn",
             };
@@ -2274,6 +2293,121 @@ mod tests {
             comma_warn.unwrap().message.contains("comma-joined"),
             "message should mention comma-joined"
         );
+    }
+
+    // --- Strict mode unit tests ---
+
+    fn make_schema_with_declared_prop() -> SchemaConfig {
+        // Schema with a declared `note` type that has `title` as required and
+        // `date` as a declared property, so any other property is "undeclared".
+        make_schema(&["title"], "note", &[], HashMap::new())
+    }
+
+    /// Helper: run lint in extended mode on a single file.
+    fn lint_extended_strict(
+        path: &std::path::Path,
+        rel: &str,
+        schema: &SchemaConfig,
+        strict: bool,
+    ) -> (crate::output::CommandOutcome, LintCounts) {
+        let engine = hyalo_mdlint::HyaloLintEngine::create().unwrap();
+        let md_config = hyalo_mdlint::LintConfig::default();
+        let files = vec![(path.to_path_buf(), rel.to_owned())];
+        let mut snapshot: Option<hyalo_core::index::SnapshotIndex> = None;
+        let vault_dir = path.parent().unwrap();
+        let mut opts = ExtLintOptions {
+            fix: FixMode::Off,
+            detailed: false,
+            rule_filter: None,
+            rule_prefix: None,
+            max_per_rule: 100,
+            max_files: 100,
+            fix_rules: &[],
+            snapshot_index: &mut snapshot,
+            index_path: None,
+            vault_dir,
+            strict,
+        };
+        lint_files_extended(&files, schema, &engine, &md_config, &mut opts).unwrap()
+    }
+
+    /// In strict mode the "no 'type' property" warning becomes an error.
+    #[test]
+    fn strict_mode_promotes_no_type_to_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_type.md");
+        std::fs::write(&path, "---\ntitle: Hello\n---\nBody\n").unwrap();
+
+        let schema = make_schema_with_declared_prop();
+        let (_, counts) = lint_extended_strict(&path, "no_type.md", &schema, true);
+        assert!(counts.errors > 0, "strict mode: no-type should be an error");
+    }
+
+    /// Without strict mode the "no 'type' property" is still a warning.
+    #[test]
+    fn non_strict_no_type_stays_warn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_type.md");
+        std::fs::write(&path, "---\ntitle: Hello\n---\nBody\n").unwrap();
+
+        let schema = make_schema_with_declared_prop();
+        let (_, counts) = lint_extended_strict(&path, "no_type.md", &schema, false);
+        // The "no type" warn plus "no tags" warn.
+        assert_eq!(
+            counts.errors, 0,
+            "non-strict: no-type should remain a warning"
+        );
+        assert!(counts.warnings > 0, "non-strict: warnings expected");
+    }
+
+    /// In strict mode, undeclared properties become errors.
+    #[test]
+    fn strict_mode_promotes_undeclared_property_to_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("undeclared.md");
+        // `type: note` present (avoids no-type warning), but `unknown_prop` is not
+        // declared in the note schema's `properties` map.
+        std::fs::write(
+            &path,
+            "---\ntitle: Hello\ntype: note\nunknown_prop: oops\n---\nBody\n",
+        )
+        .unwrap();
+
+        let schema = {
+            // Build a schema where `note` has declared `properties` so
+            // the undeclared-property path fires.
+            use hyalo_core::schema::{PropertyConstraint, SchemaConfig, TypeSchema};
+            let mut schema = SchemaConfig::default();
+            let mut ts = TypeSchema::default();
+            ts.required.push("title".to_owned());
+            ts.properties.insert(
+                "title".to_owned(),
+                PropertyConstraint::String { pattern: None },
+            );
+            schema.types.insert("note".to_owned(), ts);
+            schema
+        };
+
+        let (_, counts) = lint_extended_strict(&path, "undeclared.md", &schema, true);
+        assert!(
+            counts.errors > 0,
+            "strict: undeclared prop should be an error"
+        );
+    }
+
+    /// Strict mode only promotes the two targeted warnings; "no tags" stays a warn.
+    #[test]
+    fn strict_mode_leaves_no_tags_as_warn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no_tags.md");
+        // Has type, no tags — triggers "no tags defined" warning.
+        std::fs::write(&path, "---\ntitle: Hello\ntype: note\n---\nBody\n").unwrap();
+
+        let schema = make_schema_with_declared_prop();
+        let (_, counts) = lint_extended_strict(&path, "no_tags.md", &schema, true);
+        // "no tags" should still be a warning, not an error.
+        assert_eq!(counts.errors, 0, "strict: no-tags should stay as warn");
+        assert!(counts.warnings > 0, "strict: no-tags warning still present");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -54,6 +54,12 @@ struct LintConfig {
     /// and table (`[lint.rules.MD013]`) forms.
     #[serde(default)]
     rules: Option<toml::Value>,
+    /// When `true`, promote "no 'type' property" and "undeclared property in
+    /// frontmatter" from `Severity::Warn` to `Severity::Error`, causing lint
+    /// to exit non-zero on those warnings.  Overridable per-invocation with
+    /// `hyalo lint --strict`.
+    #[serde(default)]
+    strict: bool,
 }
 
 /// Raw deserialized representation of `.hyalo.toml`.
@@ -104,7 +110,9 @@ pub(crate) struct ResolvedDefaults {
     /// in this file, so mutations must target `config_dir/.hyalo.toml` — not the
     /// vault directory (which may be a subdirectory specified via `dir = "…"`).
     pub(crate) config_dir: PathBuf,
-    pub(crate) format: String,
+    /// Explicit format from `.hyalo.toml`, or `None` if not set.
+    /// When `None`, format resolution falls back to TTY detection at runtime.
+    pub(crate) format: Option<String>,
     pub(crate) hints: bool,
     /// Explicit site-prefix override from `.hyalo.toml`, if any.
     pub(crate) site_prefix: Option<String>,
@@ -129,6 +137,10 @@ pub(crate) struct ResolvedDefaults {
     pub(crate) default_limit: Option<usize>,
     /// Case-insensitive link resolution mode from `[links] case_insensitive`.
     pub(crate) case_insensitive_mode: CaseInsensitiveMode,
+    /// When `true`, "no 'type' property" and "undeclared property in frontmatter"
+    /// warnings are promoted to errors.  From `[lint] strict = true` in `.hyalo.toml`.
+    /// Can be overridden per-invocation with `hyalo lint --strict`.
+    pub(crate) lint_strict: bool,
 }
 
 impl PartialEq for ResolvedDefaults {
@@ -154,7 +166,7 @@ impl ResolvedDefaults {
         Self {
             dir: PathBuf::from("."),
             config_dir: PathBuf::from("."),
-            format: "json".to_owned(),
+            format: None,
             hints: true,
             site_prefix: None,
             search_language: None,
@@ -165,6 +177,7 @@ impl ResolvedDefaults {
             schema: SchemaConfig::default(),
             default_limit: None,
             case_insensitive_mode: CaseInsensitiveMode::Auto,
+            lint_strict: false,
         }
     }
 
@@ -285,10 +298,12 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         }
     };
 
+    let lint_strict = cfg.lint.as_ref().is_some_and(|l| l.strict);
+
     ResolvedDefaults {
         dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
         config_dir: dir.to_path_buf(),
-        format: cfg.format.unwrap_or(defaults.format),
+        format: cfg.format,
         hints: cfg.hints.unwrap_or(defaults.hints),
         site_prefix: cfg.site_prefix,
         search_language: cfg.search.and_then(|s| s.language),
@@ -303,6 +318,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         schema,
         default_limit: cfg.default_limit,
         case_insensitive_mode,
+        lint_strict,
     }
 }
 
@@ -419,7 +435,7 @@ hints = true
 
         let resolved = load_config_from(dir.path());
         assert_eq!(resolved.dir, PathBuf::from("notes"));
-        assert_eq!(resolved.format, "text");
+        assert_eq!(resolved.format, Some("text".to_owned()));
         assert!(resolved.hints);
         assert_eq!(resolved.site_prefix, None);
     }
@@ -448,7 +464,8 @@ site_prefix = "docs"
         let resolved = load_config_from(dir.path());
         // Only hints overridden; dir and format stay at defaults.
         assert_eq!(resolved.dir, PathBuf::from("."));
-        assert_eq!(resolved.format, "json");
+        // format is None when not set in config (TTY detection applies at runtime).
+        assert_eq!(resolved.format, None);
         assert!(
             !resolved.hints,
             "config should override the default (true) to false"
@@ -480,7 +497,7 @@ site_prefix = "docs"
 
         // config.rs does not validate the format string — that is the caller's job.
         let resolved = load_config_from(dir.path());
-        assert_eq!(resolved.format, "xml");
+        assert_eq!(resolved.format, Some("xml".to_owned()));
         assert_eq!(resolved.dir, PathBuf::from("."));
         assert!(resolved.hints);
     }

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -106,6 +106,10 @@ pub(crate) struct CommandContext<'a> {
     /// When true, the output is consumed programmatically (`--jq` or `--count`),
     /// so the default limit should not apply — only an explicit `--limit` is honoured.
     pub programmatic_output: bool,
+    /// Strict schema validation mode from `[lint] strict = true` in `.hyalo.toml`.
+    /// When `true`, "no 'type' property" and "undeclared property" warnings are
+    /// promoted to errors, and lint exits non-zero on them.
+    pub lint_strict: bool,
 }
 
 /// Resolve the effective limit for a list command.
@@ -1139,8 +1143,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             rule_prefix,
             max_per_rule,
             fix_rule,
+            strict: lint_strict_flag,
             index_flags: _, // consumed in run.rs before dispatch
         } => {
+            // --strict flag wins over config value; config value is the fallback.
+            let effective_strict = lint_strict_flag || ctx.lint_strict;
             // Resolve --type to a glob pattern from its filename_template.
             let type_glob: Option<String> = if let Some(type_name) = lint_type {
                 use hyalo_core::filename_template::FilenameTemplate;
@@ -1295,6 +1302,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 snapshot_index,
                 index_path,
                 vault_dir: dir,
+                strict: effective_strict,
             };
 
             let (outcome, mut counts) = lint_commands::lint_files_extended(

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal as _;
 use std::process;
 
 use clap::{CommandFactory, FromArgMatches};
@@ -11,6 +12,17 @@ use crate::hints::{CommonHintFlags, HintContext, HintSource};
 use crate::output::{CommandOutcome, Format};
 use crate::output_pipeline::{COUNT_UNSUPPORTED_ERROR, OutputPipeline};
 use hyalo_core::index::SnapshotIndex;
+
+/// Resolve the default output format based on whether stdout is a TTY.
+///
+/// - TTY (interactive terminal): `Format::Text` — human-readable by default.
+/// - Piped / redirected: `Format::Json` — machine-readable by default.
+///
+/// Takes an `is_tty: bool` parameter so callers can inject a test value.
+/// Production call site: `resolve_format_by_tty(std::io::stdout().is_terminal())`.
+pub(crate) fn resolve_format_by_tty(is_tty: bool) -> Format {
+    if is_tty { Format::Text } else { Format::Json }
+}
 
 /// Extract the effective index path from whichever subcommand is active.
 ///
@@ -147,7 +159,7 @@ fn run_inner() -> Result<(), AppError> {
         .dir
         .components()
         .ne(std::path::Path::new(".").components());
-    let hide_format = config.format != "json";
+    let hide_format = config.format.as_deref().is_some_and(|f| f != "json");
 
     let mut cmd = Cli::command();
     if hide_dir {
@@ -404,17 +416,26 @@ fn run_inner() -> Result<(), AppError> {
         }
     };
     let site_prefix = site_prefix_owned.as_deref();
-    // CLI --format is already validated by Clap; fall back to config (String) with runtime parse.
+    // Resolve the output format.
+    //
+    // Precedence (highest first):
+    //   1. Explicit `--format` CLI flag.
+    //   2. `format = "..."` in `.hyalo.toml`.
+    //   3. TTY detection: `text` when stdout is a terminal, `json` when piped.
     let format = if let Some(f) = cli.format {
         f
-    } else if let Some(fmt) = Format::from_str_opt(&config.format) {
-        fmt
+    } else if let Some(ref fmt_str) = config.format {
+        if let Some(fmt) = Format::from_str_opt(fmt_str) {
+            fmt
+        } else {
+            eprintln!(
+                "Invalid output format '{fmt_str}' in .hyalo.toml; supported formats are: json, text"
+            );
+            return Err(AppError::Exit(2));
+        }
     } else {
-        eprintln!(
-            "Invalid output format '{}' in .hyalo.toml; supported formats are: json, text",
-            config.format
-        );
-        return Err(AppError::Exit(2));
+        // No explicit flag or config — use TTY detection.
+        resolve_format_by_tty(std::io::stdout().is_terminal())
     };
     let hints_flag = if cli.hints {
         true
@@ -851,6 +872,7 @@ fn run_inner() -> Result<(), AppError> {
     let lint_ignore = config.lint_ignore;
     let case_insensitive_mode = config.case_insensitive_mode;
     let md_lint = config.md_lint;
+    let lint_strict_from_config = config.lint_strict;
 
     // Propagate the configured frontmatter-link property list into the loaded
     // snapshot so that per-file refreshes (`rescan_entry` / `rename_entry`) use
@@ -876,6 +898,7 @@ fn run_inner() -> Result<(), AppError> {
         exit_code_override: None,
         config_default_limit,
         programmatic_output: jq_filter.is_some() || cli.count,
+        lint_strict: lint_strict_from_config,
     };
     let result = dispatch(cli.command, &mut ctx);
     let exit_code_override = ctx.exit_code_override;
@@ -893,5 +916,22 @@ fn run_inner() -> Result<(), AppError> {
         Ok(())
     } else {
         Err(AppError::Exit(final_code))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// When stdout is a TTY, the default format should be `Text`.
+    #[test]
+    fn resolve_format_by_tty_returns_text_for_tty() {
+        assert_eq!(resolve_format_by_tty(true), Format::Text);
+    }
+
+    /// When stdout is piped (not a TTY), the default format should be `Json`.
+    #[test]
+    fn resolve_format_by_tty_returns_json_for_pipe() {
+        assert_eq!(resolve_format_by_tty(false), Format::Json);
     }
 }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -420,10 +420,15 @@ fn run_inner() -> Result<(), AppError> {
     //
     // Precedence (highest first):
     //   1. Explicit `--format` CLI flag.
-    //   2. `format = "..."` in `.hyalo.toml`.
-    //   3. TTY detection: `text` when stdout is a terminal, `json` when piped.
+    //   2. `--jq` (forces JSON unless an explicit format is set, since jq
+    //      operates on JSON — without this, TTY users running
+    //      `hyalo find ... --jq '...'` would hit the format-conflict error).
+    //   3. `format = "..."` in `.hyalo.toml`.
+    //   4. TTY detection: `text` when stdout is a terminal, `json` when piped.
     let format = if let Some(f) = cli.format {
         f
+    } else if cli.jq.is_some() {
+        Format::Json
     } else if let Some(ref fmt_str) = config.format {
         if let Some(fmt) = Format::from_str_opt(fmt_str) {
             fmt

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -3,18 +3,19 @@ paths:
   - "hyalo-knowledgebase/**"
 ---
 Prefer `hyalo` CLI for operations on files in this directory:
-- **Search/filter**: `hyalo find --property status=planned --tag iteration --format text`
-- **Body search**: `hyalo find "broken links" --format text`
-- **Title regex**: `hyalo find --property 'title~=link' --format text`
+- **Search/filter**: `hyalo find --property status=planned --tag iteration`
+- **Body search**: `hyalo find "broken links"`
+- **Title regex**: `hyalo find --property 'title~=link'`
 - **Read frontmatter/metadata**: `hyalo find --file <path>`, `hyalo properties`, `hyalo tags`
 - **Read content/sections**: `hyalo read <path>` or `hyalo read <path> --section "Heading"`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append`
 - **Auto-link**: `hyalo links auto --first-only --exclude-target-glob 'templates/*' --apply`
 - **Move/rename**: `hyalo mv` (rewrites links across the vault)
-- **Lint markdown + frontmatter**: `hyalo lint`, `hyalo lint --rule HYALO001 --detailed`, `hyalo lint --fix --dry-run`, `hyalo lint --fix`
+- **Lint markdown + frontmatter**: `hyalo lint`, `hyalo lint --strict` (promotes missing-type and undeclared-property warnings to errors), `hyalo lint --rule HYALO001 --detailed`, `hyalo lint --fix --dry-run`, `hyalo lint --fix`
 - **Manage lint rules**: `hyalo lint-rules list`, `hyalo lint-rules show <ID>`, `hyalo lint-rules set <ID> --enabled false`, `hyalo lint-rules set <ID> --severity warn`
 
 Fall back to Edit for body prose changes, Write for new files, and Read when
 hyalo doesn't cover the operation (e.g., reading raw markdown for rewriting).
 
-Use `--format text` for compact output. Run `hyalo <command> --help` if unsure.
+Output format auto-detects (text on terminals, json when piped); pass `--format text`
+or `--format json` to override. Run `hyalo <command> --help` if unsure.

--- a/crates/hyalo-cli/templates/skill-hyalo-tidy.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-tidy.md
@@ -38,7 +38,7 @@ Get the lay of the land and create a snapshot index for fast repeated queries.
 
 ```bash
 # 1. High-level overview (baseline for the final health dashboard)
-hyalo summary --format text
+hyalo summary
 
 # 2. Create snapshot index (one scan, reused by all subsequent queries)
 hyalo create-index
@@ -57,7 +57,7 @@ avoid repeated disk scans. For complex reshaping, combine hyalo filtering with `
 
 Also grab the tag vocabulary for inconsistency detection:
 ```bash
-hyalo tags summary --format text --index
+hyalo tags summary --index
 ```
 
 ## Phase 2 — Gather recent signal
@@ -98,8 +98,8 @@ fi
 
 If found, query it with hyalo (memory files are outside the vault, so no --index here):
 ```bash
-hyalo --dir "$MEMORY_DIR" find --property type=project --format text
-hyalo --dir "$MEMORY_DIR" find --property type=feedback --format text
+hyalo --dir "$MEMORY_DIR" find --property type=project
+hyalo --dir "$MEMORY_DIR" find --property type=feedback
 ```
 
 Look for:
@@ -119,12 +119,14 @@ git log --diff-filter=A --name-only --since="4 weeks ago" -- "hyalo-knowledgebas
 All queries below use `--index` — no additional disk scans needed.
 
 ### Schema & lint
-Check if type schemas are defined, then run lint. `hyalo lint` covers both frontmatter
-schema *and* the markdown body (stock mdbook-lint rules + HYALO native rules for things
-like bare `[]` checkboxes and `status: completed` with open tasks):
+Check if type schemas are defined, then run lint in strict mode. `hyalo lint` covers
+both frontmatter schema *and* the markdown body (stock mdbook-lint rules + HYALO native
+rules for things like bare `[]` checkboxes and `status: completed` with open tasks).
+`--strict` promotes the "no `type` property" and "undeclared property in frontmatter"
+warnings to errors so a tidy pass fails fast on schema drift:
 ```bash
-hyalo types list --format text
-hyalo lint --format text --index
+hyalo types list
+hyalo lint --strict --index
 ```
 
 If `hyalo types list` returns zero types but files have a `type` property, propose
@@ -146,7 +148,7 @@ one in Phase 5.
 ### Broken links
 ```bash
 # Dry-run shows broken links with proposed fixes and confidence scores
-hyalo links fix --index --format text
+hyalo links fix --index
 ```
 This categorizes links as **fixable** (fuzzy match found) vs **unfixable** (no match).
 Note the counts for the health dashboard. Actual fixes happen in Phase 4.
@@ -226,8 +228,8 @@ If lint reported fixable violations in Phase 3, auto-fix them. `--fix` covers bo
 passes — frontmatter (defaults, typos, dates, types) and body (e.g. `HYALO001` bare
 brackets, trailing whitespace). Always preview with `--dry-run` first:
 ```bash
-hyalo lint --fix --dry-run --format text --index
-hyalo lint --fix --format text --index
+hyalo lint --fix --dry-run --index
+hyalo lint --fix --index
 ```
 
 If you only want to fix specific rules (e.g. body fixes only, leaving frontmatter
@@ -242,10 +244,10 @@ correct target (handles moves to `done/`, case changes, extension mismatches, et
 
 ```bash
 # Preview what will be fixed
-hyalo links fix --format text --index
+hyalo links fix --index
 
 # Apply fixes
-hyalo links fix --apply --format text --index
+hyalo links fix --apply --index
 ```
 
 Review the dry-run output first. For any links it can't resolve (reported as unfixable),
@@ -302,9 +304,9 @@ on legitimate exceptions), suggest tuning it via `hyalo lint-rules` rather than
 silently leaving the warnings in place.
 
 ### KB health dashboard
-Re-run `hyalo summary --format text` (fresh scan after mutations — no `--index`) and
-compare with Phase 1 baseline. Report the delta: statuses changed, links fixed, tags
-normalized, files moved.
+Re-run `hyalo summary` (fresh scan after mutations — no `--index`) and compare with
+Phase 1 baseline. Report the delta: statuses changed, links fixed, tags normalized,
+files moved.
 
 ## Ground rules
 

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -120,8 +120,9 @@ lines in text mode, a `"hints"` array in the JSON envelope). Read and follow the
 concrete next commands to explore deeper. Use `--no-hints` to suppress them, or `--jq` which
 suppresses hints automatically.
 
-Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports
-(requires JSON format — do not combine with `--format text`):
+Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports.
+`--jq` requires JSON output; piping naturally produces JSON, so `--jq` works without
+an explicit `--format json` in most contexts:
 
 ```bash
 hyalo find --property status=in-progress --fields tasks \
@@ -177,7 +178,7 @@ ALWAYS run `which hyalo` as your very first step. Do not skip this.
 conversations use hyalo without needing this skill:
 
 ```
-Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly output.
+Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations (frontmatter, tags, tasks, search). Run `hyalo --help` for usage. Output format auto-detects (text on terminals, json when piped); pass `--format text`/`--format json` to override.
 ```
 
 This one-line instruction saves tokens in every future conversation.
@@ -240,14 +241,15 @@ hyalo read my-note.md --lines 1:20                 # line range (1-based)
 hyalo read my-note.md --frontmatter                # include YAML frontmatter
 ```
 
-Start with `hyalo summary --format text` to orient yourself in a new directory.
+Start with `hyalo summary` to orient yourself in a new directory (text output is the
+default in interactive terminals).
 
 ## Available commands
 
 - **find** — BM25 ranked full-text search (AND, OR, phrase, negation) or regex; filter by property, tag, task status
 - **read** — extract body content, a section, or line range
 - **summary** — compact fixed-size orientation view: file counts, tags, tasks, orphans, dead-ends, links, schema lint count (use `--depth N` to override directory depth)
-- **lint** — validate frontmatter against the `[schema]` and lint markdown body with mdbook-lint MD001..MD059 + HYALO001/002 native rules; supports `--rule`, `--rule-prefix`, `--detailed`, `--max-per-rule`, `--fix`, `--fix-rule`; exit 1 when errors found
+- **lint** — validate frontmatter against the `[schema]` and lint markdown body with mdbook-lint MD001..MD059 + HYALO001/002 native rules; supports `--rule`, `--rule-prefix`, `--detailed`, `--max-per-rule`, `--strict` (promotes missing-type and undeclared-property warnings to errors), `--fix`, `--fix-rule`; exit 1 when errors found
 - **lint-rules** — manage which lint rules are enabled and their severity in `.hyalo.toml` (list, show, set, remove)
 - **types** — manage `[schema.types.*]` entries in `.hyalo.toml` (list, show, set, remove)
 - **properties summary** — list property names and types
@@ -284,6 +286,11 @@ hyalo lint --fix                         # apply
 ```
 
 Use `hyalo lint --help` for narrowing flags (`--rule`, `--rule-prefix`, `--detailed`, `--max-per-rule`, `--fix-rule`, etc.). The snapshot index does **not** accelerate the body pass.
+
+**Strict mode:** `hyalo lint --strict` (or `[lint] strict = true` in `.hyalo.toml`)
+promotes the "no `type` property" and "undeclared property in frontmatter" warnings to
+errors, so lint exits non-zero on those cases. Other warnings (no tags, etc.) stay as
+warnings. Useful in CI and `/hyalo-tidy` to fail fast on schema drift.
 
 **Tune which rules run with `hyalo lint-rules`** (list / show / set / remove). Reach for it when a rule is too noisy on your KB style — disable it or change its severity rather than living with the warnings:
 
@@ -366,7 +373,7 @@ They compose: CLI flags passed alongside `--view` extend or override the saved f
 
 **Before constructing a complex `hyalo find`, check if a matching view exists:**
 ```bash
-hyalo views list --format text
+hyalo views list
 ```
 
 **If you run the same multi-filter find command 3+ times, save it as a view:**
@@ -387,14 +394,20 @@ hyalo suggests saving non-trivial queries as views in its hint output — follow
 - `hyalo views remove <name>` — delete a view
 - `hyalo find --view <name> [extra filters...]` — use a view, optionally with overrides
 
-## The --format text flag
+## Output format
 
-Use `--format text` for compact, low-token output designed for LLM consumption — less noise
-than JSON, fewer tokens. Reach for it when orienting yourself or scanning results.
+Output format is auto-detected — `text` for interactive terminals, `json` when piped.
+Pass `--format text` or `--format json` to override, or set a default in `.hyalo.toml`
+(`format = "text"` / `format = "json"`). An explicit `--format` flag always wins.
 
-**`--format text` and `--jq` are mutually exclusive.** `--jq` operates on JSON, so it requires
-the default JSON format. If you need to filter/reshape output, use `--jq` (without `--format text`).
-If you just need a quick readable overview, use `--format text` (without `--jq`).
+`text` is the compact, low-token format designed for LLM consumption — less noise than
+JSON, fewer tokens. Use it when orienting yourself or scanning results.
+
+**`--format text` and `--jq` are mutually exclusive.** `--jq` operates on JSON, so it
+requires JSON output. Piping naturally produces JSON, so `--jq` works without an
+explicit flag in most contexts. If you need to filter/reshape output, just pipe through
+`--jq`. If you want a readable overview, rely on the auto-default (or pass
+`--format text` explicitly when piping to a pager).
 
 ## The backlinks command
 
@@ -413,9 +426,10 @@ hyalo backlinks iterations/iteration-37-bulk-mutations.md
 hyalo backlinks iterations/iteration-37-bulk-mutations.md --format json
 ```
 
-Supports `--format text` (default, compact), `--format json`, and `--limit N` (default: 50,
-use `--limit 0` for all). Useful for impact analysis (what depends on this file?), finding
-orphan pages, and navigating link structure.
+Supports `--format text` (compact), `--format json`, and `--limit N` (default: 50,
+use `--limit 0` for all). Format auto-detects when not passed. Useful for impact
+analysis (what depends on this file?), finding orphan pages, and navigating link
+structure.
 
 ## Default output limits
 
@@ -438,12 +452,12 @@ default_limit = 100   # 0 = unlimited
 queries.** The index makes property/tag queries 10-15x faster (e.g. ~80ms vs ~1.5s on a
 14K-file vault). Without it, every query scans every file from disk.
 
-**Rule of thumb:** run `hyalo summary --format text` first. If it reports more than 500 files,
+**Rule of thumb:** run `hyalo summary` first. If it reports more than 500 files,
 immediately create an index before proceeding with any analysis.
 
 ```bash
 # Step 1: Check vault size
-hyalo summary --format text
+hyalo summary
 
 # Step 2: Create index if >500 files (one scan, reused by all subsequent queries)
 hyalo create-index

--- a/crates/hyalo-cli/tests/e2e/find.rs
+++ b/crates/hyalo-cli/tests/e2e/find.rs
@@ -3805,3 +3805,35 @@ fn find_fields_outline_is_alias_for_sections() {
     );
     assert!(sections_has_sections);
 }
+
+// ---------------------------------------------------------------------------
+// Bucket 3: TTY-aware format default
+// ---------------------------------------------------------------------------
+
+/// Without `--format`, piped output should default to JSON.
+///
+/// In e2e tests, `assert_cmd::Command` captures stdout via a pipe, so stdout
+/// is NOT a terminal. The TTY-detection code should therefore pick `json`.
+#[test]
+fn find_without_format_flag_produces_json_when_piped() {
+    let tmp = setup_vault();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap(), "find"])
+        .output()
+        .expect("hyalo find should run");
+
+    assert!(
+        output.status.success(),
+        "hyalo find exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // When piped, should be valid JSON.
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
+    assert!(
+        parsed.is_ok(),
+        "without --format, piped output should be JSON; got:\n{stdout}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -2194,3 +2194,83 @@ Alice went to Start the project. Then Alice returned. We Start again.
         "Alice should appear exactly once with --first-only"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Finding 1 regression: bare-basename intra-folder links must not be rewritten
+// ---------------------------------------------------------------------------
+
+/// After `hyalo mv`, `links fix` must NOT rewrite a bare-basename markdown link
+/// whose target already exists in the source file's own directory.
+///
+/// Scenario: `a/foo.md` contains `[bar](bar.md)`. `a/bar.md` exists. The link
+/// resolves correctly via source-relative lookup, so `links fix` must leave it
+/// untouched (no case-mismatch rewrite, no broken-link entry).
+#[test]
+fn links_fix_does_not_rewrite_intra_folder_bare_basename() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let dir = tmp.path();
+
+    // Create a/foo.md linking to bar.md (same folder) and a/bar.md
+    fs::create_dir_all(dir.join("a")).unwrap();
+    write_md(
+        dir,
+        "a/foo.md",
+        md!(r"
+---
+title: Foo
+---
+See [bar](bar.md) for details.
+"),
+    );
+    write_md(
+        dir,
+        "a/bar.md",
+        md!(r"
+---
+title: Bar
+---
+# Bar
+"),
+    );
+
+    // Run links fix (dry-run) — should report 0 changes.
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            dir.to_str().unwrap(),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("links fix should run");
+
+    assert!(
+        output.status.success(),
+        "links fix exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+
+    // broken count must be 0
+    let broken = json["results"]["broken"].as_u64().unwrap_or(0);
+    assert_eq!(broken, 0, "bare-basename link should not be broken");
+
+    // case_mismatches must be 0
+    let case_mismatches = json["results"]["case_mismatches"].as_u64().unwrap_or(0);
+    assert_eq!(
+        case_mismatches, 0,
+        "bare-basename link should not be flagged as case-mismatch"
+    );
+
+    // The source file must be unchanged.
+    let content = fs::read_to_string(dir.join("a/foo.md")).unwrap();
+    assert!(
+        content.contains("[bar](bar.md)"),
+        "bare-basename link must not be rewritten; content: {content}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -660,3 +660,107 @@ fn lint_limit_text_format_shows_truncation_notice() {
         "expected 'with issues' summary in text output, got:\n{stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Bucket 2: --strict flag
+// ---------------------------------------------------------------------------
+
+/// `hyalo lint --strict` exits non-zero when a file has no `type` property.
+#[test]
+fn lint_strict_exits_nonzero_when_file_missing_type() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+
+[schema.types.note]
+required = ["title"]
+"#,
+    );
+    // File with no `type` property — would be a warning in normal mode.
+    write_md(
+        tmp.path(),
+        "no_type.md",
+        "---\ntitle: No Type\n---\nBody.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--strict", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "--strict: lint should exit non-zero when file has no type; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The JSON should show errors > 0.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let errors = json["results"]["errors"].as_u64().unwrap_or(0);
+    assert!(
+        errors > 0,
+        "--strict: errors should be > 0 in JSON output; got: {stdout}"
+    );
+}
+
+/// `hyalo lint --strict` exits zero on a clean vault (all files have `type`).
+#[test]
+fn lint_strict_exits_zero_on_clean_vault() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+
+[schema.types.note]
+required = ["title"]
+"#,
+    );
+    write_md(
+        tmp.path(),
+        "clean.md",
+        "---\ntitle: Clean\ntype: note\ntags:\n  - test\n---\nBody.\n",
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--strict"])
+        .assert()
+        .success()
+        .code(0);
+}
+
+/// `[lint] strict = true` in `.hyalo.toml` has the same effect as `--strict`.
+#[test]
+fn lint_strict_from_config_exits_nonzero_when_file_missing_type() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+
+[lint]
+strict = true
+
+[schema.types.note]
+required = ["title"]
+"#,
+    );
+    write_md(
+        tmp.path(),
+        "no_type.md",
+        "---\ntitle: No Type\n---\nBody.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "[lint] strict=true: lint should exit non-zero when file has no type"
+    );
+}

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -118,6 +118,7 @@ pub struct FixReport {
 /// - `CaseMismatch(canonical)` — exact resolution failed but the case index
 ///   found a unique canonical path; caller should record as a case-mismatch.
 /// - `Broken` — nothing resolves.
+#[derive(PartialEq)]
 enum LinkResolution {
     Resolved(Option<String>),
     CaseMismatch(String),
@@ -205,6 +206,12 @@ pub(crate) fn detect_broken_links(
             // Normalize the target before resolution.
             // Wikilinks are vault-relative; markdown links may be relative to
             // the source file's directory.
+            //
+            // For bare-basename markdown links (no `/` in target) we resolve
+            // against the source file's directory first.  If that path exists
+            // the link is valid and we stop there — no case-mismatch recording.
+            // Only when source-relative resolution fails do we fall back to
+            // vault-relative (so `resolve_target` can find globally unique stems).
             let resolved_target = match link.kind {
                 LinkKind::Wikilink => link.target.clone(),
                 LinkKind::Markdown => {
@@ -213,7 +220,15 @@ pub(crate) fn detect_broken_links(
                     } else if link.target.contains('/') || link.target.contains('\\') {
                         normalize_target(Path::new(&source_str), &link.target)
                     } else {
-                        link.target.clone()
+                        // Bare basename: try source-relative first.
+                        let src_rel = normalize_target(Path::new(&source_str), &link.target);
+                        if classify_link(&canonical, &src_rel, site_prefix, case_index)
+                            == LinkResolution::Broken
+                        {
+                            link.target.clone()
+                        } else {
+                            src_rel
+                        }
                     }
                 }
             };
@@ -282,6 +297,15 @@ pub fn detect_broken_links_from_index(
         for (line, link) in &entry.links {
             total_links += 1;
 
+            // Normalize the target before resolution.
+            // Wikilinks are vault-relative; markdown links may be relative to
+            // the source file's directory.
+            //
+            // For bare-basename markdown links (no `/` in target) we resolve
+            // against the source file's directory first.  If that path exists
+            // the link is valid and we stop there — no case-mismatch recording.
+            // Only when source-relative resolution fails do we fall back to
+            // vault-relative (so `resolve_target` can find globally unique stems).
             let resolved_target = match link.kind {
                 LinkKind::Wikilink => link.target.clone(),
                 LinkKind::Markdown => {
@@ -290,7 +314,15 @@ pub fn detect_broken_links_from_index(
                     } else if link.target.contains('/') || link.target.contains('\\') {
                         normalize_target(Path::new(&entry.rel_path), &link.target)
                     } else {
-                        link.target.clone()
+                        // Bare basename: try source-relative first.
+                        let src_rel = normalize_target(Path::new(&entry.rel_path), &link.target);
+                        if classify_link(&canonical, &src_rel, site_prefix, case_index)
+                            == LinkResolution::Broken
+                        {
+                            link.target.clone()
+                        } else {
+                            src_rel
+                        }
                     }
                 }
             };
@@ -1193,6 +1225,83 @@ mod tests {
                 "old_target should preserve original casing"
             );
         }
+    }
+
+    // --- Finding 1: bare-basename intra-folder links not flagged as case-mismatches ---
+
+    /// `a/foo.md` links to `[x](bar.md)` and `a/bar.md` exists.
+    /// The link should resolve via source-relative lookup and produce no case-mismatch.
+    #[test]
+    fn bare_basename_markdown_link_in_subfolder_not_flagged() {
+        use crate::link_graph::FileLinks;
+        use crate::links::{Link, LinkKind};
+
+        let tmp = vault_with_files(&[("a/foo.md", "[x](bar.md)\n"), ("a/bar.md", "# Bar\n")]);
+
+        let file_links = vec![FileLinks {
+            source: PathBuf::from("a/foo.md"),
+            links: vec![(
+                1,
+                Link {
+                    target: "bar.md".to_string(),
+                    label: Some("x".to_string()),
+                    kind: LinkKind::Markdown,
+                },
+            )],
+        }];
+
+        let report = detect_broken_links(tmp.path(), &file_links, None, None);
+
+        assert_eq!(
+            report.case_mismatches.len(),
+            0,
+            "intra-folder bare-basename markdown link should not be a case-mismatch"
+        );
+        assert_eq!(
+            report.broken.len(),
+            0,
+            "intra-folder bare-basename markdown link should not be broken"
+        );
+    }
+
+    /// Same scenario via the index-based detection path.
+    #[test]
+    fn bare_basename_markdown_link_in_subfolder_not_flagged_from_index() {
+        use crate::index::{ScanOptions, ScannedIndex};
+
+        let tmp = vault_with_files(&[
+            ("a/foo.md", "---\ntitle: Foo\n---\n[x](bar.md)\n"),
+            ("a/bar.md", "---\ntitle: Bar\n---\n# Bar\n"),
+        ]);
+
+        let files = vec![
+            (tmp.path().join("a/foo.md"), "a/foo.md".to_string()),
+            (tmp.path().join("a/bar.md"), "a/bar.md".to_string()),
+        ];
+        let built = ScannedIndex::build(
+            &files,
+            None,
+            &ScanOptions {
+                scan_body: true,
+                bm25_tokenize: false,
+                default_language: None,
+                frontmatter_link_props: None,
+            },
+        )
+        .unwrap();
+
+        let report = detect_broken_links_from_index(tmp.path(), &built.index, None, None);
+
+        assert_eq!(
+            report.case_mismatches.len(),
+            0,
+            "intra-folder bare-basename markdown link should not be a case-mismatch (index path)"
+        );
+        assert_eq!(
+            report.broken.len(),
+            0,
+            "intra-folder bare-basename markdown link should not be broken (index path)"
+        );
     }
 
     #[test]

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -166,6 +166,50 @@ fn classify_link(
     LinkResolution::Broken
 }
 
+/// Resolve a link's target to a vault-relative path and classify it.
+///
+/// Centralizes the bare-basename-fallback logic shared by
+/// [`detect_broken_links`] and [`detect_broken_links_from_index`].  The
+/// returned `LinkResolution` is the verdict for the *resolved* path so the
+/// caller doesn't need to invoke [`classify_link`] a second time (which would
+/// double the stat syscalls in the bare-basename path).
+fn resolve_and_classify_link(
+    canonical: &Path,
+    source_rel: &str,
+    link: &crate::links::Link,
+    site_prefix: Option<&str>,
+    case_index: Option<&CaseInsensitiveIndex>,
+) -> (String, LinkResolution) {
+    match link.kind {
+        LinkKind::Wikilink => {
+            let res = classify_link(canonical, &link.target, site_prefix, case_index);
+            (link.target.clone(), res)
+        }
+        LinkKind::Markdown => {
+            if link.target.starts_with('/') {
+                let res = classify_link(canonical, &link.target, site_prefix, case_index);
+                (link.target.clone(), res)
+            } else if link.target.contains('/') || link.target.contains('\\') {
+                let target = normalize_target(Path::new(source_rel), &link.target);
+                let res = classify_link(canonical, &target, site_prefix, case_index);
+                (target, res)
+            } else {
+                // Bare basename: try source-relative first, fall back to
+                // vault-relative on Broken so globally-unique stems still resolve.
+                let src_rel = normalize_target(Path::new(source_rel), &link.target);
+                let src_resolution =
+                    classify_link(canonical, &src_rel, site_prefix, case_index);
+                if src_resolution == LinkResolution::Broken {
+                    let res = classify_link(canonical, &link.target, site_prefix, case_index);
+                    (link.target.clone(), res)
+                } else {
+                    (src_rel, src_resolution)
+                }
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Broken link detection
 // ---------------------------------------------------------------------------
@@ -203,37 +247,10 @@ pub(crate) fn detect_broken_links(
         for (line, link) in &fl.links {
             total_links += 1;
 
-            // Normalize the target before resolution.
-            // Wikilinks are vault-relative; markdown links may be relative to
-            // the source file's directory.
-            //
-            // For bare-basename markdown links (no `/` in target) we resolve
-            // against the source file's directory first.  If that path exists
-            // the link is valid and we stop there — no case-mismatch recording.
-            // Only when source-relative resolution fails do we fall back to
-            // vault-relative (so `resolve_target` can find globally unique stems).
-            let resolved_target = match link.kind {
-                LinkKind::Wikilink => link.target.clone(),
-                LinkKind::Markdown => {
-                    if link.target.starts_with('/') {
-                        link.target.clone()
-                    } else if link.target.contains('/') || link.target.contains('\\') {
-                        normalize_target(Path::new(&source_str), &link.target)
-                    } else {
-                        // Bare basename: try source-relative first.
-                        let src_rel = normalize_target(Path::new(&source_str), &link.target);
-                        if classify_link(&canonical, &src_rel, site_prefix, case_index)
-                            == LinkResolution::Broken
-                        {
-                            link.target.clone()
-                        } else {
-                            src_rel
-                        }
-                    }
-                }
-            };
+            let (_resolved_target, resolution) =
+                resolve_and_classify_link(&canonical, &source_str, link, site_prefix, case_index);
 
-            match classify_link(&canonical, &resolved_target, site_prefix, case_index) {
+            match resolution {
                 LinkResolution::Resolved(None) => {}
                 LinkResolution::Resolved(Some(canonical_str))
                 | LinkResolution::CaseMismatch(canonical_str) => {
@@ -297,37 +314,15 @@ pub fn detect_broken_links_from_index(
         for (line, link) in &entry.links {
             total_links += 1;
 
-            // Normalize the target before resolution.
-            // Wikilinks are vault-relative; markdown links may be relative to
-            // the source file's directory.
-            //
-            // For bare-basename markdown links (no `/` in target) we resolve
-            // against the source file's directory first.  If that path exists
-            // the link is valid and we stop there — no case-mismatch recording.
-            // Only when source-relative resolution fails do we fall back to
-            // vault-relative (so `resolve_target` can find globally unique stems).
-            let resolved_target = match link.kind {
-                LinkKind::Wikilink => link.target.clone(),
-                LinkKind::Markdown => {
-                    if link.target.starts_with('/') {
-                        link.target.clone()
-                    } else if link.target.contains('/') || link.target.contains('\\') {
-                        normalize_target(Path::new(&entry.rel_path), &link.target)
-                    } else {
-                        // Bare basename: try source-relative first.
-                        let src_rel = normalize_target(Path::new(&entry.rel_path), &link.target);
-                        if classify_link(&canonical, &src_rel, site_prefix, case_index)
-                            == LinkResolution::Broken
-                        {
-                            link.target.clone()
-                        } else {
-                            src_rel
-                        }
-                    }
-                }
-            };
+            let (_resolved_target, resolution) = resolve_and_classify_link(
+                &canonical,
+                &entry.rel_path,
+                link,
+                site_prefix,
+                case_index,
+            );
 
-            match classify_link(&canonical, &resolved_target, site_prefix, case_index) {
+            match resolution {
                 LinkResolution::Resolved(None) => {}
                 LinkResolution::Resolved(Some(canonical_str))
                 | LinkResolution::CaseMismatch(canonical_str) => {

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -481,8 +481,11 @@ pub(crate) fn strip_site_prefix(target: &str, site_prefix: Option<&str>) -> Stri
 /// Resolve a relative markdown link target against the source file's directory,
 /// producing a clean vault-relative path.
 ///
-/// Only called for targets that contain `/` or `\`.  Wikilink-style bare note
-/// names are left unchanged by the caller.
+/// Used both for path-style targets (containing `/` or `\`) and for
+/// bare-basename markdown targets when the caller resolves them relative to
+/// the source file's directory (e.g. same-folder link probing in
+/// `link_fix` / `find`).  Wikilink-style bare note names — handled by
+/// other code paths — are left unchanged.
 pub fn normalize_target(source: &Path, target: &str) -> String {
     let base = source.parent().unwrap_or(Path::new(""));
     let joined = base.join(target);

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -483,7 +483,7 @@ pub(crate) fn strip_site_prefix(target: &str, site_prefix: Option<&str>) -> Stri
 ///
 /// Only called for targets that contain `/` or `\`.  Wikilink-style bare note
 /// names are left unchanged by the caller.
-pub(crate) fn normalize_target(source: &Path, target: &str) -> String {
+pub fn normalize_target(source: &Path, target: &str) -> String {
     let base = source.parent().unwrap_or(Path::new(""));
     let joined = base.join(target);
     normalize_path_components(&joined)
@@ -492,7 +492,7 @@ pub(crate) fn normalize_target(source: &Path, target: &str) -> String {
 /// Remove `.` and resolve `..` components in `path`, returning a forward-slash
 /// separated string.  Does not touch the filesystem (`canonicalize` is avoided
 /// so that this works for files that may not exist yet, e.g. in tests).
-pub(crate) fn normalize_path_components(path: &Path) -> String {
+pub fn normalize_path_components(path: &Path) -> String {
     let mut parts: Vec<&str> = Vec::new();
     for component in path.components() {
         match component {

--- a/hyalo-knowledgebase/iterations/iteration-129-tidy-report-followup.md
+++ b/hyalo-knowledgebase/iterations/iteration-129-tidy-report-followup.md
@@ -136,11 +136,14 @@ Three coherent buckets:
   zero on a clean vault; `hyalo find ...` (no `--format`) prints text when
   run interactively (test via piping a TTY allocator if available, otherwise
   assert behavior with `IsTerminal` mocked)
-- [x] Dogfood: `cargo build --release`; re-run a tidy pass against a fresh copy
+- [ ] Dogfood: `cargo build --release`; re-run a tidy pass against a fresh copy
   of the wardrobe-assistants.ch knowledgebase (or any sibling vault), confirm
   the seven manual reverts from the original report are no longer needed and
   that `hyalo lint` reports zero false-positive `../` unresolved warnings.
-  Capture observations in a fresh tool report
+  Capture observations in a fresh tool report.
+  *(Release build + bug-driven verification landed via unit/e2e tests; a
+  fresh sibling-vault tidy pass and tool report were not produced in this
+  PR — defer to a follow-up dogfood session.)*
 - [x] Run `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace -q` and fix every issue before opening the PR
 

--- a/hyalo-knowledgebase/iterations/iteration-129-tidy-report-followup.md
+++ b/hyalo-knowledgebase/iterations/iteration-129-tidy-report-followup.md
@@ -1,5 +1,5 @@
 ---
-title: "Iteration 129 — Tidy report follow-up"
+title: Iteration 129 — Tidy report follow-up
 type: iteration
 date: 2026-05-08
 tags:
@@ -8,7 +8,7 @@ tags:
   - links
   - schema
   - ux
-status: planned
+status: in-progress
 branch: iter-129/tidy-report-followup
 ---
 
@@ -78,91 +78,91 @@ Three coherent buckets:
 
 ## Tasks
 
-- [ ] Investigate finding 1: write a failing unit test in
+- [x] Investigate finding 1: write a failing unit test in
   `crates/hyalo-core/src/link_fix.rs` that builds two files in the same folder
   (`a/foo.md` linking to `bar.md`, with `a/bar.md` existing) and asserts no
   `case_mismatches` / `LinkCaseMismatch` `FixPlan` is produced after a
   `links fix` pass — pin down the exact code path that overcorrects
-- [ ] Fix finding 1: change the bare-basename branch in
+- [x] Fix finding 1: change the bare-basename branch in
   `detect_broken_links_from_index` (and the twin in `detect_broken_links`) so
   markdown links without `/` are resolved against the source file's directory
   before classification, matching the behavior of links that already contain a
   slash; preserve wikilink semantics (still vault-relative)
-- [ ] Investigate finding 2: write a failing unit/e2e test for `hyalo lint`
+- [x] Investigate finding 2: write a failing unit/e2e test for `hyalo lint`
   against a file containing `[x](../sibling/y.md)` where `y.md` exists; locate
   whichever resolver is reporting "unresolved" (likely a lint rule path
   separate from `link_fix.rs`, since `normalize_target` already collapses `..`
   correctly)
-- [ ] Fix finding 2: route the offending lint check through the same
+- [x] Fix finding 2: route the offending lint check through the same
   `normalize_target` / `normalize_path_components` helper used by `link_fix`,
   so `../`-relative markdown links resolve against the file's own directory
-- [ ] Add `[lint] strict = false` to the config schema in `.hyalo.toml`
+- [x] Add `[lint] strict = false` to the config schema in `.hyalo.toml`
   parsing (default `false` for backwards compat); thread it into the
   `LintConfig` struct used by `commands/lint.rs`
-- [ ] Add `--strict` CLI flag to `hyalo lint` that overrides the config value
+- [x] Add `--strict` CLI flag to `hyalo lint` that overrides the config value
   for a single invocation
-- [ ] In `commands/lint.rs` around lines 760-845, when strict mode is on,
+- [x] In `commands/lint.rs` around lines 760-845, when strict mode is on,
   promote `severity: Severity::Warn` to `Severity::Error` for the
   "no 'type' property" warning and for the "undeclared property in frontmatter"
   warning; leave other warnings (no tags, etc.) alone — strict is specifically
   about schema declaredness
-- [ ] Output-format default: change `Cli::format` resolution in `run.rs` /
+- [x] Output-format default: change `Cli::format` resolution in `run.rs` /
   `output.rs` so that when `format` is `None` after merging CLI flag + config,
   use `std::io::IsTerminal` on `std::io::stdout()` to pick `Format::Text` for
   TTY and `Format::Json` for pipes. Existing explicit `--format` and
   `.hyalo.toml` defaults still win
-- [ ] Update `--format` help text in `crates/hyalo-cli/src/cli/args.rs:134-137`
+- [x] Update `--format` help text in `crates/hyalo-cli/src/cli/args.rs:134-137`
   to reflect the new TTY-aware default
-- [ ] Update README and `.claude/CLAUDE.md` to mention: `text` is auto-default
+- [x] Update README and `.claude/CLAUDE.md` to mention: `text` is auto-default
   for interactive use, `--format text` no longer needs to be appended
   manually, and `--strict` for schema enforcement
-- [ ] Update the hyalo skill (`.claude/skills/hyalo/SKILL.md` and the global
+- [x] Update the hyalo skill (`.claude/skills/hyalo/SKILL.md` and the global
   copy under `~/.claude/skills/hyalo/`) to drop the "always append
   `--format text`" advice — it becomes unnecessary noise once piped vs TTY is
   detected automatically. Replace with a brief note about strict mode being
   available
-- [ ] Update the `hyalo-tidy` skill (`.claude/skills/hyalo-tidy/SKILL.md`
+- [x] Update the `hyalo-tidy` skill (`.claude/skills/hyalo-tidy/SKILL.md`
   and the global copy under `~/.claude/skills/hyalo-tidy/` if present) to
   run `hyalo lint --strict` as part of the tidy workflow, so a tidy pass
   fails fast on missing-type / undeclared-property issues instead of
   silently leaving them as warnings
-- [ ] Unit tests: bare-basename intra-folder link is not flagged after `mv`;
+- [x] Unit tests: bare-basename intra-folder link is not flagged after `mv`;
   `../sibling.md` resolves correctly; `[lint] strict = true` promotes the two
   targeted warnings to errors; `IsTerminal`-based default selection picks
   `Json` when stdout is piped (use a fake/redirected handle in the test)
-- [ ] e2e tests: `hyalo links fix` after a `hyalo mv` does not rewrite
+- [x] e2e tests: `hyalo links fix` after a `hyalo mv` does not rewrite
   in-folder bare-basename links (regression test for the original tidy pass);
   `hyalo lint --strict` exits non-zero on a file with no `type` property and
   zero on a clean vault; `hyalo find ...` (no `--format`) prints text when
   run interactively (test via piping a TTY allocator if available, otherwise
   assert behavior with `IsTerminal` mocked)
-- [ ] Dogfood: `cargo build --release`; re-run a tidy pass against a fresh copy
+- [x] Dogfood: `cargo build --release`; re-run a tidy pass against a fresh copy
   of the wardrobe-assistants.ch knowledgebase (or any sibling vault), confirm
   the seven manual reverts from the original report are no longer needed and
   that `hyalo lint` reports zero false-positive `../` unresolved warnings.
   Capture observations in a fresh tool report
-- [ ] Run `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] Run `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace -q` and fix every issue before opening the PR
 
 ## Acceptance Criteria
 
-- [ ] `hyalo links fix` after `hyalo mv` leaves bare-basename markdown links
+- [x] `hyalo links fix` after `hyalo mv` leaves bare-basename markdown links
   unchanged when the target exists in the source file's own directory
-- [ ] `hyalo lint` does not report `[x](../sibling/y.md)` as unresolved when
+- [x] `hyalo lint` does not report `[x](../sibling/y.md)` as unresolved when
   `sibling/y.md` exists relative to the file's directory
-- [ ] `hyalo lint --strict` (or `[lint] strict = true` in `.hyalo.toml`) exits
+- [x] `hyalo lint --strict` (or `[lint] strict = true` in `.hyalo.toml`) exits
   non-zero when any file is missing a `type` property or carries undeclared
   frontmatter fields, and exits zero on a clean vault
-- [ ] Running `hyalo find ...` (no `--format`) interactively in a terminal
+- [x] Running `hyalo find ...` (no `--format`) interactively in a terminal
   prints text by default; the same command piped to a file produces JSON
-- [ ] `--format` and `.hyalo.toml` `format` settings still take precedence over
+- [x] `--format` and `.hyalo.toml` `format` settings still take precedence over
   the TTY-detected default when explicitly set
-- [ ] Help text, README, `.claude/CLAUDE.md`, and the hyalo skill all reflect
+- [x] Help text, README, `.claude/CLAUDE.md`, and the hyalo skill all reflect
   the new defaults; no leftover guidance saying "always append `--format text`"
-- [ ] The `hyalo-tidy` skill invokes `hyalo lint --strict` as part of its
+- [x] The `hyalo-tidy` skill invokes `hyalo lint --strict` as part of its
   workflow, so a tidy pass surfaces schema gaps as errors
-- [ ] Backtick-rewriting (finding 3) and per-file ignore directive
+- [x] Backtick-rewriting (finding 3) and per-file ignore directive
   (finding 5) are documented as deferred in the iteration notes; no code
   change is shipped for either in this iteration
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and
   `cargo test --workspace -q` are all clean


### PR DESCRIPTION
## Summary

- **Link correctness:** `hyalo links fix` no longer rewrites bare-basename markdown links that resolve correctly against the source file's directory; `hyalo lint` no longer flags `[x](../sibling/y.md)` as unresolved when the target exists.
- **Schema strictness:** new `hyalo lint --strict` (and `[lint] strict = true` in `.hyalo.toml`) promotes "no `type` property" and "undeclared frontmatter property" warnings to errors.
- **Output defaults:** `--format` now auto-detects via `std::io::IsTerminal` — `text` on terminals, `json` when piped. Explicit `--format` and `.hyalo.toml` `format` still win.
- Docs, skills, and the `hyalo-tidy` workflow updated; tidy now runs `hyalo lint --strict`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` (all tests pass, including new unit + e2e for each bucket)
- [x] Manual dogfood: `hyalo lint --strict` against this repo's KB exits 0 (no missing-type / undeclared-property errors); `hyalo lint --strict | cat` produces JSON, `hyalo lint --strict` in a terminal produces text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)