### PR TITLE
refactor: remove unsafe UTF-8 shortcuts and add Miri support

### DIFF
--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -1168,6 +1168,7 @@ pub fn lint_files_extended(
     md_lint_config: &hyalo_mdlint::LintConfig,
     opts: &mut ExtLintOptions<'_>,
 ) -> Result<(CommandOutcome, LintCounts)> {
+    #[cfg(not(miri))]
     use rayon::prelude::*;
 
     // Build rule filter list
@@ -1188,24 +1189,25 @@ pub fn lint_files_extended(
     let strict = opts.strict;
 
     // Process files in parallel. Each worker lints one file.
-    let per_file: Vec<Result<PerFileLintResult>> = files
-        .par_iter()
-        .map(|(full_path, rel_path)| {
-            lint_one_file_extended(
-                full_path,
-                rel_path,
-                schema,
-                md_lint_engine,
-                md_lint_config,
-                &rule_filter,
-                schema_has_completed,
-                opts.fix,
-                opts.fix_rules,
-                opts.max_per_rule,
-                strict,
-            )
-        })
-        .collect();
+    let lint_file = |(full_path, rel_path): &(std::path::PathBuf, String)| {
+        lint_one_file_extended(
+            full_path,
+            rel_path,
+            schema,
+            md_lint_engine,
+            md_lint_config,
+            &rule_filter,
+            schema_has_completed,
+            opts.fix,
+            opts.fix_rules,
+            opts.max_per_rule,
+            strict,
+        )
+    };
+    #[cfg(not(miri))]
+    let per_file: Vec<Result<PerFileLintResult>> = files.par_iter().map(lint_file).collect();
+    #[cfg(miri)]
+    let per_file: Vec<Result<PerFileLintResult>> = files.iter().map(lint_file).collect();
 
     // Merge results serially.
     let mut all_results: Vec<PerFileLintResult> = Vec::with_capacity(files.len());

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
+#[cfg(not(miri))]
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -173,19 +174,22 @@ impl ScannedIndex {
             },
             <[String]>::to_vec,
         );
-        let results: Vec<Result<(IndexEntry, Option<FileLinks>)>> = files
-            .par_iter()
-            .map(|(full_path, rel_path)| {
-                scan_one_file(
-                    full_path,
-                    rel_path,
-                    options.scan_body,
-                    options.bm25_tokenize,
-                    default_language,
-                    &fm_link_props,
-                )
-            })
-            .collect();
+        let scan = |(full_path, rel_path): &(std::path::PathBuf, String)| {
+            scan_one_file(
+                full_path,
+                rel_path,
+                options.scan_body,
+                options.bm25_tokenize,
+                default_language,
+                &fm_link_props,
+            )
+        };
+        #[cfg(not(miri))]
+        let results: Vec<Result<(IndexEntry, Option<FileLinks>)>> =
+            files.par_iter().map(scan).collect();
+        #[cfg(miri)]
+        let results: Vec<Result<(IndexEntry, Option<FileLinks>)>> =
+            files.iter().map(scan).collect();
 
         for (i, result) in results.into_iter().enumerate() {
             match result {

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -91,18 +91,19 @@ pub fn scan_slice_multi(data: &[u8], visitors: &mut [&mut dyn FileVisitor]) -> R
         return Ok(());
     }
 
-    // Validate UTF-8 upfront; if valid we can slice zero-copy.
+    // Validate UTF-8 upfront; if valid we slice zero-copy.
     // If invalid, replace bad bytes with U+FFFD (lossy) so scanning continues.
-    let is_valid_utf8 = std::str::from_utf8(data).is_ok();
+    let utf8 = std::str::from_utf8(data);
+    let is_valid_utf8 = utf8.is_ok();
     let owned_text = if is_valid_utf8 {
         None
     } else {
         Some(String::from_utf8_lossy(data).into_owned())
     };
-    let text: &str = match &owned_text {
-        Some(s) => s,
-        // SAFETY: we just validated UTF-8 above.
-        None => unsafe { std::str::from_utf8_unchecked(data) },
+    let text: &str = match (&owned_text, utf8) {
+        (Some(s), _) => s,
+        (None, Ok(s)) => s,
+        (None, Err(_)) => unreachable!("is_valid_utf8 implies Ok"),
     };
 
     let mut active: Vec<bool> = vec![true; num];
@@ -885,6 +886,7 @@ Line 6
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "tempfile chmod unsupported under Miri")]
     fn non_utf8_file_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("bad.md");

--- a/crates/hyalo-core/src/scanner/strip.rs
+++ b/crates/hyalo-core/src/scanner/strip.rs
@@ -3,13 +3,6 @@ use std::borrow::Cow;
 /// Strip inline code spans from a line, replacing their content with spaces
 /// to preserve byte positions for link parsing.
 /// Returns a borrowed reference when no backticks are present (zero allocation).
-///
-/// # Safety constraint
-///
-/// The `unsafe` block at the end of this function relies on the fact that
-/// backtick (0x60) and space (0x20) are both single-byte ASCII characters.
-/// Any future change to the delimiter or replacement byte must preserve this
-/// single-byte-ASCII invariant to keep the UTF-8 validity proof sound.
 pub fn strip_inline_code(line: &str) -> Cow<'_, str> {
     if !line.contains('`') {
         return Cow::Borrowed(line);
@@ -62,16 +55,8 @@ pub fn strip_inline_code(line: &str) -> Cow<'_, str> {
         }
     }
 
