### PR TITLE
iter-160: fix lint-rules panic + links fix frontmatter no-op (release blockers)

### DIFF
--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -994,7 +994,10 @@ Repeatable (AND).\n\
             repaired without modifying files. Equivalent to `hyalo links fix --dry-run`.\n\n\
             OUTPUT: JSON object with broken/fixable/unfixable counts, per-fix details \
             (source, line, old_target, new_target, strategy, confidence), and \
-            the list of links that could not be matched.\n\
+            the list of links that could not be matched. With --apply it also \
+            reports applied_fixes (fixes actually written to disk) plus \
+            unapplied/unapplied_fixes for plans whose on-disk text no longer \
+            matched — only applied_fixes were durably written.\n\
             SIDE EFFECTS: None unless `links fix --apply` is passed.\n\n\
             TIP: For read-only auditing, use 'hyalo summary' (link health overview)\n\
             or 'hyalo find --broken-links' (list files with unresolved links).\n\n\

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -110,6 +110,11 @@ pub fn links_fix(
     let ambiguous_count = ambiguous.len();
 
     let mut modified_files = Vec::new();
+    // Fixes that were part of the plan but produced no on-disk change (e.g. a
+    // frontmatter occurrence whose text no longer matched what detection saw).
+    // Empty in dry-run mode: nothing has been attempted yet, so nothing can
+    // be reported as unapplied.
+    let mut unapplied_fixes: Vec<hyalo_core::link_fix::FixPlan> = Vec::new();
 
     if !dry_run {
         // Merge broken-link fixes and case-mismatch fixes into a single batch
@@ -119,14 +124,50 @@ pub fn links_fix(
         let mut all_fixes = fix_report.fixes.clone();
         all_fixes.extend(case_mismatches.iter().cloned());
         if !all_fixes.is_empty() {
-            apply_fixes(dir, &all_fixes, site_prefix)?;
+            let (plans, unapplied) = apply_fixes(dir, &all_fixes, site_prefix)?;
+            unapplied_fixes = unapplied;
 
-            // Collect unique modified files for the caller to patch the index.
-            let deduped: std::collections::HashSet<&str> =
-                all_fixes.iter().map(|f| f.source.as_str()).collect();
-            modified_files = deduped.into_iter().map(str::to_owned).collect();
+            // Only files that actually received a rewrite are "modified" —
+            // do not patch the index for files whose fixes were all unapplied.
+            modified_files = plans.into_iter().map(|p| p.rel_path).collect();
         }
     }
+    let unapplied_count = unapplied_fixes.len();
+
+    // Fixes actually written to disk this run (or, in dry-run, the full
+    // plan — nothing has been attempted yet so "applied" is meaningless).
+    // Reporting only the successfully-applied subset here is what makes
+    // "Applied: yes" honest: a fix that never landed on disk must not appear
+    // as if it did, or a fix-loop driven by this count will never converge.
+    let applied_fixes: Vec<_> = if dry_run {
+        Vec::new()
+    } else {
+        let unapplied_keys: std::collections::HashSet<(&str, usize, &str, &str)> = unapplied_fixes
+            .iter()
+            .map(|f| {
+                (
+                    f.source.as_str(),
+                    f.line,
+                    f.old_target.as_str(),
+                    f.new_target.as_str(),
+                )
+            })
+            .collect();
+        fix_report
+            .fixes
+            .iter()
+            .chain(case_mismatches.iter())
+            .filter(|f| {
+                !unapplied_keys.contains(&(
+                    f.source.as_str(),
+                    f.line,
+                    f.old_target.as_str(),
+                    f.new_target.as_str(),
+                ))
+            })
+            .cloned()
+            .collect()
+    };
 
     let output = serde_json::json!({
         "broken": broken.len(),
@@ -136,6 +177,9 @@ pub fn links_fix(
         "fixes": fix_report.fixes,
         "unfixable_links": fix_report.unfixable,
         "applied": !dry_run,
+        "applied_fixes": applied_fixes,
+        "unapplied": unapplied_count,
+        "unapplied_fixes": unapplied_fixes,
         "case_mismatches": case_mismatch_count,
         "case_mismatch_fixes": case_mismatches,
         "ambiguous": ambiguous_count,

--- a/crates/hyalo-cli/src/commands/lint_rules.rs
+++ b/crates/hyalo-cli/src/commands/lint_rules.rs
@@ -219,11 +219,18 @@ pub(crate) fn set_rule(
         }
     } else if need_severity_override {
         // Table form is required to carry severity.
-        if doc.get("lint").is_none() {
-            doc["lint"] = toml_edit::Item::Table(toml_edit::Table::new());
-        }
-        let lint_rules =
-            doc["lint"]["rules"].or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+        let lint_rules = match lint_rules_table_mut(&mut doc) {
+            Ok(item) => item,
+            Err(err) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format,
+                    &err.to_string(),
+                    None,
+                    Some("fix or remove the malformed entry in .hyalo.toml"),
+                    None,
+                )));
+            }
+        };
 
         // If the existing entry is a scalar bool, promote it to a table so
         // we can index into it without panicking. Handle both regular and
@@ -260,11 +267,18 @@ pub(crate) fn set_rule(
         rule_entry["severity"] = toml_edit::value(target_severity_str.clone());
     } else {
         // Only `enabled` diverges from default — scalar form is enough.
-        if doc.get("lint").is_none() {
-            doc["lint"] = toml_edit::Item::Table(toml_edit::Table::new());
-        }
-        let lint_rules =
-            doc["lint"]["rules"].or_insert(toml_edit::Item::Table(toml_edit::Table::new()));
+        let lint_rules = match lint_rules_table_mut(&mut doc) {
+            Ok(item) => item,
+            Err(err) => {
+                return Ok(CommandOutcome::UserError(format_error(
+                    format,
+                    &err.to_string(),
+                    None,
+                    Some("fix or remove the malformed entry in .hyalo.toml"),
+                    None,
+                )));
+            }
+        };
 
         if let Some(existing) = lint_rules.get_mut(rule_id)
             && (existing.is_table() || existing.is_inline_table())
@@ -358,6 +372,31 @@ pub(crate) fn set_rule(
         "wrote": wrote,
     });
     Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+}
