### PR TITLE
feat(iter-144): index-suggestion hint for slow queries + large vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- **iter-144**: Index-suggestion hints. Two new automatic hints surface
+  `hyalo create-index` when no snapshot index is active:
+  - **Slow-query hint** — fires on `find`, `lint`, `backlinks`,
+    `properties summary`, `tags summary`, `summary`, and `read` when the
+    command takes longer than 500 ms. Suppressed by `--quiet` or when
+    `--index`/`--index-file` is already in use.
+  - **Large-vault summary hint** — fires from `hyalo summary` when the
+    vault contains more than 500 files and no index is active.
+  Both hints count toward the existing `MAX_HINTS` cap and are suppressed
+  by `--no-hints` like all other hints.
+
 ### Changed
 
 - **iter-143**: New `hyalo lint` hint — when SCHEMA violations land on a file

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ hyalo drop-index            # clean up
 
 Mutations with `--index` patch the index in-place, keeping it current for subsequent queries.
 
+hyalo surfaces the index recommendation automatically: if a query takes longer than 500 ms or `hyalo summary` reports more than 500 files, a hint appears suggesting `hyalo create-index`. Both hints are suppressed when `--index`/`--index-file` is already in use.
+
 ## Building from source
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ hyalo drop-index            # clean up
 
 Mutations with `--index` patch the index in-place, keeping it current for subsequent queries.
 
-hyalo surfaces the index recommendation automatically: if a query takes longer than 500 ms or `hyalo summary` reports more than 500 files, a hint appears suggesting `hyalo create-index`. Both hints are suppressed when `--index`/`--index-file` is already in use.
+hyalo surfaces the index recommendation automatically: if a command takes longer than 500 ms or `hyalo summary` reports more than 500 files, a hint appears suggesting `hyalo create-index`. Both hints are suppressed when `--index`/`--index-file` is already in use, when `--quiet` is set, or when `--no-hints` is passed.
 
 ## Building from source
 

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -7,6 +7,18 @@
 /// Maximum number of hints to return from any generator.
 const MAX_HINTS: usize = 5;
 
+/// Wall-clock threshold for the slow-query hint (milliseconds).
+///
+/// Rationale: shorter than the human "this is slow" threshold (~1 s) with
+/// margin; longer than typical disk scans on small vaults (~100 ms).
+pub(crate) const SLOW_QUERY_THRESHOLD_MS: u64 = 500;
+
+/// File count threshold for the large-vault summary hint.
+///
+/// Rationale: vaults above this size see measurable benefit from a snapshot
+/// index; below it the disk scan is fast enough not to warrant the hint.
+pub(crate) const LARGE_VAULT_FILE_COUNT: u64 = 500;
+
 /// Prefix used by lint for frontmatter parse errors. Shared between
 /// `commands::lint` and the hint generator to avoid brittle string coupling.
 pub(crate) const PARSE_ERROR_PREFIX: &str = "could not parse frontmatter";
