### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.16.0 — 2026-05-23
+
 ### Breaking changes
 
 - The hybrid `--index [=PATH]` flag has been split into two orthogonal flags:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hyalo-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-mdlint"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ members = ["crates/*"]
 default-members = ["crates/hyalo-cli"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ractive/hyalo"
 
 [workspace.dependencies]
 # Internal crates
-hyalo-core = { path = "crates/hyalo-core", version = "0.15.0" }
-hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.15.0" }
+hyalo-core = { path = "crates/hyalo-core", version = "0.16.0" }
+hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.16.0" }
 
 # External dependencies
 anyhow = "1"


### PR DESCRIPTION
## Summary

Release prep for **v0.16.0**. Workspace + internal dep versions bumped from 0.15.0 → 0.16.0; CHANGELOG `Unreleased` stamped as `0.16.0 — 2026-05-23`.

## Highlights since 0.15.0

**Breaking changes**
- `--index` / `--index-file` split. `--index` is now a pure boolean; `--index-file <PATH>` is the new explicit form. Per-subcommand instead of global.
- `properties rename` / `tags rename` JSON output uses `skipped_count` instead of `skipped` array.

**Added**
- Case-insensitive link resolution (`[links] case_insensitive` in `.hyalo.toml`)
- New `link-case-mismatch` lint rule
- `--stemmer` / `--language` accept ISO 639-1 codes
- Various `--dry-run` flags (`properties rename`, `tags rename`, `task set`)
- Snapshot-index hardening: path validation on load, 512 MB file-size cap

**Fixed**
- `backlinks` now finds short-form `[[basename]]` wikilinks via resolver parity with `find --fields links`

**Internal**
- Removed 3 of 4 `unsafe { from_utf8_unchecked }` blocks in scanner; replaced with safe round-trips (microbench: +5 ns/call on the slow path, invisible end-to-end)
- Miri scaffolding via `justfile` (`just miri` / `just miri-filter`)
- Documented in [decision-log DEC-042] and [research/miri-unsafe-audit]

## Known issue (release-blocker debate)

Two link-resolution e2e tests have been failing on `ubuntu-latest` and `windows-latest` since iter-136 (`case_insensitive_links_fix_dry_run_reports_case_mismatches`, `mv_bare_wikilink_no_broken_links_after_move`). Tracked in `backlog/cross-platform-link-resolution-failures.md` with concrete suggested-fix paths. macOS CI is green.

**Decision needed before merge/tag:** ship 0.16.0 with these failures (consistent with iter-136 and PR #157 having been merged through), or hold the release for the cross-platform investigation. I lean toward shipping — the failures are in tests, not in user-facing functionality, and holding 0.16.0 hostage delays the unsafe removal + case-insensitive link resolution + backlinks fix.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` — green on macOS
- [x] `target/release/hyalo --version` reports `0.16.0`
- [ ] After merge: tag and `gh release create v0.16.0` to trigger package builds (Homebrew, winget, deb, rpm)