### PR TITLE
iter-146: embed git sha + date in `hyalo --version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
 
 ### Changed
 
+- **iter-146**: `hyalo --version` now includes the git short-sha and commit
+  date — e.g. `hyalo 0.16.0 (abc123def456 2026-05-26)`. A `+dirty` suffix is
+  appended when the working tree had uncommitted changes at build time.
+  Builds without a `.git` directory (crates.io tarball, offline) fall back
+  silently to the bare `hyalo <semver>` form. Set
+  `CARGO_HYALO_FORCE_NO_GIT=1` to force the bare form; CI can pre-supply
+  `GIT_COMMIT` + `GIT_COMMIT_DATE` to skip the shell-out.
+
 - **iter-145**: Unified file-input resolver (`commands/inputs.rs`) replaces
   three separate seams: `resolve_files_from_for_command`, `collect_files`,
   and `resolve_single_file`. All `<FILE>`/`--file` commands now go through

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ See `hyalo types --help` for managing schemas from the CLI, and `hyalo lint` to 
 When you run hyalo from a directory that has a `.hyalo.toml`, it becomes _context-aware_:
 
 - **`hyalo --help`** prepends a short banner confirming which vault `dir` is active — useful when working from shell history or AI agent loops. Banner emojis (`ℹ️ `/`⚠️`) are TTY-gated: piped output is plain text.
-- **`hyalo --version`** appends `(kb dir: <dir>)` so the resolved directory is visible at a glance.
+- **`hyalo --version`** appends `(kb dir: <dir>)` so the resolved directory is visible at a glance. The base version string also includes the git short-sha and commit date when hyalo was built from a checkout — e.g. `hyalo 0.16.0 (abc123def456 2026-05-26)`. A `+dirty` suffix marks builds made with uncommitted changes. Set `CARGO_HYALO_FORCE_NO_GIT=1` at build time to force the bare semver form.
 - **`hyalo summary`** includes the resolved `kb dir:` as its first output line. The `--format json` envelope exposes the same value as a top-level `dir` field alongside `total`, `tags`, `properties`, etc.
 - **`hyalo config`** prints the full resolved configuration — handy for debugging `.hyalo.toml` resolution or feeding config into an LLM context.
 - Running from _inside_ the vault directory emits a warning banner suggesting you `cd ..` to the project root so hyalo can find `.hyalo.toml`.

--- a/crates/hyalo-cli/build.rs
+++ b/crates/hyalo-cli/build.rs
@@ -1,0 +1,87 @@
+//! Build script that embeds git provenance (short sha + commit date) into the
+//! compiled `hyalo` binary via the `HYALO_BUILD_VERSION_SHA` and
+//! `HYALO_BUILD_DATE` env vars (consumed by `env!` in `cli/args.rs`).
+//!
+//! Failure modes (missing git, not a git repo, shell-out fails) degrade to
+//! empty strings rather than panicking — a broken build script breaks every
+//! consumer, including `cargo install` from a crates.io tarball.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_HYALO_FORCE_NO_GIT");
+    println!("cargo:rerun-if-env-changed=GIT_COMMIT");
+    println!("cargo:rerun-if-env-changed=GIT_COMMIT_DATE");
+
+    let (sha, date) = resolve_provenance();
+
+    println!("cargo:rustc-env=HYALO_BUILD_VERSION_SHA={sha}");
+    println!("cargo:rustc-env=HYALO_BUILD_DATE={date}");
+}
+
+fn resolve_provenance() -> (String, String) {
+    // Tarball / forced-off path: emit empty strings, skip git entirely.
+    if std::env::var_os("CARGO_HYALO_FORCE_NO_GIT").is_some() {
+        return (String::new(), String::new());
+    }
+
+    // CI/CD hermetic path: caller-supplied values, skip the shell-out.
+    if let (Ok(sha), Ok(date)) = (
+        std::env::var("GIT_COMMIT"),
+        std::env::var("GIT_COMMIT_DATE"),
+    ) && !sha.is_empty()
+        && !date.is_empty()
+    {
+        return (sha, date);
+    }
+
+    // Resolve the .git directory so worktrees / submodules work.
+    let git_dir = match run_git(&["rev-parse", "--git-dir"]) {
+        Some(s) if !s.is_empty() => PathBuf::from(s),
+        _ => return (String::new(), String::new()),
+    };
+
+    // Rerun directives — these paths change on commits / branch switches.
+    let head = git_dir.join("HEAD");
+    if head.exists() {
+        println!("cargo:rerun-if-changed={}", head.display());
+    }
+    let refs = git_dir.join("refs");
+    if refs.exists() {
+        println!("cargo:rerun-if-changed={}", refs.display());
+    }
+    let packed_refs = git_dir.join("packed-refs");
+    if packed_refs.exists() {
+        println!("cargo:rerun-if-changed={}", packed_refs.display());
+    }
+
+    let sha = match run_git(&["rev-parse", "--short=12", "HEAD"]) {
+        Some(s) if !s.is_empty() => s,
+        _ => return (String::new(), String::new()),
+    };
+
+    let date = match run_git(&["show", "-s", "--format=%cs", "HEAD"]) {
+        Some(s) if !s.is_empty() => s,
+        _ => return (String::new(), String::new()),
+    };
+
+    // Append +dirty if there are uncommitted changes.
+    let dirty = match run_git(&["status", "--porcelain"]) {
+        Some(s) => !s.is_empty(),
+        None => false,
+    };
+
+    let sha = if dirty { format!("{sha}+dirty") } else { sha };
+
+    (sha, date)
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?;
+    Some(s.trim().to_string())
+}

--- a/crates/hyalo-cli/build.rs
+++ b/crates/hyalo-cli/build.rs
@@ -42,6 +42,19 @@ fn resolve_provenance() -> (String, String) {
         _ => return (String::new(), String::new()),
     };
 
+    // Cargo's default "rerun if any package file changes" is suppressed as
+    // soon as we emit any rerun-if-changed, so re-declare crate sources
+    // explicitly. Without this, edits under src/ would not refresh the
+    // `+dirty` marker computed from `git status --porcelain`. Also watch
+    // `.git/index` so staging changes (which also flip dirty state) refresh.
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+    let index = git_dir.join("index");
+    if index.exists() {
+        println!("cargo:rerun-if-changed={}", index.display());
+    }
+
     // Rerun directives — these paths change on commits / branch switches.
     let head = git_dir.join("HEAD");
     if head.exists() {

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use clap::{Args, Parser, Subcommand};
 
@@ -93,10 +94,37 @@ pub(crate) fn resolve_single_file(
     }
 }
 
+/// Compose a version string in the form `"{PKG} ({SHA} {DATE})"`.
+///
+/// Returns the bare `pkg` string when `sha` is empty (tarball / offline build).
+fn format_version_string(pkg: &str, sha: &str, date: &str) -> String {
+    if sha.is_empty() {
+        pkg.to_string()
+    } else {
+        format!("{pkg} ({sha} {date})")
+    }
+}
+
+/// Return the long-form version string used by `--version` / `-V`.
+///
+/// Memoized in a `OnceLock` because clap's `version =` attribute requires a
+/// `&'static str`. The SHA and date come from env vars set by `build.rs`
+/// (`HYALO_BUILD_VERSION_SHA`, `HYALO_BUILD_DATE`).
+pub(crate) fn build_version_string() -> &'static str {
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION.get_or_init(|| {
+        format_version_string(
+            env!("CARGO_PKG_VERSION"),
+            env!("HYALO_BUILD_VERSION_SHA"),
+            env!("HYALO_BUILD_DATE"),
+        )
+    })
+}
+
 #[derive(Parser)]
 #[command(
     name = "hyalo",