@@ -75,6 +87,14 @@ pub struct HintContext {
     pub format: Option<String>,
     /// Explicit `--hints` from CLI (not from config).
     pub hints: bool,
+    /// Wall-clock elapsed time for the command body (set after dispatch).
+    /// Used by the slow-query hint; `None` means not yet measured.
+    pub elapsed_ms: Option<u64>,
+    /// Whether `--quiet` / `-q` was passed.  Suppresses the slow-query hint.
+    pub quiet: bool,
+    /// Whether an `--index` / `--index-file` snapshot was active for this run.
+    /// Suppresses index-suggestion hints when already using an index.
+    pub has_index: bool,
     // Find context
     pub fields: Vec<String>,
     pub sort: Option<String>,
@@ -135,6 +155,9 @@ impl HintContext {
             glob: vec![],
             format: None,
             hints: false,
+            elapsed_ms: None,
+            quiet: false,
+            has_index: false,
             fields: vec![],
             sort: None,
             has_limit: false,
@@ -232,6 +255,14 @@ pub fn generate_hints_with_counters(
         HintSource::Types { .. } => hints_for_types(ctx, data),
         HintSource::New { file } => hints_for_new(ctx, file),
     };
+    // iter-144: slow-query index-suggestion hint. Appended after per-command
+    // hints so domain-specific hints are not displaced; counts toward MAX_HINTS.
+    if hints.len() < MAX_HINTS
+        && let Some(hint) = slow_query_hint(ctx)
+    {
+        hints.push(hint);
+    }
+
     // iter-143: `--files-from`-aware hints. Counters are passed in from the
     // output pipeline (the envelope merge happens *after* hint generation,
     // so `data` doesn't carry them yet). Prepended so the `MAX_HINTS` cap
@@ -240,6 +271,44 @@ pub fn generate_hints_with_counters(
     let mut ff_hints = files_from_hints(counters);
     ff_hints.append(&mut hints);
     ff_hints.into_iter().take(MAX_HINTS).collect()
+}
+
+/// Return an index-suggestion hint when the command was slow and no index is active.
+///
+/// Eligible sources: `find`, `lint`, `backlinks`, `properties summary`,
+/// `tags summary`, `summary`, and `read` — commands that scan the vault and
+/// benefit from a snapshot index.
+///
+/// Suppressed when:
+/// - `ctx.quiet` is true (`--quiet` flag).
+/// - `ctx.has_index` is true (snapshot already active).
+/// - `elapsed_ms` is below [`SLOW_QUERY_THRESHOLD_MS`].
+fn slow_query_hint(ctx: &HintContext) -> Option<Hint> {
+    // Only eligible commands produce vault scans that an index can speed up.
+    let eligible = matches!(
+        ctx.source,
+        HintSource::Find
+            | HintSource::Lint
+            | HintSource::Backlinks
+            | HintSource::PropertiesSummary
+            | HintSource::TagsSummary
+            | HintSource::Summary
+            | HintSource::Read
+    );
+    if !eligible {
+        return None;
+    }
+    if ctx.quiet || ctx.has_index {
+        return None;
+    }
+    let elapsed = ctx.elapsed_ms?;
+    if elapsed <= SLOW_QUERY_THRESHOLD_MS {
+        return None;
+    }
+    Some(Hint::new(
+        format!("Query took {elapsed} ms. Create an index for faster queries:"),
+        "hyalo create-index".to_owned(),
+    ))
 }
 
 /// Return `--files-from`-counter hints when the resolver reported non-zero
@@ -628,6 +697,22 @@ fn hints_for_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
             hints.push(Hint::new(
                 format!("Filter by status: {value}"),
                 build_command_no_glob(ctx, &["find", "--property", &filter]),
+            ));
+        }
+    }
+
+    // Large-vault index-suggestion hint. Fires when the vault exceeds the
+    // LARGE_VAULT_FILE_COUNT threshold and no snapshot index is active.
+    if hints.len() < MAX_HINTS && !ctx.has_index {
+        let files_total = data
+            .get("files")
+            .and_then(|f| f.get("total"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        if files_total > LARGE_VAULT_FILE_COUNT {
+            hints.push(Hint::new(
+                format!("Vault has {files_total} files — create an index for faster queries:"),
+                "hyalo create-index".to_owned(),
             ));
         }
     }
@@ -3157,6 +3242,178 @@ mod tests {
         assert!(
             !hints.iter().any(|h| h.cmd.contains("lint --fix")),
             "after applying fixes, should not suggest fix again: {hints:?}"
+        );
+    }
+
+    // --- slow_query_hint ---
+
+    fn data_empty_array() -> serde_json::Value {
+        json!([])
+    }
+
+    /// Slow find with no index should emit the slow-query hint.
+    #[test]
+    fn slow_query_hint_fires_for_slow_find() {
+        let mut c = ctx(HintSource::Find);
+        c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS + 1);
+        let h = slow_query_hint(&c);
+        assert!(h.is_some(), "expected slow-query hint");
+        let h = h.unwrap();
+        assert!(h.cmd == "hyalo create-index", "cmd: {}", h.cmd);
+        assert!(h.description.contains("ms"), "desc: {}", h.description);
+    }
+
+    /// Exactly at the threshold (not strictly greater) should NOT fire.
+    #[test]
+    fn slow_query_hint_does_not_fire_at_threshold() {
+        let mut c = ctx(HintSource::Find);
+        c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS);
+        assert!(slow_query_hint(&c).is_none());
+    }
+
+    /// Fast query should not emit the hint.
+    #[test]
+    fn slow_query_hint_does_not_fire_when_fast() {
+        let mut c = ctx(HintSource::Find);
+        c.elapsed_ms = Some(50);
+        assert!(slow_query_hint(&c).is_none());
+    }
+
+    /// `--quiet` suppresses the slow-query hint even when slow.
+    #[test]
+    fn slow_query_hint_suppressed_by_quiet() {
+        let mut c = ctx(HintSource::Find);
+        c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS + 100);
+        c.quiet = true;
+        assert!(slow_query_hint(&c).is_none());
+    }
+
+    /// Active index suppresses the slow-query hint even when slow.
+    #[test]
+    fn slow_query_hint_suppressed_when_has_index() {
+        let mut c = ctx(HintSource::Find);
+        c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS + 100);
+        c.has_index = true;
+        assert!(slow_query_hint(&c).is_none());
+    }
+
+    /// Missing elapsed (`None`) means not yet measured — no hint.
+    #[test]
+    fn slow_query_hint_not_emitted_when_elapsed_none() {
+        let mut c = ctx(HintSource::Find);
+        c.elapsed_ms = None;
+        assert!(slow_query_hint(&c).is_none());
+    }
+
+    /// Ineligible source (e.g. Set) never emits slow-query hint.
+    #[test]
+    fn slow_query_hint_not_emitted_for_ineligible_source() {
+        let mut c = ctx(HintSource::Set);
+        c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS + 100);
+        assert!(slow_query_hint(&c).is_none());
+    }
+
+    /// All eligible sources should emit the hint when slow and no index.
+    #[test]
+    fn slow_query_hint_fires_for_all_eligible_sources() {
+        for source in [
+            HintSource::Find,
+            HintSource::Lint,
+            HintSource::Backlinks,
+            HintSource::PropertiesSummary,
+            HintSource::TagsSummary,
+            HintSource::Summary,
+            HintSource::Read,
+        ] {
+            let mut c = ctx(source);
+            c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS + 1);
+            assert!(
+                slow_query_hint(&c).is_some(),
+                "expected slow-query hint for source"
+            );
+        }
+    }
+
+    /// Slow-query hint appears in generate_hints output (via generate_hints_with_counters).
+    #[test]
+    fn slow_query_hint_surfaces_through_generate_hints() {
+        let mut c = ctx(HintSource::Find);
+        c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS + 1);
+        let hints = generate_hints(&c, &data_empty_array(), Some(0));
+        assert!(
+            hints.iter().any(|h| h.cmd == "hyalo create-index"),
+            "expected create-index hint: {hints:?}"
+        );
+    }
+
+    // --- large-vault summary hint ---
+
+    fn summary_data(files_total: u64) -> serde_json::Value {
+        json!({
+            "files": {"total": files_total, "by_directory": []},
+            "properties": [],
+            "tags": {"tags": [], "total": 0},
+            "status": [],
+            "tasks": {"total": 0, "done": 0},
+            "recent_files": []
+        })
+    }
+
+    /// Large vault (above threshold) with no index should emit the large-vault hint.
+    #[test]
+    fn large_vault_summary_hint_fires_when_over_threshold() {
+        let c = ctx(HintSource::Summary);
+        let data = summary_data(LARGE_VAULT_FILE_COUNT + 1);
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.cmd == "hyalo create-index" && h.description.contains("files")),
+            "expected large-vault hint: {hints:?}"
+        );
+    }
+
+    /// Exactly at the threshold (not strictly greater) should NOT fire.
+    #[test]
+    fn large_vault_summary_hint_does_not_fire_at_threshold() {
+        let c = ctx(HintSource::Summary);
+        let data = summary_data(LARGE_VAULT_FILE_COUNT);
+        let hints = generate_hints(&c, &data, None);
+        // The hint should not appear.
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.cmd == "hyalo create-index" && h.description.contains("files")),
+            "unexpected large-vault hint at threshold: {hints:?}"
+        );
+    }
+
+    /// Small vault should not emit the large-vault hint.
+    #[test]
+    fn large_vault_summary_hint_not_fired_for_small_vault() {
+        let c = ctx(HintSource::Summary);
+        let data = summary_data(10);
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.cmd == "hyalo create-index" && h.description.contains("files")),
+            "unexpected large-vault hint for small vault: {hints:?}"
+        );
+    }
+
+    /// Active index suppresses the large-vault hint.
+    #[test]
+    fn large_vault_summary_hint_suppressed_when_has_index() {
+        let mut c = ctx(HintSource::Summary);
+        c.has_index = true;
+        let data = summary_data(LARGE_VAULT_FILE_COUNT + 100);
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.cmd == "hyalo create-index" && h.description.contains("files")),
+            "large-vault hint should be suppressed with active index: {hints:?}"
         );
     }
 }

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -257,8 +257,12 @@ pub fn generate_hints_with_counters(
     };
     // iter-144: slow-query index-suggestion hint. Appended after per-command
     // hints so domain-specific hints are not displaced; counts toward MAX_HINTS.
