### PR TITLE
feat(lint): --format github for PR annotations + lint own KB in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,21 @@ jobs:
       - run: cargo test --workspace
       - name: Verify CLI runs
         run: cargo run -p hyalo-cli -- --help
+
+  # Dogfood: lint the project's own knowledgebase and surface any schema/body
+  # violations as inline PR annotations. `.hyalo.toml` at the repo root sets
+  # `dir = "hyalo-knowledgebase"`, so `hyalo lint` targets the vault, and
+  # `--format github` emits `::error`/`::warning` workflow commands. Paths are
+  # repo-root-relative because the job runs from the checkout root. The lint
+  # exits non-zero on errors, failing the check. Annotations are
+  # platform-independent, so this runs on ubuntu only.
+  lint-kb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Build hyalo
+        run: cargo build --release -p hyalo-cli
+      - name: Lint knowledgebase
+        run: ./target/release/hyalo lint --strict --format github

--- a/.hyalo.toml
+++ b/.hyalo.toml
@@ -143,6 +143,24 @@ fields = ["tasks"]
 properties = ["status=in-progress"]
 
 [lint]
+# Frozen historical records: completed iterations, done backlog items, and
+# dogfood/review logs are snapshots of past state. They legitimately carry old
+# formatting and aspirational/unchecked housekeeping tasks, so they are excluded
+# from the CI lint gate (which protects the *live* knowledgebase). See
+# iteration-170.
+ignore = [
+  "iterations/done/**",
+  "backlog/done/**",
+  "dogfood-results/**",
+  "reviews/**",
+  "research/**",
+  "promotion-plan.md",
+]
 
 [lint.rules]
 MD013 = true
+# Completed iterations often keep a trailing "mark completed / move to done"
+# housekeeping checkbox unticked. That is a normal, not an error, state for this
+# vault, so HYALO002 is advisory (warn) here rather than a CI-failing error.
+[lint.rules.HYALO002]
+severity = "warn"

--- a/README.md
+++ b/README.md
@@ -461,6 +461,60 @@ It is mutually exclusive with `--glob` and `--file`.
 and `task read` (which are single-file commands and will return an error if
 `--glob` is used).
 
+### GitHub PR annotations (`--format github`)
+
+`hyalo lint --format github` emits one [GitHub Actions workflow command] per
+violation, so findings render as **inline annotations on the PR diff** — no `jq`
+glue required. Errors become `::error`, warnings become `::warning`, and a
+one-line `N errors, M warnings in K files` summary is printed at the end so the
+job log stays readable. The lint still exits non-zero on errors, failing the
+check. `--format github` is lint-only; other subcommands reject it.
+
+Drop this into a workflow to lint your whole vault on every PR:
+
+```yaml
+# .github/workflows/lint-kb.yml
+name: Lint knowledgebase
+on:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Install hyalo (Homebrew, cargo-binstall, or a release binary — see
+      # Installation). The setup-hyalo action is coming in a follow-up.
+      - run: cargo install hyalo --locked
+      # Run from the repo root so annotation paths resolve against the workspace.
+      # `.hyalo.toml` sets `dir = "..."`, so `hyalo lint` targets the vault.
+      - run: hyalo lint --strict --format github
+```
+
+Paths are emitted **relative to the repository root**: vault-relative paths are
+prefixed with the vault dir's path relative to the current directory, so the job
+**must run from the repo root** for annotations to land on the right file/line.
+
+For a diff-aware variant that only annotates files touched on the branch, combine
+it with `--files-from -`:
+
+```yaml
+      - run: |
+          git fetch origin main --depth=1
+          git diff --name-only origin/main -- '**/*.md' \
+            | hyalo lint --strict --files-from - --format github
+```
+
+For **OKF** vaults, add an optional second step to catch reserved-file
+(`index.md` / `log.md`) drift — `hyalo okf index` is dry-run by default and exits
+non-zero when the on-disk artifacts are stale:
+
+```yaml
+      - name: Check OKF reserved-file drift
+        run: hyalo okf index   # dry-run; non-zero exit on drift
+```
+
+[GitHub Actions workflow command]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+
 ### Snapshot index
 
 For workflows that run many queries in a short window (CI, automation, LLM tool loops):

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ jobs:
       - uses: actions/checkout@v4
       # Install hyalo (Homebrew, cargo-binstall, or a release binary — see
       # Installation). The setup-hyalo action is coming in a follow-up.
-      - run: cargo install hyalo --locked
+      - run: cargo install hyalo-cli --locked
       # Run from the repo root so annotation paths resolve against the workspace.
       # `.hyalo.toml` sets `dir = "..."`, so `hyalo lint` targets the vault.
       - run: hyalo lint --strict --format github

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1064,6 +1064,15 @@ Repeatable (AND).\n\
             `--max-per-rule`). Use --detailed for full per-violation output. Use --format json\n\
             for a JSON payload with `rule_groups`, `total`, `rules_fired`,\n\
             `files_with_violations`, and `files_truncated`.\n\n\
+            GITHUB ANNOTATIONS: --format github (lint-only) emits one GitHub Actions workflow\n\
+            command per violation — `::error file=<path>,line=<line>,title=<RULE_ID>::<message>`\n\
+            (warnings use `::warning`) — so findings render as inline annotations on the PR diff,\n\
+            followed by a one-line `N errors, M warnings in K files` summary. Message data is\n\
+            escaped per the workflow-command spec. Paths are emitted RELATIVE TO THE REPO ROOT:\n\
+            vault-relative paths are prefixed with the vault dir's path relative to the current\n\
+            directory, so CI must run `hyalo lint` from the repository root for annotations to\n\
+            resolve. Composes with --strict, --rule/--rule-prefix, --max-per-rule, and\n\
+            `[lint] ignore`; exit codes are unchanged. Other subcommands reject `--format github`.\n\n\
             FILTER FLAGS:\n\
             \u{00a0} --rule <ID>             restrict to a single rule\n\
             \u{00a0} --rule-prefix <PREFIX>  restrict to rules with this prefix (e.g. HYALO)\n\
@@ -1104,7 +1113,8 @@ Repeatable (AND).\n\
             \u{00a0} hyalo lint --fix\n\
             \u{00a0} hyalo lint --profile okf         # validate OKF bundle conformance\n\
             \u{00a0} hyalo lint --profile skills      # validate a directory of SKILL.md skills\n\
-            \u{00a0} hyalo lint --profile changelog   # validate CHANGELOG.md (Keep a Changelog)\n\n\
+            \u{00a0} hyalo lint --profile changelog   # validate CHANGELOG.md (Keep a Changelog)\n\
+            \u{00a0} hyalo lint --strict --format github   # inline PR annotations in GitHub Actions\n\n\
             INDEX NOTE: The snapshot index does not accelerate the body pass — body bytes are\n\
             not indexed. The frontmatter pass and file enumeration still benefit from --index.\n\n\
             SIDE EFFECTS: None without --fix. With --fix (and without --dry-run), mutated files\n\

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -64,7 +64,8 @@ pub(crate) fn collect_config_report(cwd: &Path) -> anyhow::Result<ConfigReport> 
 /// Run `hyalo config` and return a `CommandOutcome` ready for the output pipeline.
 pub(crate) fn run_config(report: &ConfigReport, format: Format) -> CommandOutcome {
     match format {
-        Format::Json => run_config_json(report),
+        // `github` is rejected for non-lint commands upstream; treat as JSON here.
+        Format::Json | Format::Github => run_config_json(report),
         Format::Text => run_config_text(report),
     }
 }

--- a/crates/hyalo-cli/src/commands/lint_github.rs
+++ b/crates/hyalo-cli/src/commands/lint_github.rs
@@ -35,7 +35,9 @@ use std::fmt::Write as _;
 ///
 /// `payload` is the `results` value produced by the lint command — the
 /// serialized `ExtLintOutput` (or its `--fix` variant), i.e. an object with a