-    version,
+    version = build_version_string(),
     about = "Query, filter, and mutate YAML frontmatter across markdown file collections",
     long_about = "Hyalo — query, filter, and mutate YAML frontmatter across markdown file collections.\n\n\
         Compatible with Obsidian vaults, Zettelkasten systems, and any directory of .md files \
@@ -1595,4 +1623,36 @@ pub(crate) enum TagsAction {
         #[command(flatten)]
         index_flags: IndexFlags,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_version_string, format_version_string};
+
+    #[test]
+    fn format_version_string_with_sha() {
+        let s = format_version_string("0.16.0", "abc123def456", "2026-05-26");
+        assert_eq!(s, "0.16.0 (abc123def456 2026-05-26)");
+    }
+
+    #[test]
+    fn format_version_string_with_dirty_sha() {
+        let s = format_version_string("0.16.0", "abc123def456+dirty", "2026-05-26");
+        assert_eq!(s, "0.16.0 (abc123def456+dirty 2026-05-26)");
+    }
+
+    #[test]
+    fn format_version_string_returns_pkg_version_when_sha_empty() {
+        let s = format_version_string("0.16.0", "", "");
+        assert_eq!(s, "0.16.0");
+    }
+
+    #[test]
+    fn build_version_string_starts_with_pkg_version() {
+        let v = build_version_string();
+        assert!(
+            v.starts_with(env!("CARGO_PKG_VERSION")),
+            "version string {v:?} should start with CARGO_PKG_VERSION"
+        );
+    }
 }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -393,10 +393,11 @@ fn run_inner() -> Result<(), AppError> {
     }
 
     // Append `(kb dir: <dir>)` to the version string when .hyalo.toml is in CWD.
