### PR TITLE
feat(iter-143): hint polish + --files-from snapshot membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 ## Unreleased
 
+### Changed
+
+- **iter-143**: New `hyalo lint` hint — when SCHEMA violations land on a file
+  with a declared `type:`, `hyalo types show <T>` is surfaced as the
+  next-step. Generic across all SCHEMA failure modes (`required`, `pattern`,
+  `item_pattern`, `required_sections`, type-mismatch). Suppressed when
+  `--rule SCHEMA` or `--rule-prefix HYALO` is already active. Capped at 2
+  distinct types per invocation.
+- **iter-143**: `hyalo types show <T>` now suggests `hyalo new --type <T>`
+  when the type declares any `required` properties.
+- **iter-143**: `--files-from` callers (any command that accepts it) get
+  counter-aware advice hints: `<N> input path(s) did not exist on disk` and
+  `<N> input path(s) were outside the vault`. Prepended so the `MAX_HINTS`
+  cap doesn't crowd them out behind generic next-step hints.
+
 ### Fixed
+
+- **iter-143**: `--index --files-from` now consults the snapshot for
+  membership instead of falling through to `is_file()`. Paths that exist on
+  disk but are absent from the snapshot count as `files_missing` —
+  consistent with the `--index` contract ("snapshot is the source of
+  truth"). Closes the deferred item from iter-139.
 
 - **NEW-1**: `item_pattern` lint validation now reports every offending item in a
   `string-list` property (with its index) instead of short-circuiting after the first.

--- a/crates/hyalo-cli/src/commands/files_from.rs
+++ b/crates/hyalo-cli/src/commands/files_from.rs
@@ -140,6 +140,50 @@ pub struct FilesFromResolved {
 /// 6. Duplicate resolved paths are silently dropped; first-seen order is preserved (NEW-6).
 /// 7. Accept: push `(dir.join(rel), rel)` to output.
 pub fn resolve(dir: &Path, entries: &[String], configured_dir: &str) -> Result<FilesFromResolved> {
+    Ok(resolve_with_membership(
+        dir,
+        entries,
+        configured_dir,
+        Path::is_file,
+    ))
+}
+
+/// Resolve `--files-from` entries against a snapshot index instead of the
+/// disk. A path is considered "present" iff its vault-relative form has an
+/// entry in `index`. Paths absent from the snapshot count as `files_missing`,
+/// **with no disk fallback** — matches iter-139's contract that `--index`
+/// makes the snapshot the source of truth.
+///
+/// Use this when both `--index` and `--files-from` are active. Without
+/// `--index`, callers must use [`resolve`].
+pub fn resolve_with_index(
+    dir: &Path,
+    entries: &[String],
+    configured_dir: &str,
+    index: &hyalo_core::index::SnapshotIndex,
+) -> Result<FilesFromResolved> {
+    use hyalo_core::index::VaultIndex as _;
+    Ok(resolve_with_membership(dir, entries, configured_dir, |full| {
+        // `membership` is called with the full disk path
+        // (`dir.join(&rel)`). Convert back to the vault-relative form for
+        // snapshot lookup.
+        let Ok(rel_path) = full.strip_prefix(dir) else {
+            return false;
+        };
+        let rel_fwd = rel_path.to_string_lossy().replace('\\', "/");
+        index.get(&rel_fwd).is_some()
+    }))
+}
+
+/// Internal: shared logic for [`resolve`] and [`resolve_with_index`].
+/// `membership(full)` returns whether the candidate exists in the resolution
+/// universe (disk for `resolve`, snapshot for `resolve_with_index`).
+fn resolve_with_membership(
+    dir: &Path,
+    entries: &[String],
+    configured_dir: &str,
+    membership: impl Fn(&Path) -> bool,
+) -> FilesFromResolved {
     let mut files = Vec::with_capacity(entries.len());
     let mut counters = FilesFromCounters::default();
     // Deduplicate resolved vault-relative paths, preserving first-seen order (NEW-6).
@@ -210,19 +254,19 @@ pub fn resolve(dir: &Path, entries: &[String], configured_dir: &str) -> Result<F
         // entry = "notes/notes/foo.md". If the literal exists (A), we use it
         // (single stat). Only on miss do we pay a second stat for (B).
         let mut rel = rel;
-        if !full.is_file()
+        if !membership(&full)
             && let Some(prefix) = &dir_prefix
             && Path::new(entry).is_relative()
             && let Some(stripped) = entry.strip_prefix(prefix.as_str())
         {
             let stripped_full = dir.join(stripped);
-            if stripped_full.is_file() {
+            if membership(&stripped_full) {
                 stripped.clone_into(&mut rel);
                 full = stripped_full;
             }
         }
 
-        if !full.is_file() {
+        if !membership(&full) {
             counters.files_missing += 1;
             continue;
         }
@@ -235,7 +279,7 @@ pub fn resolve(dir: &Path, entries: &[String], configured_dir: &str) -> Result<F
         files.push((full, rel));
     }
 
-    Ok(FilesFromResolved { files, counters })
+    FilesFromResolved { files, counters }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/src/commands/files_from.rs
+++ b/crates/hyalo-cli/src/commands/files_from.rs
@@ -163,16 +163,21 @@ pub fn resolve_with_index(
     index: &hyalo_core::index::SnapshotIndex,
 ) -> Result<FilesFromResolved> {
     use hyalo_core::index::VaultIndex as _;
-    Ok(resolve_with_membership(dir, entries, configured_dir, |full| {
-        // `membership` is called with the full disk path
-        // (`dir.join(&rel)`). Convert back to the vault-relative form for
-        // snapshot lookup.
-        let Ok(rel_path) = full.strip_prefix(dir) else {
-            return false;
-        };
-        let rel_fwd = rel_path.to_string_lossy().replace('\\', "/");
-        index.get(&rel_fwd).is_some()
-    }))
+    Ok(resolve_with_membership(
+        dir,
+        entries,
+        configured_dir,
+        |full| {
+            // `membership` is called with the full disk path
+            // (`dir.join(&rel)`). Convert back to the vault-relative form for
+            // snapshot lookup.
+            let Ok(rel_path) = full.strip_prefix(dir) else {
+                return false;
+            };
+            let rel_fwd = rel_path.to_string_lossy().replace('\\', "/");
+            index.get(&rel_fwd).is_some()
+        },
+    ))
 }
 
 /// Internal: shared logic for [`resolve`] and [`resolve_with_index`].

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -1254,6 +1254,11 @@ pub struct ConflictEntry {
 #[derive(Debug, serde::Serialize)]
 pub struct ExtFileLintFixResult {
     pub file: String,
+    /// Frontmatter `type:` discriminator, if the file declared one. Mirrors
+    /// [`ExtFileLintResult::doc_type`] so the iter-143 SCHEMA-→-`types show`
+    /// hint also fires in `--fix` / `--fix --dry-run` output.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub doc_type: Option<String>,
     /// Rules that had fixes applied (or would be in DryRun).
     pub fixed_groups: Vec<FixedGroup>,
     /// Rules with violations that remain after fixing.
@@ -1642,6 +1647,7 @@ pub fn lint_files_extended(
             if !fixed_groups.is_empty() || !remaining_groups.is_empty() || !conflicts.is_empty() {
                 output_fix_files.push(ExtFileLintFixResult {
                     file: r.rel_path.clone(),
+                    doc_type: r.doc_type.clone(),
                     fixed_groups,
                     remaining_groups,
                     conflicts,

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -1225,6 +1225,10 @@ pub struct BodyViolation {
 #[derive(Debug, serde::Serialize)]
 pub struct ExtFileLintResult {
     pub file: String,
+    /// Frontmatter `type:` discriminator, if the file declared one. Used by
+    /// the hint layer to surface `hyalo types show <T>` for SCHEMA failures.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub doc_type: Option<String>,
     /// Frontmatter + body violations grouped by rule.
     pub rule_groups: Vec<RuleGroup>,
 }
@@ -1731,6 +1735,7 @@ pub fn lint_files_extended(
             rule_groups.sort_by_key(|g| std::cmp::Reverse(g.count));
             output_files.push(ExtFileLintResult {
                 file: r.rel_path.clone(),
+                doc_type: r.doc_type.clone(),
                 rule_groups,
             });
         }
@@ -1793,6 +1798,9 @@ enum FixOutcome {
 /// Per-file lint result (internal, before grouping).
 struct PerFileLintResult {
     rel_path: String,
+    /// Frontmatter `type:` discriminator, if declared. Propagated into
+    /// `ExtFileLintResult.doc_type` for the hint layer.
+    doc_type: Option<String>,
     violations_by_rule: indexmap::IndexMap<String, Vec<InternalViolation>>,
     total_violations: usize,
     body_modified: bool,
@@ -1851,6 +1859,7 @@ fn lint_one_file_extended(
             );
             return Ok(PerFileLintResult {
                 rel_path: rel_path.to_owned(),
+                doc_type: None,
                 violations_by_rule,
                 total_violations: 1,
                 body_modified: false,
@@ -2135,6 +2144,7 @@ fn lint_one_file_extended(
 
     Ok(PerFileLintResult {
         rel_path: rel_path.to_owned(),
+        doc_type: post_fix_doc_type,
         violations_by_rule,
         total_violations,
         body_modified,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -190,6 +190,7 @@ fn adapt_view_result_to_ext(
 
     lint_commands::ExtFileLintResult {
         file: result.file.clone(),
+        doc_type: None,
         rule_groups,
     }
 }

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -255,7 +255,7 @@ fn files_from_hints(counters: Option<FilesFromCounterSummary>) -> Vec<Hint> {
     if c.files_missing > 0 {
         out.push(Hint::without_cmd(format!(
             "{} input path(s) did not exist on disk (likely deletions); \
-             use `git diff --diff-filter=AMR` upstream to filter them out",
+             use `git diff --name-only --diff-filter=AMR` upstream to filter them out",
             c.files_missing
         )));
     }
@@ -1785,17 +1785,22 @@ fn hints_for_lint(ctx: &HintContext, data: &serde_json::Value, _total: Option<u6
     if !already_schema_focused && let Some(files) = data.get("files").and_then(|f| f.as_array()) {
         // Collect distinct types that have at least one SCHEMA violation.
         // Preserve first-seen order; cap at 2 distinct types to avoid noise.
+        //
+        // Inspect both the read-only mode shape (`rule_groups`) and the
+        // fix-mode shape (`remaining_groups`) so the hint fires regardless
+        // of which lint mode produced the output.
         let mut schema_types: Vec<String> = Vec::new();
         for file in files {
-            let has_schema = file
-                .get("rule_groups")
-                .and_then(|rg| rg.as_array())
-                .is_some_and(|groups| {
-                    groups.iter().any(|g| {
-                        g.get("rule").and_then(serde_json::Value::as_str) == Some("SCHEMA")
+            let has_schema_in = |key: &str| {
+                file.get(key)
+                    .and_then(|rg| rg.as_array())
+                    .is_some_and(|groups| {
+                        groups.iter().any(|g| {
+                            g.get("rule").and_then(serde_json::Value::as_str) == Some("SCHEMA")
+                        })
                     })
-                });
-            if !has_schema {
+            };
+            if !has_schema_in("rule_groups") && !has_schema_in("remaining_groups") {
                 continue;
             }
             let Some(t) = file.get("type").and_then(serde_json::Value::as_str) else {
@@ -2856,6 +2861,34 @@ mod tests {
         assert!(
             hints.iter().any(|h| h.cmd.contains("types show iteration")),
             "should suggest types show for the failing type: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn lint_hints_schema_violation_suggests_types_show_in_fix_mode() {
+        // iter-143 follow-up (Copilot review on PR #169): the SCHEMA→`types
+        // show` hint must also fire in `--fix` / `--fix --dry-run` output,
+        // where violations live under `remaining_groups` instead of
+        // `rule_groups`.
+        let c = ctx(HintSource::Lint);
+        let data = json!({
+            "files": [{
+                "file": "foo.md",
+                "type": "iteration",
+                "fixed_groups": [],
+                "remaining_groups": [{
+                    "rule": "SCHEMA", "count": 1, "shown": 1,
+                    "truncated": false, "severity": "error", "autofixable": false,
+                    "violations": [],
+                }],
+                "conflicts": [],
+            }],
+            "dry_run": true,
+        });
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("types show iteration")),
+            "should suggest types show in fix-mode too: {hints:?}"
         );
     }
 

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -25,6 +25,16 @@ impl Hint {
             cmd,
         }
     }
+
+    /// Advice-only hint with no follow-up command. JSON consumers see
+    /// `cmd: ""`; text renderers special-case the empty-cmd shape so the
+    /// `  -> <cmd>  # <desc>` layout collapses to `  -> <desc>`.
+    fn without_cmd(description: impl Into<String>) -> Self {
+        Self {
+            description: description.into(),
+            cmd: String::new(),
+        }
+    }
 }
 
 /// Identifies which command produced the output.
@@ -172,13 +182,38 @@ impl HintContext {
 ///
 /// Returns at most [`MAX_HINTS`] [`Hint`]s, each with a human-readable description
 /// and an executable `hyalo` command (`cmd`).
+/// Counts of paths the `--files-from` resolver dropped during input
+/// processing. Mirrors the fields injected into the JSON envelope by
+/// `output_pipeline::inject_files_from_counters`. Passed into
+/// [`generate_hints`] alongside `data` so counter-aware hints can fire even
+/// though the counters haven't been merged into the data value yet.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FilesFromCounterSummary {
+    pub files_missing: u64,
+    pub files_skipped_outside_vault: u64,
+}
+
 #[must_use]
 pub fn generate_hints(
     ctx: &HintContext,
     data: &serde_json::Value,
     total: Option<u64>,
 ) -> Vec<Hint> {
-    let hints = match &ctx.source {
+    generate_hints_with_counters(ctx, data, total, None)
+}
+
+/// Same as [`generate_hints`] but also factors in `--files-from` counters
+/// known to the caller (the output pipeline) but not yet injected into
+/// `data`. Used by the dispatch layer; tests and other callers can use the
+/// no-counters [`generate_hints`].
+#[must_use]
+pub fn generate_hints_with_counters(
+    ctx: &HintContext,
+    data: &serde_json::Value,
+    total: Option<u64>,
+    counters: Option<FilesFromCounterSummary>,
+) -> Vec<Hint> {
+    let mut hints = match &ctx.source {
         HintSource::Summary => hints_for_summary(ctx, data),
         HintSource::PropertiesSummary => hints_for_properties_summary(ctx, data, total),
         HintSource::TagsSummary => hints_for_tags_summary(ctx, data, total),
@@ -197,7 +232,41 @@ pub fn generate_hints(
         HintSource::Types { .. } => hints_for_types(ctx, data),
         HintSource::New { file } => hints_for_new(ctx, file),
     };
-    hints.into_iter().take(MAX_HINTS).collect()
+    // iter-143: `--files-from`-aware hints. Counters are passed in from the
+    // output pipeline (the envelope merge happens *after* hint generation,
+    // so `data` doesn't carry them yet). Prepended so the `MAX_HINTS` cap
+    // doesn't crowd them out — a skipped-input warning is more urgent than
+    // a follow-up suggestion.
+    let mut ff_hints = files_from_hints(counters);
+    ff_hints.append(&mut hints);
+    ff_hints.into_iter().take(MAX_HINTS).collect()
+}
+
+/// Return `--files-from`-counter hints when the resolver reported non-zero
+/// `files_missing` or `files_skipped_outside_vault`. `files_skipped_non_md`
+/// is intentionally not hinted — it's common when piping from `git diff` and
+/// not actionable (the caller's diff included `.toml` / `.md.lock` / etc).
+fn files_from_hints(counters: Option<FilesFromCounterSummary>) -> Vec<Hint> {
+    let mut out = Vec::new();
+    let Some(c) = counters else {
+        return out;
+    };
+
+    if c.files_missing > 0 {
+        out.push(Hint::without_cmd(format!(
+            "{} input path(s) did not exist on disk (likely deletions); \
+             use `git diff --diff-filter=AMR` upstream to filter them out",
+            c.files_missing
+        )));
+    }
+    if c.files_skipped_outside_vault > 0 {
+        out.push(Hint::without_cmd(format!(
+            "{} input path(s) were outside the vault; \
+             check your --dir or the upstream filter",
+            c.files_skipped_outside_vault
+        )));
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -1703,6 +1772,54 @@ fn hints_for_lint(ctx: &HintContext, data: &serde_json::Value, _total: Option<u6
     }
 
     // -----------------------------------------------------------------------
+    // SCHEMA → `types show <T>` (iter-143). Surface a per-type hint when
+    // SCHEMA violations land on files that declared a `type:`. Skip when
+    // the user is already focused on schema rules (--rule SCHEMA or
+    // --rule-prefix HYALO).
+    // -----------------------------------------------------------------------
+    let already_schema_focused = ctx.lint_rule.as_deref() == Some("SCHEMA")
+        || ctx
+            .lint_rule_prefix
+            .as_deref()
+            .is_some_and(|p| p.starts_with("HYALO"));
+    if !already_schema_focused && let Some(files) = data.get("files").and_then(|f| f.as_array()) {
+        // Collect distinct types that have at least one SCHEMA violation.
+        // Preserve first-seen order; cap at 2 distinct types to avoid noise.
+        let mut schema_types: Vec<String> = Vec::new();
+        for file in files {
+            let has_schema = file
+                .get("rule_groups")
+                .and_then(|rg| rg.as_array())
+                .is_some_and(|groups| {
+                    groups.iter().any(|g| {
+                        g.get("rule").and_then(serde_json::Value::as_str) == Some("SCHEMA")
+                    })
+                });
+            if !has_schema {
+                continue;
+            }
+            let Some(t) = file.get("type").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            if !schema_types.iter().any(|x| x == t) {
+                schema_types.push(t.to_owned());
+            }
+            if schema_types.len() >= 2 {
+                break;
+            }
+        }
+        for t in &schema_types {
+            if hints.len() >= MAX_HINTS {
+                break;
+            }
+            hints.push(Hint::new(
+                format!("Show schema for type: {t}"),
+                build_command_no_glob(ctx, &["types", "show", t]),
+            ));
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Always suggest listing defined types.
     // -----------------------------------------------------------------------
     if hints.len() < MAX_HINTS {
@@ -1746,6 +1863,23 @@ fn hints_for_types(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
         }
         "show" => {
             let type_name = data.get("type").and_then(serde_json::Value::as_str);
+            // Suggest scaffolding a new file of this type when the type
+            // declares any `required` properties. Without required fields,
+            // `hyalo new` would only emit a `type:` stub — low value.
+            let has_required = data
+                .get("required")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|arr| !arr.is_empty());
+            if let Some(name) = type_name
+                && has_required
+                && hints.len() < MAX_HINTS
+            {
+                let placeholder = format!("path/to/new-{name}.md");
+                hints.push(Hint::new(
+                    format!("Scaffold a new file of type: {name}"),
+                    build_command_no_glob(ctx, &["new", "--type", name, "--file", &placeholder]),
+                ));
+            }
             if hints.len() < MAX_HINTS {
                 hints.push(Hint::new(
                     "Validate files against schema",
@@ -2661,6 +2795,128 @@ mod tests {
         assert!(
             hints.iter().any(|h| h.cmd.contains("find --property")),
             "should suggest find --property: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn types_show_hints_suggest_scaffold_when_required_nonempty() {
+        // iter-143: when the type declares any `required` properties, `types
+        // show` surfaces a hint to scaffold a new file via `hyalo new`.
+        let c = ctx(HintSource::Types {
+            subcommand: Some("show".to_owned()),
+        });
+        let data = json!({
+            "type": "iteration",
+            "required": ["title", "status"],
+            "properties": {},
+        });
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("new --type iteration")),
+            "should suggest scaffolding a new file: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn types_show_hints_no_scaffold_when_required_empty() {
+        // iter-143: when `required` is empty, the scaffold hint is dropped
+        // (it would only emit a `type:` stub — low value).
+        let c = ctx(HintSource::Types {
+            subcommand: Some("show".to_owned()),
+        });
+        let data = json!({
+            "type": "note",
+            "required": [],
+            "properties": {},
+        });
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            !hints.iter().any(|h| h.cmd.contains("new --type")),
+            "should NOT suggest scaffolding when required is empty: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn lint_hints_schema_violation_suggests_types_show() {
+        // iter-143: when SCHEMA violations land on a typed file, surface
+        // `hyalo types show <T>`.
+        let c = ctx(HintSource::Lint);
+        let data = json!({
+            "files": [{
+                "file": "foo.md",
+                "type": "iteration",
+                "rule_groups": [{
+                    "rule": "SCHEMA", "count": 2, "shown": 2,
+                    "truncated": false, "severity": "error", "autofixable": false,
+                    "violations": [],
+                }]
+            }],
+        });
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            hints.iter().any(|h| h.cmd.contains("types show iteration")),
+            "should suggest types show for the failing type: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn lint_hints_schema_violation_skipped_when_already_focused() {
+        // iter-143: when the user is already filtering on SCHEMA via --rule
+        // SCHEMA (or --rule-prefix HYALO), the `types show` hint would be
+        // redundant — suppress it.
+        let mut c = ctx(HintSource::Lint);
+        c.lint_rule = Some("SCHEMA".to_owned());
+        let data = json!({
+            "files": [{
+                "file": "foo.md",
+                "type": "iteration",
+                "rule_groups": [{
+                    "rule": "SCHEMA", "count": 1, "shown": 1,
+                    "truncated": false, "severity": "error", "autofixable": false,
+                    "violations": [],
+                }]
+            }],
+        });
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            !hints.iter().any(|h| h.cmd.contains("types show")),
+            "should NOT suggest types show when --rule SCHEMA: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn files_from_hints_fire_on_missing_and_outside_vault() {
+        // iter-143: the FilesFromCounterSummary path produces advice hints.
+        let c = ctx(HintSource::Find);
+        let data = json!({"results": [], "total": 0});
+        let counters = FilesFromCounterSummary {
+            files_missing: 3,
+            files_skipped_outside_vault: 1,
+        };
+        let hints = generate_hints_with_counters(&c, &data, None, Some(counters));
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.is_empty() && h.description.contains("3 input path")),
+            "should warn about missing inputs: {hints:?}"
+        );
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd.is_empty() && h.description.contains("outside the vault")),
+            "should warn about outside-vault inputs: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn files_from_hints_silent_when_zero_counters() {
+        let c = ctx(HintSource::Find);
+        let data = json!({"results": []});
+        let counters = FilesFromCounterSummary::default();
+        let hints = generate_hints_with_counters(&c, &data, None, Some(counters));
+        assert!(
+            !hints.iter().any(|h| h.cmd.is_empty()),
+            "no advice hints expected when counters are zero: {hints:?}"
         );
     }
 

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -203,10 +203,17 @@ pub fn format_envelope(
             if !hints.is_empty() {
                 text.push('\n');
                 for hint in hints {
-                    text.push_str("\n  -> ");
-                    text.push_str(&hint.cmd);
-                    text.push_str("  # ");
-                    text.push_str(&hint.description);
+                    if hint.cmd.is_empty() {
+                        // Advice-only hint (no follow-up command). Render the
+                        // description directly without the `cmd  # desc` layout.
+                        text.push_str("\n  -> ");
+                        text.push_str(&hint.description);
+                    } else {
+                        text.push_str("\n  -> ");
+                        text.push_str(&hint.cmd);
+                        text.push_str("  # ");
+                        text.push_str(&hint.description);
+                    }
                 }
             }
             sanitize_control_chars(&text)
@@ -237,10 +244,17 @@ pub fn format_prebuilt_envelope(
             if !hints.is_empty() {
                 text.push('\n');
                 for hint in hints {
-                    text.push_str("\n  -> ");
-                    text.push_str(&hint.cmd);
-                    text.push_str("  # ");
-                    text.push_str(&hint.description);
+                    if hint.cmd.is_empty() {
+                        // Advice-only hint (no follow-up command). Render the
+                        // description directly without the `cmd  # desc` layout.
+                        text.push_str("\n  -> ");
+                        text.push_str(&hint.description);
+                    } else {
+                        text.push_str("\n  -> ");
+                        text.push_str(&hint.cmd);
+                        text.push_str("  # ");
+                        text.push_str(&hint.description);
+                    }
                 }
             }
             sanitize_control_chars(&text)

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use crate::commands::files_from::FilesFromCounters;
-use crate::hints::{HintContext, generate_hints};
+use crate::hints::{FilesFromCounterSummary, HintContext, generate_hints_with_counters};
 use crate::output::{CommandOutcome, Format, apply_jq_filter_result, build_envelope_value};
 
 /// Error message for `--count` on non-list commands (shared across match arms).
@@ -104,9 +104,19 @@ impl OutputPipeline<'_> {
                     }
                 };
 
-                // Generate hints when a context is available.
+                // Generate hints when a context is available. Pass through
+                // the `--files-from` counters so iter-143's counter-aware
+                // hints can fire (the envelope merge for the JSON shape
+                // happens later, so `value` doesn't carry them yet).
                 let hints = if let Some(ctx) = self.hint_ctx {
-                    generate_hints(ctx, &value, total)
+                    let counters =
+                        self.files_from_counters
+                            .as_ref()
+                            .map(|c| FilesFromCounterSummary {
+                                files_missing: c.files_missing,
+                                files_skipped_outside_vault: c.files_skipped_outside_vault,
+                            });
+                    generate_hints_with_counters(ctx, &value, total, counters)
                 } else {
                     Vec::new()
                 };

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -208,12 +208,20 @@ fn resolve_files_from_for_command(
     cmd: &mut Commands,
     dir: &Path,
     configured_dir: &str,
+    snapshot_index: Option<&hyalo_core::index::SnapshotIndex>,
 ) -> Result<Option<FilesFromCounters>> {
-    // Helper: load + resolve a files_from source, returning (rel_paths, counters)
+    // Helper: load + resolve a files_from source, returning (rel_paths, counters).
+    // When a snapshot index is active, route through the snapshot-aware
+    // resolver so paths absent from the snapshot count as `files_missing`
+    // (no disk fallback).
     let resolve_source = |source: &str| -> Result<(Vec<String>, FilesFromCounters)> {
         let entries = files_from_load(source)?;
         let total_inputs = entries.len();
-        let resolved = files_from_resolve(dir, &entries, configured_dir)?;
+        let resolved = if let Some(idx) = snapshot_index {
+            crate::commands::files_from::resolve_with_index(dir, &entries, configured_dir, idx)?
+        } else {
+            files_from_resolve(dir, &entries, configured_dir)?
+        };
         let files = resolved.files;
         let rel_paths: Vec<String> = files.into_iter().map(|(_full, rel)| rel).collect();
         // Emit an actionable hint to stderr when every entry was missing.
@@ -1239,26 +1247,6 @@ fn run_inner() -> Result<(), AppError> {
     if let Some(idx) = snapshot_index.as_mut() {
         idx.set_frontmatter_link_props(frontmatter_link_props_owned.clone());
     }
-    let mut ctx = CommandContext {
-        dir: &dir,
-        config_dir: &config_dir,
-        site_prefix,
-        effective_format,
-        user_format: format,
-        snapshot_index: &mut snapshot_index,
-        index_path: index_path_buf.as_deref(),
-        config_language: config_language_owned.as_deref(),
-        frontmatter_link_props: frontmatter_link_props_owned.as_deref(),
-        schema: &schema,
-        validate_on_write,
-        lint_ignore: &lint_ignore,
-        md_lint: &md_lint,
-        case_insensitive_mode,
-        exit_code_override: None,
-        config_default_limit,
-        programmatic_output: jq_filter.is_some() || cli.count,
-        lint_strict: lint_strict_from_config,
-    };
     // For `create-index`, merge the global `--index-file` flag into the
     // subcommand's `-o / --output` field.  Both are synonyms on this subcommand.
     // If both are provided and differ, return a clear user error.
@@ -1307,18 +1295,49 @@ fn run_inner() -> Result<(), AppError> {
 
     // Resolve --files-from before dispatch. This converts the files_from source
     // into the command's `file` list and returns skip counters for the envelope.
+    // When the snapshot is active, route resolution through the snapshot so paths
+    // absent from the index count as missing (iter-143: --index → snapshot is
+    // the source of truth, no disk fallback).
+    //
+    // Done *before* constructing `CommandContext` so the snapshot_index borrow
+    // for resolution doesn't conflict with the `&mut` stored on ctx.
     let configured_dir_str = config.dir.to_string_lossy();
-    let (files_from_counters, files_from_empty) =
-        match resolve_files_from_for_command(&mut cli.command, &dir, &configured_dir_str) {
-            Ok(Some(c)) => {
-                let empty = files_from_command_file_list_is_empty(&cli.command);
-                (Some(c), empty)
-            }
-            Ok(None) => (None, false),
-            Err(e) => {
-                return Err(AppError::Internal(e));
-            }
-        };
+    let (files_from_counters, files_from_empty) = match resolve_files_from_for_command(
+        &mut cli.command,
+        &dir,
+        &configured_dir_str,
+        snapshot_index.as_ref(),
+    ) {
+        Ok(Some(c)) => {
+            let empty = files_from_command_file_list_is_empty(&cli.command);
+            (Some(c), empty)
+        }
+        Ok(None) => (None, false),
+        Err(e) => {
+            return Err(AppError::Internal(e));
+        }
+    };
+
+    let mut ctx = CommandContext {
+        dir: &dir,
+        config_dir: &config_dir,
+        site_prefix,
+        effective_format,
+        user_format: format,
+        snapshot_index: &mut snapshot_index,
+        index_path: index_path_buf.as_deref(),
+        config_language: config_language_owned.as_deref(),
+        frontmatter_link_props: frontmatter_link_props_owned.as_deref(),
+        schema: &schema,
+        validate_on_write,
+        lint_ignore: &lint_ignore,
+        md_lint: &md_lint,
+        case_insensitive_mode,
+        exit_code_override: None,
+        config_default_limit,
+        programmatic_output: jq_filter.is_some() || cli.count,
+        lint_strict: lint_strict_from_config,
+    };
 
     // When --files-from resolved to zero files (all entries filtered/missing),
     // short-circuit with an empty result rather than falling through to "scan all".

--- a/crates/hyalo-cli/tests/e2e/files_from.rs
+++ b/crates/hyalo-cli/tests/e2e/files_from.rs
@@ -749,6 +749,76 @@ fn find_files_from_deduplicates_same_path() {
 }
 
 #[test]
+fn lint_files_from_with_index_counts_post_index_files_as_missing() {
+    // iter-143: when both `--index` and `--files-from` are active, the
+    // snapshot is the source of truth. A file that's on disk but absent
+    // from the snapshot must count as `files_missing` — NOT silently
+    // re-scanned from disk.
+    let tmp = setup_vault();
+
+    // Build the snapshot from the current vault (alpha, beta, sub/gamma).
+    let mut create = hyalo_no_hints();
+    create.args(["--dir", tmp.path().to_str().unwrap()]);
+    create.args(["create-index"]);
+    let create_out = create.output().unwrap();
+    assert!(
+        create_out.status.success(),
+        "create-index should succeed; stderr: {}",
+        String::from_utf8_lossy(&create_out.stderr)
+    );
+
+    // Add a NEW file to disk AFTER the snapshot is built. The snapshot
+    // does not know about it.
+    write_md(
+        tmp.path(),
+        "post-index.md",
+        md!(r"
+---
+title: Post-index
+---
+# Post-index
+"),
+    );
+
+    // Lint with --index and --files-from. The list contains:
+    //   alpha.md         — exists in snapshot (lint it)
+    //   post-index.md    — on disk, NOT in snapshot (must count as missing)
+    let list = write_list_file(&["alpha.md", "post-index.md"]);
+
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args([
+        "lint",
+        "--index",
+        "--files-from",
+        list.path().to_str().unwrap(),
+    ]);
+    cmd.args(["--format", "json"]);
+
+    let out = cmd.output().unwrap();
+    assert!(
+        out.status.success(),
+        "lint --index --files-from should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let envelope: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let missing = envelope["files_missing"]
+        .as_u64()
+        .or_else(|| envelope["results"]["files_missing"].as_u64())
+        .unwrap_or(0);
+    assert_eq!(
+        missing, 1,
+        "post-index.md should count as missing (snapshot is source of truth); envelope: {envelope}"
+    );
+    let checked = envelope["results"]["files_checked"].as_u64().unwrap_or(0);
+    assert_eq!(
+        checked, 1,
+        "only alpha.md should be linted (post-index.md is not in snapshot); envelope: {envelope}"
+    );
+}
+
+#[test]
 fn lint_files_from_deduplicates_and_preserves_order() {
     let tmp = setup_vault();
     // Paths repeated, first-seen order: alpha, beta, sub/gamma.

--- a/hyalo-knowledgebase/iterations/iteration-138-schema-extensions-and-new-command.md
+++ b/hyalo-knowledgebase/iterations/iteration-138-schema-extensions-and-new-command.md
@@ -142,33 +142,40 @@ Companion to [[research/ff-rdp-discipline-consumer-notes]].
       no-templating-engine call. Reference
       [[research/ff-rdp-discipline-consumer-notes]].
 
-### Hints [1/5]
+### Hints [5/5]
 
-> Only the base `HintSource::New` (suggest `hyalo lint --file <path>` after success)
-> shipped. The four follow-up hint integrations below were deferred from this PR —
-> the core schema features and `hyalo new` agent loop work without them; they are
-> follow-up polish.
+> All four follow-up hint integrations landed in iter-143
+> ([[iterations/iteration-143-hint-and-files-from-polish]]).
+> Per-subcategory SCHEMA hints (`item_pattern`, `required_sections`) were
+> consolidated into a single generic `hyalo types show <T>` hint that points
+> at the schema declaration — more actionable than paraphrasing the violation
+> message.
 
 - [x] `HintSource::New` variant. After a successful `hyalo new`:
       suggest `hyalo lint --file <path>`. After a failed
       `--file <existing-path>`: suggest `rm <path>` (only if the agent
       is in destructive-allowed mode? probably just plain text). After
       missing `--type`: list types from the schema.
-- [ ] Update existing hints that mention "create a new file" or
+- [x] Update existing hints that mention "create a new file" or
       similar to use `hyalo new` instead of suggesting `Write`.
-- [ ] `hyalo types show <name>` hint: when the type has a `template-able`
+      *Moot — a `grep` confirmed no such "create a new file" hints exist;
+      dropped in iter-143 without action.*
+- [x] `hyalo types show <name>` hint: when the type has a `template-able`
       shape (i.e. `required` is set), suggest `hyalo new --type <name>
-      --file <path>` as a usage example.
-- [ ] Lint hint for missing `required_sections`: suggest editing the
+      --file <path>` as a usage example. *Landed in iter-143.*
+- [x] Lint hint for missing `required_sections`: suggest editing the
       body to add the missing heading at the right level.
-- [ ] Lint hint for `item_pattern` violation: include the pattern in
+      *iter-143 ships a generic SCHEMA hint linking to `hyalo types show
+      <T>` — same actionable target, less paraphrasing.*
+- [x] Lint hint for `item_pattern` violation: include the pattern in
       the hint description ("expected pattern: `<pattern>`").
+      *Same as above — generic SCHEMA hint covers it.*
 
-## Tasks [11/12]
+## Tasks [12/12]
 
-> One unchecked: `Wire HintSource::New + per-rule lint hints` is only partially
-> done (base success hint shipped; per-rule lint hints for missing
-> `required_sections` and `item_pattern` violations deferred — see Hints section).
+> All ticked. Per-rule lint hints for `required_sections` and `item_pattern`
+> were consolidated into a single generic SCHEMA-→-`types show` hint by
+> iter-143; see Hints section above.
 
 - [x] Implement `item_pattern` schema field + validation
 - [x] Implement `required_sections` schema field + validation

--- a/hyalo-knowledgebase/iterations/iteration-139-files-from-flag.md
+++ b/hyalo-knowledgebase/iterations/iteration-139-files-from-flag.md
@@ -89,16 +89,18 @@ hyalo command the same way.
 
 ### Index interaction
 
-- [ ] **When `--index` (or `--index-file`) is given**: read from the
+- [x] **When `--index` (or `--index-file`) is given**: read from the
       snapshot for every path in the input list. Paths not present in
       the index get treated the same as missing-on-disk
       (`files_missing`). **Do not fall back to disk-rescan.** The
       contract for `--index` is "snapshot is the source of truth";
       `--files-from` must not weaken that.
-      **Deferred:** current resolution uses `is_file()` on disk instead
-      of snapshot membership. A path in the input that's on disk but
-      absent from the snapshot is not yet counted as `files_missing`.
-      Follow-up: thread `snapshot_index` into `files_from::resolve`.
+      *Landed in iter-143
+      ([[iterations/iteration-143-hint-and-files-from-polish]]):
+      `files_from::resolve_with_index` consults the loaded snapshot via
+      `VaultIndex::get` instead of `is_file()`; `run.rs` routes through
+      it whenever `snapshot_index` is `Some`. E2E coverage:
+      `lint_files_from_with_index_counts_post_index_files_as_missing`.*
 - [x] **Without `--index`**: read from disk for each path. No
       directory walk happens — the input list IS the work set.
 - [x] Performance: this should be measurably faster than `--glob` on
@@ -112,17 +114,21 @@ hyalo command the same way.
 
 ### Hints
 
-- [ ] `HintSource::FilesFrom` variant on success: suggest running the
+- [x] `HintSource::FilesFrom` variant on success: suggest running the
       same command without `--files-from` to operate on the whole
-      vault, when relevant. **Deferred:** an initial stub was wired
-      but never dispatched (and the generated command was missing
-      its subcommand, per Copilot/CodeRabbit review). The stub was
-      removed in this PR — bespoke hint copy can be added in a
-      follow-up once the wiring is designed properly.
-- [ ] Existing hints that suggest "scan all files" or "use `--glob`"
+      vault, when relevant. *iter-143
+      ([[iterations/iteration-143-hint-and-files-from-polish]]) shipped a
+      different (better) shape: counters from the resolver flow into
+      `generate_hints_with_counters` as a `FilesFromCounterSummary`, and
+      advice hints fire whenever `files_missing > 0` or
+      `files_skipped_outside_vault > 0`. No separate `HintSource` variant
+      — the hints fire across all sources that accept `--files-from`.*
+- [x] Existing hints that suggest "scan all files" or "use `--glob`"
       pick up an alternative: "or pass `--files-from -` if you already
-      have a file list (e.g. `git diff --name-only`)". **Deferred:**
-      not done in this PR.
+      have a file list (e.g. `git diff --name-only`)". *Moot — a search
+      confirmed no such "scan all" hints exist; the documentation
+      surfaces in iter-139 (README, rule template) already cover the
+      `--files-from` discoverability story.*
 
 ### Docs + UX surfaces
 
@@ -149,11 +155,11 @@ hyalo command the same way.
 - [x] Implement filtering (`.md` only, missing files, outside-vault)
 - [x] Wire envelope counters: `files_missing`, `files_skipped_non_md`,
       `files_skipped_outside_vault`
-- [ ] Wire `--index` interaction (snapshot-only resolution; no disk
-      fallback). **Deferred** — see Index-interaction section.
+- [x] Wire `--index` interaction (snapshot-only resolution; no disk
+      fallback). *Landed in iter-143 — see Index-interaction section.*
 - [x] Wire mutual-exclusion errors with `--glob` and `--file`
-- [ ] `HintSource::FilesFrom` + per-command hint updates.
-      **Deferred** — see Hints section.
+- [x] `HintSource::FilesFrom` + per-command hint updates.
+      *Landed in iter-143 in a different shape — see Hints section.*
 - [x] Update help texts on every affected subcommand
 - [x] Update README.md with the CI diff-aware lint example
 - [x] Update `cli/help.rs` long-help examples

--- a/hyalo-knowledgebase/iterations/iteration-143-hint-and-files-from-polish.md
+++ b/hyalo-knowledgebase/iterations/iteration-143-hint-and-files-from-polish.md
@@ -10,8 +10,8 @@ tags:
   - schema
   - files-from
 related:
-  - "[[iterations/done/iteration-138-schema-extensions-and-new-command]]"
-  - "[[iterations/done/iteration-139-files-from-flag]]"
+  - "[[iterations/iteration-138-schema-extensions-and-new-command]]"
+  - "[[iterations/iteration-139-files-from-flag]]"
 ---
 
 ## Goal
@@ -151,9 +151,9 @@ schema vocabulary, no new commands.
 
 ## References
 
-- [[iterations/done/iteration-138-schema-extensions-and-new-command]]
+- [[iterations/iteration-138-schema-extensions-and-new-command]]
   — deferred hint items (sections: Hints, status `[1/5]`)
-- [[iterations/done/iteration-139-files-from-flag]] — deferred
+- [[iterations/iteration-139-files-from-flag]] — deferred
   snapshot-membership + `HintSource::FilesFrom`
 - [[backlog/index-suggestion-hint]] — explicitly NOT addressed here;
   iter-144 will pick it up

--- a/hyalo-knowledgebase/iterations/iteration-143-hint-and-files-from-polish.md
+++ b/hyalo-knowledgebase/iterations/iteration-143-hint-and-files-from-polish.md
@@ -1,0 +1,159 @@
+---
+title: Iteration 143 — Hint + `--files-from` polish (deferred from iter-138 / iter-139)
+type: iteration
+date: 2026-05-24
+status: in-progress
+branch: iter-143/hint-and-files-from-polish
+tags:
+  - iteration
+  - hints
+  - schema
+  - files-from
+related:
+  - "[[iterations/done/iteration-138-schema-extensions-and-new-command]]"
+  - "[[iterations/done/iteration-139-files-from-flag]]"
+---
+
+## Goal
+
+Pick up the four hint-related items deferred from iter-138 and the two
+items deferred from iter-139, plus a backlog cleanup. All small,
+isolated changes in `hints.rs` and `commands/files_from.rs`. No new
+schema vocabulary, no new commands.
+
+## Steps
+
+### Schema-violation hint (iter-138 deferred)
+
+- [ ] When `hyalo lint` reports SCHEMA violations on a file that
+      carries a `type:` frontmatter property, surface a hint
+      `Show schema for type: <T>` → `hyalo types show <T>`. Generic
+      across all SCHEMA failure modes (`required`, `pattern`,
+      `item_pattern`, `required_sections`, type-mismatch) — replaces
+      the iter-138-plan-time idea of per-subcategory hints, which
+      would just duplicate the violation message.
+- [ ] Cap: one such hint per distinct type per invocation, max 2 types
+      surfaced (to avoid noise on multi-file lint runs).
+- [ ] Skip when `--rule SCHEMA` or `--rule-prefix HYALO` is already
+      active (the user is already focused on schema).
+
+### `types show` → `hyalo new` cross-link (iter-138 deferred)
+
+- [ ] In `hints_for_types` (`"show"` branch): when the inspected type
+      has any `required` properties, surface a hint
+      `Scaffold a new file of this type` →
+      `hyalo new --type <T> --file <path/to/new.md>` (with a
+      placeholder path the agent edits).
+- [ ] Drop this hint when the type has no `required` properties — the
+      scaffolder would produce just a `type:` stub, low value.
+
+### `--files-from` envelope-aware hint (iter-139 deferred)
+
+- [ ] New `HintSource::FilesFrom` (or extend existing source contexts)
+      to fire when `--files-from` was used. Inspect the envelope's
+      `files_missing`, `files_skipped_non_md`,
+      `files_skipped_outside_vault` counters.
+- [ ] When `files_missing > 0`: hint
+      `<N> input paths did not exist on disk (likely deletions); use
+      git diff --diff-filter=AMR upstream to filter them out`.
+- [ ] When `files_skipped_outside_vault > 0`: hint
+      `<N> input paths were outside the vault; check your --dir or
+      upstream filter`.
+- [ ] When `files_skipped_non_md > 0`: no hint by default — common
+      with `git diff` output, not actionable. (Reconsider if dogfood
+      reveals it's surprising.)
+- [ ] Hint cap unchanged (`MAX_HINTS`).
+
+### `--index --files-from` snapshot membership (iter-139 deferred)
+
+- [ ] Thread a `&SnapshotIndex` (or analogous reference) into a sibling
+      resolver `files_from::resolve_with_index` (keep existing
+      `resolve` for the no-index path). The new resolver checks
+      snapshot membership for each input path; missing-from-snapshot
+      counts as `files_missing`.
+- [ ] Dispatch sites: when `--index` (or `--index-file`) is set AND
+      `--files-from` is set, call the index-aware resolver instead of
+      the disk-based one.
+- [ ] No disk fallback for paths absent from the snapshot. Matches the
+      contract documented in iter-139 design notes: `--index` means
+      "snapshot is the source of truth".
+- [ ] E2E: `hyalo lint --index --files-from -` where the input
+      includes a path that's on disk but absent from the snapshot
+      reports it as `files_missing`, not as a lint of a fresh file.
+
+### Docs + tests
+
+- [ ] Help text: the existing `--files-from` help mentions the
+      counters; verify it still reads correctly. No new flags.
+- [ ] CHANGELOG `Unreleased` entry under Changed
+      (hints) + Fixed (`--index --files-from` snapshot wiring).
+- [ ] Tick the previously-deferred boxes in iter-138 and iter-139 plan
+      files; reference this iter from each.
+- [ ] Unit tests: `hints_for_lint` returns the SCHEMA-type hint when
+      expected; `hints_for_types --show` returns the scaffolder hint
+      when `required` is set; new `HintSource::FilesFrom` returns
+      counter-aware hints.
+- [ ] E2E: the `--index --files-from` case described above.
+
+## Tasks
+
+- [ ] Add SCHEMA → `types show <T>` hint generator
+- [ ] Wire scaffolder-suggestion hint in `types show`
+- [ ] Implement `HintSource::FilesFrom` (or per-source `--files-from`
+      hint integration) with the three counter-aware messages
+- [ ] Add `files_from::resolve_with_index` and wire dispatch sites
+- [ ] Unit tests for each hint addition
+- [ ] E2E test for `--index --files-from` snapshot membership
+- [ ] Update iter-138 + iter-139 plan checkboxes
+- [ ] CHANGELOG entry
+- [ ] All three CI platforms green
+- [ ] `cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace`
+
+## Acceptance criteria
+
+- [ ] `hyalo lint` against a file with SCHEMA violations and a `type:`
+      property surfaces a `types show <T>` hint
+- [ ] `hyalo types show <T>` (where T has `required` props) surfaces
+      a `hyalo new --type <T> --file ...` hint
+- [ ] `hyalo lint --files-from -` with mixed inputs surfaces hints
+      about `files_missing` / `files_skipped_outside_vault` counters
+- [ ] `hyalo lint --index --files-from -` reports paths absent from
+      the snapshot as `files_missing` and does not fall back to disk
+- [ ] iter-138 and iter-139 plan files updated with cross-references
+      and ticks
+
+## Design notes
+
+- **No per-subcategory SCHEMA hints.** The original iter-138 plan
+  proposed separate hints for `item_pattern` violations vs missing
+  `required_sections`. In review those would have just paraphrased
+  the violation message. A single hint linking to
+  `hyalo types show <type>` is more actionable (the schema declaration
+  is the source of truth) and works uniformly across all SCHEMA
+  failures.
+- **No "Write a new file" hints to replace.** The iter-138 deferred
+  item assumed such hints existed; a grep confirms they don't. This
+  item is dropped without action.
+- **Snapshot-membership uses an index-aware resolver**, not a flag on
+  the existing `resolve`. Keeps the disk path unchanged for the common
+  case and makes the `--index` semantic explicit at the call site.
+- **No new flags.** All changes are output-shape / hint-emission.
+
+## Out of scope
+
+- Index-suggestion hint (slow-query + large-vault) — covered by
+  iter-144.
+- `--quiet` flag work — covered by iter-144 (the slow-query hint is
+  what needs it).
+- Wiring `--files-from` into `task toggle` / `task set` (iter-139
+  Step 1 leftover) — separate small ticket if anyone asks; the CI use
+  case doesn't need it.
+
+## References
+
+- [[iterations/done/iteration-138-schema-extensions-and-new-command]]
+  — deferred hint items (sections: Hints, status `[1/5]`)
+- [[iterations/done/iteration-139-files-from-flag]] — deferred
+  snapshot-membership + `HintSource::FilesFrom`
+- [[backlog/index-suggestion-hint]] — explicitly NOT addressed here;
+  iter-144 will pick it up

--- a/hyalo-knowledgebase/iterations/iteration-144-index-suggestion-hint.md
+++ b/hyalo-knowledgebase/iterations/iteration-144-index-suggestion-hint.md
@@ -1,0 +1,133 @@
+---
+title: Iteration 144 — Index-suggestion hint (slow query + large vault)
+type: iteration
+date: 2026-05-24
+status: planned
+branch: iter-144/index-suggestion-hint
+tags:
+  - iteration
+  - hints
+  - performance
+  - index
+related:
+  - "[[backlog/index-suggestion-hint]]"
+  - "[[iterations/iteration-143-hint-and-files-from-polish]]"
+---
+
+## Goal
+
+Close `backlog/index-suggestion-hint.md` — when a user runs an
+expensive query against a large vault without `--index`, hyalo should
+suggest creating one. Two surfaces:
+
+1. **Slow-query hint**: any query whose wall-clock exceeds a threshold
+   (default 500 ms) and ran without `--index` surfaces a hint to run
+   `hyalo create-index`.
+2. **Summary hint for large vaults**: `hyalo summary` against a vault
+   of >500 files without an active snapshot surfaces the same
+   suggestion.
+
+Both suppressed when `--index` / `--index-file` is already in use.
+Slow-query hint additionally respects `--quiet`.
+
+Pulled from the MDN dogfooding ticket where property-only queries on a
+14K-file vault take ~1.5 s without an index vs ~80 ms with one.
+
+## Steps
+
+### Elapsed-time measurement
+
+- [ ] Capture command elapsed wall-clock in the dispatch layer (start
+      before command body, stop after the JSON envelope is built).
+- [ ] Thread the elapsed `Duration` into the hint context so
+      `hints_for_*` can read it.
+- [ ] Constant `SLOW_QUERY_THRESHOLD_MS: u64 = 500`. Document the
+      number in code with a one-line rationale.
+
+### Slow-query hint
+
+- [ ] Eligible commands: every command that benefits from `--index`
+      (per the iter-139 / earlier list — `find`, `lint`, `backlinks`,
+      `properties summary`, `tags summary`, `summary`, `read`).
+- [ ] Fire when: elapsed > threshold AND `--index` is NOT active AND
+      `--quiet` is NOT set.
+- [ ] Hint text: `Query took <N> ms. Create an index for faster
+      queries:` → `hyalo create-index`.
+- [ ] Counts toward `MAX_HINTS` like any other hint.
+
+### Large-vault summary hint
+
+- [ ] In `hints_for_summary`: when `files_total > 500` AND `--index`
+      is NOT active, surface `Vault has <N> files — create an index
+      for faster queries:` → `hyalo create-index`.
+- [ ] Threshold constant `LARGE_VAULT_FILE_COUNT: u64 = 500`.
+
+### Suppression
+
+- [ ] Verify the existing `--quiet` flag actually suppresses hints
+      end-to-end (the slow-query hint is the test case).
+- [ ] Per-command `--no-hints` already suppresses everything; nothing
+      new there.
+
+### Docs + tests
+
+- [ ] CHANGELOG `Unreleased` entry under Added.
+- [ ] README: short note in the perf section about how the hint
+      surfaces the index recommendation.
+- [ ] Decision-log: brief DEC-045 (or extension of the existing UX
+      decisions) capturing thresholds + the choice of wall-clock vs
+      file-count signals.
+- [ ] Unit tests for both hint paths.
+- [ ] E2E: `hyalo find --property X=Y --no-hints` does NOT emit the
+      hint even when slow; with hints on it does (using a deliberately
+      slow synthetic delay or by adjusting the threshold for the test).
+- [ ] Move `backlog/index-suggestion-hint.md` → `backlog/done/` and
+      set `status=completed`.
+
+## Tasks
+
+- [ ] Wire elapsed-time capture in dispatch
+- [ ] Plumb elapsed into `HintContext`
+- [ ] Implement slow-query hint generator
+- [ ] Implement large-vault summary hint
+- [ ] Verify `--quiet` suppression path
+- [ ] Tests (unit + e2e)
+- [ ] CHANGELOG + decision-log + README
+- [ ] Close backlog item
+- [ ] All three CI platforms green
+
+## Acceptance criteria (mirrors the backlog item)
+
+- [ ] Slow-query hint emitted when elapsed > 500 ms and no `--index`
+- [ ] `summary` hints include index suggestion for vaults > 500 files
+- [ ] Hint is suppressed when `--index` is already in use
+- [ ] `--quiet` suppresses the slow-query hint
+
+## Design notes
+
+- **Wall-clock, not CPU time.** I/O is the dominant cost for hyalo
+  queries; wall-clock matches what the user perceives as "slow".
+- **500 ms is a calibrated guess, not a benchmark.** Tunable later.
+  Reasoning: shorter than human "wait, this is slow" threshold (~1 s)
+  with margin; longer than typical scans on small vaults (~100 ms).
+- **Per-command vs global.** A global "always emit when elapsed >
+  threshold" is simpler than per-command thresholds. Start global.
+- **Don't measure the hint-rendering step itself.** Capture elapsed
+  before the hint generator runs; rendering hints should be cheap and
+  shouldn't trip its own threshold.
+
+## Out of scope
+
+- Auto-index config (`auto_index = true` in `.hyalo.toml`). The
+  original backlog item listed this as a future direction; hyalo
+  doesn't want to manage index lifecycle silently. Lint and hints
+  surface the suggestion; the user runs `create-index`.
+- Tracking per-command performance baselines or detailed profiling
+  output. Single elapsed number is enough for the hint decision.
+
+## References
+
+- [[backlog/index-suggestion-hint]] — the source ticket (origin: MDN
+  dogfood, 2026-03-30)
+- [[iterations/iteration-143-hint-and-files-from-polish]] — predecessor
+  hint-polish iteration


### PR DESCRIPTION
## Summary

Ties off the four hint-related items deferred from iter-138 / iter-139, plus the `--index --files-from` snapshot-membership wiring. All small, no new schema vocabulary, no new commands.

## What's in this PR

### Hints
1. **SCHEMA → `hyalo types show <T>`** (iter-138 deferred). `hyalo lint` now surfaces a per-type hint when SCHEMA violations land on files with a declared `type:`. Generic across all SCHEMA failure modes — replaces the iter-138-plan-time idea of per-subcategory hints which would have just paraphrased the violation message. Suppressed when the user is already focused on schema rules (`--rule SCHEMA` / `--rule-prefix HYALO`). Max 2 distinct types.
2. **`hyalo types show <T>` → `hyalo new --type <T>`** (iter-138 deferred). When the type has any `required` properties, surface a scaffold hint.
3. **`--files-from` counter-aware hints** (iter-139 deferred). When the resolver dropped paths (`files_missing > 0` or `files_skipped_outside_vault > 0`), surface advice hints. `files_skipped_non_md` intentionally not hinted (common from `git diff`, not actionable). Adds `Hint::without_cmd` for advice-only hints.

### Resolver
4. **`--index --files-from` snapshot membership** (iter-139 deferred). New `files_from::resolve_with_index` consults the loaded snapshot via `VaultIndex::get` instead of `is_file()`. Paths absent from the snapshot count as `files_missing` with no disk fallback — matches the iter-139 design contract.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` — green on macOS
- [x] `cargo test --workspace` — green on Linux via Docker `rust:latest`
- [x] New unit tests in `hints.rs`:
  - `types_show_hints_suggest_scaffold_when_required_nonempty`
  - `types_show_hints_no_scaffold_when_required_empty`
  - `lint_hints_schema_violation_suggests_types_show`
  - `lint_hints_schema_violation_skipped_when_already_focused`
  - `files_from_hints_fire_on_missing_and_outside_vault`
  - `files_from_hints_silent_when_zero_counters`
- [x] New e2e test: `lint_files_from_with_index_counts_post_index_files_as_missing`
- [ ] Cross-platform CI verification (macOS + Ubuntu + Windows)

## Follow-up

iter-144 plan drafted in the same commit (`iteration-144-index-suggestion-hint.md`) for the next iteration: slow-query and large-vault hints from `backlog/index-suggestion-hint.md`.