### PR TITLE
fix(backlinks): resolve short-form wikilinks to deep paths

### DIFF
--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -330,6 +330,18 @@ pub(crate) struct FileLinks {
     pub(crate) links: Vec<(usize, Link)>,
 }
 
+/// Strip a trailing `.md` extension from `s`, matching any ASCII casing
+/// (e.g. `.md`, `.MD`, `.Md`, `.mD`). Returns the input unchanged when no
+/// `.md` suffix is present. Used to derive a basename stem for case_index
+/// lookups, keeping behavior consistent with `discovery::resolve_target`.
+fn strip_md_extension(s: &str) -> &str {
+    if s.len() >= 3 && s.as_bytes()[s.len() - 3..].eq_ignore_ascii_case(b".md") {
+        &s[..s.len() - 3]
+    } else {
+        s
+    }
+}
+
 /// Normalize and insert one file's links into the shared index.
 fn insert_file_links(
     index: &mut HashMap<String, Vec<BacklinkEntry>>,
@@ -367,24 +379,20 @@ fn insert_file_links(
         // Compute an extra storage key for bare-basename wikilinks that
         // unambiguously resolve to a known vault file, so
         // `backlinks("rdp/resources/reflow.md")` finds `[[reflow]]` written
-        // anywhere in the vault. We store under BOTH the raw written target
-        // and the resolved path key so the original `link.target` round-trips
-        // in serialized output unchanged.
+        // anywhere in the vault. The canonical path is stored with the `.md`
+        // suffix stripped — matching how path-form wikilinks (`[[a/b]]`) are
+        // stored — so that `backlinks()`'s built-in `.md` toggle handles both
+        // query forms naturally. We skip insertion when the resolved key would
+        // equal the raw target (only `.md`-suffix difference) to avoid
+        // double-counting via the toggle.
         let resolved_key = (link.kind == LinkKind::Wikilink
             && !link.target.contains('/')
             && !link.target.contains('\\'))
         .then(|| {
-            let stem = link
-                .target
-                .strip_suffix(".md")
-                .or_else(|| link.target.strip_suffix(".MD"))
-                .unwrap_or(&link.target);
-            case_index.lookup_stem(stem).and_then(|canon| {
-                canon
-                    .strip_suffix(".md")
-                    .or_else(|| canon.strip_suffix(".MD"))
-                    .map(str::to_owned)
-            })
+            let stem = strip_md_extension(&link.target);
+            case_index
+                .lookup_stem(stem)
+                .map(|canon| strip_md_extension(canon).to_owned())
         })
         .flatten()
         .filter(|resolved| *resolved != link.target);
@@ -1337,6 +1345,26 @@ mod tests {
         // Same query without the .md suffix must yield the same result.
         let bl_no_md = graph.backlinks("rdp/resources/reflow");
         assert_eq!(bl_no_md.len(), 3, "query without .md must match too");
+    }
+
+    #[test]
+    fn backlinks_short_form_with_mixed_case_md_extension() {
+        // `[[reflow.Md]]` (mixed-case .md) must resolve the same as `[[reflow]]`,
+        // consistent with `discovery::resolve_target` which is case-insensitive
+        // on the .md extension.
+        let vault = create_vault(&[
+            ("rdp/resources/reflow.md", "Content\n"),
+            ("src.md", "[[reflow]] and [[reflow.Md]] and [[reflow.MD]]\n"),
+        ]);
+        let build = LinkGraph::build(vault.path(), None, None).unwrap();
+        let graph = build.graph;
+
+        let bl = graph.backlinks("rdp/resources/reflow.md");
+        assert_eq!(
+            bl.len(),
+            3,
+            "all three .md casings must resolve as backlinks"
+        );
     }
 
     #[test]

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -100,12 +100,16 @@ impl LinkGraph {
         let mut warnings: Vec<(PathBuf, String)> = Vec::new();
         let mut case_index = CaseInsensitiveIndex::new();
 
-        for (full_path, rel) in files {
-            // Insert each discovered path into the case-insensitive index using
-            // forward-slash form so lookups are platform-independent.
+        // First pass: fully populate the case index so that bare-basename
+        // wikilink resolution in `insert_file_links` can see every vault file
+        // regardless of scan order.
+        for (_full_path, rel) in files {
             let rel_fwd = rel.to_string_lossy().replace('\\', "/");
             case_index.insert(&rel_fwd);
+        }
 
+        // Second pass: scan files and insert resolved links.
+        for (full_path, rel) in files {
             let mut visitor =
                 LinkGraphVisitor::with_frontmatter_props(rel.clone(), fm_props.clone());
             match scanner::scan_file_multi(full_path, &mut [&mut visitor]) {
@@ -116,7 +120,12 @@ impl LinkGraph {
                 }
                 Err(e) => return Err(e),
             }
-            insert_file_links(&mut index, visitor.into_file_links(), site_prefix);
+            insert_file_links(
+                &mut index,
+                visitor.into_file_links(),
+                site_prefix,
+                &case_index,
+            );
         }
 
         Ok(LinkGraphBuild {
@@ -146,7 +155,7 @@ impl LinkGraph {
             case_index.insert(&rel_fwd);
         }
         for fl in file_links {
-            insert_file_links(&mut index, fl, site_prefix);
+            insert_file_links(&mut index, fl, site_prefix, &case_index);
         }
         LinkGraphBuild {
             graph: Self { index },
@@ -326,6 +335,7 @@ fn insert_file_links(
     index: &mut HashMap<String, Vec<BacklinkEntry>>,
     file_links: FileLinks,
     site_prefix: Option<&str>,
+    case_index: &CaseInsensitiveIndex,
 ) {
     for (line, mut link) in file_links.links {
         // Normalize markdown link targets that contain path separators
@@ -353,14 +363,44 @@ fn insert_file_links(
                 link.target = normalize_target(&file_links.source, &link.target);
             }
         }
+
+        // Compute an extra storage key for bare-basename wikilinks that
+        // unambiguously resolve to a known vault file, so
+        // `backlinks("rdp/resources/reflow.md")` finds `[[reflow]]` written
+        // anywhere in the vault. We store under BOTH the raw written target
+        // and the resolved path key so the original `link.target` round-trips
+        // in serialized output unchanged.
+        let resolved_key = (link.kind == LinkKind::Wikilink
+            && !link.target.contains('/')
+            && !link.target.contains('\\'))
+        .then(|| {
+            let stem = link
+                .target
+                .strip_suffix(".md")
+                .or_else(|| link.target.strip_suffix(".MD"))
+                .unwrap_or(&link.target);
+            case_index.lookup_stem(stem).and_then(|canon| {
+                canon
+                    .strip_suffix(".md")
+                    .or_else(|| canon.strip_suffix(".MD"))
+                    .map(str::to_owned)
+            })
+        })
+        .flatten()
+        .filter(|resolved| *resolved != link.target);
+
+        let entry = BacklinkEntry {
+            source: file_links.source.clone(),
+            line,
+            link: link.clone(),
+        };
         index
             .entry(link.target.clone())
             .or_default()
-            .push(BacklinkEntry {
-                source: file_links.source.clone(),
-                line,
-                link,
-            });
+            .push(entry.clone());
+        if let Some(key) = resolved_key {
+            index.entry(key).or_default().push(entry);
+        }
     }
 }
 
@@ -1262,6 +1302,65 @@ mod tests {
             bl_skipped.len(),
             0,
             "non-configured property should not be indexed when custom list is set"
+        );
+    }
+
+    #[test]
+    fn backlinks_resolves_short_form_wikilink_to_deep_path() {
+        // Regression: hyalo backlinks must find short-form `[[basename]]`
+        // wikilinks that resolve unambiguously to a deep vault path. All three
+        // wikilink forms (short bare, long-form with label, short with label)
+        // pointing at the same file should appear in the backlinks list.
+        let vault = create_vault(&[
+            ("rdp/resources/reflow.md", "Content\n"),
+            (
+                "_quirk-test.md",
+                "Line 6: [[reflow]]\n\
+                 Line 7: [[rdp/resources/reflow|reflow]]\n\
+                 Line 8: [[reflow|reflow]]\n",
+            ),
+        ]);
+        let build = LinkGraph::build(vault.path(), None, None).unwrap();
+        let graph = build.graph;
+
+        let bl = graph.backlinks("rdp/resources/reflow.md");
+        assert_eq!(
+            bl.len(),
+            3,
+            "all three wikilink forms should be found as backlinks; got: {:?}",
+            bl.iter().map(|e| &e.link.target).collect::<Vec<_>>()
+        );
+        for entry in &bl {
+            assert_eq!(entry.source, PathBuf::from("_quirk-test.md"));
+        }
+
+        // Same query without the .md suffix must yield the same result.
+        let bl_no_md = graph.backlinks("rdp/resources/reflow");
+        assert_eq!(bl_no_md.len(), 3, "query without .md must match too");
+    }
+
+    #[test]
+    fn backlinks_ambiguous_basename_not_resolved() {
+        // When two files share the same basename, `[[reflow]]` is ambiguous —
+        // it must NOT be attributed as a backlink to either file (avoids
+        // false-positive over-matching). Path-form wikilinks still work.
+        let vault = create_vault(&[
+            ("a/reflow.md", "A\n"),
+            ("b/reflow.md", "B\n"),
+            ("src.md", "[[reflow]] and [[a/reflow]]\n"),
+        ]);
+        let build = LinkGraph::build(vault.path(), None, None).unwrap();
+        let graph = build.graph;
+
+        // Path-form wikilink is found unambiguously.
+        let bl_a = graph.backlinks("a/reflow.md");
+        assert_eq!(bl_a.len(), 1, "path-form [[a/reflow]] resolves to a/");
+        // Ambiguous short form is not attributed to either file.
+        let bl_b = graph.backlinks("b/reflow.md");
+        assert_eq!(
+            bl_b.len(),
+            0,
+            "ambiguous short form must not match b/reflow.md"
         );
     }
 


### PR DESCRIPTION
## Summary
- `hyalo backlinks <target.md>` silently dropped incoming `[[basename]]` wikilinks even though `find --fields links` resolved the same wikilinks correctly. The two commands now agree.
- Root cause: the link graph keyed entries by the raw written wikilink target while queries used the resolved vault path.
- Fix: pre-populate the case index with every vault path in a first pass, then during link insertion store bare-basename wikilinks under their resolved vault path (in addition to the raw key, so the `target` field still round-trips unchanged). Ambiguous basenames fall through to current behavior — no over-matching.

## Test plan
- [x] New regression test `backlinks_resolves_short_form_wikilink_to_deep_path` matches the user-reported reproducer (3 wikilink forms all returned)
- [x] New guard test `backlinks_ambiguous_basename_not_resolved` confirms no false-positive when two files share a basename
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` — 698 hyalo-core lib + 969 e2e + 532 hyalo-cli unit, all green
- [x] Verified end-to-end via `target/release/hyalo backlinks` against the reproducer vault — all three wikilink forms now appear

Note: Ubuntu/Windows CI failures are pre-existing and identical to those merged in PR #157; not introduced by this change.