+    // Preserves the git-provenance suffix produced by `build_version_string()`.
     if cwd_has_config {
         let version_with_dir = format!(
             "{} (kb dir: {})",
-            env!("CARGO_PKG_VERSION"),
+            crate::cli::args::build_version_string(),
             config.dir.display()
         );
         cmd = cmd.version(version_with_dir);

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -40,4 +40,5 @@ mod summary;
 mod tags;
 mod task;
 mod types;
+mod version;
 mod views;

--- a/crates/hyalo-cli/tests/e2e/version.rs
+++ b/crates/hyalo-cli/tests/e2e/version.rs
@@ -1,0 +1,48 @@
+use regex::Regex;
+use tempfile::TempDir;
+
+use super::common::hyalo;
+
+/// Pattern matching `hyalo <semver> (<sha7-12>[+dirty] <YYYY-MM-DD>)`.
+/// The bare-semver fallback (tarball / `CARGO_HYALO_FORCE_NO_GIT=1`) is also accepted.
+fn version_re() -> Regex {
+    Regex::new(
+        r"^hyalo \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?: \([0-9a-f]{7,12}(?:\+dirty)? \d{4}-\d{2}-\d{2}\))?\n?$",
+    )
+    .unwrap()
+}
+
+#[test]
+fn version_long_flag_matches_provenance_shape() {
+    // Run from a clean tempdir so the cwd-config `(kb dir: ...)` suffix doesn't trip the regex.
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .arg("--version")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "hyalo --version should succeed");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let re = version_re();
+    assert!(
+        re.is_match(&stdout),
+        "--version output {stdout:?} does not match expected shape"
+    );
+}
+
+#[test]
+fn version_short_flag_matches_long_flag() {
+    let tmp = TempDir::new().unwrap();
+    let long = hyalo()
+        .current_dir(tmp.path())
+        .arg("--version")
+        .output()
+        .unwrap();
+    let short = hyalo().current_dir(tmp.path()).arg("-V").output().unwrap();
+    assert!(long.status.success());
+    assert!(short.status.success());
+    assert_eq!(
+        long.stdout, short.stdout,
+        "-V should match --version output exactly"
+    );
+}

--- a/hyalo-knowledgebase/iterations/iteration-146-version-git-provenance.md
+++ b/hyalo-knowledgebase/iterations/iteration-146-version-git-provenance.md
@@ -2,7 +2,7 @@
 title: Iteration 146 — Embed git sha + date in `hyalo --version`
 type: iteration
 date: 2026-05-26
-status: in-progress
+status: completed
 branch: iter-146/version-git-provenance
 tags:
   - iteration
@@ -118,7 +118,7 @@ Wire it into the `#[command(...)]` macro at line 99: change
 - [x] Unit tests in `args.rs` for both paths (sha present,
       sha empty).
 - [x] New `tests/e2e/version.rs` with the binary-level assertion.
-      Register the file in `tests/e2e/main.rs`.
+      Register the file in `tests/e2e/mod.rs`.
 - [x] README + CHANGELOG entries.
 - [x] Confirm `cargo build --release` followed by
       `target/release/hyalo --version` prints the new format on the

--- a/hyalo-knowledgebase/iterations/iteration-146-version-git-provenance.md
+++ b/hyalo-knowledgebase/iterations/iteration-146-version-git-provenance.md
@@ -2,7 +2,7 @@
 title: Iteration 146 — Embed git sha + date in `hyalo --version`
 type: iteration
 date: 2026-05-26
-status: planned
+status: in-progress
 branch: iter-146/version-git-provenance
 tags:
   - iteration
@@ -107,46 +107,46 @@ Wire it into the `#[command(...)]` macro at line 99: change
 
 ## Steps
 
-- [ ] Create `crates/hyalo-cli/build.rs` with the git-provenance
+- [x] Create `crates/hyalo-cli/build.rs` with the git-provenance
       logic, including the env-var override paths and the
       `CARGO_HYALO_FORCE_NO_GIT` escape hatch.
-- [ ] Add `build_version_string()` to `cli/args.rs` with a
+- [x] Add `build_version_string()` to `cli/args.rs` with a
       `format_version_string(pkg, sha, date)` helper that the unit
       tests can exercise directly.
-- [ ] Wire `version = build_version_string()` into the `#[command]`
+- [x] Wire `version = build_version_string()` into the `#[command]`
       macro.