+    // Dedupe against the large-vault hint emitted by `hints_for_summary`:
+    // when a `summary` run is *both* slow and large, only one create-index
+    // hint should occupy a slot.
     if hints.len() < MAX_HINTS
         && let Some(hint) = slow_query_hint(ctx)
+        && !hints.iter().any(|h| h.cmd == hint.cmd)
     {
         hints.push(hint);
     }
@@ -306,7 +310,7 @@ fn slow_query_hint(ctx: &HintContext) -> Option<Hint> {
         return None;
     }
     Some(Hint::new(
-        format!("Query took {elapsed} ms. Create an index for faster queries:"),
+        format!("Command took {elapsed} ms. Create an index for faster queries:"),
         "hyalo create-index".to_owned(),
     ))
 }
@@ -703,7 +707,8 @@ fn hints_for_summary(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
 
     // Large-vault index-suggestion hint. Fires when the vault exceeds the
     // LARGE_VAULT_FILE_COUNT threshold and no snapshot index is active.
-    if hints.len() < MAX_HINTS && !ctx.has_index {
+    // Suppressed by `--quiet` to match the slow-query hint's behavior.
+    if hints.len() < MAX_HINTS && !ctx.has_index && !ctx.quiet {
         let files_total = data
             .get("files")
             .and_then(|f| f.get("total"))
@@ -3414,6 +3419,39 @@ mod tests {
                 .iter()
                 .any(|h| h.cmd == "hyalo create-index" && h.description.contains("files")),
             "large-vault hint should be suppressed with active index: {hints:?}"
+        );
+    }
+
+    /// `--quiet` suppresses the large-vault hint (parity with slow-query hint).
+    #[test]
+    fn large_vault_summary_hint_suppressed_by_quiet() {
+        let mut c = ctx(HintSource::Summary);
+        c.quiet = true;
+        let data = summary_data(LARGE_VAULT_FILE_COUNT + 100);
+        let hints = generate_hints(&c, &data, None);
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.cmd == "hyalo create-index" && h.description.contains("files")),
+            "large-vault hint should be suppressed by --quiet: {hints:?}"
+        );
+    }
+
+    /// When both slow-query and large-vault conditions fire, only one
+    /// `create-index` hint should appear in the envelope (dedupe by `cmd`).
+    #[test]
+    fn create_index_hint_deduped_when_both_conditions_fire() {
+        let mut c = ctx(HintSource::Summary);
+        c.elapsed_ms = Some(SLOW_QUERY_THRESHOLD_MS + 1);
+        let data = summary_data(LARGE_VAULT_FILE_COUNT + 100);
+        let hints = generate_hints(&c, &data, None);
+        let n = hints
+            .iter()
+            .filter(|h| h.cmd == "hyalo create-index")
+            .count();
+        assert_eq!(
+            n, 1,
+            "expected exactly one create-index hint, got {n}: {hints:?}"
         );
     }
 }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1,6 +1,7 @@
 use std::io::IsTerminal as _;
 use std::path::Path;
 use std::process;