-/// `files` array whose entries carry `rule_groups[].violations[]`, plus the
+/// `files` array whose entries carry `rule_groups[].violations[]` (read-only
+/// lint) or `remaining_groups[].violations[]` (fix mode — `fixed_groups` are
+/// omitted from annotations since they're no longer problems), plus the
 /// top-level `errors` / `warnings` / `files_with_violations` counters.
 ///
 /// `path_prefix` is prepended (with a `/` separator, always forward-slash for
@@ -52,10 +54,30 @@ pub fn render(payload: &serde_json::Value, path_prefix: &str) -> String {
                 .get("file")
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("?");
-            let full_path = join_path(&prefix, file);
+            // `.hyalo.toml` view-lint findings (see `validate_views`) are reported
+            // as the literal filename `.hyalo.toml`, which always lives at the
+            // config root (repo root in the common case where CI runs from
+            // there) — never inside the vault dir. Every other entry is
+            // vault-relative and needs the prefix; this one must not get it, or
+            // the annotation points at a path that doesn't exist.
+            let full_path = if file == ".hyalo.toml" {
+                file.to_owned()
+            } else {
+                join_path(&prefix, file)
+            };
 
-            // New shape: violations grouped by rule under `rule_groups`.
-            if let Some(rule_groups) = file_entry.get("rule_groups").and_then(|rg| rg.as_array()) {
+            // New shape (read-only lint): violations grouped by rule under
+            // `rule_groups`. Fix-mode (`--fix`/`--fix --dry-run`) instead groups
+            // *unresolved* violations under `remaining_groups` — same per-group
+            // shape, different key — with `fixed_groups` for violations already
+            // resolved (nothing to annotate there since the PR diff no longer
+            // shows them as problems).
+            let groups_key = if file_entry.get("rule_groups").is_some() {
+                "rule_groups"
+            } else {
+                "remaining_groups"
+            };
+            if let Some(rule_groups) = file_entry.get(groups_key).and_then(|rg| rg.as_array()) {
                 for group in rule_groups {
                     let rule = group
                         .get("rule")
@@ -158,12 +180,21 @@ fn write_command(
 ///
 /// Per the workflow-command spec: `%` → `%25`, `\r` → `%0D`, `\n` → `%0A`.
 /// Order matters — `%` must be escaped first so the `%` in later replacements
-/// is not double-escaped.
+/// is not double-escaped. Message text ultimately originates from linted file
+/// content (body text, property values), so after the spec escapes are applied
+/// any *other* raw control bytes (e.g. ANSI escape sequences) are stripped via
+/// [`crate::output::sanitize_control_chars`] — the same defense other CLI
+/// output paths use — to prevent terminal/log injection in the Actions job log.
+/// This must run after the `\r`/`\n` replacement above, since
+/// `sanitize_control_chars` would otherwise silently drop a raw `\r` instead of
+/// letting it become `%0D`.
 #[must_use]
 pub fn escape_data(s: &str) -> String {
-    s.replace('%', "%25")
+    let escaped = s
+        .replace('%', "%25")
         .replace('\r', "%0D")
-        .replace('\n', "%0A")
+        .replace('\n', "%0A");
+    crate::output::sanitize_control_chars(&escaped)
 }
 
 /// Escape a workflow-command *property* value (e.g. `file=`, `title=`).
@@ -327,6 +358,10 @@ mod tests {
 
     #[test]
     fn render_handles_legacy_flat_violations() {
+        // `.hyalo.toml` view-lint findings are always reported at the config
+        // root (repo root in the common case), never inside the vault dir, so
+        // the vault-dir prefix must NOT apply here even though every other file
+        // entry gets prefixed with "kb".
         let payload = json!({
             "files": [
                 {
@@ -344,7 +379,84 @@ mod tests {
         let first = out.lines().next().unwrap();
         assert_eq!(
             first,
-            "::warning file=kb/.hyalo.toml::view 'x' has no narrowing filter"
+            "::warning file=.hyalo.toml::view 'x' has no narrowing filter"
         );
+    }
+
+    /// Fix-mode (`--fix`/`--fix --dry-run`) payloads group unresolved
+    /// violations under `remaining_groups`, not `rule_groups`. The renderer
+    /// must annotate those too — `fixed_groups` are intentionally skipped since
+    /// they're no longer problems.
+    #[test]
+    fn render_handles_fix_mode_remaining_groups() {
+        let payload = json!({
+            "files": [
+                {
+                    "file": "notes/a.md",
+                    "fixed_groups": [
+                        {"rule": "MD047", "count": 1, "violations": []}
+                    ],
+                    "remaining_groups": [
+                        {
+                            "rule": "MD013",
+                            "severity": "warn",
+                            "violations": [
+                                {"line": 5, "message": "Line length is 90 characters, expected no more than 80"}
+                            ]
+                        }
+                    ],
+                    "conflicts": []
+                }
+            ],
+            "errors": 0,
+            "warnings": 1,
+            "files_with_violations": 1
+        });
+        let out = render(&payload, "");
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(
+            lines[0],
+            "::warning file=notes/a.md,line=5,title=MD013::Line length is 90 characters, expected no more than 80"
+        );
+        assert_eq!(lines[1], "0 errors, 1 warning in 1 file");
+    }
+
+    /// A fix-mode payload with zero remaining violations (everything fixed)
+    /// produces no annotations at all — matches `render_clean_payload_is_summary_only`.
+    #[test]
+    fn render_fix_mode_all_fixed_is_summary_only() {
+        let payload = json!({
+            "files": [
+                {
+                    "file": "notes/a.md",
+                    "fixed_groups": [
+                        {"rule": "MD047", "count": 1, "violations": []}
+                    ],
+                    "remaining_groups": [],
+                    "conflicts": []
+                }
+            ],
+            "errors": 0,
+            "warnings": 0,
+            "files_with_violations": 0
+        });
+        let out = render(&payload, "");
+        assert_eq!(out, "0 errors, 0 warnings in 0 files");
+    }
+
+    /// Raw control bytes (e.g. an ANSI escape sequence smuggled in via file
+    /// content) are stripped from messages after the workflow-command escapes
+    /// are applied, so they can't inject terminal/log control sequences into
+    /// the Actions job log. `\r`/`\n`/`%` still round-trip through the spec's
+    /// percent-escaping rather than being silently dropped.
+    #[test]
+    fn escape_data_strips_other_control_bytes_but_keeps_percent_escapes() {
+        // ESC (0x1B) starts a raw ANSI sequence — must be stripped.
+        let with_ansi = "\u{1b}[31mred\u{1b}[0m text";
+        assert_eq!(escape_data(with_ansi), "[31mred[0m text");
+        // \r and \n still become %0D / %0A, not stripped.
+        assert_eq!(escape_data("a\r\nb"), "a%0D%0Ab");
+        // A bell character (0x07) is stripped too.
+        assert_eq!(escape_data("beep\u{7}beep"), "beepbeep");
     }
 }

--- a/crates/hyalo-cli/src/commands/lint_github.rs
+++ b/crates/hyalo-cli/src/commands/lint_github.rs
@@ -1,0 +1,350 @@
+//! GitHub Actions workflow-command rendering for `hyalo lint`.
+//!
+//! When `hyalo lint --format github` runs inside a GitHub Actions job, each
+//! violation is emitted as a [workflow command] so the finding renders as an
+//! inline annotation on the PR diff — no `jq` glue (which would violate the
+//! no-polyglot-tooling rule) required.
+//!
+//! Output shape, one line per violation:
+//!
+//! ```text
+//! ::error file=<repo-root-relative path>,line=<line>,title=<RULE_ID>::<message>
+//! ::warning file=...,line=...,title=...::...
+//! ```
+//!
+//! followed by a single plain-text summary line so the job log stays readable:
+//!
+//! ```text
+//! N errors, M warnings in K files
+//! ```
+//!
+//! [workflow command]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+//!
+//! ## Path resolution
+//!
+//! GitHub resolves annotation `file=` paths against the **workspace root** (the
+//! checked-out repo), not the hyalo vault dir. The lint payload carries
+//! vault-relative paths, so the renderer prefixes each with `path_prefix` — the
+//! vault dir expressed relative to the current working directory. CI is assumed
+//! to run `hyalo lint` from the repository root; the README documents this.
+
+use std::fmt::Write as _;
+
+/// Render the extended lint JSON payload as GitHub Actions workflow commands
+/// plus a trailing summary line.
+///
+/// `payload` is the `results` value produced by the lint command — the
+/// serialized `ExtLintOutput` (or its `--fix` variant), i.e. an object with a
+/// `files` array whose entries carry `rule_groups[].violations[]`, plus the
+/// top-level `errors` / `warnings` / `files_with_violations` counters.
+///
+/// `path_prefix` is prepended (with a `/` separator, always forward-slash for
+/// portability) to each vault-relative file path so annotations resolve against
+/// the repo root. Pass an empty string when the vault dir *is* the CWD.
+#[must_use]
+pub fn render(payload: &serde_json::Value, path_prefix: &str) -> String {
+    let mut out = String::new();
+    let prefix = normalize_prefix(path_prefix);
+
+    if let Some(files) = payload.get("files").and_then(|f| f.as_array()) {
+        for file_entry in files {
+            let file = file_entry
+                .get("file")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("?");
+            let full_path = join_path(&prefix, file);
+
+            // New shape: violations grouped by rule under `rule_groups`.
+            if let Some(rule_groups) = file_entry.get("rule_groups").and_then(|rg| rg.as_array()) {
+                for group in rule_groups {
+                    let rule = group
+                        .get("rule")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("");
+                    let severity = group
+                        .get("severity")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("warn");
+                    if let Some(violations) = group.get("violations").and_then(|v| v.as_array()) {
+                        for v in violations {
+                            // line 0 (or absent) means "no specific line" — GitHub
+                            // attaches such annotations to the top of the file.
+                            let line = v
+                                .get("line")
+                                .and_then(serde_json::Value::as_u64)
+                                .filter(|&l| l > 0);
+                            let message = v
+                                .get("message")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("");
+                            write_command(&mut out, severity, &full_path, line, rule, message);
+                        }
+                    }
+                }
+            } else if let Some(violations) = file_entry.get("violations").and_then(|v| v.as_array())
+            {
+                // Legacy flat shape (e.g. `.hyalo.toml` view violations).
+                for v in violations {
+                    let severity = v
+                        .get("severity")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("warn");
+                    let message = v
+                        .get("message")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("");
+                    write_command(&mut out, severity, &full_path, None, "", message);
+                }
+            }
+        }
+    }
+
+    // Trailing summary line, using the same field-name fallbacks the text
+    // renderer uses so both read-only and `--fix` payloads are covered.
+    let errors = payload
+        .get("errors")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let warnings = payload
+        .get("warnings")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let files_with_issues = payload
+        .get("files_with_violations")
+        .or_else(|| payload.get("files_with_issues"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let _ = write!(
+        out,
+        "{errors} {}, {warnings} {} in {files_with_issues} {}",
+        plural(errors, "error", "errors"),
+        plural(warnings, "warning", "warnings"),
+        plural(files_with_issues, "file", "files"),
+    );
+
+    out
+}
+
+/// Pick the singular or plural word based on `n`.
+fn plural<'a>(n: u64, singular: &'a str, plural: &'a str) -> &'a str {
+    if n == 1 { singular } else { plural }
+}
+
+/// Write one `::error`/`::warning` workflow command line to `out`.
+fn write_command(
+    out: &mut String,
+    severity: &str,
+    file: &str,
+    line: Option<u64>,
+    rule: &str,
+    message: &str,
+) {
+    let command = if severity == "error" {
+        "error"
+    } else {
+        "warning"
+    };
+    let _ = write!(out, "::{command} file={}", escape_property(file));
+    if let Some(l) = line {
+        let _ = write!(out, ",line={l}");
+    }
+    if !rule.is_empty() {
+        let _ = write!(out, ",title={}", escape_property(rule));
+    }
+    let _ = writeln!(out, "::{}", escape_data(message));
+}
+
+/// Escape a workflow-command *message* (the part after `::`).
+///
+/// Per the workflow-command spec: `%` → `%25`, `\r` → `%0D`, `\n` → `%0A`.
+/// Order matters — `%` must be escaped first so the `%` in later replacements
+/// is not double-escaped.
+#[must_use]
+pub fn escape_data(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+
+/// Escape a workflow-command *property* value (e.g. `file=`, `title=`).
+///
+/// Properties additionally escape `:` → `%3A` and `,` → `%2C` on top of the
+/// data escapes, since those characters are the property delimiters.
+#[must_use]
+pub fn escape_property(s: &str) -> String {
+    escape_data(s).replace(':', "%3A").replace(',', "%2C")
+}
+
+/// Normalize a path prefix: strip a leading `./`, convert backslashes to
+/// forward slashes, and drop any trailing slash so [`join_path`] can add
+/// exactly one separator.
+fn normalize_prefix(prefix: &str) -> String {
+    let p = prefix.replace('\\', "/");
+    let p = p.strip_prefix("./").unwrap_or(&p);
+    p.trim_end_matches('/').to_owned()
+}
+
+/// Join a normalized prefix with a vault-relative file path using a forward
+/// slash. An empty prefix (vault dir == CWD) returns the file unchanged (minus
+/// any `./`).
+fn join_path(prefix: &str, file: &str) -> String {
+    let file = file.replace('\\', "/");
+    let file = file.strip_prefix("./").unwrap_or(&file);
+    if prefix.is_empty() {
+        file.to_owned()
+    } else {
+        format!("{prefix}/{file}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn escape_data_handles_percent_and_newlines() {
+        // Percent must be escaped first so later replacements aren't double-escaped.
+        assert_eq!(escape_data("100% done"), "100%25 done");
+        assert_eq!(escape_data("line1\nline2"), "line1%0Aline2");
+        assert_eq!(escape_data("a\r\nb"), "a%0D%0Ab");
+        assert_eq!(escape_data("mix %\r\n%"), "mix %25%0D%0A%25");
+        assert_eq!(escape_data("plain text"), "plain text");
+    }
+
+    #[test]
+    fn escape_property_also_escapes_colon_and_comma() {
+        assert_eq!(escape_property("a:b,c"), "a%3Ab%2Cc");
+        // Colon/comma escapes compose with the data escapes.
+        assert_eq!(escape_property("50%,x:y"), "50%25%2Cx%3Ay");
+        // Windows-style path separators are left to the caller (join_path); a
+        // bare colon in a drive-less path is still escaped.
+        assert_eq!(escape_property("notes/a.md"), "notes/a.md");
+    }
+
+    #[test]
+    fn normalize_prefix_strips_dot_slash_and_trailing_slash() {
+        assert_eq!(normalize_prefix("./kb/"), "kb");
+        assert_eq!(normalize_prefix("kb"), "kb");
+        assert_eq!(normalize_prefix("sub\\kb/"), "sub/kb");
+        assert_eq!(normalize_prefix("."), ".");
+        assert_eq!(normalize_prefix(""), "");
+    }
+
+    #[test]
+    fn join_path_prefixes_relative_paths() {
+        assert_eq!(join_path("kb", "notes/a.md"), "kb/notes/a.md");
+        assert_eq!(join_path("", "notes/a.md"), "notes/a.md");
+        assert_eq!(join_path("", "./notes/a.md"), "notes/a.md");
+        assert_eq!(join_path("sub/kb", "a.md"), "sub/kb/a.md");
+        // Backslash file paths are normalized to forward slashes.
+        assert_eq!(join_path("kb", "notes\\a.md"), "kb/notes/a.md");
+    }
+
+    #[test]
+    fn render_emits_error_and_warning_commands_with_prefix() {
+        let payload = json!({
+            "files": [
+                {
+                    "file": "notes/a.md",
+                    "rule_groups": [
+                        {
+                            "rule": "HYALO001",
+                            "severity": "error",
+                            "violations": [
+                                {"line": 3, "message": "missing required property \"title\""}
+                            ]
+                        },
+                        {
+                            "rule": "SCHEMA",
+                            "severity": "warn",
+                            "violations": [
+                                {"line": 1, "message": "no 'type' property"}
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "errors": 1,
+            "warnings": 1,
+            "files_with_violations": 1
+        });
+        let out = render(&payload, "kb");
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(
+            lines[0],
+            "::error file=kb/notes/a.md,line=3,title=HYALO001::missing required property \"title\""
+        );
+        assert_eq!(
+            lines[1],
+            "::warning file=kb/notes/a.md,line=1,title=SCHEMA::no 'type' property"
+        );
+        assert_eq!(lines[2], "1 error, 1 warning in 1 file");
+    }
+
+    #[test]
+    fn render_clean_payload_is_summary_only() {
+        let payload = json!({
+            "files": [],
+            "errors": 0,
+            "warnings": 0,
+            "files_with_violations": 0
+        });
+        let out = render(&payload, "");
+        assert_eq!(out, "0 errors, 0 warnings in 0 files");
+    }
+
+    #[test]
+    fn render_escapes_message_and_omits_zero_line() {
+        let payload = json!({
+            "files": [
+                {
+                    "file": "a.md",
+                    "rule_groups": [
+                        {
+                            "rule": "MD013",
+                            "severity": "error",
+                            "violations": [
+                                {"line": 0, "message": "line, with: comma%and\nnewline"}
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "errors": 1,
+            "warnings": 0,
+            "files_with_violations": 1
+        });
+        let out = render(&payload, "");
+        let first = out.lines().next().unwrap();
+        // line=0 is omitted (annotations without a line attach to the file top).
+        // Commas/colons/percent/newline in the *message* use data-escaping only.
+        assert_eq!(
+            first,
+            "::error file=a.md,title=MD013::line, with: comma%25and%0Anewline"
+        );
+    }
+
+    #[test]
+    fn render_handles_legacy_flat_violations() {
+        let payload = json!({
+            "files": [
+                {
+                    "file": ".hyalo.toml",
+                    "violations": [
+                        {"severity": "warn", "message": "view 'x' has no narrowing filter"}
+                    ]
+                }
+            ],
+            "errors": 0,
+            "warnings": 1,
+            "files_with_issues": 1
+        });
+        let out = render(&payload, "kb");
+        let first = out.lines().next().unwrap();
+        assert_eq!(
+            first,
+            "::warning file=kb/.hyalo.toml::view 'x' has no narrowing filter"
+        );
+    }
+}

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod init;
 pub(crate) mod inputs;
 pub mod links;
 pub mod lint;
+pub mod lint_github;
 pub mod lint_rules;
 pub mod madr;
 pub mod madr_lint;

--- a/crates/hyalo-cli/src/commands/new.rs
+++ b/crates/hyalo-cli/src/commands/new.rs
@@ -156,7 +156,8 @@ pub(crate) fn create_new(
     // ------------------------------------------------------------------
     let out = match format {
         Format::Text => format!("created {rel_path}\n"),
-        Format::Json => {
+        // `github` is rejected for non-lint commands upstream; treat as JSON here.
+        Format::Json | Format::Github => {
             let val = serde_json::json!({
                 "type": type_name,
                 "file": rel_path,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -1763,7 +1763,13 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let github_output = ctx.user_format == crate::output::Format::Github;
 
             let max_per_rule_eff = if github_output {
-                0 // unlimited
+                // `usize::MAX`, not `0` — the fix-mode output path uses
+                // `.take(n)`/`.min(n)` to cap violations shown per rule, so `0`
+                // would truncate every rule group to zero shown violations and
+                // silently drop annotations. The non-fix path separately bypasses
+                // this cap via `opts.detailed`, but fix-mode does not, so the
+                // sentinel must mean "unlimited" in both paths.
+                usize::MAX
             } else {
                 max_per_rule.unwrap_or_else(|| ctx.md_lint.max_violations_per_rule())
             };

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -1756,14 +1756,27 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let md_engine = hyalo_mdlint::HyaloLintEngine::create()
                 .map_err(|e| anyhow::anyhow!("failed to create lint engine: {e}"))?;
 
-            let max_per_rule_eff =
-                max_per_rule.unwrap_or_else(|| ctx.md_lint.max_violations_per_rule());
+            // `--format github` emits one annotation per violation, so every
+            // finding must be materialized: force `detailed` and lift the
+            // per-rule / per-file caps. Otherwise the summary-mode truncation
+            // would silently drop annotations from the PR check.
+            let github_output = ctx.user_format == crate::output::Format::Github;
+
+            let max_per_rule_eff = if github_output {
+                0 // unlimited
+            } else {
+                max_per_rule.unwrap_or_else(|| ctx.md_lint.max_violations_per_rule())
+            };
             // CLI --limit overrides the config max_files when provided.
-            let max_files_eff = cli_limit.unwrap_or_else(|| ctx.md_lint.max_files());
+            let max_files_eff = if github_output {
+                cli_limit.unwrap_or(usize::MAX)
+            } else {
+                cli_limit.unwrap_or_else(|| ctx.md_lint.max_files())
+            };
 
             let mut ext_opts = lint_commands::ExtLintOptions {
                 fix: fix_mode,
-                detailed,
+                detailed: detailed || github_output,
                 rule_filter: rule.as_deref(),
                 rule_prefix: rule_prefix.as_deref(),
                 max_per_rule: max_per_rule_eff,

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -31,6 +31,10 @@ type JaqFilterCache = HashMap<String, jaq_core::compile::Filter<Native<D>>>;
 pub enum Format {
     Json,
     Text,
+    /// GitHub Actions workflow-command output. Lint-only: emits one
+    /// `::error`/`::warning file=…,line=…,title=…::message` line per violation
+    /// so findings render as inline PR annotations. Non-lint commands reject it.
+    Github,
 }
 
 impl std::fmt::Display for Format {
@@ -38,6 +42,7 @@ impl std::fmt::Display for Format {
         match self {
             Format::Json => f.write_str("json"),
             Format::Text => f.write_str("text"),
+            Format::Github => f.write_str("github"),
         }
     }
 }
@@ -131,7 +136,9 @@ pub(crate) fn sanitize_control_chars(s: &str) -> String {
 #[must_use]
 pub fn format_success(format: Format, value: &serde_json::Value) -> String {
     match format {
-        Format::Json => serde_json::to_string_pretty(value)
+        // `Github` is rendered by the output pipeline (lint-only); if it ever
+        // reaches a generic formatter, fall back to JSON rather than panicking.
+        Format::Json | Format::Github => serde_json::to_string_pretty(value)
             .expect("serializing serde_json::Value is infallible"),
         Format::Text => {
             let mut cache = JaqFilterCache::new();
@@ -203,7 +210,7 @@ pub fn format_envelope(
     hints: &[crate::hints::Hint],
 ) -> String {
     match format {
-        Format::Json => {
+        Format::Json | Format::Github => {
             let envelope = build_envelope_value(value, total, hints);
             serde_json::to_string_pretty(&envelope)
                 .expect("serializing serde_json::Value is infallible")
@@ -247,7 +254,7 @@ pub fn format_prebuilt_envelope(
     results_value: &serde_json::Value,
 ) -> String {
     match format {
-        Format::Json => serde_json::to_string_pretty(envelope)
+        Format::Json | Format::Github => serde_json::to_string_pretty(envelope)
             .expect("serializing serde_json::Value is infallible"),
         Format::Text => {
             let mut cache = JaqFilterCache::new();
@@ -326,7 +333,7 @@ pub fn format_error(
     cause: Option<&str>,
 ) -> String {
     match format {
-        Format::Json => {
+        Format::Json | Format::Github => {
             let mut obj = json!({"error": error});
             if let Some(p) = path {
                 obj["path"] = json!(p);
@@ -372,7 +379,7 @@ pub fn format_budget_error(
 ) -> String {
     let safe_file = sanitize_control_chars(&e.file);
     match format {
-        Format::Json => {
+        Format::Json | Format::Github => {
             let obj = serde_json::json!({
                 "error": "frontmatter would exceed size budget",
                 "limit_bytes": e.limit_bytes,

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -24,6 +24,11 @@ pub(crate) struct OutputPipeline<'a> {
     pub count: bool,
     /// When `--files-from` was used, inject skip counters into the envelope.
     pub files_from_counters: Option<FilesFromCounters>,
+    /// Path prefix for `--format github` annotations: the vault dir expressed
+    /// relative to CWD, prepended to each vault-relative file path so GitHub
+    /// resolves annotations against the repo root. Empty when the vault dir is
+    /// the CWD. Only consulted when `user_format == Format::Github`.
+    pub github_path_prefix: String,
 }
 
 /// Inject `files_missing`, `files_skipped_non_md`, and `files_skipped_outside_vault`
@@ -116,6 +121,18 @@ impl OutputPipeline<'_> {
                         return 2;
                     }
                 };
+
+                // `--format github`: render lint violations as GitHub Actions
+                // workflow commands (inline PR annotations) plus a summary line.
+                // This bypasses the JSON envelope, hints, and jq entirely — those
+                // are rejected for `github` upstream. `github` is lint-only, so
+                // `value` here is always the extended lint payload.
+                if self.user_format == Format::Github {
+                    let rendered =
+                        crate::commands::lint_github::render(&value, &self.github_path_prefix);
+                    println!("{rendered}");
+                    return 0;
+                }
 
                 // Generate hints when a context is available. Pass through
                 // the `--files-from` counters so iter-143's counter-aware

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -50,6 +50,44 @@ fn early_format(
         .unwrap_or_else(|| resolve_format_by_tty(std::io::stdout().is_terminal()))
 }
 
+/// Express the resolved vault `dir` as a path relative to `cwd`, using
+/// forward slashes, for `--format github` annotation prefixing.
+///
+/// GitHub resolves annotation `file=` paths against the workspace (repo) root,
+/// which is assumed to be the CWD. Strategy:
+///
+///   1. If `dir` is already relative (the common case — `.hyalo.toml` sets
+///      `dir = "hyalo-knowledgebase"`), it *is* the CWD-relative prefix; a bare
+///      `.` collapses to the empty prefix.
+///   2. Otherwise, canonicalize both `dir` and `cwd` and strip the CWD prefix.
+///   3. If the vault lies outside the CWD (or canonicalization fails), fall back
+///      to the empty prefix so paths stay vault-relative rather than emitting a
+///      confusing absolute or `../`-laden path.
+fn vault_dir_relative_to_cwd(dir: &std::path::Path, cwd: &std::path::Path) -> String {
+    let to_fwd = |p: &std::path::Path| p.to_string_lossy().replace('\\', "/");
+    let clean = |s: String| -> String {
+        let s = s.strip_prefix("./").unwrap_or(&s).to_owned();
+        let trimmed = s.trim_end_matches('/');
+        if trimmed == "." {
+            String::new()
+        } else {
+            trimmed.to_owned()
+        }
+    };
+
+    if dir.is_relative() {
+        return clean(to_fwd(dir));
+    }
+
+    if let (Ok(dir_abs), Ok(cwd_abs)) = (dunce::canonicalize(dir), dunce::canonicalize(cwd))
+        && let Ok(rel) = dir_abs.strip_prefix(&cwd_abs)
+    {
+        return clean(to_fwd(rel));
+    }
+
+    String::new()
+}
+
 /// Extract the effective index path from whichever subcommand is active.
 ///
 /// Walks the command tree and retrieves `IndexFlags` from the matching arm,
@@ -920,6 +958,49 @@ fn run_inner() -> Result<(), AppError> {
         );
         return Err(AppError::Exit(2));
     }
+    // `--format github` is lint-only: it emits GitHub Actions workflow commands
+    // for lint violations. Reject it for every other subcommand with a clear
+    // message listing the valid formats, so `hyalo find --format github` fails
+    // fast instead of producing meaningless output.
+    if format == Format::Github && !matches!(cli.command, Commands::Lint { .. }) {
+        eprintln!(
+            "{}",
+            crate::output::format_error(
+                Format::Text,
+                "--format github is only supported by `hyalo lint`",
+                None,
+                Some("valid formats for this command are: json, text"),
+                None,
+            )
+        );
+        return Err(AppError::Exit(2));
+    }
+    // `--count` prints a bare integer; it is meaningless alongside the
+    // annotation stream `--format github` produces. Reject the combination.
+    if format == Format::Github && cli.count {
+        eprintln!(
+            "{}",
+            crate::output::format_error(
+                Format::Text,
+                "--count cannot be combined with --format github",
+                None,
+                Some("--format github emits inline annotations; drop --count to see them"),
+                None,
+            )
+        );
+        return Err(AppError::Exit(2));
+    }
+
+    // Compute the annotation path prefix for `--format github`: the vault dir
+    // expressed relative to CWD. GitHub resolves annotation `file=` paths
+    // against the workspace (repo) root, but lint emits vault-relative paths, so
+    // each is prefixed with this. CI is assumed to run from the repo root.
+    let github_path_prefix = if format == Format::Github {
+        vault_dir_relative_to_cwd(&dir, &cwd)
+    } else {
+        String::new()
+    };
+
     // Always force JSON internally so the output pipeline can wrap results in the
     // envelope.  The user-requested format is applied by the pipeline afterwards.
     let effective_format = Format::Json;
@@ -1390,6 +1471,7 @@ fn run_inner() -> Result<(), AppError> {
                     hint_ctx: hint_ctx.as_ref(),
                     count: cli.count,
                     files_from_counters: None,
+                    github_path_prefix: String::new(),
                 };
                 let code = pipeline.finalize(Ok(CommandOutcome::UserError(out)));
                 return if code == 0 {
@@ -1501,6 +1583,7 @@ fn run_inner() -> Result<(), AppError> {
         hint_ctx: hint_ctx.as_ref(),
         count: cli.count,
         files_from_counters: final_files_from_counters,
+        github_path_prefix,
     };
     let code = pipeline.finalize(result);
     // Commands like `lint` may override the exit code even on success output.
@@ -1526,5 +1609,44 @@ mod tests {
     #[test]
     fn resolve_format_by_tty_returns_json_for_pipe() {
         assert_eq!(resolve_format_by_tty(false), Format::Json);
+    }
+
+    /// A relative vault dir is used verbatim as the CWD-relative prefix.
+    #[test]
+    fn vault_prefix_relative_dir_used_verbatim() {
+        let cwd = std::path::Path::new("/repo");
+        assert_eq!(
+            vault_dir_relative_to_cwd(std::path::Path::new("hyalo-knowledgebase"), cwd),
+            "hyalo-knowledgebase"
+        );
+        assert_eq!(
+            vault_dir_relative_to_cwd(std::path::Path::new("sub/kb"), cwd),
+            "sub/kb"
+        );
+        assert_eq!(
+            vault_dir_relative_to_cwd(std::path::Path::new("./kb/"), cwd),
+            "kb"
+        );
+    }
+
+    /// A `.` vault dir (vault == CWD) collapses to an empty prefix.
+    #[test]
+    fn vault_prefix_dot_dir_is_empty() {
+        let cwd = std::path::Path::new("/repo");
+        assert_eq!(
+            vault_dir_relative_to_cwd(std::path::Path::new("."), cwd),
+            ""
+        );
+    }
+
+    /// An absolute vault dir under the CWD is stripped to a relative prefix.
+    #[test]
+    fn vault_prefix_absolute_dir_under_cwd() {
+        let tmp = std::env::temp_dir().join(format!("hyalo-prefix-{}", std::process::id()));
+        let kb = tmp.join("kb");
+        std::fs::create_dir_all(&kb).unwrap();
+        let got = vault_dir_relative_to_cwd(&kb, &tmp);
+        assert_eq!(got, "kb");
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -292,6 +292,12 @@ promotes the "no `type` property" and "undeclared property in frontmatter" warni
 errors, so lint exits non-zero on those cases. Useful in CI and `/hyalo-tidy` to fail
 fast on schema drift.
 
+**GitHub PR annotations:** `hyalo lint --strict --format github` (lint-only) emits
+`::error`/`::warning file=…,line=…,title=<RULE_ID>::<message>` GitHub Actions workflow
+commands so violations render as inline PR annotations, plus a one-line summary. Paths are
+repo-root-relative, so run it from the repository root. Composes with `--files-from -` for a
+diff-aware variant. Other subcommands reject `--format github`.
+
 **Tune which rules run with `hyalo lint-rules`** (list / show / set / remove). Reach for it when a rule is too noisy on your KB style — disable it or change its severity rather than living with the warnings:
 
 ```bash

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -2014,6 +2014,37 @@ Body.
     }
 }
 
+/// `--fix --dry-run --format github` uses the fix-mode payload shape
+/// (`remaining_groups`, not `rule_groups`) — the renderer must still emit
+/// annotations for violations that fix mode can't resolve (a missing required
+/// property isn't autofixable), not silently produce zero annotations.
+#[test]
+fn lint_github_fix_dry_run_emits_remaining_violations() {
+    let tmp = setup_vault_with_schema();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "lint",
+            "--fix",
+            "--dry-run",
+            "--format",
+            "github",
+            "missing_date.md",
+        ])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        stdout.contains("::error file=missing_date.md,"),
+        "expected a remaining-violation annotation under --fix --dry-run; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("missing required property"),
+        "expected the SCHEMA message; got:\n{stdout}"
+    );
+    assert_eq!(output.status.code().unwrap(), 1, "errors -> exit 1");
+}
+
 /// `--format github` is rejected for non-lint subcommands with a clear error.
 #[test]
 fn github_format_rejected_for_non_lint() {

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -1858,3 +1858,179 @@ fn lint_okf_bundle_absolute_links_not_broken() {
         "bundle-absolute link should resolve, not appear broken; stdout: {stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --format github (GitHub Actions annotations)
+// ---------------------------------------------------------------------------
+
+/// A vault with errors + warnings emits `::error`/`::warning` workflow commands
+/// (paths relative to the repo root — here the vault IS the CWD, so no prefix)
+/// plus a summary line, and exits 1.
+#[test]
+fn lint_github_emits_annotations_and_exits_one() {
+    let tmp = setup_vault_with_schema();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "github", "missing_date.md"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap(), 1, "errors -> exit 1");
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    // A missing required property is an error annotation on the right file.
+    assert!(
+        stdout.contains("::error file=missing_date.md,"),
+        "expected error annotation for missing_date.md; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("title=SCHEMA::") && stdout.contains("missing required property"),
+        "expected SCHEMA title + message; got:\n{stdout}"
+    );
+    // Summary line is the last non-empty line.
+    let last = stdout.lines().rfind(|l| !l.is_empty()).unwrap();
+    assert!(
+        last.contains("error") && last.contains("warning") && last.contains(" in "),
+        "expected summary line; got: {last}"
+    );
+}
+
+/// A clean vault under `--format github` prints only the summary line and exits 0.
+#[test]
+fn lint_github_clean_vault_summary_only_exit_zero() {
+    let tmp = setup_vault_with_schema();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "github", "clean.md"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap(), 0, "clean -> exit 0");
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        !stdout.contains("::error") && !stdout.contains("::warning"),
+        "clean vault should have no annotations; got:\n{stdout}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "0 errors, 0 warnings in 0 files",
+        "expected summary-only output"
+    );
+}
+
+/// `--strict` flips the missing-`type` annotation from `::warning` to `::error`.
+#[test]
+fn lint_github_strict_promotes_warning_to_error() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        r#"dir = "."
+
+[schema.default]
+required = ["title"]
+
+[schema.types.note]
+required = ["title"]
+"#,
+    );
+    // A file with `title` but no `type` — triggers the missing-type warning.
+    write_md(
+        tmp.path(),
+        "no_type.md",
+        md!(r"
+---
+title: No Type
+---
+Body.
+"),
+    );
+
+    // Without --strict: missing-type is a warning.
+    let warn_out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "github", "no_type.md"])
+        .output()
+        .unwrap();
+    let warn_stdout = std::str::from_utf8(&warn_out.stdout).unwrap();
+    assert!(
+        warn_stdout.contains("::warning file=no_type.md,"),
+        "expected warning annotation without --strict; got:\n{warn_stdout}"
+    );
+    assert_eq!(warn_out.status.code().unwrap(), 0, "warning-only -> exit 0");
+
+    // With --strict: promoted to an error, exit 1.
+    let strict_out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--strict", "--format", "github", "no_type.md"])
+        .output()
+        .unwrap();
+    let strict_stdout = std::str::from_utf8(&strict_out.stdout).unwrap();
+    assert!(
+        strict_stdout.contains("::error file=no_type.md,"),
+        "expected error annotation with --strict; got:\n{strict_stdout}"
+    );
+    assert_eq!(
+        strict_out.status.code().unwrap(),
+        1,
+        "strict error -> exit 1"
+    );
+}
+
+/// Paths are prefixed with the vault dir relative to CWD when linting from a
+/// parent directory (`--dir sub/kb`), so annotations resolve against the repo root.
+#[test]
+fn lint_github_prefixes_paths_when_dir_below_cwd() {
+    let tmp = TempDir::new().unwrap();
+    let kb = tmp.path().join("kb");
+    std::fs::create_dir_all(&kb).unwrap();
+    write_schema_toml(
+        &kb,
+        r#"[schema.default]
+required = ["title"]
+"#,
+    );
+    write_md(
+        &kb,
+        "bad.md",
+        md!(r"
+---
+title: Bad
+status: nope
+---
+Body.
+"),
+    );
+
+    // Run from the parent (repo root), pointing --dir at the vault subdir.
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--dir", "kb", "--format", "github", "bad.md"])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    // Every annotation path must be prefixed with the vault dir.
+    for line in stdout.lines().filter(|l| l.starts_with("::")) {
+        assert!(
+            line.contains("file=kb/bad.md"),
+            "annotation path should be repo-root-relative (kb/bad.md); got: {line}"
+        );
+    }
+}
+
+/// `--format github` is rejected for non-lint subcommands with a clear error.
+#[test]
+fn github_format_rejected_for_non_lint() {
+    let tmp = setup_vault_with_schema();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--format", "github", "note"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code().unwrap(),
+        2,
+        "non-lint github -> exit 2"
+    );
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        stderr.contains("only supported by `hyalo lint`"),
+        "expected lint-only rejection message; got:\n{stderr}"
+    );
+}

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -721,3 +721,34 @@ the catalog so `lint-rules set OKF-* --enabled false` writes a real override. Pe
 permissive-consumption model every OKF rule is **warn** — SPEC §9 errors come only from the
 schema pass (missing frontmatter / empty-or-missing `type`); broken links, reserved-file
 structure, and citation issues never reject.
+
+## DEC-050: `hyalo lint --format github` for PR Annotations, as a Third Output Format (2026-07-17)
+
+**Decision:** Add `github` to the `--format` value set as a **lint-only** output mode that
+emits one GitHub Actions workflow command per violation
+(`::error file=<path>,line=<line>,title=<RULE_ID>::<message>`, warnings → `::warning`),
+followed by a one-line `N errors, M warnings in K files` summary. Every other subcommand
+rejects `--format github` with a clear message listing the valid formats. Annotation paths
+are emitted **relative to the repository root** — vault-relative paths are prefixed with the
+vault dir's path relative to CWD — so CI must run from the repo root.
+
+**Why:**
+- **No polyglot glue.** Native workflow-command output means findings render as inline PR
+  annotations without a `jq` transform, which the no-polyglot-tooling rule forbids anyway.
+- **Reuses the existing lint payload.** The renderer walks the same
+  `files[].rule_groups[].violations[]` shape the text/json formatters consume; only the
+  presentation differs. `--strict`, `--rule`/`--rule-prefix`, `--limit`, and `[lint] ignore`
+  compose unchanged; exit codes are unchanged.
+- **Lint-only keeps the contract honest.** Workflow commands only make sense for
+  file/line/message findings. Rejecting `github` elsewhere avoids meaningless output and a
+  fake-general format. It is deliberately **not** accepted as a `.hyalo.toml` `format` value.
+
+**Consequences:** Rendering lives in `crates/hyalo-cli/src/commands/lint_github.rs` (escaping
+per the workflow-command spec: `%`→`%25`, `\r`→`%0D`, `\n`→`%0A`; properties also `:`→`%3A`,
+`,`→`%2C`). `--format github` forces `detailed` and lifts the per-rule/per-file caps in
+dispatch so no annotation is silently dropped, and is rejected together with `--count`/`--jq`.
+The repo dogfoods this via a `lint-kb` CI job. Frozen historical trees
+(`iterations/done/**`, `backlog/done/**`, `dogfood-results/**`, `reviews/**`, `research/**`,
+`promotion-plan.md`) are added to `[lint] ignore`, and `HYALO002` is downgraded to **warn**
+in this vault because completed iterations legitimately keep a trailing unchecked
+housekeeping task — so the gate protects the live knowledgebase without churning history.

--- a/hyalo-knowledgebase/iterations/iteration-159-pi-integration.md
+++ b/hyalo-knowledgebase/iterations/iteration-159-pi-integration.md
@@ -8,7 +8,7 @@ tags:
 - integration
 - pi
 status: completed
-branch: pi-integration
+branch: iter-159/pi-integration
 ---
 
 ## Goal

--- a/hyalo-knowledgebase/iterations/iteration-170-lint-github-annotations.md
+++ b/hyalo-knowledgebase/iterations/iteration-170-lint-github-annotations.md
@@ -31,7 +31,7 @@ without jq glue — which would violate the no-polyglot-tooling rule anyway.
 
 ## Tasks
 
-### 1. `--format github` for lint
+### 1. `--format github` for lint [6/6]
 
 - [x] Accept a `github` output format for `hyalo lint` (and `lint --fix --dry-run`), emitting one GitHub Actions workflow command per violation: `::error file=<path>,line=<line>,title=<RULE_ID>::<message>` (warnings → `::warning`)
 - [x] Decide and document scope: `github` is lint-only — other subcommands reject it with a clear error listing valid formats
@@ -40,13 +40,13 @@ without jq glue — which would violate the no-polyglot-tooling rule anyway.
 - [x] `--strict` promotion, `--rule`/`--rule-prefix`, `--limit`, and `[lint] ignore` all compose with the new format unchanged; exit codes unchanged
 - [x] After annotations, print a one-line summary to stdout (`N errors, M warnings in K files`) so the job log stays readable
 
-### 2. Dogfood: lint the knowledgebase in CI
+### 2. Dogfood: lint the knowledgebase in CI [3/3]
 
 - [x] Add a `lint-kb` job to `.github/workflows/ci.yml`: build `hyalo-cli` (or reuse the test job's build cache) and run `hyalo lint --strict --format github` against `hyalo-knowledgebase/`
 - [x] Fix (or explicitly waive via `[lint] ignore` / rule config) any violations the new gate surfaces in the existing KB, in the same PR
 - [x] Job runs on ubuntu only (annotations are platform-independent)
 
-### 3. Tests
+### 3. Tests [5/5]
 
 - [x] Unit: workflow-command escaping (all special chars, multi-line messages)
 - [x] Unit: path prefixing when vault dir ≠ CWD (`--dir sub/kb`), including `.` vault
@@ -54,16 +54,39 @@ without jq glue — which would violate the no-polyglot-tooling rule anyway.
 - [x] e2e: `--strict` flips missing-type/undeclared-property annotations from `::warning` to `::error`
 - [x] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
 
-### 4. Docs sync (same PR)
+### 4. Docs sync (same PR) [4/4]
 
 - [x] README: new "CI / PR checks" section with a copy-paste workflow snippet (checkout → install → `hyalo lint --strict --format github`), incl. the diff-aware `--files-from -` variant
 - [x] Document the reserved-file drift check for OKF vaults in the same snippet: `hyalo okf index` (dry-run by default, non-zero exit on drift — landed in iter-165) as an optional second CI step
 - [x] `hyalo lint --help` documents the `github` format and repo-root path behavior
 - [x] Knowledgebase: record the format decision in the decision log
 
-## Acceptance criteria
+## Acceptance criteria [4/4]
 
 - [x] A GitHub Actions job running `hyalo lint --strict --format github` on a vault with violations fails the check and shows inline annotations on the PR diff at the right file/line
 - [x] Clean vault → green check, no annotations
 - [x] hyalo's own CI lints `hyalo-knowledgebase/` and is green on main
 - [x] No output change for existing `text`/`json` formats
+
+## PR review follow-ups (fixed in this PR)
+
+GitHub Copilot's automated review on PR #198 caught two correctness bugs in the
+`--fix --dry-run --format github` path (explicitly in scope per task 1) that the
+initial e2e coverage didn't reach because it only exercised read-only lint:
+
+- `max_per_rule` sentinel for "unlimited" was `0`, but the fix-mode output
+  builder uses `.take(n)`/`.min(n)` literally — `0` truncated every rule group
+  to zero shown violations. Fixed to `usize::MAX`.
+- `lint_github::render()` only read the read-only `rule_groups` shape; fix-mode
+  payloads use `remaining_groups`, so annotations were silently empty under
+  `--fix`/`--fix --dry-run` even after the fix above. Now renders both shapes.
+- `.hyalo.toml` view-lint findings are config-root-relative, not
+  vault-relative, but were getting the vault-dir prefix applied like every
+  other file entry. Fixed with a literal-name special case.
+- `escape_data` didn't strip non-spec control bytes (e.g. smuggled ANSI
+  escapes); now sanitizes after applying the workflow-command escapes.
+- README CI snippet said `cargo install hyalo`; corrected to `hyalo-cli`
+  (the published crate name).
+
+All five fixes have regression tests (unit + e2e); `cargo fmt` / clippy /
+`cargo test --workspace -q` green after the fix commit.

--- a/hyalo-knowledgebase/iterations/iteration-170-lint-github-annotations.md
+++ b/hyalo-knowledgebase/iterations/iteration-170-lint-github-annotations.md
@@ -7,7 +7,7 @@ tags:
   - lint
   - ci
   - github-actions
-status: planned
+status: completed
 branch: iter-170/lint-github-annotations
 ---
 
@@ -33,37 +33,37 @@ without jq glue — which would violate the no-polyglot-tooling rule anyway.
 
 ### 1. `--format github` for lint
 
-- [ ] Accept a `github` output format for `hyalo lint` (and `lint --fix --dry-run`), emitting one GitHub Actions workflow command per violation: `::error file=<path>,line=<line>,title=<RULE_ID>::<message>` (warnings → `::warning`)
-- [ ] Decide and document scope: `github` is lint-only — other subcommands reject it with a clear error listing valid formats
-- [ ] Emit paths **relative to the repository root** (annotations resolve against the workspace, not the vault dir): prefix vault-relative paths with the vault dir's path relative to CWD; document the assumption that CI runs from the repo root
-- [ ] Escape message data per the workflow-command spec (`%` → `%25`, `\r` → `%0D`, `\n` → `%0A`; in properties also `:` → `%3A`, `,` → `%2C`)
-- [ ] `--strict` promotion, `--rule`/`--rule-prefix`, `--limit`, and `[lint] ignore` all compose with the new format unchanged; exit codes unchanged
-- [ ] After annotations, print a one-line summary to stdout (`N errors, M warnings in K files`) so the job log stays readable
+- [x] Accept a `github` output format for `hyalo lint` (and `lint --fix --dry-run`), emitting one GitHub Actions workflow command per violation: `::error file=<path>,line=<line>,title=<RULE_ID>::<message>` (warnings → `::warning`)
+- [x] Decide and document scope: `github` is lint-only — other subcommands reject it with a clear error listing valid formats
+- [x] Emit paths **relative to the repository root** (annotations resolve against the workspace, not the vault dir): prefix vault-relative paths with the vault dir's path relative to CWD; document the assumption that CI runs from the repo root
+- [x] Escape message data per the workflow-command spec (`%` → `%25`, `\r` → `%0D`, `\n` → `%0A`; in properties also `:` → `%3A`, `,` → `%2C`)
+- [x] `--strict` promotion, `--rule`/`--rule-prefix`, `--limit`, and `[lint] ignore` all compose with the new format unchanged; exit codes unchanged
+- [x] After annotations, print a one-line summary to stdout (`N errors, M warnings in K files`) so the job log stays readable
 
 ### 2. Dogfood: lint the knowledgebase in CI
 
-- [ ] Add a `lint-kb` job to `.github/workflows/ci.yml`: build `hyalo-cli` (or reuse the test job's build cache) and run `hyalo lint --strict --format github` against `hyalo-knowledgebase/`
-- [ ] Fix (or explicitly waive via `[lint] ignore` / rule config) any violations the new gate surfaces in the existing KB, in the same PR
-- [ ] Job runs on ubuntu only (annotations are platform-independent)
+- [x] Add a `lint-kb` job to `.github/workflows/ci.yml`: build `hyalo-cli` (or reuse the test job's build cache) and run `hyalo lint --strict --format github` against `hyalo-knowledgebase/`
+- [x] Fix (or explicitly waive via `[lint] ignore` / rule config) any violations the new gate surfaces in the existing KB, in the same PR
+- [x] Job runs on ubuntu only (annotations are platform-independent)
 
 ### 3. Tests
 
-- [ ] Unit: workflow-command escaping (all special chars, multi-line messages)
-- [ ] Unit: path prefixing when vault dir ≠ CWD (`--dir sub/kb`), including `.` vault
-- [ ] e2e: `lint --format github` on a fixture vault with errors + warnings → exact expected `::error`/`::warning` lines, exit code 1; clean vault → summary only, exit 0
-- [ ] e2e: `--strict` flips missing-type/undeclared-property annotations from `::warning` to `::error`
-- [ ] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
+- [x] Unit: workflow-command escaping (all special chars, multi-line messages)
+- [x] Unit: path prefixing when vault dir ≠ CWD (`--dir sub/kb`), including `.` vault
+- [x] e2e: `lint --format github` on a fixture vault with errors + warnings → exact expected `::error`/`::warning` lines, exit code 1; clean vault → summary only, exit 0
+- [x] e2e: `--strict` flips missing-type/undeclared-property annotations from `::warning` to `::error`
+- [x] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
 
 ### 4. Docs sync (same PR)
 
-- [ ] README: new "CI / PR checks" section with a copy-paste workflow snippet (checkout → install → `hyalo lint --strict --format github`), incl. the diff-aware `--files-from -` variant
-- [ ] Document the reserved-file drift check for OKF vaults in the same snippet: `hyalo okf index` (dry-run by default, non-zero exit on drift — landed in iter-165) as an optional second CI step
-- [ ] `hyalo lint --help` documents the `github` format and repo-root path behavior
-- [ ] Knowledgebase: record the format decision in the decision log
+- [x] README: new "CI / PR checks" section with a copy-paste workflow snippet (checkout → install → `hyalo lint --strict --format github`), incl. the diff-aware `--files-from -` variant
+- [x] Document the reserved-file drift check for OKF vaults in the same snippet: `hyalo okf index` (dry-run by default, non-zero exit on drift — landed in iter-165) as an optional second CI step
+- [x] `hyalo lint --help` documents the `github` format and repo-root path behavior
+- [x] Knowledgebase: record the format decision in the decision log
 
 ## Acceptance criteria
 
-- [ ] A GitHub Actions job running `hyalo lint --strict --format github` on a vault with violations fails the check and shows inline annotations on the PR diff at the right file/line
-- [ ] Clean vault → green check, no annotations
-- [ ] hyalo's own CI lints `hyalo-knowledgebase/` and is green on main
-- [ ] No output change for existing `text`/`json` formats
+- [x] A GitHub Actions job running `hyalo lint --strict --format github` on a vault with violations fails the check and shows inline annotations on the PR diff at the right file/line
+- [x] Clean vault → green check, no annotations
+- [x] hyalo's own CI lints `hyalo-knowledgebase/` and is green on main
+- [x] No output change for existing `text`/`json` formats

--- a/hyalo-knowledgebase/iterations/iteration-171-setup-hyalo-action.md
+++ b/hyalo-knowledgebase/iterations/iteration-171-setup-hyalo-action.md
@@ -53,8 +53,9 @@ versioning and allows a floating `@v1` tag. Skills land in consumer repos via
 ### 3. Consumer recipes (docs, in the hyalo repo)
 
 - [ ] README "CI / PR checks" section (from iter-170) upgraded to use `ractive/setup-hyalo@v1` instead of manual download; full snippet: checkout → setup-hyalo → `hyalo lint --strict --format github`
-- [ ] Diff-aware variant documented: `git diff --name-only origin/main...HEAD -- '*.md' | hyalo lint --files-from - --strict --format github`
+- [ ] Diff-aware variant documented — reuse the exact snippet iter-170 already shipped in the README rather than a fresh one: `git diff --name-only origin/main -- '**/*.md' | hyalo lint --strict --files-from - --format github` (note: **not** `origin/main...HEAD -- '*.md'` — align on the landed syntax so the repo doesn't carry two slightly different diff-aware examples)
 - [ ] Agent recipe documented: `claude-code-action` workflow with a preceding `setup-hyalo` step, `allowed_tools: Bash(hyalo:*)`, and the repo carrying the skill from `hyalo init --claude` — so `@claude` mentions can triage/fix lint findings with `hyalo set` / `lint --fix`
+- [ ] If the agent recipe demonstrates `hyalo lint --fix` (mutating or `--dry-run`) combined with `--format github`, sanity-check against a file with an unfixable violation (e.g. a missing required property) — iter-170's PR review found the fix-mode output path uses a different JSON shape (`remaining_groups`) than read-only lint (`rule_groups`), which the github-format renderer initially missed entirely; that's fixed on main now, but any *new* lint output consumer should assume both shapes exist and test both, not just the read-only path
 - [ ] Convert hyalo's own `lint-kb` CI job (iter-170) to use the published action — end-to-end dogfood of the release artifact path
 
 ### 4. Verification


### PR DESCRIPTION
## Summary
- Add a **lint-only `--format github`** output mode: emits one GitHub Actions workflow command per violation (`::error`/`::warning file=…,line=…,title=<RULE_ID>::<message>`) plus a one-line `N errors, M warnings in K files` summary, so `hyalo lint` findings render as **inline PR annotations** with no `jq` glue. Message/property data is escaped per the workflow-command spec.
- **Repo-root-relative paths**: vault-relative paths are prefixed with the vault dir's path relative to CWD, so annotations resolve against the workspace when CI runs from the repo root. The format is rejected for non-lint subcommands and alongside `--count`/`--jq`; it forces `detailed` and lifts the per-rule/per-file caps so no annotation is silently dropped.
- **Dogfood in CI**: new `lint-kb` job runs `hyalo lint --strict --format github` against `hyalo-knowledgebase/`. To keep the gate meaningful without churning history, frozen archival trees (`iterations/done/**`, `backlog/done/**`, `dogfood-results/**`, `reviews/**`, `research/**`, `promotion-plan.md`) are added to `[lint] ignore`, `HYALO002` is downgraded to warn in this vault (completed iterations keep a trailing housekeeping checkbox), and the one live data error (iteration-159 branch) is fixed. KB now lints clean (0 errors).
- **Docs**: README "GitHub PR annotations" section with copy-paste workflow (incl. `--files-from -` diff-aware variant and the optional `okf index` drift check), `lint --help`, hyalo SKILL, and decision-log DEC-050.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all green
- [x] Unit tests: workflow-command escaping (percent/CR/LF, colon/comma), path prefixing/join, render for error+warning+legacy shapes, clean payload, line-0 omission
- [x] e2e tests: annotations + exit 1 on a vault with errors; summary-only + exit 0 on clean; `--strict` flips warning→error; `--dir sub/kb` path prefixing; non-lint rejection
- [x] xtask gates (check-ac-fidelity / check-feature-fanout / check-help-drift) green
- [x] Release binary lints the KB clean from the repo root (exit 0)## Claims vs code
<generated 2026-07-17T05:28:04Z by ralph-loop>

_No claims extracted from commit messages._