### PR TITLE
docs: setup-hyalo action (staged) + CI/agent recipes (iter-171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,12 @@ Drop this into a workflow to lint your whole vault on every PR. The
 [`setup-hyalo`](https://github.com/ractive/setup-hyalo) action installs the
 prebuilt binary in seconds — no compilation — so the whole check is two steps:
 
+> **Note**: `ractive/setup-hyalo` is not published yet — the snippets below (and
+> in the agent section) show the intended usage once it ships. Until then,
+> install hyalo with one of the [other methods](#installation) (e.g.
+> `cargo install hyalo-cli --locked`, Homebrew, or a release binary) in place of
+> the `setup-hyalo` step.
+
 ```yaml
 # .github/workflows/lint-kb.yml
 name: Lint knowledgebase

--- a/README.md
+++ b/README.md
@@ -470,7 +470,9 @@ one-line `N errors, M warnings in K files` summary is printed at the end so the
 job log stays readable. The lint still exits non-zero on errors, failing the
 check. `--format github` is lint-only; other subcommands reject it.
 
-Drop this into a workflow to lint your whole vault on every PR:
+Drop this into a workflow to lint your whole vault on every PR. The
+[`setup-hyalo`](https://github.com/ractive/setup-hyalo) action installs the
+prebuilt binary in seconds — no compilation — so the whole check is two steps:
 
 ```yaml
 # .github/workflows/lint-kb.yml
@@ -482,13 +484,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Install hyalo (Homebrew, cargo-binstall, or a release binary — see
-      # Installation). The setup-hyalo action is coming in a follow-up.
-      - run: cargo install hyalo-cli --locked
+      - uses: ractive/setup-hyalo@v1          # installs hyalo, adds it to PATH
       # Run from the repo root so annotation paths resolve against the workspace.
       # `.hyalo.toml` sets `dir = "..."`, so `hyalo lint` targets the vault.
       - run: hyalo lint --strict --format github
 ```
+
+Pin the binary with `with: { version: v0.17.0 }`; the default `latest` tracks the
+newest release. If you'd rather not depend on the action, install hyalo any other
+way (Homebrew, `cargo-binstall`, `cargo install hyalo-cli --locked`, or a release
+binary — see [Installation](#installation)) before the lint step.
 
 Paths are emitted **relative to the repository root**: vault-relative paths are
 prefixed with the vault dir's path relative to the current directory, so the job
@@ -514,6 +519,47 @@ non-zero when the on-disk artifacts are stale:
 ```
 
 [GitHub Actions workflow command]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+
+### `@claude` agent on GitHub (claude-code-action)
+
+Because [`setup-hyalo`](https://github.com/ractive/setup-hyalo) puts the binary on
+`PATH` before the agent runs, a [`claude-code-action`](https://github.com/anthropics/claude-code-action)
+workflow can hand `@claude` the full hyalo toolbox — so an `@claude` mention on a
+PR or issue can triage and *fix* lint findings (`hyalo lint --fix`, `hyalo set`,
+`hyalo mv`) rather than just report them. Commit the hyalo skill first with
+`hyalo init --claude` (add `--profile okf` for an OKF bundle) so the agent knows
+to prefer the CLI over raw file edits.
+
+```yaml
+# .github/workflows/claude.yml
+name: claude
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  claude:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ractive/setup-hyalo@v1          # hyalo on PATH before the agent starts
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Let the agent run any hyalo subcommand (lint/find/set/mv/task/...).
+          allowed_tools: Bash(hyalo:*)
+```
+
+The committed skill routes the agent to commands like
+`hyalo lint --strict --format github` (see findings), `hyalo lint --fix`
+(auto-fix the fixable rules), and `hyalo set <file> --property status=done`
+(targeted frontmatter edits). Fix-mode and read-only lint use different JSON
+shapes (`remaining_groups` vs `rule_groups`); `--format github` renders both, so
+`hyalo lint --fix --format github` still annotates any violation left unfixable
+(e.g. a missing required property) after the auto-fix pass.
 
 ### Snapshot index
 

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -752,3 +752,39 @@ The repo dogfoods this via a `lint-kb` CI job. Frozen historical trees
 `promotion-plan.md`) are added to `[lint] ignore`, and `HYALO002` is downgraded to **warn**
 in this vault because completed iterations legitimately keep a trailing unchecked
 housekeeping task — so the gate protects the live knowledgebase without churning history.
+
+## DEC-051: `setup-hyalo` lives in a separate repo with a floating `@v1` tag (2026-07-17)
+
+**Decision:** Ship the install-hyalo GitHub Action as its own repository
+`ractive/setup-hyalo` (composite bash action), **not** as a folder inside the
+hyalo repo, and give it an independent version line: a full `vMAJOR.MINOR.PATCH`
+tag plus a moving `vMAJOR` tag that consumers reference as `ractive/setup-hyalo@v1`.
+
+**Why:** This is the `dtolnay/rust-toolchain` pattern. A separate repo decouples
+action versioning from binary versioning (the hyalo binary can release without
+retagging the action, and vice versa), keeps the action's marketplace/`@v1`
+surface clean, and lets the action be pinned by SHA independently of the
+`version:` input that pins the binary. The action stays pure bash + `curl` (no
+Node/Python — consistent with the no-polyglot rule); it resolves the runner
+platform to a release target, downloads + caches the prebuilt archive, and adds
+the binary to `PATH`. hyalo ships **no** `x86_64-apple-darwin` build, so the
+action fails fast with a clear message on Intel macOS runners (use `macos-14`+ or
+`cargo install`).
+
+**Retag protocol:** cut `vX.Y.Z`, then `git tag -f v1 && git push -f origin v1`;
+only move the floating major for backwards-compatible changes, bump to `v2` on a
+breaking change. When hyalo cuts a release, run the action's `smoke` workflow
+(`workflow_dispatch`, `version:` = new tag) to confirm the new archives install
+on all three OSes — automating this into the hyalo release pipeline is deferred
+(follow the `ractive/release-workflows` change protocol).
+
+**Blocked (2026-07-17):** the automated iteration run could not `gh repo create`
+the public `ractive/setup-hyalo` repo — creating a new public repository requires
+human authorization in the web UI and was denied by the environment's safety
+classifier. The full, platform-verified action tree (`action.yml`, matrix `smoke`
+workflow, fixture vault, MIT `LICENSE`, README) is built and its install logic was
+validated end-to-end on macOS bash 3.2 (latest + pinned + warm-cache + input
+validation). It awaits a human to create the repo and push the tree, after which
+hyalo's own `lint-kb` CI job switches from build-from-source to
+`uses: ractive/setup-hyalo@v1` (deliberately **not** switched now — pointing live
+CI at a not-yet-published action would break every PR check).

--- a/hyalo-knowledgebase/iterations/iteration-171-setup-hyalo-action.md
+++ b/hyalo-knowledgebase/iterations/iteration-171-setup-hyalo-action.md
@@ -7,7 +7,7 @@ tags:
   - ci
   - github-actions
   - distribution
-status: planned
+status: in-progress
 branch: iter-171/setup-hyalo-action
 ---
 
@@ -36,14 +36,14 @@ versioning and allows a floating `@v1` tag. Skills land in consumer repos via
 
 ### 1. `ractive/setup-hyalo` repo (new, separate repo)
 
-- [ ] `action.yml` composite action; inputs: `version` (default `latest`), `github-token` (default `${{ github.token }}`, for release-asset API rate limits)
-- [ ] Resolve runner platform → release asset name: linux/macos x86_64+aarch64 (`.tar.gz`), windows x86_64+aarch64 (`.zip`); fail with a clear error on unsupported platforms
-- [ ] `version: latest` resolves via the GitHub releases API; explicit `version: vX.Y.Z` downloads that tag; validate the input format
-- [ ] Cache the extracted binary in the tool cache keyed by version + platform; add to `GITHUB_PATH`
-- [ ] Implementation stays shell (bash) + `gh`/`curl` inside the composite steps — no Node/Python (consistent with the no-polyglot rule); Windows steps use bash (available on all GitHub-hosted runners)
-- [ ] Output: `version` (resolved version), and a post-install `hyalo --version` sanity step
-- [ ] Smoke-test workflow in the action repo: matrix over ubuntu/macos/windows × `latest`/pinned version → `hyalo --version` + `hyalo lint` on a tiny fixture vault
-- [ ] MIT license, README with usage, pin-by-SHA guidance
+- [x] `action.yml` composite action; inputs: `version` (default `latest`), `github-token` (default `${{ github.token }}`, for release-asset API rate limits)
+- [x] Resolve runner platform → release asset name: linux/macos x86_64+aarch64 (`.tar.gz`), windows x86_64+aarch64 (`.zip`); fail with a clear error on unsupported platforms
+- [x] `version: latest` resolves via the GitHub releases API; explicit `version: vX.Y.Z` downloads that tag; validate the input format
+- [x] Cache the extracted binary in the tool cache keyed by version + platform; add to `GITHUB_PATH`
+- [x] Implementation stays shell (bash) + `gh`/`curl` inside the composite steps — no Node/Python (consistent with the no-polyglot rule); Windows steps use bash (available on all GitHub-hosted runners)
+- [x] Output: `version` (resolved version), and a post-install `hyalo --version` sanity step
+- [x] Smoke-test workflow in the action repo: matrix over ubuntu/macos/windows × `latest`/pinned version → `hyalo --version` + `hyalo lint` on a tiny fixture vault
+- [x] MIT license, README with usage, pin-by-SHA guidance
 
 ### 2. Versioning & release protocol
 
@@ -52,21 +52,54 @@ versioning and allows a floating `@v1` tag. Skills land in consumer repos via
 
 ### 3. Consumer recipes (docs, in the hyalo repo)
 
-- [ ] README "CI / PR checks" section (from iter-170) upgraded to use `ractive/setup-hyalo@v1` instead of manual download; full snippet: checkout → setup-hyalo → `hyalo lint --strict --format github`
-- [ ] Diff-aware variant documented — reuse the exact snippet iter-170 already shipped in the README rather than a fresh one: `git diff --name-only origin/main -- '**/*.md' | hyalo lint --strict --files-from - --format github` (note: **not** `origin/main...HEAD -- '*.md'` — align on the landed syntax so the repo doesn't carry two slightly different diff-aware examples)
-- [ ] Agent recipe documented: `claude-code-action` workflow with a preceding `setup-hyalo` step, `allowed_tools: Bash(hyalo:*)`, and the repo carrying the skill from `hyalo init --claude` — so `@claude` mentions can triage/fix lint findings with `hyalo set` / `lint --fix`
-- [ ] If the agent recipe demonstrates `hyalo lint --fix` (mutating or `--dry-run`) combined with `--format github`, sanity-check against a file with an unfixable violation (e.g. a missing required property) — iter-170's PR review found the fix-mode output path uses a different JSON shape (`remaining_groups`) than read-only lint (`rule_groups`), which the github-format renderer initially missed entirely; that's fixed on main now, but any *new* lint output consumer should assume both shapes exist and test both, not just the read-only path
+- [x] README "CI / PR checks" section (from iter-170) upgraded to use `ractive/setup-hyalo@v1` instead of manual download; full snippet: checkout → setup-hyalo → `hyalo lint --strict --format github`
+- [x] Diff-aware variant documented — reuse the exact snippet iter-170 already shipped in the README rather than a fresh one: `git diff --name-only origin/main -- '**/*.md' | hyalo lint --strict --files-from - --format github` (note: **not** `origin/main...HEAD -- '*.md'` — align on the landed syntax so the repo doesn't carry two slightly different diff-aware examples)
+- [x] Agent recipe documented: `claude-code-action` workflow with a preceding `setup-hyalo` step, `allowed_tools: Bash(hyalo:*)`, and the repo carrying the skill from `hyalo init --claude` — so `@claude` mentions can triage/fix lint findings with `hyalo set` / `lint --fix`
+- [x] If the agent recipe demonstrates `hyalo lint --fix` (mutating or `--dry-run`) combined with `--format github`, sanity-check against a file with an unfixable violation (e.g. a missing required property) — iter-170's PR review found the fix-mode output path uses a different JSON shape (`remaining_groups`) than read-only lint (`rule_groups`), which the github-format renderer initially missed entirely; that's fixed on main now, but any *new* lint output consumer should assume both shapes exist and test both, not just the read-only path
 - [ ] Convert hyalo's own `lint-kb` CI job (iter-170) to use the published action — end-to-end dogfood of the release artifact path
 
 ### 4. Verification
 
 - [ ] Smoke matrix in the action repo green on all three OSes
 - [ ] A real PR in the hyalo repo shows inline lint annotations produced via the action
-- [ ] Knowledgebase: record the separate-repo + floating-tag decision in the decision log
+- [x] Knowledgebase: record the separate-repo + floating-tag decision in the decision log
 
 ## Acceptance criteria
 
 - [ ] `uses: ractive/setup-hyalo@v1` followed by `hyalo lint --strict --format github` is a working two-step PR check on ubuntu, macos, and windows runners
 - [ ] Pinned `version:` input installs exactly that release; `latest` tracks the newest
 - [ ] hyalo's own CI uses the action for its KB lint job
-- [ ] README documents both the PR-check and the claude-code-action recipes
+- [x] README documents both the PR-check and the claude-code-action recipes
+
+## Status (2026-07-17)
+
+**Landed in the hyalo repo (this PR):**
+
+- Full `ractive/setup-hyalo` action tree built and **staged** under
+  `research/setup-hyalo-action/` (see its `PUBLISH.md`): `action.yml` (composite
+  bash, `version` + `github-token` inputs, platform→target resolution, tool-cache
+  keyed by version+platform, `GITHUB_PATH`, `version` output + `hyalo --version`
+  sanity step), matrix `smoke.yml` (ubuntu/macos-14/windows × latest/pinned →
+  `hyalo --version` + `hyalo lint` on a fixture vault), MIT `LICENSE`, README
+  (usage, inputs/outputs, pin-by-SHA, retag protocol, manual release smoke test).
+- Install logic **verified end-to-end on macOS bash 3.2**: `latest` + pinned +
+  warm-cache paths, and version-input rejection. Two portability bugs found and
+  fixed: empty-array expansion under `set -u` (bash 3.2), and a `pipefail` +
+  `grep -m1` broken-pipe abort — both would have broken the action on real
+  runners.
+- README upgraded: "GitHub PR annotations" workflow now uses
+  `ractive/setup-hyalo@v1`; new `@claude` agent recipe (`claude-code-action` +
+  `setup-hyalo` + `allowed_tools: Bash(hyalo:*)`); fix-mode `--format github`
+  behavior verified against an unfixable missing-property violation.
+- Decision recorded: [[decision-log#DEC-051]] (separate repo + floating `@v1`).
+
+**Blocked — needs a human:**
+
+- `gh repo create ractive/setup-hyalo` (public) is denied to the automated run;
+  creating a new public repo requires web-UI authorization. Publish via the steps
+  in `research/setup-hyalo-action/PUBLISH.md`, then tag `v1.0.0` + `v1`.
+- hyalo's own `lint-kb` CI job is **intentionally left on build-from-source** —
+  pointing live CI at the not-yet-published `ractive/setup-hyalo@v1` would break
+  every PR check. Flip it after the action repo is published.
+- Smoke-matrix green + a real annotated PR are verifiable only once the repo is
+  public.

--- a/hyalo-knowledgebase/iterations/iteration-171-setup-hyalo-action.md
+++ b/hyalo-knowledgebase/iterations/iteration-171-setup-hyalo-action.md
@@ -48,7 +48,7 @@ versioning and allows a floating `@v1` tag. Skills land in consumer repos via
 ### 2. Versioning & release protocol
 
 - [ ] Tag `v1` (floating) + `v1.0.0` on the action repo; document the retag protocol in the action README
-- [ ] Decide + document whether the hyalo release pipeline should smoke-test `setup-hyalo` with each new release (follow the ractive/release-workflows change protocol from the KB); no automation required this iteration — a documented manual step is enough
+- [x] Decide + document whether the hyalo release pipeline should smoke-test `setup-hyalo` with each new release (follow the ractive/release-workflows change protocol from the KB); no automation required this iteration — a documented manual step is enough
 
 ### 3. Consumer recipes (docs, in the hyalo repo)
 

--- a/hyalo-knowledgebase/research/setup-hyalo-action/.github/workflows/smoke.yml
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/.github/workflows/smoke.yml
@@ -1,0 +1,41 @@
+name: smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-14 is arm64 (aarch64-apple-darwin) — the only macOS target hyalo ships.
+        os: [ubuntu-latest, macos-14, windows-latest]
+        version: [latest, v0.17.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install hyalo via setup-hyalo
+        id: hyalo
+        uses: ./
+        with:
+          version: ${{ matrix.version }}
+
+      - name: hyalo --version
+        shell: bash
+        run: hyalo --version
+
+      - name: Report resolved version
+        shell: bash
+        run: echo "resolved=${{ steps.hyalo.outputs.version }}"
+
+      - name: Lint the fixture vault
+        shell: bash
+        working-directory: test/fixture-vault
+        run: hyalo lint --strict --format github

--- a/hyalo-knowledgebase/research/setup-hyalo-action/.github/workflows/smoke.yml
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/.github/workflows/smoke.yml
@@ -33,7 +33,12 @@ jobs:
 
       - name: Report resolved version
         shell: bash
-        run: echo "resolved=${{ steps.hyalo.outputs.version }}"
+        env:
+          # Pass through env, not direct ${{ }} interpolation into the script
+          # body — keeps the smoke workflow free of injection surfaces even
+          # though the action validates the tag format.
+          RESOLVED: ${{ steps.hyalo.outputs.version }}
+        run: echo "resolved=$RESOLVED"
 
       - name: Lint the fixture vault
         shell: bash

--- a/hyalo-knowledgebase/research/setup-hyalo-action/.gitignore
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.swp
+*~

--- a/hyalo-knowledgebase/research/setup-hyalo-action/LICENSE
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hyalo-knowledgebase/research/setup-hyalo-action/PUBLISH.md
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/PUBLISH.md
@@ -1,0 +1,26 @@
+# Staged `ractive/setup-hyalo` repo
+
+This directory is the **complete, ready-to-push tree** for the standalone
+`ractive/setup-hyalo` GitHub Action (see [[decision-log#DEC-051]] and
+[[iterations/iteration-171-setup-hyalo-action]]).
+
+It lives under `research/` (a lint-ignored path) because the automated iteration
+run was **not permitted to create a new public GitHub repository** — that action
+requires human authorization in the web UI.
+
+## To publish
+
+```sh
+cd hyalo-knowledgebase/research/setup-hyalo-action
+git init && git add -A && git commit -m "feat: setup-hyalo composite action"
+gh repo create ractive/setup-hyalo --public --source=. --push
+git tag v1.0.0 && git tag v1
+git push origin v1.0.0 && git push origin v1
+```
+
+Then flip hyalo's own `.github/workflows/ci.yml` `lint-kb` job from
+build-from-source to `uses: ractive/setup-hyalo@v1` and run the action's `smoke`
+workflow to confirm the matrix is green on ubuntu/macos/windows.
+
+The install logic in `action.yml` was validated end-to-end on macOS bash 3.2
+(latest + pinned + warm-cache paths, and input-format rejection).

--- a/hyalo-knowledgebase/research/setup-hyalo-action/PUBLISH.md
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/PUBLISH.md
@@ -12,15 +12,22 @@ requires human authorization in the web UI.
 
 ```sh
 cd hyalo-knowledgebase/research/setup-hyalo-action
-git init && git add -A && git commit -m "feat: setup-hyalo composite action"
+git init && git add -A
+git status   # review: only the staged action files, no .DS_Store/editor droppings
+git commit -m "feat: setup-hyalo composite action"
 gh repo create ractive/setup-hyalo --public --source=. --push
 git tag v1.0.0 && git tag v1
 git push origin v1.0.0 && git push origin v1
 ```
 
-Then flip hyalo's own `.github/workflows/ci.yml` `lint-kb` job from
-build-from-source to `uses: ractive/setup-hyalo@v1` and run the action's `smoke`
-workflow to confirm the matrix is green on ubuntu/macos/windows.
+Then, **in this order**:
+
+1. Wait for the action repo's `smoke` workflow to go green on all three OSes
+   (ubuntu / macos-14 / windows). The Windows unzip path has only been exercised
+   in CI — it was not part of the local end-to-end verification — so do not skip
+   the matrix.
+2. Only after the matrix is green, flip hyalo's own `.github/workflows/ci.yml`
+   `lint-kb` job from build-from-source to `uses: ractive/setup-hyalo@v1`.
 
 The install logic in `action.yml` was validated end-to-end on macOS bash 3.2
 (latest + pinned + warm-cache paths, and input-format rejection).

--- a/hyalo-knowledgebase/research/setup-hyalo-action/README.md
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/README.md
@@ -1,0 +1,105 @@
+# setup-hyalo
+
+A composite GitHub Action that installs the prebuilt [`hyalo`](https://github.com/ractive/hyalo)
+CLI on a runner in seconds and puts it on `PATH`. Use it to add a `hyalo lint`
+PR check to any repository — or to give a [`claude-code-action`](https://github.com/anthropics/claude-code-action)
+agent the `hyalo` binary so it can query and fix your markdown knowledgebase.
+
+No compilation, no Node/Python — the action is pure `bash` + `curl` and downloads
+a release archive that already matches the runner platform.
+
+## Usage
+
+```yaml
+name: Lint knowledgebase
+on:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ractive/setup-hyalo@v1
+      - run: hyalo lint --strict --format github
+```
+
+`--format github` renders each violation as an inline annotation on the PR diff.
+The lint exits non-zero on errors, so the check fails when your vault has schema
+or markdown violations.
+
+## Inputs
+
+| Input          | Default                | Description                                                                 |
+| -------------- | ---------------------- | --------------------------------------------------------------------------- |
+| `version`      | `latest`               | Release to install. `latest` tracks the newest release; pin a tag like `v0.17.0`. |
+| `github-token` | `${{ github.token }}`  | Token for the release-asset API (raises the anonymous rate limit).          |
+
+## Outputs
+
+| Output    | Description                                                     |
+| --------- | ------------------------------------------------------------- |
+| `version` | The resolved version tag that was installed (e.g. `v0.17.0`). |
+
+```yaml
+      - uses: ractive/setup-hyalo@v1
+        id: hyalo
+        with:
+          version: v0.17.0
+      - run: echo "installed ${{ steps.hyalo.outputs.version }}"
+```
+
+## Supported runners
+
+| OS      | Architecture      | Release target                | Notes                                    |
+| ------- | ----------------- | ----------------------------- | ---------------------------------------- |
+| Linux   | x86_64 / aarch64  | `*-unknown-linux-gnu`         | `ubuntu-latest`, arm runners             |
+| macOS   | aarch64 (arm64)   | `aarch64-apple-darwin`        | `macos-14`+; x86_64 macOS is unsupported |
+| Windows | x86_64 / aarch64  | `*-pc-windows-msvc` (`.zip`)  | steps run in `bash` (preinstalled)       |
+
+hyalo does not publish an x86_64 macOS binary. On an Intel macOS runner the
+action fails with a clear message — use an arm64 runner (`macos-14` or newer) or
+`cargo install hyalo-cli` instead.
+
+## Caching
+
+The extracted binary is cached under `RUNNER_TOOL_CACHE`, keyed by version +
+platform. Repeat runs on the same version skip the download.
+
+## Pinning
+
+For a floating major tag, `@v1` gives you the latest compatible action. To pin
+exactly, reference a full commit SHA:
+
+```yaml
+      - uses: ractive/setup-hyalo@<full-sha>  # v1.0.0
+```
+
+Pinning the **action** (`@v1` / SHA) is independent of pinning the **binary**
+(`version:` input). Pin both for fully reproducible CI.
+
+## Versioning & release protocol
+
+- The action is versioned independently of the hyalo binary (the
+  `dtolnay/rust-toolchain` pattern), so the binary can release without retagging
+  the action.
+- Releases carry a full `vMAJOR.MINOR.PATCH` tag **and** a moving `vMAJOR` tag.
+- To cut a release: tag `vX.Y.Z`, then move the floating major tag to it:
+
+  ```sh
+  git tag v1.0.0
+  git tag -f v1
+  git push origin v1.0.0
+  git push -f origin v1
+  ```
+
+- Only retag the floating major tag for backwards-compatible changes; a breaking
+  change bumps the major tag (`v2`).
+- **hyalo release smoke test (manual):** when hyalo cuts a new release, run this
+  action's `smoke` workflow (`workflow_dispatch`) with `version:` set to the new
+  tag to confirm the new archive installs on all three OSes before announcing it.
+  Automating this into the hyalo release pipeline is deferred — see the
+  `ractive/release-workflows` change protocol.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/hyalo-knowledgebase/research/setup-hyalo-action/action.yml
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/action.yml
@@ -90,6 +90,14 @@ runs:
             echo "::error::setup-hyalo: could not resolve the latest release tag from the GitHub API"
             exit 1
           fi
+          # The API-resolved tag feeds paths, the download URL, and GITHUB_OUTPUT
+          # (which callers may interpolate into scripts) — hold it to the same
+          # format as the explicit input, so a malformed/spoofed API response
+          # can't smuggle path traversal or shell metacharacters downstream.
+          if ! printf '%s' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::setup-hyalo: latest release tag '$version' does not look like a version tag (vX.Y.Z)"
+            exit 1
+          fi
         else
           version="$INPUT_VERSION"
         fi
@@ -104,15 +112,36 @@ runs:
           url="https://github.com/${REPO}/releases/download/${version}/${asset}"
           echo "setup-hyalo: downloading ${url}"
           tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
           curl -fsSL ${auth[@]+"${auth[@]}"} -o "${tmp}/${asset}" "$url" \
             || { echo "::error::setup-hyalo: download failed for ${asset} (does release ${version} publish target ${target}?)"; exit 1; }
-          mkdir -p "$cache_root"
+
+          # ---- verify the archive against the release's SHA256SUMS ----------
+          curl -fsSL ${auth[@]+"${auth[@]}"} -o "${tmp}/SHA256SUMS" \
+            "https://github.com/${REPO}/releases/download/${version}/SHA256SUMS" \
+            || { echo "::error::setup-hyalo: release ${version} publishes no SHA256SUMS — refusing to install an unverified archive"; exit 1; }
+          if command -v sha256sum >/dev/null 2>&1; then
+            actual="$(sha256sum "${tmp}/${asset}" | awk '{print $1}')"
+          else
+            actual="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"
+          fi
+          expected="$(awk -v a="$asset" '$2 == a || $2 == "*"a {print $1; exit}' "${tmp}/SHA256SUMS")"
+          if [ -z "$expected" ]; then
+            echo "::error::setup-hyalo: SHA256SUMS for ${version} has no entry for ${asset}"
+            exit 1
+          fi
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::setup-hyalo: checksum mismatch for ${asset} (expected ${expected}, got ${actual})"
+            exit 1
+          fi
+          echo "setup-hyalo: sha256 verified (${actual})"
+
+          mkdir -p -m 0755 "$cache_root"
           if [ "$ext" = "zip" ]; then
             unzip -q -o "${tmp}/${asset}" -d "$cache_root"
           else
             tar -xzf "${tmp}/${asset}" -C "$cache_root"
           fi
-          rm -rf "$tmp"
           if [ ! -x "${cache_root}/${bin}" ]; then
             chmod +x "${cache_root}/${bin}" 2>/dev/null || true
           fi

--- a/hyalo-knowledgebase/research/setup-hyalo-action/action.yml
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/action.yml
@@ -1,0 +1,131 @@
+name: setup-hyalo
+description: Install the prebuilt hyalo CLI (markdown knowledgebase linter/query tool) on the runner and add it to PATH.
+author: ractive
+branding:
+  icon: check-circle
+  color: blue
+
+inputs:
+  version:
+    description: >-
+      hyalo release to install. Use "latest" (default) to track the newest
+      release, or an explicit tag like "v0.17.0" to pin.
+    required: false
+    default: latest
+  github-token:
+    description: >-
+      Token used for GitHub release-asset API calls (raises the anonymous rate
+      limit). Defaults to the workflow token.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  version:
+    description: The resolved hyalo version tag that was installed (e.g. v0.17.0).
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        REPO: ractive/hyalo
+      run: |
+        set -euo pipefail
+
+        # ---- validate the version input -------------------------------------
+        if [ "$INPUT_VERSION" != "latest" ] && ! printf '%s' "$INPUT_VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::setup-hyalo: invalid 'version' input '$INPUT_VERSION' — expected 'latest' or a tag like 'v1.2.3'"
+          exit 1
+        fi
+
+        # ---- detect runner platform → release target ------------------------
+        os="$(uname -s)"
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64|amd64)   arch=x86_64 ;;
+          aarch64|arm64)  arch=aarch64 ;;
+          *) echo "::error::setup-hyalo: unsupported CPU architecture '$arch'"; exit 1 ;;
+        esac
+
+        ext=tar.gz
+        bin=hyalo
+        case "$os" in
+          Linux)
+            # Release ships gnu and musl linux builds; gnu is the safe default on hosted runners.
+            target="${arch}-unknown-linux-gnu" ;;
+          Darwin)
+            if [ "$arch" != "aarch64" ]; then
+              echo "::error::setup-hyalo: no prebuilt macOS binary for '$arch' — hyalo publishes aarch64-apple-darwin only. Use an arm64 macOS runner (macos-14 or newer) or 'cargo install hyalo-cli'."
+              exit 1
+            fi
+            target="aarch64-apple-darwin" ;;
+          MINGW*|MSYS*|CYGWIN*|Windows_NT)
+            target="${arch}-pc-windows-msvc"
+            ext=zip
+            bin=hyalo.exe ;;
+          *) echo "::error::setup-hyalo: unsupported OS '$os'"; exit 1 ;;
+        esac
+        echo "setup-hyalo: runner detected as ${os}/${arch} -> target ${target}"
+
+        # ---- resolve the version tag ----------------------------------------
+        api="https://api.github.com/repos/${REPO}"
+        # Bash 3.2 (macOS runners) errors on "${arr[@]}" for an empty array under
+        # `set -u`, so guard every expansion with the "${arr[@]+...}" idiom.
+        auth=()
+        if [ -n "${GH_TOKEN:-}" ]; then
+          auth=(-H "Authorization: Bearer ${GH_TOKEN}")
+        fi
+
+        if [ "$INPUT_VERSION" = "latest" ]; then
+          # Fetch to a variable first: piping curl into `grep -m1` closes the pipe
+          # early, and under `pipefail` curl's write error (exit 23) would abort
+          # the step. Parse the buffered body instead.
+          release_json="$(curl -fsSL ${auth[@]+"${auth[@]}"} -H "Accept: application/vnd.github+json" "${api}/releases/latest")"
+          version="$(printf '%s' "$release_json" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name" *: *"([^"]+)".*/\1/')"
+          if [ -z "$version" ]; then
+            echo "::error::setup-hyalo: could not resolve the latest release tag from the GitHub API"
+            exit 1
+          fi
+        else
+          version="$INPUT_VERSION"
+        fi
+        echo "setup-hyalo: installing ${REPO} ${version}"
+
+        # ---- tool cache -----------------------------------------------------
+        cache_root="${RUNNER_TOOL_CACHE:-${HOME}/.cache}/hyalo/${version}/${target}"
+        if [ -x "${cache_root}/${bin}" ]; then
+          echo "setup-hyalo: cache hit at ${cache_root}"
+        else
+          asset="hyalo-${version}-${target}.${ext}"
+          url="https://github.com/${REPO}/releases/download/${version}/${asset}"
+          echo "setup-hyalo: downloading ${url}"
+          tmp="$(mktemp -d)"
+          curl -fsSL ${auth[@]+"${auth[@]}"} -o "${tmp}/${asset}" "$url" \
+            || { echo "::error::setup-hyalo: download failed for ${asset} (does release ${version} publish target ${target}?)"; exit 1; }
+          mkdir -p "$cache_root"
+          if [ "$ext" = "zip" ]; then
+            unzip -q -o "${tmp}/${asset}" -d "$cache_root"
+          else
+            tar -xzf "${tmp}/${asset}" -C "$cache_root"
+          fi
+          rm -rf "$tmp"
+          if [ ! -x "${cache_root}/${bin}" ]; then
+            chmod +x "${cache_root}/${bin}" 2>/dev/null || true
+          fi
+          if [ ! -e "${cache_root}/${bin}" ]; then
+            echo "::error::setup-hyalo: extracted archive did not contain '${bin}'"
+            exit 1
+          fi
+        fi
+
+        # ---- expose on PATH + outputs ---------------------------------------
+        echo "$cache_root" >> "$GITHUB_PATH"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Verify hyalo runs
+      shell: bash
+      run: hyalo --version

--- a/hyalo-knowledgebase/research/setup-hyalo-action/test/fixture-vault/.hyalo.toml
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/test/fixture-vault/.hyalo.toml
@@ -1,0 +1,6 @@
+# Tiny fixture vault used by the smoke workflow to prove `hyalo lint` runs
+# end-to-end after the action installs the binary.
+dir = "."
+
+[schema.types.note]
+required = ["title", "type"]

--- a/hyalo-knowledgebase/research/setup-hyalo-action/test/fixture-vault/hello.md
+++ b/hyalo-knowledgebase/research/setup-hyalo-action/test/fixture-vault/hello.md
@@ -1,0 +1,8 @@
+---
+title: Hello
+type: note
+---
+
+# Hello
+
+A tiny valid note so `hyalo lint --strict` exits zero in the smoke test.


### PR DESCRIPTION
## Summary

- Builds and **stages** the standalone `ractive/setup-hyalo` composite GitHub Action under `hyalo-knowledgebase/research/setup-hyalo-action/`: `action.yml` (bash-only; `version`/`github-token` inputs, platform→release-target resolution, tool-cache keyed by version+platform, `GITHUB_PATH`, `version` output + `hyalo --version` sanity step), matrix `smoke.yml` (ubuntu/macos-14/windows × latest/pinned → lint a fixture vault), MIT `LICENSE`, README (usage, inputs/outputs, pin-by-SHA, retag protocol, manual release smoke test).
- README recipes: the GitHub PR-annotations workflow now uses `ractive/setup-hyalo@v1`; a new `@claude` agent recipe wires `claude-code-action` + `setup-hyalo` + `allowed_tools: Bash(hyalo:*)`.
- Records `DEC-051` (separate repo + floating `@v1`, `dtolnay/rust-toolchain` pattern).
- **No Rust changes** — docs + a bash action tree.

## Blocked (needs a human)

- `gh repo create ractive/setup-hyalo` (public) was denied to the automated run — creating a new public repo requires web-UI authorization. Push steps are in `research/setup-hyalo-action/PUBLISH.md`.
- hyalo's own `lint-kb` CI job is **intentionally left on build-from-source**; flip it to `uses: ractive/setup-hyalo@v1` only after the action repo is published (pointing live CI at a nonexistent action would break every PR).

## Test plan

- Action install logic validated end-to-end on macOS bash 3.2: `latest` + pinned + warm-cache paths + version-input rejection. Two portability bugs found and fixed (empty-array under `set -u`; `pipefail` + `grep -m1` broken pipe).
- `action.yml` and `smoke.yml` YAML validated.
- `hyalo lint --fix --dry-run --format github` confirmed to annotate an unfixable missing-property violation and exit non-zero.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` all green.
- `xtask check-help-drift` + `check-ac-fidelity` green; KB `hyalo lint --strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)