+use std::time::Instant;
 
 use anyhow::Result;
 use clap::{CommandFactory, FromArgMatches};
@@ -869,7 +870,7 @@ fn run_inner() -> Result<(), AppError> {
     // Build hint context before the command dispatch.
     // Only include CLI-explicit flags in hints — config values are inherited
     // automatically when the user runs the hint command from the same CWD.
-    let hint_ctx = if hints_flag && jq_filter.is_none() {
+    let mut hint_ctx = if hints_flag && jq_filter.is_none() {
         // Capture the three global flags that every HintContext arm needs.
         // Computed once here so each arm can call HintContext::from_common
         // instead of repeating the same three field assignments.
@@ -1201,6 +1202,18 @@ fn run_inner() -> Result<(), AppError> {
     let index_path_buf: Option<std::path::PathBuf> =
         effective_index_path_for(&cli.command, &dir, cli.index_file.as_deref());
 
+    // Propagate --quiet and has-index into hint context now that we know both.
+    // `quiet` suppresses the slow-query hint; `has_index` suppresses all
+    // index-suggestion hints when a snapshot is already in use.
+    // `has_index` is set from index_path_buf because the snapshot load may fail
+    // (fall back to disk scan), but the *intent* to use an index is what matters
+    // for hint suppression — we don't want to suggest creating an index that the
+    // user already requested.
+    if let Some(ref mut ctx) = hint_ctx {
+        ctx.quiet = cli.quiet;
+        ctx.has_index = index_path_buf.is_some();
+    }
+
     let mut snapshot_index: Option<SnapshotIndex> = if let Some(ref p) = index_path_buf {
         match SnapshotIndex::load(p) {
             Ok(Some(idx)) => {
@@ -1341,12 +1354,25 @@ fn run_inner() -> Result<(), AppError> {
 
     // When --files-from resolved to zero files (all entries filtered/missing),
     // short-circuit with an empty result rather than falling through to "scan all".
+    //
+    // Capture wall-clock elapsed around the dispatch body so the slow-query
+    // hint can fire when the command took longer than SLOW_QUERY_THRESHOLD_MS.
+    // We measure here (not inside dispatch) so hint rendering is excluded.
+    let dispatch_start = Instant::now();
     let result = if files_from_empty {
         // Produce the appropriate empty payload for the command type.
         Ok(empty_result_for_command(&cli.command))
     } else {
         dispatch(cli.command, &mut ctx)
     };
+    // Saturate at u64::MAX on absurdly long runs (> ~585 million years).
+    let elapsed_ms = u64::try_from(dispatch_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+    // Inject elapsed into hint context so slow_query_hint can read it.
+    if let Some(ref mut hctx) = hint_ctx {
+        hctx.elapsed_ms = Some(elapsed_ms);
+    }
+
     let exit_code_override = ctx.exit_code_override;
 
     let pipeline = OutputPipeline {

--- a/crates/hyalo-cli/tests/e2e/hints.rs
+++ b/crates/hyalo-cli/tests/e2e/hints.rs
@@ -1887,9 +1887,10 @@ fn find_no_hints_emits_no_hints() {
     );
 }
 
-/// `hyalo find --hints` with hints enabled must not suppress the hint envelope
-/// on a fast query (the slow-query hint won't fire, but other hints may).
-/// This tests that hints work end-to-end when enabled.
+/// `hyalo find --hints` on a fast small-vault query: the slow-query hint
+/// won't fire, but `find` always emits "Narrow by ..." drill-down hints,
+/// so the envelope's `hints` array must be non-empty. This distinguishes
+/// the `--hints` path from `--no-hints` (which empties the array).
 #[test]
 fn find_with_hints_emits_hints_envelope() {
     let tmp = setup_vault();
@@ -1904,10 +1905,12 @@ fn find_with_hints_emits_hints_envelope() {
     let parsed: serde_json::Value =
         serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
 
-    // The envelope must contain a "hints" key.
+    let hints = parsed["hints"]
+        .as_array()
+        .expect("--hints: envelope should have 'hints' array");
     assert!(
-        parsed.get("hints").is_some(),
-        "--hints: envelope should have 'hints' key: {stdout}"
+        !hints.is_empty(),
+        "--hints: expected non-empty hints array on a populated vault: {stdout}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e/hints.rs
+++ b/crates/hyalo-cli/tests/e2e/hints.rs
@@ -1850,3 +1850,126 @@ status = "draft"
         "lint --fix --dry-run should hint `lint --fix` (without --dry-run) to apply fixes: {hints:#?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// iter-144: index-suggestion hints
+// ---------------------------------------------------------------------------
+
+/// `hyalo find --no-hints` must not emit any hints, including the slow-query
+/// index-suggestion hint — even if the query were somehow slow.
+/// This verifies the `--no-hints` suppression path end-to-end.
+#[test]
+fn find_no_hints_emits_no_hints() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--no-hints", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
+
+    // With --no-hints the envelope should not contain a "hints" key at all,
+    // or it should be an empty array — either way no hint cmds are present.
+    if let Some(hints) = parsed.get("hints").and_then(|h| h.as_array()) {
+        assert!(
+            hints.is_empty(),
+            "--no-hints: expected empty hints array, got: {hints:?}"
+        );
+    }
+    // No `create-index` suggestion should appear anywhere in the output.
+    assert!(
+        !stdout.contains("create-index"),
+        "--no-hints: create-index should not appear in output: {stdout}"
+    );
+}
+
+/// `hyalo find --hints` with hints enabled must not suppress the hint envelope
+/// on a fast query (the slow-query hint won't fire, but other hints may).
+/// This tests that hints work end-to-end when enabled.
+#[test]
+fn find_with_hints_emits_hints_envelope() {
+    let tmp = setup_vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--hints", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
+
+    // The envelope must contain a "hints" key.
+    assert!(
+        parsed.get("hints").is_some(),
+        "--hints: envelope should have 'hints' key: {stdout}"
+    );
+}
+
+/// `hyalo summary --hints` on a large vault (>500 files) emits the large-vault
+/// index-suggestion hint. We seed a vault with 501 empty files to trigger it.
+#[test]
+fn summary_large_vault_hint_fires_for_large_vault() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Seed 501 markdown files — one more than LARGE_VAULT_FILE_COUNT.
+    for i in 0..=500u32 {
+        write_md(
+            tmp.path(),
+            &format!("file{i:04}.md"),
+            &format!("---\ntitle: File {i}\n---\n# Body\n"),
+        );
+    }
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["summary", "--hints", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
+
+    let hints = parsed["hints"].as_array().expect("hints should be array");
+    let has_index_hint = hints.iter().any(|h| {
+        h["cmd"].as_str().unwrap_or("") == "hyalo create-index"
+            && h["description"].as_str().unwrap_or("").contains("files")
+    });
+    assert!(
+        has_index_hint,
+        "expected large-vault create-index hint for 501-file vault: {hints:#?}"
+    );
+}
+
+/// `hyalo summary --hints` on a small vault (≤500 files) does NOT emit the
+/// large-vault index-suggestion hint.
+#[test]
+fn summary_large_vault_hint_absent_for_small_vault() {
+    let tmp = setup_vault(); // only 3 files
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["summary", "--hints", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
+
+    let hints = parsed["hints"].as_array().expect("hints should be array");
+    let has_large_vault_hint = hints.iter().any(|h| {
+        h["cmd"].as_str().unwrap_or("") == "hyalo create-index"
+            && h["description"].as_str().unwrap_or("").contains("files")
+    });
+    assert!(
+        !has_large_vault_hint,
+        "unexpected large-vault hint for small vault: {hints:#?}"
+    );
+}

--- a/hyalo-knowledgebase/backlog/done/index-suggestion-hint.md
+++ b/hyalo-knowledgebase/backlog/done/index-suggestion-hint.md
@@ -4,7 +4,7 @@ type: backlog
 date: 2026-03-30
 origin: dogfood MDN runs 2026-03-30
 priority: medium
-status: planned
+status: completed
 tags:
   - ux
   - performance

--- a/hyalo-knowledgebase/backlog/done/index-suggestion-hint.md
+++ b/hyalo-knowledgebase/backlog/done/index-suggestion-hint.md
@@ -34,7 +34,7 @@ Add `auto_index = true` so vaults can opt in to automatic index creation.
 
 ## Acceptance criteria
 
-- [ ] Slow query hint emitted when elapsed >500ms and no `--index`
-- [ ] `summary` hints include index suggestion for vaults >500 files
-- [ ] Hint is suppressed when `--index` is already in use
-- [ ] `--quiet` suppresses the slow-query hint
+- [x] Slow query hint emitted when elapsed >500ms and no `--index`
+- [x] `summary` hints include index suggestion for vaults >500 files
+- [x] Hint is suppressed when `--index` is already in use
+- [x] `--quiet` suppresses the slow-query hint

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -574,3 +574,41 @@ Research across tools:
 - Callers don't need to filter git diff output — non-.md paths are skipped silently
 - No git binary required; works in any CI environment with hyalo on PATH
 - `--files-from` is available on `find`, `lint`, `mv`, `set`, `remove`, and `append` — the commands that already accept `--glob`
+
+## DEC-045: Wall-Clock Signal for Index-Suggestion Hints (2026-05-25)
+
+**Context:** iter-144 — index-suggestion hint for slow queries and large vaults.
+
+**Decision:** Use wall-clock elapsed time (not CPU time or file count alone) as
+the primary signal for the slow-query hint, with a 500 ms threshold. Use file
+count (>500 files) as the signal for the large-vault summary hint.
+
+**Rationale:**
+
+- **Wall-clock, not CPU time.** I/O is the dominant cost for hyalo vault scans;
+  wall-clock matches what the user perceives as "slow". CPU time would exclude
+  I/O wait and underreport the user-visible latency.
+- **500 ms slow-query threshold.** Shorter than the human "wait, this is slow"
+  threshold (~1 s) with margin; longer than typical scans on small vaults
+  (~100 ms). Calibrated from MDN dogfooding where property-only queries on a
+  14K-file vault took ~1.5 s without an index vs ~80 ms with one.
+- **500 files large-vault threshold.** Vaults above this size show measurable
+  benefit from a snapshot index. Below it, disk scan is fast enough not to
+  warrant the hint.
+- **Global threshold, not per-command.** A single threshold for all eligible
+  commands is simpler than per-command tuning. Eligible commands are those that
+  scan the vault: `find`, `lint`, `backlinks`, `properties summary`,
+  `tags summary`, `summary`, `read`.
+- **Suppress on --index / --index-file active.** If the user already requested
+  a snapshot, suppress both hints — even if the index load failed and fell back
+  to a disk scan. The intent to use an index is the suppression signal, not the
+  outcome.
+- **Suppress slow-query hint on --quiet.** `--quiet` is the user's explicit
+  opt-out from advisory output; it should silence the hint.
+
+**Alternatives rejected:**
+- Per-command thresholds: premature tuning, adds complexity without data.
+- Auto-index config (`auto_index = true`): hyalo shouldn't manage index
+  lifecycle silently. Lint and hints surface the suggestion; the user runs
+  `create-index`.
+- CPU time: misses I/O wait, doesn't reflect user-perceived latency.

--- a/hyalo-knowledgebase/iterations/done/iteration-143-hint-and-files-from-polish.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-143-hint-and-files-from-polish.md
@@ -155,5 +155,5 @@ schema vocabulary, no new commands.
   — deferred hint items (sections: Hints, status `[1/5]`)
 - [[iterations/iteration-139-files-from-flag]] — deferred
   snapshot-membership + `HintSource::FilesFrom`
-- [[backlog/index-suggestion-hint]] — explicitly NOT addressed here;
+- [[index-suggestion-hint]] — explicitly NOT addressed here;
   iter-144 will pick it up

--- a/hyalo-knowledgebase/iterations/iteration-144-index-suggestion-hint.md
+++ b/hyalo-knowledgebase/iterations/iteration-144-index-suggestion-hint.md
@@ -86,15 +86,15 @@ Pulled from the MDN dogfooding ticket where property-only queries on a
 
 ## Tasks
 
-- [ ] Wire elapsed-time capture in dispatch
-- [ ] Plumb elapsed into `HintContext`
-- [ ] Implement slow-query hint generator
-- [ ] Implement large-vault summary hint
-- [ ] Verify `--quiet` suppression path
-- [ ] Tests (unit + e2e)
-- [ ] CHANGELOG + decision-log + README
-- [ ] Close backlog item
-- [ ] All three CI platforms green
+- [x] Wire elapsed-time capture in dispatch
+- [x] Plumb elapsed into `HintContext`
+- [x] Implement slow-query hint generator
+- [x] Implement large-vault summary hint
+- [x] Verify `--quiet` suppression path
+- [x] Tests (unit + e2e)
+- [x] CHANGELOG + decision-log + README
+- [x] Close backlog item
+- [x] All three CI platforms green
 
 ## Acceptance criteria (mirrors the backlog item)
 
@@ -127,7 +127,7 @@ Pulled from the MDN dogfooding ticket where property-only queries on a
 
 ## References
 
-- [[backlog/index-suggestion-hint]] — the source ticket (origin: MDN
+- [[index-suggestion-hint]] — the source ticket (origin: MDN
   dogfood, 2026-03-30)
 - [[iteration-143-hint-and-files-from-polish]] — predecessor
   hint-polish iteration

--- a/hyalo-knowledgebase/iterations/iteration-144-index-suggestion-hint.md
+++ b/hyalo-knowledgebase/iterations/iteration-144-index-suggestion-hint.md
@@ -98,10 +98,10 @@ Pulled from the MDN dogfooding ticket where property-only queries on a
 
 ## Acceptance criteria (mirrors the backlog item)
 
-- [ ] Slow-query hint emitted when elapsed > 500 ms and no `--index`
-- [ ] `summary` hints include index suggestion for vaults > 500 files
-- [ ] Hint is suppressed when `--index` is already in use
-- [ ] `--quiet` suppresses the slow-query hint
+- [x] Slow-query hint emitted when elapsed > 500 ms and no `--index`
+- [x] `summary` hints include index suggestion for vaults > 500 files
+- [x] Hint is suppressed when `--index` is already in use
+- [x] `--quiet` suppresses the slow-query hint
 
 ## Design notes
 


### PR DESCRIPTION
## Summary
- Capture command wall-clock elapsed in dispatch and plumb it into `HintContext`.
- New slow-query hint: when elapsed > 500 ms, no `--index`/`--index-file` is active, and `--quiet` is not set, suggest `hyalo create-index`. Eligible commands: `find`, `lint`, `backlinks`, `properties summary`, `tags summary`, `summary`, `read`.
- New large-vault summary hint: when `hyalo summary` sees > 500 files without an index, suggest `hyalo create-index`.
- Thresholds (`SLOW_QUERY_THRESHOLD_MS = 500`, `LARGE_VAULT_FILE_COUNT = 500`) live as documented constants in `crates/hyalo-cli/src/hints.rs`.
- Closes `backlog/index-suggestion-hint.md` (moved to `backlog/done/`).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` (incl. 13 new unit tests + 4 new e2e tests covering both hints, suppression by `--quiet`, `--no-hints`, and `--index`)
- [x] xtask gates: `check-ac-fidelity`, `check-feature-fanout`, `check-help-drift`
- [ ] Manual verification against MDN-sized vault (post-merge dogfood)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic index-creation suggestions now appear when queries exceed 500ms or vaults contain over 500 files in `find`, `lint`, `backlinks`, `summary`, and related commands.
  * Hints are suppressed when an index is already active, `--quiet` is used, or `--no-hints` is specified.

* **Documentation**
  * Updated README and decision logs documenting index-suggestion behavior and thresholds.

* **Tests**
  * Added end-to-end test coverage for index-suggestion hints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ractive/hyalo/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->