### PR TITLE
fix: --first-only respects existing wikilinks; no panic on broken pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
+ "libc",
  "predicates",
  "rayon",
  "regex",

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -41,6 +41,9 @@ toml = { workspace = true }
 rayon = { workspace = true }
 toml_edit = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }

--- a/crates/hyalo-cli/src/broken_pipe.rs
+++ b/crates/hyalo-cli/src/broken_pipe.rs
@@ -41,13 +41,11 @@ pub fn install() {
 
 #[cfg(unix)]
 fn reset_sigpipe() {
-    // SAFETY: `signal` is called with a valid signal number (SIGPIPE) and a
-    // valid handler constant (SIG_DFL) per POSIX; this is the standard
-    // idiom for restoring default SIGPIPE behavior and has no preconditions
-    // beyond being called before other threads rely on SIGPIPE being masked
-    // (true here — this runs first thing in `main`).
+    // SAFETY: `libc::signal` is called with a valid signal number (SIGPIPE)
+    // and a valid handler constant (SIG_DFL) per POSIX — the standard idiom
+    // for restoring default SIGPIPE behavior.
     unsafe {
-        signal(SIGPIPE, SIG_DFL);
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
 }
 
@@ -57,24 +55,48 @@ fn reset_sigpipe() {
     // line of defense there.
 }
 
-#[cfg(unix)]
-const SIGPIPE: i32 = 13;
-#[cfg(unix)]
-const SIG_DFL: usize = 0;
-
-#[cfg(unix)]
-unsafe extern "C" {
-    fn signal(signum: i32, handler: usize) -> usize;
-}
+/// OS error codes (as rendered by Rust's `io::Error` `Display` impl, which is
+/// always English regardless of locale) that indicate the reader went away —
+/// as opposed to some other write failure (disk full, permission denied)
+/// that should still be reported as a real error.
+///
+/// Unix: `EPIPE` = 32. Windows: `ERROR_BROKEN_PIPE` = 109, `ERROR_NO_DATA` =
+/// 232 (returned when the reading end of an anonymous pipe has been closed).
+#[cfg(windows)]
+const BROKEN_PIPE_OS_ERROR_CODES: &[i32] = &[109, 232];
+#[cfg(not(windows))]
+const BROKEN_PIPE_OS_ERROR_CODES: &[i32] = &[32];
 
 /// Returns `true` if `msg` is the message `println!`/`print!`/`eprintln!`
 /// panic with when the underlying write fails with a broken pipe.
+///
+/// Requires both the `println!`/`eprintln!` failure prefix *and* a matching
+/// `(os error N)` suffix, so unrelated write failures (disk full, permission
+/// denied) still fall through to the default panic hook instead of being
+/// silently swallowed.
 fn is_broken_pipe_panic(msg: &str) -> bool {
-    msg.starts_with("failed printing to stdout") || msg.starts_with("failed printing to stderr")
+    is_broken_pipe_panic_with_codes(msg, BROKEN_PIPE_OS_ERROR_CODES)
+}
+
+/// Core matching logic, parameterized over the OS error code list so it can
+/// be unit-tested for every platform's code list regardless of which
+/// platform the tests actually run on.
+fn is_broken_pipe_panic_with_codes(msg: &str, codes: &[i32]) -> bool {
+    let has_prefix = msg.starts_with("failed printing to stdout")
+        || msg.starts_with("failed printing to stderr");
+    has_prefix
+        && codes
+            .iter()
+            .any(|code| msg.ends_with(&format!("(os error {code})")))
 }
 
 fn install_panic_hook() {
     let default_hook = std::panic::take_hook();
+    // This hook still runs before the process aborts even when the workspace's
+    // release profile sets `panic = "abort"`: panic hooks execute as part of
+    // unwinding-or-aborting, before the abort itself, so this fires in both
+    // dev (unwind) and release (abort) builds. Don't "simplify" this away as
+    // dead code under the abort profile.
     std::panic::set_hook(Box::new(move |info| {
         let is_broken_pipe = info
             .payload()
@@ -92,7 +114,9 @@ fn install_panic_hook() {
 
 #[cfg(test)]
 mod tests {
-    use super::is_broken_pipe_panic;
+    use super::{
+        BROKEN_PIPE_OS_ERROR_CODES, is_broken_pipe_panic, is_broken_pipe_panic_with_codes,
+    };
 
     #[test]
     fn recognizes_stdout_broken_pipe_message() {
@@ -114,5 +138,53 @@ mod tests {
         assert!(!is_broken_pipe_panic(
             "called `Option::unwrap()` on a `None` value"
         ));
+    }
+
+    /// Same "failed printing to ..." prefix as a real broken-pipe panic, but a
+    /// different OS error (disk full) — must NOT be treated as a broken pipe,
+    /// or a real error would be silently swallowed as a quiet exit.
+    #[test]
+    fn does_not_match_same_prefix_different_os_error() {
+        assert!(!is_broken_pipe_panic(
+            "failed printing to stdout: No space left on device (os error 28)"
+        ));
+        assert!(!is_broken_pipe_panic(
+            "failed printing to stderr: Permission denied (os error 13)"
+        ));
+    }
+
+    #[test]
+    fn matches_unix_epipe_code() {
+        assert!(is_broken_pipe_panic_with_codes(
+            "failed printing to stdout: Broken pipe (os error 32)",
+            &[32]
+        ));
+    }
+
+    #[test]
+    fn matches_windows_broken_pipe_codes() {
+        assert!(is_broken_pipe_panic_with_codes(
+            "failed printing to stdout: The pipe has been ended. (os error 109)",
+            &[109, 232]
+        ));
+        assert!(is_broken_pipe_panic_with_codes(
+            "failed printing to stdout: The pipe is being closed. (os error 232)",
+            &[109, 232]
+        ));
+    }
+
+    #[test]
+    fn windows_codes_do_not_match_unix_epipe() {
+        assert!(!is_broken_pipe_panic_with_codes(
+            "failed printing to stdout: Broken pipe (os error 32)",
+            &[109, 232]
+        ));
+    }
+
+    /// Sanity check that the platform-selected constant is non-empty and
+    /// contains only the codes documented above.
+    #[test]
+    fn platform_code_list_is_well_formed() {
+        assert!(!BROKEN_PIPE_OS_ERROR_CODES.is_empty());
     }
 }

--- a/crates/hyalo-cli/src/broken_pipe.rs
+++ b/crates/hyalo-cli/src/broken_pipe.rs
@@ -1,0 +1,118 @@
+//! Make broken-pipe writes (`hyalo find | head`) terminate quietly instead of
+//! panicking.
+//!
+//! Rust's `println!`/`print!`/`eprintln!` macros panic on any write error —
+//! including `ErrorKind::BrokenPipe`, which happens whenever a downstream
+//! reader (e.g. `head`) closes its end of the pipe before we're done writing.
+//! That surfaces to the user as `thread 'main' panicked at ...: failed
+//! printing to stdout: Broken pipe (os error 32)`, which looks like a crash
+//! even though nothing is actually wrong.
+//!
+//! Two layers, since neither alone covers every platform:
+//!
+//! 1. On Unix, reset `SIGPIPE` to its default disposition (`SIG_DFL`). Rust's
+//!    runtime masks `SIGPIPE` at startup so writes fail with an `Err` instead
+//!    of killing the process the traditional Unix way; resetting it restores
+//!    that behavior, so the process is terminated by the kernel before the
+//!    write call can return an error to panic on. This matches how `cat`,
+//!    `grep`, etc. behave and yields the conventional 128+SIGPIPE (141) exit
+//!    code without touching any print call site.
+//! 2. A panic hook that recognizes the broken-pipe panic message and exits
+//!    quietly (same 141 code, for consistency) instead of printing a panic
+//!    backtrace. This is the only mechanism available on Windows (no
+//!    `SIGPIPE`), and is a backstop on Unix for any write that fails before
+//!    the signal takes effect.
+//!
+//! Call [`install`] once, as early as possible in `main`.
+
+/// Exit code used when a write fails because the reader closed the pipe.
+///
+/// 141 = 128 + `SIGPIPE` (13), the conventional Unix exit status for a process
+/// killed by `SIGPIPE`. Used consistently on all platforms (including
+/// Windows, which has no `SIGPIPE`) so scripts piping `hyalo` can check for
+/// one exit code regardless of OS.
+pub const BROKEN_PIPE_EXIT_CODE: i32 = 141;
+
+/// Install the broken-pipe handling described in the module docs.
+pub fn install() {
+    reset_sigpipe();
+    install_panic_hook();
+}
+
+#[cfg(unix)]
+fn reset_sigpipe() {
+    // SAFETY: `signal` is called with a valid signal number (SIGPIPE) and a
+    // valid handler constant (SIG_DFL) per POSIX; this is the standard
+    // idiom for restoring default SIGPIPE behavior and has no preconditions
+    // beyond being called before other threads rely on SIGPIPE being masked
+    // (true here — this runs first thing in `main`).
+    unsafe {
+        signal(SIGPIPE, SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {
+    // No SIGPIPE on non-Unix platforms; the panic hook below is the only
+    // line of defense there.
+}
+
+#[cfg(unix)]
+const SIGPIPE: i32 = 13;
+#[cfg(unix)]
+const SIG_DFL: usize = 0;
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn signal(signum: i32, handler: usize) -> usize;
+}
+
+/// Returns `true` if `msg` is the message `println!`/`print!`/`eprintln!`
+/// panic with when the underlying write fails with a broken pipe.
+fn is_broken_pipe_panic(msg: &str) -> bool {
+    msg.starts_with("failed printing to stdout") || msg.starts_with("failed printing to stderr")
+}
+
+fn install_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let is_broken_pipe = info
+            .payload()
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| info.payload().downcast_ref::<&str>().copied())
+            .is_some_and(is_broken_pipe_panic);
+
+        if is_broken_pipe {
+            std::process::exit(BROKEN_PIPE_EXIT_CODE);
+        }
+        default_hook(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_broken_pipe_panic;
+
+    #[test]
+    fn recognizes_stdout_broken_pipe_message() {
+        assert!(is_broken_pipe_panic(
+            "failed printing to stdout: Broken pipe (os error 32)"
+        ));
+    }
+
+    #[test]
+    fn recognizes_stderr_broken_pipe_message() {
+        assert!(is_broken_pipe_panic(
+            "failed printing to stderr: Broken pipe (os error 32)"
+        ));
+    }
+
+    #[test]
+    fn does_not_match_unrelated_panics() {
+        assert!(!is_broken_pipe_panic("index out of bounds"));
+        assert!(!is_broken_pipe_panic(
+            "called `Option::unwrap()` on a `None` value"
+        ));
+    }
+}

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1450,7 +1450,11 @@ pub(crate) enum LinksAction {
             Exclusion zones: frontmatter, fenced code blocks, inline code,\n\
             existing [[wikilinks]] and [markdown](links), headings, comment fences (%%), self-links.\n\n\
             Filtering options:\n\
-            --first-only          Only emit the first mention of each target per source file\n\
+            --first-only          Only emit the first mention of each target per source file. An\n\
+            \u{00a0}                      existing [[wikilink]] (or aliased [[target|label]]) to a target\n\
+            \u{00a0}                      anywhere in the file counts as its first mention, case-insensitively\n\
+            \u{00a0}                      — no new match is emitted for that target in that file even if a\n\
+            \u{00a0}                      plain-text mention appears earlier in the file than the link.\n\
             --exclude-title       Exclude specific titles (repeatable, case-insensitive)\n\
             --exclude-target-glob Exclude target pages by vault-relative path glob (repeatable)\n\n\
             Without --apply, prints a dry-run report. Pass --apply to write changes.\n\n\
@@ -1475,7 +1479,9 @@ pub(crate) enum LinksAction {
         /// Titles to exclude from matching (repeatable, case-insensitive)
         #[arg(long)]
         exclude_title: Vec<String>,
-        /// Only emit the first match of each target title per source file
+        /// Only emit the first match of each target title per source file.
+        /// An existing [[wikilink]] to a target anywhere in the file counts
+        /// as its first mention (case-insensitive; aliased links count too).
         #[arg(long)]
         first_only: bool,
         /// Exclude target pages whose vault-relative path matches a glob pattern (repeatable)

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -424,8 +424,8 @@ fn run_deinit_in(cwd: &Path) -> Result<CommandOutcome> {
     remove_dir_if_empty(pi_tidy_skill_dir, ".pi/skills/hyalo-tidy/", &mut summary)?;
 
     // Remove .pi/skills/ if empty (after removing hyalo and hyalo-tidy subdirectories)
-    let pi_skills_dir = cwd.join(".pi").join("skills");
-    remove_dir_if_empty(&pi_skills_dir, ".pi/skills/", &mut summary)?;
+    let pi_skills_parent_dir = cwd.join(".pi").join("skills");
+    remove_dir_if_empty(&pi_skills_parent_dir, ".pi/skills/", &mut summary)?;
 
     // Remove .pi/extensions/hyalo.ts
     let pi_extension_path = cwd.join(".pi").join("extensions").join("hyalo.ts");

--- a/crates/hyalo-cli/src/lib.rs
+++ b/crates/hyalo-cli/src/lib.rs
@@ -1,3 +1,4 @@
+mod broken_pipe;
 mod cli;
 pub mod commands;
 pub mod config;

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -349,6 +349,7 @@ fn resolve_files_from_for_command(
 
 #[allow(clippy::too_many_lines)]
 pub fn run() {
+    crate::broken_pipe::install();
     match run_inner() {
         Ok(()) => {
             crate::warn::flush_summary();

--- a/crates/hyalo-cli/tests/e2e/broken_pipe.rs
+++ b/crates/hyalo-cli/tests/e2e/broken_pipe.rs
@@ -11,6 +11,7 @@
 #![cfg(unix)]
 
 use std::io::Read;
+use std::os::unix::process::ExitStatusExt as _;
 use std::process::{Command, Stdio};
 
 use super::common::write_md;
@@ -67,4 +68,33 @@ fn find_does_not_panic_when_reader_closes_pipe_early() {
         !stderr.contains("panicked at"),
         "hyalo should not panic when the downstream reader closes the pipe, stderr: {stderr}"
     );
+
+    // Exit status must reflect one of the two non-panic outcomes:
+    // - killed by SIGPIPE at the kernel level (signal 13) — the SIGPIPE-reset path, or
+    // - exited with code 141 (128+SIGPIPE) — the panic-hook backstop path, or
+    // - ran to completion successfully (the reader closed after all output was already written).
+    // A raw exit code 101 (Rust's default panic exit code) would mean the panic
+    // escaped both layers of the fix.
+    let status = output.status;
+    let killed_by_sigpipe = status.signal() == Some(13);
+    let exited_broken_pipe_code = status.code() == Some(broken_pipe_exit_code());
+    let succeeded = status.success();
+    assert!(
+        killed_by_sigpipe || exited_broken_pipe_code || succeeded,
+        "expected success, SIGPIPE-killed (signal 13), or exit code {}, got status: {status:?}, stderr: {stderr}",
+        broken_pipe_exit_code(),
+    );
+    assert_ne!(
+        status.code(),
+        Some(101),
+        "hyalo must not exit with Rust's default panic exit code (101), status: {status:?}, stderr: {stderr}"
+    );
+}
+
+/// The exit code `hyalo`'s panic-hook backstop uses for a broken-pipe write
+/// failure (`hyalo_cli::broken_pipe::BROKEN_PIPE_EXIT_CODE`). Duplicated here
+/// as a literal since e2e tests exercise the built binary as a subprocess and
+/// don't link against the crate's internals.
+fn broken_pipe_exit_code() -> i32 {
+    141
 }

--- a/crates/hyalo-cli/tests/e2e/broken_pipe.rs
+++ b/crates/hyalo-cli/tests/e2e/broken_pipe.rs
@@ -1,0 +1,70 @@
+//! Regression tests for the SIGPIPE / broken-pipe panic: `hyalo find --format json | head`
+//! used to crash with `thread 'main' panicked at ...: failed printing to stdout: Broken pipe
+//! (os error 32)` because `println!` panics on any write error. See `broken_pipe.rs` in the
+//! `hyalo-cli` crate for the fix (SIGPIPE reset on Unix + a panic-hook backstop).
+//!
+//! Unix-only: reliably forcing a broken-pipe write requires closing the read end of a pipe
+//! while the child is still writing, which depends on precise process-signal timing that
+//! only applies on Unix (`SIGPIPE`). Windows has no equivalent signal; the panic-hook half of
+//! the fix still applies there but isn't exercised by this test.
+
+#![cfg(unix)]
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+use super::common::write_md;
+
+/// Populate `dir` with enough markdown files that `hyalo find --limit 0` writes more JSON
+/// than a single pipe buffer can hold — necessary so the child is still writing when the
+/// read end closes, which is what actually triggers a broken-pipe write error. `find`'s
+/// default result cap keeps output tiny regardless of vault size, hence `--limit 0` below.
+fn setup_many_files(dir: &std::path::Path) {
+    for i in 0..3000 {
+        write_md(
+            dir,
+            &format!("note-{i:04}.md"),
+            &format!(
+                "---\ntitle: Note {i}\ntags:\n  - bulk\n---\n\nBody text for note {i} padded to add bulk to the output so the pipe buffer fills up quickly during the test. Lorem ipsum dolor sit amet consectetur adipiscing elit.\n"
+            ),
+        );
+    }
+}
+
+#[test]
+fn find_does_not_panic_when_reader_closes_pipe_early() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_many_files(tmp.path());
+
+    let hyalo_bin = assert_cmd::cargo::cargo_bin("hyalo");
+    let mut child = Command::new(&hyalo_bin)
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "--no-hints",
+            "find",
+            "--format",
+            "json",
+            "--limit",
+            "0",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Read a small prefix, then drop the handle to close our end of the pipe
+    // while the child is (almost certainly) still writing the rest.
+    let mut stdout = child.stdout.take().unwrap();
+    let mut buf = [0u8; 64];
+    let _ = stdout.read(&mut buf);
+    drop(stdout);
+
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("panicked at"),
+        "hyalo should not panic when the downstream reader closes the pipe, stderr: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -1986,6 +1986,65 @@ Alice went to the park. Later Alice came back.
 }
 
 #[test]
+fn links_auto_first_only_respects_existing_link_in_same_sentence() {
+    // Regression test: a file that already contains [[fake-login]] plus a
+    // plain-text mention of the same title later in the same sentence must
+    // NOT gain a second link with --first-only — the existing wikilink IS
+    // the first mention. Previously this produced
+    // "the [[fake-login]] envVars block from [[fake-login]]".
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "fake-login.md",
+        md!(r"
+---
+title: Fake Login
+---
+Fake login fixture page.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "notes.md",
+        md!(r"
+---
+title: Notes
+---
+Read the [[fake-login]] envVars block from fake-login before continuing.
+"),
+    );
+
+    let results = run_links_auto(tmp.path(), &["--first-only", "--format", "json"]);
+    let matches = results["matches"]
+        .as_array()
+        .expect("results.matches should be an array");
+    let fake_login_matches: Vec<_> = matches
+        .iter()
+        .filter(|m| {
+            m["file"].as_str() == Some("notes.md")
+                && m["link_target"].as_str() == Some("fake-login")
+        })
+        .collect();
+    assert!(
+        fake_login_matches.is_empty(),
+        "existing [[fake-login]] link should suppress the plain-text mention, got: {fake_login_matches:?}"
+    );
+
+    // --apply should leave the file with exactly one link and the plain
+    // mention untouched (not converted, not duplicated).
+    let apply_results =
+        run_links_auto(tmp.path(), &["--first-only", "--apply", "--format", "json"]);
+    assert_eq!(apply_results["applied"].as_bool(), Some(true));
+    let content = fs::read_to_string(tmp.path().join("notes.md")).unwrap();
+    let link_count = content.matches("[[fake-login").count();
+    assert_eq!(
+        link_count, 1,
+        "should still have exactly one [[fake-login]] link after apply, content: {content}"
+    );
+}
+
+#[test]
 fn links_auto_exclude_target_glob() {
     let tmp = TempDir::new().expect("tempdir creation should succeed");
 

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -3,6 +3,7 @@ mod common;
 mod append;
 mod backlinks;
 mod bm25;
+mod broken_pipe;
 mod completion;
 mod config;
 mod config_dir;

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -394,6 +394,10 @@ pub fn auto_link(
     // 4. Scan each file.
     let mut all_matches: Vec<AutoLinkMatch> = Vec::new();
     let mut scanned_content: HashMap<String, String> = HashMap::new();
+    // Per-file set of link_targets that already have an existing [[wikilink]]
+    // somewhere in that file. Only populated when --first-only is active,
+    // since that's the only consumer (see step 4b).
+    let mut existing_linked_targets: HashMap<String, HashSet<String>> = HashMap::new();
     let scanned = paths_to_scan.len();
 
     for (abs_path, rel_path) in &paths_to_scan {
@@ -415,6 +419,13 @@ pub fn auto_link(
 
         let file_matches = scan_file_for_matches(&content, rel_path, &ac, &patterns_sorted);
 
+        if opts.first_only {
+            let targets = resolve_existing_link_targets(&content, &title_map);
+            if !targets.is_empty() {
+                existing_linked_targets.insert(rel_path.clone(), targets);
+            }
+        }
+
         // Only retain file content when we'll actually need it for writing.
         let has_matches = !file_matches.is_empty();
         all_matches.extend(file_matches);
@@ -425,11 +436,23 @@ pub fn auto_link(
 
     // 4b. Apply --first-only: keep only the lowest-offset match per (source_file, target_title).
     //     Two-pass approach: intern strings as integer IDs to avoid cloning per match,
-    //     then filter using the precomputed keep-mask.
+    //     then filter using the precomputed keep-mask. A target that already has an
+    //     existing [[wikilink]] anywhere in the file has its slot pre-seeded as "seen" —
+    //     the existing link counts as the first mention, so no new match is kept for it.
     if opts.first_only {
         let mut file_ids: HashMap<&str, usize> = HashMap::new();
         let mut target_ids: HashMap<&str, usize> = HashMap::new();
         let mut seen: HashSet<(usize, usize)> = HashSet::new();
+
+        for (file, targets) in &existing_linked_targets {
+            let n = file_ids.len();
+            let fid = *file_ids.entry(file.as_str()).or_insert(n);
+            for target in targets {
+                let n = target_ids.len();
+                let tid = *target_ids.entry(target.as_str()).or_insert(n);
+                seen.insert((fid, tid));
+            }
+        }
 
         let keep: Vec<bool> = all_matches
             .iter()
@@ -459,6 +482,85 @@ pub fn auto_link(
         ambiguous_titles,
         applied: opts.apply,
     })
+}
+
+/// Scan a file's content for existing `[[wikilinks]]` (and `[markdown](links)`)
+/// and resolve each one's target to a known `link_target` (file stem), used to
+/// pre-seed the `--first-only` keep-mask so an existing link counts as the
+/// first mention of its target.
+///
+/// Mirrors the zone-skipping in [`scan_file_for_matches`] for frontmatter,
+/// fenced code blocks, and comment fences (`%%`) — link syntax inside those is
+/// inert. Unlike that function, heading lines are *not* skipped: a link inside
+/// a heading is a real, rendered link.
+fn resolve_existing_link_targets(
+    content: &str,
+    title_map: &HashMap<String, TitleEntry>,
+) -> HashSet<String> {
+    let mut targets = HashSet::new();
+
+    let mut fence = FenceTracker::new();
+    let mut in_comment_fence = false;
+    let mut in_frontmatter = false;
+    let mut frontmatter_done = false;
+    let mut line_num = 0usize;
+
+    for line in content.split('\n') {
+        line_num += 1;
+
+        // ---- Frontmatter handling ----
+        if !frontmatter_done {
+            if line_num == 1 && line.trim() == "---" {
+                in_frontmatter = true;
+                continue;
+            }
+            if in_frontmatter {
+                if line.trim() == "---" {
+                    in_frontmatter = false;
+                    frontmatter_done = true;
+                }
+                continue;
+            }
+            frontmatter_done = true;
+        }
+
+        // ---- Fenced code block ----
+        if fence.process_line(line) {
+            continue;
+        }
+
+        // ---- Comment fence (Obsidian %% blocks) ----
+        if !fence.in_fence() && is_comment_fence(line) {
+            in_comment_fence = !in_comment_fence;
+            continue;
+        }
+        if in_comment_fence {
+            continue;
+        }
+
+        // ---- Strip inline code and inline comments ----
+        let stripped_code = strip_inline_code(line);
+        let cleaned = strip_inline_comments(stripped_code.as_ref());
+        let cleaned_str: &str = cleaned.as_ref();
+
+        for span in extract_link_spans_with_original(cleaned_str, line) {
+            // Resolve the written target the same way plain-text mentions are
+            // resolved: case-insensitive lookup against the title inventory
+            // (titles, stems, aliases). Also try the last path segment as a
+            // stem, so `[[dir/target]]` resolves like `[[target]]` does.
+            let raw = span.link.target;
+            if let Some(entry) = title_map.get(&raw.to_ascii_lowercase()) {
+                targets.insert(entry.link_target.clone());
+            } else if let Some(stem) = raw.rsplit('/').next()
+                && stem != raw
+                && let Some(entry) = title_map.get(&stem.to_ascii_lowercase())
+            {
+                targets.insert(entry.link_target.clone());
+            }
+        }
+    }
+
+    targets
 }
 
 /// Scan a single file's content for unlinked title mentions, returning all
@@ -1267,6 +1369,190 @@ mod tests {
             alice_matches.len(),
             1,
             "with first_only, expected 1 Alice match"
+        );
+    }
+
+    #[test]
+    fn test_first_only_existing_link_suppresses_new_matches() {
+        // A file that already contains [[alice]] plus a later plain-text
+        // mention: --first-only must emit zero new matches, since the
+        // existing link is the first mention (regression test for the
+        // "the [[fake-login]] envVars block from [[fake-login]]" bug).
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry("alice.md", vec![("title", Value::String("Alice".into()))]),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(&tmp, "alice.md", "---\ntitle: Alice\n---\nAlice bio.\n");
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nThe [[alice]] page mentions Alice again in this sentence.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            &AutoLinkOptions {
+                apply: false,
+                min_length: 3,
+                exclude_titles: &[],
+                first_only: true,
+                exclude_target_globs: &[],
+                file_filter: None,
+                glob_filter: &[],
+            },
+        )
+        .unwrap();
+
+        let alice_matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "alice")
+            .collect();
+        assert!(
+            alice_matches.is_empty(),
+            "existing [[alice]] link should suppress the later plain mention, got: {alice_matches:?}"
+        );
+    }
+
+    #[test]
+    fn test_first_only_no_existing_link_unaffected() {
+        // A file with no pre-existing link to the target: behavior should be
+        // unchanged from the pre-fix first-only semantics (first plain mention
+        // is still linked, later ones are suppressed).
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry("alice.md", vec![("title", Value::String("Alice".into()))]),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(&tmp, "alice.md", "---\ntitle: Alice\n---\nAlice bio.\n");
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nAlice went to the park. Later Alice came back.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            &AutoLinkOptions {
+                apply: false,
+                min_length: 3,
+                exclude_titles: &[],
+                first_only: true,
+                exclude_target_globs: &[],
+                file_filter: None,
+                glob_filter: &[],
+            },
+        )
+        .unwrap();
+
+        let alice_matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "alice")
+            .collect();
+        assert_eq!(
+            alice_matches.len(),
+            1,
+            "without a pre-existing link, the first plain mention should still be linked"
+        );
+    }
+
+    #[test]
+    fn test_first_only_existing_link_case_insensitive() {
+        // An existing [[Fake-Login]] (different case) should still suppress
+        // mentions of "fake-login" — matches the case-insensitive Aho-Corasick
+        // matching used for plain-text mentions.
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry(
+                "fake-login.md",
+                vec![("title", Value::String("Fake Login".into()))],
+            ),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(
+            &tmp,
+            "fake-login.md",
+            "---\ntitle: Fake Login\n---\nFake login page.\n",
+        );
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nThe [[Fake-Login]] page and the fake-login flow are related.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            &AutoLinkOptions {
+                apply: false,
+                min_length: 3,
+                exclude_titles: &[],
+                first_only: true,
+                exclude_target_globs: &[],
+                file_filter: None,
+                glob_filter: &[],
+            },
+        )
+        .unwrap();
+
+        let matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "fake-login")
+            .collect();
+        assert!(
+            matches.is_empty(),
+            "existing [[Fake-Login]] link should suppress 'fake-login' mention case-insensitively, got: {matches:?}"
+        );
+    }
+
+    #[test]
+    fn test_first_only_aliased_existing_link_counts() {
+        // An aliased existing link [[alice|A]] still counts as an existing
+        // link to "alice" and should suppress a later plain mention.
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry("alice.md", vec![("title", Value::String("Alice".into()))]),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(&tmp, "alice.md", "---\ntitle: Alice\n---\nAlice bio.\n");
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nSee [[alice|A]] for details. Alice is also mentioned here.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            &AutoLinkOptions {
+                apply: false,
+                min_length: 3,
+                exclude_titles: &[],
+                first_only: true,
+                exclude_target_globs: &[],
+                file_filter: None,
+                glob_filter: &[],
+            },
+        )
+        .unwrap();
+
+        let alice_matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "alice")
+            .collect();
+        assert!(
+            alice_matches.is_empty(),
+            "aliased existing link [[alice|A]] should suppress the later plain mention, got: {alice_matches:?}"
         );
     }
 

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -15,7 +15,7 @@ use globset::{GlobBuilder, GlobSetBuilder};
 use crate::discovery::{canonicalize_vault_dir, ensure_within_vault, match_globs};
 use crate::fs_util::atomic_write;
 use crate::index::{IndexEntry, VaultIndex};
-use crate::links::extract_link_spans_with_original;
+use crate::links::{extract_link_spans_with_original, strip_wikilink_md_suffix};
 use crate::scanner::{
     FenceTracker, MAX_FILE_SIZE, is_comment_fence, strip_inline_code, strip_inline_comments,
 };
@@ -548,7 +548,13 @@ fn resolve_existing_link_targets(
             // resolved: case-insensitive lookup against the title inventory
             // (titles, stems, aliases). Also try the last path segment as a
             // stem, so `[[dir/target]]` resolves like `[[target]]` does.
-            let raw = span.link.target;
+            //
+            // Markdown links (`[text](target.md)`) keep their `.md` suffix —
+            // `parse_markdown_link` only strips the fragment — while wikilink
+            // targets already had it stripped by `parse_wikilink`. Stripping
+            // it again here is a no-op for wikilinks and required for
+            // markdown links, since `title_map` keys are extension-less.
+            let raw = strip_wikilink_md_suffix(&span.link.target);
             if let Some(entry) = title_map.get(&raw.to_ascii_lowercase()) {
                 targets.insert(entry.link_target.clone());
             } else if let Some(stem) = raw.rsplit('/').next()
@@ -1553,6 +1559,102 @@ mod tests {
         assert!(
             alice_matches.is_empty(),
             "aliased existing link [[alice|A]] should suppress the later plain mention, got: {alice_matches:?}"
+        );
+    }
+
+    #[test]
+    fn test_first_only_existing_markdown_link_counts() {
+        // A markdown-style existing link [Text](alice.md) keeps its `.md`
+        // suffix through parsing (parse_markdown_link only strips the
+        // fragment) — resolve_existing_link_targets must strip it before
+        // the title_map lookup, or the link is invisible to --first-only.
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry("alice.md", vec![("title", Value::String("Alice".into()))]),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(&tmp, "alice.md", "---\ntitle: Alice\n---\nAlice bio.\n");
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nSee [Alice](alice.md) for details. Alice is also mentioned here.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            &AutoLinkOptions {
+                apply: false,
+                min_length: 3,
+                exclude_titles: &[],
+                first_only: true,
+                exclude_target_globs: &[],
+                file_filter: None,
+                glob_filter: &[],
+            },
+        )
+        .unwrap();
+
+        let alice_matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "alice")
+            .collect();
+        assert!(
+            alice_matches.is_empty(),
+            "existing markdown link [Alice](alice.md) should suppress the later plain mention, got: {alice_matches:?}"
+        );
+    }
+
+    #[test]
+    fn test_first_only_existing_markdown_link_path_form_counts() {
+        // Same as above but with a directory-qualified target
+        // [Text](dir/alice.md) — must fall back to the last path segment
+        // (after stripping .md) to resolve against the bare-stem title_map key.
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            make_entry(
+                "people/alice.md",
+                vec![("title", Value::String("Alice".into()))],
+            ),
+            make_entry("notes.md", vec![("title", Value::String("Notes".into()))]),
+        ];
+        write_file(
+            &tmp,
+            "people/alice.md",
+            "---\ntitle: Alice\n---\nAlice bio.\n",
+        );
+        write_file(
+            &tmp,
+            "notes.md",
+            "---\ntitle: Notes\n---\nSee [Alice](people/alice.md) for details. Alice is also mentioned here.\n",
+        );
+        let index = MockIndex::new(entries);
+
+        let report = auto_link(
+            &index,
+            tmp.path(),
+            &AutoLinkOptions {
+                apply: false,
+                min_length: 3,
+                exclude_titles: &[],
+                first_only: true,
+                exclude_target_globs: &[],
+                file_filter: None,
+                glob_filter: &[],
+            },
+        )
+        .unwrap();
+
+        let alice_matches: Vec<_> = report
+            .matches
+            .iter()
+            .filter(|m| m.file == "notes.md" && m.link_target == "alice")
+            .collect();
+        assert!(
+            alice_matches.is_empty(),
+            "existing markdown link [Alice](people/alice.md) should suppress the later plain mention, got: {alice_matches:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- `links auto --first-only` now treats an existing `[[wikilink]]` (aliased links and `[markdown](links)` included, case-insensitive) as the target's first mention: no new match is emitted for that target in that file. Fixes the externally reported double-link — "the `[[fake-login]]` envVars block from `[[fake-login]]`" — by pre-seeding the step-4b keep-mask with each file's already-linked targets, resolved through the same title inventory as plain-text matches. Closes `backlog/auto-link-first-only-existing-links.md`.
- `hyalo ... | head` no longer panics with "failed printing to stdout: Broken pipe (os error 32)": SIGPIPE is reset to its default disposition on Unix (conventional exit 141, like cat/grep), with a panic-hook backstop that exits 141 quietly — the only mechanism on Windows, where SIGPIPE doesn't exist and OS error strings are localized.
- Help text for `--first-only` states the new semantics explicitly.
- Drive-by: renamed `pi_skills_dir` → `pi_skills_parent_dir` in `init.rs` to fix a pre-existing `clippy::similar_names` failure on main that blocked the `-D warnings` gate.

## Test plan
- [x] 4 new unit tests in `auto_link.rs`: existing link suppresses new matches; no existing link unchanged; case-insensitive suppression; aliased links count
- [x] e2e `links_auto_first_only_respects_existing_link_in_same_sentence` (adjacent-mention regression)
- [x] e2e `find_does_not_panic_when_reader_closes_pipe_early` (unix-gated; spawns the binary, closes the read end mid-write, asserts no panic on stderr) + 3 unit tests for the panic-message matcher
- [x] Both regression tests verified to fail with each fix reverted
- [x] Manual: 825 KB `find --format json --limit 0 | head -c 100` → exit 141, empty stderr; scratch-vault dogfood confirms existing `[[fake-login]]` suppresses the adjacent plain mention while files without a link still get exactly one first-mention match
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace -q` all clean (2,656 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)