### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.16.0 — 2026-05-23
+
 ### Breaking changes
 
 - The hybrid `--index [=PATH]` flag has been split into two orthogonal flags:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hyalo-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-mdlint"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ members = ["crates/*"]
 default-members = ["crates/hyalo-cli"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ractive/hyalo"
 
 [workspace.dependencies]
 # Internal crates
-hyalo-core = { path = "crates/hyalo-core", version = "0.15.0" }
-hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.15.0" }
+hyalo-core = { path = "crates/hyalo-core", version = "0.16.0" }
+hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.16.0" }
 
 # External dependencies
 anyhow = "1"


### PR DESCRIPTION
## Summary

Release v0.16.0. Workspace + internal dep versions bumped to 0.16.0; CHANGELOG `Unreleased` stamped as `0.16.0 — 2026-05-23`.

Replaces stale #161 (which was opened before the iter-137 cross-platform fixes landed).

## What's in v0.16.0

**Breaking**
- `--index` / `--index-file` flag split, made per-subcommand
- `properties rename` / `tags rename` JSON output uses `skipped_count` instead of `skipped` array

**Added**
- Case-insensitive link resolution (`[links] case_insensitive` in `.hyalo.toml`)
- `link-case-mismatch` lint rule
- `--stemmer` / `--language` accepts ISO 639-1 codes
- `--dry-run` flags on `properties rename`, `tags rename`, `task set`
- Snapshot-index hardening: path validation + 512 MB size cap

**Fixed**
- `backlinks` now finds short-form `[[basename]]` wikilinks via resolver parity with `find --fields links`
- Obsidian short-form bare wikilink resolution works on case-sensitive filesystems regardless of `[links] case_insensitive` mode
- `links fix` reports short-form stem mismatches as `LinkCaseMismatch` (consistent with path-form)
- Windows main-thread stack overflow when running the binary (now 8 MB via `.cargo/config.toml`)

**Internal**
- Removed 3 of 4 `unsafe { from_utf8_unchecked }` blocks in scanner
- Miri scaffolding via `justfile`
- bm25 round-trip test uses relative tolerance instead of `f64::EPSILON`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` green on macOS locally
- [x] `cargo test --workspace` green on Linux via Docker
- [x] `target/release/hyalo --version` reports `0.16.0`
- [ ] Expect CI green on all three platforms (Linux + macOS + Windows)
- [ ] After merge: tag `v0.16.0` and run `gh release create v0.16.0` to publish via Homebrew / winget / deb / rpm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security hardening for index loading with path validation and size limits.

* **Bug Fixes**
  * Improved link-resolution accuracy.
  * Enhanced casing and mismatch reporting.

* **Breaking Changes**
  * Updated --index/--index-file flag semantics.
  * JSON output field renamed (properties/tags).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ractive/hyalo/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->