### PR TITLE
iter-158: codebase-review fixes — 2 criticals, 13 highs, 7 mediums

### DIFF
--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -849,6 +849,10 @@ Repeatable (AND).\n\
             read/write files on disk but also patch the index in-place after each\n\
             mutation — keeping it current for subsequent queries. This is safe as\n\
             long as no external tool modifies vault files while the index is active.\n\n\
+            PERFORMANCE: a body-text query combined with a narrow metadata filter\n\
+            (e.g. `find \"query\" --property status=x`) still reads the whole vault\n\
+            without an index, because BM25 relevance is ranked against full-vault\n\
+            statistics. On large vaults, create an index for this workload.\n\n\
             OUTPUT: JSON object with `path`, `files_indexed`, and `warnings`.\n\
             SIDE EFFECTS: Writes a binary file (default: .hyalo-index in --dir).\n\n\
             FLAG ALIASES: on this subcommand, `--index-file PATH` (the global flag) is\n\

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -341,7 +341,7 @@ pub fn find(
                 break 'bm25 Some(map);
             }
 
-            // Build BM25 index from candidates.
+            // Build BM25 corpus statistics.
             //
             // Fast path: when the index has pre-tokenized data and no section filter
             // is active (section filters require scoping to specific line ranges, which
@@ -353,108 +353,133 @@ pub fn find(
             let mut pre_tok_inputs: Vec<PreTokenizedInput> = Vec::new();
             let mut doc_inputs: Vec<DocumentInput> = Vec::new();
 
-            for &idx in &candidates {
-                let entry = &scoped_entries[idx];
+            // Tokenizes a single entry into `pre_tok_inputs` or `doc_inputs`. Shared by
+            // both loops below so the two corpus-scoping strategies (candidates-only vs.
+            // full-scoped-corpus) don't duplicate the tokenization logic. Scoped to this
+            // block so the closure (and its mutable borrows of `pre_tok_inputs` /
+            // `doc_inputs`) is dropped before those vectors are consumed below.
+            {
+                let mut collect_entry = |entry: &hyalo_core::index::IndexEntry| {
+                    // Use pre-tokenized data only when:
+                    // 1. The index entry has stored tokens, AND
+                    // 2. No section filter is active (section filters require line-level body slicing), AND
+                    // 3. The cached language matches the effective language for this entry.
+                    if !has_section_filter && let Some(ref tokens) = entry.bm25_tokens {
+                        let fm_lang = entry.properties.get("language").and_then(|v| v.as_str());
+                        let effective_lang = resolve_language(fm_lang, language, config_language);
+                        let cached_lang_matches = entry
+                            .bm25_language
+                            .as_deref()
+                            .and_then(|s| parse_language(s).ok())
+                            == Some(effective_lang);
 
-                // Use pre-tokenized data only when:
-                // 1. The index entry has stored tokens, AND
-                // 2. No section filter is active (section filters require line-level body slicing), AND
-                // 3. The cached language matches the effective language for this entry.
-                if !has_section_filter && let Some(ref tokens) = entry.bm25_tokens {
+                        if cached_lang_matches {
+                            pre_tok_inputs.push(PreTokenizedInput {
+                                rel_path: entry.rel_path.clone(),
+                                tokens: tokens.clone(),
+                            });
+                            return;
+                        }
+                        // Fall through to disk-read tokenization when language mismatches.
+                    }
+
+                    // Slow path: read the file from disk.
+                    let full_path = dir.join(&entry.rel_path);
+                    let file_content = match std::fs::read_to_string(&full_path) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            crate::warn::warn(format!("skipping {}: {e}", entry.rel_path));
+                            return;
+                        }
+                    };
+                    // Feed only the body (after frontmatter) to BM25 so that frontmatter
+                    // YAML (including tag values) does not influence scoring.
+                    let raw_body = hyalo_core::frontmatter::body_only(&file_content);
+
+                    // When section filters are active, restrict the BM25 body to lines
+                    // that fall within the matching section scope. This preserves the
+                    // expectation that "pattern + --section X" only matches files where
+                    // the pattern appears inside section X, not elsewhere in the document.
+                    let body = if has_section_filter {
+                        let scope_ranges =
+                            build_section_scope(&entry.sections, section_filters, usize::MAX);
+                        if scope_ranges.is_empty() {
+                            // No matching section — this candidate should have been filtered
+                            // in Phase 1, but guard here just in case.
+                            return;
+                        }
+                        // Index line numbers are 1-based relative to the full file (frontmatter + body).
+                        // Count lines in the frontmatter prefix to offset body line numbers correctly.
+                        let fm_prefix_len = file_content.len() - raw_body.len();
+                        let fm_lines = file_content[..fm_prefix_len].lines().count();
+                        raw_body
+                            .lines()
+                            .enumerate()
+                            .filter_map(|(i, line)| {
+                                // body line i corresponds to file line (fm_lines + i + 1) (1-based)
+                                let file_line = fm_lines + i + 1;
+                                if in_scope(&scope_ranges, file_line) {
+                                    Some(line)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    } else {
+                        raw_body.to_owned()
+                    };
+
+                    let title_val = extract_title(&entry.properties, Some(&entry.sections));
+                    let title_str = title_val.as_str().unwrap_or("").to_owned();
                     let fm_lang = entry.properties.get("language").and_then(|v| v.as_str());
-                    let effective_lang = resolve_language(fm_lang, language, config_language);
-                    let cached_lang_matches = entry
-                        .bm25_language
-                        .as_deref()
-                        .and_then(|s| parse_language(s).ok())
-                        == Some(effective_lang);
-
-                    if cached_lang_matches {
-                        pre_tok_inputs.push(PreTokenizedInput {
-                            rel_path: entry.rel_path.clone(),
-                            tokens: tokens.clone(),
-                        });
-                        continue;
-                    }
-                    // Fall through to disk-read tokenization when language mismatches.
-                }
-
-                // Slow path: read the file from disk.
-                let full_path = dir.join(&entry.rel_path);
-                let file_content = match std::fs::read_to_string(&full_path) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        crate::warn::warn(format!("skipping {}: {e}", entry.rel_path));
-                        continue;
-                    }
+                    let lang = resolve_language(fm_lang, language, config_language);
+                    doc_inputs.push(DocumentInput {
+                        rel_path: entry.rel_path.clone(),
+                        title: title_str,
+                        body,
+                        language: lang,
+                    });
                 };
-                // Feed only the body (after frontmatter) to BM25 so that frontmatter
-                // YAML (including tag values) does not influence scoring.
-                let raw_body = hyalo_core::frontmatter::body_only(&file_content);
 
-                // When section filters are active, restrict the BM25 body to lines
-                // that fall within the matching section scope. This preserves the
-                // expectation that "pattern + --section X" only matches files where
-                // the pattern appears inside section X, not elsewhere in the document.
-                let body = if has_section_filter {
-                    let scope_ranges =
-                        build_section_scope(&entry.sections, section_filters, usize::MAX);
-                    if scope_ranges.is_empty() {
-                        // No matching section — this candidate should have been filtered
-                        // in Phase 1, but guard here just in case.
-                        continue;
+                if has_section_filter {
+                    // Section filters require per-candidate line-range slicing, and the
+                    // persisted-index fast path above is skipped entirely whenever a section
+                    // filter is active — so both the --index and no-index runs already build
+                    // this exact candidates-only corpus. No cross-path parity gap here.
+                    for &idx in &candidates {
+                        collect_entry(scoped_entries[idx]);
                     }
-                    // Index line numbers are 1-based relative to the full file (frontmatter + body).
-                    // Count lines in the frontmatter prefix to offset body line numbers correctly.
-                    let fm_prefix_len = file_content.len() - raw_body.len();
-                    let fm_lines = file_content[..fm_prefix_len].lines().count();
-                    raw_body
-                        .lines()
-                        .enumerate()
-                        .filter_map(|(i, line)| {
-                            // body line i corresponds to file line (fm_lines + i + 1) (1-based)
-                            let file_line = fm_lines + i + 1;
-                            if in_scope(&scope_ranges, file_line) {
-                                Some(line)
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n")
                 } else {
-                    raw_body.to_owned()
-                };
-
-                let title_val = extract_title(&entry.properties, Some(&entry.sections));
-                let title_str = title_val.as_str().unwrap_or("").to_owned();
-                let fm_lang = entry.properties.get("language").and_then(|v| v.as_str());
-                let lang = resolve_language(fm_lang, language, config_language);
-                doc_inputs.push(DocumentInput {
-                    rel_path: entry.rel_path.clone(),
-                    title: title_str,
-                    body,
-                    language: lang,
-                });
-            }
+                    // H-8 fix: build corpus statistics (N, per-term document frequency, avgdl)
+                    // over the FULL scoped corpus (all of `scoped_entries`, before metadata
+                    // filtering), not just the metadata-passing candidates. This matches what
+                    // the persisted-index path does (`bm25_idx.score` computes IDF over the
+                    // whole indexed vault) so --index and no-index runs agree on ranking.
+                    // Scoring is intersected with metadata-passing candidates below.
+                    for entry in scoped_entries.iter().copied() {
+                        collect_entry(entry);
+                    }
+                }
+            } // end collect_entry scope
 
             // Score all documents. When the corpus is a mix of pre-tokenized and
             // freshly-read documents, we build two separate corpora and merge scores.
             // This is safe because BM25 scores are relative within a corpus — mixing
             // them directly would be incorrect. However, the common case is that ALL
-            // candidates come from the same source (all pre-tokenized or all from disk),
+            // entries come from the same source (all pre-tokenized or all from disk),
             // so the mixed case only arises during a rolling index upgrade where some
             // entries were indexed before BM25 support was added.
-            let scored = if doc_inputs.is_empty() {
-                // All candidates were pre-tokenized — fast path.
+            let scored_corpus = if doc_inputs.is_empty() {
+                // All entries were pre-tokenized — fast path.
                 let corpus = Bm25InvertedIndex::build_from_tokens(pre_tok_inputs);
                 corpus.score(pat, &stemmer)
             } else if pre_tok_inputs.is_empty() {
-                // All candidates need file reads — original slow path.
+                // All entries need file reads — original slow path.
                 let corpus = Bm25InvertedIndex::build(doc_inputs);
                 corpus.score(pat, &stemmer)
             } else {
-                // Mixed: some candidates have pre-tokenized data from the index, others were
+                // Mixed: some entries have pre-tokenized data from the index, others were
                 // read from disk. Tokenize the disk-read entries and combine into a single
                 // pre-tokenized corpus so all BM25 scores are computed on the same basis.
                 let mut all_pre_tok = pre_tok_inputs;
@@ -465,7 +490,22 @@ pub fn find(
                 corpus.score(pat, &stemmer)
             };
 
+            // When no section filter is active, `scored_corpus` was scored against the
+            // full scoped corpus — intersect with metadata-passing candidates here,
+            // mirroring the persisted-index fast path above. When a section filter is
+            // active, `scored_corpus` already only contains candidates.
+            let scored: Vec<hyalo_core::bm25::Bm25Match> = if has_section_filter {
+                scored_corpus
+            } else {
+                scored_corpus
+                    .into_iter()
+                    .filter(|m| candidate_paths.contains(m.rel_path.as_str()))
+                    .collect()
+            };
+
             // Warn if the query has low discriminative power (matches most docs with low scores).
+            // Use candidate count as denominator so the heuristic is based on the
+            // result set actually returned to the user, not the full scoped corpus.
             let total_corpus_docs = candidates.len();
             if is_low_discriminative(&scored, total_corpus_docs) {
                 crate::warn::warn(

--- a/crates/hyalo-cli/src/commands/find/tests.rs
+++ b/crates/hyalo-cli/src/commands/find/tests.rs
@@ -494,6 +494,101 @@ fn find_pattern_includes_score_field() {
 }
 
 #[test]
+fn find_property_filter_bm25_uses_full_corpus_idf_not_candidate_only() {
+    // H-8 regression: with a --property filter narrowing candidates down to 2
+    // files, one containing a term rare across the whole vault ("alpha",
+    // present in only 1 of 12 files) and the other containing a term common
+    // across the vault ("beta", present in 11 of 12 files), BM25 IDF must be
+    // computed over the full scoped corpus, not just the 2 candidates.
+    //
+    // Pre-fix, the candidate-only corpus saw each of "alpha" and "beta"
+    // appear in exactly 1 of the 2 candidates, producing identical (tied)
+    // IDF — and therefore identical scores — for both files, which also
+    // diverged from the persisted `--index` path (which always scores
+    // against the full vault). Post-fix, the rare term must clearly outrank
+    // the common one, matching standard BM25 semantics and persisted-index
+    // parity.
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join("k1.md"),
+        md!(r"
+---
+status: keep
+---
+# k1
+alpha alpha content
+"),
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("k2.md"),
+        md!(r"
+---
+status: keep
+---
+# k2
+beta beta content
+"),
+    )
+    .unwrap();
+    for i in 1..=10 {
+        fs::write(
+            tmp.path().join(format!("s{i}.md")),
+            format!("---\nstatus: skip\n---\n# s{i}\nbeta beta beta filler {i}\n"),
+        )
+        .unwrap();
+    }
+
+    let filters = vec![hyalo_core::filter::parse_property_filter("status=keep").unwrap()];
+    let fields = Fields::default();
+    let out = unwrap_success(
+        run_find(
+            tmp.path(),
+            None,
+            Some("alpha OR beta"),
+            None,
+            &filters,
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &fields,
+            None,
+            false,
+            None,
+            false,
+            None,
+            Format::Json,
+        )
+        .unwrap(),
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+    let arr = parsed.as_array().unwrap();
+    assert_eq!(arr.len(), 2, "expected exactly 2 candidates: {arr:?}");
+
+    let score_of = |file: &str| -> f64 {
+        arr.iter()
+            .find(|r| r["file"] == file)
+            .unwrap_or_else(|| panic!("missing {file} in results: {arr:?}"))["score"]
+            .as_f64()
+            .unwrap()
+    };
+    let k1_score = score_of("k1.md");
+    let k2_score = score_of("k2.md");
+    assert!(
+        k1_score > k2_score,
+        "k1.md (rare term 'alpha' across the full vault) should outrank k2.md \
+         (common term 'beta') under full-corpus IDF; got k1={k1_score} k2={k2_score}"
+    );
+    assert!(
+        (k1_score - k2_score).abs() > 0.5,
+        "expected a clear score gap between rare- and common-term matches \
+         (a candidate-only corpus would tie these); got k1={k1_score} k2={k2_score}"
+    );
+}
+
+#[test]
 fn find_no_pattern_no_matches_field() {
     let tmp = setup_vault();
     let fields = Fields::default();

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -11,6 +11,7 @@
 ///     schema)
 ///
 /// Exit code: 0 = clean, 1 = errors found, 2 = internal error.
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -21,7 +22,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use hyalo_core::filename_template::FilenameTemplate;
-use hyalo_core::frontmatter::{read_frontmatter, write_frontmatter};
+use hyalo_core::frontmatter::{check_mtime, read_frontmatter, read_mtime, write_frontmatter};
 use hyalo_core::scanner;
 use hyalo_core::schema::{
     self, PropertyConstraint, SchemaConfig, TypeSchema, parse_required_section_entry,
@@ -1606,9 +1607,7 @@ pub fn lint_files_extended(
                         count: remaining,
                         shown,
                         truncated,
-                        severity: remaining_owned
-                            .first()
-                            .map_or("warn".to_owned(), |v| v.severity.clone()),
+                        severity: group_severity(&remaining_owned),
                         autofixable: true,
                         violations: body_violations,
                     });
@@ -1737,9 +1736,7 @@ pub fn lint_files_extended(
                         .find(|e| &e.id == rule_id)
                         .is_some_and(|e| e.autofixable)
                 };
-                let severity = violations
-                    .first()
-                    .map_or_else(|| "warn".to_owned(), |v| v.severity.clone());
+                let severity = group_severity(violations);
 
                 let shown = if opts.detailed {
                     violations.len()
@@ -1819,6 +1816,24 @@ struct InternalViolation {
     fixed: bool,
 }
 
+/// Severity label for a group of violations under one rule id.
+///
+/// Most rule groups hold violations that all share one severity (hyalo
+/// assigns severity per rule, not per violation), but the synthetic
+/// `"SCHEMA"` group folds together several distinct checks (missing
+/// required field, undeclared property, missing type, ...) that can mix
+/// error and warn — using `violations.first()` there mislabels the whole
+/// group whenever a warn happens to be first. Returns the max severity
+/// across the group instead, which is correct for both the uniform and
+/// mixed cases.
+fn group_severity(violations: &[InternalViolation]) -> String {
+    if violations.iter().any(|v| v.severity == "error") {
+        "error".to_owned()
+    } else {
+        "warn".to_owned()
+    }
+}
+
 /// Outcome for a single diagnostic's fix attempt (internal, used in fix-mode).
 #[derive(Debug)]
 enum FixOutcome {
@@ -1867,6 +1882,59 @@ fn lint_one_file_extended(
     max_per_rule: usize,
     strict: bool,
 ) -> Result<PerFileLintResult> {
+    // One rule's fix can expose a fresh violation for another rule (e.g. a
+    // trimmed line changing what counts as a duplicate blank line), so a
+    // single lint→fix pass over the body does not always converge. Bounds
+    // the lint→fix→re-lint loop below.
+    const MAX_BODY_FIX_PASSES: usize = 5;
+
+    // Stat before reading: oversized files are skipped rather than loaded
+    // whole into memory (mirrors `scanner::scan_file_multi`'s own guard).
+    let meta =
+        std::fs::metadata(full_path).with_context(|| format!("failed to stat {rel_path}"))?;
+    if meta.len() > scanner::MAX_FILE_SIZE {
+        eprintln!(
+            "warning: skipping {} ({} MiB exceeds {} MiB limit)",
+            full_path.display(),
+            meta.len() / (1024 * 1024),
+            scanner::MAX_FILE_SIZE / (1024 * 1024)
+        );
+        let mut violations_by_rule = indexmap::IndexMap::new();
+        violations_by_rule.insert(
+            "FILE".to_owned(),
+            vec![InternalViolation {
+                line: 1,
+                column: 1,
+                message: format!(
+                    "file exceeds {} MiB size limit — skipped, not linted",
+                    scanner::MAX_FILE_SIZE / (1024 * 1024)
+                ),
+                severity: "warn".to_owned(),
+                fix: None,
+                fixed: false,
+            }],
+        );
+        return Ok(PerFileLintResult {
+            rel_path: rel_path.to_owned(),
+            doc_type: None,
+            violations_by_rule,
+            total_violations: 1,
+            body_modified: false,
+            fix_actions: Vec::new(),
+            body_fix_outcomes: Vec::new(),
+            post_fix_schema_remaining: None,
+        });
+    }
+
+    // Baseline mtime fingerprint for TOCTOU detection around fix-mode
+    // writes below. Derived from the stat above instead of a second
+    // `read_mtime` round-trip.
+    let mut mtime0: (std::time::SystemTime, u64) = (
+        meta.modified()
+            .with_context(|| format!("mtime not available for {rel_path}"))?,
+        meta.len(),
+    );
+
     // Read the file content once.
     let content =
         std::fs::read_to_string(full_path).with_context(|| format!("reading {rel_path}"))?;
@@ -2049,8 +2117,15 @@ fn lint_one_file_extended(
             let actions = apply_fixes(rel_path, &mut mutable, schema);
             if !actions.is_empty() {
                 if matches!(fix, FixMode::Apply) {
+                    check_mtime(full_path, mtime0)?;
                     write_frontmatter(full_path, &mutable)
                         .with_context(|| format!("writing fixed frontmatter to {rel_path}"))?;
+                    // Re-baseline: the write above legitimately changed the
+                    // file's mtime, and a later body-fix write in this same
+                    // call must not mistake it for a concurrent modification.
+                    mtime0 = read_mtime(full_path).with_context(|| {
+                        format!("re-reading mtime for {rel_path} after frontmatter fix")
+                    })?;
                 }
                 fix_actions = actions;
             }
@@ -2126,8 +2201,23 @@ fn lint_one_file_extended(
         .and_then(|v| v.as_str())
         .map(str::to_owned);
 
-    let body_diagnostics = engine.lint_body(
-        body_content,
+    // Track per-diagnostic outcomes for the new fix-mode JSON shape.
+    let mut body_fix_outcomes: Vec<(String, FixOutcome)> = Vec::new();
+    // Diagnostics that were fixed, accumulated across every pass below
+    // (each carries its own line/column, valid against the body revision it
+    // was found in — fine for display, since only `fixed`-derived counts
+    // and messages are surfaced, never the byte offsets).
+    let mut fixed_diagnostics: Vec<hyalo_mdlint::Diagnostic> = Vec::new();
+    // The body text, mutated in place across fix passes.
+    let mut working_body: String = body_content.to_owned();
+
+    // Re-lint and re-fix the working body up to `MAX_BODY_FIX_PASSES` times,
+    // or until nothing more changes — whichever comes first. Read-only mode
+    // and DryRun both run this same in-memory loop; only `FixMode::Apply`
+    // writes the result to disk (below), so DryRun still previews the
+    // fully-converged outcome.
+    let mut current_diagnostics = engine.lint_body(
+        &working_body,
         rel_path,
         frontmatter_status.as_deref(),
         schema_has_completed,
@@ -2135,62 +2225,104 @@ fn lint_one_file_extended(
         rule_filter,
     )?;
 
-    // Apply body fixes if requested.
-    // Track per-diagnostic outcomes for the new fix-mode JSON shape.
-    let mut body_fix_outcomes: Vec<(String, FixOutcome)> = Vec::new();
-    // Set of body-diagnostic indices whose fix was Applied. Used below to
-    // mark `InternalViolation.fixed`, so downstream remaining/severity
-    // accounting can filter out fixed violations.
-    let mut applied_indices: std::collections::HashSet<usize> = std::collections::HashSet::new();
-
-    if matches!(fix, FixMode::Apply | FixMode::DryRun) && !body_diagnostics.is_empty() {
+    if matches!(fix, FixMode::Apply | FixMode::DryRun) {
         let fix_all_rules = fix_rules.is_empty();
-        let fixable_indices: Vec<usize> = body_diagnostics
-            .iter()
-            .enumerate()
-            .filter(|(_, d)| d.fix.is_some())
-            .filter(|(_, d)| fix_all_rules || fix_rules.iter().any(|r| r == &d.rule_id))
-            .map(|(i, _)| i)
-            .collect();
 
-        if !fixable_indices.is_empty() {
+        for _ in 0..MAX_BODY_FIX_PASSES {
+            if current_diagnostics.is_empty() {
+                break;
+            }
+            let fixable_indices: Vec<usize> = current_diagnostics
+                .iter()
+                .enumerate()
+                .filter(|(_, d)| d.fix.is_some())
+                .filter(|(_, d)| fix_all_rules || fix_rules.iter().any(|r| r == &d.rule_id))
+                .map(|(i, _)| i)
+                .collect();
+            if fixable_indices.is_empty() {
+                break;
+            }
+
             let fixable_refs: Vec<&hyalo_mdlint::Diagnostic> = fixable_indices
                 .iter()
-                .map(|&i| &body_diagnostics[i])
+                .map(|&i| &current_diagnostics[i])
                 .collect();
-            let (new_body, outcomes) = apply_body_fixes(body_content, &fixable_refs);
+            let (new_body, outcomes) = apply_body_fixes(&working_body, &fixable_refs);
 
-            // Record per-diagnostic outcomes.
-            for (slot, orig_idx) in fixable_indices.iter().enumerate() {
-                let rule_id = body_diagnostics[*orig_idx].rule_id.clone();
-                let outcome = match &outcomes[slot] {
+            let mut applied_this_pass: std::collections::HashSet<usize> =
+                std::collections::HashSet::new();
+            for (slot, &orig_idx) in fixable_indices.iter().enumerate() {
+                let rule_id = current_diagnostics[orig_idx].rule_id.clone();
+                match &outcomes[slot] {
                     FixOutcome::Applied => {
-                        applied_indices.insert(*orig_idx);
-                        FixOutcome::Applied
+                        applied_this_pass.insert(orig_idx);
+                        body_fix_outcomes.push((rule_id, FixOutcome::Applied));
                     }
-                    FixOutcome::Conflict { blocking_rule } => FixOutcome::Conflict {
-                        blocking_rule: blocking_rule.clone(),
-                    },
-                    FixOutcome::NoFix => FixOutcome::NoFix,
-                };
-                body_fix_outcomes.push((rule_id, outcome));
+                    FixOutcome::Conflict { blocking_rule } => {
+                        body_fix_outcomes.push((
+                            rule_id,
+                            FixOutcome::Conflict {
+                                blocking_rule: blocking_rule.clone(),
+                            },
+                        ));
+                    }
+                    FixOutcome::NoFix => body_fix_outcomes.push((rule_id, FixOutcome::NoFix)),
+                }
             }
 
-            if new_body != body_content && matches!(fix, FixMode::Apply) {
-                // Reconstruct full file: frontmatter + fixed body.
-                let frontmatter_part = &content[..body_start];
-                let new_content = format!("{frontmatter_part}{new_body}");
-                std::fs::write(full_path, &new_content)
-                    .with_context(|| format!("writing fixed body to {rel_path}"))?;
-                body_modified = true;
+            if applied_this_pass.is_empty() {
+                // Every fixable diagnostic this pass hit a conflict or
+                // turned out to be a no-op — no progress possible, stop.
+                break;
             }
+
+            for (i, d) in current_diagnostics.into_iter().enumerate() {
+                if applied_this_pass.contains(&i) {
+                    fixed_diagnostics.push(d);
+                }
+                // Diagnostics that weren't applied are dropped rather than
+                // carried forward: their byte offsets are stale against
+                // `new_body`, and any still-unresolved issue is rediscovered
+                // with correct positions by the re-lint below.
+            }
+
+            working_body = new_body;
+            current_diagnostics = engine.lint_body(
+                &working_body,
+                rel_path,
+                frontmatter_status.as_deref(),
+                schema_has_completed,
+                md_lint_config,
+                rule_filter,
+            )?;
         }
     }
 
-    // Group body diagnostics by rule.
-    for (i, d) in body_diagnostics.into_iter().enumerate() {
-        let sev = format!("{}", d.severity);
-        let fix_val = d.fix.as_ref().map(|f| {
+    if matches!(fix, FixMode::Apply) && working_body != body_content {
+        // Re-derive the frontmatter bytes fresh from disk when a
+        // frontmatter fix already landed above — `content[..body_start]` is
+        // a snapshot from before that write and would silently revert it if
+        // reused here.
+        let frontmatter_part: Cow<'_, str> = if fix_actions.is_empty() {
+            Cow::Borrowed(&content[..body_start])
+        } else {
+            let fresh = std::fs::read_to_string(full_path)
+                .with_context(|| format!("re-reading {rel_path} after frontmatter fix"))?;
+            let fresh_body_start = find_body_start(&fresh);
+            Cow::Owned(fresh[..fresh_body_start].to_owned())
+        };
+        check_mtime(full_path, mtime0)?;
+        let new_content = format!("{frontmatter_part}{working_body}");
+        hyalo_core::fs_util::atomic_write(full_path, new_content.as_bytes())
+            .with_context(|| format!("writing fixed body to {rel_path}"))?;
+        body_modified = true;
+    }
+
+    // Group body diagnostics by rule: violations fixed across any pass,
+    // followed by whatever remains after the loop above (or the single
+    // read-only lint pass, when fix-mode is off).
+    let diag_to_violation = |d: hyalo_mdlint::Diagnostic, fixed: bool| {
+        let fix = d.fix.as_ref().map(|f| {
             serde_json::json!({
                 "description": f.description,
                 "start": f.start,
@@ -2198,18 +2330,28 @@ fn lint_one_file_extended(
                 "replacement": f.replacement,
             })
         });
-        let fixed = applied_indices.contains(&i);
+        InternalViolation {
+            line: d.line,
+            column: d.column,
+            message: d.message,
+            severity: format!("{}", d.severity),
+            fix,
+            fixed,
+        }
+    };
+    for d in fixed_diagnostics {
+        let rule_id = d.rule_id.clone();
         violations_by_rule
-            .entry(d.rule_id.clone())
+            .entry(rule_id)
             .or_default()
-            .push(InternalViolation {
-                line: d.line,
-                column: d.column,
-                message: d.message,
-                severity: sev,
-                fix: fix_val,
-                fixed,
-            });
+            .push(diag_to_violation(d, true));
+    }
+    for d in current_diagnostics {
+        let rule_id = d.rule_id.clone();
+        violations_by_rule
+            .entry(rule_id)
+            .or_default()
+            .push(diag_to_violation(d, false));
     }
 
     let total_violations = violations_by_rule.values().map(Vec::len).sum();
@@ -2232,68 +2374,80 @@ fn lint_one_file_extended(
 ///
 /// Returns `(fixed_content, outcomes)` where `outcomes[i]` corresponds to
 /// `fixes[i]` — either `Applied`, `Conflict`, or (for diagnostics without a
-/// fix) `NoFix`.
+/// fix, a fix that lost a conflict, or a fix that turned out to be a
+/// byte-for-byte no-op) `NoFix`.
 ///
-/// Fixes are applied in descending start-offset order so that earlier ranges
-/// (lower offsets) remain valid against the partially mutated buffer.
+/// Conflict resolution and buffer mutation use two different orderings on
+/// purpose:
+/// - **Winner selection** happens in priority order (`Error` before `Warn`,
+///   then descending start offset), so a higher-severity fix (e.g. HYALO001)
+///   is never displaced by an overlapping lower-severity one (e.g. MD009)
+///   just because the latter happens to sort first by offset.
+/// - **Buffer mutation** of the resulting non-overlapping winners always
+///   proceeds in descending start-offset order, which is required for
+///   correctness: each edit's range must still be valid against the
+///   partially mutated buffer, and that only holds if edits at higher
+///   offsets (later in the string) are applied first.
 fn apply_body_fixes(body: &str, fixes: &[&hyalo_mdlint::Diagnostic]) -> (String, Vec<FixOutcome>) {
-    // Build (original_index, start, end) sorted by start descending.
-    let mut indexed: Vec<(usize, usize, usize)> = fixes
+    let severity_rank = |sev: hyalo_mdlint::DiagSeverity| match sev {
+        hyalo_mdlint::DiagSeverity::Error => 0,
+        hyalo_mdlint::DiagSeverity::Warn => 1,
+    };
+
+    // (original_index, start, end), ordered by selection priority.
+    let mut candidates: Vec<(usize, usize, usize)> = fixes
         .iter()
         .enumerate()
         .filter_map(|(i, d)| d.fix.as_ref().map(|f| (i, f.start, f.end)))
         .collect();
-    indexed.sort_by_key(|(_, start, _)| std::cmp::Reverse(*start));
+    candidates.sort_by(|&(ia, sa, _), &(ib, sb, _)| {
+        severity_rank(fixes[ia].severity)
+            .cmp(&severity_rank(fixes[ib].severity))
+            .then(sb.cmp(&sa))
+    });
 
-    let mut result = body.to_owned();
-    let mut applied: Vec<(usize, usize, usize)> = Vec::new(); // (orig_idx, start, end)
+    let mut winners: Vec<(usize, usize, usize)> = Vec::new(); // (orig_idx, start, end)
     let mut outcome_map: std::collections::HashMap<usize, FixOutcome> =
         std::collections::HashMap::new();
 
-    for (orig_idx, start, end) in &indexed {
-        let start = *start;
-        let end = *end;
-        // Check overlap with already-applied ranges.
-        let conflict_with = applied
-            .iter()
-            .find(|(_, as_, ae)| start < *ae && end > *as_);
+    for &(orig_idx, start, end) in &candidates {
+        let conflict_with = winners.iter().find(|(_, ws, we)| start < *we && end > *ws);
         if let Some(&(blocking_idx, _, _)) = conflict_with {
             let blocking_rule = fixes[blocking_idx].rule_id.clone();
-            outcome_map.insert(*orig_idx, FixOutcome::Conflict { blocking_rule });
+            outcome_map.insert(orig_idx, FixOutcome::Conflict { blocking_rule });
             continue;
         }
-        if end > result.len() {
-            // Out-of-bounds — treat as conflict with "bounds".
+        if end > body.len() {
             outcome_map.insert(
-                *orig_idx,
+                orig_idx,
                 FixOutcome::Conflict {
                     blocking_rule: "out-of-bounds".to_owned(),
                 },
             );
             continue;
         }
-        let replacement = fixes[*orig_idx]
+        winners.push((orig_idx, start, end));
+    }
+
+    // Mutate the buffer in descending start order (see doc comment above).
+    winners.sort_by_key(|&(_, start, _)| std::cmp::Reverse(start));
+    let mut result = body.to_owned();
+    for (orig_idx, start, end) in winners {
+        let replacement = fixes[orig_idx]
             .fix
             .as_ref()
             .map_or("", |f| f.replacement.as_str());
+        if result[start..end] == *replacement {
+            // Byte-for-byte no-op: nothing changed, don't count it as fixed.
+            outcome_map.insert(orig_idx, FixOutcome::NoFix);
+            continue;
+        }
         result.replace_range(start..end, replacement);
-        applied.push((*orig_idx, start, end));
-        outcome_map.insert(*orig_idx, FixOutcome::Applied);
+        outcome_map.insert(orig_idx, FixOutcome::Applied);
     }
 
-    // Build outcomes in original order.
     let outcomes: Vec<FixOutcome> = (0..fixes.len())
-        .map(|i| {
-            outcome_map.remove(&i).unwrap_or_else(|| {
-                if fixes[i].fix.is_some() {
-                    // Had a fix but not selected — NoFix (shouldn't happen since we
-                    // only pass fixable diagnostics, but be safe).
-                    FixOutcome::NoFix
-                } else {
-                    FixOutcome::NoFix
-                }
-            })
-        })
+        .map(|i| outcome_map.remove(&i).unwrap_or(FixOutcome::NoFix))
         .collect();
 
     (result, outcomes)
@@ -2301,8 +2455,14 @@ fn apply_body_fixes(body: &str, fixes: &[&hyalo_mdlint::Diagnostic]) -> (String,
 
 /// Find the byte offset where the document body starts (after the closing `---` line).
 /// Returns 0 if no frontmatter is found.
+///
+/// The opening check mirrors the shared frontmatter policy (iter-158 C-1):
+/// an optional single UTF-8 BOM, then a line that is exactly `---` — so lint
+/// splits BOM-prefixed files the same way the read/write paths do instead of
+/// treating the whole file as body.
 fn find_body_start(content: &str) -> usize {
-    if !content.starts_with("---") {
+    let rest = content.strip_prefix('\u{feff}').unwrap_or(content);
+    if !(rest.starts_with("---\n") || rest.starts_with("---\r\n") || rest == "---") {
         return 0;
     }
     // Find the second `---` delimiter.
@@ -3157,5 +3317,101 @@ mod tests {
             section_viols.is_empty(),
             "extra headings should not cause violations, got: {section_viols:?}"
         );
+    }
+
+    // --- apply_body_fixes ---
+
+    fn mk_diag(
+        rule_id: &str,
+        severity: hyalo_mdlint::DiagSeverity,
+        start: usize,
+        end: usize,
+        replacement: &str,
+    ) -> hyalo_mdlint::Diagnostic {
+        hyalo_mdlint::Diagnostic {
+            rule_id: rule_id.to_owned(),
+            rule_name: rule_id.to_owned(),
+            message: String::new(),
+            line: 1,
+            column: 1,
+            severity,
+            fix: Some(hyalo_mdlint::DiagFix {
+                description: String::new(),
+                start,
+                end,
+                replacement: replacement.to_owned(),
+            }),
+        }
+    }
+
+    #[test]
+    fn apply_body_fixes_error_wins_overlap_regardless_of_offset() {
+        // Two fixes over the same range: a Warn fix that would sort first by
+        // descending-offset (its start is >= the Error fix's start) must not
+        // beat the overlapping Error fix.
+        let warn = mk_diag("MD009", hyalo_mdlint::DiagSeverity::Warn, 0, 10, "warn-fix");
+        let error = mk_diag(
+            "HYALO001",
+            hyalo_mdlint::DiagSeverity::Error,
+            0,
+            10,
+            "error-fix",
+        );
+        let (result, outcomes) = apply_body_fixes("0123456789", &[&warn, &error]);
+        assert_eq!(result, "error-fix");
+        assert!(matches!(outcomes[1], FixOutcome::Applied));
+        assert!(matches!(outcomes[0], FixOutcome::Conflict { .. }));
+    }
+
+    #[test]
+    fn apply_body_fixes_no_op_replacement_is_not_applied() {
+        let noop = mk_diag("MD047", hyalo_mdlint::DiagSeverity::Warn, 4, 5, "\n");
+        let (result, outcomes) = apply_body_fixes("body\n", &[&noop]);
+        assert_eq!(result, "body\n", "content must not change");
+        assert!(
+            matches!(outcomes[0], FixOutcome::NoFix),
+            "byte-for-byte no-op must not be reported as Applied: {:?}",
+            outcomes[0]
+        );
+    }
+
+    #[test]
+    fn apply_body_fixes_non_overlapping_fixes_both_apply() {
+        let a = mk_diag("MD009", hyalo_mdlint::DiagSeverity::Warn, 0, 1, "A");
+        let b = mk_diag("MD009", hyalo_mdlint::DiagSeverity::Warn, 2, 3, "B");
+        let (result, outcomes) = apply_body_fixes("xyz", &[&a, &b]);
+        assert_eq!(result, "AyB");
+        assert!(matches!(outcomes[0], FixOutcome::Applied));
+        assert!(matches!(outcomes[1], FixOutcome::Applied));
+    }
+
+    // --- group_severity ---
+
+    fn iv(severity: &str) -> InternalViolation {
+        InternalViolation {
+            line: 1,
+            column: 1,
+            message: String::new(),
+            severity: severity.to_owned(),
+            fix: None,
+            fixed: false,
+        }
+    }
+
+    #[test]
+    fn group_severity_is_error_when_any_violation_is_error() {
+        let violations = vec![iv("warn"), iv("error"), iv("warn")];
+        assert_eq!(group_severity(&violations), "error");
+    }
+
+    #[test]
+    fn group_severity_is_warn_when_all_warn() {
+        let violations = vec![iv("warn"), iv("warn")];
+        assert_eq!(group_severity(&violations), "warn");
+    }
+
+    #[test]
+    fn group_severity_empty_defaults_to_warn() {
+        assert_eq!(group_severity(&[]), "warn");
     }
 }

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -2471,8 +2471,12 @@ fn find_body_start(content: &str) -> usize {
     if let Some(pos) = rest.find("\n---") {
         // Skip past `\n---\n` or `\n---` at end.
         let abs = after_first + pos + 4; // skip \n---
-        // Skip the trailing newline after `---`.
-        if abs < content.len() && content.as_bytes()[abs] == b'\n' {
+        // Skip the terminator after the closing `---` — LF or CRLF, so the
+        // body slice never starts with a stray carriage return on CRLF files.
+        let bytes = content.as_bytes();
+        if bytes.get(abs) == Some(&b'\r') && bytes.get(abs + 1) == Some(&b'\n') {
+            abs + 2
+        } else if bytes.get(abs) == Some(&b'\n') {
             abs + 1
         } else {
             abs
@@ -3383,6 +3387,38 @@ mod tests {
         assert_eq!(result, "AyB");
         assert!(matches!(outcomes[0], FixOutcome::Applied));
         assert!(matches!(outcomes[1], FixOutcome::Applied));
+    }
+
+    #[test]
+    fn apply_body_fixes_adjacent_touching_ranges_both_apply() {
+        // end == start is NOT an overlap (strict inequalities in the
+        // conflict check): [0,2) and [2,4) must both apply.
+        let a = mk_diag("MD009", hyalo_mdlint::DiagSeverity::Warn, 0, 2, "AA");
+        let b = mk_diag("MD009", hyalo_mdlint::DiagSeverity::Warn, 2, 4, "BB");
+        let (result, outcomes) = apply_body_fixes("wxyz", &[&a, &b]);
+        assert_eq!(result, "AABB");
+        assert!(matches!(outcomes[0], FixOutcome::Applied));
+        assert!(matches!(outcomes[1], FixOutcome::Applied));
+    }
+
+    // --- find_body_start line-ending handling ---
+
+    #[test]
+    fn find_body_start_skips_crlf_after_closing_delimiter() {
+        let content = "---\r\ntitle: T\r\n---\r\nbody line\r\n";
+        let start = find_body_start(content);
+        assert_eq!(
+            &content[start..],
+            "body line\r\n",
+            "body must not start with a stray CR on CRLF files"
+        );
+    }
+
+    #[test]
+    fn find_body_start_bom_prefixed_frontmatter_is_split() {
+        let content = "\u{feff}---\ntitle: T\n---\nbody line\n";
+        let start = find_body_start(content);
+        assert_eq!(&content[start..], "body line\n");
     }
 
     // --- group_severity ---

--- a/crates/hyalo-cli/src/commands/mutation.rs
+++ b/crates/hyalo-cli/src/commands/mutation.rs
@@ -24,7 +24,11 @@ use hyalo_core::index::{SnapshotIndex, format_modified};
 ///
 /// Extracts the new tag set from the already-updated `props`, writes
 /// `properties`, `tags`, and `modified` back into the in-memory entry, then
-/// marks `index_dirty` so the caller knows a save is needed.
+/// re-scans the file to refresh its `links` field and the persisted
+/// [`hyalo_core::link_graph::LinkGraph`] — frontmatter link properties
+/// (`related`, `depends-on`, ...) feed the graph, so a property mutation can
+/// change a file's outbound edges. Finally marks `index_dirty` so the caller
+/// knows a save is needed.
 ///
 /// This is a no-op when `snapshot_index` is `None` or when the entry for
 /// `rel_path` is not present in the index (e.g. a newly created file that
@@ -43,6 +47,7 @@ pub fn update_index_entry(
         entry.properties = props;
         entry.tags = new_tags;
         entry.modified = format_modified(full_path)?;
+        idx.refresh_links(full_path, rel_path)?;
         *index_dirty = true;
     }
     Ok(())

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::commands::mutation;
 use crate::output::{CommandOutcome, Format};
-use hyalo_core::discovery::{discover_files, match_globs};
+use hyalo_core::discovery::{canonicalize_vault_dir, discover_files, match_globs};
 use hyalo_core::filter::{PropertyFilter, matches_frontmatter_filters};
 use hyalo_core::index::SnapshotIndex;
 use hyalo_core::link_rewrite::{self, Replacement, RewritePlan, SkippedAmbiguous};
@@ -382,6 +382,29 @@ fn build_rename_map(
     // Drop no-op renames (source already at destination).
     proposed.retain(|(old_rel, new_rel)| old_rel != new_rel);
 
+    // H-3: reject destinations that would escape the vault through a
+    // symlinked directory component, even when the destination's parent
+    // directories don't exist yet. Checked before any fs mutation so the
+    // whole batch fails atomically rather than escaping partway through.
+    if !proposed.is_empty() {
+        let canonical_vault = canonicalize_vault_dir(dir).map_err(|e| {
+            let out = crate::output::format_error(
+                format,
+                "failed to canonicalize vault directory",
+                Some(&e.to_string()),
+                None,
+                None,
+            );
+            CommandOutcome::UserError(out)
+        })?;
+        for (_, new_rel) in &proposed {
+            if let Err(msg) = ensure_dest_within_vault(&canonical_vault, dir, new_rel) {
+                let out = crate::output::format_error(format, &msg, Some(new_rel), None, None);
+                return Err(CommandOutcome::UserError(out));
+            }
+        }
+    }
+
     // Detect basename collisions (two sources mapping to the same dest).
     let mut dest_to_sources: HashMap<String, Vec<String>> = HashMap::new();
     for (src, dst) in &proposed {
@@ -493,6 +516,17 @@ fn build_rename_map(
 /// On failure of any rename, roll back already-applied renames.
 /// If link rewrite fails after renames succeeded, also rolls back renames.
 fn execute_batch_mv(dir: &Path, renames: &[(String, String)], plans: &[RewritePlan]) -> Result<()> {
+    // H-3 defense-in-depth: re-verify every destination stays within the
+    // vault right before mutating the filesystem. `build_rename_map` already
+    // rejects escaping destinations, but this guard makes the invariant
+    // explicit here too and survives future refactors (mirrors the same
+    // check in `link_rewrite::execute_plans`).
+    let canonical_vault = canonicalize_vault_dir(dir)
+        .context("failed to canonicalize vault directory for write safety check")?;
+    for (_, new_rel) in renames {
+        ensure_dest_within_vault(&canonical_vault, dir, new_rel).map_err(anyhow::Error::msg)?;
+    }
+
     // Capture source mtimes upfront to detect concurrent modifications.
     let mut src_mtimes: Vec<(String, String, (std::time::SystemTime, u64))> = Vec::new();
     for (old_rel, new_rel) in renames {
@@ -570,6 +604,57 @@ fn execute_batch_mv(dir: &Path, renames: &[(String, String)], plans: &[RewritePl
 // ---------------------------------------------------------------------------
 // Validation helpers
 // ---------------------------------------------------------------------------
+
+/// Walk up from `path` to find the nearest ancestor that exists on disk.
+///
+/// Used to find a safe point to canonicalize when the destination itself
+/// (and possibly several of its parent directories) doesn't exist yet.
+fn nearest_existing_ancestor(path: &Path) -> PathBuf {
+    let mut current = path;
+    loop {
+        if current.exists() {
+            return current.to_path_buf();
+        }
+        match current.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => current = parent,
+            _ => return current.to_path_buf(),
+        }
+    }
+}
+
+/// Verify that a prospective destination `new_rel` (relative to `dir`) stays
+/// within the vault, even when its parent directories don't exist yet or an
+/// in-vault path component is a symlink that resolves outside the vault
+/// (H-3).
+///
+/// `fs::create_dir_all` only ever creates plain directories — never symlinks
+/// — so canonicalizing the nearest *existing* ancestor of the destination and
+/// checking it resolves inside `canonical_vault` is sufficient to guarantee
+/// every path component that would be created below it also stays in the
+/// vault. Must be called before any `fs::create_dir_all`/`fs::rename` on the
+/// destination.
+fn ensure_dest_within_vault(
+    canonical_vault: &Path,
+    dir: &Path,
+    new_rel: &str,
+) -> std::result::Result<(), String> {
+    let dst = dir.join(new_rel);
+    let start = dst.parent().unwrap_or(dir);
+    let ancestor = nearest_existing_ancestor(start);
+    let canonical_ancestor = dunce::canonicalize(&ancestor).map_err(|e| {
+        format!(
+            "failed to verify destination {} stays within the vault: {e}",
+            ancestor.display()
+        )
+    })?;
+    if canonical_ancestor.starts_with(canonical_vault) {
+        Ok(())
+    } else {
+        Err(format!(
+            "target path resolves outside vault boundary: {new_rel}"
+        ))
+    }
+}
 
 /// Validate the `--to` argument for single-file mode.
 /// Returns vault-relative normalized path or a CommandOutcome error.
@@ -652,6 +737,27 @@ fn validate_target_single(
         return Err(CommandOutcome::UserError(out));
     }
 
+    // H-3: reject destinations that would escape the vault through a
+    // symlinked directory component, even when the target's parent
+    // directories don't exist yet.
+    let canonical_vault = match canonicalize_vault_dir(dir) {
+        Ok(c) => c,
+        Err(e) => {
+            let out = crate::output::format_error(
+                format,
+                "failed to canonicalize vault directory",
+                Some(&e.to_string()),
+                None,
+                None,
+            );
+            return Err(CommandOutcome::UserError(out));
+        }
+    };
+    if let Err(msg) = ensure_dest_within_vault(&canonical_vault, dir, &normalized) {
+        let out = crate::output::format_error(format, &msg, Some(&normalized), None, None);
+        return Err(CommandOutcome::UserError(out));
+    }
+
     Ok(normalized)
 }
 
@@ -727,6 +833,15 @@ fn execute_mv(
 ) -> Result<()> {
     let src = dir.join(old_rel);
     let dst = dir.join(new_rel);
+
+    // H-3 defense-in-depth: re-verify the destination stays within the vault
+    // right before mutating the filesystem. `validate_target_single` already
+    // rejects escaping destinations, but this guard makes the invariant
+    // explicit here too and survives future refactors (mirrors the same
+    // check in `link_rewrite::execute_plans`).
+    let canonical_vault = canonicalize_vault_dir(dir)
+        .context("failed to canonicalize vault directory for write safety check")?;
+    ensure_dest_within_vault(&canonical_vault, dir, new_rel).map_err(anyhow::Error::msg)?;
 
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -5,7 +5,6 @@ use anyhow::{Context, Result};
 use hyalo_core::frontmatter;
 use hyalo_core::heading::{SectionFilter, parse_atx_heading};
 use hyalo_core::scanner;
-use std::io::BufRead;
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
@@ -138,35 +137,69 @@ fn collect_headings(body_lines: &[String]) -> Vec<String> {
 // Read body lines from file (raw, no stripping)
 // ---------------------------------------------------------------------------
 
+/// Placeholder pushed in place of a body line that exceeds
+/// [`scanner::MAX_BODY_LINE_BYTES`] (mirrors the scanner's own per-line cap;
+/// see [`scanner::read_line_capped`]).
+///
+/// A real dropped line would shift every subsequent 1-based line number, which
+/// would silently corrupt `--lines`/`--section` addressing — so the line's
+/// *position* is preserved even though its content is not.
+fn oversized_line_placeholder() -> String {
+    format!(
+        "<line skipped: exceeds {} MiB per-line limit>",
+        scanner::MAX_BODY_LINE_BYTES / (1024 * 1024)
+    )
+}
+
 /// Read the raw body lines from a markdown file, skipping frontmatter.
 /// Returns the lines with their trailing newlines stripped.
+///
+/// Uses [`scanner::read_line_capped`] rather than `BufRead::lines()` so a
+/// single pathological line (e.g. a minified blob with no newlines) cannot
+/// balloon memory — such a line is replaced with [`oversized_line_placeholder`]
+/// instead of being buffered in full.
 fn read_body_lines(path: &Path) -> Result<Vec<String>> {
     let file =
         std::fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
     let mut reader = std::io::BufReader::new(file);
 
-    // Read first line to check for frontmatter
+    // Read first line (capped) to check for frontmatter.
     let mut first_line = String::new();
-    let n = reader
-        .read_line(&mut first_line)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let (n, first_truncated) =
+        scanner::read_line_capped(&mut reader, &mut first_line, scanner::MAX_BODY_LINE_BYTES)
+            .with_context(|| format!("failed to read {}", path.display()))?;
     if n == 0 {
         return Ok(Vec::new());
     }
 
-    let first_trimmed = first_line.trim_end_matches(['\n', '\r']);
-    let fm_lines = frontmatter::skip_frontmatter(&mut reader, first_trimmed)?;
-
     let mut lines = Vec::new();
 
-    if fm_lines == 0 {
-        // No frontmatter — first line is body content
-        lines.push(first_trimmed.to_owned());
+    if first_truncated {
+        // A real `---` frontmatter delimiter is 3 bytes, so a line this long
+        // can only be body content.
+        lines.push(oversized_line_placeholder());
+    } else {
+        let first_trimmed = first_line.trim_end_matches(['\n', '\r']);
+        let fm_lines = frontmatter::skip_frontmatter(&mut reader, first_trimmed)?;
+        if fm_lines == 0 {
+            // No frontmatter — first line is body content
+            lines.push(first_trimmed.to_owned());
+        }
     }
 
-    for line_result in reader.lines() {
-        let line = line_result.with_context(|| format!("failed to read {}", path.display()))?;
-        lines.push(line);
+    loop {
+        let mut buf = String::new();
+        let (n, truncated) =
+            scanner::read_line_capped(&mut reader, &mut buf, scanner::MAX_BODY_LINE_BYTES)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        if truncated {
+            lines.push(oversized_line_placeholder());
+        } else {
+            lines.push(buf.trim_end_matches(['\n', '\r']).to_owned());
+        }
     }
 
     Ok(lines)
@@ -190,6 +223,27 @@ pub fn run(
         Ok(r) => r,
         Err(e) => return Ok(super::resolve_error_to_outcome(e, format)),
     };
+
+    // `read` targets one explicit file, so — unlike the read-only scanner,
+    // which silently skips oversized files across a whole vault — an
+    // oversized target here must be a hard, clear error rather than a
+    // silent skip or an unbounded read.
+    let file_size = std::fs::metadata(&full_path)
+        .with_context(|| format!("failed to stat {}", full_path.display()))?
+        .len();
+    if file_size > scanner::MAX_FILE_SIZE {
+        return Ok(CommandOutcome::UserError(format_error(
+            format,
+            &format!(
+                "file too large to read ({} MiB exceeds {} MiB limit)",
+                file_size / (1024 * 1024),
+                scanner::MAX_FILE_SIZE / (1024 * 1024)
+            ),
+            Some(&rel_path),
+            None,
+            None,
+        )));
+    }
 
     // Parse line range early so we fail fast on bad input
     let line_range = if let Some(range_str) = lines {
@@ -346,6 +400,90 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- read_body_lines: per-line memory cap --
+
+    #[test]
+    fn read_body_lines_normal_file_unchanged() {
+        // Pin exact output for an ordinary small file — the capped reader must
+        // be byte-for-byte equivalent to the old `BufRead::lines()` loop.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("normal.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: T\n---\nLine one\nLine two\nLine three\n",
+        )
+        .unwrap();
+
+        let lines = read_body_lines(&path).unwrap();
+        assert_eq!(lines, vec!["Line one", "Line two", "Line three"]);
+    }
+
+    #[test]
+    fn read_body_lines_no_frontmatter_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("normal.md");
+        std::fs::write(&path, "# Heading\n\nBody text\n").unwrap();
+
+        let lines = read_body_lines(&path).unwrap();
+        assert_eq!(lines, vec!["# Heading", "", "Body text"]);
+    }
+
+    #[test]
+    fn read_body_lines_oversized_middle_line_is_placeholdered() {
+        // A line exceeding MAX_BODY_LINE_BYTES must not be buffered whole —
+        // it is replaced with a placeholder, and surrounding lines survive
+        // with their positions intact (mirrors the scanner's per-line cap).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("huge-line.md");
+        let huge: String = "x".repeat(scanner::MAX_BODY_LINE_BYTES + 1);
+        let content = format!("before\n{huge}\nafter\n");
+        std::fs::write(&path, &content).unwrap();
+
+        let lines = read_body_lines(&path).unwrap();
+        assert_eq!(lines.len(), 3, "line count must be preserved: {lines:?}");
+        assert_eq!(lines[0], "before");
+        assert_ne!(lines[1], huge, "oversized line must not be buffered whole");
+        assert!(
+            lines[1].contains("skipped"),
+            "expected placeholder, got: {}",
+            lines[1]
+        );
+        assert_eq!(
+            lines[2], "after",
+            "line position after the skip must survive"
+        );
+    }
+
+    #[test]
+    fn read_body_lines_oversized_first_line_no_frontmatter_confusion() {
+        // A file whose very first line alone exceeds the cap can't possibly be
+        // a valid `---` frontmatter delimiter — it must be treated as body.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("huge-first.md");
+        let huge: String = "y".repeat(scanner::MAX_BODY_LINE_BYTES + 1);
+        std::fs::write(&path, format!("{huge}\nafter\n")).unwrap();
+
+        let lines = read_body_lines(&path).unwrap();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("skipped"));
+        assert_eq!(lines[1], "after");
+    }
+
+    #[test]
+    fn read_body_lines_line_exactly_at_cap_passes_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("exact.md");
+        let exact: String = "z".repeat(scanner::MAX_BODY_LINE_BYTES);
+        std::fs::write(&path, format!("{exact}\nnext\n")).unwrap();
+
+        let lines = read_body_lines(&path).unwrap();
+        assert_eq!(
+            lines[0], exact,
+            "line at the limit must pass through intact"
+        );
+        assert_eq!(lines[1], "next");
+    }
 
     // -- parse_line_range --
 

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -368,7 +368,13 @@ fn inject_ext_file_result(
 
 /// Patch the snapshot index for a list of vault-relative paths that were
 /// modified on disk.  Uses `refresh_entry` to fully re-scan each file
-/// (properties, tags, links, sections, tasks), then flushes to disk once.
+/// (properties, tags, links, sections, tasks, modified timestamp), then
+/// `refresh_links` to patch the persisted `LinkGraph`'s outbound edges —
+/// `refresh_entry` alone does not touch the graph (see its doc comment),
+/// so callers whose modification rewrites body wikilinks (`links fix
+/// --apply`, `links auto --apply`) need both or `backlinks`/`find --fields
+/// links` would keep returning pre-mutation results until a full
+/// `create-index` rebuild. Flushes to disk once at the end.
 fn patch_index_for_modified_files(
     snapshot_index: &mut Option<SnapshotIndex>,
     index_path: Option<&Path>,
@@ -388,6 +394,15 @@ fn patch_index_for_modified_files(
             Ok(false) => {} // not in index, nothing to update
             Err(e) => {
                 eprintln!("warning: could not refresh index entry for {rel}: {e:#}");
+                continue;
+            }
+        }
+        let full_path = dir.join(rel);
+        match idx.refresh_links(&full_path, rel) {
+            Ok(true) => dirty = true,
+            Ok(false) => {} // not in index, nothing to update
+            Err(e) => {
+                eprintln!("warning: could not refresh link graph for {rel}: {e:#}");
             }
         }
     }
@@ -471,14 +486,26 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             {
                 Ok(f) => f,
                 Err(e) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e.to_string(),
+                        None,
+                        None,
+                        None,
+                    )));
                 }
             };
             // Parse task filter
             let task_filter = match task.as_deref().map(filter::parse_task_filter) {
                 Some(Ok(f)) => Some(f),
                 Some(Err(e)) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e.to_string(),
+                        None,
+                        None,
+                        None,
+                    )));
                 }
                 None => None,
             };
@@ -486,14 +513,26 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let parsed_fields = match filter::Fields::parse(&fields) {
                 Ok(f) => f,
                 Err(e) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e.to_string(),
+                        None,
+                        None,
+                        None,
+                    )));
                 }
             };
             // Parse sort
             let sort_field = match sort.as_deref().map(filter::parse_sort) {
                 Some(Ok(f)) => Some(f),
                 Some(Err(e)) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e.to_string(),
+                        None,
+                        None,
+                        None,
+                    )));
                 }
                 None => None,
             };
@@ -505,13 +544,25 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             {
                 Ok(f) => f,
                 Err(e) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e,
+                        None,
+                        None,
+                        None,
+                    )));
                 }
             };
 
             for t in &tag {
                 if let Err(msg) = crate::commands::tags::validate_tag(t) {
-                    return Ok(CommandOutcome::UserError(format!("Error: {msg}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &msg,
+                        None,
+                        None,
+                        None,
+                    )));
                 }
             }
 
@@ -519,15 +570,23 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             if let Some(ref lang) = language
                 && let Err(e) = parse_language(lang)
             {
-                return Ok(CommandOutcome::UserError(format!(
-                    "invalid --language value {lang:?}: {e}"
+                return Ok(CommandOutcome::UserError(crate::output::format_error(
+                    effective_format,
+                    &format!("invalid --language value {lang:?}: {e}"),
+                    None,
+                    None,
+                    None,
                 )));
             }
             if let Some(cfg_lang) = ctx.config_language
                 && let Err(e) = parse_language(cfg_lang)
             {
-                return Ok(CommandOutcome::UserError(format!(
-                    "invalid [search].language config value {cfg_lang:?}: {e}"
+                return Ok(CommandOutcome::UserError(crate::output::format_error(
+                    effective_format,
+                    &format!("invalid [search].language config value {cfg_lang:?}: {e}"),
+                    None,
+                    None,
+                    None,
                 )));
             }
 
@@ -1118,7 +1177,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
                 Err(e) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e,
+                        None,
+                        None,
+                        None,
+                    )));
                 }
             };
             let do_validate = validate || ctx.validate_on_write;
@@ -1156,7 +1221,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
                 Err(e) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e,
+                        None,
+                        None,
+                        None,
+                    )));
                 }
             };
             remove_commands::remove(
@@ -1191,7 +1262,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let where_prop_filters = match parse_where_filters(&where_properties, &where_tags) {
                 Ok(f) => f,
                 Err(e) => {
-                    return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e,
+                        None,
+                        None,
+                        None,
+                    )));
                 }
             };
             let do_validate = validate || ctx.validate_on_write;
@@ -1284,7 +1361,15 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 .collect::<Result<Vec<_>, _>>()
             {
                 Ok(f) => f,
-                Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+                Err(e) => {
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        effective_format,
+                        &e.to_string(),
+                        None,
+                        None,
+                        None,
+                    )));
+                }
             };
             // Build type filters as additional property filters (type=<value>)
             let type_filters: Vec<hyalo_core::filter::PropertyFilter> = {
@@ -1292,7 +1377,15 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 for t in &r#type {
                     match hyalo_core::filter::parse_property_filter(&format!("type={t}")) {
                         Ok(f) => tf.push(f),
-                        Err(e) => return Ok(CommandOutcome::UserError(format!("Error: {e}"))),
+                        Err(e) => {
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &e.to_string(),
+                                None,
+                                None,
+                                None,
+                            )));
+                        }
                     }
                 }
                 tf
@@ -1304,9 +1397,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let has_file = file_positional.is_some() || file.is_some();
 
             if !has_selectors && !has_file {
-                return Ok(CommandOutcome::UserError(
-                    "Error: no source selection provided: pass a FILE (single-file mode) or at least one of --glob/--property/--tag/--type (batch mode)".to_string(),
-                ));
+                return Ok(CommandOutcome::UserError(crate::output::format_error(
+                    effective_format,
+                    "no source selection provided: pass a FILE (single-file mode) or at least one of --glob/--property/--tag/--type (batch mode)",
+                    None,
+                    None,
+                    None,
+                )));
             }
 
             let is_batch = has_selectors;
@@ -1315,7 +1412,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 // Validate tag filters.
                 for t in &tag {
                     if let Err(msg) = crate::commands::tags::validate_tag(t) {
-                        return Ok(CommandOutcome::UserError(format!("Error: {msg}")));
+                        return Ok(CommandOutcome::UserError(crate::output::format_error(
+                            effective_format,
+                            &msg,
+                            None,
+                            None,
+                            None,
+                        )));
                     }
                 }
 
@@ -1341,7 +1444,15 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             } else {
                 let file = match resolve_single_file(file_positional, file) {
                     Ok(f) => f,
-                    Err(e) => return Ok(CommandOutcome::UserError(format!("{e}"))),
+                    Err(e) => {
+                        return Ok(CommandOutcome::UserError(crate::output::format_error(
+                            effective_format,
+                            &e.to_string(),
+                            None,
+                            None,
+                            None,
+                        )));
+                    }
                 };
                 let effective_dry_run = dry_run;
                 mv_commands::mv(
@@ -1766,9 +1877,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     mut filters,
                 } => {
                     if pattern.is_some() && filters.regexp.is_some() {
-                        return Ok(CommandOutcome::UserError(
-                            "Error: PATTERN and --regexp are mutually exclusive".to_owned(),
-                        ));
+                        return Ok(CommandOutcome::UserError(crate::output::format_error(
+                            effective_format,
+                            "PATTERN and --regexp are mutually exclusive",
+                            None,
+                            None,
+                            None,
+                        )));
                     }
                     filters.pattern = pattern;
                     crate::commands::views::set_view(
@@ -1795,8 +1910,12 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                             filters.merge_from(&overlay);
                         }
                         None => {
-                            return Ok(CommandOutcome::UserError(format!(
-                                "Error: unknown view '{name}'\n\n  tip: run 'hyalo views list' to see available views"
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &format!("unknown view '{name}'"),
+                                None,
+                                Some("run 'hyalo views list' to see available views"),
+                                None,
                             )));
                         }
                     }
@@ -1828,21 +1947,35 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     }
                     for t in &tag {
                         if let Err(msg) = crate::commands::tags::validate_tag(t) {
-                            return Ok(CommandOutcome::UserError(format!("Error: {msg}")));
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &msg,
+                                None,
+                                None,
+                                None,
+                            )));
                         }
                     }
                     if let Some(ref lang) = language
                         && let Err(e) = parse_language(lang)
                     {
-                        return Ok(CommandOutcome::UserError(format!(
-                            "invalid --language value {lang:?}: {e}"
+                        return Ok(CommandOutcome::UserError(crate::output::format_error(
+                            effective_format,
+                            &format!("invalid --language value {lang:?}: {e}"),
+                            None,
+                            None,
+                            None,
                         )));
                     }
                     if let Some(cfg_lang) = ctx.config_language
                         && let Err(e) = parse_language(cfg_lang)
                     {
-                        return Ok(CommandOutcome::UserError(format!(
-                            "invalid [search].language config value {cfg_lang:?}: {e}"
+                        return Ok(CommandOutcome::UserError(crate::output::format_error(
+                            effective_format,
+                            &format!("invalid [search].language config value {cfg_lang:?}: {e}"),
+                            None,
+                            None,
+                            None,
                         )));
                     }
                     let prop_filters: Vec<filter::PropertyFilter> = match properties
@@ -1852,26 +1985,50 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     {
                         Ok(f) => f,
                         Err(e) => {
-                            return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &e.to_string(),
+                                None,
+                                None,
+                                None,
+                            )));
                         }
                     };
                     let task_filter = match task.as_deref().map(filter::parse_task_filter) {
                         Some(Ok(f)) => Some(f),
                         Some(Err(e)) => {
-                            return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &e.to_string(),
+                                None,
+                                None,
+                                None,
+                            )));
                         }
                         None => None,
                     };
                     let parsed_fields = match filter::Fields::parse(&fields) {
                         Ok(f) => f,
                         Err(e) => {
-                            return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &e.to_string(),
+                                None,
+                                None,
+                                None,
+                            )));
                         }
                     };
                     let sort_field = match sort.as_deref().map(filter::parse_sort) {
                         Some(Ok(f)) => Some(f),
                         Some(Err(e)) => {
-                            return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &e.to_string(),
+                                None,
+                                None,
+                                None,
+                            )));
                         }
                         None => None,
                     };
@@ -1882,7 +2039,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     {
                         Ok(f) => f,
                         Err(e) => {
-                            return Ok(CommandOutcome::UserError(format!("Error: {e}")));
+                            return Ok(CommandOutcome::UserError(crate::output::format_error(
+                                effective_format,
+                                &e,
+                                None,
+                                None,
+                                None,
+                            )));
                         }
                     };
                     let file: Vec<String> = file

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -367,11 +367,10 @@ fn inject_ext_file_result(
 }
 
 /// Patch the snapshot index for a list of vault-relative paths that were
-/// modified on disk.  Uses `refresh_entry` to fully re-scan each file
-/// (properties, tags, links, sections, tasks, modified timestamp), then
-/// `refresh_links` to patch the persisted `LinkGraph`'s outbound edges —
-/// `refresh_entry` alone does not touch the graph (see its doc comment),
-/// so callers whose modification rewrites body wikilinks (`links fix
+/// modified on disk.  Uses `refresh_entry_and_links` to re-scan each file
+/// once, refreshing the full entry (properties, tags, links, sections,
+/// tasks, modified timestamp) AND the persisted `LinkGraph`'s outbound
+/// edges — callers whose modification rewrites body wikilinks (`links fix
 /// --apply`, `links auto --apply`) need both or `backlinks`/`find --fields
 /// links` would keep returning pre-mutation results until a full
 /// `create-index` rebuild. Flushes to disk once at the end.
@@ -389,20 +388,11 @@ fn patch_index_for_modified_files(
     };
     let mut dirty = false;
     for rel in modified_files {
-        match idx.refresh_entry(dir, rel) {
+        match idx.refresh_entry_and_links(dir, rel) {
             Ok(true) => dirty = true,
             Ok(false) => {} // not in index, nothing to update
             Err(e) => {
                 eprintln!("warning: could not refresh index entry for {rel}: {e:#}");
-                continue;
-            }
-        }
-        let full_path = dir.join(rel);
-        match idx.refresh_links(&full_path, rel) {
-            Ok(true) => dirty = true,
-            Ok(false) => {} // not in index, nothing to update
-            Err(e) => {
-                eprintln!("warning: could not refresh link graph for {rel}: {e:#}");
             }
         }
     }

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -113,7 +113,12 @@ impl Format {
 ///
 /// Removes bytes 0x00-0x08, 0x0B-0x0C, 0x0E-0x1F, 0x7F, and 0x9B-0x9F
 /// (C0/C1 control codes minus `\n` (0x0A) and `\t` (0x09)).
-fn sanitize_control_chars(s: &str) -> String {
+///
+/// `pub(crate)` so `CommandOutcome::RawOutput` print sites (which bypass the
+/// JSON pipeline and therefore never pass through [`format_success`] /
+/// [`format_envelope`]) can sanitize file-derived content before writing it
+/// to the terminal — see `output_pipeline.rs` and `run.rs`.
+pub(crate) fn sanitize_control_chars(s: &str) -> String {
     s.chars()
         .filter(|&c| {
             // Keep printable chars, newline, and tab

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -5,7 +5,11 @@ use crate::hints::{FilesFromCounterSummary, HintContext, generate_hints_with_cou
 use crate::output::{CommandOutcome, Format, apply_jq_filter_result, build_envelope_value};
 
 /// Error message for `--count` on non-list commands (shared across match arms).
-pub(crate) const COUNT_UNSUPPORTED_ERROR: &str = "Error: --count is only supported for list commands (find, tags summary, properties summary, backlinks, lint)";
+///
+/// Deliberately has no "Error: " prefix baked in — callers route it through
+/// [`crate::output::format_error`] so it renders correctly under both
+/// `--format text` (which adds the prefix) and `--format json`.
+pub(crate) const COUNT_UNSUPPORTED_ERROR: &str = "--count is only supported for list commands (find, tags summary, properties summary, backlinks, lint)";
 
 /// Encapsulates the post-command output pipeline: jq filtering, hint generation,
 /// and envelope wrapping.
@@ -84,7 +88,16 @@ impl OutputPipeline<'_> {
                         println!("{n}");
                         return 0;
                     }
-                    eprintln!("{COUNT_UNSUPPORTED_ERROR}");
+                    eprintln!(
+                        "{}",
+                        crate::output::format_error(
+                            self.user_format,
+                            COUNT_UNSUPPORTED_ERROR,
+                            None,
+                            None,
+                            None,
+                        )
+                    );
                     return 2;
                 }
 
@@ -164,7 +177,16 @@ impl OutputPipeline<'_> {
             }
             Ok(CommandOutcome::RawOutput(output)) => {
                 if self.count {
-                    eprintln!("{COUNT_UNSUPPORTED_ERROR}");
+                    eprintln!(
+                        "{}",
+                        crate::output::format_error(
+                            self.user_format,
+                            COUNT_UNSUPPORTED_ERROR,
+                            None,
+                            None,
+                            None,
+                        )
+                    );
                     return 2;
                 }
                 // Raw output bypasses the JSON pipeline — print directly to stdout.
@@ -172,7 +194,12 @@ impl OutputPipeline<'_> {
                 // println! matches pre-refactor behavior: the content string already ends
                 // with '\n', and the extra newline from println! preserves empty-line
                 // endings (e.g. `--lines :2` where line 2 is blank).
-                println!("{output}");
+                //
+                // Sanitized here (unlike the JSON pipeline above) because RawOutput
+                // is raw file body content that never passes through format_success/
+                // format_envelope — without this, a vault file containing ANSI escapes
+                // or other control bytes would inject them straight into the terminal.
+                println!("{}", crate::output::sanitize_control_chars(&output));
                 0
             }
             Ok(CommandOutcome::UserError(output)) => {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -29,6 +29,27 @@ pub(crate) fn resolve_format_by_tty(is_tty: bool) -> Format {
     if is_tty { Format::Text } else { Format::Json }
 }
 
+/// Best-effort output format for errors raised while resolving `--dir`,
+/// before the full format-resolution block (which needs the final `dir`/
+/// `config` and therefore runs later) has executed.
+///
+/// Mirrors that later precedence — explicit `--format` > `--jq` forcing
+/// JSON > config `format` > TTY detection — using whichever config is
+/// already in scope at the call site. For an invalid `--dir` (missing or a
+/// file) there is no target config to reload anyway, so the ambient config
+/// is the only one that could plausibly apply; this is not an approximation
+/// in that case, just an early evaluation of the same rule.
+fn early_format(
+    cli_format: Option<Format>,
+    jq_present: bool,
+    config_format: Option<&str>,
+) -> Format {
+    cli_format
+        .or(if jq_present { Some(Format::Json) } else { None })
+        .or_else(|| config_format.and_then(Format::from_str_opt))
+        .unwrap_or_else(|| resolve_format_by_tty(std::io::stdout().is_terminal()))
+}
+
 /// Extract the effective index path from whichever subcommand is active.
 ///
 /// Walks the command tree and retrieves `IndexFlags` from the matching arm,
@@ -551,14 +572,21 @@ fn run_inner() -> Result<(), AppError> {
                 | Commands::Config
         )
     {
-        eprintln!("{COUNT_UNSUPPORTED_ERROR}");
+        let fmt = early_format(cli.format, cli.jq.is_some(), config.format.as_deref());
+        eprintln!(
+            "{}",
+            crate::output::format_error(fmt, COUNT_UNSUPPORTED_ERROR, None, None, None)
+        );
         return Err(AppError::Exit(2));
     }
     if let Commands::Init { claude } = cli.command {
         let init_dir = cli.dir.as_deref().and_then(|p| p.to_str());
         match init_commands::run_init(init_dir, claude) {
             Ok(CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output)) => {
-                println!("{output}");
+                // Sanitized because RawOutput content may echo raw file text (init/deinit
+                // summaries can include vault-derived strings) that never passes through
+                // the JSON pipeline's own sanitization.
+                println!("{}", crate::output::sanitize_control_chars(&output));
                 return Ok(());
             }
             Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
@@ -568,7 +596,10 @@ fn run_inner() -> Result<(), AppError> {
     if let Commands::Deinit = cli.command {
         match init_commands::run_deinit() {
             Ok(CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output)) => {
-                println!("{output}");
+                // Sanitized because RawOutput content may echo raw file text (init/deinit
+                // summaries can include vault-derived strings) that never passes through
+                // the JSON pipeline's own sanitization.
+                println!("{}", crate::output::sanitize_control_chars(&output));
                 return Ok(());
             }
             Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
@@ -596,7 +627,10 @@ fn run_inner() -> Result<(), AppError> {
             crate::commands::config::collect_config_report(&cwd).map_err(AppError::Internal)?;
         match crate::commands::config::run_config(&report, format) {
             CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output) => {
-                print!("{output}");
+                // Sanitized because the text-mode RawOutput branch echoes the raw
+                // .hyalo.toml contents (`report.raw_contents`), which never passes
+                // through the JSON pipeline's own sanitization.
+                print!("{}", crate::output::sanitize_control_chars(&output));
                 return Ok(());
             }
             CommandOutcome::UserError(output) => return Err(AppError::User(output)),
@@ -633,15 +667,26 @@ fn run_inner() -> Result<(), AppError> {
     let (dir, config) = if let Some(cli_dir) = cli.dir {
         // Validate before loading config to avoid misleading file-read warnings.
         if !cli_dir.exists() {
-            return Err(AppError::User(format!(
-                "Error: --dir path '{}' does not exist.",
-                cli_dir.display()
+            let fmt = early_format(cli.format, cli.jq.is_some(), config.format.as_deref());
+            return Err(AppError::User(crate::output::format_error(
+                fmt,
+                &format!("--dir path '{}' does not exist.", cli_dir.display()),
+                None,
+                None,
+                None,
             )));
         }
         if cli_dir.is_file() {
-            return Err(AppError::User(format!(
-                "Error: --dir path '{}' is a file, not a directory. Use --file to target a single file.",
-                cli_dir.display()
+            let fmt = early_format(cli.format, cli.jq.is_some(), config.format.as_deref());
+            return Err(AppError::User(crate::output::format_error(
+                fmt,
+                &format!(
+                    "--dir path '{}' is a file, not a directory. Use --file to target a single file.",
+                    cli_dir.display()
+                ),
+                None,
+                None,
+                None,
             )));
         }
         let target_config = crate::config::load_config_from(&cli_dir);
@@ -674,15 +719,26 @@ fn run_inner() -> Result<(), AppError> {
     // Validate that the resolved dir exists and is a directory (for the
     // non-CLI case where dir comes from .hyalo.toml).
     if !dir.exists() {
-        return Err(AppError::User(format!(
-            "Error: --dir path '{}' does not exist.",
-            dir.display()
+        let fmt = early_format(cli.format, cli.jq.is_some(), config.format.as_deref());
+        return Err(AppError::User(crate::output::format_error(
+            fmt,
+            &format!("--dir path '{}' does not exist.", dir.display()),
+            None,
+            None,
+            None,
         )));
     }
     if dir.is_file() {
-        return Err(AppError::User(format!(
-            "Error: --dir path '{}' is a file, not a directory. Use --file to target a single file.",
-            dir.display()
+        let fmt = early_format(cli.format, cli.jq.is_some(), config.format.as_deref());
+        return Err(AppError::User(crate::output::format_error(
+            fmt,
+            &format!(
+                "--dir path '{}' is a file, not a directory. Use --file to target a single file.",
+                dir.display()
+            ),
+            None,
+            None,
+            None,
         )));
     }
 
@@ -789,15 +845,16 @@ fn run_inner() -> Result<(), AppError> {
                 .min_by_key(|(d, _)| *d)
                 .map(|(_, k)| k);
             let tip = if let Some(s) = suggestion {
-                format!(
-                    "  did you mean: hyalo find --view {s}\n  \
-                     tip: run 'hyalo views list' to see all views"
-                )
+                format!("did you mean: hyalo find --view {s}?")
             } else {
-                "  tip: run 'hyalo views list' to see available views".to_owned()
+                "run 'hyalo views list' to see available views".to_owned()
             };
-            return Err(AppError::User(format!(
-                "Error: unknown view '{view_name}'\n\n{tip}"
+            return Err(AppError::User(crate::output::format_error(
+                format,
+                &format!("unknown view '{view_name}'"),
+                None,
+                Some(&tip),
+                None,
             )));
         }
     }
@@ -832,15 +889,31 @@ fn run_inner() -> Result<(), AppError> {
     };
     // --count replaces the entire output pipeline, so check its conflicts first.
     if cli.count && jq_filter.is_some() {
-        eprintln!("Error: --count cannot be combined with --jq");
         eprintln!(
-            "  --count prints the bare total; --jq applies a custom filter — use one or the other"
+            "{}",
+            crate::output::format_error(
+                format,
+                "--count cannot be combined with --jq",
+                None,
+                Some(
+                    "--count prints the bare total; --jq applies a custom filter — use one or the other"
+                ),
+                None,
+            )
         );
         return Err(AppError::Exit(2));
     }
     if jq_filter.is_some() && format != Format::Json {
-        eprintln!("Error: --jq cannot be combined with --format {format}");
-        eprintln!("  --jq always operates on JSON output; drop --format or use --format json");
+        eprintln!(
+            "{}",
+            crate::output::format_error(
+                format,
+                &format!("--jq cannot be combined with --format {format}"),
+                None,
+                Some("--jq always operates on JSON output; drop --format or use --format json"),
+                None,
+            )
+        );
         return Err(AppError::Exit(2));
     }
     // Always force JSON internally so the output pipeline can wrap results in the

--- a/crates/hyalo-cli/tests/e2e/append.rs
+++ b/crates/hyalo-cli/tests/e2e/append.rs
@@ -638,3 +638,40 @@ fn append_without_dry_run_has_dry_run_false() {
         "file was not written:\n{content}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// iter-158 C-1: BOM-prefixed files must round-trip through `append` without
+// a duplicate frontmatter block, with the BOM preserved.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn append_property_on_bom_file_round_trips_without_duplicate_block() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "\u{feff}---\ntitle: Note\naliases:\n  - old-name\n---\nBody.\n",
+    );
+
+    let (status, json, stderr) = append_json(
+        &tmp,
+        &["--property", "aliases=new-name", "--file", "note.md"],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["results"]["modified"].as_array().unwrap().len(), 1);
+
+    let bytes = fs::read(tmp.path().join("note.md")).unwrap();
+    let content = String::from_utf8(bytes).unwrap();
+    assert!(
+        content.starts_with("\u{feff}---\n"),
+        "BOM must be preserved: {content}"
+    );
+    assert_eq!(
+        content.matches("\u{feff}---\n").count() + content.matches("\n---\n").count(),
+        2,
+        "expected exactly one frontmatter block (one BOM-opening + one closing), got:\n{content}"
+    );
+    assert!(content.contains("old-name"), "content:\n{content}");
+    assert!(content.contains("new-name"), "content:\n{content}");
+    assert!(content.ends_with("Body.\n"), "body corrupted:\n{content}");
+}

--- a/crates/hyalo-cli/tests/e2e/errors.rs
+++ b/crates/hyalo-cli/tests/e2e/errors.rs
@@ -397,8 +397,11 @@ title: Test
     );
     let file_path = tmp.path().join("note.md");
 
+    // Explicit --format text: this test checks the human-readable message.
+    // (Default piped output is JSON — see json_errors.rs for that coverage.)
     let output = hyalo_no_hints()
         .args(["--dir", file_path.to_str().unwrap()])
+        .args(["--format", "text"])
         .args(["find"])
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e/find.rs
+++ b/crates/hyalo-cli/tests/e2e/find.rs
@@ -3921,6 +3921,110 @@ fn find_desc_alias_for_reverse() {
 // UX-6: `find ""` matches all files; combined with --tag still filters (iter-133)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// H-8: BM25 score/rank parity between the persisted --index path and the
+// default live-scan path when a --property filter narrows the candidate set.
+// ---------------------------------------------------------------------------
+
+fn setup_h8_parity_vault() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    write_md(
+        tmp.path(),
+        "k1.md",
+        md!(r"
+---
+status: keep
+---
+# k1
+alpha alpha content
+"),
+    );
+    write_md(
+        tmp.path(),
+        "k2.md",
+        md!(r"
+---
+status: keep
+---
+# k2
+beta beta content
+"),
+    );
+    for i in 1..=10 {
+        write_md(
+            tmp.path(),
+            &format!("s{i}.md"),
+            &format!("---\nstatus: skip\n---\n# s{i}\nbeta beta beta filler {i}\n"),
+        );
+    }
+    tmp
+}
+
+#[test]
+fn find_index_parity_rank_and_score_match_no_index_with_property_filter() {
+    let tmp = setup_h8_parity_vault();
+
+    // Live-scan path (no --index): a --property filter narrows 12 files down
+    // to 2 candidates before BM25 scoring.
+    let (status, json_no_index, stderr) =
+        find_json(&tmp, &["alpha OR beta", "--property", "status=keep"]);
+    assert!(status.success(), "stderr: {stderr}");
+    let no_index_results = unwrap_results(&json_no_index);
+
+    // Persisted-index path: build the snapshot, then re-run the same query
+    // with --index.
+    let create_index_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(
+        create_index_output.status.success(),
+        "create-index failed: {}",
+        String::from_utf8_lossy(&create_index_output.stderr)
+    );
+
+    let (status, json_index, stderr) = find_json(
+        &tmp,
+        &["alpha OR beta", "--property", "status=keep", "--index"],
+    );
+    assert!(status.success(), "stderr: {stderr}");
+    let index_results = unwrap_results(&json_index);
+
+    let no_index_files: Vec<&str> = no_index_results
+        .iter()
+        .map(|r| r["file"].as_str().expect("field 'file' should be a string"))
+        .collect();
+    let index_files: Vec<&str> = index_results
+        .iter()
+        .map(|r| r["file"].as_str().expect("field 'file' should be a string"))
+        .collect();
+    assert_eq!(
+        no_index_files, index_files,
+        "rank order must match between --index and no-index runs: \
+         no_index={no_index_results:?} index={index_results:?}"
+    );
+
+    for (a, b) in no_index_results.iter().zip(index_results.iter()) {
+        let score_a = a["score"].as_f64().expect("score field should be a number");
+        let score_b = b["score"].as_f64().expect("score field should be a number");
+        assert!(
+            (score_a - score_b).abs() < 1e-9,
+            "score mismatch for {}: no-index={score_a} index={score_b}",
+            a["file"]
+        );
+    }
+
+    // Sanity: the filter actually narrowed the corpus to 2 of 12 files, and
+    // the rare term ("alpha", 1 of 12 files) outranks the common term
+    // ("beta", 11 of 12 files) under full-corpus IDF.
+    assert_eq!(no_index_files.len(), 2, "expected exactly 2 candidates");
+    assert_eq!(
+        no_index_files[0], "k1.md",
+        "k1.md (rare term) should outrank k2.md (common term) under full-corpus IDF"
+    );
+}
+
 #[test]
 fn find_empty_pattern_with_tag_filter_still_applies_tag() {
     let tmp = setup_vault();
@@ -3939,5 +4043,43 @@ fn find_empty_pattern_with_tag_filter_still_applies_tag() {
     assert_eq!(
         json["total"], 0,
         "empty pattern + nonexistent tag should return 0 results, got: {json}"
+    );
+}
+
+#[test]
+fn find_sees_frontmatter_of_bom_prefixed_file() {
+    // iter-158 C-1 follow-through: the scanner shares the opening-delimiter
+    // policy with the read/write paths, so a UTF-8 BOM before `---` must not
+    // hide a file's frontmatter from `find`.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("bom.md"),
+        b"\xEF\xBB\xBF---\ntitle: Bom Note\nstatus: bom-draft\n---\n\nBody text.\n",
+    )
+    .unwrap();
+    // Control: leading whitespace before `---` is NOT frontmatter.
+    std::fs::write(
+        tmp.path().join("lead.md"),
+        b" ---\ntitle: Lead\nstatus: bom-draft\n---\nBody.\n",
+    )
+    .unwrap();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--property", "status=bom-draft", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let files: Vec<&str> = json["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["file"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        files,
+        vec!["bom.md"],
+        "BOM file's frontmatter must be visible; leading-space pseudo-frontmatter must not"
     );
 }

--- a/crates/hyalo-cli/tests/e2e/index.rs
+++ b/crates/hyalo-cli/tests/e2e/index.rs
@@ -1118,6 +1118,188 @@ fn chained_mutations_with_index_keep_index_consistent() {
 }
 
 // ---------------------------------------------------------------------------
+// H-7: mutating a frontmatter link property with --index must patch the
+// persisted LinkGraph, not just the entry's properties/tags/modified.
+// ---------------------------------------------------------------------------
+
+/// Two notes with no initial link between them, used to verify that
+/// `set`/`remove` on a frontmatter link property (`depends-on`) keeps the
+/// persisted link graph in sync when run with `--index`.
+fn setup_link_mutation_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Note
+---
+# Note
+"),
+    );
+    write_md(
+        tmp.path(),
+        "foo.md",
+        md!(r"
+---
+title: Foo
+---
+"),
+    );
+    tmp
+}
+
+/// Run `hyalo backlinks --file <target>` and return the sorted list of
+/// backlink source paths. `use_index` toggles the bare `--index` flag.
+fn backlink_sources(tmp: &TempDir, target: &str, use_index: bool) -> Vec<String> {
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args(["backlinks", "--file", target]);
+    if use_index {
+        cmd.arg("--index");
+    }
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "backlinks failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let mut sources: Vec<String> = json["results"]["backlinks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["source"].as_str().unwrap().to_owned())
+        .collect();
+    sources.sort();
+    sources
+}
+
+#[test]
+fn set_frontmatter_link_property_with_index_updates_persisted_graph() {
+    let tmp = setup_link_mutation_vault();
+    let index_path = create_default_index(&tmp);
+
+    // Before the mutation, foo.md has no backlinks.
+    assert!(
+        backlink_sources(&tmp, "foo.md", true).is_empty(),
+        "foo.md should have no backlinks before the mutation"
+    );
+
+    // Set a frontmatter link property (`depends-on`) via --index. This writes
+    // note.md to disk and, per the IndexFlags contract, must patch the
+    // persisted index so subsequent --index queries stay accurate.
+    run_with_index(
+        &tmp,
+        &index_path,
+        &[
+            "set",
+            "--property",
+            "depends-on=[[foo]]",
+            "--file",
+            "note.md",
+        ],
+    );
+
+    // A FRESH process reading the persisted index must see the new backlink.
+    // Before the fix this returned [] (H-7).
+    assert_eq!(
+        backlink_sources(&tmp, "foo.md", true),
+        vec!["note.md".to_owned()],
+        "persisted graph must reflect the new depends-on link"
+    );
+
+    // Ground truth: a live disk scan must agree with the index.
+    assert_eq!(
+        backlink_sources(&tmp, "foo.md", true),
+        backlink_sources(&tmp, "foo.md", false),
+        "index-based and disk-scan backlinks must agree after the mutation"
+    );
+}
+
+#[test]
+fn remove_frontmatter_link_property_with_index_updates_persisted_graph() {
+    let tmp = setup_link_mutation_vault();
+    let index_path = create_default_index(&tmp);
+
+    // Seed a depends-on link via --index first.
+    run_with_index(
+        &tmp,
+        &index_path,
+        &[
+            "set",
+            "--property",
+            "depends-on=[[foo]]",
+            "--file",
+            "note.md",
+        ],
+    );
+    assert_eq!(
+        backlink_sources(&tmp, "foo.md", true),
+        vec!["note.md".to_owned()],
+        "sanity check: depends-on link should be indexed before removal"
+    );
+
+    // Now remove the property via --index.
+    run_with_index(
+        &tmp,
+        &index_path,
+        &["remove", "--property", "depends-on", "--file", "note.md"],
+    );
+
+    // The persisted graph must no longer report the backlink.
+    assert!(
+        backlink_sources(&tmp, "foo.md", true).is_empty(),
+        "removing depends-on must clear the persisted backlink"
+    );
+    assert_eq!(
+        backlink_sources(&tmp, "foo.md", true),
+        backlink_sources(&tmp, "foo.md", false),
+        "index-based and disk-scan backlinks must agree after removal"
+    );
+}
+
+#[test]
+fn find_fields_links_with_index_reflects_new_target_after_mutation() {
+    let tmp = setup_link_mutation_vault();
+    let index_path = create_default_index(&tmp);
+
+    // Before the mutation, note.md has no outbound links.
+    let before = run_find(&tmp, &["--file", "note.md", "--fields", "links", "--index"]);
+    assert!(
+        unwrap_results(&before)[0]["links"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "note.md should have no outbound links before the mutation"
+    );
+
+    run_with_index(
+        &tmp,
+        &index_path,
+        &[
+            "set",
+            "--property",
+            "depends-on=[[foo]]",
+            "--file",
+            "note.md",
+        ],
+    );
+
+    let after = run_find(&tmp, &["--file", "note.md", "--fields", "links", "--index"]);
+    let targets: Vec<&str> = unwrap_results(&after)[0]["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|l| l["target"].as_str().unwrap())
+        .collect();
+    assert!(
+        targets.contains(&"foo"),
+        "note.md's `links` field should include the new depends-on target; got: {targets:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Regression: --property regex filter with YAML array values
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e/json_errors.rs
+++ b/crates/hyalo-cli/tests/e2e/json_errors.rs
@@ -1,0 +1,616 @@
+//! Regression tests for iter-158 finding H-6 (argument-validation errors must
+//! respect --format, not just eprintln! plain text), finding M (raw-output
+//! control-character sanitization), and finding [19] (`links fix --index`
+//! leaving the persisted link graph stale).
+//!
+//! H-6's root pattern was `CommandOutcome::UserError(format!("Error: {e}"))`
+//! sites in dispatch.rs and bare `eprintln!`s in run.rs that never checked
+//! the requested output format — meaning `--format json` (and the default
+//! piped format) emitted plain text instead of `{"error": ...}` on stderr.
+
+use super::common::{hyalo_no_hints, md, write_md};
+use tempfile::TempDir;
+
+fn setup_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        md!(r"
+---
+title: Test
+---
+# Body
+Some text.
+"),
+    );
+    tmp
+}
+
+/// Assert `stderr` is a JSON object with a non-empty `.error` string field.
+fn assert_json_error(stderr: &[u8]) -> serde_json::Value {
+    let text = String::from_utf8_lossy(stderr);
+    let json: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("stderr is not valid JSON: {e}\nstderr: {text}"));
+    assert!(
+        json.get("error")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|s| !s.is_empty()),
+        "expected non-empty .error field, got: {json}"
+    );
+    json
+}
+
+// ---------------------------------------------------------------------------
+// find: argument-validation errors under --format json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_bad_task_filter_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find", "--task", "???"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let json = assert_json_error(&output.stderr);
+    assert!(json["error"].as_str().unwrap().contains("task filter"));
+}
+
+#[test]
+fn find_bad_fields_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find", "--fields", "nosuchfield"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = assert_json_error(&output.stderr);
+    assert!(json["error"].as_str().unwrap().contains("nosuchfield"));
+}
+
+#[test]
+fn find_bad_sort_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find", "--sort", "nosuchsort"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = assert_json_error(&output.stderr);
+    assert!(json["error"].as_str().unwrap().contains("nosuchsort"));
+}
+
+#[test]
+fn find_bad_tag_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find", "--tag", "has space"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_json_error(&output.stderr);
+}
+
+#[test]
+fn find_bad_section_regex_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find", "--section", "/[/"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_json_error(&output.stderr);
+}
+
+#[test]
+fn find_bad_property_regex_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find", "--property", "title~=/[/"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_json_error(&output.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// set / remove: --where-property errors under --format json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_bad_where_property_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args([
+            "set",
+            "--property",
+            "x=1",
+            "--where-property",
+            "title~=/[/",
+            "--glob",
+            "**/*.md",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_json_error(&output.stderr);
+}
+
+#[test]
+fn remove_bad_where_property_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["remove", "--property", "x", "--where-property", "p~=/[/"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_json_error(&output.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// mv: batch-mode filter-parsing errors under --format json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mv_bad_where_filter_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args([
+            "mv",
+            "--property",
+            "p~=/[/",
+            "--to",
+            "renamed/",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_json_error(&output.stderr);
+}
+
+#[test]
+fn mv_no_source_selection_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["mv", "--to", "renamed/"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = assert_json_error(&output.stderr);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("no source selection")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// views run: filter re-validation errors under --format json (same code
+// pattern as `find`, exercised via a saved view instead of CLI flags —
+// these were among the sites the review flagged as "links/mv where-filter
+// parsing" line numbers, which had drifted onto this block).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn views_run_bad_tag_override_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let set_output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["views", "set", "myview", "--property", "title=Test"])
+        .output()
+        .unwrap();
+    assert!(
+        set_output.status.success(),
+        "views set failed: {set_output:?}"
+    );
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["views", "run", "myview", "--tag", "has space"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_json_error(&output.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// run.rs-level errors: --dir validation, unknown view, --count/--jq conflicts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dir_missing_is_json_under_format_json() {
+    let tmp = TempDir::new().unwrap();
+    let nonexistent = tmp.path().join("does_not_exist");
+    let output = hyalo_no_hints()
+        .args(["--dir", nonexistent.to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let json = assert_json_error(&output.stderr);
+    assert!(json["error"].as_str().unwrap().contains("does not exist"));
+}
+
+#[test]
+fn dir_missing_is_text_under_format_text() {
+    let tmp = TempDir::new().unwrap();
+    let nonexistent = tmp.path().join("does_not_exist");
+    let output = hyalo_no_hints()
+        .args(["--dir", nonexistent.to_str().unwrap()])
+        .args(["--format", "text"])
+        .args(["find"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("Error: --dir path"),
+        "expected human-readable text, got: {stderr}"
+    );
+    assert!(serde_json::from_str::<serde_json::Value>(&stderr).is_err());
+}
+
+#[test]
+fn dir_is_a_file_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let file_path = tmp.path().join("note.md");
+    let output = hyalo_no_hints()
+        .args(["--dir", file_path.to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = assert_json_error(&output.stderr);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("is a file, not a directory")
+    );
+}
+
+#[test]
+fn unknown_view_is_json_under_format_json() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["find", "--view", "nosuchview"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = assert_json_error(&output.stderr);
+    assert!(json["error"].as_str().unwrap().contains("unknown view"));
+}
+
+#[test]
+fn unknown_view_is_text_under_format_text() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "text"])
+        .args(["find", "--view", "nosuchview"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown view"), "stderr: {stderr}");
+    assert!(serde_json::from_str::<serde_json::Value>(&stderr).is_err());
+}
+
+#[test]
+fn count_with_jq_conflict_is_json_by_default() {
+    let tmp = setup_vault();
+    // No explicit --format: --jq forces JSON internally, so the conflict
+    // error must also be JSON (this is the exact H-6 repro).
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--count", "--jq", ".total"])
+        .args(["find"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let json = assert_json_error(&output.stderr);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("--count cannot be combined with --jq")
+    );
+}
+
+#[test]
+fn jq_with_format_text_conflict_is_json_under_format_json_precedence() {
+    let tmp = setup_vault();
+    // --format json + --jq + (irrelevant since format already json) — the
+    // interesting case is --format text + --jq, which must still render the
+    // *conflict error itself* as text since `format` at that point is Text.
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "text"])
+        .args(["--jq", ".total"])
+        .args(["tags", "summary"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--jq cannot be combined with --format text"));
+    assert!(serde_json::from_str::<serde_json::Value>(&stderr).is_err());
+}
+
+#[test]
+fn count_unsupported_command_is_json_under_format_json_success_arm() {
+    // Exercises OutputPipeline::finalize's Success arm (total == None) --
+    // e.g. `set` never returns a `total`, so --count is rejected there.
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["--count", "set", "--property", "x=1", "--file", "note.md"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let json = assert_json_error(&output.stderr);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("only supported for list commands")
+    );
+}
+
+#[test]
+fn count_unsupported_command_is_json_under_format_json_raw_output_arm() {
+    // Exercises OutputPipeline::finalize's RawOutput arm -- `read` bypasses
+    // the JSON pipeline entirely in text mode.
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["--count", "read", "note.md"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    assert_json_error(&output.stderr);
+}
+
+#[test]
+fn count_unsupported_command_is_json_under_format_json_pre_dispatch() {
+    // Exercises the run.rs early rejection (before Init/Deinit/Completion/
+    // Config dispatch) -- these commands never reach the output pipeline.
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["--count", "config"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(2));
+    let json = assert_json_error(&output.stderr);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("only supported for list commands")
+    );
+}
+
+#[test]
+fn count_unsupported_command_is_text_under_format_text() {
+    let tmp = setup_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "text"])
+        .args(["--count", "read", "note.md"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("only supported for list commands"));
+    assert!(serde_json::from_str::<serde_json::Value>(&stderr).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// read: control-character sanitization (finding M)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_text_mode_strips_raw_control_bytes() {
+    let tmp = TempDir::new().unwrap();
+    // Body contains a raw ANSI color escape (\x1b[31m ... \x1b[0m) and a bell
+    // (\x07). Neither byte should reach the terminal in text mode.
+    write_md(
+        tmp.path(),
+        "evil.md",
+        "---\ntitle: Evil\n---\n# Body\nline with \x1b[31mred\x1b[0m and bell \x07 end\n",
+    );
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "text"])
+        .args(["read", "evil.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "raw ESC byte leaked into text-mode stdout"
+    );
+    assert!(
+        !output.stdout.contains(&0x07),
+        "raw BEL byte leaked into text-mode stdout"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("red"),
+        "sanitization should not eat surrounding text"
+    );
+}
+
+#[test]
+fn read_json_mode_escapes_control_bytes() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "evil.md",
+        "---\ntitle: Evil\n---\n# Body\nline with \x1b[31mred\x1b[0m and bell \x07 end\n",
+    );
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["--format", "json"])
+        .args(["read", "evil.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    // No raw control bytes on the wire...
+    assert!(!output.stdout.contains(&0x1b));
+    assert!(!output.stdout.contains(&0x07));
+    // ...but the content is preserved, JSON-escaped.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let content = json["results"]["content"].as_str().unwrap();
+    assert!(
+        content.contains('\u{1b}'),
+        "escaped ESC should round-trip through JSON"
+    );
+    assert!(
+        content.contains('\u{7}'),
+        "escaped BEL should round-trip through JSON"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// links fix --index: persisted LinkGraph must be patched, not just the entry
+// (finding [19])
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_apply_index_keeps_backlinks_graph_in_sync() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r"
+---
+title: A
+---
+# A
+See [[B]] for more.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        md!(r"
+---
+title: B
+---
+# B
+Nothing here.
+"),
+    );
+
+    let dir = tmp.path().to_str().unwrap();
+
+    let create = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args(["--format", "json"])
+        .args(["create-index"])
+        .output()
+        .unwrap();
+    assert!(create.status.success(), "create-index failed: {create:?}");
+
+    // Case-mismatch fix: [[B]] -> [[b]] (b.md is the on-disk file).
+    let fix = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args(["--format", "json"])
+        .args(["links", "fix", "--apply", "--index"])
+        .output()
+        .unwrap();
+    assert!(fix.status.success(), "links fix failed: {fix:?}");
+    let fix_json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&fix.stdout)).unwrap();
+    assert_eq!(
+        fix_json["results"]["case_mismatches"], 1,
+        "expected exactly one case-mismatch fix"
+    );
+
+    // The on-disk file was rewritten...
+    let a_contents = std::fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        a_contents.contains("[[b]]"),
+        "expected rewritten target on disk: {a_contents}"
+    );
+
+    // ...and a FRESH process querying backlinks --index must see the same
+    // thing the live (non-indexed) scan sees — before the fix, refresh_entry
+    // alone left the persisted LinkGraph pointing at the stale "B" target,
+    // so this backlinks --index query returned zero results.
+    let indexed = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args(["--format", "json"])
+        .args(["backlinks", "b.md", "--index"])
+        .output()
+        .unwrap();
+    assert!(
+        indexed.status.success(),
+        "backlinks --index failed: {indexed:?}"
+    );
+    let indexed_json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&indexed.stdout)).unwrap();
+
+    let live = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args(["--format", "json"])
+        .args(["backlinks", "b.md"])
+        .output()
+        .unwrap();
+    assert!(live.status.success(), "backlinks (live) failed: {live:?}");
+    let live_json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&live.stdout)).unwrap();
+
+    assert_eq!(
+        indexed_json["total"], 1,
+        "stale graph: expected 1 backlink via --index"
+    );
+    assert_eq!(
+        indexed_json["results"]["backlinks"], live_json["results"]["backlinks"],
+        "indexed backlinks must match the live scan after links fix --apply --index"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -1430,3 +1430,265 @@ fn lint_required_sections_out_of_order_is_violation() {
         "expected order violation in output, got:\n{combined}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// iter-158: lint --fix pipeline fixes (byte/char columns, MD009 blank-line
+// injection, MD047 convergence, frontmatter+body combined write, severity
+// tiebreak, oversized-file skip, idempotency)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lint_fix_md009_does_not_inject_blank_line() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\nx   \ny\n");
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD009"])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.ends_with("x\ny\n"),
+        "MD009 fix must not insert a blank line, got: {content:?}"
+    );
+}
+
+#[test]
+fn lint_fix_md009_preserves_crlf_line_endings() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\r\ntitle: Note\r\n---\r\nx   \r\ny\r\n",
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD009"])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.ends_with("x\r\ny\r\n"),
+        "MD009 fix must keep CRLF endings uniformly, got: {content:?}"
+    );
+    assert!(
+        !content.contains("\n\r\n"),
+        "MD009 fix must not produce mixed/duplicated line endings, got: {content:?}"
+    );
+}
+
+#[test]
+fn lint_fix_hyalo001_non_ascii_line() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Note\n---\n\n[] café task\n",
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "HYALO001"])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("- [ ] café task"),
+        "HYALO001 fix must apply on a non-ASCII line, got: {content:?}"
+    );
+}
+
+#[test]
+fn lint_fix_md009_trailing_space_on_cjk_line() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Note\n---\n日本語のテキスト   \n",
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD009"])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.ends_with("日本語のテキスト\n"),
+        "MD009 fix must strip trailing spaces on a CJK line, got: {content:?}"
+    );
+}
+
+#[test]
+fn lint_fix_md047_converges_in_one_run() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\nbody\n\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD047", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let val: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(val["results"]["total_fixed"], 1);
+    assert_eq!(val["results"]["total_remaining"], 0);
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.ends_with("body\n") && !content.ends_with("body\n\n"),
+        "MD047 must converge to exactly one trailing newline in one run, got: {content:?}"
+    );
+
+    // A second run must report zero fixes — no perpetual "fixed=1" loop.
+    let output2 = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD047", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout2 = std::str::from_utf8(&output2.stdout).unwrap();
+    let val2: serde_json::Value = serde_json::from_str(stdout2).unwrap();
+    assert_eq!(val2["results"]["total_fixed"], 0);
+    assert_eq!(val2["results"]["files"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn lint_fix_frontmatter_and_body_fixes_both_persist() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        "dir = \".\"\n\n[schema.default]\nrequired = [\"title\"]\n\n[schema.default.defaults]\nstatus = \"draft\"\n",
+    );
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Note\n---\nline with trailing space   \n",
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix"])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("status: draft"),
+        "frontmatter default fix must persist, got: {content:?}"
+    );
+    assert!(
+        content.contains("line with trailing space\n"),
+        "body fix must persist alongside the frontmatter fix, got: {content:?}"
+    );
+    assert!(
+        !content.contains("space   \n"),
+        "trailing spaces must actually be removed, got: {content:?}"
+    );
+}
+
+#[test]
+fn lint_fix_idempotent_second_run_is_a_no_op() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Note\n---\n- [] task with trailing space   \nAnother line.\n\n\n\nToo many blanks above.\n",
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix"])
+        .assert()
+        .success();
+    let after_first = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let val: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        val["results"]["total_fixed"], 0,
+        "second --fix run should find nothing left to fix, got: {stdout}"
+    );
+
+    let after_second = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert_eq!(
+        after_first, after_second,
+        "file bytes must be unchanged by the second --fix run"
+    );
+}
+
+#[test]
+fn lint_fix_error_severity_wins_overlap_with_warn() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    // Bare checkbox (HYALO001, Error) with trailing whitespace on the same
+    // line (MD009, Warn) — their fix ranges overlap.
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n[] task   \n");
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix"])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        content.contains("- [ ] task"),
+        "HYALO001's fix must win the overlap, got: {content:?}"
+    );
+    assert!(
+        !content.contains("task   \n"),
+        "trailing spaces should also converge across passes, got: {content:?}"
+    );
+}
+
+#[test]
+fn lint_oversized_file_is_skipped_with_warning() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    let path = tmp.path().join("big.md");
+    let file = std::fs::File::create(&path).unwrap();
+    // Sparse file: exceeds the 100 MiB scanner limit without writing real
+    // bytes to disk.
+    file.set_len(101 * 1024 * 1024).unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json", "big.md"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("skipping") && stderr.contains("big.md"),
+        "expected a skip warning on stderr, got: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "an oversized-file skip is a warning, not an error"
+    );
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let val: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        val["results"]["files_with_violations"], 1,
+        "the skipped file must be reported as not-clean, not silently dropped"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -19,6 +19,7 @@ mod hyalo_config;
 mod index;
 mod init;
 mod jq;
+mod json_errors;
 mod links;
 mod links_iter136;
 mod lint;

--- a/crates/hyalo-cli/tests/e2e/mv.rs
+++ b/crates/hyalo-cli/tests/e2e/mv.rs
@@ -2,6 +2,9 @@ use super::common::{hyalo_no_hints, md, write_md};
 use std::fs;
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use std::os::unix::fs as unix_fs;
+
 // ---------------------------------------------------------------------------
 // `hyalo mv` — move/rename file with link updates
 // ---------------------------------------------------------------------------
@@ -1365,5 +1368,204 @@ fn mv_dot_slash_wikilink_unrelated_not_rewritten() {
     assert!(
         content.contains("[[./c]]"),
         "[[./c]] should not be rewritten when b.md is moved, got: {content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// H-3: `mv` must not escape the vault through a symlinked destination
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn mv_single_symlink_escape_rejected() {
+    // `vault/escapelink` is a symlink pointing outside the vault. Moving a
+    // file into it must be rejected before any filesystem mutation happens.
+    let vault = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    write_md(vault.path(), "note.md", "---\ntitle: src\n---\nbody\n");
+    unix_fs::symlink(outside.path(), vault.path().join("escapelink")).unwrap();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["mv", "--file", "note.md", "--to", "escapelink/escaped.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, got success: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("outside vault boundary"),
+        "expected vault-boundary error, got: {stderr}"
+    );
+
+    // Source untouched; nothing written outside the vault.
+    assert!(
+        vault.path().join("note.md").exists(),
+        "source file must remain unmoved"
+    );
+    assert!(
+        !outside.path().join("escaped.md").exists(),
+        "file must not have escaped the vault"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn mv_single_symlink_escape_nested_dirs_rejected() {
+    // The destination's parent directories don't exist yet — `create_dir_all`
+    // must not be allowed to fabricate directories outside the vault by
+    // walking through the symlink.
+    let vault = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    write_md(vault.path(), "note.md", "---\ntitle: src\n---\nbody\n");
+    unix_fs::symlink(outside.path(), vault.path().join("escapelink")).unwrap();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "mv",
+            "--file",
+            "note.md",
+            "--to",
+            "escapelink/deep/nested/escaped.md",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, got success: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        vault.path().join("note.md").exists(),
+        "source file must remain unmoved"
+    );
+    assert!(
+        !outside.path().join("deep").exists(),
+        "create_dir_all must not fabricate directories outside the vault"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn mv_single_symlink_free_still_works() {
+    // Sanity check: a legitimate in-vault move with no symlinks involved
+    // must continue to work after the H-3 vault-boundary check was added.
+    let vault = TempDir::new().unwrap();
+    write_md(vault.path(), "note.md", "---\ntitle: src\n---\nbody\n");
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["mv", "--file", "note.md", "--to", "sub/dir/note.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!vault.path().join("note.md").exists());
+    assert!(vault.path().join("sub/dir/note.md").exists());
+}
+
+// ---------------------------------------------------------------------------
+// H-4: single-file `mv` must rewrite inbound frontmatter wikilinks too
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mv_single_file_rewrites_frontmatter_wikilink() {
+    // Regression test for H-4: single-file mv previously only rewrote body
+    // wikilinks via `plan_inbound_rewrites`, leaving frontmatter link
+    // properties (related/depends-on/supersedes/superseded-by) dangling.
+    // Mirrors `t12_frontmatter_wikilink_rewrite` (mv_batch.rs) for the
+    // single-file path.
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r#"
+---
+title: A
+related:
+  - "[[notes/b]]"
+---
+body [[notes/b]]
+"#),
+    );
+    write_md(tmp.path(), "notes/b.md", "---\ntitle: B\n---\nc\n");
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["mv", "--file", "notes/b.md", "--to", "archive/b.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["results"]["total_links_updated"], 2,
+        "both the frontmatter and body wikilinks must be counted: {json}"
+    );
+
+    let content = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        content.contains("- \"[[archive/b]]\""),
+        "frontmatter wikilink must be rewritten: {content}"
+    );
+    assert!(
+        content.contains("body [[archive/b]]"),
+        "body wikilink must be rewritten: {content}"
+    );
+    assert!(
+        !content.contains("notes/b"),
+        "old target must be gone everywhere: {content}"
+    );
+}
+
+#[test]
+fn mv_single_file_rewrites_aliased_frontmatter_wikilink() {
+    // Aliased wikilinks (`[[path|Label]]`) inside frontmatter must preserve
+    // the alias while the path portion is rewritten.
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r#"
+---
+title: A
+related:
+  - "[[notes/b|My Label]]"
+---
+body.
+"#),
+    );
+    write_md(tmp.path(), "notes/b.md", "---\ntitle: B\n---\nc\n");
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["mv", "--file", "notes/b.md", "--to", "archive/b.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let content = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        content.contains("[[archive/b|My Label]]"),
+        "alias must be preserved while path is rewritten: {content}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e/mv_batch.rs
+++ b/crates/hyalo-cli/tests/e2e/mv_batch.rs
@@ -5,6 +5,9 @@ use super::common::{hyalo_no_hints, md, write_md};
 use std::fs;
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use std::os::unix::fs as unix_fs;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1000,4 +1003,44 @@ Content of foo.
         ref_content.contains("[[foo|My Alias]]"),
         "alias must be preserved in short-form link, got: {ref_content}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// H-3: batch `mv` must not escape the vault through a symlinked destination
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn mv_batch_symlink_escape_rejected() {
+    // `vault/escapelink` is a symlink pointing outside the vault. A batch
+    // move targeting it must be rejected before any of the matched files
+    // are renamed.
+    let vault = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    write_md(vault.path(), "note.md", "---\nstatus: x\n---\nbody\n");
+    write_md(vault.path(), "note2.md", "---\nstatus: x\n---\nbody\n");
+    unix_fs::symlink(outside.path(), vault.path().join("escapelink")).unwrap();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["mv", "--glob", "*.md", "--to", "escapelink", "--apply"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, got success: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("outside vault boundary"),
+        "expected vault-boundary error, got: {stderr}"
+    );
+
+    // No source file was moved and nothing was written outside the vault.
+    assert!(vault.path().join("note.md").exists());
+    assert!(vault.path().join("note2.md").exists());
+    assert!(!outside.path().join("note.md").exists());
+    assert!(!outside.path().join("note2.md").exists());
 }

--- a/crates/hyalo-cli/tests/e2e/read.rs
+++ b/crates/hyalo-cli/tests/e2e/read.rs
@@ -1,4 +1,5 @@
 use super::common::{hyalo_no_hints, md, write_md};
+use std::fs;
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -720,4 +721,148 @@ fn read_files_from_single_file_succeeds() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     assert!(stdout.contains("Heading One"), "expected file content");
+}
+
+// ---------------------------------------------------------------------------
+// Memory caps: oversized file refused, oversized single line handled safely.
+// ---------------------------------------------------------------------------
+
+/// `read` targets one explicit file — an oversized target must be a hard,
+/// clear error (not a silent skip, and not an unbounded read).
+#[test]
+fn read_oversized_file_refused() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("big.md");
+    // Sparse file just over the scanner size cap; no real disk usage.
+    let f = fs::File::create(&path).unwrap();
+    f.set_len(hyalo_core::scanner::MAX_FILE_SIZE + 1).unwrap();
+    drop(f);
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "big.md"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(
+        stderr.contains("too large") && stderr.contains("exceeds"),
+        "stderr: {stderr}"
+    );
+}
+
+/// Same oversized-file refusal under `--format json` must still produce a
+/// valid, parseable JSON error (not a raw panic or plain-text leak).
+#[test]
+fn read_oversized_file_refused_json_format() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("big.md");
+    let f = fs::File::create(&path).unwrap();
+    f.set_len(hyalo_core::scanner::MAX_FILE_SIZE + 1).unwrap();
+    drop(f);
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "big.md", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let combined = if output.stdout.is_empty() {
+        &output.stderr
+    } else {
+        &output.stdout
+    };
+    let json: serde_json::Value = serde_json::from_slice(combined).unwrap_or_else(|e| {
+        panic!(
+            "expected valid JSON error, got error {e}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let err_text = json
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("expected top-level 'error' field in JSON error output: {json}"));
+    assert!(err_text.contains("too large"), "error text: {err_text}");
+}
+
+/// A single line larger than the per-line cap must not be buffered whole —
+/// the file (well under the whole-file size cap) is still readable, and the
+/// oversized line is replaced with a placeholder instead of hanging or
+/// ballooning memory. Uses a sparse file (mostly NUL bytes, which are valid
+/// UTF-8) so the test stays fast without writing real megabytes of data.
+#[test]
+fn read_oversized_single_line_is_placeholdered_not_buffered() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("huge-line.md");
+    // 2 MiB single line (no newline at all) — over the 1 MiB per-line cap,
+    // but comfortably under the 100 MiB whole-file cap.
+    let f = fs::File::create(&path).unwrap();
+    f.set_len(2 * 1024 * 1024).unwrap();
+    drop(f);
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "huge-line.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(
+        stdout.contains("skipped"),
+        "expected placeholder text, got: {stdout:?}"
+    );
+    // Behavioral proxy for "not buffered whole": output is tiny, not ~2 MiB.
+    assert!(
+        stdout.len() < 4096,
+        "output suspiciously large ({} bytes) — oversized line may have leaked through",
+        stdout.len()
+    );
+}
+
+/// Pin exact output for an ordinary small file across the fix — the capped
+/// reader must remain byte-for-byte equivalent to the previous
+/// `BufRead::lines()` based implementation for normal input.
+#[test]
+fn read_normal_file_output_byte_identical() {
+    let tmp = setup();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "note.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(
+        stdout,
+        "# Heading One\n\
+\n\
+First paragraph.\n\
+\n\
+## Problem\n\
+\n\
+Problem text line 1.\n\
+Problem text line 2.\n\
+\n\
+## Solution\n\
+\n\
+Solution text.\n\
+\n\
+### Details\n\
+\n\
+Nested details.\n\
+\n\
+## Problem\n\
+\n\
+Second problem section.\n\
+\n"
+    );
 }

--- a/crates/hyalo-cli/tests/e2e/read.rs
+++ b/crates/hyalo-cli/tests/e2e/read.rs
@@ -866,3 +866,55 @@ Second problem section.\n\
 \n"
     );
 }
+
+// ---------------------------------------------------------------------------
+// skip_frontmatter shares the opening-delimiter policy (iter-158 review fix)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_bom_file_shows_body_not_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("bom.md"),
+        b"\xEF\xBB\xBF---\ntitle: Note\nstatus: draft\n---\nBody line one.\nBody line two.\n",
+    )
+    .unwrap();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "bom.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let content = json["results"]["content"].as_str().unwrap();
+    assert!(
+        !content.contains("title: Note"),
+        "frontmatter must not be dumped as body content, got: {content:?}"
+    );
+    assert!(content.contains("Body line one."));
+    assert!(content.contains("Body line two."));
+}
+
+#[test]
+fn read_leading_space_dashes_file_shows_full_content() {
+    // ` ---` never opens frontmatter, so every line is body — nothing may be
+    // silently swallowed as pseudo-frontmatter.
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("lead.md"),
+        b" ---\nsome: body\ntext: here\n---\nreal body line.\n",
+    )
+    .unwrap();
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "lead.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let content = json["results"]["content"].as_str().unwrap();
+    assert!(
+        content.contains("some: body") && content.contains("real body line."),
+        "no lines may be swallowed as pseudo-frontmatter, got: {content:?}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/remove.rs
+++ b/crates/hyalo-cli/tests/e2e/remove.rs
@@ -661,3 +661,45 @@ fn remove_without_dry_run_has_dry_run_false() {
         "file was not written:\n{content}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// iter-158 C-1: BOM-prefixed files must round-trip through `remove` without
+// corruption, and the property must actually be removed (not just appear to
+// be, per the bug report's note that BOM files falsely reported success).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_property_on_bom_file_actually_removes_it() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "\u{feff}---\ntitle: Note\nstatus: draft\n---\nBody.\n",
+    );
+
+    let (status, json, stderr) = remove_json(&tmp, &["--property", "status", "--file", "note.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(
+        json["modified"].as_array().unwrap().len(),
+        1,
+        "expected the property to be reported as removed: {json}"
+    );
+
+    let bytes = fs::read(tmp.path().join("note.md")).unwrap();
+    assert_eq!(
+        String::from_utf8(bytes).unwrap(),
+        "\u{feff}---\ntitle: Note\n---\nBody.\n",
+        "expected status removed in place, BOM preserved, no duplicate block"
+    );
+
+    // Verify the removal is real, not just reported: re-reading the file
+    // must no longer see `status` at all.
+    let (status2, json2, stderr2) =
+        remove_json(&tmp, &["--property", "status", "--file", "note.md"]);
+    assert!(status2.success(), "stderr: {stderr2}");
+    assert_eq!(
+        json2["skipped"].as_array().unwrap().len(),
+        1,
+        "status should already be gone: {json2}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/set.rs
+++ b/crates/hyalo-cli/tests/e2e/set.rs
@@ -1312,3 +1312,134 @@ fn set_date_rejects_non_leap_feb_29() {
         "2023-02-29 should be rejected (2023 is not a leap year), stderr: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// iter-158 C-1: read/write opening-delimiter predicate drift corrupted files
+// on BOM-prefixed, leading-whitespace, and CRLF documents, and rejected
+// oversized files unsafely. These are the CLI-level regression tests.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_bom_file_round_trips_without_duplicate_block() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "\u{feff}---\ntitle: Note\nstatus: draft\n---\nBody.\n",
+    );
+
+    let (status, json, stderr) =
+        set_json(&tmp, &["--property", "status=done", "--file", "note.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    let bytes = fs::read(tmp.path().join("note.md")).unwrap();
+    assert_eq!(
+        String::from_utf8(bytes).unwrap(),
+        "\u{feff}---\ntitle: Note\nstatus: done\n---\nBody.\n",
+        "expected the original BOM-prefixed block updated in place, not duplicated"
+    );
+}
+
+#[test]
+fn set_leading_space_file_prepends_new_block_without_corrupting_pseudo_block() {
+    let tmp = TempDir::new().unwrap();
+    let original = " ---\ntitle: Note\nstatus: draft\n---\nBody.\n";
+    write_md(tmp.path(), "note.md", original);
+
+    let (status, json, stderr) =
+        set_json(&tmp, &["--property", "status=done", "--file", "note.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert_eq!(
+        content,
+        format!("---\nstatus: done\n---\n{original}"),
+        "expected exactly one new frontmatter block prepended, with the old \
+         ` ---` pseudo-block preserved verbatim as body"
+    );
+
+    // The read and write paths must agree that ` ---` never opens frontmatter,
+    // so `find --property status=done` sees the newly written property.
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--property", "status=done"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = envelope["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "find should see the newly written property: {envelope}"
+    );
+    assert_eq!(results[0]["file"], "note.md");
+}
+
+#[test]
+fn set_crlf_file_stays_uniform_crlf_after_mutation() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\r\ntitle: Note\r\nstatus: draft\r\n---\r\nBody.\r\n",
+    );
+
+    let (status, json, stderr) =
+        set_json(&tmp, &["--property", "status=done", "--file", "note.md"]);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["modified"].as_array().unwrap().len(), 1);
+
+    let bytes = fs::read(tmp.path().join("note.md")).unwrap();
+    assert_eq!(
+        String::from_utf8(bytes).unwrap(),
+        "---\r\ntitle: Note\r\nstatus: done\r\n---\r\nBody.\r\n",
+        "expected uniform CRLF line endings after mutation"
+    );
+}
+
+#[test]
+fn set_refuses_oversized_file_and_leaves_it_untouched() {
+    use std::io::Read as _;
+
+    let tmp = TempDir::new().unwrap();
+    let original = b"---\ntitle: Note\n---\nBody.\n";
+    write_md(tmp.path(), "big.md", std::str::from_utf8(original).unwrap());
+    // Sparse-extend well past the 100 MiB write guard without writing real data.
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .open(tmp.path().join("big.md"))
+        .unwrap();
+    file.set_len(100 * 1024 * 1024 + 1).unwrap();
+    drop(file);
+
+    let (status, _json, stderr) =
+        set_json(&tmp, &["--property", "status=done", "--file", "big.md"]);
+    assert!(
+        !status.success(),
+        "oversized file must be refused, not silently rewritten"
+    );
+    assert!(
+        stderr.contains("MiB") && stderr.contains("limit"),
+        "expected a size-limit error, got stderr: {stderr}"
+    );
+
+    let meta = fs::metadata(tmp.path().join("big.md")).unwrap();
+    assert_eq!(
+        meta.len(),
+        100 * 1024 * 1024 + 1,
+        "file size must be unchanged after a refused write"
+    );
+    let mut prefix = vec![0u8; original.len()];
+    fs::File::open(tmp.path().join("big.md"))
+        .unwrap()
+        .read_exact(&mut prefix)
+        .unwrap();
+    assert_eq!(prefix, original, "file content must be untouched");
+}

--- a/crates/hyalo-cli/tests/e2e/task.rs
+++ b/crates/hyalo-cli/tests/e2e/task.rs
@@ -1425,6 +1425,236 @@ fn task_toggle_files_from_empty_input_exits_zero() {
     assert!(status.success(), "stderr: {stderr}");
 }
 
+// ---------------------------------------------------------------------------
+// H-9: task toggle/set must be fence- and comment-aware, matching task read.
+// ---------------------------------------------------------------------------
+
+/// Fixture with a `%%` comment block containing a checkbox-looking line.
+///
+/// ```text
+/// 1: ---
+/// 2: title: Test
+/// 3: ---
+/// 4: # Tasks
+/// 5: - [ ] Real task
+/// 6: %%
+/// 7: - [ ] Inside comment
+/// 8: %%
+/// ```
+const LINE_IN_COMMENT_BLOCK: usize = 7;
+
+fn setup_comment_task_file(tmp: &tempfile::TempDir) {
+    let content = "---\ntitle: Test\n---\n# Tasks\n- [ ] Real task\n%%\n- [ ] Inside comment\n%%\n";
+    write_md(tmp.path(), "comment_tasks.md", content);
+}
+
+#[test]
+fn task_toggle_inside_code_block_exits_1_and_file_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_task_file(&tmp);
+    let original = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+
+    let (status, _json, stderr) = run_task_toggle(&tmp, "tasks.md", LINE_IN_CODE_BLOCK);
+    assert!(!status.success());
+    assert_eq!(status.code(), Some(1));
+    assert!(stderr.contains("not a task"), "stderr: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+    assert_eq!(after, original, "fenced line must not be mutated");
+}
+
+#[test]
+fn task_set_status_inside_code_block_exits_1_and_file_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_task_file(&tmp);
+    let original = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+
+    let (status, _json, stderr) = run_task_set_status(&tmp, "tasks.md", LINE_IN_CODE_BLOCK, "x");
+    assert!(!status.success());
+    assert_eq!(status.code(), Some(1));
+    assert!(stderr.contains("not a task"), "stderr: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+    assert_eq!(after, original, "fenced line must not be mutated");
+}
+
+#[test]
+fn task_toggle_inside_comment_block_exits_1_and_file_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_comment_task_file(&tmp);
+    let original = fs::read_to_string(tmp.path().join("comment_tasks.md")).unwrap();
+
+    let (status, _json, stderr) = run_task_toggle(&tmp, "comment_tasks.md", LINE_IN_COMMENT_BLOCK);
+    assert!(!status.success());
+    assert_eq!(status.code(), Some(1));
+    assert!(stderr.contains("not a task"), "stderr: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("comment_tasks.md")).unwrap();
+    assert_eq!(after, original, "commented line must not be mutated");
+}
+
+#[test]
+fn task_set_status_inside_comment_block_exits_1_and_file_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_comment_task_file(&tmp);
+    let original = fs::read_to_string(tmp.path().join("comment_tasks.md")).unwrap();
+
+    let (status, _json, stderr) =
+        run_task_set_status(&tmp, "comment_tasks.md", LINE_IN_COMMENT_BLOCK, "x");
+    assert!(!status.success());
+    assert_eq!(status.code(), Some(1));
+    assert!(stderr.contains("not a task"), "stderr: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("comment_tasks.md")).unwrap();
+    assert_eq!(after, original, "commented line must not be mutated");
+}
+
+#[test]
+fn task_toggle_valid_line_with_frontmatter_and_fence_untouched() {
+    // Frontmatter shifts every body line number; confirm fence-aware
+    // validation still resolves the correct physical line and leaves the
+    // fenced checkbox-looking line alone.
+    let tmp = tempfile::tempdir().unwrap();
+    setup_task_file(&tmp);
+
+    let (status, json, stderr) = run_task_toggle(&tmp, "tasks.md", LINE_INCOMPLETE);
+    assert!(status.success(), "stderr: {stderr}");
+    assert_eq!(json["line"], LINE_INCOMPLETE);
+    assert_eq!(json["status"], "x");
+
+    let content = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+    assert!(content.contains("- [x] First task"));
+    assert!(
+        content.contains("- [ ] Not a real task"),
+        "fenced line must remain untouched"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// M: --dry-run parity — dry-run and the real run must agree, for both the
+// failure case (fenced line) and the success case (valid line).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_toggle_dry_run_and_real_run_agree_on_fenced_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_task_file(&tmp);
+
+    let mut dry_cmd = hyalo_no_hints();
+    dry_cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    dry_cmd.args([
+        "task",
+        "toggle",
+        "--file",
+        "tasks.md",
+        "--line",
+        &LINE_IN_CODE_BLOCK.to_string(),
+        "--dry-run",
+    ]);
+    let dry_output = dry_cmd.output().unwrap();
+    let dry_stderr = String::from_utf8_lossy(&dry_output.stderr).to_string();
+
+    let (real_status, _real_json, real_stderr) =
+        run_task_toggle(&tmp, "tasks.md", LINE_IN_CODE_BLOCK);
+
+    assert!(
+        !dry_output.status.success(),
+        "dry-run must fail on a fenced line"
+    );
+    assert!(
+        !real_status.success(),
+        "real run must fail on a fenced line"
+    );
+    assert_eq!(
+        dry_output.status.code(),
+        real_status.code(),
+        "dry-run and real run must agree on exit code"
+    );
+    assert!(
+        dry_stderr.contains("not a task"),
+        "dry-run stderr: {dry_stderr}"
+    );
+    assert!(
+        real_stderr.contains("not a task"),
+        "real stderr: {real_stderr}"
+    );
+
+    let content = fs::read_to_string(tmp.path().join("tasks.md")).unwrap();
+    assert!(
+        content.contains("- [ ] Not a real task"),
+        "fenced line must remain untouched after either run"
+    );
+}
+
+#[test]
+fn task_toggle_dry_run_predicts_real_run_on_valid_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_task_file(&tmp);
+
+    let (dry_status, dry_json, dry_stderr) = run_task_cmd_json(
+        &tmp,
+        &[
+            "task",
+            "toggle",
+            "--file",
+            "tasks.md",
+            "--line",
+            &LINE_INCOMPLETE.to_string(),
+            "--dry-run",
+        ],
+    );
+    assert!(dry_status.success(), "stderr: {dry_stderr}");
+
+    let (real_status, real_json, real_stderr) = run_task_toggle(&tmp, "tasks.md", LINE_INCOMPLETE);
+    assert!(real_status.success(), "stderr: {real_stderr}");
+
+    let dry_result = &dry_json["results"];
+    assert_eq!(dry_result["line"], real_json["line"]);
+    assert_eq!(dry_result["status"], real_json["status"]);
+    assert_eq!(dry_result["done"], real_json["done"]);
+    assert_eq!(dry_result["text"], real_json["text"]);
+}
+
+// ---------------------------------------------------------------------------
+// M: oversized files must be refused (not silently skipped) and left
+// untouched — a mutation command always targets an explicit file.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_toggle_oversized_file_refused_and_untouched() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("big.md");
+    // Sparse file just over the scanner size cap; no real disk usage.
+    let f = fs::File::create(&path).unwrap();
+    f.set_len(hyalo_core::scanner::MAX_FILE_SIZE + 1).unwrap();
+    drop(f);
+    let before_len = fs::metadata(&path).unwrap().len();
+
+    let (status, _json, stderr) = run_task_toggle(&tmp, "big.md", 1);
+    assert!(!status.success());
+    assert!(stderr.contains("too large"), "stderr: {stderr}");
+
+    let after_len = fs::metadata(&path).unwrap().len();
+    assert_eq!(before_len, after_len, "oversized file must not be modified");
+}
+
+#[test]
+fn task_set_status_oversized_file_refused_and_untouched() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("big.md");
+    let f = fs::File::create(&path).unwrap();
+    f.set_len(hyalo_core::scanner::MAX_FILE_SIZE + 1).unwrap();
+    drop(f);
+    let before_len = fs::metadata(&path).unwrap().len();
+
+    let (status, _json, stderr) = run_task_set_status(&tmp, "big.md", 1, "x");
+    assert!(!status.success());
+    assert!(stderr.contains("too large"), "stderr: {stderr}");
+
+    let after_len = fs::metadata(&path).unwrap().len();
+    assert_eq!(before_len, after_len, "oversized file must not be modified");
+}
+
 #[test]
 fn task_toggle_glob_single_file() {
     // Passing --glob that matches exactly one file works (SingleOrMany policy).

--- a/crates/hyalo-core/src/frontmatter/mod.rs
+++ b/crates/hyalo-core/src/frontmatter/mod.rs
@@ -5,6 +5,7 @@ mod types;
 
 use anyhow::Context as _;
 
+pub(crate) use parse::is_opening_delimiter;
 pub use parse::{
     FrontmatterBudgetError, body_only, check_frontmatter_size_budget, hyalo_options,
     read_frontmatter, skip_frontmatter, write_frontmatter,
@@ -97,7 +98,10 @@ pub fn as_budget_error(err: &anyhow::Error) -> Option<&FrontmatterBudgetError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parse::{Document, detect_list_indent_style, read_frontmatter_from_reader};
+    use parse::{
+        Document, LineEnding, detect_list_indent_style, opening_delimiter,
+        read_frontmatter_from_reader,
+    };
     use serde_json::Value;
     use std::fmt::Write as _;
     use std::path::Path;
@@ -932,5 +936,307 @@ Body.
             serialized.contains("tags:\n  - a\n  - b"),
             "indented list style should be preserved: {serialized}"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Opening-delimiter policy tests (iter-158 C-1: read/write predicate drift)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn opening_delimiter_plain_lf() {
+        let d = opening_delimiter("---\n").unwrap();
+        assert!(!d.has_bom);
+        assert_eq!(d.line_ending, LineEnding::Lf);
+    }
+
+    #[test]
+    fn opening_delimiter_plain_crlf() {
+        let d = opening_delimiter("---\r\n").unwrap();
+        assert!(!d.has_bom);
+        assert_eq!(d.line_ending, LineEnding::CrLf);
+    }
+
+    #[test]
+    fn opening_delimiter_bom_lf() {
+        let d = opening_delimiter("\u{feff}---\n").unwrap();
+        assert!(d.has_bom);
+        assert_eq!(d.line_ending, LineEnding::Lf);
+    }
+
+    #[test]
+    fn opening_delimiter_bom_crlf() {
+        let d = opening_delimiter("\u{feff}---\r\n").unwrap();
+        assert!(d.has_bom);
+        assert_eq!(d.line_ending, LineEnding::CrLf);
+    }
+
+    #[test]
+    fn opening_delimiter_bare_no_terminator() {
+        // End-of-input with no trailing newline at all (e.g. a file that is
+        // exactly `---`) still opens a delimiter line; callers decide what
+        // "nothing follows" means.
+        assert!(opening_delimiter("---").is_some());
+    }
+
+    #[test]
+    fn opening_delimiter_rejects_leading_whitespace() {
+        assert!(
+            opening_delimiter(" ---\n").is_none(),
+            "leading whitespace before `---` must not open frontmatter"
+        );
+    }
+
+    #[test]
+    fn opening_delimiter_rejects_extra_dashes() {
+        assert!(opening_delimiter("----\n").is_none());
+    }
+
+    #[test]
+    fn opening_delimiter_rejects_trailing_junk() {
+        assert!(opening_delimiter("--- \n").is_none());
+        assert!(opening_delimiter("---x\n").is_none());
+    }
+
+    #[test]
+    fn opening_delimiter_rejects_non_dash_line() {
+        assert!(opening_delimiter("title: x\n").is_none());
+    }
+
+    // ---------------------------------------------------------------------------
+    // BOM handling (iter-158 C-1a)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn streaming_bom_frontmatter_is_recognized() {
+        let input = "\u{feff}---\ntitle: Note\nstatus: draft\n---\nBody.\n";
+        let props = read_frontmatter_from_reader(input.as_bytes()).unwrap();
+        assert_eq!(props.get("title"), Some(&Value::String("Note".into())));
+        assert_eq!(props.get("status"), Some(&Value::String("draft".into())));
+    }
+
+    #[test]
+    fn extract_frontmatter_bom_matches_streaming_reader() {
+        // Document::parse (backed by extract_frontmatter) must agree with
+        // read_frontmatter_from_reader on a BOM-prefixed document: both must
+        // see the same properties, not "no frontmatter" for one and real
+        // properties for the other.
+        let content = "\u{feff}---\ntitle: Note\n---\nBody.\n";
+        let doc = Document::parse(content).unwrap();
+        let streamed = read_frontmatter_from_reader(content.as_bytes()).unwrap();
+        assert_eq!(doc.properties(), &streamed);
+        assert_eq!(
+            doc.properties().get("title"),
+            Some(&Value::String("Note".into()))
+        );
+        assert_eq!(doc.body(), "Body.\n");
+    }
+
+    #[test]
+    fn write_frontmatter_preserves_bom_and_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bom.md");
+        std::fs::write(
+            &path,
+            "\u{feff}---\ntitle: Note\nstatus: draft\n---\nBody.\n",
+        )
+        .unwrap();
+
+        let mut props = read_frontmatter(&path).unwrap();
+        assert_eq!(
+            props.get("status"),
+            Some(&Value::String("draft".into())),
+            "read path must see the real frontmatter, not treat the BOM file as empty"
+        );
+        props.insert("status".to_owned(), Value::String("done".into()));
+        write_frontmatter(&path, &props).unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(
+            bytes.starts_with("\u{feff}---\n".as_bytes()),
+            "BOM must be preserved at the start of the file"
+        );
+        let content = String::from_utf8(bytes).unwrap();
+        // Exactly one frontmatter block: only two `---` delimiter lines.
+        assert_eq!(
+            content.matches("---\n").count(),
+            2,
+            "expected exactly one frontmatter block, got:\n{content}"
+        );
+        assert!(content.contains("status: done"), "content:\n{content}");
+        assert!(content.ends_with("Body.\n"), "body corrupted:\n{content}");
+
+        // remove must also work against the BOM file and actually remove the key.
+        let mut props = read_frontmatter(&path).unwrap();
+        props.shift_remove("status");
+        write_frontmatter(&path, &props).unwrap();
+        let final_props = read_frontmatter(&path).unwrap();
+        assert!(
+            final_props.get("status").is_none(),
+            "status should have been removed: {final_props:?}"
+        );
+        let final_bytes = std::fs::read(&path).unwrap();
+        assert!(
+            final_bytes.starts_with("\u{feff}".as_bytes()),
+            "BOM must still be preserved after removing the last mutated property"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Leading-whitespace pseudo-frontmatter (iter-158 C-1b)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn streaming_leading_space_is_no_frontmatter() {
+        let input = " ---\ntitle: Note\nstatus: draft\n---\nBody.\n";
+        let props = read_frontmatter_from_reader(input.as_bytes()).unwrap();
+        assert!(
+            props.is_empty(),
+            "leading whitespace before `---` must not be treated as frontmatter: {props:?}"
+        );
+    }
+
+    #[test]
+    fn write_frontmatter_leading_space_prepends_without_duplicating() {
+        use indexmap::IndexMap;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("space.md");
+        let original = " ---\ntitle: Note\nstatus: draft\n---\nBody.\n";
+        std::fs::write(&path, original).unwrap();
+
+        // read_frontmatter must agree with write_frontmatter: no frontmatter here.
+        let props = read_frontmatter(&path).unwrap();
+        assert!(props.is_empty());
+
+        let mut new_props = IndexMap::new();
+        new_props.insert("status".to_owned(), Value::String("done".into()));
+        write_frontmatter(&path, &new_props).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        // Exactly one new frontmatter block at the very top...
+        assert!(
+            content.starts_with("---\nstatus: done\n---\n"),
+            "expected a single new frontmatter block at top:\n{content}"
+        );
+        // ...and the old pseudo-block survives untouched as body content: the
+        // whole original file (byte-for-byte) is now the tail of the new one.
+        assert!(
+            content.ends_with(original),
+            "old pseudo-block must be preserved verbatim in the body:\n{content}"
+        );
+        assert_eq!(
+            content.len(),
+            "---\nstatus: done\n---\n".len() + original.len(),
+            "new block should be prepended, not merged/duplicated:\n{content}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Bare `---` with no closing delimiter and nothing else in the file
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn write_frontmatter_bare_dash_is_not_unclosed_error() {
+        use indexmap::IndexMap;
+
+        // A file that is exactly `---\n` has no frontmatter per
+        // read_frontmatter_from_reader (see streaming_solo_dash_is_no_frontmatter).
+        // find_body_offset must agree, or write_frontmatter would spuriously
+        // fail with "unclosed frontmatter" on a file read_frontmatter reports
+        // as having no properties at all.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bare.md");
+        std::fs::write(&path, "---\n").unwrap();
+
+        assert!(read_frontmatter(&path).unwrap().is_empty());
+
+        let mut props = IndexMap::new();
+        props.insert("status".to_owned(), Value::String("done".into()));
+        write_frontmatter(&path, &props).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.starts_with("---\nstatus: done\n---\n"), "{content}");
+        assert!(
+            content.ends_with("---\n"),
+            "original bare dash lost: {content}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // CRLF preservation (iter-158 C-1 MEDIUM)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    #[allow(clippy::naive_bytecount)] // Test-only, tiny buffer; not worth a new dependency.
+    fn write_frontmatter_crlf_round_trips_uniformly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("crlf.md");
+        std::fs::write(
+            &path,
+            "---\r\ntitle: Note\r\nstatus: draft\r\n---\r\nBody.\r\n",
+        )
+        .unwrap();
+
+        let mut props = read_frontmatter(&path).unwrap();
+        props.insert("status".to_owned(), Value::String("done".into()));
+        write_frontmatter(&path, &props).unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        let lf_count = bytes.iter().filter(|&&b| b == b'\n').count();
+        let crlf_count = bytes.windows(2).filter(|w| w == b"\r\n").count();
+        assert_eq!(
+            lf_count,
+            crlf_count,
+            "every LF must be part of a CRLF pair: {:?}",
+            String::from_utf8_lossy(&bytes)
+        );
+        assert!(
+            String::from_utf8_lossy(&bytes).contains("status: done\r\n"),
+            "content: {:?}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Oversized-file guard (iter-158 C-1 MEDIUM)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn write_frontmatter_rejects_oversized_file() {
+        use indexmap::IndexMap;
+        use std::io::Read as _;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("big.md");
+        std::fs::write(&path, "---\ntitle: Note\n---\nBody.\n").unwrap();
+        // Sparse-extend well past MAX_FILE_SIZE without writing real data.
+        let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        file.set_len(crate::scanner::MAX_FILE_SIZE + 1).unwrap();
+        drop(file);
+
+        let mut props = IndexMap::new();
+        props.insert("status".to_owned(), Value::String("done".into()));
+        let result = write_frontmatter(&path, &props);
+        assert!(
+            result.is_err(),
+            "oversized file must be refused, not silently rewritten"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("MiB") && err.contains("exceeds") && err.contains("limit"),
+            "expected a size-limit error message, got: {err}"
+        );
+
+        // File must be untouched: still its original length, and the readable
+        // prefix must still be the original frontmatter (not corrupted).
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(meta.len(), crate::scanner::MAX_FILE_SIZE + 1);
+        let original = b"---\ntitle: Note\n---\nBody.\n";
+        let mut prefix = vec![0u8; original.len()];
+        std::fs::File::open(&path)
+            .unwrap()
+            .read_exact(&mut prefix)
+            .unwrap();
+        assert_eq!(prefix, original);
     }
 }

--- a/crates/hyalo-core/src/frontmatter/mod.rs
+++ b/crates/hyalo-core/src/frontmatter/mod.rs
@@ -409,6 +409,32 @@ Body.
         assert_eq!(doc.properties(), &streamed);
     }
 
+    // --- skip_frontmatter must share the opening-delimiter policy ---
+
+    #[test]
+    fn skip_frontmatter_recognizes_bom_prefixed_opening() {
+        let input = "\u{feff}---\ntitle: Note\n---\nBody.\n";
+        let mut reader = input.as_bytes();
+        let mut first_line = String::new();
+        std::io::BufRead::read_line(&mut reader, &mut first_line).unwrap();
+        let consumed = skip_frontmatter(&mut reader, &first_line).unwrap();
+        assert_eq!(consumed, 3, "BOM + `---` must open frontmatter");
+        // Reader is positioned at the body.
+        let mut body = String::new();
+        std::io::Read::read_to_string(&mut reader, &mut body).unwrap();
+        assert_eq!(body, "Body.\n");
+    }
+
+    #[test]
+    fn skip_frontmatter_rejects_leading_whitespace_opening() {
+        let input = " ---\ntitle: Note\n---\nBody.\n";
+        let mut reader = input.as_bytes();
+        let mut first_line = String::new();
+        std::io::BufRead::read_line(&mut reader, &mut first_line).unwrap();
+        let consumed = skip_frontmatter(&mut reader, &first_line).unwrap();
+        assert_eq!(consumed, 0, "` ---` must NOT open frontmatter");
+    }
+
     // --- Budget boundary tests for skip_frontmatter ---
 
     fn make_frontmatter_with_n_lines(n: usize) -> String {

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -562,7 +562,7 @@ fn find_body_offset(file: &mut File) -> Result<FrontmatterSpan> {
 /// (including the opening and closing `---` delimiters). Returns 0 if no frontmatter is present.
 /// The reader is left positioned at the first line after the closing `---`.
 pub fn skip_frontmatter<R: BufRead>(reader: &mut R, first_line: &str) -> Result<usize> {
-    if first_line.trim() != "---" {
+    if opening_delimiter(first_line).is_none() {
         return Ok(0);
     }
 

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -106,6 +106,79 @@ pub(super) fn detect_list_indent_style(yaml: &str) -> bool {
     false
 }
 
+// ---------------------------------------------------------------------------
+// Shared opening-delimiter policy
+// ---------------------------------------------------------------------------
+
+/// UTF-8 byte-order mark. Some editors (Notepad, Excel) prepend this to
+/// files; hyalo recognizes it and preserves it verbatim on rewrite rather
+/// than treating it as part of the frontmatter delimiter itself.
+const BOM: &str = "\u{feff}";
+
+/// Line-ending style of an existing frontmatter block, so a rewrite can keep
+/// the block — and thus the whole file — on one consistent style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LineEnding {
+    Lf,
+    CrLf,
+}
+
+impl LineEnding {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            LineEnding::Lf => "\n",
+            LineEnding::CrLf => "\r\n",
+        }
+    }
+}
+
+/// What [`opening_delimiter`] reports about a recognized opening `---` line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct OpeningDelimiter {
+    /// Whether the line was prefixed with a UTF-8 BOM.
+    pub(super) has_bom: bool,
+    /// The line ending following the `---` (irrelevant at end-of-input).
+    pub(super) line_ending: LineEnding,
+}
+
+/// Single source of truth for "does this line open a frontmatter block?"
+///
+/// `line` is the first line of a document, terminator included (`\n`,
+/// `\r\n`, or none at end-of-input), optionally prefixed by a single UTF-8
+/// BOM. A line opens frontmatter only when — after stripping at most one
+/// leading BOM — it is exactly `---` followed by a line terminator or
+/// end-of-input. Leading whitespace before `---` is deliberately **not**
+/// accepted (e.g. `" ---"` does not open frontmatter): this matches
+/// Obsidian/Jekyll and keeps the check unambiguous.
+///
+/// `extract_frontmatter`, `read_frontmatter_from_reader`, and
+/// `find_body_offset` all call this helper instead of hand-rolling their own
+/// check, so the read and write paths can never disagree about whether a
+/// file has frontmatter — a prior drift between the three caused file
+/// corruption on `set`/`remove`/`append` for BOM-prefixed and
+/// leading-whitespace files (iter-158 C-1).
+pub(super) fn opening_delimiter(line: &str) -> Option<OpeningDelimiter> {
+    let (has_bom, rest) = match line.strip_prefix(BOM) {
+        Some(rest) => (true, rest),
+        None => (false, line),
+    };
+    let (dashes, line_ending) = match rest.strip_suffix("\r\n") {
+        Some(r) => (r, LineEnding::CrLf),
+        None => (rest.strip_suffix('\n').unwrap_or(rest), LineEnding::Lf),
+    };
+    (dashes == "---").then_some(OpeningDelimiter {
+        has_bom,
+        line_ending,
+    })
+}
+
+/// Crate-visible form of [`opening_delimiter`] for sibling modules (the
+/// scanner), so every parse path in the crate shares the same
+/// opening-delimiter policy and cannot drift from the read/write paths.
+pub(crate) fn is_opening_delimiter(line: &str) -> bool {
+    opening_delimiter(line).is_some()
+}
+
 /// Represents parsed frontmatter and the remaining body content.
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // Used in tests only
@@ -227,28 +300,48 @@ pub fn read_frontmatter(path: &Path) -> Result<IndexMap<String, Value>> {
 /// If `props` is empty (all properties removed), no frontmatter block is written —
 /// the file starts directly with the body.
 pub fn write_frontmatter(path: &Path, props: &IndexMap<String, Value>) -> Result<()> {
-    // --- Step 1: find the byte offset where the body starts and detect indent style ---
+    // --- Step 0: open the file and guard against unbounded memory use ---
+    // Step 2 below reads the whole body into memory; refuse up front rather
+    // than let `read_to_end` allocate without bound for a huge file.
     let mut file =
         File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let file_size = file
+        .metadata()
+        .with_context(|| format!("failed to stat {}", path.display()))?
+        .len();
+    if file_size > crate::scanner::MAX_FILE_SIZE {
+        parse_bail!(
+            "refusing to rewrite {}: {} MiB exceeds {} MiB limit",
+            path.display(),
+            file_size / (1024 * 1024),
+            crate::scanner::MAX_FILE_SIZE / (1024 * 1024)
+        );
+    }
 
-    let body_offset = find_body_offset(&mut file)?;
+    // --- Step 1: find the byte offset where the body starts and detect indent style ---
+    let span = find_body_offset(&mut file)?;
 
     // Detect list indent style from the existing frontmatter before overwriting
-    let compact_list_indent = if body_offset > 0 {
+    let compact_list_indent = if span.body_offset > 0 {
         file.seek(SeekFrom::Start(0))
             .with_context(|| format!("failed to seek in {}", path.display()))?;
         // body_offset is the byte position within the file; on 32-bit targets a
         // frontmatter section larger than 4 GiB would truncate here, but that is
         // unreachable in practice.
         #[allow(clippy::cast_possible_truncation)]
-        let mut fm_bytes = vec![0u8; body_offset as usize];
+        let mut fm_bytes = vec![0u8; span.body_offset as usize];
         file.read_exact(&mut fm_bytes)
             .with_context(|| format!("failed to read frontmatter of {}", path.display()))?;
         let fm_str = String::from_utf8_lossy(&fm_bytes);
-        // Extract just the YAML content between the --- delimiters
+        // Extract just the YAML content between the --- delimiters, using the
+        // exact opening prefix `find_body_offset` recognized (BOM + line ending).
+        let opening_prefix = format!(
+            "{}---{}",
+            if span.has_bom { BOM } else { "" },
+            span.line_ending.as_str()
+        );
         let yaml_content = fm_str
-            .strip_prefix("---\n")
-            .or_else(|| fm_str.strip_prefix("---\r\n"))
+            .strip_prefix(opening_prefix.as_str())
             .unwrap_or(&fm_str);
         detect_list_indent_style(yaml_content)
     } else {
@@ -256,7 +349,7 @@ pub fn write_frontmatter(path: &Path, props: &IndexMap<String, Value>) -> Result
     };
 
     // --- Step 2: read the body bytes from that offset ---
-    file.seek(SeekFrom::Start(body_offset))
+    file.seek(SeekFrom::Start(span.body_offset))
         .with_context(|| format!("failed to seek in {}", path.display()))?;
     let mut body_bytes = Vec::new();
     file.read_to_end(&mut body_bytes)
@@ -265,26 +358,40 @@ pub fn write_frontmatter(path: &Path, props: &IndexMap<String, Value>) -> Result
 
     // --- Step 3: serialize new frontmatter ---
     let mut out: Vec<u8> = Vec::new();
+    // Preserve a leading BOM the original file had. When `body_offset == 0`
+    // (no recognized frontmatter) any BOM is already part of `body_bytes`
+    // untouched; this only matters when frontmatter was recognized and thus
+    // excluded from `body_bytes`.
+    if span.has_bom {
+        out.extend_from_slice(BOM.as_bytes());
+    }
     if !props.is_empty() {
         let mut yaml = serde_saphyr::to_string_with_options(
             props,
             hyalo_serializer_options(compact_list_indent),
         )
         .context("failed to serialize YAML")?;
-        // Normalize trailing newline before the budget check so the check
-        // sees the exact byte/line count we are about to write — otherwise
-        // a YAML of exactly MAX_FRONTMATTER_BYTES could pass the check yet
-        // be written as MAX_FRONTMATTER_BYTES + 1.
         if !yaml.ends_with('\n') {
             yaml.push('\n');
+        }
+        // Match the original frontmatter's line ending so the block (and
+        // thus the whole file) doesn't end up with mixed CRLF/LF lines. Do
+        // this before the budget check below so the check sees the exact
+        // bytes about to be written — otherwise a YAML of exactly
+        // MAX_FRONTMATTER_BYTES could pass the check yet be written larger.
+        let eol = span.line_ending.as_str();
+        if eol == "\r\n" {
+            yaml = yaml.replace('\n', "\r\n");
         }
 
         // Pre-flight budget check: reject before touching the file.
         check_frontmatter_size_budget(&yaml, path).map_err(anyhow::Error::new)?;
 
-        out.extend_from_slice(b"---\n");
+        out.extend_from_slice(b"---");
+        out.extend_from_slice(eol.as_bytes());
         out.extend_from_slice(yaml.as_bytes());
-        out.extend_from_slice(b"---\n");
+        out.extend_from_slice(b"---");
+        out.extend_from_slice(eol.as_bytes());
     }
     out.extend_from_slice(&body_bytes);
 
@@ -362,20 +469,47 @@ pub fn check_frontmatter_size_budget(
     Ok(())
 }
 
+/// Byte offset and framing of the frontmatter block found by [`find_body_offset`].
+struct FrontmatterSpan {
+    /// Byte offset where the body starts. `0` means the file has no
+    /// frontmatter — the entire file is body.
+    body_offset: u64,
+    /// Whether the file began with a UTF-8 BOM (only meaningful when
+    /// `body_offset > 0`; preserved verbatim on rewrite).
+    has_bom: bool,
+    /// Line ending used by the existing frontmatter block (only meaningful
+    /// when `body_offset > 0`).
+    line_ending: LineEnding,
+}
+
 /// Find the byte offset in `file` where the body starts (i.e. the byte immediately
-/// after the closing `---\n` of the frontmatter block).
+/// after the closing `---` line of the frontmatter block), along with the BOM
+/// and line-ending style the block was written with.
 ///
-/// Returns `0` if the file has no frontmatter, which means the entire file is body.
-fn find_body_offset(file: &mut File) -> Result<u64> {
+/// Returns `body_offset: 0` if the file has no frontmatter, which means the
+/// entire file is body. Uses [`opening_delimiter`] — the exact predicate
+/// [`extract_frontmatter`] and [`read_frontmatter_from_reader`] also use — so
+/// the read and write paths can never disagree about whether a file has
+/// frontmatter.
+fn find_body_offset(file: &mut File) -> Result<FrontmatterSpan> {
     let mut reader = BufReader::new(&mut *file);
     let mut line = String::new();
 
-    // Peek at the first line
+    let no_frontmatter = FrontmatterSpan {
+        body_offset: 0,
+        has_bom: false,
+        line_ending: LineEnding::Lf,
+    };
+
+    // Peek at the first line.
     let n = reader.read_line(&mut line).context("failed to read line")?;
-    if n == 0 || line.trim_end_matches(['\n', '\r']) != "---" {
-        // No frontmatter — body starts at offset 0
-        return Ok(0);
+    if n == 0 {
+        return Ok(no_frontmatter);
     }
+    let Some(opening) = opening_delimiter(&line) else {
+        // No frontmatter — body starts at offset 0
+        return Ok(no_frontmatter);
+    };
 
     let mut content_bytes: usize = 0;
     let mut line_count: usize = 0;
@@ -384,6 +518,17 @@ fn find_body_offset(file: &mut File) -> Result<u64> {
         line.clear();
         let n = reader.read_line(&mut line).context("failed to read line")?;
         if n == 0 {
+            if line_count == 0 {
+                // The opening `---` was the only line in the file (e.g. a
+                // file that is exactly `---` or `---\n`) — no content and no
+                // closing delimiter follow, so treat this as "no
+                // frontmatter" rather than an error. This matches
+                // `read_frontmatter_from_reader`'s bare-dash handling; if the
+                // two disagreed here, `set`/`remove`/`append` would fail on
+                // a file that `read_frontmatter` reports as having no
+                // properties at all.
+                return Ok(no_frontmatter);
+            }
             parse_bail!(
                 "unclosed frontmatter: file starts with `---` but no closing `---` was found"
             );
@@ -406,7 +551,11 @@ fn find_body_offset(file: &mut File) -> Result<u64> {
     let pos = reader
         .stream_position()
         .context("failed to get stream position")?;
-    Ok(pos)
+    Ok(FrontmatterSpan {
+        body_offset: pos,
+        has_bom: opening.has_bom,
+        line_ending: opening.line_ending,
+    })
 }
 
 /// Skip past frontmatter in a buffered reader. Returns the number of lines consumed
@@ -457,9 +606,9 @@ pub(crate) fn read_frontmatter_from_reader<R: BufRead>(
 ) -> Result<IndexMap<String, Value>> {
     let mut lines = reader.lines();
 
-    // First line must be `---`
+    // First line must open a frontmatter block (see `opening_delimiter`).
     match lines.next() {
-        Some(Ok(line)) if line.trim() == "---" => {}
+        Some(Ok(line)) if opening_delimiter(&line).is_some() => {}
         _ => return Ok(IndexMap::new()),
     }
 
@@ -511,34 +660,28 @@ pub(crate) fn read_frontmatter_from_reader<R: BufRead>(
 /// Returns `Ok((Some(yaml_content), body))` if frontmatter is found,
 /// `Ok((None, full_content))` if no frontmatter is present, or an error if the file
 /// starts with `---` but has no closing delimiter (which would cause corruption on write).
-#[allow(dead_code)] // Called by Document::parse, which is used in tests only
+///
+/// Used by both `Document::parse` (tests only) and the public `body_only`.
+#[allow(dead_code)] // Also called by body_only; extract_frontmatter itself is exercised via tests.
 fn extract_frontmatter(content: &str) -> Result<(Option<&str>, &str)> {
-    // Frontmatter must start with `---` on the very first line
-    if !content.starts_with("---") {
+    // Recognize the opening delimiter on the first line — same predicate as
+    // `read_frontmatter_from_reader` and `find_body_offset` (see
+    // `opening_delimiter`), so this never disagrees with them about whether
+    // `content` has frontmatter.
+    let first_line_end = content.find('\n').map_or(content.len(), |i| i + 1);
+    let first_line = &content[..first_line_end];
+    if opening_delimiter(first_line).is_none() {
         return Ok((None, content));
     }
 
-    let after_opening = &content[3..];
-    // The opening `---` must be followed by a newline (or be exactly `---`).
-    // If after stripping the newline the rest is empty, the file is exactly
-    // `---` or `---\n` — no frontmatter content or closing delimiter follows,
-    // so treat as "no frontmatter" (consistent with the streaming reader path).
-    let after_opening = if let Some(rest) = after_opening.strip_prefix('\n') {
-        if rest.is_empty() {
-            return Ok((None, content));
-        }
-        rest
-    } else if let Some(rest) = after_opening.strip_prefix("\r\n") {
-        if rest.is_empty() {
-            return Ok((None, content));
-        }
-        rest
-    } else if after_opening.is_empty() {
-        // File is exactly `---` with nothing after
+    let after_opening = &content[first_line_end..];
+    if after_opening.is_empty() {
+        // The opening `---` (optionally BOM-prefixed) was the only line in
+        // the document — no content and no closing delimiter follow, so
+        // treat as "no frontmatter" (consistent with the streaming reader
+        // path's bare-dash handling).
         return Ok((None, content));
-    } else {
-        return Ok((None, content));
-    };
+    }
 
     // Find the closing `---`
     if let Some(pos) = find_closing_delimiter(after_opening) {

--- a/crates/hyalo-core/src/fs_util.rs
+++ b/crates/hyalo-core/src/fs_util.rs
@@ -14,7 +14,7 @@ use tempfile::NamedTempFile;
 /// When `path` already exists, the original file's permissions are preserved.
 /// `NamedTempFile` defaults to mode `0600`, so without this step rewrites
 /// would silently tighten file permissions on every mutation.
-pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
+pub fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
     let parent = path
         .parent()
         .context("cannot determine parent directory for atomic write")?;

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -308,6 +308,13 @@ pub struct SnapshotIndex {
     /// [`SnapshotIndex::set_frontmatter_link_props`]; `None` falls back to
     /// [`DEFAULT_FRONTMATTER_LINK_PROPERTIES`].
     frontmatter_link_props: Option<Vec<String>>,
+    /// Lazily built case-insensitive path lookup used by incremental link
+    /// refreshes ([`refresh_links`](Self::refresh_links)). Rebuilding it per
+    /// refreshed file would be O(entries × refreshed files) in bulk loops
+    /// (`lint --fix --index`, `links fix --apply`), so it is cached here and
+    /// invalidated whenever the set of indexed paths changes
+    /// ([`rebuild_path_index`](Self::rebuild_path_index)). Not persisted.
+    case_index_cache: Option<CaseInsensitiveIndex>,
 }
 
 impl SnapshotIndex {
@@ -440,12 +447,43 @@ impl SnapshotIndex {
 
         self.graph.remove_source(rel_path);
         if let Some(fl) = file_links {
-            let case_index = self.build_case_index();
-            let site_prefix = self.header.site_prefix.clone();
-            self.graph
-                .insert_links(fl, site_prefix.as_deref(), &case_index);
+            self.insert_graph_links(fl);
         }
 
+        Ok(true)
+    }
+
+    /// Insert a file's outbound links into the graph, using (and lazily
+    /// building) the cached case-insensitive index. The cache is taken out
+    /// and put back so `self.graph` and `self.header` can be borrowed
+    /// alongside it.
+    fn insert_graph_links(&mut self, fl: FileLinks) {
+        let case_index = self
+            .case_index_cache
+            .take()
+            .unwrap_or_else(|| self.build_case_index());
+        self.graph
+            .insert_links(fl, self.header.site_prefix.as_deref(), &case_index);
+        self.case_index_cache = Some(case_index);
+    }
+
+    /// Re-scan `rel_path` once and refresh both its full index entry (like
+    /// [`Self::refresh_entry`]) and the persisted link graph (like
+    /// [`Self::refresh_links`]) — one disk read instead of two for callers
+    /// that need both, e.g. `links fix --apply --index` patching every
+    /// rewritten file.
+    ///
+    /// Returns `Ok(true)` if `rel_path` was found and refreshed, `Ok(false)`
+    /// if it is not in the index (a no-op).
+    pub fn refresh_entry_and_links(&mut self, dir: &Path, rel_path: &str) -> Result<bool> {
+        if !self.path_index.contains_key(rel_path) {
+            return Ok(false);
+        }
+        let file_links = self.rescan_entry(dir, rel_path)?;
+        self.graph.remove_source(rel_path);
+        if let Some(fl) = file_links {
+            self.insert_graph_links(fl);
+        }
         Ok(true)
     }
 
@@ -534,7 +572,12 @@ impl SnapshotIndex {
     }
 
     /// Rebuild the path → index lookup after insertions/removals.
+    ///
+    /// Also drops the cached case-insensitive index: every code path that
+    /// changes the set of indexed paths funnels through here, so this is the
+    /// single invalidation point for [`Self::case_index_cache`].
     fn rebuild_path_index(&mut self) {
+        self.case_index_cache = None;
         self.path_index = self
             .entries
             .iter()
@@ -689,6 +732,7 @@ impl SnapshotIndex {
                     header: data.header,
                     bm25_index: data.bm25_index,
                     frontmatter_link_props: None,
+                    case_index_cache: None,
                 })
             }
             Err(e) => {

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::bm25::{Bm25InvertedIndex, resolve_language, tokenize};
+use crate::case_index::CaseInsensitiveIndex;
 use crate::filter::extract_tags;
 use crate::frontmatter;
 use crate::link_graph::{
@@ -372,15 +373,80 @@ impl SnapshotIndex {
     /// update the link graph separately. Returns `Ok(None)` if the file
     /// is not in the index.
     pub(crate) fn rescan_entry(&mut self, dir: &Path, rel_path: &str) -> Result<Option<FileLinks>> {
+        self.rescan_entry_at(&dir.join(rel_path), rel_path)
+    }
+
+    /// Shared implementation behind [`rescan_entry`] and [`refresh_links`]:
+    /// scan `full_path` from disk and replace the index entry for `rel_path`
+    /// wholesale. Returns the file's `FileLinks` for graph updates, or `None`
+    /// if `rel_path` is not in the index.
+    fn rescan_entry_at(&mut self, full_path: &Path, rel_path: &str) -> Result<Option<FileLinks>> {
         let Some(&idx) = self.path_index.get(rel_path) else {
             return Ok(None);
         };
-        let full_path = dir.join(rel_path);
         let fm_props = self.effective_frontmatter_link_props();
-        let (entry, file_links) =
-            scan_one_file(&full_path, rel_path, true, false, None, &fm_props)?;
+        let (entry, file_links) = scan_one_file(full_path, rel_path, true, false, None, &fm_props)?;
         self.entries[idx] = entry;
         Ok(file_links)
+    }
+
+    /// Build a case-insensitive lookup index from every path currently known
+    /// to this snapshot. Used to resolve bare-basename wikilinks (e.g.
+    /// `[[note]]` matching a unique `sub/note.md`) the same way a full
+    /// [`LinkGraph::build`] does, without persisting the case index in the
+    /// snapshot itself.
+    fn build_case_index(&self) -> CaseInsensitiveIndex {
+        let mut case_index = CaseInsensitiveIndex::new();
+        case_index.set_case_insensitive_paths(true);
+        for entry in &self.entries {
+            case_index.insert(&entry.rel_path);
+        }
+        case_index
+    }
+
+    /// Re-scan the body/frontmatter of `rel_path` (already written to disk at
+    /// `full_path`) and refresh the parts of its index entry and the
+    /// persisted [`LinkGraph`] that are derived from wikilinks: the entry's
+    /// `sections`, `tasks`, and `links` fields, plus the graph's outbound
+    /// edges for this file.
+    ///
+    /// `properties`, `tags`, and `modified` are left untouched — callers that
+    /// already know the new values in memory (e.g. `set`/`append`/`remove`)
+    /// should patch those directly, since they don't require a disk read.
+    /// `bm25_tokens`/`bm25_language` are also left untouched: those are only
+    /// populated by `create-index --bm25` and this incremental refresh never
+    /// re-tokenizes the body.
+    ///
+    /// This closes the gap where a frontmatter link property (`related`,
+    /// `depends-on`, ...) mutated via `set`/`append`/`remove`/`lint --fix`
+    /// with `--index` left the persisted link graph stale — `backlinks` and
+    /// `find --fields backlinks`/`links` would return pre-mutation results
+    /// until a full `create-index` rebuild.
+    ///
+    /// Returns `Ok(true)` if `rel_path` was found and refreshed, `Ok(false)`
+    /// if it is not in the index (a no-op).
+    pub fn refresh_links(&mut self, full_path: &Path, rel_path: &str) -> Result<bool> {
+        let Some(&idx) = self.path_index.get(rel_path) else {
+            return Ok(false);
+        };
+        let fm_props = self.effective_frontmatter_link_props();
+        let (scanned, file_links) =
+            scan_one_file(full_path, rel_path, true, false, None, &fm_props)?;
+
+        let entry = &mut self.entries[idx];
+        entry.sections = scanned.sections;
+        entry.tasks = scanned.tasks;
+        entry.links = scanned.links;
+
+        self.graph.remove_source(rel_path);
+        if let Some(fl) = file_links {
+            let case_index = self.build_case_index();
+            let site_prefix = self.header.site_prefix.clone();
+            self.graph
+                .insert_links(fl, site_prefix.as_deref(), &case_index);
+        }
+
+        Ok(true)
     }
 
     /// Re-scan a single file from disk and replace its index entry in-place.

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -310,6 +310,43 @@ impl LinkGraph {
             }
         }
     }
+
+    /// Remove every outbound edge whose source is `rel_path`, across all
+    /// target keys. Target keys left with no remaining entries are dropped
+    /// entirely, matching the invariant `backlinks()` relies on (an absent
+    /// key means "no linkers").
+    ///
+    /// `rel_path` is compared against each edge's source normalized to
+    /// forward slashes, so this matches sources stored with either the
+    /// platform separator (entries from a full vault scan) or a literal
+    /// forward slash (entries from [`LinkGraph::insert_links`]) — see
+    /// [`LinkGraph::all_sources`] for the same normalization.
+    ///
+    /// Used to clear a file's stale edges before re-inserting fresh ones
+    /// after an incremental re-scan (`set`/`append`/`remove`/`lint --fix`
+    /// with `--index`).
+    pub(crate) fn remove_source(&mut self, rel_path: &str) {
+        self.index.retain(|_, entries| {
+            entries.retain(|e| e.source.to_string_lossy().replace('\\', "/") != rel_path);
+            !entries.is_empty()
+        });
+    }
+
+    /// Insert one file's freshly-scanned links into the graph.
+    ///
+    /// This does **not** remove any existing edges for the file's source —
+    /// callers refreshing a file's edges after a mutation should call
+    /// [`remove_source`] first to clear the old ones, then this method to
+    /// insert the new ones (mirroring how a full index build populates the
+    /// graph from every file's [`FileLinks`], one file at a time).
+    pub(crate) fn insert_links(
+        &mut self,
+        file_links: FileLinks,
+        site_prefix: Option<&str>,
+        case_index: &CaseInsensitiveIndex,
+    ) {
+        insert_file_links(&mut self.index, file_links, site_prefix, case_index);
+    }
 }
 
 /// Returns `true` when `entry` is a self-link — i.e. the source file and the
@@ -1250,6 +1287,125 @@ mod tests {
             src_fwd, "notes/new.md",
             "source path must be updated to new path"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // H-7: remove_source / insert_links — incremental edge replacement
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn remove_source_clears_all_edges_for_a_file() {
+        // "source.md" links to both "a" (wikilink) and "b.md" (markdown), plus a
+        // self-link. remove_source must clear all three edges and leave "other.md"
+        // untouched.
+        let vault = create_vault(&[
+            ("source.md", "See [[a]], [link](b.md), and [[source]].\n"),
+            ("other.md", "See [[a]]\n"),
+        ]);
+        let build = LinkGraph::build(vault.path(), None, None).unwrap();
+        let mut graph = build.graph;
+
+        assert_eq!(
+            graph.backlinks("a").len(),
+            2,
+            "a should have 2 backlinks before removal"
+        );
+        assert_eq!(graph.backlinks("b.md").len(), 1);
+
+        graph.remove_source("source.md");
+
+        // source.md's edges are gone, but other.md's edge to "a" survives.
+        let bl_a = graph.backlinks("a");
+        assert_eq!(bl_a.len(), 1, "only other.md's edge to 'a' should remain");
+        assert_eq!(bl_a[0].source, PathBuf::from("other.md"));
+        assert!(
+            graph.backlinks("b.md").is_empty(),
+            "source.md's only edge to b.md must be gone"
+        );
+        assert!(
+            graph.backlinks("source").is_empty(),
+            "source.md's self-link must be gone"
+        );
+    }
+
+    #[test]
+    fn insert_links_adds_edges_without_touching_other_sources() {
+        let mut graph = LinkGraph::default();
+        let mut case_index = CaseInsensitiveIndex::new();
+        case_index.set_case_insensitive_paths(true);
+        case_index.insert("note.md");
+        case_index.insert("target.md");
+
+        graph.insert_links(
+            FileLinks {
+                source: PathBuf::from("note.md"),
+                links: vec![(
+                    1,
+                    Link {
+                        target: "target".to_owned(),
+                        label: None,
+                        kind: LinkKind::Wikilink,
+                    },
+                )],
+            },
+            None,
+            &case_index,
+        );
+
+        let bl = graph.backlinks("target");
+        assert_eq!(bl.len(), 1);
+        assert_eq!(bl[0].source, PathBuf::from("note.md"));
+    }
+
+    #[test]
+    fn remove_source_then_insert_links_replaces_edges() {
+        // Mirrors the incremental-refresh path used by `set`/`append`/`remove`
+        // with `--index`: a file's old edges are removed, then its freshly
+        // scanned links are inserted — the graph must reflect only the new
+        // state afterward, matching what a full rebuild would produce.
+        let vault = create_vault(&[
+            ("note.md", "---\ndepends-on: '[[old-dep]]'\n---\nBody\n"),
+            ("old-dep.md", "Content\n"),
+            ("new-dep.md", "Content\n"),
+        ]);
+        let build = LinkGraph::build(vault.path(), None, None).unwrap();
+        let mut graph = build.graph;
+        assert_eq!(
+            graph.backlinks("old-dep").len(),
+            1,
+            "sanity: old dep linked"
+        );
+
+        let mut case_index = CaseInsensitiveIndex::new();
+        case_index.set_case_insensitive_paths(true);
+        for p in ["note.md", "old-dep.md", "new-dep.md"] {
+            case_index.insert(p);
+        }
+
+        graph.remove_source("note.md");
+        graph.insert_links(
+            FileLinks {
+                source: PathBuf::from("note.md"),
+                links: vec![(
+                    1,
+                    Link {
+                        target: "new-dep".to_owned(),
+                        label: None,
+                        kind: LinkKind::Wikilink,
+                    },
+                )],
+            },
+            None,
+            &case_index,
+        );
+
+        assert!(
+            graph.backlinks("old-dep").is_empty(),
+            "stale edge to old-dep must be gone after replacement"
+        );
+        let bl_new = graph.backlinks("new-dep");
+        assert_eq!(bl_new.len(), 1, "new edge to new-dep must be present");
+        assert_eq!(bl_new[0].source, PathBuf::from("note.md"));
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -412,15 +412,20 @@ pub fn execute_plans(vault_dir: &Path, plans: &[RewritePlan]) -> Result<()> {
 // Inbound rewrite planning
 // ---------------------------------------------------------------------------
 
-/// Walk every body line in `content` and return [`Replacement`]s for links
-/// that target the moved file, plus any [`SkippedAmbiguous`] entries for
-/// links that were skipped due to ambiguity (NEW-3).
+/// Walk every line in `content` — including YAML frontmatter — and return
+/// [`Replacement`]s for links that target the moved file, plus any
+/// [`SkippedAmbiguous`] entries for links that were skipped due to ambiguity
+/// (NEW-3).
 ///
-/// Uses [`LinkResolver`] to match links and [`LinkWriter`] to emit the new
-/// target in the user's original written form (BUG-1 fix: `[[sub/target]]`
-/// stays path-form after rename, not collapsed to `[[renamed]]`).
+/// Body links are matched via [`LinkResolver`] and rewritten with
+/// [`LinkWriter`] so the new target is emitted in the user's original written
+/// form (BUG-1 fix: `[[sub/target]]` stays path-form after rename, not
+/// collapsed to `[[renamed]]`). Wikilinks found inside YAML frontmatter link
+/// properties (`related`, `depends-on`, `supersedes`, `superseded-by`) are
+/// also rewritten (H-4 fix: previously only the batch mv path did this,
+/// leaving single-file mv with dangling frontmatter wikilinks).
 ///
-/// When `allow_ambiguous` is `false`, bare wikilinks whose stem matches
+/// When `allow_ambiguous` is `false`, bare body wikilinks whose stem matches
 /// multiple vault files are skipped with a stderr warning instead of being
 /// silently rewritten to an incorrect target (BUG-2 fix).
 #[allow(clippy::too_many_arguments)]
@@ -430,7 +435,7 @@ fn plan_inbound_rewrites(
     old_rel: &str,
     old_stem: &str,
     new_rel: &str,
-    _new_stem: &str,
+    new_stem: &str,
     site_prefix: Option<&str>,
     case_index: Option<&CaseInsensitiveIndex>,
     allow_ambiguous: bool,
@@ -459,7 +464,15 @@ fn plan_inbound_rewrites(
                 if line.trim() == "---" {
                     in_frontmatter = false;
                     frontmatter_done = true;
+                    continue;
                 }
+                // H-4: also rewrite wikilinks inside frontmatter link
+                // properties so single-file mv doesn't leave dangling
+                // frontmatter links (previously only the batch path did this).
+                let fm_repls = plan_frontmatter_wikilink_rewrites(
+                    line, line_num, old_rel, old_stem, new_rel, new_stem, case_index,
+                );
+                replacements.extend(fm_repls);
                 continue;
             }
             // No frontmatter block found; mark done.
@@ -953,7 +966,7 @@ pub fn plan_batch_mv(
 
         let mut all_replacements = Vec::new();
         for (old_rel, old_stem, new_rel, new_stem) in move_pairs {
-            let repls = plan_inbound_rewrites_with_fm(
+            let (repls, skipped) = plan_inbound_rewrites(
                 &content,
                 source_rel,
                 old_rel,
@@ -964,6 +977,20 @@ pub fn plan_batch_mv(
                 Some(&case_index),
                 allow_ambiguous,
             );
+            // Batch mode doesn't surface skipped-ambiguous links in a JSON
+            // envelope (unlike single-file `plan_mv`) — preserve the prior
+            // stderr-only warning behavior here.
+            for s in skipped {
+                eprintln!(
+                    "warning: skipping ambiguous bare wikilink [[{}]] in {}:{} — matches {} \
+                     files: {}. Use --allow-ambiguous to rewrite anyway.",
+                    s.target,
+                    s.source,
+                    s.line,
+                    s.candidates.len(),
+                    s.candidates.join(", ")
+                );
+            }
             all_replacements.extend(repls);
         }
 
@@ -1072,174 +1099,6 @@ pub fn plan_batch_mv(
     }
 
     Ok(plans.into_values().collect())
-}
-
-/// Walk every line (including frontmatter) in `content` and return
-/// [`Replacement`]s for links targeting the moved file.
-///
-/// Unlike `plan_inbound_rewrites`, this function also rewrites wikilinks
-/// found inside YAML frontmatter values for the configured link properties
-/// (`related`, `depends-on`, `supersedes`, `superseded-by`).
-///
-/// Uses [`LinkResolver`] + [`LinkWriter`] for consistent form-preserving
-/// rewrites (BUG-1/BUG-2 fix).
-#[allow(clippy::too_many_arguments)]
-fn plan_inbound_rewrites_with_fm(
-    content: &str,
-    source_rel: &str,
-    old_rel: &str,
-    old_stem: &str,
-    new_rel: &str,
-    new_stem: &str,
-    site_prefix: Option<&str>,
-    case_index: Option<&CaseInsensitiveIndex>,
-    allow_ambiguous: bool,
-) -> Vec<Replacement> {
-    let resolver_idx = case_index.unwrap_or(&EMPTY_CASE_INDEX);
-    let resolver = LinkResolver::new(resolver_idx, site_prefix);
-
-    let mut replacements = Vec::new();
-    let mut fence = FenceTracker::new();
-    let mut in_comment_fence = false;
-    let mut in_frontmatter = false;
-    let mut frontmatter_done = false;
-    let mut line_num = 0usize;
-
-    for line in content.split('\n') {
-        line_num += 1;
-
-        // ---- Frontmatter handling ----
-        if !frontmatter_done {
-            if line_num == 1 && line.trim() == "---" {
-                in_frontmatter = true;
-                continue;
-            }
-            if in_frontmatter {
-                if line.trim() == "---" {
-                    in_frontmatter = false;
-                    frontmatter_done = true;
-                    continue;
-                }
-                // Scan for wikilinks inside frontmatter link properties.
-                let fm_repls = plan_frontmatter_wikilink_rewrites(
-                    line, line_num, old_rel, old_stem, new_rel, new_stem, case_index,
-                );
-                replacements.extend(fm_repls);
-                continue;
-            }
-            frontmatter_done = true;
-        }
-
-        // ---- Comment fence ----
-        if in_comment_fence {
-            if is_comment_fence(line) {
-                in_comment_fence = false;
-            }
-            continue;
-        }
-
-        // ---- Fenced code block ----
-        if fence.process_line(line) {
-            continue;
-        }
-
-        // ---- Comment fence opening ----
-        if is_comment_fence(line) {
-            in_comment_fence = true;
-            continue;
-        }
-
-        // ---- Body links ----
-        let stripped_code = strip_inline_code(line);
-        let cleaned = strip_inline_comments(stripped_code.as_ref());
-        let spans = extract_link_spans_with_original(&cleaned, line);
-
-        for span in spans {
-            // BUG-2: bare wikilink ambiguity check (same as plan_inbound_rewrites).
-            let mut bare_ambiguous_match = false;
-            if span.kind == LinkKind::Wikilink {
-                let t = &span.link.target;
-                let normalized = if let Some(wo) = t.strip_prefix("./") {
-                    std::borrow::Cow::Owned(normalize_target(Path::new(source_rel), wo))
-                } else {
-                    std::borrow::Cow::Borrowed(t.as_str())
-                };
-                let is_bare = !(normalized.contains('/') || normalized.contains('\\'));
-                if is_bare && case_index.is_some() {
-                    let t_norm = normalized.to_ascii_lowercase();
-                    let stem = if std::path::Path::new(&t_norm)
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
-                    {
-                        &t_norm[..t_norm.len() - 3]
-                    } else {
-                        &t_norm
-                    };
-                    let res = resolver.resolve_stem(stem);
-                    match res {
-                        Resolution::Hit { ref vault_path } => {
-                            let matches_old = vault_path == old_rel
-                                || vault_path == old_stem
-                                || vault_path.strip_suffix(".md") == Some(old_stem);
-                            if !matches_old {
-                                continue;
-                            }
-                        }
-                        Resolution::Ambiguous(ref candidates) => {
-                            if !allow_ambiguous {
-                                eprintln!(
-                                    "warning: skipping ambiguous bare wikilink [[{t}]] in \
-                                     {source_rel}:{line_num} — matches {} files: {}. \
-                                     Use --allow-ambiguous to rewrite anyway.",
-                                    candidates.len(),
-                                    candidates.join(", ")
-                                );
-                                continue;
-                            }
-                            let matches_old = candidates.iter().any(|c| {
-                                c == old_rel
-                                    || c == old_stem
-                                    || c.strip_suffix(".md") == Some(old_stem)
-                            });
-                            if !matches_old {
-                                continue;
-                            }
-                            bare_ambiguous_match = true;
-                        }
-                        Resolution::Broken => continue,
-                    }
-                }
-            }
-
-            if !bare_ambiguous_match
-                && !resolver.matches_target(&span, source_rel, old_rel, old_stem)
-            {
-                continue;
-            }
-
-            if let Some(SpanReplacement {
-                byte_offset,
-                old_text,
-                new_text,
-            }) = LinkWriter::rewrite(
-                &span,
-                line,
-                new_rel,
-                source_rel,
-                PreserveForm::Preserve,
-                site_prefix,
-            ) {
-                replacements.push(Replacement {
-                    line: line_num,
-                    byte_offset,
-                    old_text,
-                    new_text,
-                });
-            }
-        }
-    }
-
-    replacements
 }
 
 /// Find and plan wikilink replacements inside a single frontmatter YAML line.
@@ -1818,8 +1677,9 @@ mod tests {
     }
 
     #[test]
-    fn plan_mv_frontmatter_links_untouched() {
-        // Links inside frontmatter must not be rewritten.
+    fn plan_mv_frontmatter_links_rewritten() {
+        // H-4: single-file mv must rewrite wikilinks inside frontmatter link
+        // properties (e.g. `related`), not just in the document body.
         let vault = create_vault(&[
             ("a.md", "---\nrelated: \"[[sub/b]]\"\n---\nBody [[sub/b]]\n"),
             ("sub/b.md", "Content\n"),
@@ -1828,8 +1688,13 @@ mod tests {
             .unwrap()
             .plans;
         assert_eq!(plans.len(), 1);
-        assert_eq!(plans[0].replacements.len(), 1);
-        assert_eq!(plans[0].replacements[0].line, 4); // Body line
+        assert_eq!(plans[0].replacements.len(), 2);
+        let lines: Vec<usize> = plans[0].replacements.iter().map(|r| r.line).collect();
+        assert!(
+            lines.contains(&2),
+            "frontmatter line not rewritten: {plans:?}"
+        );
+        assert!(lines.contains(&4), "body line not rewritten: {plans:?}");
     }
 
     #[test]

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -20,7 +20,6 @@ use crate::frontmatter::hyalo_options;
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use serde_json::Value;
-#[cfg(test)]
 use std::io::BufRead;
 use std::path::Path;
 
@@ -167,7 +166,7 @@ pub fn scan_slice_multi(data: &[u8], visitors: &mut [&mut dyn FileVisitor]) -> R
 
     let any_needs_fm = visitors.iter().any(|v| v.needs_frontmatter());
 
-    let (mut fm_props, fm_lines) = if first_line.trim() == "---" {
+    let (mut fm_props, fm_lines) = if crate::frontmatter::is_opening_delimiter(first_line) {
         use crate::frontmatter::{MAX_FRONTMATTER_BYTES, MAX_FRONTMATTER_LINES};
 
         let mut yaml = if any_needs_fm {
@@ -343,7 +342,7 @@ pub(crate) fn scan_reader_multi<R: BufRead>(
 
     // Try to parse frontmatter
     let any_needs_fm = visitors.iter().any(|v| v.needs_frontmatter());
-    let (mut fm_props, fm_lines) = if first_trimmed.trim() == "---" {
+    let (mut fm_props, fm_lines) = if crate::frontmatter::is_opening_delimiter(&first_trimmed) {
         use crate::frontmatter::{MAX_FRONTMATTER_BYTES, MAX_FRONTMATTER_LINES};
 
         // Read past frontmatter lines, optionally collecting YAML content
@@ -491,7 +490,7 @@ pub(crate) fn scan_reader_multi<R: BufRead>(
 /// Lines longer than this are skipped (the line counter still advances).
 /// 1 MiB is ample for any real Markdown line; files with no newlines (e.g.
 /// accidentally-added minified blobs) would otherwise exhaust memory.
-const MAX_BODY_LINE_BYTES: usize = 1024 * 1024; // 1 MiB
+pub const MAX_BODY_LINE_BYTES: usize = 1024 * 1024; // 1 MiB
 
 /// Read one newline-terminated line into `buf`, but stop after `limit` bytes.
 ///
@@ -499,8 +498,11 @@ const MAX_BODY_LINE_BYTES: usize = 1024 * 1024; // 1 MiB
 /// reader is positioned just after where the logical line ended (i.e. excess
 /// bytes are drained until the next `\n` or EOF), and the caller should treat
 /// the line as skipped.
-#[cfg(test)]
-fn read_line_capped<R: BufRead>(
+///
+/// Exposed beyond `#[cfg(test)]` so other crates (e.g. `hyalo-cli`'s `read`
+/// command) can stream a single file with the same per-line memory bound the
+/// scanner enforces, instead of an uncapped `BufRead::lines()`.
+pub fn read_line_capped<R: BufRead>(
     reader: &mut R,
     buf: &mut String,
     limit: usize,
@@ -531,7 +533,19 @@ fn read_line_capped<R: BufRead>(
         };
 
         if buf.len() >= limit {
-            // Already over quota — just drain.
+            // Quota was exactly filled by a previous iteration. If the very
+            // next byte is the newline (`pos == 0`), the line's content is
+            // exactly `limit` bytes — nothing was actually discarded, so this
+            // is not a truncation, just a line landing on the boundary.
+            if newline_pos == Some(0) {
+                reader.consume(1);
+                total += 1;
+                // Keep parity with the other non-truncated paths, which
+                // include the terminating newline in `buf`.
+                buf.push('\n');
+                return Ok((total, false));
+            }
+            // Otherwise there is more line content beyond the quota — drain it.
             reader.consume(consume);
             total += consume;
             if newline_pos.is_some() {
@@ -581,7 +595,6 @@ fn read_line_capped<R: BufRead>(
 }
 
 /// Consume bytes from `reader` until (and including) a `\n`, or until EOF.
-#[cfg(test)]
 fn drain_until_newline<R: BufRead>(reader: &mut R) -> std::io::Result<()> {
     loop {
         let available = match reader.fill_buf() {
@@ -716,6 +729,29 @@ Second line
         assert_eq!(lines[0].1, 1);
         assert_eq!(lines[1].0, "Second line");
         assert_eq!(lines[1].1, 2);
+    }
+
+    #[test]
+    fn bom_prefixed_frontmatter_is_recognized() {
+        // Shares the opening-delimiter policy with the read/write paths
+        // (iter-158 C-1): a single UTF-8 BOM before `---` still opens
+        // frontmatter, so the block is skipped instead of scanned as body.
+        let input = "\u{feff}---\ntitle: Test\n---\nHello world\n";
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].0, "Hello world");
+        assert_eq!(lines[0].1, 4);
+    }
+
+    #[test]
+    fn leading_whitespace_dashes_are_not_frontmatter() {
+        // ` ---` does not open frontmatter (same policy as read/write paths),
+        // so every line is body content.
+        let input = " ---\ntitle: Test\n---\nHello world\n";
+        let lines = collect_lines(input);
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0].0, " ---");
+        assert_eq!(lines[3].0, "Hello world");
     }
 
     #[test]
@@ -1644,5 +1680,57 @@ code only
         let lines = collect_lines(&input);
         assert_eq!(lines[0].0, exactly, "line at limit must pass through");
         assert_eq!(lines[1].0, "next");
+    }
+
+    // -- read_line_capped: direct boundary regression test --
+    //
+    // `body_line_limit_exact_boundary_passes` above exercises the same
+    // boundary through `scan_reader`, which has its own (separate) line
+    // splitting logic. `read_line_capped` is exercised here directly with a
+    // small `BufReader` capacity to force the exact-limit newline to land at
+    // the very start of a freshly-filled internal buffer — the case that
+    // previously tripped the `buf.len() >= limit` quota check into reporting
+    // a spurious truncation even though no content was actually discarded.
+    #[test]
+    fn read_line_capped_exact_boundary_not_truncated() {
+        let limit = 16usize;
+        let chunk_cap = 4usize; // forces multiple fill_buf() calls before the limit
+        let line: String = "a".repeat(limit);
+        let input = format!("{line}\nnext\n");
+        let mut reader = std::io::BufReader::with_capacity(chunk_cap, input.as_bytes());
+
+        let mut buf = String::new();
+        let (n, truncated) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        assert!(
+            !truncated,
+            "line exactly at the limit must not be truncated"
+        );
+        assert_eq!(buf, format!("{line}\n"));
+        assert_eq!(n, limit + 1);
+
+        buf.clear();
+        let (_, truncated2) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        assert!(!truncated2, "subsequent line must be read normally");
+        assert_eq!(buf, "next\n");
+    }
+
+    #[test]
+    fn read_line_capped_one_byte_over_is_truncated() {
+        // Sanity check alongside the exact-boundary test: one byte *past* the
+        // limit must still be reported as truncated.
+        let limit = 16usize;
+        let chunk_cap = 4usize;
+        let line: String = "a".repeat(limit + 1);
+        let input = format!("{line}\nnext\n");
+        let mut reader = std::io::BufReader::with_capacity(chunk_cap, input.as_bytes());
+
+        let mut buf = String::new();
+        let (_, truncated) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        assert!(truncated, "line one byte over the limit must be truncated");
+
+        buf.clear();
+        let (_, truncated2) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        assert!(!truncated2, "subsequent line must be read normally");
+        assert_eq!(buf, "next\n");
     }
 }

--- a/crates/hyalo-core/src/tasks.rs
+++ b/crates/hyalo-core/src/tasks.rs
@@ -5,6 +5,7 @@
 //! Used by the `tasks` command family and the `summary` command.
 
 use anyhow::{Context, Result, bail};
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -431,9 +432,58 @@ fn mutate_task_line(line: &str, line_num: usize, new_status: char) -> Option<(St
     Some((modified, info))
 }
 
+/// Bail with a consistent "file too large" error for mutation entry points.
+/// Mutation commands target one explicit file, so — unlike the read-only
+/// scanner, which silently skips oversized files across a whole vault — an
+/// oversized target here must be a hard error, not a silent no-op.
+fn bail_if_too_large(path: &Path, file_size: u64) -> Result<()> {
+    if file_size > scanner::MAX_FILE_SIZE {
+        bail!(
+            "file too large to modify ({} MiB exceeds {} MiB limit): {}",
+            file_size / (1024 * 1024),
+            scanner::MAX_FILE_SIZE / (1024 * 1024),
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Compute the set of 1-based line numbers that are valid task checkboxes,
+/// i.e. the same lines `read_task` and `find_task_lines` would recognize.
+/// Skips frontmatter, fenced code blocks, and `%%` comment blocks so that
+/// mutation entry points reject exactly the lines the read path rejects.
+fn valid_task_line_set(content: &[u8]) -> Result<HashSet<usize>> {
+    let mut extractor = TaskExtractor::new();
+    scanner::scan_slice_multi(content, &mut [&mut extractor])?;
+    Ok(extractor.into_tasks().into_iter().map(|t| t.line).collect())
+}
+
+/// Validate that `line` is in range and refers to an actual task checkbox —
+/// not frontmatter, a fenced code block, or a `%%` comment block. Returns the
+/// raw line text on success.
+fn validate_task_line<'a>(
+    file_lines: &[&'a str],
+    line_count: usize,
+    valid_lines: &HashSet<usize>,
+    line: usize,
+) -> Result<&'a str> {
+    if line == 0 || line > line_count {
+        bail!("line {line} is out of range (file has {line_count} lines)");
+    }
+    if !valid_lines.contains(&line) {
+        bail!("line {line} is not a task");
+    }
+    Ok(file_lines[line - 1])
+}
+
 /// Toggle task completion: `[ ]` → `[x]`, `[x]`/`[X]` → `[ ]`, custom → `[x]`.
 /// Returns the updated `TaskInfo`. Writes the file in-place.
 pub fn toggle_task(path: &Path, line: usize) -> Result<TaskInfo> {
+    let file_size = std::fs::metadata(path)
+        .with_context(|| format!("failed to stat {}", path.display()))?
+        .len();
+    bail_if_too_large(path, file_size)?;
+
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
     let lines: Vec<&str> = content.split('\n').collect();
@@ -445,13 +495,10 @@ pub fn toggle_task(path: &Path, line: usize) -> Result<TaskInfo> {
         lines.len()
     };
 
-    if line == 0 || line > line_count {
-        bail!("line {line} is out of range (file has {line_count} lines)");
-    }
-
-    let target = lines[line - 1];
-    let (current_status, _done) = detect_task_checkbox(target)
-        .ok_or_else(|| anyhow::anyhow!("line {line} is not a task checkbox"))?;
+    let valid_lines = valid_task_line_set(content.as_bytes())?;
+    let target = validate_task_line(&lines, line_count, &valid_lines, line)?;
+    let (current_status, _done) =
+        detect_task_checkbox(target).ok_or_else(|| anyhow::anyhow!("line {line} is not a task"))?;
 
     let new_status = if current_status == 'x' || current_status == 'X' {
         ' '
@@ -472,6 +519,11 @@ pub fn toggle_task(path: &Path, line: usize) -> Result<TaskInfo> {
 /// Set a custom status character on a task.
 /// Returns the updated `TaskInfo`. Writes the file in-place.
 pub fn set_task_status(path: &Path, line: usize, status: char) -> Result<TaskInfo> {
+    let file_size = std::fs::metadata(path)
+        .with_context(|| format!("failed to stat {}", path.display()))?
+        .len();
+    bail_if_too_large(path, file_size)?;
+
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
     let lines: Vec<&str> = content.split('\n').collect();
@@ -481,14 +533,8 @@ pub fn set_task_status(path: &Path, line: usize, status: char) -> Result<TaskInf
         lines.len()
     };
 
-    if line == 0 || line > line_count {
-        bail!("line {line} is out of range (file has {line_count} lines)");
-    }
-
-    let target = lines[line - 1];
-    // Validate that the line is a task
-    detect_task_checkbox(target)
-        .ok_or_else(|| anyhow::anyhow!("line {line} is not a task checkbox"))?;
+    let valid_lines = valid_task_line_set(content.as_bytes())?;
+    let target = validate_task_line(&lines, line_count, &valid_lines, line)?;
 
     let (modified_line, info) = mutate_task_line(target, line, status)
         .ok_or_else(|| anyhow::anyhow!("failed to mutate task on line {line}"))?;
@@ -513,6 +559,8 @@ pub fn find_task_lines(path: &Path) -> Result<Vec<crate::types::FindTaskInfo>> {
 /// Errors if any line is not a task checkbox.
 pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
     let mtime = frontmatter::read_mtime(path)?;
+    bail_if_too_large(path, mtime.1)?;
+
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
     let file_lines: Vec<&str> = content.split('\n').collect();
@@ -521,6 +569,7 @@ pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
     } else {
         file_lines.len()
     };
+    let valid_lines = valid_task_line_set(content.as_bytes())?;
 
     let mut deduped = lines.to_vec();
     deduped.sort_unstable();
@@ -530,12 +579,9 @@ pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
     let mut replacements: Vec<(usize, String)> = Vec::with_capacity(deduped.len());
 
     for &line in &deduped {
-        if line == 0 || line > line_count {
-            bail!("line {line} is out of range (file has {line_count} lines)");
-        }
-        let target = file_lines[line - 1];
+        let target = validate_task_line(&file_lines, line_count, &valid_lines, line)?;
         let (current_status, _done) = detect_task_checkbox(target)
-            .ok_or_else(|| anyhow::anyhow!("line {line} is not a task checkbox"))?;
+            .ok_or_else(|| anyhow::anyhow!("line {line} is not a task"))?;
         let new_status = if current_status == 'x' || current_status == 'X' {
             ' '
         } else {
@@ -560,6 +606,8 @@ pub fn toggle_tasks(path: &Path, lines: &[usize]) -> Result<Vec<TaskInfo>> {
 /// Lines are 1-based. Errors if any line is not a task checkbox.
 pub fn set_tasks_status(path: &Path, lines: &[usize], status: char) -> Result<Vec<TaskInfo>> {
     let mtime = frontmatter::read_mtime(path)?;
+    bail_if_too_large(path, mtime.1)?;
+
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
     let file_lines: Vec<&str> = content.split('\n').collect();
@@ -568,6 +616,7 @@ pub fn set_tasks_status(path: &Path, lines: &[usize], status: char) -> Result<Ve
     } else {
         file_lines.len()
     };
+    let valid_lines = valid_task_line_set(content.as_bytes())?;
 
     let mut deduped = lines.to_vec();
     deduped.sort_unstable();
@@ -577,12 +626,7 @@ pub fn set_tasks_status(path: &Path, lines: &[usize], status: char) -> Result<Ve
     let mut replacements: Vec<(usize, String)> = Vec::with_capacity(deduped.len());
 
     for &line in &deduped {
-        if line == 0 || line > line_count {
-            bail!("line {line} is out of range (file has {line_count} lines)");
-        }
-        let target = file_lines[line - 1];
-        detect_task_checkbox(target)
-            .ok_or_else(|| anyhow::anyhow!("line {line} is not a task checkbox"))?;
+        let target = validate_task_line(&file_lines, line_count, &valid_lines, line)?;
         let (modified_line, info) = mutate_task_line(target, line, status)
             .ok_or_else(|| anyhow::anyhow!("failed to mutate task on line {line}"))?;
         replacements.push((line, modified_line));
@@ -1102,5 +1146,220 @@ Regular text.
         // Line 1 is the opening comment fence — not a task
         let task = read_task(&path, 1).unwrap();
         assert!(task.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // H-9: mutation entry points must reject fenced/comment-block lines
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn toggle_task_rejects_line_inside_code_block() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "```\n- [ ] Inside code\n```\n- [ ] Real task\n";
+        fs::write(&path, original).unwrap();
+
+        let result = toggle_task(&path, 2);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a task"));
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, original, "fenced line must not be mutated");
+    }
+
+    #[test]
+    fn toggle_task_rejects_line_inside_comment_block() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "%%\n- [ ] Inside comment\n%%\n- [ ] Real task\n";
+        fs::write(&path, original).unwrap();
+
+        let result = toggle_task(&path, 2);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a task"));
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, original, "commented line must not be mutated");
+    }
+
+    #[test]
+    fn set_task_status_rejects_line_inside_code_block() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "```\n- [ ] Inside code\n```\n- [ ] Real task\n";
+        fs::write(&path, original).unwrap();
+
+        let result = set_task_status(&path, 2, 'x');
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a task"));
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, original, "fenced line must not be mutated");
+    }
+
+    #[test]
+    fn toggle_tasks_rejects_line_inside_code_block() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "- [ ] Real task\n```\n- [ ] Inside code\n```\n";
+        fs::write(&path, original).unwrap();
+
+        let result = toggle_tasks(&path, &[3]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a task"));
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, original, "fenced line must not be mutated");
+    }
+
+    #[test]
+    fn toggle_tasks_rejects_line_inside_comment_block() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "- [ ] Real task\n%%\n- [ ] Inside comment\n%%\n";
+        fs::write(&path, original).unwrap();
+
+        let result = toggle_tasks(&path, &[3]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a task"));
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, original, "commented line must not be mutated");
+    }
+
+    #[test]
+    fn toggle_tasks_bulk_call_rejects_whole_batch_when_one_line_is_fenced() {
+        // A mixed batch with one valid and one fenced line must fail atomically —
+        // the valid line must not be toggled either.
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "- [ ] Real task\n```\n- [ ] Inside code\n```\n";
+        fs::write(&path, original).unwrap();
+
+        let result = toggle_tasks(&path, &[1, 3]);
+        assert!(result.is_err());
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            content, original,
+            "no line should be mutated when the batch contains an invalid line"
+        );
+    }
+
+    #[test]
+    fn set_tasks_status_rejects_line_inside_code_block() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "- [ ] Real task\n```\n- [ ] Inside code\n```\n";
+        fs::write(&path, original).unwrap();
+
+        let result = set_tasks_status(&path, &[3], 'x');
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a task"));
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, original, "fenced line must not be mutated");
+    }
+
+    #[test]
+    fn set_tasks_status_rejects_line_inside_comment_block() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        let original = "- [ ] Real task\n%%\n- [ ] Inside comment\n%%\n";
+        fs::write(&path, original).unwrap();
+
+        let result = set_tasks_status(&path, &[3], 'x');
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a task"));
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, original, "commented line must not be mutated");
+    }
+
+    #[test]
+    fn toggle_tasks_valid_line_with_frontmatter_toggles_correct_physical_line() {
+        // Frontmatter offsets the body by a fixed number of lines; make sure
+        // fence-aware validation still resolves to the right physical line.
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("tasks.md");
+        fs::write(
+            &path,
+            md!(r"
+---
+title: Test
+---
+```
+- [ ] Not a task (fenced)
+```
+- [ ] Real task
+"),
+        )
+        .unwrap();
+
+        // Physical lines: 1 `---`, 2 `title:`, 3 `---`, 4 ` ``` `, 5 fenced task,
+        // 6 ` ``` `, 7 real task.
+        let infos = toggle_tasks(&path, &[7]).unwrap();
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].line, 7);
+        assert_eq!(infos[0].text, "Real task");
+        assert_eq!(infos[0].status, 'x');
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("- [x] Real task"));
+        // The fenced line must remain untouched.
+        assert!(content.contains("- [ ] Not a task (fenced)"));
+    }
+
+    // -----------------------------------------------------------------
+    // M: mutation entry points must refuse oversized files without
+    // reading them into memory.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn toggle_task_rejects_oversized_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("big.md");
+        let f = fs::File::create(&path).unwrap();
+        f.set_len(scanner::MAX_FILE_SIZE + 1).unwrap();
+
+        let result = toggle_task(&path, 1);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too large"));
+    }
+
+    #[test]
+    fn set_task_status_rejects_oversized_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("big.md");
+        let f = fs::File::create(&path).unwrap();
+        f.set_len(scanner::MAX_FILE_SIZE + 1).unwrap();
+
+        let result = set_task_status(&path, 1, 'x');
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too large"));
+    }
+
+    #[test]
+    fn toggle_tasks_rejects_oversized_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("big.md");
+        let f = fs::File::create(&path).unwrap();
+        f.set_len(scanner::MAX_FILE_SIZE + 1).unwrap();
+
+        let result = toggle_tasks(&path, &[1]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too large"));
+    }
+
+    #[test]
+    fn set_tasks_status_rejects_oversized_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("big.md");
+        let f = fs::File::create(&path).unwrap();
+        f.set_len(scanner::MAX_FILE_SIZE + 1).unwrap();
+
+        let result = set_tasks_status(&path, &[1], 'x');
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too large"));
     }
 }

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -396,7 +396,7 @@ impl HyaloLintEngine {
                     let fix = if *rule_id == "MD047" {
                         md047_fix(body_content)
                     } else {
-                        convert_fix(&v, body_content)
+                        convert_fix(&v, body_content, rule_id)
                     };
                     diagnostics.push(Diagnostic {
                         rule_id: rule_id.to_string(),
@@ -420,7 +420,7 @@ impl HyaloLintEngine {
                 .check(&doc)
                 .with_context(|| format!("running HYALO001 on {rel_path}"))?;
             for v in violations {
-                let fix = convert_fix(&v, body_content);
+                let fix = convert_fix(&v, body_content, "HYALO001");
                 diagnostics.push(Diagnostic {
                     rule_id: "HYALO001".to_owned(),
                     rule_name: v.rule_name.clone(),
@@ -459,16 +459,41 @@ impl HyaloLintEngine {
     }
 }
 
+/// Upstream rules disagree on what a `Fix` column means: some compute
+/// columns from byte lengths (`line.len() + 1` style — MD009, and our own
+/// HYALO001), others index into a `Vec<char>` and emit char positions (at
+/// least MD034 and MD011). Using the wrong unit on a line with multibyte
+/// UTF-8 lands the fix on the wrong byte offset and corrupts the file, so
+/// the walk must be chosen per rule. Only rules whose column math has been
+/// verified byte-based belong here; everything else gets the char-based
+/// walk, whose worst case is a dropped fix rather than corruption.
+fn rule_uses_byte_columns(rule_id: &str) -> bool {
+    matches!(rule_id, "MD009" | "HYALO001")
+}
+
 /// Convert an upstream `Fix` (line/column positions) to a byte-offset `DiagFix`.
 ///
+/// The column unit is selected per rule (see [`rule_uses_byte_columns`]).
 /// The conversion from line+column to byte offsets is best-effort; if
 /// conversion fails the fix is silently dropped (the violation is still
 /// reported without a fix).
-fn convert_fix(v: &mdbook_lint_core::Violation, content: &str) -> Option<DiagFix> {
+fn convert_fix(v: &mdbook_lint_core::Violation, content: &str, rule_id: &str) -> Option<DiagFix> {
+    let byte_columns = rule_uses_byte_columns(rule_id);
     let fix = v.fix.as_ref()?;
-    let start = line_col_to_byte(content, fix.start.line, fix.start.column)?;
-    let mut end = line_col_to_byte(content, fix.end.line, fix.end.column)?;
+    let start = line_col_to_byte(content, fix.start.line, fix.start.column, byte_columns)?;
+    let mut end = line_col_to_byte(content, fix.end.line, fix.end.column, byte_columns)?;
     let mut replacement = fix.replacement.clone().unwrap_or_default();
+
+    // Upstream MD011 emits its end column as the 1-based position OF the
+    // closing ']' (its own source comments "+1 because end_pos is 0-based
+    // position of ']'"), i.e. inclusive — one short as an exclusive end, so
+    // applying the fix as-is leaves a stray ']' behind on every line, ASCII
+    // included. Extend the range by one, but only when the byte at `end`
+    // really is the ']' the range claims to cover, so a future upstream
+    // correction cannot make this overshoot.
+    if rule_id == "MD011" && content[end..].starts_with(']') {
+        end += 1;
+    }
 
     // Some upstream rules (MD009, MD023, ...) express "replace this whole
     // line" with an end column of `line_len + 1` and a replacement that
@@ -523,6 +548,9 @@ fn convert_fix(v: &mdbook_lint_core::Violation, content: &str) -> Option<DiagFix
 /// length instead, so any number of trailing newlines converges to exactly
 /// one in a single application.
 fn md047_fix(body: &str) -> Option<DiagFix> {
+    // Match the body's own line-ending style so the fix never flips a CRLF
+    // file to LF (or vice versa).
+    let nl = if body.contains("\r\n") { "\r\n" } else { "\n" };
     if body.is_empty() {
         return Some(DiagFix {
             description: "Add newline at end of file".to_owned(),
@@ -536,22 +564,33 @@ fn md047_fix(body: &str) -> Option<DiagFix> {
             description: "Add newline at end of file".to_owned(),
             start: body.len(),
             end: body.len(),
-            replacement: "\n".to_owned(),
+            replacement: nl.to_owned(),
         });
     }
-    let trailing = body
-        .as_bytes()
-        .iter()
-        .rev()
-        .take_while(|&&b| b == b'\n')
-        .count();
-    if trailing <= 1 {
+    // Count trailing line terminators, treating each CRLF pair as one.
+    let bytes = body.as_bytes();
+    let mut content_end = bytes.len();
+    let mut terminators = 0usize;
+    while content_end > 0 && bytes[content_end - 1] == b'\n' {
+        content_end -= if content_end >= 2 && bytes[content_end - 2] == b'\r' {
+            2
+        } else {
+            1
+        };
+        terminators += 1;
+    }
+    if terminators <= 1 {
         return None; // MD047 would not have fired.
     }
-    let keep_one_at = body.len() - trailing + 1;
+    // Keep the first terminator after the content, drop the rest.
+    let first_terminator_len = if bytes.get(content_end) == Some(&b'\r') {
+        2
+    } else {
+        1
+    };
     Some(DiagFix {
         description: "Remove extra trailing newlines".to_owned(),
-        start: keep_one_at,
+        start: content_end + first_terminator_len,
         end: body.len(),
         replacement: String::new(),
     })
@@ -559,12 +598,21 @@ fn md047_fix(body: &str) -> Option<DiagFix> {
 
 /// Convert a 1-based (line, column) pair to a 0-based byte offset.
 ///
-/// Columns are 1-based **byte** positions within the line (matching how
-/// upstream rules compute them, e.g. `line.len() - trailing + 1`), so the
-/// walk advances by each character's UTF-8 byte length rather than by one
-/// per character — otherwise any line containing multibyte UTF-8 causes
-/// byte columns to overshoot character columns and the walk never matches.
-fn line_col_to_byte(text: &str, target_line: usize, target_col: usize) -> Option<usize> {
+/// `byte_columns` selects the column unit (see [`rule_uses_byte_columns`]):
+/// when `true`, columns are 1-based **byte** positions within the line
+/// (`line.len() - trailing + 1` style) and the walk advances by each
+/// character's UTF-8 byte length; when `false`, columns are 1-based **char**
+/// positions (`Vec<char>` indices) and the walk advances by one per
+/// character. Using the wrong unit on a multibyte line either drops the fix
+/// (byte target unreachable by char walk) or lands on the wrong byte
+/// (char target overshot by byte walk) — the latter corrupts content, which
+/// is why unverified rules default to the char walk.
+fn line_col_to_byte(
+    text: &str,
+    target_line: usize,
+    target_col: usize,
+    byte_columns: bool,
+) -> Option<usize> {
     let mut cur_line = 1;
     let mut cur_col = 1;
     for (offset, ch) in text.char_indices() {
@@ -575,7 +623,7 @@ fn line_col_to_byte(text: &str, target_line: usize, target_col: usize) -> Option
             cur_line += 1;
             cur_col = 1;
         } else {
-            cur_col += ch.len_utf8();
+            cur_col += if byte_columns { ch.len_utf8() } else { 1 };
         }
     }
     if cur_line == target_line && cur_col == target_col {
@@ -644,7 +692,9 @@ mod tests {
         let text = "café\n";
         // Byte column 6 is the position right after 'é' (byte offset 5,
         // since c=1,a=1,f=1,é=2 bytes -> line is 5 bytes long).
-        assert_eq!(line_col_to_byte(text, 1, 6), Some(5));
+        assert_eq!(line_col_to_byte(text, 1, 6, true), Some(5));
+        // Char column 5 is the same position under the char convention.
+        assert_eq!(line_col_to_byte(text, 1, 5, false), Some(5));
     }
 
     #[test]
@@ -682,6 +732,68 @@ mod tests {
         let fix = d.fix.as_ref().expect("MD009 fix should not be dropped");
         let fixed = apply(body, fix);
         assert_eq!(fixed, "日本語のテキスト\n");
+    }
+
+    // --- Char-column rules (MD034, MD011) must not be corrupted by the
+    // byte-column walk when multibyte UTF-8 precedes the flagged span ---
+
+    #[test]
+    fn md034_fix_correct_on_line_with_multibyte_prefix() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "café http://example.com is a site.\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD034".to_owned()])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD034")
+            .expect("MD034 should fire on a bare URL");
+        let fix = d.fix.as_ref().expect("MD034 fix should convert");
+        let fixed = apply(body, fix);
+        // The byte-column walk used to eat the space before the URL and
+        // leave a stray fragment: "café<http://example.com>m is a site."
+        assert_eq!(fixed, "café <http://example.com> is a site.\n");
+    }
+
+    #[test]
+    fn md011_fix_correct_on_line_with_multibyte_prefix() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "café (some text)[http://example.com] end.\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD011".to_owned()])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD011")
+            .expect("MD011 should fire on a reversed link");
+        let fix = d.fix.as_ref().expect("MD011 fix should convert");
+        let fixed = apply(body, fix);
+        assert_eq!(fixed, "café [some text](http://example.com) end.\n");
+    }
+
+    // --- md047_fix must handle CRLF terminators ---
+
+    #[test]
+    fn md047_fix_crlf_removes_extra_trailing_newlines_in_one_pass() {
+        let body = "body\r\n\r\n\r\n";
+        let fix = md047_fix(body).expect("multiple trailing CRLF should produce a fix");
+        let fixed = apply(body, &fix);
+        assert_eq!(fixed, "body\r\n");
+    }
+
+    #[test]
+    fn md047_fix_crlf_adds_matching_terminator() {
+        let body = "line one\r\nlast line";
+        let fix = md047_fix(body).expect("missing trailing newline should produce a fix");
+        let fixed = apply(body, &fix);
+        assert_eq!(fixed, "line one\r\nlast line\r\n");
+    }
+
+    #[test]
+    fn md047_fix_crlf_single_trailing_newline_is_clean() {
+        assert!(md047_fix("body\r\n").is_none());
     }
 
     // --- H-1b: MD009 must not duplicate the line terminator ---

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -390,7 +390,14 @@ impl HyaloLintEngine {
 
                 let sev = effective_severity(rule_id);
                 for v in violations {
-                    let fix = convert_fix(&v, body_content);
+                    // MD047's own fix positions don't survive translation to
+                    // byte offsets for the common "N trailing newlines" case
+                    // (see `md047_fix`) — compute it directly instead.
+                    let fix = if *rule_id == "MD047" {
+                        md047_fix(body_content)
+                    } else {
+                        convert_fix(&v, body_content)
+                    };
                     diagnostics.push(Diagnostic {
                         rule_id: rule_id.to_string(),
                         rule_name: v.rule_name.clone(),
@@ -460,8 +467,42 @@ impl HyaloLintEngine {
 fn convert_fix(v: &mdbook_lint_core::Violation, content: &str) -> Option<DiagFix> {
     let fix = v.fix.as_ref()?;
     let start = line_col_to_byte(content, fix.start.line, fix.start.column)?;
-    let end = line_col_to_byte(content, fix.end.line, fix.end.column)?;
-    let replacement = fix.replacement.clone().unwrap_or_default();
+    let mut end = line_col_to_byte(content, fix.end.line, fix.end.column)?;
+    let mut replacement = fix.replacement.clone().unwrap_or_default();
+
+    // Some upstream rules (MD009, MD023, ...) express "replace this whole
+    // line" with an end column of `line_len + 1` and a replacement that
+    // re-adds its own trailing '\n', expecting to consume the line's
+    // original terminator too. Translated through `line_col_to_byte`, that
+    // end column lands *on* the first byte of the terminator (CR on CRLF
+    // input, LF otherwise) rather than past it — so consuming only
+    // `[start, end)` leaves the original terminator in place and the
+    // replacement's own '\n' creates a duplicate blank line.
+    //
+    // Other rules (MD022, ...) use the *same* end-column shape to express a
+    // deliberate insertion: the replacement is the untouched original line
+    // plus an extra '\n', meant to add a new line while leaving the
+    // existing terminator alone. Tell the two apart by comparing the
+    // replacement (minus its trailing '\n') against the original
+    // `[start, end)` slice: identical means "insert before the terminator",
+    // different means "replace the line, including its terminator".
+    if let Some(without_nl) = replacement.strip_suffix('\n')
+        && content
+            .get(start..end)
+            .is_some_and(|orig| orig != without_nl)
+    {
+        let bytes = content.as_bytes();
+        if bytes.get(end) == Some(&b'\r') && bytes.get(end + 1) == Some(&b'\n') {
+            // CRLF terminator: consume both bytes and keep the replacement's
+            // ending CRLF-style so the fix doesn't flip the file to LF-only.
+            end += 2;
+            replacement.truncate(replacement.len() - 1);
+            replacement.push_str("\r\n");
+        } else if bytes.get(end) == Some(&b'\n') {
+            end += 1;
+        }
+    }
+
     Some(DiagFix {
         description: fix.description.clone(),
         start,
@@ -470,7 +511,59 @@ fn convert_fix(v: &mdbook_lint_core::Violation, content: &str) -> Option<DiagFix
     })
 }
 
+/// Compute a corrected single-pass fix for MD047 (single-trailing-newline),
+/// bypassing upstream's own `Fix` positions entirely.
+///
+/// Upstream computes its "remove extra trailing newlines" fix range in
+/// line/column terms that, once translated to byte offsets via
+/// [`line_col_to_byte`], is a byte-for-byte no-op when the body has exactly
+/// two trailing newlines (so `--fix` would report "fixed" forever without
+/// the file ever changing) and only removes one newline per application
+/// otherwise. Compute the correct range directly against the body's byte
+/// length instead, so any number of trailing newlines converges to exactly
+/// one in a single application.
+fn md047_fix(body: &str) -> Option<DiagFix> {
+    if body.is_empty() {
+        return Some(DiagFix {
+            description: "Add newline at end of file".to_owned(),
+            start: 0,
+            end: 0,
+            replacement: "\n".to_owned(),
+        });
+    }
+    if !body.ends_with('\n') {
+        return Some(DiagFix {
+            description: "Add newline at end of file".to_owned(),
+            start: body.len(),
+            end: body.len(),
+            replacement: "\n".to_owned(),
+        });
+    }
+    let trailing = body
+        .as_bytes()
+        .iter()
+        .rev()
+        .take_while(|&&b| b == b'\n')
+        .count();
+    if trailing <= 1 {
+        return None; // MD047 would not have fired.
+    }
+    let keep_one_at = body.len() - trailing + 1;
+    Some(DiagFix {
+        description: "Remove extra trailing newlines".to_owned(),
+        start: keep_one_at,
+        end: body.len(),
+        replacement: String::new(),
+    })
+}
+
 /// Convert a 1-based (line, column) pair to a 0-based byte offset.
+///
+/// Columns are 1-based **byte** positions within the line (matching how
+/// upstream rules compute them, e.g. `line.len() - trailing + 1`), so the
+/// walk advances by each character's UTF-8 byte length rather than by one
+/// per character — otherwise any line containing multibyte UTF-8 causes
+/// byte columns to overshoot character columns and the walk never matches.
 fn line_col_to_byte(text: &str, target_line: usize, target_col: usize) -> Option<usize> {
     let mut cur_line = 1;
     let mut cur_col = 1;
@@ -482,7 +575,7 @@ fn line_col_to_byte(text: &str, target_line: usize, target_col: usize) -> Option
             cur_line += 1;
             cur_col = 1;
         } else {
-            cur_col += 1;
+            cur_col += ch.len_utf8();
         }
     }
     if cur_line == target_line && cur_col == target_col {
@@ -533,5 +626,162 @@ mod tests {
             .lint_body("[] Open task\n", "test.md", None, false, &config, &[])
             .unwrap();
         assert!(diagnostics.iter().any(|d| d.rule_id == "HYALO001"));
+    }
+
+    /// Apply a `DiagFix` to `body`, as `apply_body_fixes` in the CLI would.
+    fn apply(body: &str, fix: &DiagFix) -> String {
+        let mut out = body.to_owned();
+        out.replace_range(fix.start..fix.end, &fix.replacement);
+        out
+    }
+
+    // --- H-1a: line_col_to_byte must use byte columns, not char columns ---
+
+    #[test]
+    fn line_col_to_byte_handles_multibyte_utf8() {
+        // "café" — 'é' is 2 bytes in UTF-8, so byte and char columns diverge
+        // partway through the line.
+        let text = "café\n";
+        // Byte column 6 is the position right after 'é' (byte offset 5,
+        // since c=1,a=1,f=1,é=2 bytes -> line is 5 bytes long).
+        assert_eq!(line_col_to_byte(text, 1, 6), Some(5));
+    }
+
+    #[test]
+    fn hyalo001_fix_applies_on_non_ascii_line() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "[] café task\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "HYALO001")
+            .expect("HYALO001 should fire");
+        let fix = d.fix.as_ref().expect("HYALO001 fix should not be dropped");
+        let fixed = apply(body, fix);
+        assert!(
+            fixed.starts_with("- [ ]"),
+            "expected bare checkbox to be fixed, got: {fixed:?}"
+        );
+    }
+
+    #[test]
+    fn md009_fix_applies_on_trailing_space_cjk_line() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "日本語のテキスト   \n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD009")
+            .expect("MD009 should fire");
+        let fix = d.fix.as_ref().expect("MD009 fix should not be dropped");
+        let fixed = apply(body, fix);
+        assert_eq!(fixed, "日本語のテキスト\n");
+    }
+
+    // --- H-1b: MD009 must not duplicate the line terminator ---
+
+    #[test]
+    fn md009_fix_does_not_inject_blank_line() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "x   \ny\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD009")
+            .expect("MD009 should fire");
+        let fix = d.fix.as_ref().expect("MD009 fix should not be dropped");
+        let fixed = apply(body, fix);
+        assert_eq!(fixed, "x\ny\n", "fix must not insert a blank line");
+    }
+
+    #[test]
+    fn md009_fix_preserves_crlf_line_endings() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "x   \r\ny\r\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD009")
+            .expect("MD009 should fire");
+        let fix = d.fix.as_ref().expect("MD009 fix should not be dropped");
+        let fixed = apply(body, fix);
+        assert_eq!(
+            fixed, "x\r\ny\r\n",
+            "fix must keep CRLF endings, not flip to mixed/LF"
+        );
+    }
+
+    // --- H-1c: MD047 must converge in a single application ---
+
+    #[test]
+    fn md047_fix_converges_two_trailing_newlines_in_one_pass() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "body\n\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD047")
+            .expect("MD047 should fire");
+        let fix = d.fix.as_ref().expect("MD047 fix should not be dropped");
+        let fixed = apply(body, fix);
+        assert_eq!(
+            fixed, "body\n",
+            "must converge to a single trailing newline"
+        );
+
+        // A second run against the fixed body must report no violation.
+        let diagnostics2 = engine
+            .lint_body(&fixed, "test.md", None, false, &config, &[])
+            .unwrap();
+        assert!(!diagnostics2.iter().any(|d| d.rule_id == "MD047"));
+    }
+
+    #[test]
+    fn md047_fix_converges_many_trailing_newlines_in_one_pass() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "body\n\n\n\n\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD047")
+            .expect("MD047 should fire");
+        let fix = d.fix.as_ref().expect("MD047 fix should not be dropped");
+        let fixed = apply(body, fix);
+        assert_eq!(fixed, "body\n");
+    }
+
+    #[test]
+    fn md047_fix_adds_missing_trailing_newline() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "body without newline";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD047")
+            .expect("MD047 should fire");
+        let fix = d.fix.as_ref().expect("MD047 fix should not be dropped");
+        let fixed = apply(body, fix);
+        assert_eq!(fixed, "body without newline\n");
     }
 }

--- a/hyalo-knowledgebase/iterations/iteration-158-review-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-158-review-fixes.md
@@ -7,7 +7,7 @@ tags:
   - review
   - security
   - correctness
-status: planned
+status: in-progress
 branch: iter-158/review-fixes-2026-06
 ---
 
@@ -43,11 +43,12 @@ rejects (a UTF-8 BOM, or a leading space before `---`), `write_frontmatter` prep
 new frontmatter block on top of the original file and demotes the real frontmatter to
 body — reported as success (exit 0). Affects `set`/`remove`/`append`.
 
-- [ ] Reconcile the three opening-delimiter predicates so the reader and `find_body_offset` always agree on where the frontmatter ends
-- [ ] Strip a leading UTF-8 BOM once at all three entry points (mirror `files_from.rs:43`)
-- [ ] Test: BOM-prefixed file round-trips through `set`/`remove`/`append` with no duplicate block and no data demoted to body
-- [ ] Test: leading-whitespace `---` either parses consistently or is rejected — never silently duplicated
-- [ ] Test: `remove --property X` on these files actually removes X (not leaves it in a buried block)
+- [x] Reconcile the three opening-delimiter predicates so the reader and `find_body_offset` always agree on where the frontmatter ends
+- [x] Strip a leading UTF-8 BOM once at all three entry points (mirror `files_from.rs:43`)
+- [x] Test: BOM-prefixed file round-trips through `set`/`remove`/`append` with no duplicate block and no data demoted to body
+- [x] Test: leading-whitespace `---` either parses consistently or is rejected — never silently duplicated
+- [x] Test: `remove --property X` on these files actually removes X (not leaves it in a buried block)
+- [x] Extend the shared policy to the scanner and lint's body split (dogfood found `find` still blind to BOM frontmatter; `scanner/mod.rs` had two more hand-rolled opening checks, `lint.rs` `find_body_start` a third)
 
 ## High
 
@@ -58,12 +59,12 @@ rules + HYALO001 emit *byte* columns. Plus whole-file rules (MD047) are fed body
 text. Consequences: MD009 injects a spurious blank line; autofix is silently dropped for
 any non-ASCII line; MD047 never converges (reports `fixed=1` forever).
 
-- [ ] Make `line_col_to_byte` advance by `ch.len_utf8()` (treat columns as byte offsets)
-- [ ] Treat an end column of `line_len+1` as past-the-newline so an MD009 replacement that re-adds `\n` does not duplicate it
-- [ ] Run whole-file rules (MD047) against full file content, or adjust offsets for the body split
-- [ ] Test: MD009 fix removes trailing spaces without adding a blank line
-- [ ] Test: bare `[]` / trailing spaces on a line containing non-ASCII (e.g. `café`, CJK, emoji) are actually fixed
-- [ ] Test: MD047 converges to a single trailing newline and stops reporting a fix
+- [x] Make `line_col_to_byte` advance by `ch.len_utf8()` (treat columns as byte offsets)
+- [x] Treat an end column of `line_len+1` as past-the-newline so an MD009 replacement that re-adds `\n` does not duplicate it
+- [x] Run whole-file rules (MD047) against full file content, or adjust offsets for the body split
+- [x] Test: MD009 fix removes trailing spaces without adding a blank line
+- [x] Test: bare `[]` / trailing spaces on a line containing non-ASCII (e.g. `café`, CJK, emoji) are actually fixed
+- [x] Test: MD047 converges to a single trailing newline and stops reporting a fix
 
 ### H-2 — `lint --fix` body write is non-atomic and reverts the frontmatter fix
 
@@ -72,10 +73,10 @@ and reconstructs the file from the *stale* pre-fix frontmatter slice captured at
 ~1871, clobbering a frontmatter fix written earlier in the same run. No mtime guard exists
 in `lint_one_file_extended`.
 
-- [ ] Reconstruct the body write from post-frontmatter-fix on-disk content (ideally a single combined frontmatter+body write)
-- [ ] Route the body write through `fs_util::atomic_write`
-- [ ] Add the `read_mtime` → `check_mtime` guard before the write (parity with `set`/`remove`/`append`/`task`)
-- [ ] Test: a file needing both a schema/frontmatter fix and a body fix ends with both applied
+- [x] Reconstruct the body write from post-frontmatter-fix on-disk content (ideally a single combined frontmatter+body write)
+- [x] Route the body write through `fs_util::atomic_write`
+- [x] Add the `read_mtime` → `check_mtime` guard before the write (parity with `set`/`remove`/`append`/`task`)
+- [x] Test: a file needing both a schema/frontmatter fix and a body fix ends with both applied
 
 ### H-3 — `hyalo mv` escapes the vault through a symlinked destination
 
@@ -83,8 +84,8 @@ in `lint_one_file_extended`.
 destination or calls `ensure_within_vault`; only literal `..`/absolute components are
 rejected. A symlinked destination directory inside the vault relocates the file outside.
 
-- [ ] Canonicalize the destination's nearest existing ancestor and `ensure_within_vault` before any fs mutation, in `execute_mv` and `execute_batch_mv`
-- [ ] Test: `mv` into a symlink-that-points-outside is rejected (mirror `resolve_file_rejects_symlink_escape`)
+- [x] Canonicalize the destination's nearest existing ancestor and `ensure_within_vault` before any fs mutation, in `execute_mv` and `execute_batch_mv`
+- [x] Test: `mv` into a symlink-that-points-outside is rejected (mirror `resolve_file_rejects_symlink_escape`)
 
 ### H-4 — Single-file `mv` leaves dangling frontmatter wikilinks
 
@@ -93,8 +94,8 @@ rejected. A symlinked destination directory inside the vault relocates the file 
 frontmatter link properties). Single-file moves leave `related`/`depends-on`/etc.
 pointing at the old path.
 
-- [ ] Make `plan_mv` rewrite frontmatter link-property wikilinks (call `plan_inbound_rewrites_with_fm` or fold the branch in)
-- [ ] Test: single-file `mv` rewrites inbound frontmatter wikilinks (mirror batch `t12_frontmatter_wikilink_rewrite`)
+- [x] Make `plan_mv` rewrite frontmatter link-property wikilinks (call `plan_inbound_rewrites_with_fm` or fold the branch in)
+- [x] Test: single-file `mv` rewrites inbound frontmatter wikilinks (mirror batch `t12_frontmatter_wikilink_rewrite`)
 
 ### H-5 — `lint` and `read` read whole files into memory with no size cap
 
@@ -102,9 +103,9 @@ pointing at the old path.
 and `crates/hyalo-cli/src/commands/read.rs:160` (`Vec<String>`, no per-line cap) bypass
 the scanner's 100 MiB `MAX_FILE_SIZE`. Measured 1.7–2.7 GiB RSS on large inputs.
 
-- [ ] `lint_one_file_extended`: stat-and-skip on `scanner::MAX_FILE_SIZE` before `read_to_string` (emit the scanner's stderr warning)
-- [ ] `read_body_lines`: stat-and-skip on `MAX_FILE_SIZE` and replace `reader.lines()` with `read_line_capped` (per-line `MAX_BODY_LINE_BYTES`)
-- [ ] Test: oversized file is skipped/refused by `lint` and `read` instead of OOMing
+- [x] `lint_one_file_extended`: stat-and-skip on `scanner::MAX_FILE_SIZE` before `read_to_string` (emit the scanner's stderr warning)
+- [x] `read_body_lines`: stat-and-skip on `MAX_FILE_SIZE` and replace `reader.lines()` with `read_line_capped` (per-line `MAX_BODY_LINE_BYTES`)
+- [x] Test: oversized file is skipped/refused by `lint` and `read` instead of OOMing
 
 ### H-6 — Error output is not JSON under `--format json`
 
@@ -114,9 +115,9 @@ at ~18 sites (find: 474/481/489/496/508/514; mutation/lint/mv/links:
 default piped mode) this emits plain text, breaking the documented `{"error": …}`
 envelope. Sibling commands via `format_error` are already correct.
 
-- [ ] Route every `dispatch.rs` `UserError(format!("Error: …"))` site through `crate::output::format_error(format, …)`
-- [ ] Make `AppError::User`/`AppError::Exit` format-aware in `run.rs:338` instead of bare `eprintln!`
-- [ ] Test: `find --task '???'`, `set --where-property 'p~=/[/'`, `find --tag 'has space'`, etc. under `--format json` produce stderr parseable as JSON with an `.error` field
+- [x] Route every `dispatch.rs` `UserError(format!("Error: …"))` site through `crate::output::format_error(format, …)`
+- [x] Make `AppError::User`/`AppError::Exit` format-aware in `run.rs:338` instead of bare `eprintln!`
+- [x] Test: `find --task '???'`, `set --where-property 'p~=/[/'`, `find --tag 'has space'`, etc. under `--format json` produce stderr parseable as JSON with an `.error` field
 
 ### H-7 — `--index` mutations corrupt the persisted link graph
 
@@ -125,8 +126,8 @@ envelope. Sibling commands via `format_error` are already correct.
 `entry.links` and the snapshot `LinkGraph` are never refreshed, so a persisted-wrong
 backlink graph survives until a full `create-index`.
 
-- [ ] Route `update_index_entry` through `refresh_entry` (re-scan links) plus a link-graph update for the source path (mirror `rename_index_entry`)
-- [ ] Test: `set --file X --property related='[[foo]]' --index` then `backlinks foo --index` matches the live scan
+- [x] Route `update_index_entry` through `refresh_entry` (re-scan links) plus a link-graph update for the source path (mirror `rename_index_entry`)
+- [x] Test: `set --file X --property related='[[foo]]' --index` then `backlinks foo --index` matches the live scan
 
 ### H-8 — BM25 ranking diverges between `--index` and default paths under a metadata filter
 
@@ -135,8 +136,8 @@ the metadata-passing candidates (IDF over the filtered subset) while the persist
 path (`:318-341`) computes IDF over the full vault. Same query+filter ranks differently
 depending on `--index`.
 
-- [ ] Seed the candidate-only corpus with full-vault corpus statistics (N, document frequencies, avgdl), or score over all scoped entries then intersect
-- [ ] Test: identical ranking for a body query + metadata filter with and without `--index`
+- [x] Seed the candidate-only corpus with full-vault corpus statistics (N, document frequencies, avgdl), or score over all scoped entries then intersect
+- [x] Test: identical ranking for a body query + metadata filter with and without `--index`
 
 ### H-9 — `task toggle/set --line N` mutates checkbox lines inside code fences
 
@@ -145,18 +146,18 @@ resolve `--line` by raw indexing and validate only with `detect_task_checkbox`, 
 fence/comment state — unlike every other task path. Contradicts the documented contract
 and the `task_read_inside_code_block_exits_1` guard on the read path.
 
-- [ ] Make `toggle_tasks`/`set_tasks_status` fence/comment-aware (resolve valid task lines via the scanner) and reject `--line` inside a fence/`%%` with the existing "line N is not a task" error
-- [ ] Test: `task toggle --line N` inside a code fence exits 1 (mirror the read-path test)
+- [x] Make `toggle_tasks`/`set_tasks_status` fence/comment-aware (resolve valid task lines via the scanner) and reject `--line` inside a fence/`%%` with the existing "line N is not a task" error
+- [x] Test: `task toggle --line N` inside a code fence exits 1 (mirror the read-path test)
 
 ## Key medium (folded in — same root cause / cheap once nearby)
 
-- [ ] **CRLF frontmatter preserved**, not silently converted to LF (`crates/hyalo-core/src/frontmatter/parse.rs:285`); also covers MD009-on-CRLF (`engine.rs:460`) once H-1 lands
-- [ ] **`lint --fix` idempotency** (`crates/hyalo-cli/src/commands/lint.rs:2146`): re-lint after applying until a fixpoint (or guarantee single-pass convergence); mostly resolved by H-1 but verify a second pass changes nothing
-- [ ] **Fix conflict resolution severity tiebreak** (`lint.rs:2239`): an Error fix must win over an overlapping Warn fix on the same range
-- [ ] **`--dry-run` matches the real toggle for fenced `--line`** (`commands/tasks.rs:185` vs `:235`) — resolved by H-9; add a test asserting parity
-- [ ] **Schema lint group severity = max, not first violation** (`lint.rs:1741`): a genuine schema error must not be labelled `warn` because of ordering
-- [ ] **`read` text output control-byte sanitization** (`output_pipeline.rs:175`, `run.rs:561/571/599`): route the `RawOutput` body through `sanitize_control_chars` (extend iter-122)
-- [ ] **Size caps on remaining mutation paths**: `tasks.rs:437` and `frontmatter/parse.rs:262` (`write_frontmatter`) read whole files with no `MAX_FILE_SIZE` gate
+- [x] **CRLF frontmatter preserved**, not silently converted to LF (`crates/hyalo-core/src/frontmatter/parse.rs:285`); also covers MD009-on-CRLF (`engine.rs:460`) once H-1 lands
+- [x] **`lint --fix` idempotency** (`crates/hyalo-cli/src/commands/lint.rs:2146`): re-lint after applying until a fixpoint (or guarantee single-pass convergence); mostly resolved by H-1 but verify a second pass changes nothing
+- [x] **Fix conflict resolution severity tiebreak** (`lint.rs:2239`): an Error fix must win over an overlapping Warn fix on the same range
+- [x] **`--dry-run` matches the real toggle for fenced `--line`** (`commands/tasks.rs:185` vs `:235`) — resolved by H-9; add a test asserting parity
+- [x] **Schema lint group severity = max, not first violation** (`lint.rs:1741`): a genuine schema error must not be labelled `warn` because of ordering
+- [x] **`read` text output control-byte sanitization** (`output_pipeline.rs:175`, `run.rs:561/571/599`): route the `RawOutput` body through `sanitize_control_chars` (extend iter-122)
+- [x] **Size caps on remaining mutation paths**: `tasks.rs:437` and `frontmatter/parse.rs:262` (`write_frontmatter`) read whole files with no `MAX_FILE_SIZE` gate
 
 ## Deferred (follow-up iteration / backlog)
 
@@ -171,23 +172,31 @@ Not in scope for this iteration — captured here so they aren't lost:
 - iter-157 stem-map behaviour change doc note (`dispatch.rs:62`)
 - Rust nits: clone in `link_graph.rs:416`; duplicate intersection in `bm25.rs:693`; copy-pasted task dispatch (`dispatch.rs:911`); mdlint per-call allocations (`engine.rs:327`)
 
+Discovered during this iteration's implementation:
+
+- Oversized file inside a `--glob` mutation batch aborts the whole batch instead of per-file skip (set/remove/append treat the new `write_frontmatter` size error as fatal, not skippable)
+- `plan_frontmatter_wikilink_rewrites` doesn't strip `#fragment` — anchored frontmatter wikilinks like `supersedes: "[[b#sec]]"` are not rewritten by `mv` in either single or batch mode (pre-existing, verified on both paths)
+- `lint --fix` cosmetic: a fix that loses a pass-1 conflict but applies cleanly in pass 2 still counts in `total_conflicts` even though nothing remains unresolved (`fixed`/`remaining` counts are accurate)
+- `rename_index_entry` (mv `--index` path) still uses `refresh_entry` for rewritten files, so their graph edges go stale — same class as H-7; `SnapshotIndex::refresh_links` is the ready building block
+- Live-scan BM25 with a narrow metadata filter + body query now costs the same as an unfiltered query (correct global IDF requires reading the full scoped corpus) — documented in `create-index --help`; consider a runtime hint suggesting `--index` when filter selectivity is high
+
 ## Quality Gates
 
-- [ ] `cargo fmt`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo test --workspace -q`
+- [x] `cargo fmt`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings`
+- [x] `cargo test --workspace -q`
 
 ## Acceptance Criteria
 
-- [ ] C-1: BOM and leading-whitespace files survive `set`/`remove`/`append` with no duplicated frontmatter block and no data loss
-- [ ] H-1: MD009 adds no blank line; non-ASCII lines are fixed; MD047 converges
-- [ ] H-2: combined frontmatter+body `--fix` keeps both fixes; body write is atomic with an mtime guard
-- [ ] H-3: `mv` into a symlink escaping the vault is rejected
-- [ ] H-4: single-file `mv` rewrites frontmatter wikilinks
-- [ ] H-5: `lint` and `read` refuse/skip oversized files instead of exhausting memory
-- [ ] H-6: invalid-filter errors emit valid JSON under `--format json` across find/set/remove/append/lint/mv/links
-- [ ] H-7: `--index` mutation keeps the persisted link graph correct
-- [ ] H-8: BM25 ranking is identical with and without `--index` under a metadata filter
-- [ ] H-9: `task toggle/set --line` refuses lines inside code fences
-- [ ] Documentation (help text, README, knowledgebase) updated where behaviour changes
-- [ ] All quality gates pass
+- [x] C-1: BOM and leading-whitespace files survive `set`/`remove`/`append` with no duplicated frontmatter block and no data loss
+- [x] H-1: MD009 adds no blank line; non-ASCII lines are fixed; MD047 converges
+- [x] H-2: combined frontmatter+body `--fix` keeps both fixes; body write is atomic with an mtime guard
+- [x] H-3: `mv` into a symlink escaping the vault is rejected
+- [x] H-4: single-file `mv` rewrites frontmatter wikilinks
+- [x] H-5: `lint` and `read` refuse/skip oversized files instead of exhausting memory
+- [x] H-6: invalid-filter errors emit valid JSON under `--format json` across find/set/remove/append/lint/mv/links
+- [x] H-7: `--index` mutation keeps the persisted link graph correct
+- [x] H-8: BM25 ranking is identical with and without `--index` under a metadata filter
+- [x] H-9: `task toggle/set --line` refuses lines inside code fences
+- [x] Documentation (help text, README, knowledgebase) updated where behaviour changes
+- [x] All quality gates pass


### PR DESCRIPTION
## Summary
- Fixes all critical and high findings (plus 7 same-root-cause mediums) from the 2026-06 full-codebase review (`hyalo-knowledgebase/reviews/codebase-review-2026-06-11.md`); plan and per-finding checklists in `hyalo-knowledgebase/iterations/iteration-158-review-fixes.md`.
- **Data loss (C-1):** one shared BOM-aware opening-delimiter predicate now backs the frontmatter read, write, scanner, and lint body-split paths — `set`/`remove`/`append` no longer corrupt BOM or leading-whitespace files, and `find` sees BOM files' frontmatter.
- **`lint --fix` corruption trio (H-1/H-2):** byte-correct column conversion (non-ASCII lines fixable, MD009 no longer injects blank lines, MD047 converges), single atomic write with mtime guard, and a fixpoint loop making `--fix` idempotent in one run.
- **Security/robustness:** `mv` can no longer escape the vault through symlinked destinations (H-3); `lint`/`read` gate on the 100 MiB size cap with per-line capping in `read` (H-5, ~2.7 GiB RSS → ~13 MB); `read` output is terminal-escape sanitized.
- **Correctness/consistency:** single-file `mv` rewrites frontmatter wikilinks (H-4); every error path emits the documented `{"error": …}` JSON envelope under `--format json` (H-6, 26 sites); `--index` mutations keep the persisted link graph in sync via new `SnapshotIndex::refresh_links` (H-7, also `links fix --apply --index`); live-scan BM25 ranking now matches `--index` exactly under metadata filters (H-8); `task toggle/set --line` refuses lines inside code fences/`%%` comments (H-9).
- Mediums folded in: CRLF preservation, fix-conflict severity tiebreak, schema lint group max-severity, size caps on task/frontmatter mutation paths. Newly discovered lower-priority items are recorded in the iteration doc's Deferred section.

## Test plan
- [x] `cargo fmt` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` 2,635 passed / 0 failed
- [x] ~90 new unit/e2e tests across all findings; key ones verified fail-before/pass-after against pre-fix code via git stash
- [x] Empirical repros from the review re-run against the release binary: BOM/leading-space round-trips, symlink-escape `mv`, MD009/MD047 convergence, JSON error envelopes, `backlinks --index` parity, BM25 rank/score parity (1e-9), fenced `--line` rejection, RSS measurements for `lint`/`read`
- [x] Dogfood on a copy of the real knowledgebase: `lint --fix` converges in one pass (442 fixed; second run 0); `find`/BM25 sanity checks
- [x] xtask gates: check-ac-fidelity, check-feature-fanout, check-help-drift all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (commit 48539b7)

Local two-agent review + Copilot review ran against this branch; all confirmed findings fixed:

- **[Local, high]** `skip_frontmatter` was the last predicate not migrated to the shared opening-delimiter policy — `hyalo read` dumped frontmatter as body on BOM files and swallowed lines on leading-whitespace files. Fixed + unit/e2e tests.
- **[Local, high]** `line_col_to_byte` now selects byte vs char columns per rule: MD034/MD011 emit char columns upstream, so the uniform byte walk corrupted their fixes on multibyte lines. Unverified rules default to the char walk (worst case: dropped fix, never corruption). Also fixes MD011's upstream inclusive-end column, which corrupted even ASCII fixes (pre-existing on main).
- **[Copilot]** `find_body_start` skips CRLF after the closing `---` (no stray CR at body start); `md047_fix` is CRLF-aware; `patch_index_for_modified_files` re-scans each file once via new `refresh_entry_and_links` instead of twice.
- **[Local, perf]** `SnapshotIndex` caches the case-insensitive index for incremental link refreshes (was O(entries × files) in bulk `lint --fix --index` / `links fix --apply` loops), invalidated at the single `rebuild_path_index` choke point.

Accepted without change: `early_format` best-effort edge (documented), inherent residual mv TOCTOU window (defense-in-depth documented), lint pass-1 conflict count cosmetic. Gates re-run: fmt/clippy clean, 2,647 tests, 0 failures.