-    // SAFETY: `result` starts as an exact byte-for-byte copy of the valid UTF-8
-    // input `line`. We only mutate `result` by overwriting contiguous spans
-    // `start..i` with ASCII space bytes (0x20). Both `start` and `i` are
-    // indices of backtick delimiters (0x60), which are single-byte ASCII
-    // characters and therefore always lie on UTF-8 code-point boundaries.
-    // Each modified span is completely replaced by a run of ASCII bytes (valid
-    // single-byte UTF-8 code points), while the prefix and suffix outside the
-    // span remain unchanged valid UTF-8. Concatenating unchanged valid UTF-8
-    // segments with runs of ASCII bytes yields valid UTF-8 overall.
-    Cow::Owned(unsafe { String::from_utf8_unchecked(result) })
+    // ASCII-only substitutions preserve UTF-8 validity; re-validate to avoid unsafe.
+    Cow::Owned(String::from_utf8(result).expect("ASCII substitution preserves UTF-8"))
 }
 
 /// Check if a line is an Obsidian comment fence (`%%` on its own line).
@@ -89,13 +74,6 @@ pub(crate) fn is_comment_fence(line: &str) -> bool {
 ///
 /// Returns a borrowed reference when no `%%` is present (zero allocation).
 /// Unmatched opening `%%` is treated as literal text.
-///
-/// # Safety constraint
-///
-/// The `unsafe` block at the end of this function relies on the fact that
-/// percent (0x25) and space (0x20) are both single-byte ASCII characters.
-/// Any future change to the delimiter or replacement byte must preserve this
-/// single-byte-ASCII invariant to keep the UTF-8 validity proof sound.
 pub fn strip_inline_comments(line: &str) -> Cow<'_, str> {
     if !line.contains("%%") {
         return Cow::Borrowed(line);
@@ -143,16 +121,7 @@ pub fn strip_inline_comments(line: &str) -> Cow<'_, str> {
     if result == bytes {
         Cow::Borrowed(line)
     } else {
-        // SAFETY: `result` starts as an exact byte-for-byte copy of the valid
-        // UTF-8 input `line`. We only mutate `result` by overwriting contiguous
-        // spans `open..i+2` with ASCII space bytes (0x20). Both `open` and the
-        // closing `%%` position are indices of percent-sign delimiters (0x25),
-        // which are single-byte ASCII characters and therefore always lie on
-        // UTF-8 code-point boundaries. Each modified span is completely replaced
-        // by a run of ASCII bytes (valid single-byte UTF-8 code points), while
-        // the prefix and suffix outside the span remain unchanged valid UTF-8.
-        // Concatenating unchanged valid UTF-8 segments with runs of ASCII bytes
-        // yields valid UTF-8 overall.
-        Cow::Owned(unsafe { String::from_utf8_unchecked(result) })
+        // ASCII-only substitutions preserve UTF-8 validity; re-validate to avoid unsafe.
+        Cow::Owned(String::from_utf8(result).expect("ASCII substitution preserves UTF-8"))
     }
 }

--- a/crates/hyalo-core/src/scanner/strip.rs
+++ b/crates/hyalo-core/src/scanner/strip.rs
@@ -56,7 +56,10 @@ pub fn strip_inline_code(line: &str) -> Cow<'_, str> {
     }
 
     // ASCII-only substitutions preserve UTF-8 validity; re-validate to avoid unsafe.
-    Cow::Owned(String::from_utf8(result).expect("ASCII substitution preserves UTF-8"))
+    Cow::Owned(
+        String::from_utf8(result)
+            .expect("strip_inline_code: ASCII backtick→space substitution must preserve UTF-8"),
+    )
 }
 
 /// Check if a line is an Obsidian comment fence (`%%` on its own line).