+
+/// Get (creating if absent) the `[lint.rules]` table as a mutable `Item`.
+///
+/// Returns a user-facing error if `lint` or `lint.rules` exist but are not
+/// TOML tables (e.g. the user hand-edited `.hyalo.toml` into something like
+/// `lint = "oops"`). We prefer a clear error over a panic on user input —
+/// mirrors `ensure_schema_types_table` in `types.rs` for the identical
+/// malformed-config scenario.
+fn lint_rules_table_mut(doc: &mut toml_edit::DocumentMut) -> Result<&mut toml_edit::Item> {
+    if doc.get("lint").is_none() {
+        doc["lint"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let lint = doc["lint"].as_table_mut().ok_or_else(|| {
+        anyhow::anyhow!("malformed .hyalo.toml: `lint` is not a table — expected `[lint]` section")
+    })?;
+    if !lint.contains_key("rules") {
+        lint.insert("rules", toml_edit::Item::Table(toml_edit::Table::new()));
+    }
+    if !lint["rules"].is_table() && !lint["rules"].is_inline_table() {
+        return Err(anyhow::anyhow!(
+            "malformed .hyalo.toml: `lint.rules` is not a table — expected `[lint.rules]` section"
+        ));
+    }
+    Ok(&mut lint["rules"])
 }
 
 /// Remove `[lint.rules]` and `[lint]` from `doc` when they have no surviving
@@ -683,6 +722,137 @@ mod tests {
         );
 
         let _ = (schema, &md_lint);
+    }
+
+    /// CRITICAL reproducer: `.hyalo.toml` with `lint` as a non-table scalar
+    /// must return a clean error from `set --severity`, not panic via
+    /// `IndexMut` on a non-table `Item`.
+    #[test]
+    fn set_severity_malformed_lint_scalar_returns_error() {
+        let dir = tempdir().unwrap();
+        let toml_path = dir.path().join(".hyalo.toml");
+        std::fs::write(&toml_path, "lint = \"oops\"\n").unwrap();
+
+        let engine = make_engine();
+        let md_lint = load_md_lint(dir.path());
+
+        let result = set_rule(
+            dir.path(),
+            "MD013",
+            None,
+            Some("error"),
+            false,
+            &engine,
+            &md_lint,
+            Format::Json,
+        );
+
+        let outcome = result.expect("malformed `lint` scalar must not panic or bubble up");
+        let CommandOutcome::UserError(msg) = outcome else {
+            panic!("expected UserError outcome, got {outcome:?}");
+        };
+        assert!(
+            msg.contains("malformed") && msg.contains("lint"),
+            "unexpected error: {msg}"
+        );
+
+        // The file must be left untouched — no partial write on error.
+        let contents_after = std::fs::read_to_string(&toml_path).unwrap();
+        assert_eq!(contents_after, "lint = \"oops\"\n");
+    }
+
+    /// CRITICAL reproducer: same malformed config for the `--enabled` path
+    /// (scalar-form branch), which used the same unguarded `doc["lint"]["rules"]`
+    /// indexing.
+    #[test]
+    fn set_enabled_malformed_lint_scalar_returns_error() {
+        let dir = tempdir().unwrap();
+        let toml_path = dir.path().join(".hyalo.toml");
+        std::fs::write(&toml_path, "lint = \"oops\"\n").unwrap();
+
+        let engine = make_engine();
+        let md_lint = load_md_lint(dir.path());
+
+        // MD013 defaults to enabled=false, so `--enabled true` diverges from
+        // the default and takes the scalar-form (`else`) branch.
+        let result = set_rule(
+            dir.path(),
+            "MD013",
+            Some(true),
+            None,
+            false,
+            &engine,
+            &md_lint,
+            Format::Json,
+        );
+
+        let outcome = result.expect("malformed `lint` scalar must not panic or bubble up");
+        let CommandOutcome::UserError(msg) = outcome else {
+            panic!("expected UserError outcome, got {outcome:?}");
+        };
+        assert!(
+            msg.contains("malformed") && msg.contains("lint"),
+            "unexpected error: {msg}"
+        );
+
+        let contents_after = std::fs::read_to_string(&toml_path).unwrap();
+        assert_eq!(contents_after, "lint = \"oops\"\n");
+    }
+
+    /// `lint.rules` present but not a table (e.g. hand-edited into a scalar)
+    /// must also error cleanly rather than panic.
+    #[test]
+    fn set_severity_malformed_lint_rules_scalar_returns_error() {
+        let dir = tempdir().unwrap();
+        let toml_path = dir.path().join(".hyalo.toml");
+        std::fs::write(&toml_path, "[lint]\nrules = \"oops\"\n").unwrap();
+
+        let engine = make_engine();
+        let md_lint = load_md_lint(dir.path());
+
+        let result = set_rule(
+            dir.path(),
+            "MD013",
+            None,
+            Some("error"),
+            false,
+            &engine,
+            &md_lint,
+            Format::Json,
+        );
+
+        let outcome = result.expect("malformed `lint.rules` scalar must not panic or bubble up");
+        let CommandOutcome::UserError(msg) = outcome else {
+            panic!("expected UserError outcome, got {outcome:?}");
+        };
+        assert!(
+            msg.contains("malformed") && msg.contains("lint.rules"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// `lint-rules remove` already guards its read path with `.and_then`
+    /// chains (no blind indexing), so a malformed `lint` scalar must fall
+    /// through to "no override found" rather than panicking or erroring.
+    #[test]
+    fn remove_rule_malformed_lint_scalar_does_not_panic() {
+        let dir = tempdir().unwrap();
+        let toml_path = dir.path().join(".hyalo.toml");
+        std::fs::write(&toml_path, "lint = \"oops\"\n").unwrap();
+
+        let engine = make_engine();
+        let md_lint = load_md_lint(dir.path());
+
+        let outcome = remove_rule(dir.path(), "MD013", false, &engine, &md_lint, Format::Json)
+            .expect("remove must not panic on malformed lint scalar");
+
+        match outcome {
+            CommandOutcome::Success { output, .. } => {
+                let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+                assert_eq!(v["removed"], false);
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -493,9 +493,15 @@ const TAG_MUTATION_FILTER: &str = r#""\(if .dry_run then "[dry-run] " else "" en
 /// Empty case: `No backlinks found for "file"`.
 const BACKLINKS_RESULT_FILTER: &str = r#"if (.backlinks | length) == 0 then "No backlinks found for \"\(.file)\"" else "\(.backlinks | length) \(if (.backlinks | length) == 1 then "backlink" else "backlinks" end) for \"\(.file)\"\n\(.backlinks | map("  \(.source): line \(.line)") | join("\n"))" end"#;
 
-/// `LinksFix result`: `{ambiguous, ambiguous_links, applied, broken, case_mismatch_fixes, case_mismatches, fixable, fixes, ignored, unfixable, unfixable_links}`
+/// `LinksFix result`: `{ambiguous, ambiguous_links, applied, applied_fixes, broken, case_mismatch_fixes, case_mismatches, fixable, fixes, ignored, unapplied, unapplied_fixes, unfixable, unfixable_links}`
 /// Format: summary line with fix status. Includes case-mismatch and ambiguous counts when non-zero.
-const LINKS_FIX_FILTER: &str = r#""Broken links: \(.broken)\nFixable: \(.fixable)\nUnfixable: \(.unfixable)\nIgnored: \(.ignored)\(if .case_mismatches > 0 then "\nCase mismatches: \(.case_mismatches)" else "" end)\(if .ambiguous > 0 then "\nAmbiguous (short-form): \(.ambiguous)" else "" end)\nApplied: \(if .applied then "yes" else "no" end)\(if (.fixes | length) > 0 then "\n\(.fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\"") | join("\n"))" else "" end)\(if (.case_mismatch_fixes | length) > 0 then "\nCase-mismatch fixes:\n\(.case_mismatch_fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\" [link-case-mismatch]") | join("\n"))" else "" end)\(if (.ambiguous_links | length) > 0 then "\nAmbiguous links:\n\(.ambiguous_links | map("  \(.source) line \(.line): \"\(.target)\" [ambiguous]") | join("\n"))" else "" end)""#;
+/// On `--apply`, the per-fix detail lines show only fixes that were actually
+/// written to disk (`applied_fixes`); on dry-run they show the full plan
+/// (`fixes`), since nothing has been attempted yet. A non-zero `unapplied`
+/// count (fixes whose on-disk text no longer matched the plan) gets its own
+/// section so a stale or partially-applied run is never silently reported as
+/// fully applied.
+const LINKS_FIX_FILTER: &str = r#""Broken links: \(.broken)\nFixable: \(.fixable)\nUnfixable: \(.unfixable)\nIgnored: \(.ignored)\(if .case_mismatches > 0 then "\nCase mismatches: \(.case_mismatches)" else "" end)\(if .ambiguous > 0 then "\nAmbiguous (short-form): \(.ambiguous)" else "" end)\nApplied: \(if .applied then "yes" else "no" end)\(if .applied then "\(if (.applied_fixes | length) > 0 then "\n\(.applied_fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\"") | join("\n"))" else "" end)\(if .unapplied > 0 then "\nUnapplied (plan did not match on-disk text): \(.unapplied)\n\(.unapplied_fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\"") | join("\n"))" else "" end)" else "\(if (.fixes | length) > 0 then "\n\(.fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\"") | join("\n"))" else "" end)" end)\(if (.case_mismatch_fixes | length) > 0 then "\nCase-mismatch fixes:\n\(.case_mismatch_fixes | map("  \(.source) line \(.line): \"\(.old_target)\" → \"\(.new_target)\" [link-case-mismatch]") | join("\n"))" else "" end)\(if (.ambiguous_links | length) > 0 then "\nAmbiguous links:\n\(.ambiguous_links | map("  \(.source) line \(.line): \"\(.target)\" [ambiguous]") | join("\n"))" else "" end)""#;
 
 /// `LinksAuto result`: `{ambiguous_titles, applied, matches, scanned, total}`
 /// Format: summary line + per-match details.
@@ -575,7 +581,7 @@ fn lookup_filter(key_sig: &str) -> Option<&'static str> {
         // BacklinksResult
         "backlinks,file" => Some(BACKLINKS_RESULT_FILTER),
         // LinksFix result
-        "ambiguous,ambiguous_links,applied,broken,case_mismatch_fixes,case_mismatches,fixable,fixes,ignored,unfixable,unfixable_links" => {
+        "ambiguous,ambiguous_links,applied,applied_fixes,broken,case_mismatch_fixes,case_mismatches,fixable,fixes,ignored,unapplied,unapplied_fixes,unfixable,unfixable_links" => {
             Some(LINKS_FIX_FILTER)
         }
         // LinksAuto result

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -2829,3 +2829,193 @@ See [[Corina]] for details.
         "--apply --expand-short-form must rewrite [[Corina]] to [[sub/Corina]]; content: {content}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// links fix: frontmatter wikilinks (H-bug — frontmatter fixes were reported
+// as applied but never written to disk; see iteration-160)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn links_fix_apply_rewrites_frontmatter_and_body_wikilinks() {
+    // Minimal repro from the bug report: a broken target referenced both in
+    // a frontmatter `related:` list and in the body of the same file.
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sub/real-target.md",
+        md!(r"
+---
+title: Real Target
+---
+Body.
+"),
+    );
+
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r#"
+---
+title: A
+related: ["[[wrong/real-target]]"]
+---
+Body also links [[wrong/real-target]].
+"#),
+    );
+
+    let apply_output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--apply",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix --apply should run");
+    assert!(
+        apply_output.status.success(),
+        "links fix --apply exited non-zero: {}",
+        String::from_utf8_lossy(&apply_output.stderr)
+    );
+
+    let apply_json: serde_json::Value =
+        serde_json::from_slice(&apply_output.stdout).expect("apply stdout should be valid JSON");
+
+    assert_eq!(
+        apply_json["results"]["broken"].as_u64(),
+        Some(2),
+        "expected 2 broken links (frontmatter + body): {apply_json}"
+    );
+    assert_eq!(
+        apply_json["results"]["fixable"].as_u64(),
+        Some(2),
+        "expected both occurrences to be fixable: {apply_json}"
+    );
+    assert_eq!(
+        apply_json["results"]["unapplied"].as_u64(),
+        Some(0),
+        "no fix should be reported unapplied: {apply_json}"
+    );
+    let applied_fixes = apply_json["results"]["applied_fixes"]
+        .as_array()
+        .expect("'applied_fixes' should be an array");
+    assert_eq!(
+        applied_fixes.len(),
+        2,
+        "both the frontmatter and body fix must be reported as applied: {apply_json}"
+    );
+
+    // The actual assertion that matters: both occurrences must be rewritten
+    // on disk, not just reported as applied.
+    let written = fs::read_to_string(tmp.path().join("a.md")).expect("a.md should be readable");
+    assert!(
+        !written.contains("wrong/real-target"),
+        "broken target must not remain anywhere in the file, got:\n{written}"
+    );
+    assert_eq!(
+        written.matches("[[sub/real-target]]").count(),
+        2,
+        "both frontmatter and body wikilinks must be rewritten, got:\n{written}"
+    );
+
+    // Re-running must report the fix-loop has converged: 0 broken, 0 fixable.
+    // Before the fix, the frontmatter occurrence was reported as applied but
+    // never written, so a re-run kept reporting it as fixable forever.
+    let rerun_output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix (dry-run) should run after apply");
+    assert!(rerun_output.status.success());
+
+    let rerun_json: serde_json::Value =
+        serde_json::from_slice(&rerun_output.stdout).expect("rerun stdout should be valid JSON");
+    assert_eq!(
+        rerun_json["results"]["broken"].as_u64(),
+        Some(0),
+        "fix-loop must converge — no broken links should remain: {rerun_json}"
+    );
+    assert_eq!(
+        rerun_json["results"]["fixable"].as_u64(),
+        Some(0),
+        "fix-loop must converge — no fixable links should remain: {rerun_json}"
+    );
+}
+
+#[test]
+fn links_fix_dry_run_does_not_write_frontmatter() {
+    // Dry-run must remain plan-only: no file should be touched, and the
+    // 'applied' flag must be false with no unapplied/applied_fixes noise.
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    write_md(
+        tmp.path(),
+        "sub/real-target.md",
+        md!(r"
+---
+title: Real Target
+---
+Body.
+"),
+    );
+
+    write_md(
+        tmp.path(),
+        "a.md",
+        md!(r#"
+---
+title: A
+related: ["[[wrong/real-target]]"]
+---
+Body also links [[wrong/real-target]].
+"#),
+    );
+
+    let before = fs::read_to_string(tmp.path().join("a.md")).expect("a.md should be readable");
+
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "links",
+            "fix",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo links fix (dry-run) should run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["results"]["applied"].as_bool(), Some(false));
+    assert_eq!(
+        json["results"]["unapplied"].as_u64(),
+        Some(0),
+        "dry-run has attempted nothing, so nothing can be unapplied: {json}"
+    );
+    assert_eq!(
+        json["results"]["applied_fixes"].as_array().map(Vec::len),
+        Some(0),
+        "dry-run must not report any fix as applied: {json}"
+    );
+
+    let after = fs::read_to_string(tmp.path().join("a.md")).expect("a.md should be readable");
+    assert_eq!(before, after, "dry-run must not modify the file");
+}

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -908,8 +908,8 @@ pub fn apply_fixes(
         let (replacements, satisfied) =
             build_replacements_for_file(&content, source_rel, file_fixes, site_prefix);
 
-        for fix in file_fixes {
-            if !satisfied.contains(&(fix.line, fix.old_target.as_str())) {
+        for (idx, fix) in file_fixes.iter().enumerate() {
+            if !satisfied.contains(&idx) {
                 unapplied.push((*fix).clone());
             }
         }
@@ -936,28 +936,31 @@ pub fn apply_fixes(
 /// link properties and links in the document body (code fences and Obsidian
 /// comment fences are skipped for the latter).
 ///
-/// Returns `(replacements, satisfied)` where `satisfied` is the set of
-/// `(fix.line, fix.old_target)` keys that were matched to an on-disk
-/// occurrence and rewritten. Callers use `satisfied` to detect fixes whose
-/// on-disk text no longer matches what detection saw (stale plan) so they
-/// are never misreported as applied.
-fn build_replacements_for_file<'f>(
+/// Returns `(replacements, satisfied)` where `satisfied` holds the indices
+/// (into `fixes`) of plans that were matched to an on-disk occurrence and
+/// rewritten. Tracking is per-occurrence: each on-disk match consumes the
+/// first not-yet-satisfied plan with that target, so duplicate plans for the
+/// same `(line, old_target)` — a legitimate case when the same broken target
+/// appears twice — are only satisfied by distinct occurrences. Callers use
+/// the unsatisfied remainder to detect fixes whose on-disk text no longer
+/// matches what detection saw (stale plan) so they are never misreported as
+/// applied.
+fn build_replacements_for_file(
     content: &str,
     source_rel: &str,
-    fixes: &[&'f FixPlan],
+    fixes: &[&FixPlan],
     _site_prefix: Option<&str>,
-) -> (
-    Vec<Replacement>,
-    std::collections::HashSet<(usize, &'f str)>,
-) {
-    // Index fixes by line number for O(1) lookup during the scan.
-    let mut fixes_by_line: HashMap<usize, Vec<&FixPlan>> = HashMap::new();
-    for fix in fixes {
-        fixes_by_line.entry(fix.line).or_default().push(fix);
+) -> (Vec<Replacement>, std::collections::HashSet<usize>) {
+    // Index fixes by line number for O(1) lookup during the scan, carrying
+    // each plan's index into `fixes` for per-occurrence satisfaction
+    // tracking.
+    let mut fixes_by_line: HashMap<usize, Vec<(usize, &FixPlan)>> = HashMap::new();
+    for (idx, fix) in fixes.iter().enumerate() {
+        fixes_by_line.entry(fix.line).or_default().push((idx, fix));
     }
 
     let mut replacements = Vec::new();
-    let mut satisfied: std::collections::HashSet<(usize, &str)> = std::collections::HashSet::new();
+    let mut satisfied: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let mut fence = FenceTracker::new();
     let mut in_comment_fence = false;
     let mut in_frontmatter = false;
@@ -970,14 +973,17 @@ fn build_replacements_for_file<'f>(
     // them up once and match by `old_target` against every `[[...]]`
     // occurrence anywhere in the frontmatter block, regardless of which
     // physical line it sits on.
-    let frontmatter_fixes: &[&FixPlan] = fixes_by_line.get(&1).map_or(&[], Vec::as_slice);
+    let frontmatter_fixes: &[(usize, &FixPlan)] = fixes_by_line.get(&1).map_or(&[], Vec::as_slice);
 
     for line in content.split('\n') {
         line_num += 1;
 
         // --- Frontmatter ---
         if !frontmatter_done {
-            if line_num == 1 && line.trim() == "---" {
+            // BOM-aware: detection (scanner) enters frontmatter via the same
+            // predicate, so the rewrite path must too or BOM-prefixed files
+            // silently keep their broken frontmatter links.
+            if line_num == 1 && crate::frontmatter::is_opening_delimiter(line) {
                 in_frontmatter = true;
                 continue;
             }
@@ -992,9 +998,18 @@ fn build_replacements_for_file<'f>(
                         let Some(link) = parse_wikilink(occ.target) else {
                             continue;
                         };
-                        let Some(fix) = frontmatter_fixes
-                            .iter()
-                            .find(|f| f.old_target == link.target)
+                        // Prefer a not-yet-satisfied plan so duplicate plans
+                        // for the same target are consumed one occurrence
+                        // each; fall back to an already-satisfied one so
+                        // extra on-disk occurrences still get rewritten.
+                        let matching = || {
+                            frontmatter_fixes
+                                .iter()
+                                .filter(|(_, f)| f.old_target == link.target)
+                        };
+                        let Some(&(fix_idx, fix)) = matching()
+                            .find(|(idx, _)| !satisfied.contains(idx))
+                            .or_else(|| matching().next())
                         else {
                             continue;
                         };
@@ -1024,7 +1039,7 @@ fn build_replacements_for_file<'f>(
                                 new_text,
                             });
                         }
-                        satisfied.insert((fix.line, fix.old_target.as_str()));
+                        satisfied.insert(fix_idx);
                     }
                 }
                 continue;
@@ -1072,10 +1087,19 @@ fn build_replacements_for_file<'f>(
                 }
             };
 
-            // Find the fix for this particular span.
-            let Some(fix) = line_fixes.iter().find(|f| {
-                f.old_target == normalized_span_target || f.old_target == span.link.target
-            }) else {
+            // Find the fix for this particular span, preferring a
+            // not-yet-satisfied plan (duplicate plans for the same target are
+            // consumed one occurrence each) and falling back to an
+            // already-satisfied one so extra occurrences still get rewritten.
+            let matching = || {
+                line_fixes.iter().filter(|(_, f)| {
+                    f.old_target == normalized_span_target || f.old_target == span.link.target
+                })
+            };
+            let Some(&(fix_idx, fix)) = matching()
+                .find(|(idx, _)| !satisfied.contains(idx))
+                .or_else(|| matching().next())
+            else {
                 continue;
             };
 
@@ -1121,7 +1145,7 @@ fn build_replacements_for_file<'f>(
                     new_text,
                 });
             }
-            satisfied.insert((fix.line, fix.old_target.as_str()));
+            satisfied.insert(fix_idx);
         }
     }
 
@@ -1679,6 +1703,114 @@ mod tests {
         assert!(plans.is_empty(), "no replacement should have been produced");
         assert_eq!(unapplied.len(), 1);
         assert_eq!(unapplied[0].old_target, "stale/target");
+    }
+
+    #[test]
+    fn apply_fixes_duplicate_plans_single_occurrence_reports_one_unapplied() {
+        // Two FixPlans with identical (line, old_target) — e.g. detection saw
+        // two occurrences but a concurrent edit removed one — must consume
+        // distinct on-disk occurrences. With only one occurrence on disk,
+        // exactly one plan is satisfied and the other is unapplied; keying
+        // satisfaction on (line, old_target) instead of plan identity would
+        // silently absorb the second plan.
+        let tmp = vault_with_files(&[
+            (
+                "a.md",
+                "---\ntitle: a\nrelated: [\"[[wrong/target]]\"]\n---\nBody.\n",
+            ),
+            ("sub/target.md", "Content\n"),
+        ]);
+
+        let plan = FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "wrong/target".to_string(),
+            new_target: "sub/target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        };
+        let fixes = vec![plan.clone(), plan];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].replacements.len(), 1);
+        assert_eq!(
+            unapplied.len(),
+            1,
+            "second duplicate plan had no occurrence to consume and must be unapplied"
+        );
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert!(written.contains("[[sub/target]]"));
+    }
+
+    #[test]
+    fn apply_fixes_rewrites_frontmatter_wikilink_in_bom_file() {
+        // A UTF-8 BOM before the opening `---` must not disable the
+        // frontmatter rewrite path — the scanner (detection side) is
+        // BOM-aware, so the write path has to be too.
+        let tmp = vault_with_files(&[
+            (
+                "a.md",
+                "\u{feff}---\ntitle: a\nrelated: [\"[[wrong/target]]\"]\n---\nBody.\n",
+            ),
+            ("sub/target.md", "Content\n"),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "wrong/target".to_string(),
+            new_target: "sub/target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        }];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        assert!(unapplied.is_empty(), "unexpected unapplied: {unapplied:?}");
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert!(
+            written.starts_with('\u{feff}'),
+            "BOM must be preserved through the rewrite"
+        );
+        assert!(written.contains("[[sub/target]]"));
+    }
+
+    #[test]
+    fn apply_fixes_duplicate_plans_two_occurrences_both_satisfied() {
+        // Two plans, two on-disk occurrences of the same broken target in the
+        // frontmatter block: each occurrence consumes one plan, both are
+        // rewritten, nothing is unapplied.
+        let tmp = vault_with_files(&[
+            (
+                "a.md",
+                "---\ntitle: a\nrelated: [\"[[wrong/target]]\", \"[[wrong/target]]\"]\n---\nBody.\n",
+            ),
+            ("sub/target.md", "Content\n"),
+        ]);
+
+        let plan = FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "wrong/target".to_string(),
+            new_target: "sub/target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        };
+        let fixes = vec![plan.clone(), plan];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].replacements.len(), 2);
+        assert!(
+            unapplied.is_empty(),
+            "both plans consumed by distinct occurrences: {unapplied:?}"
+        );
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert_eq!(written.matches("[[sub/target]]").count(), 2);
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -26,8 +26,10 @@ use crate::discovery::canonicalize_vault_dir;
 use crate::discovery::resolve_target;
 use crate::index::VaultIndex;
 use crate::link_graph::{FileLinks, normalize_target};
-use crate::link_rewrite::{Replacement, RewritePlan, apply_replacements, execute_plans};
-use crate::links::{LinkKind, extract_link_spans_with_original};
+use crate::link_rewrite::{
+    Replacement, RewritePlan, apply_replacements, execute_plans, find_frontmatter_wikilinks,
+};
+use crate::links::{LinkKind, extract_link_spans_with_original, parse_wikilink};
 use crate::scanner::{
     FenceTracker, MAX_FILE_SIZE, is_comment_fence, strip_inline_code, strip_inline_comments,
 };
@@ -857,15 +859,20 @@ pub fn plan_fixes(broken: &[BrokenLinkInfo], matcher: &LinkMatcher) -> FixReport
 /// Convert fix plans to [`RewritePlan`]s and apply them to disk.
 ///
 /// Groups fixes by source file, reads each file once, builds [`Replacement`]s
-/// for every fix in that file, applies them via [`apply_replacements`], and
-/// writes back via [`execute_plans`].
+/// for every fix in that file (both body links and frontmatter link-property
+/// wikilinks), applies them via [`apply_replacements`], and writes back via
+/// [`execute_plans`].
 ///
-/// Returns the list of [`RewritePlan`]s for reporting.
+/// Returns `(plans, unapplied)` where `plans` are the [`RewritePlan`]s
+/// actually written to disk, and `unapplied` lists the input [`FixPlan`]s
+/// that produced no [`Replacement`] (e.g. because the on-disk text no longer
+/// matches what detection saw). Callers should treat `unapplied` fixes as
+/// NOT applied when reporting results — do not assume every input fix landed.
 pub fn apply_fixes(
     dir: &Path,
     fixes: &[FixPlan],
     site_prefix: Option<&str>,
-) -> Result<Vec<RewritePlan>> {
+) -> Result<(Vec<RewritePlan>, Vec<FixPlan>)> {
     // Group fixes by source file.
     let mut by_source: HashMap<&str, Vec<&FixPlan>> = HashMap::new();
     for fix in fixes {
@@ -873,6 +880,7 @@ pub fn apply_fixes(
     }
 
     let mut plans: Vec<RewritePlan> = Vec::new();
+    let mut unapplied: Vec<FixPlan> = Vec::new();
 
     for (source_rel, file_fixes) in &by_source {
         let abs_path = dir.join(source_rel.replace('\\', "/"));
@@ -886,6 +894,7 @@ pub fn apply_fixes(
                 file_size / (1024 * 1024),
                 MAX_FILE_SIZE / (1024 * 1024)
             );
+            unapplied.extend(file_fixes.iter().map(|f| (*f).clone()));
             continue;
         }
         let file_mtime = meta
@@ -896,8 +905,14 @@ pub fn apply_fixes(
         let content = std::fs::read_to_string(&abs_path)
             .with_context(|| format!("reading {}", abs_path.display()))?;
 
-        let replacements =
+        let (replacements, satisfied) =
             build_replacements_for_file(&content, source_rel, file_fixes, site_prefix);
+
+        for fix in file_fixes {
+            if !satisfied.contains(&(fix.line, fix.old_target.as_str())) {
+                unapplied.push((*fix).clone());
+            }
+        }
 
         if !replacements.is_empty() {
             let rewritten_content = apply_replacements(&content, &replacements);
@@ -913,18 +928,28 @@ pub fn apply_fixes(
 
     execute_plans(dir, &plans)?;
 
-    Ok(plans)
+    Ok((plans, unapplied))
 }
 
-/// Walk `content` line by line (skipping frontmatter, code fences, comment
-/// fences) and build [`Replacement`]s for all link fixes that apply to this
-/// file.
-fn build_replacements_for_file(
+/// Walk `content` line by line and build [`Replacement`]s for all link fixes
+/// that apply to this file — both `[[wikilink]]`s inside YAML frontmatter
+/// link properties and links in the document body (code fences and Obsidian
+/// comment fences are skipped for the latter).
+///
+/// Returns `(replacements, satisfied)` where `satisfied` is the set of
+/// `(fix.line, fix.old_target)` keys that were matched to an on-disk
+/// occurrence and rewritten. Callers use `satisfied` to detect fixes whose
+/// on-disk text no longer matches what detection saw (stale plan) so they
+/// are never misreported as applied.
+fn build_replacements_for_file<'f>(
     content: &str,
     source_rel: &str,
-    fixes: &[&FixPlan],
+    fixes: &[&'f FixPlan],
     _site_prefix: Option<&str>,
-) -> Vec<Replacement> {
+) -> (
+    Vec<Replacement>,
+    std::collections::HashSet<(usize, &'f str)>,
+) {
     // Index fixes by line number for O(1) lookup during the scan.
     let mut fixes_by_line: HashMap<usize, Vec<&FixPlan>> = HashMap::new();
     for fix in fixes {
@@ -932,11 +957,20 @@ fn build_replacements_for_file(
     }
 
     let mut replacements = Vec::new();
+    let mut satisfied: std::collections::HashSet<(usize, &str)> = std::collections::HashSet::new();
     let mut fence = FenceTracker::new();
     let mut in_comment_fence = false;
     let mut in_frontmatter = false;
     let mut frontmatter_done = false;
     let mut line_num = 0usize;
+
+    // Frontmatter-derived FixPlans always carry `line: 1` (see
+    // `LinkGraphVisitor::extract_frontmatter_wikilinks`, which has no
+    // meaningful per-line info once YAML is parsed into a `Value`). Look
+    // them up once and match by `old_target` against every `[[...]]`
+    // occurrence anywhere in the frontmatter block, regardless of which
+    // physical line it sits on.
+    let frontmatter_fixes: &[&FixPlan] = fixes_by_line.get(&1).map_or(&[], Vec::as_slice);
 
     for line in content.split('\n') {
         line_num += 1;
@@ -951,6 +985,47 @@ fn build_replacements_for_file(
                 if line.trim() == "---" {
                     in_frontmatter = false;
                     frontmatter_done = true;
+                    continue;
+                }
+                if !frontmatter_fixes.is_empty() {
+                    for occ in find_frontmatter_wikilinks(line) {
+                        let Some(link) = parse_wikilink(occ.target) else {
+                            continue;
+                        };
+                        let Some(fix) = frontmatter_fixes
+                            .iter()
+                            .find(|f| f.old_target == link.target)
+                        else {
+                            continue;
+                        };
+
+                        // Preserve alias (`path|Label`) and written form
+                        // (path-form vs bare stem), mirroring `mv`'s
+                        // frontmatter rewriter.
+                        let alias_suffix = occ.target.find('|').map_or("", |i| &occ.target[i..]);
+                        let new_stem = fix
+                            .new_target
+                            .strip_suffix(".md")
+                            .unwrap_or(&fix.new_target);
+                        let new_wikilink_target =
+                            if link.target.contains('/') || link.target.contains('\\') {
+                                new_stem.to_string()
+                            } else {
+                                new_stem.rsplit('/').next().unwrap_or(new_stem).to_string()
+                            };
+
+                        let old_text = line[occ.full_start..occ.full_end].to_string();
+                        let new_text = format!("[[{new_wikilink_target}{alias_suffix}]]");
+                        if old_text != new_text {
+                            replacements.push(Replacement {
+                                line: line_num,
+                                byte_offset: occ.full_start,
+                                old_text,
+                                new_text,
+                            });
+                        }
+                        satisfied.insert((fix.line, fix.old_target.as_str()));
+                    }
                 }
                 continue;
             }
@@ -1046,10 +1121,11 @@ fn build_replacements_for_file(
                     new_text,
                 });
             }
+            satisfied.insert((fix.line, fix.old_target.as_str()));
         }
     }
 
-    replacements
+    (replacements, satisfied)
 }
 
 // ---------------------------------------------------------------------------
@@ -1346,9 +1422,13 @@ mod tests {
             confidence: 0.9,
         }];
 
-        let plans = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
+        assert!(
+            unapplied.is_empty(),
+            "expected no unapplied fixes: {unapplied:?}"
+        );
         let written = fs::read_to_string(tmp.path().join("index.md")).unwrap();
         assert!(
             written.contains("[[correct-name]]"),
@@ -1374,14 +1454,231 @@ mod tests {
             confidence: 1.0,
         }];
 
-        let plans = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
+        assert!(
+            unapplied.is_empty(),
+            "expected no unapplied fixes: {unapplied:?}"
+        );
         let written = fs::read_to_string(tmp.path().join("index.md")).unwrap();
         assert!(
             written.contains("[text](correct.md)"),
             "expected rewritten link, got: {written}"
         );
+    }
+
+    // --- apply_fixes: frontmatter wikilink rewrite (H-bug: frontmatter fixes
+    // were silently no-op'd — see iteration-160 fix) ---
+
+    #[test]
+    fn apply_fixes_rewrites_frontmatter_only_wikilink() {
+        let tmp = vault_with_files(&[
+            (
+                "a.md",
+                "---\ntitle: A\nrelated: [\"[[wrong/real-target]]\"]\n---\nBody.\n",
+            ),
+            ("sub/real-target.md", "Content\n"),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "wrong/real-target".to_string(),
+            new_target: "sub/real-target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        }];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1, "frontmatter fix must produce a RewritePlan");
+        assert!(
+            unapplied.is_empty(),
+            "expected no unapplied fixes: {unapplied:?}"
+        );
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert!(
+            written.contains("[[sub/real-target]]"),
+            "frontmatter wikilink was not rewritten, got: {written}"
+        );
+        assert!(!written.contains("wrong/real-target"), "got: {written}");
+    }
+
+    #[test]
+    fn apply_fixes_rewrites_body_only_wikilink_line_one() {
+        // Regression guard: when the fix is on physical line 1 but there is
+        // NO frontmatter block, the body-link scan must still run — the
+        // frontmatter-lookup-by-line-1 shortcut must not swallow body fixes.
+        let tmp = vault_with_files(&[
+            ("a.md", "See [[wrong/real-target]] here.\n"),
+            ("sub/real-target.md", "Content\n"),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "wrong/real-target".to_string(),
+            new_target: "sub/real-target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        }];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        assert!(
+            unapplied.is_empty(),
+            "expected no unapplied fixes: {unapplied:?}"
+        );
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert!(written.contains("[[sub/real-target]]"), "got: {written}");
+    }
+
+    #[test]
+    fn apply_fixes_rewrites_frontmatter_and_body_both_occurrences() {
+        // The exact bug report repro: same broken target in both frontmatter
+        // `related:` and the body. Both must be rewritten and both must be
+        // reported (no dedup collapsing the two).
+        let tmp = vault_with_files(&[
+            (
+                "a.md",
+                "---\ntitle: A\nrelated: [\"[[wrong/real-target]]\"]\n---\nBody also links [[wrong/real-target]].\n",
+            ),
+            ("sub/real-target.md", "Content\n"),
+        ]);
+
+        let fixes = vec![
+            FixPlan {
+                source: "a.md".to_string(),
+                line: 1,
+                old_target: "wrong/real-target".to_string(),
+                new_target: "sub/real-target.md".to_string(),
+                strategy: FixStrategy::ShortestPath,
+                confidence: 0.95,
+            },
+            FixPlan {
+                source: "a.md".to_string(),
+                line: 5,
+                old_target: "wrong/real-target".to_string(),
+                new_target: "sub/real-target.md".to_string(),
+                strategy: FixStrategy::ShortestPath,
+                confidence: 0.95,
+            },
+        ];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        assert!(
+            unapplied.is_empty(),
+            "expected no unapplied fixes: {unapplied:?}"
+        );
+        assert_eq!(
+            plans[0].replacements.len(),
+            2,
+            "both frontmatter and body occurrences must be rewritten: {:?}",
+            plans[0].replacements
+        );
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert!(!written.contains("wrong/real-target"), "got: {written}");
+        assert_eq!(
+            written.matches("[[sub/real-target]]").count(),
+            2,
+            "got: {written}"
+        );
+    }
+
+    #[test]
+    fn apply_fixes_frontmatter_block_list_form() {
+        // YAML block-list form (not inline flow-sequence):
+        //   related:
+        //     - "[[wrong/target]]"
+        let tmp = vault_with_files(&[
+            (
+                "a.md",
+                "---\ntitle: A\nrelated:\n  - \"[[wrong/target]]\"\n---\nBody.\n",
+            ),
+            ("target.md", "Content\n"),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "wrong/target".to_string(),
+            new_target: "target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        }];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        assert!(
+            unapplied.is_empty(),
+            "expected no unapplied fixes: {unapplied:?}"
+        );
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert!(written.contains("[[target]]"), "got: {written}");
+    }
+
+    #[test]
+    fn apply_fixes_frontmatter_wikilink_alias_preserved() {
+        let tmp = vault_with_files(&[
+            (
+                "a.md",
+                "---\ntitle: A\nrelated: [\"[[wrong/target|My Label]]\"]\n---\nBody.\n",
+            ),
+            ("target.md", "Content\n"),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "wrong/target".to_string(),
+            new_target: "target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        }];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert_eq!(plans.len(), 1);
+        assert!(
+            unapplied.is_empty(),
+            "expected no unapplied fixes: {unapplied:?}"
+        );
+        let written = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+        assert!(
+            written.contains("[[target|My Label]]"),
+            "alias must be preserved, got: {written}"
+        );
+    }
+
+    #[test]
+    fn apply_fixes_reports_unapplied_when_target_not_found() {
+        // A FixPlan whose old_target text is not actually present on disk
+        // (e.g. stale plan from a concurrently-edited file) must be reported
+        // as unapplied rather than silently counted as applied.
+        let tmp = vault_with_files(&[
+            ("a.md", "No matching link here.\n"),
+            ("target.md", "Content\n"),
+        ]);
+
+        let fixes = vec![FixPlan {
+            source: "a.md".to_string(),
+            line: 1,
+            old_target: "stale/target".to_string(),
+            new_target: "target.md".to_string(),
+            strategy: FixStrategy::ShortestPath,
+            confidence: 0.95,
+        }];
+
+        let (plans, unapplied) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+
+        assert!(plans.is_empty(), "no replacement should have been produced");
+        assert_eq!(unapplied.len(), 1);
+        assert_eq!(unapplied[0].old_target, "stale/target");
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -1101,6 +1101,54 @@ pub fn plan_batch_mv(
     Ok(plans.into_values().collect())
 }
 
+/// A single `[[...]]` occurrence found on a YAML frontmatter line.
+///
+/// `target` is the raw text between the brackets, alias included (e.g.
+/// `path/to/file|My Alias`). Offsets are byte offsets into the original line.
+pub(crate) struct FrontmatterWikilinkOccurrence<'a> {
+    pub target: &'a str,
+    pub full_start: usize,
+    pub full_end: usize,
+}
+
+/// Find every `[[...]]` occurrence in a single frontmatter YAML line.
+///
+/// Matches patterns like `  - "[[path/to/file]]"` or `  - [[path/to/file]]`
+/// (YAML list items containing Obsidian wikilinks), as well as inline
+/// flow-sequence forms like `related: ["[[a]]", "[[b]]"]`. This is a raw
+/// bracket scan (not YAML-aware) shared by `mv`'s frontmatter rewriter and
+/// `links fix`'s frontmatter replacement builder so both stay symmetric.
+pub(crate) fn find_frontmatter_wikilinks(line: &str) -> Vec<FrontmatterWikilinkOccurrence<'_>> {
+    let mut occurrences = Vec::new();
+    let mut search = line;
+    let mut base_offset = 0usize;
+    while let Some(open) = search.find("[[") {
+        let after_open = open + 2;
+        if after_open >= search.len() {
+            break;
+        }
+        if let Some(close) = search[after_open..].find("]]") {
+            let target_start = after_open;
+            let target_end = after_open + close;
+            let full_start = open;
+            let full_end = target_end + 2;
+
+            occurrences.push(FrontmatterWikilinkOccurrence {
+                target: &search[target_start..target_end],
+                full_start: base_offset + full_start,
+                full_end: base_offset + full_end,
+            });
+
+            let advance = full_end;
+            base_offset += advance;
+            search = &search[advance..];
+        } else {
+            break;
+        }
+    }
+    occurrences
+}
+
 /// Find and plan wikilink replacements inside a single frontmatter YAML line.
 ///
 /// Matches patterns like `  - "[[path/to/file]]"` or `  - [[path/to/file]]`
@@ -1123,68 +1171,46 @@ fn plan_frontmatter_wikilink_rewrites(
 
     let mut replacements = Vec::new();
 
-    // Find all [[...]] occurrences in the line (may appear in quoted strings).
-    let mut search = line;
-    let mut base_offset = 0usize;
-    while let Some(open) = search.find("[[") {
-        let after_open = open + 2;
-        if after_open >= search.len() {
-            break;
-        }
-        if let Some(close) = search[after_open..].find("]]") {
-            let target_start = after_open;
-            let target_end = after_open + close;
-            let full_start = open;
-            let full_end = target_end + 2;
+    for occ in find_frontmatter_wikilinks(line) {
+        let target = occ.target;
+        // Strip alias suffix (e.g. `path|alias` → `path`)
+        let target_path = target.split('|').next().unwrap_or(target).trim();
 
-            let target = &search[target_start..target_end];
-            // Strip alias suffix (e.g. `path|alias` → `path`)
-            let target_path = target.split('|').next().unwrap_or(target).trim();
-
-            let matches = if target_path == old_stem || target_path == old_rel {
-                true
-            } else if let Some(idx) = case_index {
-                let t_norm = target_path.replace('\\', "/").to_ascii_lowercase();
-                let canonical = idx.lookup_unique(&t_norm).or_else(|| {
-                    let with_md = format!("{t_norm}.md");
-                    idx.lookup_unique(&with_md)
-                });
-                canonical == Some(old_rel) || canonical == Some(old_stem)
-            } else {
-                false
-            };
-
-            if matches {
-                let old_text = format!("[[{target}]]");
-                // Detect written form of the target path (before alias).
-                // Preserve alias if present (e.g. `path|My Alias` → `new_target|My Alias`).
-                let alias_suffix = target.find('|').map_or("", |i| &target[i..]);
-                // Preserve the user's written form: path-form → path-form, bare → bare.
-                let new_wikilink_target = if target_path.contains('/') || target_path.contains('\\')
-                {
-                    // Path-form wikilink: preserve path-form with new stem (BUG-1 fix).
-                    new_stem.to_string()
-                } else {
-                    // Bare wikilink: preserve bare form (just the basename).
-                    new_basename_stem.to_string()
-                };
-                let new_text = format!("[[{new_wikilink_target}{alias_suffix}]]");
-                if old_text != new_text {
-                    replacements.push(Replacement {
-                        line: line_num,
-                        byte_offset: base_offset + full_start,
-                        old_text,
-                        new_text,
-                    });
-                }
-            }
-
-            // Advance past this `]]`
-            let advance = full_end;
-            base_offset += advance;
-            search = &search[advance..];
+        let matches = if target_path == old_stem || target_path == old_rel {
+            true
+        } else if let Some(idx) = case_index {
+            let t_norm = target_path.replace('\\', "/").to_ascii_lowercase();
+            let canonical = idx.lookup_unique(&t_norm).or_else(|| {
+                let with_md = format!("{t_norm}.md");
+                idx.lookup_unique(&with_md)
+            });
+            canonical == Some(old_rel) || canonical == Some(old_stem)
         } else {
-            break;
+            false
+        };
+
+        if matches {
+            let old_text = format!("[[{target}]]");
+            // Detect written form of the target path (before alias).
+            // Preserve alias if present (e.g. `path|My Alias` → `new_target|My Alias`).
+            let alias_suffix = target.find('|').map_or("", |i| &target[i..]);
+            // Preserve the user's written form: path-form → path-form, bare → bare.
+            let new_wikilink_target = if target_path.contains('/') || target_path.contains('\\') {
+                // Path-form wikilink: preserve path-form with new stem (BUG-1 fix).
+                new_stem.to_string()
+            } else {
+                // Bare wikilink: preserve bare form (just the basename).
+                new_basename_stem.to_string()
+            };
+            let new_text = format!("[[{new_wikilink_target}{alias_suffix}]]");
+            if old_text != new_text {
+                replacements.push(Replacement {
+                    line: line_num,
+                    byte_offset: occ.full_start,
+                    old_text,
+                    new_text,
+                });
+            }
         }
     }
 

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0160-firefox.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0160-firefox.md
@@ -6,10 +6,10 @@ status: active
 tags: [dogfooding, iter-152, iter-153, iter-154, iter-155, iter-156]
 related:
   - "[[dogfood-results/dogfood-v0160-iter-150-crazy]]"
-  - "[[iterations/done/iteration-152-frontmatter-size-budget]]"
+  - "[[iterations/iteration-152-frontmatter-size-budget]]"
   - "[[iterations/done/iteration-153-unicode-tag-symmetry]]"
   - "[[iterations/done/iteration-154-mv-index-patch]]"
-  - "[[iterations/done/iteration-155-datetime-type]]"
+  - "[[iterations/iteration-155-datetime-type]]"
   - "[[iterations/done/iteration-156-drop-no-tags-warning]]"
 ---
 
@@ -117,7 +117,7 @@ case-insensitive / Obsidian short-form wikilink resolution. Every CLI
 invocation paid the ~2.7 s walk on a 2621-file tree, even commands that never
 resolve a wikilink.
 
-[[iterations/done/iteration-157-lazy-stem-map]] fixed this in two parts:
+[[iterations/iteration-157-lazy-stem-map]] fixed this in two parts:
 
 - **Part A** — `maybe_case_index` gained a `needs_stem_map: bool` parameter
   computed inline at each of the four call sites (Find, Summary, Links, Views)
@@ -296,7 +296,7 @@ whether a streamable / partial-load format pays off.
 Two HIGH/MEDIUM open bugs from the prior report are gone. iter-155 and iter-156
 both work end-to-end on synthetic schemas.
 
-**F-1 was diagnosed and fixed in [[iterations/done/iteration-157-lazy-stem-map]]
+**F-1 was diagnosed and fixed in [[iterations/iteration-157-lazy-stem-map]]
 during this dogfood session.** The remaining new findings are all UX-flavored —
 none of them are correctness bugs.
 

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0160-iter-144-147.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0160-iter-144-147.md
@@ -8,7 +8,7 @@ related:
   - "[[dogfood-results/dogfood-v0160-deep]]"
   - "[[iterations/done/iteration-144-index-suggestion-hint]]"
   - "[[iterations/done/iteration-145-unified-input-resolution]]"
-  - "[[iterations/iteration-147-task-files-from]]"
+  - "[[iterations/done/iteration-147-task-files-from]]"
 ---
 
 # Dogfood v0.16.0 — iter-144 through iter-147

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0160-iter-148-verify.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0160-iter-148-verify.md
@@ -6,7 +6,7 @@ status: active
 tags: [dogfooding, iter-148]
 related:
   - "[[dogfood-results/dogfood-v0160-iter-144-147]]"
-  - "[[iterations/iteration-148-dogfood-v0160-iter147-fixes]]"
+  - "[[iterations/done/iteration-148-dogfood-v0160-iter147-fixes]]"
 ---
 
 # Dogfood v0.16.0 — iter-148 fix verification

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0160-iter157-159-pr186.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0160-iter157-159-pr186.md
@@ -1,0 +1,249 @@
+---
+title: "Dogfood v0.16.0 — iter-157/158/159 + PR #186 verification, links-fix frontmatter no-op"
+type: research
+date: 2026-07-10
+status: active
+tags:
+  - dogfooding
+  - iter-157
+  - iter-158
+  - iter-159
+  - links
+  - index
+related:
+  - "[[dogfood-results/dogfood-v0160-firefox]]"
+  - "[[iterations/iteration-157-lazy-stem-map]]"
+  - "[[iterations/iteration-158-review-fixes]]"
+  - "[[iterations/iteration-159-pi-integration]]"
+  - "[[reviews/codebase-review-2026-07-10]]"
+  - "[[research/feature-gaps-2026-07-10]]"
+---
+
+# Dogfood v0.16.0 — iter-157/158/159 + PR #186
+
+Binary: `hyalo 0.16.0 (3ca89718409c 2026-07-08)`. KBs exercised: own KB
+(307 files), MDN (`../mdn/files/en-us`, 14,375 files), GitHub Docs
+(`../docs/content`, 3,710 files). VS Code docs not present on this machine.
+Scratch vaults for mutation/edge tests.
+
+## New feature verification
+
+### iter-157 — lazy + index-seeded stem map — WORKING
+
+Indexed queries on MDN no longer pay a disk walk. 114 MB index, built in
+2.8 s: property query 0.42 s, BM25 0.41 s, `summary` 0.64 s. Non-indexed
+parallel scan fallback: 1.28 s. F-1 from the firefox report stays closed at
+8× the corpus size.
+
+### iter-158 — review fixes — ALL SPOT-CHECKS PASS
+
+- **C-1 BOM**: `set` on a BOM-prefixed file preserves the BOM and edits
+  cleanly (hexdump-verified).
+- **H-3 symlink escape**: `mv target.md --to escape/stolen.md` through an
+  out-of-vault symlink → `Error: target path resolves outside vault boundary`.
+- **H-4 frontmatter rewrite on mv**: `related: ["[[target]]"]` and body link
+  both rewritten on `mv`. ✓
+- **H-6 JSON errors**: `read nonexistent.md --format json` →
+  `{"error": "file not found", "path": ...}`. ✓
+- **H-9 fenced checkbox**: `task toggle --line` on a checkbox inside a code
+  fence → `Error: line 7 is not a task`. ✓
+- **Atomicity**: 20 concurrent `set` on one file → consistent last-writer-wins
+  file, no corruption.
+
+### iter-159 — `init --pi` / `deinit` — WORKING
+
+`init --pi --dir kb` creates `.hyalo.toml`, the two `.pi/skills/` SKILL.md
+files, `.pi/extensions/hyalo.ts`, `.pi/package.json`. `deinit` removes it and
+skips absent claude artifacts with clear `skipped`/`removed` lines.
+
+### PR #186 — `--first-only` existing links + SIGPIPE — WORKING (but see BUG-2)
+
+- A file containing `[[fake-login]]` no longer gains a second link for a later
+  plain-text `fake-login` mention under `--first-only`; first-of-two plain
+  mentions in a link-free file is still proposed. Exactly as specified.
+- `find --format json | head -c 200` and `lint --format text | head -2` exit
+  quietly — no panic, empty stderr, on both JSON and text paths.
+
+## Bug regression testing (firefox report)
+
+- **F-3 (duplicate error on datetime mismatch) — STILL OPEN, now TRIPLE.**
+  A `type = "datetime"` property with value `not-a-date` produces one SCHEMA
+  error **plus** HYALO003 (date heuristic — wrong rule for a datetime-typed
+  property) **plus** HYALO004. Three reports, one defect.
+- **F-4 (`tasks` alias) — STILL OPEN** (LOW). clap tip suggests `task`.
+- **F-5 (`links --file`) — STILL OPEN** (LOW).
+- **F-6 (lint wall of warnings) — IMPROVED VIA HINTS.** On GitHub Docs, lint
+  emits a hint naming the noisiest rule
+  (`lint-rules show MD010 … # Tune MD010 if too noisy on this KB`). No
+  `--by-rule` summary table yet.
+
+## Bugs found
+
+### BUG-1: `links fix --apply` silently no-ops on frontmatter wikilinks while reporting them applied (HIGH)
+
+Repro (minimal): `a.md` with `related: ["[[wrong/real-target]]"]` **and** a
+body link `[[wrong/real-target]]`; real file at `sub/real-target.md`.
+
+```text
+$ hyalo links fix --apply
+Broken links: 2 / Fixable: 2 / Applied: yes
+  a.md line 1: "wrong/real-target" → "sub/real-target.md"
+```
+
+Body link rewritten; **frontmatter link untouched**; next dry run reports the
+same fix as fixable again. On the own KB, 13 of 15 "applied" fixes were
+frontmatter (`related:`) links — all no-ops. Impact: an agent driving a
+`links → links fix --apply → links` loop never converges and believes it
+succeeded; "Applied: yes" is a false report. Also: the detail list
+deduplicates by (source, old, new), so the frontmatter and body occurrence
+show as one line — you cannot see what was actually written.
+
+Contrast: `mv` rewrites frontmatter wikilinks correctly (H-4 fix). `links fix`
+needs the same write path. Root cause: `build_replacements_for_file`
+(`crates/hyalo-core/src/link_fix.rs:919`) walks the body only — it skips
+frontmatter by design — so frontmatter FixPlans yield no Replacement, while
+the CLI reports the original FixPlan list (not the actual RewritePlans) as
+applied.
+
+### BUG-2: Drill-down hints drop invocation flags (MEDIUM)
+
+Two instances, one class:
+
+- `links auto --first-only` (dry run) → hint says
+  `hyalo links auto --apply` **without `--first-only`**. Pasting the hint
+  applied 3 links where the dry run promised 1 — reintroducing exactly the
+  double-linking PR #186 fixed. `--exclude-target-glob` is dropped too.
+  Root cause: `hints_for_links_auto` (`crates/hyalo-cli/src/hints.rs:1520`)
+  deliberately rebuilds the command "preserving all scope-narrowing flags"
+  and handles `--min-length`/`--file`/`--exclude-title`/`--glob`, but
+  `first_only` and `exclude_target_glob` were never added — PR #186 touched
+  `args.rs` without extending the hint builder. (`--min-length 3` elision is
+  fine — 3 is the default.)
+- `create-index --index-file <outside-path> --allow-outside-vault` → the
+  follow-up hint suggests `hyalo drop-index --dir <vault>` **without
+  `--index-file`**, which deletes the *in-vault* `.hyalo-index` (a different
+  index) instead of the one just created. This actually deleted a
+  pre-existing MDN in-vault index during this session (rebuilt afterwards).
+
+Hints are the agent-facing navigation surface; they must preserve
+behavior-changing flags of the invocation they derive from.
+
+### BUG-3: Fuzzy link-fix default threshold accepts wrong matches on structured names (MEDIUM)
+
+On the own KB, `links fix` proposed
+rewriting `iterations/done/iteration-132-mv-wikilinks` to
+`iterations/done/iteration-02-links.md` at confidence 0.896 (no file named
+`iteration-132-mv-wikilinks` ever existed;
+`iteration-02-links` is unrelated). Long shared prefixes
+(`iterations/done/iteration-`) inflate Jaro-Winkler; two different iterations
+clear the 0.8 default easily. `ShortestPath` fixes were 15/15 correct,
+`FuzzyMatch` 0/2 — strategies separate cleanly. Suggestion: score fuzzy
+similarity on the basename/slug (or down-weight the common prefix), and/or
+add `--strategy` so `--apply` can be restricted to exact-basename moves.
+Workaround that worked: `--threshold 0.95`.
+
+### BUG-4: Stale snapshot index diverges silently (MEDIUM)
+
+`set` without `--index` does **not** patch an existing in-vault
+`.hyalo-index`; a later `find --index` returns pre-edit values, and
+`summary --index` misses files created outside hyalo. No staleness signal of
+any kind. Either auto-patch the in-vault index on every mutation (it is
+already found and loaded when `--index` is passed), or warn when index build
+time < newest file mtime.
+
+### BUG-5: `lint` MD-rule line numbers are body-relative, off by the frontmatter length (MEDIUM)
+
+Every MD* violation reports `line N` where N is counted from the start of the
+**body**, not the file. Verified on two corpora: this report (frontmatter
+12 lines, MD040 reported line 67, real fence at line 79) and GitHub Docs
+(frontmatter 14 lines, MD010 reported 197, real tab at 211). Meanwhile
+SCHEMA/HYALO00x findings report `line 1` regardless of where the property
+sits — two different conventions in one output. `lint --fix` itself edits the
+**correct** lines (verified with MD009/MD012), so this is purely a reporting
+defect — but any agent or editor jumping to the reported line lands
+frontmatter-length lines too early.
+
+### BUG-6: Multi-line property values print raw in text output (LOW)
+
+`set --property $'evil=x\nmalicious: injected'` is stored safely
+(`"x\nmalicious: injected"`, YAML-quoted — write path is injection-safe), but
+`find --fields properties --format text` prints the value with a literal
+newline, so `malicious: injected` renders as a fake sibling property. An LLM
+reading text output would misparse this. Escape or indent continuation lines.
+
+## UX issues
+
+### UX-1: `mv` destination is `--to`, not positional (LOW)
+
+`hyalo mv a.md b.md` fails; coreutils muscle memory (and LLM priors) expect
+positional. The clap error does show usage. A COMMON MISTAKES entry in
+`mv --help` (like `find`'s) — or accepting a positional destination — would
+remove the stumble.
+
+### UX-2: `new` has no way to set title/properties at creation (LOW)
+
+`hyalo new --type note --file x.md` scaffolds `title: TBD`; a natural
+`--title`/`--property` override would save one `set` round-trip in the
+agent fill-in loop the help text itself describes.
+
+## What worked well
+
+- **Help texts are genuinely LLM-friendly.** 19/21 subcommands have
+  EXAMPLES, most have OUTPUT + SIDE EFFECTS contracts; `find --help` has a
+  COMMON MISTAKES section (`~=` vs `=~`, `--title` vs `title~=`);
+  `new --help` explicitly documents the agent fill-in loop ("designed to fail
+  `hyalo lint`"). Error messages enumerate valid values
+  (`unknown field "file": valid fields are all, properties, …`) and errors are
+  structured JSON under `--format json`, including jq syntax errors with a
+  `cause` field.
+- **Hints quote paths correctly** — a path with spaces, parens and umlauts
+  came back copy-pasteable in the drill-down hint.
+- **Robustness edges all held**: CRLF files round-trip byte-exact through
+  `set`/`task toggle`; unicode+spaces+parens paths fine; 9.3 MB body file
+  reads/searches fine; YAML injection via `set` is neutralized by quoting;
+  malformed `.hyalo.toml` produces a caret-diagnostic warning; empty vault
+  output is calm and complete.
+- **`properties` type inference** flags data quality
+  (`priority: mixed (87 text, 6 number)`) — found a real inconsistency in the
+  own KB.
+- **jq dashboards**: `--jq '.results | map(.properties.status) | group_by(.) |
+  map({(.[0]): length}) | add'` → `{"completed":121,…}` in one call.
+- **Real repair value**: 15 genuinely broken own-KB links (done/↔root moves)
+  fixed via `links fix --apply --threshold 0.95` — 2 body-link fixes landed;
+  the 13 frontmatter ones exposed BUG-1.
+
+## Performance
+
+| KB | Files | Command | Time |
+|---|---:|---|---:|
+| MDN | 14,375 | create-index (114 MB) | 2.8 s |
+| MDN | 14,375 | find --property (indexed) | 0.42 s |
+| MDN | 14,375 | find BM25 (indexed) | 0.41 s |
+| MDN | 14,375 | summary (indexed) | 0.64 s |
+| MDN | 14,375 | find --property (scan) | 1.28 s |
+| GitHub Docs | 3,710 | summary (scan) | 0.47 s |
+| GitHub Docs | 3,710 | lint (full corpus) | 0.87 s |
+| own KB | 307 | everything | < 0.1 s |
+
+No regressions vs. prior baselines; indexed short-query latency is an order
+of magnitude better than the pre-157 firefox numbers.
+
+## Feature gaps noticed while working
+
+- **Nested-map property queries**: GitHub Docs `versions: {fpt: '*', ghes: …}`
+  is not reachable via `--property versions.fpt=*`; only existence and regex
+  over the serialized map work.
+- **`lint --by-rule` summary** (F-6 follow-up): one line per rule with counts,
+  for triage on stock corpora.
+- **`links fix --strategy` filter** (see BUG-3).
+- **Index staleness signal** (see BUG-4).
+
+## Verdict
+
+All four recent changes (iter-157/158/159, PR #186) hold up under adversarial
+testing, and the iter-158 hardening survives every probe thrown at it. The
+session's headline is BUG-1: `links fix --apply` falsely reports frontmatter
+fixes as applied — the last remaining frontmatter-vs-body asymmetry in the
+link machinery, and poison for agent fix-loops. BUG-2 (flag-dropping hints)
+is the most agent-hostile behavior found: the tool's best feature (hints)
+actively rewrites the user's intent.

--- a/hyalo-knowledgebase/iterations/done/iteration-101b-bm25-serializable-index.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-101b-bm25-serializable-index.md
@@ -11,7 +11,7 @@ tags:
 status: completed
 branch: iter-101/bm25-index-integration
 related:
-  - "[[iterations/iteration-101-bm25-ranked-search]]"
+  - "[[iterations/done/iteration-101-bm25-ranked-search]]"
   - "[[research/bm25-index-persistence]]"
 ---
 

--- a/hyalo-knowledgebase/iterations/done/iteration-103-boolean-search-operators.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-103-boolean-search-operators.md
@@ -10,8 +10,8 @@ tags:
 status: completed
 branch: iter-103/boolean-search
 related:
-  - "[[iterations/iteration-101-bm25-ranked-search]]"
-  - "[[iterations/iteration-101b-bm25-serializable-index]]"
+  - "[[iterations/done/iteration-101-bm25-ranked-search]]"
+  - "[[iterations/done/iteration-101b-bm25-serializable-index]]"
   - "[[research/benchmark-iter101-bm25]]"
 ---
 

--- a/hyalo-knowledgebase/iterations/done/iteration-136-wikilink-md-suffix-and-short-form-mv.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-136-wikilink-md-suffix-and-short-form-mv.md
@@ -14,7 +14,7 @@ tags:
   - obsidian-compat
 related:
   - "[[iterations/done/iteration-134-links-fix-short-form-wikilinks]]"
-  - "[[iterations/iteration-135-batch-mv]]"
+  - "[[iterations/done/iteration-135-batch-mv]]"
 ---
 
 ## Goal

--- a/hyalo-knowledgebase/iterations/done/iteration-137-cross-platform-link-resolution.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-137-cross-platform-link-resolution.md
@@ -11,7 +11,7 @@ tags:
   - cross-platform
   - testing
 related:
-  - "[[backlog/cross-platform-link-resolution-failures]]"
+  - "[[backlog/done/cross-platform-link-resolution-failures]]"
   - "[[iterations/done/iteration-134-links-fix-short-form-wikilinks]]"
   - "[[iterations/done/iteration-136-wikilink-md-suffix-and-short-form-mv]]"
 ---

--- a/hyalo-knowledgebase/iterations/done/iteration-144-index-suggestion-hint.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-144-index-suggestion-hint.md
@@ -10,8 +10,8 @@ tags:
   - performance
   - index
 related:
-  - "[[backlog/index-suggestion-hint]]"
-  - "[[iterations/iteration-143-hint-and-files-from-polish]]"
+  - "[[backlog/done/index-suggestion-hint]]"
+  - "[[iterations/done/iteration-143-hint-and-files-from-polish]]"
 ---
 
 ## Goal

--- a/hyalo-knowledgebase/iterations/done/iteration-148-dogfood-v0160-iter147-fixes.md
+++ b/hyalo-knowledgebase/iterations/done/iteration-148-dogfood-v0160-iter147-fixes.md
@@ -15,7 +15,7 @@ related:
   - "[[dogfood-results/dogfood-v0160-deep]]"
   - "[[iterations/done/iteration-144-index-suggestion-hint]]"
   - "[[iterations/done/iteration-145-unified-input-resolution]]"
-  - "[[iterations/iteration-147-task-files-from]]"
+  - "[[iterations/done/iteration-147-task-files-from]]"
 ---
 
 ## Goal

--- a/hyalo-knowledgebase/iterations/iteration-160-release-blockers.md
+++ b/hyalo-knowledgebase/iterations/iteration-160-release-blockers.md
@@ -1,0 +1,54 @@
+---
+type: iteration
+title: "Iteration 160 — Release blockers: lint-rules panic + links fix frontmatter no-op"
+date: 2026-07-10
+status: in-progress
+branch: iter-160/release-blockers
+tags:
+  - iteration
+  - correctness
+  - links
+  - lint
+---
+
+# Iteration 160 — Release blockers
+
+Fix the two v0.16.0 release blockers from
+[[reviews/codebase-review-2026-07-10]] and
+[[dogfood-results/dogfood-v0160-iter157-159-pr186]].
+
+## Blocker A (CRITICAL) — `lint-rules set` panics on malformed `.hyalo.toml`
+
+`crates/hyalo-cli/src/commands/lint_rules.rs:222-226` and `:263-267`: the
+guard `if doc.get("lint").is_none()` only covers "key absent". With a scalar
+(`lint = "oops"`), `doc["lint"]["rules"]` blind-indexes via `toml_edit`'s
+`IndexMut` and panics ("index not found", exit 134). `types.rs` handles the
+identical scenario via `.as_table_mut().context(...)?` — port that pattern:
+promote/replace `lint` when present-but-not-a-table at both call sites.
+
+## Blocker B (HIGH) — `links fix --apply` reports frontmatter fixes as applied but never writes them
+
+`build_replacements_for_file` (`crates/hyalo-core/src/link_fix.rs:919`) walks
+the body only, so frontmatter FixPlans yield no Replacement, while the CLI
+reports the pre-write FixPlan list as `Applied: yes`. 13/15 "applied" fixes
+on the own KB were silent no-ops; agent fix-loops never converge. `mv`
+already rewrites frontmatter wikilinks (`plan_frontmatter_wikilink_rewrites`
+in `link_rewrite.rs`) — `links fix` needs the same coverage, and the report
+must derive from what was actually written.
+
+## Tasks
+
+- [x] A: guard `lint` scalar→table promotion at both `lint_rules.rs` call sites
+- [x] A: regression test seeded with `lint = "oops"` (--severity and --enabled paths)
+- [x] B: extend `links fix --apply` to rewrite frontmatter wikilinks (mirror mv's frontmatter scanning)
+- [x] B: report applied fixes from actual written Replacements, not FixPlans
+- [x] B: e2e test — frontmatter `related:` + body link both fixed; second run reports 0 broken
+- [x] Quality gates: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q`
+- [x] Dogfood: re-run the BUG-1 minimal repro and the own-KB `links fix --apply --threshold 0.95`
+
+## Acceptance criteria
+
+- [x] `hyalo lint-rules set MD013 --severity error` on `lint = "oops"` exits 1 with a clean error (no panic), or repairs the key
+- [x] BUG-1 minimal repro: both frontmatter and body link rewritten; re-run shows 0 fixable
+- [x] Own KB: the 13 remaining frontmatter fixes actually apply; `hyalo links` then reports 13 fewer broken links
+- [x] `Applied: yes` output lists only fixes that were durably written

--- a/hyalo-knowledgebase/research/benchmark-iter101-bm25.md
+++ b/hyalo-knowledgebase/research/benchmark-iter101-bm25.md
@@ -8,7 +8,7 @@ tags:
   - search
   - benchmarking
 related:
-  - "[[iterations/iteration-101-bm25-ranked-search]]"
+  - "[[iterations/done/iteration-101-bm25-ranked-search]]"
 status: archived
 ---
 

--- a/hyalo-knowledgebase/research/feature-gaps-2026-07-10.md
+++ b/hyalo-knowledgebase/research/feature-gaps-2026-07-10.md
@@ -1,0 +1,156 @@
+---
+title: Feature gaps & ideas from the 2026-07-10 dogfood + review session
+type: research
+date: 2026-07-10
+status: active
+tags: [dogfooding, feature-ideas, ux, ai-friendliness]
+related:
+  - "[[dogfood-results/dogfood-v0160-iter157-159-pr186]]"
+  - "[[reviews/codebase-review-2026-07-10]]"
+---
+
+# Feature gaps & ideas — 2026-07-10 session
+
+Every idea below is grounded in a concrete moment from this session where the
+tool made me (an LLM agent, the primary audience) work harder than necessary.
+Ranked by expected value.
+
+## Tier 1 — directly unblocks agent workflows
+
+### 1. MCP server mode (`hyalo serve --mcp`)
+
+The biggest structural idea. Everything hyalo has built for agents — hints,
+OUTPUT contracts, structured JSON errors, COMMON MISTAKES — is compensation
+for living on the wrong side of a shell boundary. An MCP stdio server exposing
+`find`/`read`/`set`/`task`/`links`/`lint` as tools would make all of it
+native: help texts become tool schemas (machine-validated, no flag guessing —
+the `mv --to` and `--section/--all` stumbles this session simply cannot
+happen), hints become structured follow-up suggestions, and the snapshot
+index loads **once per session instead of once per invocation** — on MDN
+that's 0.4 s × every call, and it also dissolves the stale-index problem
+(BUG-4) since the server owns the index lifecycle. `hyalo init --claude`
+would register the server in `.mcp.json`. All existing CLI plumbing (dispatch
+→ JSON envelope) is already shaped like tool-call responses.
+
+### 2. Nested-map property access (`--property versions.fpt=*`)
+
+GitHub Docs (3,710 files) keeps its most important metadata in nested maps
+(`versions: {fpt: '*', ghes: '>=3.8'}`) and hyalo can only test existence or
+regex over a serialized blob. Dotted paths in `--property`, `--fields`
+display, and `set` (`hyalo set f.md --property versions.ghes='>=3.9'`) would
+make hyalo genuinely usable on Docusaurus/GitHub-Docs-style trees. The filter
+grammar already parses `K(op)V`; extend K to a path.
+
+### 3. `hyalo undo` — journal of last mutation batch
+
+Agents make mistakes; this session alone had `links fix --apply` writing a
+wrong fuzzy match candidate at 0.896 confidence (only a threshold flag saved
+it). Every mutating command already computes a full RewritePlan/atomic-write
+set — persist the pre-images to `.hyalo/journal/<timestamp>/` (last N
+batches) and add `hyalo undo [--list]`. Cheap to build on the existing
+write-path choke point, and it converts every risky `--apply` into a safe
+experiment. Git isn't always there (external KBs) and agent loops shouldn't
+need `git checkout` as their safety net.
+
+### 4. Section-level body mutation (`hyalo section append/replace`)
+
+The one workflow where an agent must still fall back to raw file editing is
+prose: append a bullet to `## Decisions`, add a row under `## Findings`.
+`task toggle` already proves the section-scoped body-write machinery exists
+(section_scanner + atomic write). `hyalo section append <file> --section
+"Findings" --text "- new insight"` (+ `--replace`) would complete the
+"never Edit directly" promise the project makes in its own CLAUDE.md. It
+also makes body edits schema-aware (`required-sections` can validate).
+
+## Tier 2 — sharpens existing features
+
+### 5. `links fix --strategy` + prefix-aware fuzzy scoring
+
+On real data this session: ShortestPath 15/15 correct, FuzzyMatch 0/2 wrong
+(shared `iterations/done/iteration-` prefix inflates Jaro-Winkler). Let
+`--apply` be restricted (`--strategy shortest-path,case`) and score fuzzy
+candidates on the differing tail (basename/slug), not the whole path. Related
+bug: BUG-3 in the dogfood report.
+
+### 6. Index freshness: warn or auto-patch
+
+Snapshot index silently serves stale results after any mutation that didn't
+pass `--index` (BUG-4). Two cheap layers: (a) mutations auto-patch an
+existing in-vault `.hyalo-index` even without the flag (the code for patching
+already exists behind the flag); (b) read commands compare index build time
+vs. the newest file mtime in the result set and print a one-line staleness
+warning with the rebuild hint.
+
+### 7. `lint --by-rule` triage table
+
+First `lint` on a stock corpus is still a wall (7,399 warnings on firefox,
+per the last report). A one-line-per-rule count table (exactly what I built
+by hand with `--jq` + `sort | uniq -c`) plus the existing "tune MD010" hint
+would make the first-run experience self-explanatory. (F-6 follow-up.)
+
+### 8. `hyalo new` property overrides + auto-numbering
+
+`new --type note --file x.md --property title="My Note"` saves the
+scaffold→set round-trip in the agent fill-in loop that `new --help` itself
+documents. Bonus: with the iteration `filename-template`
+(`iterations/iteration-{n}-{slug}.md`) already in the schema,
+`hyalo new --type iteration --slug robustness` could
+compute `{n}` (max existing + 1) and the path itself — today the agent
+duplicates that logic every iteration.
+
+### 9. `hyalo stats` — native group-by
+
+`--jq '.results | map(.properties.status) | group_by(.) | …'` works but is
+write-only jq golf. `hyalo stats --by status --tag iteration` (counts, with
+`--by property:X/tag/type/directory`) covers the most common dashboard need
+in one memorable flag, and `properties` already computes per-property type
+inference so the aggregation plumbing exists.
+
+## Tier 3 — worth a backlog entry
+
+### 10. `hyalo doctor`
+
+One command bundling what a maintainer runs serially today: broken links,
+orphans, mixed-type properties (`priority: mixed (87 text, 6 number)` was a
+real find this session), undeclared types in use (`type: review` exists in 2
+files but not in schema — also a real find), stale index, schema violations.
+Exit non-zero for CI; each finding carries its fix-command hint.
+
+### 11. Link graph export (`hyalo links graph --format dot|mermaid|json`)
+
+The link graph is already built for backlinks/orphans; serializing it would
+enable visualization and "what's reachable from X" analysis. Mermaid output
+could be pasted straight into any markdown doc — including iteration plans.
+
+### 12. `hyalo diff <file>` — semantic frontmatter diff
+
+Show property-level changes (added/removed/retyped) between working tree and
+git HEAD, or between two files. Agents reviewing their own mutations (and
+`--dry-run` outputs) would get a stable, structured view instead of unified
+text diff over YAML.
+
+### 13. Machine-readable CLI self-description (`hyalo schema --commands`)
+
+Emit the full clap tree (commands, flags, value types, defaults, examples) as
+JSON. An agent could load the entire interface in one call instead of 22
+`--help` invocations (which is exactly what the docs-audit agent had to do
+today) — and the xtask `help_drift` gate could diff prose docs against it
+mechanically, catching the M1-class drift (`default: json`) that slipped
+through.
+
+### 14. Per-KB "noise profile" bootstrap (`hyalo lint --init-profile`)
+
+Pointing hyalo at a foreign corpus (firefox, GitHub Docs) always starts with
+the same ritual: run lint, eyeball the top rules, `lint-rules set MDxxx
+--enabled false` a few times. A single command that runs the by-rule
+histogram and writes a commented `[lint.rules]` block disabling the top-N
+noisiest rules (with counts as comments) would make "adopt hyalo on an
+existing tree" a one-command experience.
+
+## Non-features deliberately not proposed
+
+- Watch mode/daemon for auto-reindex: the MCP server (idea 1) subsumes it
+  with a cleaner lifecycle.
+- A TUI: the audience is agents; investment belongs in the JSON/MCP surface.
+- Frontmatter encryption/secrets: out of scope for a knowledgebase tool;
+  CLAUDE.md security rules already cover the repo level.

--- a/hyalo-knowledgebase/reviews/codebase-review-2026-07-10.md
+++ b/hyalo-knowledgebase/reviews/codebase-review-2026-07-10.md
@@ -1,0 +1,320 @@
+---
+title: Full-codebase review 2026-07-10 — dogfood + parallel deep review + docs audit
+type: review
+date: 2026-07-10
+status: active
+tags: [review, security, correctness, dogfooding, docs]
+related:
+  - "[[reviews/codebase-review-2026-06-11]]"
+  - "[[dogfood-results/dogfood-v0160-iter157-159-pr186]]"
+---
+
+# Full-codebase review — hyalo 0.16.0 (2026-07-10)
+
+Combined output of a dogfood session (own KB, MDN 14,375 files, GitHub Docs
+3,710 files), two parallel deep code reviews (hyalo-cli + xtask;
+hyalo-core + hyalo-mdlint), and a docs-vs-implementation audit that executed
+every documented example against the binary. All findings below were verified
+against source or reproduced live against `hyalo 0.16.0 (3ca89718)`.
+
+## Findings by severity
+
+| Severity | Count | Headline |
+|---|---:|---|
+| CRITICAL | 1 | `lint-rules set` panics on malformed `.hyalo.toml` |
+| HIGH | 11 | `links fix --apply` frontmatter no-op; batch-mv rollback gap; delimiter drift siblings; index link-graph staleness on mv; CJK autofix drops; docs H1/H2 |
+| MEDIUM | ~24 | flag-dropping hints, body-relative lint lines, fuzzy threshold, non-atomic init writes, template-matcher DoS, latent unicode panic, docs M1–M6, … |
+| LOW | ~15 | ASCII-only `--section`/case-index folding, latent unwraps, terminology drift, … |
+
+## CRITICAL
+
+### `hyalo lint-rules set <RULE> --severity/--enabled` panics on malformed `.hyalo.toml`
+
+`crates/hyalo-cli/src/commands/lint_rules.rs:222-226` and `:263-267`. The
+guard `if doc.get("lint").is_none()` only covers "key absent"; with a
+hand-edited scalar (`lint = "oops"`), `doc["lint"]["rules"]` blind-indexes via
+`toml_edit`'s `IndexMut` and panics ("index not found", SIGABRT/exit 134).
+Reproduced live. `types.rs` handles the identical scenario cleanly via
+`.as_table_mut().context(...)?` — port that pattern and add a regression test
+seeded with `lint = "oops"`.
+
+## HIGH
+
+### H-A: `links fix --apply` silently no-ops on frontmatter wikilinks while reporting them applied
+
+Found by dogfood. `build_replacements_for_file`
+(`crates/hyalo-core/src/link_fix.rs:919`) walks the body only (skips
+frontmatter by design), so frontmatter FixPlans yield no Replacement — but
+the CLI reports the pre-write FixPlan list as `Applied: yes`. On the own KB,
+13 of 15 "applied" fixes were `related:` frontmatter links: all silent
+no-ops, and they reappear as fixable on the next run, so an agent fix-loop
+never converges. The detail list also dedupes by (source, old, new), hiding
+the frontmatter/body split. `mv` already rewrites frontmatter links correctly
+(`plan_frontmatter_wikilink_rewrites`) — `links fix` needs the same write
+path. Full repro in
+[[dogfood-results/dogfood-v0160-iter157-159-pr186]] BUG-1.
+
+### H-B: `mv --apply` batch mode doesn't roll back partially-applied link rewrites on failure
+
+`crates/hyalo-cli/src/commands/mv.rs:586-599`. `execute_batch_mv` renames
+files, then `link_rewrite::execute_plans` writes each rewrite plan
+independently. If plan N of M fails (e.g. concurrent edit trips the mtime
+guard), the handler rolls back the renames but not the rewrites already
+written for plans 1..N-1 — other files now hold wikilinks to paths that were
+renamed back. Fix: snapshot pre-rewrite content and restore symmetrically
+with the rename rollback.
+
+### H-C: `clap_complete::generate()` bypasses the broken-pipe panic matcher (worst on Windows)
+
+`crates/hyalo-cli/src/run.rs:612`. clap_complete's generators panic with
+"failed to write completion file", which doesn't match
+`is_broken_pipe_panic`'s expected `println!` prefix. On Unix SIGPIPE usually
+masks it; on Windows the panic hook is the only defense, so
+`hyalo completion powershell | Select-Object -First 5` shows a backtrace
+instead of a quiet exit. Broaden the matcher or buffer through `println!`.
+
+### H-D: documented examples that fail outright (docs audit)
+
+- `hyalo lint --fix-rule HYALO001` (without `--fix`) is a clap usage error
+  (exit 2) but appears in **README.md:99**, the binary's own `lint --help`
+  EXAMPLES, and **root CLAUDE.md:25**.
+- The pi skill template ships
+  `task toggle … --section "Tasks" --all`
+  (`crates/hyalo-cli/templates/skill-hyalo-pi.md:169`), but `--section` and
+  `--all` are mutually exclusive — an LLM consuming the skill will emit a
+  failing command.
+
+### H-E: iteration-158 fixes not ported to sibling code paths (hyalo-core)
+
+The core reviewer's dominant pattern: fixes applied to the canonical path but
+missed in 2–4 hand-rolled duplicates.
+
+- **BOM/delimiter drift** — `link_fix.rs:946,951`, `link_rewrite.rs:459,464`
+  (+2 more), `auto_link.rs` use raw `line.trim() == "---"` instead of the
+  BOM-aware `frontmatter::is_opening_delimiter`. A BOM-prefixed file with a
+  wikilink in frontmatter: `in_frontmatter` never activates, `mv`/`links fix`
+  silently mishandle that link. The comment claiming this "matches scanner
+  behaviour" is stale.
+- **Closing-delimiter disagreement** — `set`/`skip_frontmatter` accept an
+  indented `  ---` closer (lenient `trim()`), while `find`'s body-search path
+  (`find_closing_delimiter`) requires column 0: `set` and `find` silently
+  disagree on the same file. Unify via a symmetric `is_closing_delimiter`.
+- **Comment-fence check unguarded by code-fence state** —
+  `link_fix.rs:960-972` toggles the `%%` fence before `fence.process_line`;
+  `link_rewrite.rs` and `auto_link.rs` both guard correctly and have tests. A
+  code fence documenting `%%` syntax silently disables fixing for the rest of
+  the file.
+
+### H-F: `mv --index` leaves stale/dangling link-graph entries
+
+`link_graph.rs:424-456` (`rename_path` at 269-312), `index.rs::refresh_entry`
+(490-503). Bare-wikilink-form keys are never renamed and rewritten links are
+never inserted; `--index` and live-scan backlinks diverge permanently until a
+full rebuild. Fix: on rename, replace the file's edges wholesale
+(remove-by-source + reinsert from rescanned `FileLinks`).
+
+### H-G: case-sensitive orphan/dead-end detection
+
+`link_graph.rs:177-193` vs. `205-221`: backlink resolution is
+case-insensitive but `all_targets`/`all_sources` return raw-case keys, so a
+file linked only via `[[Web/Foo]]` is wrongly reported as an orphan of
+`web/foo.md`. Thread `case_index` through orphan detection.
+
+### H-H: `task toggle/set --section` skips nested-subsection tasks
+
+`crates/hyalo-cli/src/commands/tasks.rs:20` (`resolve_task_lines`) uses the
+flat "last-seen-heading" tag, while `read --section` uses
+`heading::build_section_scope` (inclusive subsections). **Verified live**: a
+`### Subtask` checkbox under `## Tasks` is silently skipped by
+`task toggle --section Tasks` but included by `read --section Tasks`. Reuse
+`build_section_scope` in `resolve_task_lines`.
+
+### H-I: fix-column unit misclassification drops autofixes for 6 rules on multibyte lines
+
+`crates/hyalo-mdlint/src/engine.rs:470-472`: `rule_uses_byte_columns`
+whitelists only MD009/HYALO001, but MD001/MD018/MD019/MD022/MD023/MD031 also
+emit byte-based columns (hand-traced against vendored rulesets). On a CJK
+heading, the char-walk never reaches the byte column, `convert_fix` silently
+drops the fix via `?` — violation reported, `--fix` no-ops forever. Extend
+the whitelist with CJK regression tests analogous to the MD009 one.
+
+## MEDIUM
+
+### Behavior (dogfood)
+
+- **Hints drop behavior-changing flags.** `hints_for_links_auto`
+  (`crates/hyalo-cli/src/hints.rs:1520`) rebuilds the apply command
+  preserving `--min-length`/`--file`/`--exclude-title`/`--glob` but not
+  `first_only` or `exclude_target_glob` (PR #186 extended `args.rs` without
+  extending the hint builder). Pasting the hint applied 3 links where the
+  dry run promised 1. Same class: the `drop-index` hint after
+  `create-index --index-file <custom path>` omits the path and targets the
+  in-vault index instead (this actually deleted the wrong index during the
+  session).
+- **`lint` MD-rule line numbers are body-relative** — off by exactly the
+  frontmatter line count (verified on two corpora); SCHEMA/HYALO findings
+  use a different convention (`line 1`). `--fix` edits the correct lines;
+  reporting only. Dogfood BUG-5.
+- **Fuzzy link-fix default threshold accepts wrong matches.** Shared
+  `iterations/done/iteration-` prefixes inflate Jaro-Winkler: a never-existed
+  target matched an unrelated file at 0.896. On real data ShortestPath went
+  15/15 correct, FuzzyMatch 0/2. Score the basename/slug, and/or add
+  `--strategy`. Dogfood BUG-3.
+- **Stale snapshot index diverges silently.** Mutations without `--index`
+  don't patch an existing in-vault `.hyalo-index`; later `--index` queries
+  return pre-edit values with no staleness signal. Dogfood BUG-4.
+- **Triple-reporting of one bad datetime value** (firefox F-3, still open):
+  SCHEMA error + HYALO003 (date heuristic, wrong rule for a datetime-typed
+  property) + HYALO004 for the same property/value.
+
+### Code (deep review)
+
+- **`init`/`deinit` use plain `fs::write`, not `atomic_write`** (~11 call
+  sites in init.rs), including the read-modify-write upsert of a user-editable
+  `.claude/CLAUDE.md` — a crash mid-write truncates it.
+- **`task toggle --all` re-saves the snapshot index once per task**
+  (`tasks.rs:236-239, 342-345`; `patch_index` at 377-417) instead of batching
+  like `set`/`mv` do via `save_index_if_dirty` — 200 toggles = 200 full index
+  serializations.
+- **`types set --default` vault-wide propagation** writes many files with no
+  per-file mtime guard (unlike the lint fix pipeline).
+- **`--section` matching is ASCII-only case-insensitive**
+  (`hyalo-core/src/heading.rs:168`): `--section CAFÉ` misses `## Café Notes`
+  (verified live); `--title` does full Unicode lowering. The
+  `debug_assert!(needle.is_ascii())` is compiled out in release.
+- **Three latent `unwrap()`s in production code** (`set.rs:419`,
+  `remove.rs:286`, `append.rs:299`) — currently unreachable but violate the
+  project ban; identical pattern, `mutation.rs` extraction candidate.
+- **`.hyalo.toml` writes in lint_rules.rs/types.rs are non-atomic** (direct
+  `fs::write`, no mtime guard) unlike markdown frontmatter writes.
+- **`plan_batch_mv` redundant re-read** (`link_rewrite.rs:1079`): second
+  `read_to_string` of a file already in memory with nothing invalidating the
+  first read — wasted I/O on large batches, and misleading about what it
+  guards.
+- **xtask `feature_fanout.rs:103`** flag-presence check is a substring match
+  (`--dir` would match `--dir-foo` or prose mentions).
+
+### Code (hyalo-core deep review)
+
+- **Latent unicode panic in `is_self_link`'s `strip_md`**
+  (`link_fix.rs:706-714`): `s[s.len()-3..]` panics mid-codepoint (verified in
+  isolation on `"a🎉"`). **Reachability check by team-lead**: all four call
+  sites pass discovered `.md` file paths, whose ASCII suffix keeps the slice
+  boundary-safe — two live repro attempts (emoji filename, emoji link target)
+  did not crash. Downgraded from the reviewer's CRITICAL to a latent panic:
+  one refactor away from a crash, and the sibling
+  `strip_wikilink_md_suffix` already does it safely with a regression test.
+  Fix with `Path::extension()` or an `is_char_boundary` guard.
+- **Filename-template matcher has exponential worst case**
+  (`filename_template.rs:149`): 12+ adjacent `{slug}` placeholders hung >12 s
+  (recursive backtracking, no memoization); `.hyalo.toml` loads untrusted and
+  `lint --fix` calls it per file — a real DoS vector on shared KBs. Memoize
+  or cap.
+- **Index snapshot validation gaps**: duplicate `rel_path` entries desync
+  `entries()` from `path_index` (double-counted tags in summary); size/count
+  caps checked only after full MessagePack materialization; BM25 postings
+  order not validated on load (crafted snapshot silently corrupts phrase
+  search). All three fixable inside `index.rs`/`bm25.rs` validation.
+- **Phrase-clause rejection is document-scoped** (`bm25.rs:644-725`): a doc
+  failing one phrase clause is excluded from the whole OR result set even if
+  another clause matches it.
+- **TOCTOU stat-then-read across readers** (`scanner/mod.rs:48-80` +
+  callers): nothing bounds the actual read; use `Read::take(MAX_FILE_SIZE)`.
+- **`atomic_write` has no Windows rename retry** (`fs_util.rs:17-51`):
+  transient sharing violations from AV/indexers fail the whole mutation.
+- **`!key=value` silently mis-parses** (`filter/parse.rs:86`) as equality on
+  a literal property named `!key` → silent zero results instead of a parse
+  error.
+- **Merged type schema recomputed per file** during lint
+  (`lint.rs:520` → `schema.rs:62`): O(files × schema) instead of
+  O(types × schema) on large KBs.
+- Observations: `is_external` misses `ftp:`/`tel:`/protocol-relative URLs
+  (fuzzy-matched as broken internal links); case-index folding is ASCII-only
+  (Turkish İ/ı, Cyrillic); Setext headings invisible to `--section`
+  (undocumented); dead `pub` API `remove_entry`/`insert_entry` with stale
+  doc comments; one provably-safe `.expect()` in `scanner/strip.rs:60`;
+  `plan_batch_mv` has zero direct unit tests (only e2e coverage).
+
+### Docs (audit — executed against the binary)
+
+- **M1**: top-level help "Global flags" box says `--format` default is
+  `json` (`cli/help.rs:108`); actual is TTY-aware, contradicting the long
+  help in the same output.
+- **M2**: `config --format json` emits 7 fields; help/README/CLAUDE.md
+  enumerate 6 (`raw_contents` undocumented).
+- **M3**: `--files-from` silently changes `find`'s `results` from array to
+  object, breaking the canonical `--jq '.results[].file'` recipe the help
+  itself advertises (correct: `.results.files[].file`).
+- **M4**: `find --help` COMMON MISTAKES declares `=~` wrong, but the parser
+  accepts `=~` identically to `~=` (137/137 verified) — an LLM may "fix"
+  working commands.
+- **M5**: `init`/`deinit` accept but ignore `--format json` (always print
+  human text).
+- **M6**: the documented "frontmatter would exceed size budget" exit-1 error
+  for `set`/`remove`/`append` is unreachable (8 KiB scalar read-cap fires
+  first, file silently skipped, exit 0); only `hyalo new` can reach it.
+
+## LOW
+
+- `tasks` alias for `task` still missing (firefox F-4); `links --file` still
+  rejected while peer commands accept it (F-5).
+- Multi-line property values print raw newlines in text output — a value
+  containing `\nmalicious: injected` renders as a fake sibling property
+  (write path is safely quoted; display only). Dogfood BUG-6.
+- `backlinks` help lists `label` unconditionally but it's
+  `skip_serializing_if = None`; top-level OUTPUT SHAPES omits it.
+- Invalid `--sort` error advertises `score`; the flag help doesn't list it.
+- README omits `[search] language`/`--language`/`--stemmer` and `views run`;
+  README "Releasing" invites a manual tag contrary to the
+  `gh release create` convention; CHANGELOG's `0.16.0 — 2026-05-23` date
+  predates ~2 months of work now under it.
+- Terminology drift, one directory / four names: help says "vault" (9×,
+  0× "knowledgebase"), runtime says "kb dir:", config says "dir:", README
+  mixes vault×22/knowledgebase×7, root CLAUDE.md knowledgebase-only — while
+  DEC-002 deliberately moved away from "vault". Help/README are the outliers.
+
+## What's genuinely well done (both reviewers, independently)
+
+- The **mtime+size TOCTOU fingerprint + temp-file+rename atomic-write
+  pattern** is applied uniformly across every mutating command — reused,
+  not reinvented. Held up under 20 concurrent writers in dogfood.
+- **Broken-pipe handling** (PR #186) is architecturally sound: one install
+  site, all output funneled through two print sites, verified across every
+  command; the only gap is the clap_complete path (H-C).
+- **Zero non-test `unwrap()`/`expect()`** across the entire read/query
+  surface; the two exceptions in `find/mod.rs` are guarded and commented.
+- The **byte/char-boundary autofix bug class stays fixed**: every
+  autofixable rule's offsets go through `char_indices()`/`len_utf8()`,
+  backed by CJK/emoji tests; `apply_body_fixes`' two-phase
+  (severity-priority selection, descending-offset mutation) overlap handling
+  is provably correct with explicit adjacency and out-of-bounds tests.
+- **`mv`'s vault-escape guard** is enforced at plan-time and again before
+  each fs op; link matching has deterministic ambiguity resolution.
+- **d8285aa (`--first-only`)**: `resolve_existing_link_targets` correctly
+  mirrors the scanner's zone-skipping, divergence documented; solid tests.
+- The **`unsafe { libc::kill }` PID-liveness check** (`index.rs:938-988`) is
+  the only unsafe block found and it's exemplary: guards `pid == 0`/overflow,
+  distinguishes `ESRCH` from `EPERM` correctly, accurate SAFETY comment,
+  clean non-Unix degradation.
+- **BM25 core**: Lucene-style IDF provably positive, index/query tokenizer
+  symmetry confirmed, char-based (unicode-safe), CRLF a non-issue.
+- **Fence-awareness in task mutation** is correct at every entry point with
+  atomic-batch-rejection tests — the one subsystem where byte/char handling
+  was hand-traced and found flawless.
+- Clean `cargo clippy --workspace --all-targets -- -D warnings`.
+
+## Suggested fix order
+
+1. CRITICAL lint-rules panic (small, pattern exists next door in types.rs).
+2. H-A `links fix` frontmatter write path + honest Applied reporting.
+3. H-E sibling-drift bundle (BOM delimiter ×5 call sites, closing-delimiter
+   unification, comment-fence guard) — one iteration, shared helper extract.
+4. H-H nested-subsection task toggle (reuse `build_section_scope`) and
+   H-I mdlint byte-column whitelist — both small, both silently wrong today.
+5. H-D doc/example fixes (three files + pi template; cheap, high LLM impact).
+6. H-F/H-G link-graph index staleness + case-insensitive orphans.
+7. MEDIUM hint flag-preservation (`first_only`, `exclude_target_glob`,
+   `--index-file` in drop-index hint).
+8. MEDIUM lint line-number offset (+ unify SCHEMA line convention),
+   latent `strip_md` panic, template-matcher memoization.
+9. The rest of the MEDIUMs opportunistically; batch with related files.


### PR DESCRIPTION
## Summary
- **CRITICAL fix**: `hyalo lint-rules set <RULE> --severity/--enabled` panicked (SIGABRT, exit 134) when `.hyalo.toml` carries `lint` as a non-table scalar (`lint = "oops"`). Both write paths now route through a guarded `lint_rules_table_mut()` helper that returns a clean UserError (exit 1, JSON error envelope) for present-but-not-a-table `lint`/`lint.rules`, mirroring `types.rs`'s handling of the identical malformed-`schema` case. Config file untouched on error.
- **HIGH fix**: `links fix --apply` reported frontmatter wikilink fixes as applied but never wrote them (frontmatter FixPlans carry the line-1 sentinel; `build_replacements_for_file` skipped the frontmatter block). The frontmatter block is now scanned with the same bracket scanner `mv`'s frontmatter rewriter uses (extracted as shared `find_frontmatter_wikilinks()`), preserving aliases and written form. On the own KB this makes 13 previously-no-op'd `related:` fixes land (broken links 30 → 15).
- **Honest reporting**: the JSON envelope now includes `applied_fixes` (what was actually written), `unapplied`/`unapplied_fixes` (plans whose on-disk text no longer matched); text output prints detail lines from `applied_fixes` plus an "Unapplied" section; index patching (`modified_files`) derives from actual RewritePlans. Fix-loops driven by this output now converge.
- Also fixed in passing: the links-fix text formatter is keyed on the envelope's top-level key signature — the new fields silently degraded `--format text` to a raw key dump until the key list/jq filter were updated.
- KB: 2026-07-10 dogfood report, consolidated codebase review, feature-gaps research doc, iter-160 plan, and the 13 frontmatter link repairs applied with this branch's binary.

## Test plan
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace -q` — 2,675 passed, 0 failed
- [x] xtask gates: check-ac-fidelity (iter-160 plan), check-feature-fanout, check-help-drift — all green
- [x] Live repro A: `lint = "oops"` + `lint-rules set MD013 --severity error` → JSON error, exit 1, file untouched (was: panic, exit 134)
- [x] Live repro B: vault with `related: ["[[wrong/real-target]]"]` + body link → `links fix --apply` rewrites both occurrences (listed distinctly), re-run reports 0 broken / 0 fixable
- [x] Own KB: `links fix --apply --threshold 0.95` applies all 13 frontmatter fixes; `hyalo links` drops from 28 to 15 broken
- [x] New tests: 4 lint-rules regression tests (incl. `lint.rules` scalar and remove-path), 6 link_fix unit tests (frontmatter-only / body-only / both / block-list / alias / unapplied), 2 e2e links tests (apply + dry-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)