-- [ ] Unit tests in `args.rs` for both paths (sha present,
+- [x] Unit tests in `args.rs` for both paths (sha present,
       sha empty).
-- [ ] New `tests/e2e/version.rs` with the binary-level assertion.
+- [x] New `tests/e2e/version.rs` with the binary-level assertion.
       Register the file in `tests/e2e/main.rs`.
-- [ ] README + CHANGELOG entries.
-- [ ] Confirm `cargo build --release` followed by
+- [x] README + CHANGELOG entries.
+- [x] Confirm `cargo build --release` followed by
       `target/release/hyalo --version` prints the new format on the
       developer's machine.
-- [ ] Quality gates: `cargo fmt`, `cargo clippy --workspace
+- [x] Quality gates: `cargo fmt`, `cargo clippy --workspace
       --all-targets -- -D warnings`, `cargo test --workspace -q`.
-- [ ] xtask gates: `check-ac-fidelity`, `check-feature-fanout`,
+- [x] xtask gates: `check-ac-fidelity`, `check-feature-fanout`,
       `check-help-drift`.
 
 ## Tasks
 
-- [ ] build.rs implementation
-- [ ] args.rs version-string assembly
-- [ ] Unit tests (sha + tarball paths)
-- [ ] E2E test
-- [ ] CHANGELOG + README
-- [ ] Quality + xtask gates green
+- [x] build.rs implementation
+- [x] args.rs version-string assembly
+- [x] Unit tests (sha + tarball paths)
+- [x] E2E test
+- [x] CHANGELOG + README
+- [x] Quality + xtask gates green
 
 ## Acceptance criteria
 
-- [ ] `hyalo --version` outputs `hyalo <semver> (<sha12> <YYYY-MM-DD>)`
+- [x] `hyalo --version` outputs `hyalo <semver> (<sha12> <YYYY-MM-DD>)`
       when built from a git checkout
-- [ ] `hyalo -V` matches `--version`
-- [ ] A dirty working tree at build time appends `+dirty` to the sha
-- [ ] `CARGO_HYALO_FORCE_NO_GIT=1` env var produces the bare semver
-- [ ] Build does not fail when run outside a git repo
+- [x] `hyalo -V` matches `--version`
+- [x] A dirty working tree at build time appends `+dirty` to the sha
+- [x] `CARGO_HYALO_FORCE_NO_GIT=1` env var produces the bare semver
+- [x] Build does not fail when run outside a git repo
       (e.g. `cargo install` from crates.io tarball would-be path)
-- [ ] No new runtime dependencies; no new build dependencies beyond
+- [x] No new runtime dependencies; no new build dependencies beyond
       stdlib (no `vergen`, no `built`)
 
 ## Design notes


### PR DESCRIPTION
## Summary

- New `crates/hyalo-cli/build.rs` resolves the git short-sha (12 chars) and commit date (`%cs`) at build time, plus a `+dirty` marker when the working tree has uncommitted changes. Emitted as `cargo:rustc-env` strings consumed via `env!` in `cli/args.rs`.
- `hyalo --version` / `-V` now prints `hyalo <semver> (<sha12>[+dirty] <YYYY-MM-DD>)` — uniquely identifies a binary in dogfood/bug reports.
- Silent fallback to bare `hyalo <semver>` when git is unavailable (crates.io tarball, offline) or when `CARGO_HYALO_FORCE_NO_GIT=1` is set. CI can pre-supply `GIT_COMMIT` + `GIT_COMMIT_DATE` to skip the shell-out.
- No new dependencies — pure stdlib `Command` calls; no `vergen`/`built`.
- CWD-aware `(kb dir: <dir>)` suffix is preserved on top of the new provenance segment.

## Test plan

- [x] Unit tests in `args.rs` cover `format_version_string` for sha-present, sha-with-dirty, and sha-empty (tarball) paths
- [x] E2E tests in `tests/e2e/version.rs` assert the regex shape of `--version` and that `-V` matches `--version` byte-for-byte
- [x] `cargo build --release` from the repo root prints `hyalo 0.16.0 (<sha12>+dirty 2026-05-26) (kb dir: hyalo-knowledgebase)`
- [x] Same binary run from `/tmp` prints `hyalo 0.16.0 (<sha12>+dirty 2026-05-26)` (no kb-dir suffix)
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all green
- [x] xtask gates: `check-ac-fidelity`, `check-feature-fanout`, `check-help-drift` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `hyalo --version` output now includes git commit SHA, build date, and a `+dirty` indicator for uncommitted changes.
  * Version output includes knowledge base directory in CWD-aware mode.
  * Environment variable `CARGO_HYALO_FORCE_NO_GIT=1` allows forcing plain semantic version format.

* **Documentation**
  * Updated README and CHANGELOG with expanded version output behavior.

* **Tests**
  * Added end-to-end tests validating version output format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ractive/hyalo/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->