@@ -122,6 +125,9 @@ pub fn strip_inline_comments(line: &str) -> Cow<'_, str> {
         Cow::Borrowed(line)
     } else {
         // ASCII-only substitutions preserve UTF-8 validity; re-validate to avoid unsafe.
-        Cow::Owned(String::from_utf8(result).expect("ASCII substitution preserves UTF-8"))
+        Cow::Owned(
+            String::from_utf8(result)
+                .expect("strip_inline_comments: ASCII %%→space substitution must preserve UTF-8"),
+        )
     }
 }

--- a/justfile
+++ b/justfile
@@ -12,10 +12,10 @@ check:
 fmt:
     cargo fmt --all
 
-# Run Miri against the parsing + unsafe surface of hyalo-core.
+# Run Miri against the parsing surface of hyalo-core to detect UB.
 # Targets modules that don't touch the filesystem (Miri can't shim chmod/symlinks
-# on macOS, which breaks tempfile-based tests). Covers the four `unsafe` blocks
-# in scanner/strip.rs and the YAML/markdown parsers.
+# on macOS, which breaks tempfile-based tests). Covers the scanner, YAML
+# frontmatter, BM25, link extraction, and other pure-logic parsers.
 # Requires: rustup component add --toolchain nightly miri
 miri:
     cargo +nightly miri setup

--- a/justfile
+++ b/justfile
@@ -1,0 +1,37 @@
+# Hyalo task runner. Install just: https://github.com/casey/just
+
+default:
+    @just --list
+
+# Standard quality gates (run before every commit/PR).
+check:
+    cargo fmt --all -- --check
+    cargo clippy --workspace --all-targets -- -D warnings
+    cargo test --workspace -q
+
+fmt:
+    cargo fmt --all
+
+# Run Miri against the parsing + unsafe surface of hyalo-core.
+# Targets modules that don't touch the filesystem (Miri can't shim chmod/symlinks
+# on macOS, which breaks tempfile-based tests). Covers the four `unsafe` blocks
+# in scanner/strip.rs and the YAML/markdown parsers.
+# Requires: rustup component add --toolchain nightly miri
+miri:
+    cargo +nightly miri setup
+    MIRIFLAGS="-Zmiri-disable-isolation" \
+        cargo +nightly miri test -p hyalo-core --lib -- --test-threads=1 \
+            scanner:: frontmatter:: bm25:: links:: heading:: \
+            filter:: content_search:: case_index::tests
+
+# Run Miri against an arbitrary test filter, e.g.: just miri-filter scanner::strip
+miri-filter FILTER:
+    MIRIFLAGS="-Zmiri-disable-isolation" \
+        cargo +nightly miri test -p hyalo-core --lib -- --test-threads=1 {{FILTER}}
+
+# Run Miri across all hyalo-core lib tests (most filesystem tests are
+# #[cfg_attr(miri, ignore)] or will fail — useful to inventory remaining gaps).
+miri-all:
+    cargo +nightly miri setup
+    MIRIFLAGS="-Zmiri-disable-isolation" \
+        cargo +nightly miri test -p hyalo-core --lib -- --test-threads=1


### PR DESCRIPTION
## Summary
- Remove three `from_utf8_unchecked` call sites in `scanner/{strip,mod}.rs`. Two go through `String::from_utf8(...).expect(...)` (microbench: +5 ns per with-backticks/with-comments call; invisible at MDN-scale end-to-end). The third reuses the existing `Result::Ok(s)` from the upfront UTF-8 check — zero re-validation, zero perf cost.
- Only remaining `unsafe` is `libc::kill(pid, 0)` in `index.rs` for PID-liveness — no stable std equivalent.
- Add Miri scaffolding: `#[cfg(not(miri))]` gates around rayon `par_iter` paths in `index.rs` and `lint.rs` with a serial fallback; `#[cfg_attr(miri, ignore)]` on the one tempfile-based scanner test; a `justfile` with `miri`, `miri-filter`, `miri-all`, `check`, `fmt` recipes targeting the parsing surface that doesn't touch the filesystem.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` (532 + 969 e2e + 696 + 34 = all green)
- [x] Miri pass on `scanner::` (60 tests, no UB)
- [x] Miri pass on `bm25::` / `links::` / `heading::` / `frontmatter::` (no UB; one pre-existing brittle f64 equality test in bm25 unrelated to this PR)
- [x] MDN 250MB end-to-end: `hyalo summary` ~1.1s — no measurable regression