### PR TITLE
feat(profiles): smart-merge composition, profiles list, bind=typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The `okf` profile merges a declarative config fragment into `.hyalo.toml`:
 - `validate_on_write = true` — authoring stays conformant.
 - Seed `[schema.types.*]` for common OKF concept types with recommended `# Schema`/`# Citations` sections.
 
-Profiles are **composable** and **idempotent**: multiple `--profile` runs coexist in one vault (the fragment is deep-merged, upserting only its own keys), and re-running never clobbers other config. With `--claude`, the bundled `okf` skill teaches Claude the OKF concept model, reserved-file rules, link forms, and the exact hyalo commands — hyalo owns the deterministic frontmatter/link mechanics while the LLM does the semantic work.
+Profiles are **composable** and **idempotent**: multiple `--profile` runs coexist in one vault. The fragment is deep-merged, and array config keys **union** rather than clobber — each profile's `[schema] exempt` globs, `[[schema.bind]]` entries, `[schema.default] required` fields, and `[lint] profiles` markers all accumulate, so a later `init --profile` never shrinks an earlier one's config or your hand-added entries. Hand-written comments and key order survive the merge, re-running is byte-idempotent, and when a profile overwrites a differing **scalar** value it prints a `conflict: <key> "<old>" -> "<new>"` line to stderr — nothing is lost silently. With `--claude`, the bundled `okf` skill teaches Claude the OKF concept model, reserved-file rules, link forms, and the exact hyalo commands — hyalo owns the deterministic frontmatter/link mechanics while the LLM does the semantic work.
 
 ### Reserved-file generators (`okf index` / `okf log`)
 
@@ -203,7 +203,7 @@ The profile honours OKF's **permissive-consumption** model — *warn, don't reje
 
 Advisory citation rules make the `# Citations` convention first-class: `OKF-CITATIONS-PRESENT` (a claim-bearing concept should cite), `OKF-CITATIONS-WELL-FORMED` (entries are links — both numbered `1.` and `-` bullet lists accepted), and `OKF-CITATIONS-RESOLVE` (bundle-relative / `references/…` links resolve on disk; external `http(s)` URLs are surfaced but not network-checked). Each OKF rule is individually toggleable with `hyalo lint-rules set OKF-… --enabled false` and appears in `hyalo lint-rules list`.
 
-Because the overlay reuses the init fragment, a vault created with `hyalo init --profile okf` (which records `[lint] profile = "okf"`) runs the same rules under a plain `hyalo lint` — `--profile okf` on such a vault is a no-op.
+Because the overlay reuses the init fragment, a vault created with `hyalo init --profile okf` (which records `[lint] profiles = ["okf"]`) runs the same rules under a plain `hyalo lint` — `--profile okf` on such a vault is a no-op.
 
 ## MADR profile — Architecture Decision Records
 
@@ -216,7 +216,7 @@ hyalo init --profile madr --claude   # also install the bundled `madr` skill
 
 The `madr` profile is **pure data over the same machinery as `okf`**, plus two generic mechanisms it is the first consumer of:
 
-- **Path-bound schemas (`[[schema.bind]]`)** — the `adr` type is bound to `docs/decisions/**/*.md`, so the schema applies to *that subtree only*, inside any larger vault. Files there need no explicit `type: adr` frontmatter; the binding supplies it (explicit frontmatter always wins, and a `type:` that disagrees with the binding warns). Bindings are ordered and first-match-wins.
+- **Path-bound schemas (`[[schema.bind]]`)** — the `adr` type is bound to `docs/decisions/**/*.md`, so the schema applies to *that subtree only*, inside any larger vault. Files there need no explicit `type: adr` frontmatter; the binding supplies it (explicit frontmatter always wins, and a `type:` that disagrees with the binding warns). **Bind = typing:** a bound file satisfies a `required = ["type"]` gate through its binding, so a spec-valid frontmatter-less `SKILL.md`, MADR ADR, or `CHANGELOG.md` lints clean without a hand-written `type:` key (its type-specific required properties are still enforced). Bindings are ordered and first-match-wins.
 - **Zero-padded filename tokens (`{n:04}`)** — the `adr` `filename-template` is `docs/decisions/{n:04}-{slug}.md`, producing `0007-use-postgres.md`. The pad width is a rendering minimum, so `1-x.md` and `0002-x.md` are both still recognized as ADRs.
 
 The `adr` type keeps MADR's light frontmatter (`status`, `date`, `decision-makers`/`consulted`/`informed` — the 3.x `deciders` spelling is accepted as an alias) optional-but-typed, and requires the MADR-4 short-template sections `## Context and Problem Statement`, `## Considered Options`, `## Decision Outcome`.

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -822,8 +822,11 @@ Repeatable (AND).\n\
             With --claude, also installs the hyalo skill for Claude Code.\n\
             With --pi, also installs the hyalo skill for pi.\n\
             With --profile <name>, scaffolds a preset vault flavour by merging an\n\
-            embedded config fragment into .hyalo.toml (available: okf, madr, skills).\n\
-            Multiple profiles compose in one vault; re-running upserts without clobbering.\n\
+            embedded config fragment into .hyalo.toml (available: okf, madr, skills,\n\
+            changelog). Multiple profiles compose in one vault: array keys (exempt,\n\
+            binds, [lint] profiles) union instead of clobbering, comments survive, and\n\
+            re-running is idempotent. A changed scalar prints a `conflict:` line to\n\
+            stderr — nothing is lost silently.\n\
             With --profile <name> --claude, also installs the bundled skill for it.\n\n\
             Use the global --dir flag to specify the markdown directory to record in .hyalo.toml.\n\n\
             EXAMPLES:\n\
@@ -1084,8 +1087,11 @@ Repeatable (AND).\n\
             (error), and warns — never rejects — on reserved-file (`index.md`/`log.md`) structure,\n\
             broken cross-links, missing/malformed `# Citations`, and augmentation regressions.\n\
             The overlay reuses the same fragment `hyalo init --profile okf` materializes, so on a\n\
-            vault already initialized that way plain `hyalo lint` behaves identically. Unknown\n\
-            `type` values and extra frontmatter keys are always accepted (permissive model).\n\
+            vault already initialized that way plain `hyalo lint` behaves identically. When the\n\
+            vault's `.hyalo.toml` already activates profiles via `[lint] profiles`, a `--profile`\n\
+            flag *composes* with them (adds, never replaces) and honors user `[schema] exempt`\n\
+            additions exactly like file activation. Unknown `type` values and extra frontmatter\n\
+            keys are always accepted (permissive model).\n\
             `--profile madr` binds an `adr` schema to `docs/decisions/**` and warns on dangling\n\
             supersedes / duplicate ADR numbers. `--profile skills` binds a `skill` schema to\n\
             `**/SKILL.md` (Agent Skills spec): it errors on `name` regex/length/reserved-word\n\

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -103,23 +103,17 @@ fn run_init_in(
     } else {
         let toml_content = if toml_existed {
             // Read and parse the existing file; update only the `dir` key so
-            // that other user config (format, hints, site_prefix …) is preserved.
-            // If the file is malformed, fall back to overwriting with just `dir`.
+            // that other user config (format, hints, site_prefix …) — and any
+            // hand-written comments / key order — are preserved. Editing via
+            // `toml_edit::DocumentMut` keeps decor intact, which matters for
+            // idempotency when a profile merge (also comment-preserving) runs
+            // next. If the file is malformed, fall back to overwriting with
+            // just `dir`.
             let existing_raw = fs::read_to_string(&toml_path)
                 .with_context(|| format!("failed to read {}", toml_path.display()))?;
-            if let Ok(mut table) = toml::from_str::<toml::Table>(&existing_raw) {
-                table.insert("dir".to_owned(), TomlValue::String(dir_value.clone()));
-                // Serialise back; toml::to_string always produces valid TOML.
-                if let Ok(s) = toml::to_string(&table) {
-                    s
-                } else {
-                    writeln!(
-                        summary,
-                        "warning  .hyalo.toml was malformed; existing content replaced"
-                    )
-                    .unwrap();
-                    minimal_toml_dir(&dir_value)
-                }
+            if let Ok(mut doc) = existing_raw.parse::<toml_edit::DocumentMut>() {
+                doc["dir"] = toml_edit::value(dir_value.clone());
+                doc.to_string()
             } else {
                 // Malformed existing file — overwrite with just dir and note it.
                 writeln!(
@@ -148,11 +142,18 @@ fn run_init_in(
     if let Some(profile) = profile {
         let existing_raw = fs::read_to_string(&toml_path)
             .with_context(|| format!("failed to read {}", toml_path.display()))?;
-        let merged =
-            crate::commands::profiles::merge_into_config(&existing_raw, profile.toml_fragment)
-                .with_context(|| format!("failed to apply profile '{}'", profile.name))?;
+        let (merged, conflicts) = crate::commands::profiles::merge_into_config_with_conflicts(
+            &existing_raw,
+            profile.toml_fragment,
+        )
+        .with_context(|| format!("failed to apply profile '{}'", profile.name))?;
         fs::write(&toml_path, &merged)
             .with_context(|| format!("failed to write {}", toml_path.display()))?;
+        // Surface any scalar value the profile overwrote so nothing changes
+        // silently. Arrays never shrink (they union), so only scalars conflict.
+        for conflict in &conflicts {
+            crate::warn::warn(conflict.line(profile.name));
+        }
         writeln!(
             summary,
             "updated  .hyalo.toml  (merged '{}' profile)",

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -946,7 +946,16 @@ fn validate_properties(
         .as_deref()
         .map(|t| format!(" (type: {t})"))
         .unwrap_or_default();
+    // Bind = typing: when a file's type is assigned by a `[schema.bind]` path
+    // binding (no explicit `type:` frontmatter), the binding itself satisfies a
+    // `required = ["type"]` gate — a spec-valid frontmatter-less bound file
+    // (SKILL.md, ADR, CHANGELOG.md) must lint clean. Skip only the `type`
+    // requirement in that case; every other required property is still checked.
+    let type_satisfied_by_bind = doc_type.is_none() && bound_type.is_some();
     for req in &effective_schema.required {
+        if type_satisfied_by_bind && req == "type" {
+            continue;
+        }
         match properties.get(req.as_str()) {
             None => {
                 violations.push(Violation {
@@ -2136,11 +2145,14 @@ fn lint_one_file_extended(
             .iter()
             .any(|v| v.kind == Some(VIOLATION_KIND_MISSING_TYPE));
         // Exempt / reserved files are bound to no schema, so `--strict` must
-        // not inject a missing-`type` error for them either.
+        // not inject a missing-`type` error for them either. A path-bound file
+        // (bind = typing) is fully typed by its binding, so it is likewise
+        // exempt from the missing-`type` injection.
         if strict
             && !already_has_missing_type
             && !properties.contains_key("type")
             && !schema.exempt.is_exempt(rel_path)
+            && schema.bound_type_for(rel_path).is_none()
         {
             fm_violations.push(Violation {
                 severity: Severity::Warn,
@@ -3148,6 +3160,109 @@ mod tests {
                 .violations
                 .iter()
                 .any(|v| v.severity == Severity::Warn && v.message.contains("no 'type' property"))
+        );
+    }
+
+    /// Build a `SchemaConfig` from a TOML `[schema]` fragment (as it would
+    /// appear in `.hyalo.toml`), for tests that exercise bind = typing.
+    fn schema_from_toml(fragment: &str) -> SchemaConfig {
+        let val: toml::Value = toml::from_str(fragment).expect("valid schema fragment");
+        let raw: hyalo_core::schema::RawSchemaConfig = val
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .expect("schema section present");
+        SchemaConfig::try_from(raw).expect("valid schema")
+    }
+
+    #[test]
+    fn bind_typed_frontmatterless_file_satisfies_required_type() {
+        // iter-172 bind = typing: a file whose type comes from a `[schema.bind]`
+        // path binding must satisfy `[schema.default] required = ["type"]`
+        // WITHOUT explicit `type:` frontmatter — a spec-valid frontmatter-less
+        // SKILL.md / ADR must lint clean under composed profiles.
+        let schema = schema_from_toml(
+            "\
+[schema.default]
+required = [\"type\"]
+
+[schema.types.skill]
+required = [\"name\", \"description\"]
+
+[[schema.bind]]
+glob = \"**/SKILL.md\"
+type = \"skill\"
+",
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("SKILL.md");
+        // A skill with the two required fields but NO explicit `type:`.
+        std::fs::write(
+            &path,
+            "---\nname: my-skill\ndescription: does a thing\n---\nBody\n",
+        )
+        .unwrap();
+
+        let result = lint_file(&path, "foo/SKILL.md", &schema).unwrap();
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| v.message.contains("missing required property \"type\"")),
+            "bound file must not require explicit type: {:?}",
+            result.violations
+        );
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| v.message.contains("no 'type' property")),
+            "bound file must not warn about missing type: {:?}",
+            result.violations
+        );
+        // The skill's OWN required props are still enforced (both present here),
+        // so the file is clean.
+        assert!(
+            result
+                .violations
+                .iter()
+                .all(|v| v.severity != Severity::Error),
+            "frontmatter-less bound skill lints clean: {:?}",
+            result.violations
+        );
+    }
+
+    #[test]
+    fn bind_typed_file_still_enforces_type_specific_required() {
+        // Bind = typing drops only the `type` requirement; a bound file missing
+        // its type's OWN required property still errors.
+        let schema = schema_from_toml(
+            "\
+[schema.default]
+required = [\"type\"]
+
+[schema.types.skill]
+required = [\"name\", \"description\"]
+
+[[schema.bind]]
+glob = \"**/SKILL.md\"
+type = \"skill\"
+",
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("SKILL.md");
+        // Missing `description` (a skill-required field).
+        std::fs::write(&path, "---\nname: my-skill\n---\nBody\n").unwrap();
+
+        let result = lint_file(&path, "foo/SKILL.md", &schema).unwrap();
+        assert!(
+            result
+                .violations
+                .iter()
+                .any(|v| v.severity == Severity::Error
+                    && v.message
+                        .contains("missing required property \"description\"")),
+            "type-specific required still enforced: {:?}",
+            result.violations
         );
     }
 

--- a/crates/hyalo-cli/src/commands/profiles.rs
+++ b/crates/hyalo-cli/src/commands/profiles.rs
@@ -17,7 +17,7 @@
 //! matter of adding another [`Profile`] entry, not new branches.
 
 use anyhow::{Context, Result};
-use toml::Value as TomlValue;
+use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, Value};
 
 /// The OKF `.hyalo.toml` fragment, embedded at compile time.
 const OKF_PROFILE_TOML: &str = include_str!("../../templates/profile-okf.toml");
@@ -104,48 +104,214 @@ pub fn lookup(name: &str) -> Result<&'static Profile> {
     })
 }
 
-/// Deep-merge the profile's TOML fragment into an existing (or empty) config
-/// table and return the serialised result.
-///
-/// Merge semantics (upsert, never clobber other profiles' config):
-/// - Tables are merged recursively.
-/// - Scalars/arrays from the profile fragment *overwrite* the existing value at
-///   that key — a profile owns its own keys, so re-running it refreshes them,
-///   but keys it does not touch (e.g. another profile's `[schema.types.*]`) are
-///   preserved.
-///
-/// `existing_raw` is the current `.hyalo.toml` contents (may be empty). Returns
-/// the merged TOML string ready to write back.
-pub fn merge_into_config(existing_raw: &str, fragment: &str) -> Result<String> {
-    let mut base: toml::Table = if existing_raw.trim().is_empty() {
-        toml::Table::new()
-    } else {
-        toml::from_str(existing_raw)
-            .context("existing .hyalo.toml is not valid TOML; refusing to merge profile into it")?
-    };
-    let overlay: toml::Table =
-        toml::from_str(fragment).context("embedded profile TOML fragment is not valid TOML")?;
-
-    for (key, value) in overlay {
-        merge_value(&mut base, key, value);
-    }
-
-    toml::to_string(&base).context("failed to serialise merged .hyalo.toml")
+/// A scalar key whose value changed when a profile fragment overwrote it during
+/// a merge. Surfaced so callers can print a `conflict:` line to stderr — no
+/// value is ever silently dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Conflict {
+    /// Dotted key path (e.g. `site_prefix`, `schema.default.required`).
+    pub key: String,
+    /// The previous value's TOML rendering.
+    pub old: String,
+    /// The new value's TOML rendering (from the profile fragment).
+    pub new: String,
 }
 
-/// Insert `value` at `key` in `table`, recursively merging when both sides are
-/// tables.
-fn merge_value(table: &mut toml::Table, key: String, value: TomlValue) {
-    match (table.get_mut(&key), value) {
-        (Some(TomlValue::Table(existing)), TomlValue::Table(overlay)) => {
-            for (k, v) in overlay {
-                merge_value(existing, k, v);
-            }
+impl Conflict {
+    /// The stderr line for this conflict, e.g.
+    /// `conflict: site_prefix "" -> "docs" (profile okf)`.
+    #[must_use]
+    pub fn line(&self, profile_name: &str) -> String {
+        format!(
+            "conflict: {} {} -> {} (profile {profile_name})",
+            self.key, self.old, self.new
+        )
+    }
+}
+
+/// Array-valued keys (identified by dotted path) whose entries *union* on merge
+/// instead of being replaced, so composing profiles never shrinks a list a
+/// previous profile (or the user by hand) contributed. Order is stable:
+/// existing entries first, new ones appended.
+const UNION_ARRAY_KEYS: &[&str] = &[
+    "schema.exempt",
+    "lint.ignore",
+    "schema.default.required",
+    "lint.profiles",
+];
+
+/// Deep-merge the profile's TOML fragment into an existing (or empty) config
+/// document and return the serialised result, discarding any scalar conflicts.
+///
+/// Prefer [`merge_into_config_with_conflicts`] when the caller wants to surface
+/// changed-scalar warnings. See that function for the full merge semantics.
+pub fn merge_into_config(existing_raw: &str, fragment: &str) -> Result<String> {
+    Ok(merge_into_config_with_conflicts(existing_raw, fragment)?.0)
+}
+
+/// Deep-merge the profile's TOML fragment into an existing (or empty) config
+/// document, returning `(merged_toml, conflicts)`.
+///
+/// Merge semantics (upsert, never clobber other profiles' config):
+/// - Tables are merged recursively; hand-written comments and key order in the
+///   existing document survive (the merge runs on a `toml_edit::DocumentMut`).
+/// - Array keys in [`UNION_ARRAY_KEYS`] **union**: existing entries are kept in
+///   order and new fragment entries appended (deduplicated by value).
+/// - `[[schema.bind]]` array-of-tables entries union, deduplicated by
+///   `(glob, type)`, preserving declaration order (first-match-wins).
+/// - Other scalars/arrays from the fragment *overwrite* the existing value — a
+///   profile owns its own keys, so re-running refreshes them. When an overwrite
+///   *changes* an existing differing value, a [`Conflict`] is recorded so the
+///   caller can warn; nothing is dropped silently.
+///
+/// `existing_raw` is the current `.hyalo.toml` contents (may be empty).
+pub fn merge_into_config_with_conflicts(
+    existing_raw: &str,
+    fragment: &str,
+) -> Result<(String, Vec<Conflict>)> {
+    let mut base: DocumentMut = if existing_raw.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        existing_raw
+            .parse::<DocumentMut>()
+            .context("existing .hyalo.toml is not valid TOML; refusing to merge profile into it")?
+    };
+    let overlay: DocumentMut = fragment
+        .parse::<DocumentMut>()
+        .context("embedded profile TOML fragment is not valid TOML")?;
+
+    let mut conflicts = Vec::new();
+    merge_table(base.as_table_mut(), overlay.as_table(), "", &mut conflicts);
+
+    Ok((base.to_string(), conflicts))
+}
+
+/// Recursively merge `overlay` into `base`. `path` is the dotted key prefix of
+/// `base` (empty at the root) used to classify union-array keys and to build
+/// conflict key paths.
+fn merge_table(base: &mut Table, overlay: &Table, path: &str, conflicts: &mut Vec<Conflict>) {
+    for (key, overlay_item) in overlay {
+        let child_path = if path.is_empty() {
+            key.to_owned()
+        } else {
+            format!("{path}.{key}")
+        };
+        merge_item(base, key, overlay_item, &child_path, conflicts);
+    }
+}
+
+/// Merge a single `overlay_item` into `base` at `key` (whose full dotted path is
+/// `child_path`).
+fn merge_item(
+    base: &mut Table,
+    key: &str,
+    overlay_item: &Item,
+    child_path: &str,
+    conflicts: &mut Vec<Conflict>,
+) {
+    match (base.get_mut(key), overlay_item) {
+        // Both sides are tables — recurse.
+        (Some(Item::Table(base_tbl)), Item::Table(overlay_tbl)) => {
+            merge_table(base_tbl, overlay_tbl, child_path, conflicts);
         }
-        (_, value) => {
-            table.insert(key, value);
+        // Both sides are array-of-tables (`[[schema.bind]]`) — union with dedup.
+        (Some(Item::ArrayOfTables(base_aot)), Item::ArrayOfTables(overlay_aot)) => {
+            union_array_of_tables(base_aot, overlay_aot);
+        }
+        // Both sides are inline arrays and this is a union key — union entries.
+        (Some(Item::Value(Value::Array(base_arr))), Item::Value(Value::Array(overlay_arr)))
+            if UNION_ARRAY_KEYS.contains(&child_path) =>
+        {
+            union_array(base_arr, overlay_arr);
+        }
+        // Existing scalar/array replaced by the fragment's value.
+        (Some(existing), _) => {
+            // When both sides are scalar values and they are already equal,
+            // leave the existing item untouched — replacing it would reset the
+            // key's decor (comments/blank lines), breaking idempotency and
+            // comment preservation on re-run.
+            if let (Item::Value(old_val), Item::Value(new_val)) = (&*existing, overlay_item)
+                && values_equal(old_val, new_val)
+            {
+                return;
+            }
+            // Record a conflict when a scalar value actually changes (arrays are
+            // handled by the union arm above or are profile-owned, so we don't
+            // diff them). Nothing is dropped silently.
+            if let (Item::Value(old_val), Item::Value(new_val)) = (&*existing, overlay_item)
+                && old_val.as_array().is_none()
+                && new_val.as_array().is_none()
+            {
+                conflicts.push(Conflict {
+                    key: child_path.to_owned(),
+                    old: render_value(old_val),
+                    new: render_value(new_val),
+                });
+            }
+            base.insert(key, overlay_item.clone());
+        }
+        // Key absent in base — insert as-is.
+        (None, _) => {
+            base.insert(key, overlay_item.clone());
         }
     }
+}
+
+/// Union `overlay` array entries into `base`, appending only entries not already
+/// present (compared by rendered value), preserving existing order.
+fn union_array(base: &mut Array, overlay: &Array) {
+    for item in overlay {
+        let already = base.iter().any(|existing| values_equal(existing, item));
+        if !already {
+            base.push_formatted(item.clone());
+        }
+    }
+    // Re-space the array so multi-entry unions render one-per-line consistently
+    // rather than inheriting a mix of the two sources' whitespace.
+    base.fmt();
+}
+
+/// Union `[[schema.bind]]` tables, deduplicating by `(glob, type)` and keeping
+/// existing declaration order (first-match-wins), appending only new entries.
+fn union_array_of_tables(base: &mut ArrayOfTables, overlay: &ArrayOfTables) {
+    for tbl in overlay {
+        let key = bind_key(tbl);
+        let already = base.iter().any(|existing| bind_key(existing) == key);
+        if !already {
+            base.push(tbl.clone());
+        }
+    }
+}
+
+/// Identity of a `[[schema.bind]]` table for dedup: `(glob, type)`.
+fn bind_key(tbl: &Table) -> (String, String) {
+    let glob = tbl
+        .get("glob")
+        .and_then(Item::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let ty = tbl
+        .get("type")
+        .and_then(Item::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    (glob, ty)
+}
+
+/// Compare two `toml_edit` values for semantic equality by rendered form. This
+/// ignores decor (whitespace/comments), which is exactly what we want for
+/// dedup and conflict detection.
+fn values_equal(a: &Value, b: &Value) -> bool {
+    render_value(a) == render_value(b)
+}
+
+/// Render a `toml_edit` value to its trimmed TOML form (decor stripped) for
+/// display and comparison.
+fn render_value(v: &Value) -> String {
+    // `Value`'s Display includes leading/trailing decor; a clone with default
+    // decor renders just the value token(s).
+    let cleaned = v.clone().decorated("", "");
+    cleaned.to_string().trim().to_owned()
 }
 
 #[cfg(test)]
@@ -337,6 +503,210 @@ required = [\"type\", \"status\"]
         assert!(types.contains_key("changelog"));
         assert!(types.contains_key("adr"));
         assert!(types.contains_key("BigQuery Table"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // iter-172: smart-merge composition semantics
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn four_profile_stack_unions_all_binds_and_exempt() {
+        // RB-1 reconciliation: composing okf+madr+skills+changelog into one
+        // vault must keep EVERY bind and the UNIONED exempt list — no profile's
+        // contributions may be clobbered by a later one.
+        let a = merge_into_config("", OKF_PROFILE_TOML).unwrap();
+        let b = merge_into_config(&a, MADR_PROFILE_TOML).unwrap();
+        let c = merge_into_config(&b, SKILLS_PROFILE_TOML).unwrap();
+        let d = merge_into_config(&c, CHANGELOG_PROFILE_TOML).unwrap();
+
+        let val: toml::Value = toml::from_str(&d).unwrap();
+        let raw: hyalo_core::schema::RawSchemaConfig = val
+            .get("schema")
+            .and_then(|v| v.clone().try_into().ok())
+            .expect("schema section present");
+        let cfg = hyalo_core::schema::SchemaConfig::try_from(raw).expect("valid composed schema");
+
+        // Every profile's bind survives and resolves.
+        assert_eq!(
+            cfg.bound_type_for("docs/decisions/0001-x.md"),
+            Some("adr"),
+            "madr bind survives the stack"
+        );
+        assert_eq!(
+            cfg.bound_type_for("CHANGELOG.md"),
+            Some("changelog"),
+            "changelog literal bind survives the stack"
+        );
+        // The skills profile binds SKILL.md files.
+        assert!(
+            cfg.bound_type_for(".claude/skills/foo/SKILL.md").is_some(),
+            "skills bind survives the stack"
+        );
+
+        // Unioned exempt: OKF's `**/index.md` and changelog's CHANGELOG.md both
+        // present, and none dropped.
+        assert!(cfg.exempt.is_exempt("bundle/index.md"), "OKF exempt kept");
+        assert!(
+            cfg.exempt.is_exempt("CHANGELOG.md"),
+            "changelog exempt kept"
+        );
+
+        // The active-profiles list unions all four.
+        let profiles = val["lint"]["profiles"].as_array().unwrap();
+        let names: Vec<&str> = profiles.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"okf"), "okf active: {names:?}");
+        assert!(names.contains(&"madr"), "madr active: {names:?}");
+        assert!(names.contains(&"skills"), "skills active: {names:?}");
+        assert!(names.contains(&"changelog"), "changelog active: {names:?}");
+    }
+
+    #[test]
+    fn exempt_array_unions_with_user_additions() {
+        // A user hand-adds an exempt glob; applying OKF must keep it AND add the
+        // OKF entries — arrays never shrink.
+        let existing = "\
+[schema]
+exempt = [\"my/private/**\"]
+";
+        let merged = merge_into_config(existing, OKF_PROFILE_TOML).unwrap();
+        let val: toml::Value = toml::from_str(&merged).unwrap();
+        let exempt: Vec<&str> = val["schema"]["exempt"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(
+            exempt.contains(&"my/private/**"),
+            "user entry kept: {exempt:?}"
+        );
+        assert!(
+            exempt.contains(&"**/index.md"),
+            "okf entry added: {exempt:?}"
+        );
+        assert!(exempt.contains(&"**/log.md"), "okf entry added: {exempt:?}");
+    }
+
+    #[test]
+    fn required_array_unions_user_and_profile() {
+        // `[schema.default] required`: user `["title", "type"]` + okf `["type"]`
+        // → both survive, no duplicate `type`.
+        let existing = "\
+[schema.default]
+required = [\"title\", \"type\"]
+";
+        let merged = merge_into_config(existing, OKF_PROFILE_TOML).unwrap();
+        let val: toml::Value = toml::from_str(&merged).unwrap();
+        let required: Vec<&str> = val["schema"]["default"]["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(
+            required,
+            vec!["title", "type"],
+            "user order preserved, no duplicate type: {required:?}"
+        );
+    }
+
+    #[test]
+    fn bind_entries_dedup_by_glob_and_type() {
+        // Re-applying MADR must not duplicate its bind entry.
+        let once = merge_into_config("", MADR_PROFILE_TOML).unwrap();
+        let twice = merge_into_config(&once, MADR_PROFILE_TOML).unwrap();
+        let val: toml::Value = toml::from_str(&twice).unwrap();
+        let binds = val["schema"]["bind"].as_array().unwrap();
+        let madr_binds = binds
+            .iter()
+            .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("adr"))
+            .count();
+        assert_eq!(madr_binds, 1, "bind deduped by (glob, type)");
+    }
+
+    #[test]
+    fn merge_preserves_hand_written_comments_and_order() {
+        let existing = "\
+# my hand-written header comment
+dir = \"vault\"
+
+# a note about site_prefix
+site_prefix = \"custom\"
+";
+        let merged = merge_into_config(existing, MADR_PROFILE_TOML).unwrap();
+        assert!(
+            merged.contains("# my hand-written header comment"),
+            "header comment survived: {merged}"
+        );
+        assert!(
+            merged.contains("# a note about site_prefix"),
+            "inline note survived: {merged}"
+        );
+        // `dir` still precedes the appended profile content (existing order kept).
+        let dir_pos = merged.find("dir = \"vault\"").unwrap();
+        let madr_pos = merged.find("[[schema.bind]]").unwrap();
+        assert!(dir_pos < madr_pos, "existing keys precede appended profile");
+    }
+
+    #[test]
+    fn scalar_conflict_is_reported_not_silent() {
+        // OKF sets site_prefix = ""; an existing differing value is a conflict.
+        let existing = "site_prefix = \"custom\"\n";
+        let (merged, conflicts) =
+            merge_into_config_with_conflicts(existing, OKF_PROFILE_TOML).unwrap();
+        assert_eq!(conflicts.len(), 1, "one scalar conflict: {conflicts:?}");
+        let c = &conflicts[0];
+        assert_eq!(c.key, "site_prefix");
+        assert_eq!(c.old, "\"custom\"");
+        assert_eq!(c.new, "\"\"");
+        assert_eq!(
+            c.line("okf"),
+            "conflict: site_prefix \"custom\" -> \"\" (profile okf)"
+        );
+        // The new value did win (profile owns its key).
+        let val: toml::Value = toml::from_str(&merged).unwrap();
+        assert_eq!(val["site_prefix"].as_str(), Some(""));
+    }
+
+    #[test]
+    fn no_conflict_when_scalar_unchanged() {
+        // Re-applying a profile is conflict-free (idempotent).
+        let once = merge_into_config("", OKF_PROFILE_TOML).unwrap();
+        let (_twice, conflicts) =
+            merge_into_config_with_conflicts(&once, OKF_PROFILE_TOML).unwrap();
+        assert!(
+            conflicts.is_empty(),
+            "idempotent re-run has no conflicts: {conflicts:?}"
+        );
+    }
+
+    #[test]
+    fn array_change_is_not_reported_as_conflict() {
+        // Union arrays never conflict — they grow, they don't clobber.
+        let existing = "\
+[schema]
+exempt = [\"user/only.md\"]
+";
+        let (_merged, conflicts) =
+            merge_into_config_with_conflicts(existing, OKF_PROFILE_TOML).unwrap();
+        assert!(
+            conflicts.iter().all(|c| c.key != "schema.exempt"),
+            "array union is not a conflict: {conflicts:?}"
+        );
+    }
+
+    #[test]
+    fn four_profile_stack_is_idempotent() {
+        // Re-running the whole stack yields byte-identical config.
+        let build = |base: &str| {
+            let a = merge_into_config(base, OKF_PROFILE_TOML).unwrap();
+            let b = merge_into_config(&a, MADR_PROFILE_TOML).unwrap();
+            let c = merge_into_config(&b, SKILLS_PROFILE_TOML).unwrap();
+            merge_into_config(&c, CHANGELOG_PROFILE_TOML).unwrap()
+        };
+        let once = build("");
+        let twice = build(&once);
+        assert_eq!(once, twice, "re-running the full stack is byte-idempotent");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -60,13 +60,34 @@ struct LintConfig {
     /// `hyalo lint --strict`.
     #[serde(default)]
     strict: bool,
-    /// Active conformance profile materialized into this config (e.g. `"okf"`),
-    /// written by `hyalo init --profile <name>`. When set, `hyalo lint` runs
-    /// that profile's advisory rules without needing `--profile` on the CLI —
-    /// so plain `hyalo lint` on an initialized vault behaves identically to
-    /// `hyalo lint --profile <name>` (idempotent overlay).
+    /// Active conformance profiles materialized into this config (e.g.
+    /// `["okf", "madr"]`), written by `hyalo init --profile <name>`. When set,
+    /// plain `hyalo lint` runs *every* listed profile's advisory rules without
+    /// needing `--profile` on the CLI — so an initialized vault behaves
+    /// identically to `hyalo lint --profile <name>` for each active profile
+    /// (idempotent overlay). Multiple profiles compose here.
+    #[serde(default)]
+    profiles: Vec<String>,
+    /// Deprecated single-profile alias for [`LintConfig::profiles`]. Accepted as
+    /// a one-element compat form: `profile = "okf"` behaves like
+    /// `profiles = ["okf"]`. `hyalo init --profile` now writes `profiles`.
     #[serde(default)]
     profile: Option<String>,
+}
+
+impl LintConfig {
+    /// The effective list of active conformance profiles: the `profiles` list
+    /// plus the deprecated singular `profile` alias (appended if not already
+    /// present), preserving order.
+    fn active_profiles(&self) -> Vec<String> {
+        let mut out = self.profiles.clone();
+        if let Some(single) = &self.profile
+            && !out.iter().any(|p| p == single)
+        {
+            out.push(single.clone());
+        }
+        out
+    }
 }
 
 /// Raw deserialized representation of `.hyalo.toml`.
@@ -152,10 +173,12 @@ pub(crate) struct ResolvedDefaults {
     /// `false` when the file was missing, unreadable, or malformed (in which
     /// case all other fields are hardcoded defaults).
     pub(crate) loaded_from_file: bool,
-    /// Active conformance profile from `[lint] profile` in `.hyalo.toml`
-    /// (e.g. `Some("okf")`). Enables that profile's advisory lint rules for
-    /// plain `hyalo lint`, matching the ephemeral `--profile` overlay.
-    pub(crate) lint_profile: Option<String>,
+    /// Active conformance profiles from `[lint] profiles` (or the deprecated
+    /// `[lint] profile` alias) in `.hyalo.toml` (e.g. `["okf", "madr"]`).
+    /// Enables every listed profile's advisory lint rules for plain
+    /// `hyalo lint`, matching the ephemeral `--profile` overlay. Multiple
+    /// profiles compose.
+    pub(crate) lint_profiles: Vec<String>,
 }
 
 impl PartialEq for ResolvedDefaults {
@@ -194,7 +217,7 @@ impl ResolvedDefaults {
             case_insensitive_mode: CaseInsensitiveMode::Auto,
             lint_strict: false,
             loaded_from_file: false,
-            lint_profile: None,
+            lint_profiles: Vec::new(),
         }
     }
 
@@ -346,7 +369,19 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     };
 
     let lint_strict = cfg.lint.as_ref().is_some_and(|l| l.strict);
-    let lint_profile = cfg.lint.as_ref().and_then(|l| l.profile.clone());
+    // Deprecation: the singular `[lint] profile = "..."` is a compat alias for
+    // the `profiles` list. Warn so vaults migrate, but keep honoring it.
+    if cfg.lint.as_ref().is_some_and(|l| l.profile.is_some()) {
+        crate::warn::warn(
+            "deprecated: '[lint] profile' in .hyalo.toml — use the list form \
+             'profiles = [\"<name>\"]' (multiple profiles compose)",
+        );
+    }
+    let lint_profiles = cfg
+        .lint
+        .as_ref()
+        .map(LintConfig::active_profiles)
+        .unwrap_or_default();
 
     ResolvedDefaults {
         dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
@@ -368,7 +403,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         case_insensitive_mode,
         lint_strict,
         loaded_from_file: true,
-        lint_profile,
+        lint_profiles,
     }
 }
 
@@ -486,10 +521,11 @@ pub(crate) struct ProfileOverlay {
     pub(crate) md_lint: hyalo_mdlint::LintConfig,
     pub(crate) validate_on_write: bool,
     pub(crate) lint_strict: bool,
-    /// Active profile marker from the merged `[lint] profile` key (the fragment
-    /// itself sets it), so the overlay enables the profile's advisory rules
-    /// even on a vault with no `.hyalo.toml` on disk.
-    pub(crate) lint_profile: Option<String>,
+    /// Active profile markers from the merged `[lint] profiles` list (the
+    /// fragment itself contributes its name), so the overlay enables every
+    /// active profile's advisory rules even on a vault with no `.hyalo.toml` on
+    /// disk. The requested `--profile <name>` is always present.
+    pub(crate) lint_profiles: Vec<String>,
 }
 
 /// Build a [`ProfileOverlay`] by merging the named profile's fragment into the
@@ -530,21 +566,25 @@ pub(crate) fn overlay_profile(
     let schema = parse_schema_from_toml(cfg.schema.as_ref());
     let md_lint = parse_md_lint_config(cfg.lint.as_ref());
     let lint_strict = cfg.lint.as_ref().is_some_and(|l| l.strict);
-    // The fragment sets `[lint] profile`; fall back to the requested name so the
-    // overlay always advertises an active profile even if a future fragment
-    // omits the key.
-    let lint_profile = cfg
+    // The fragment contributes its name to `[lint] profiles`; ensure the
+    // requested `--profile <name>` is always present even if a future fragment
+    // omits the key. The union preserves any profiles the on-disk config
+    // already activated (composed overlay).
+    let mut lint_profiles = cfg
         .lint
         .as_ref()
-        .and_then(|l| l.profile.clone())
-        .or_else(|| Some(profile_name.to_owned()));
+        .map(LintConfig::active_profiles)
+        .unwrap_or_default();
+    if !lint_profiles.iter().any(|p| p == profile_name) {
+        lint_profiles.push(profile_name.to_owned());
+    }
 
     Ok(ProfileOverlay {
         schema,
         md_lint,
         validate_on_write,
         lint_strict,
-        lint_profile,
+        lint_profiles,
     })
 }
 
@@ -917,6 +957,133 @@ site_prefix = "docs"
         assert!(
             warned,
             "expected a warning for invalid case_insensitive value"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // iter-172: [lint] profiles list + compat alias
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn lint_profiles_list_loaded() {
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[lint]\nprofiles = [\"okf\", \"madr\"]\n",
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(
+            resolved.lint_profiles,
+            vec!["okf".to_owned(), "madr".to_owned()],
+            "both listed profiles active"
+        );
+    }
+
+    #[test]
+    fn lint_profile_singular_is_compat_alias() {
+        // The deprecated `profile = "okf"` maps to a one-element list.
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[lint]\nprofile = \"okf\"\n",
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(resolved.lint_profiles, vec!["okf".to_owned()]);
+    }
+
+    #[test]
+    fn lint_profile_singular_emits_deprecation_warning() {
+        let _guard = crate::warn::WARN_TEST_LOCK.lock().unwrap();
+        crate::warn::reset_for_test();
+        crate::warn::init(false);
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[lint]\nprofile = \"okf\"\n",
+        )
+        .unwrap();
+
+        let _ = load_config_from(dir.path());
+        assert!(
+            crate::warn::any_tracked_starts_with("deprecated: '[lint] profile'"),
+            "singular profile alias should warn"
+        );
+    }
+
+    #[test]
+    fn lint_profiles_and_alias_union_without_duplicates() {
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[lint]\nprofiles = [\"okf\"]\nprofile = \"okf\"\n",
+        )
+        .unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert_eq!(
+            resolved.lint_profiles,
+            vec!["okf".to_owned()],
+            "duplicate alias is not appended twice"
+        );
+    }
+
+    #[test]
+    fn lint_profiles_empty_by_default() {
+        let dir = make_temp();
+        fs::write(dir.path().join(".hyalo.toml"), "dir = \"notes\"\n").unwrap();
+
+        let resolved = load_config_from(dir.path());
+        assert!(resolved.lint_profiles.is_empty());
+    }
+
+    #[test]
+    fn overlay_profile_composes_with_file_activated_profiles() {
+        // A `--profile skills` overlay on a vault whose `.hyalo.toml` already
+        // activates okf must yield BOTH profiles active (composed, not
+        // replaced) — this is the flag-vs-file parity the plan requires.
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[lint]\nprofiles = [\"okf\"]\n[schema]\nexempt = [\"**/index.md\"]\n",
+        )
+        .unwrap();
+
+        let overlay = overlay_profile(dir.path(), "skills").expect("skills overlay");
+        assert!(
+            overlay.lint_profiles.contains(&"okf".to_owned()),
+            "file-activated okf survives the overlay: {:?}",
+            overlay.lint_profiles
+        );
+        assert!(
+            overlay.lint_profiles.contains(&"skills".to_owned()),
+            "requested skills is active: {:?}",
+            overlay.lint_profiles
+        );
+    }
+
+    #[test]
+    fn overlay_profile_honors_user_exempt_additions() {
+        // mapl BUG-6: a `--profile` overlay must honor user `[schema] exempt`
+        // additions exactly like the file path does (union, not clobber).
+        let dir = make_temp();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "[schema]\nexempt = [\"my/private/**\"]\n",
+        )
+        .unwrap();
+
+        let overlay = overlay_profile(dir.path(), "okf").expect("okf overlay");
+        assert!(
+            overlay.schema.exempt.is_exempt("my/private/secret.md"),
+            "user exempt addition honored by the --profile overlay"
+        );
+        assert!(
+            overlay.schema.exempt.is_exempt("bundle/index.md"),
+            "okf exempt also active"
         );
     }
 

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -174,10 +174,11 @@ pub(crate) struct CommandContext<'a> {
     /// When `true`, "no 'type' property" and "undeclared property" warnings are
     /// promoted to errors, and lint exits non-zero on them.
     pub lint_strict: bool,
-    /// Active conformance profile (e.g. `Some("okf")`) from `[lint] profile` in
-    /// `.hyalo.toml` or an explicit `hyalo lint --profile`. Enables that
-    /// profile's advisory lint rules.
-    pub lint_profile: Option<String>,
+    /// Active conformance profiles (e.g. `["okf", "madr"]`) from
+    /// `[lint] profiles` in `.hyalo.toml` or an explicit `hyalo lint --profile`.
+    /// Enables every listed profile's advisory lint rules. Multiple profiles
+    /// compose — all their rules fire in one lint pass.
+    pub lint_profiles: Vec<String>,
     /// `--files-from` counters captured during dispatch for commands that resolve
     /// `--files-from` inside `resolve_inputs` (read/backlinks/task). Surfaced by
     /// the output pipeline as `files_from_counters` in the envelope.
@@ -427,10 +428,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
     let effective_format = ctx.effective_format;
     // Capture the active conformance profile before borrowing `ctx.snapshot_index`
     // mutably below (the lint arm needs it while that mutable borrow is live).
-    let okf_profile_active = ctx.lint_profile.as_deref() == Some("okf");
-    let madr_profile_active = ctx.lint_profile.as_deref() == Some("madr");
-    let skills_profile_active = ctx.lint_profile.as_deref() == Some("skills");
-    let changelog_profile_active = ctx.lint_profile.as_deref() == Some("changelog");
+    let profile_active = |name: &str| ctx.lint_profiles.iter().any(|p| p == name);
+    let okf_profile_active = profile_active("okf");
+    let madr_profile_active = profile_active("madr");
+    let skills_profile_active = profile_active("skills");
+    let changelog_profile_active = profile_active("changelog");
     let snapshot_index = &mut *ctx.snapshot_index;
     let index_path = ctx.index_path;
 
@@ -1610,7 +1612,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             max_per_rule,
             fix_rule,
             strict: lint_strict_flag,
-            // Profile activation is resolved in run.rs into `ctx.lint_profile`
+            // Profile activation is resolved in run.rs into `ctx.lint_profiles`
             // (it needs the raw config to overlay); the flag itself is consumed
             // there. Ignore it here.
             profile: _,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1392,9 +1392,10 @@ fn run_inner() -> Result<(), AppError> {
     let case_insensitive_mode = config.case_insensitive_mode;
     let mut md_lint = config.md_lint;
     let mut lint_strict_from_config = config.lint_strict;
-    // Active conformance profile: from `[lint] profile` in `.hyalo.toml`, or
-    // overridden by an explicit `--profile` overlay below.
-    let mut lint_profile_active = config.lint_profile;
+    // Active conformance profiles: from `[lint] profiles` in `.hyalo.toml`, or
+    // extended by an explicit `--profile` overlay below (which composes rather
+    // than replaces, so a `--profile` flag adds to the file-activated set).
+    let mut lint_profiles_active = config.lint_profiles;
 
     // `hyalo lint --profile <name>` overlays an embedded config fragment for this
     // invocation only (no `.hyalo.toml` write). The overlay reuses the same
@@ -1419,8 +1420,11 @@ fn run_inner() -> Result<(), AppError> {
                 // does not set it. An explicit `--strict` flag still wins later
                 // in dispatch.
                 lint_strict_from_config = overlay.lint_strict;
-                // The explicit --profile activates that profile's advisory rules.
-                lint_profile_active = overlay.lint_profile.or(Some(profile_name.clone()));
+                // The explicit --profile activates every profile the merged
+                // (existing file + fragment) config declares, so a `--profile`
+                // flag *adds* to whatever `[lint] profiles` the vault already
+                // activates rather than replacing it.
+                lint_profiles_active = overlay.lint_profiles;
             }
             Err(e) => {
                 return Err(AppError::User(crate::output::format_error(
@@ -1547,7 +1551,7 @@ fn run_inner() -> Result<(), AppError> {
         config_default_limit,
         programmatic_output: jq_filter.is_some() || cli.count,
         lint_strict: lint_strict_from_config,
-        lint_profile: lint_profile_active,
+        lint_profiles: lint_profiles_active,
         files_from_counters: None,
     };
 

--- a/crates/hyalo-cli/templates/profile-changelog.toml
+++ b/crates/hyalo-cli/templates/profile-changelog.toml
@@ -17,7 +17,7 @@ validate_on_write = true
 # grammar rules without `--profile changelog` on every invocation.
 # `hyalo lint --profile changelog` is then an idempotent overlay.
 [lint]
-profile = "changelog"
+profiles = ["changelog"]
 
 # `CHANGELOG.md` carries no frontmatter, so exempt it from the required-`type` /
 # frontmatter-presence checks. The grammar is enforced by the `CHANGELOG-*`

--- a/crates/hyalo-cli/templates/profile-madr.toml
+++ b/crates/hyalo-cli/templates/profile-madr.toml
@@ -12,7 +12,7 @@ validate_on_write = true
 # rules (supersede cross-check, duplicate ADR number) without `--profile madr`
 # on every invocation. `hyalo lint --profile madr` is then an idempotent overlay.
 [lint]
-profile = "madr"
+profiles = ["madr"]
 
 # The generated TOC (`README.md`) is a derived artifact, not an ADR — exempt it
 # (and any bundle `index.md`) from the `adr` schema so it is neither validated

--- a/crates/hyalo-cli/templates/profile-okf.toml
+++ b/crates/hyalo-cli/templates/profile-okf.toml
@@ -15,7 +15,7 @@ validate_on_write = true
 # without needing `--profile okf` on every invocation. `hyalo lint --profile
 # okf` on such a vault is then a no-op overlay (idempotent).
 [lint]
-profile = "okf"
+profiles = ["okf"]
 
 [schema]
 # Reserved OKF files carry no `type`, so exempt them from the required-`type`

--- a/crates/hyalo-cli/templates/profile-skills.toml
+++ b/crates/hyalo-cli/templates/profile-skills.toml
@@ -14,7 +14,7 @@ validate_on_write = true
 # `--profile skills` on every invocation. `hyalo lint --profile skills` is then
 # an idempotent overlay.
 [lint]
-profile = "skills"
+profiles = ["skills"]
 
 # Bind the `skill` schema to every `SKILL.md`, anywhere in the tree (the spec
 # locates a skill by its filename, not its directory depth). Files matching this

--- a/crates/hyalo-cli/templates/skill-hyalo-okf.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-okf.md
@@ -178,7 +178,7 @@ The OKF profile's `.hyalo.toml` sets: `[schema.default] required = ["type"]`, th
 recommended props (`title`, `description`, `resource` with a URL pattern, `tags`,
 `timestamp: datetime-tz`), `exempt = ["**/index.md", "**/log.md"]`, `site_prefix = ""`
 for bundle-root links, `validate_on_write = true` so authoring stays conformant, and
-`[lint] profile = "okf"` so a plain `hyalo lint` runs the §9 conformance + citation rules
+`[lint] profiles = ["okf"]` so a plain `hyalo lint` runs the §9 conformance + citation rules
 (no `--profile okf` needed on this vault).
 
 ## Example concept

--- a/crates/hyalo-cli/templates/skill-hyalo-skills.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-skills.md
@@ -52,7 +52,7 @@ frontmatter. Explicit frontmatter always wins.
 
 The hard `name` (regex/length) and `description` (length, no tags) constraints are enforced
 by the schema itself. On a vault initialised with `hyalo init --profile skills` (which sets
-`[lint] profile = "skills"`), plain `hyalo lint` runs these rules too.
+`[lint] profiles = ["skills"]`), plain `hyalo lint` runs these rules too.
 
 ## Scaffold
 

--- a/crates/hyalo-cli/tests/e2e/changelog_profile.rs
+++ b/crates/hyalo-cli/tests/e2e/changelog_profile.rs
@@ -101,7 +101,7 @@ fn init_writes_changelog_config() {
     let tmp = init_changelog();
     let cfg = std::fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
     assert!(
-        cfg.contains("profile = \"changelog\""),
+        cfg.contains("profiles = [\"changelog\"]"),
         "records lint profile"
     );
     assert!(cfg.contains("[[schema.bind]]"), "writes a bind entry");

--- a/crates/hyalo-cli/tests/e2e/init.rs
+++ b/crates/hyalo-cli/tests/e2e/init.rs
@@ -1186,7 +1186,7 @@ fn init_profile_okf_bundle_lints_clean_under_strict() {
         .unwrap();
 
     // A minimal, fully OKF-conformant bundle: reserved index.md/log.md (no type)
-    // plus one concept. `init --profile okf` writes `[lint] profile = "okf"`, so
+    // plus one concept. `init --profile okf` writes `[lint] profiles = ["okf"]`, so
     // plain `hyalo lint` now also runs the OKF advisory (warn-level) rules — the
     // fixture is shaped to satisfy them (link-list index, date-grouped log,
     // `# Citations` present) so the bundle lints entirely clean.

--- a/crates/hyalo-cli/tests/e2e/madr_profile.rs
+++ b/crates/hyalo-cli/tests/e2e/madr_profile.rs
@@ -50,7 +50,10 @@ fn init_madr() -> TempDir {
 fn init_writes_madr_config() {
     let tmp = init_madr();
     let cfg = std::fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
-    assert!(cfg.contains("profile = \"madr\""), "records lint profile");
+    assert!(
+        cfg.contains("profiles = [\"madr\"]"),
+        "records lint profile"
+    );
     assert!(cfg.contains("[[schema.bind]]"), "writes a bind entry");
     assert!(
         cfg.contains("docs/decisions/**/*.md"),

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -35,6 +35,7 @@ mod new;
 mod okf;
 mod okf_profile;
 mod positional_file;
+mod profile_composition;
 mod properties;
 mod quiet;
 mod read;

--- a/crates/hyalo-cli/tests/e2e/profile_composition.rs
+++ b/crates/hyalo-cli/tests/e2e/profile_composition.rs
@@ -1,0 +1,295 @@
+//! e2e tests for iter-172 profile composition semantics.
+//!
+//! Multiple `hyalo init --profile <name>` runs must compose in one vault:
+//! array config keys union (never clobber), `[lint] profiles` accumulates so
+//! every activated profile's rules fire in plain `hyalo lint`, and a
+//! frontmatter-less path-bound file lints clean. A `--profile` CLI overlay
+//! composes with the file config exactly like the file path does.
+
+use super::common::{hyalo, hyalo_no_hints, write_md};
+use std::fs;
+use std::path::Path;
+use std::process::Output;
+
+/// Run `hyalo init --profile <name>` in `dir`.
+fn init_profile(dir: &Path, profile: &str) -> Output {
+    hyalo()
+        .current_dir(dir)
+        .args(["init", "--profile", profile])
+        .output()
+        .unwrap()
+}
+
+/// Run `hyalo lint --format json` (no explicit `--profile`) in `dir` and return
+/// the parsed `results` object plus process output.
+fn lint_json(dir: &Path, extra: &[&str]) -> (serde_json::Value, Output) {
+    let mut args = vec!["--dir", ".", "--format", "json", "lint"];
+    args.extend_from_slice(extra);
+    let output = hyalo_no_hints()
+        .current_dir(dir)
+        .args(&args)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("JSON parse: {e}\n{stdout}"));
+    (json["results"].clone(), output)
+}
+
+/// True when any file's `rule_groups` fired a rule with the given id.
+fn rule_fired(results: &serde_json::Value, rule_id: &str) -> bool {
+    results["files"].as_array().is_some_and(|files| {
+        files.iter().any(|f| {
+            f["rule_groups"]
+                .as_array()
+                .is_some_and(|gs| gs.iter().any(|g| g["rule"].as_str() == Some(rule_id)))
+        })
+    })
+}
+
+/// Collect `(file, rule, severity, message)` tuples across all files, filtered
+/// so that only files whose path ends with `path_suffix` are returned.
+fn violations_for(results: &serde_json::Value, path_suffix: &str) -> Vec<(String, String, String)> {
+    let mut out = Vec::new();
+    let Some(files) = results["files"].as_array() else {
+        return out;
+    };
+    for f in files {
+        let file = f["file"].as_str().unwrap_or_default();
+        if !file.ends_with(path_suffix) {
+            continue;
+        }
+        for g in f["rule_groups"].as_array().cloned().unwrap_or_default() {
+            let rule = g["rule"].as_str().unwrap_or_default().to_owned();
+            let sev = g["severity"].as_str().unwrap_or_default().to_owned();
+            for v in g["violations"].as_array().cloned().unwrap_or_default() {
+                let msg = v["message"].as_str().unwrap_or_default().to_owned();
+                out.push((rule.clone(), sev.clone(), msg));
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// AC: three `init --profile` runs → all binds + all exemptions active at once.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn three_profile_inits_keep_all_binds_and_exempt() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    for p in ["okf", "madr", "changelog"] {
+        let out = init_profile(dir, p);
+        assert!(
+            out.status.success(),
+            "init --profile {p} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let toml = fs::read_to_string(dir.join(".hyalo.toml")).unwrap();
+    let val: toml::Value = toml::from_str(&toml).unwrap();
+
+    // All three profiles active in the list.
+    let profiles: Vec<&str> = val["lint"]["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert!(profiles.contains(&"okf"), "okf active: {profiles:?}");
+    assert!(profiles.contains(&"madr"), "madr active: {profiles:?}");
+    assert!(
+        profiles.contains(&"changelog"),
+        "changelog active: {profiles:?}"
+    );
+
+    // Binds from madr + changelog both present (array-of-tables union).
+    let raw: hyalo_core::schema::RawSchemaConfig = val["schema"].clone().try_into().unwrap();
+    let cfg = hyalo_core::schema::SchemaConfig::try_from(raw).unwrap();
+    assert_eq!(
+        cfg.bound_type_for("docs/decisions/0001-x.md"),
+        Some("adr"),
+        "madr bind present"
+    );
+    assert_eq!(
+        cfg.bound_type_for("CHANGELOG.md"),
+        Some("changelog"),
+        "changelog bind present"
+    );
+
+    // Exemptions from okf + changelog both present (array union).
+    assert!(cfg.exempt.is_exempt("bundle/index.md"), "okf exempt kept");
+    assert!(
+        cfg.exempt.is_exempt("CHANGELOG.md"),
+        "changelog exempt kept"
+    );
+}
+
+#[test]
+fn repeated_init_profile_is_byte_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    for p in ["okf", "madr"] {
+        assert!(init_profile(dir, p).status.success());
+    }
+    let first = fs::read_to_string(dir.join(".hyalo.toml")).unwrap();
+
+    // Re-run both — config must not change.
+    for p in ["okf", "madr"] {
+        assert!(init_profile(dir, p).status.success());
+    }
+    let second = fs::read_to_string(dir.join(".hyalo.toml")).unwrap();
+    assert_eq!(
+        first, second,
+        "re-running init --profile is byte-idempotent"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC: the hoppy regression — okf then madr → OKF rules still fire, reserved
+// files stay exempt, error count does not regress.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn okf_rules_fire_after_madr_init() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    assert!(init_profile(dir, "okf").status.success());
+    assert!(init_profile(dir, "madr").status.success());
+
+    // An OKF table missing its `# Citations` section triggers the OKF advisory
+    // rule — proof the OKF profile's rules are still active after madr init.
+    write_md(
+        dir,
+        "tables/blocks.md",
+        "---\ntype: BigQuery Table\ntitle: Blocks\ndescription: The blocks table.\n---\n# Schema\n\nColumns.\n",
+    );
+    // A reserved OKF index.md must stay exempt (no missing-type error).
+    write_md(
+        dir,
+        "index.md",
+        "---\nokf_version: \"0.1\"\n---\n\n<!-- okf:index:begin -->\n* [Blocks](tables/blocks.md)\n<!-- okf:index:end -->\n",
+    );
+
+    let (results, _out) = lint_json(dir, &[]);
+    // OKF citation rule fired (proves okf profile still active post-madr).
+    assert!(
+        rule_fired(&results, "OKF-CITATIONS-PRESENT"),
+        "OKF advisory rules must fire after madr init: {results}"
+    );
+    // index.md is reserved/exempt → no missing-type error for it.
+    let index_type_errors = violations_for(&results, "index.md")
+        .into_iter()
+        .filter(|(_, sev, msg)| sev == "error" && msg.contains("type"))
+        .count();
+    assert_eq!(
+        index_type_errors, 0,
+        "reserved index.md must stay exempt: {results}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC: frontmatter-less bound files (SKILL.md, ADR) lint clean under composed
+// profiles — bind = typing.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn frontmatterless_bound_files_lint_clean_under_composed_profiles() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    for p in ["okf", "skills", "changelog"] {
+        assert!(init_profile(dir, p).status.success());
+    }
+
+    // A spec-valid SKILL.md with the two required fields but NO `type:`.
+    write_md(
+        dir,
+        ".claude/skills/foo/SKILL.md",
+        "---\nname: foo\ndescription: does a thing\n---\n# Foo\n\nBody.\n",
+    );
+    // A frontmatter-less CHANGELOG.md.
+    fs::write(
+        dir.join("CHANGELOG.md"),
+        "# Changelog\n\n## [1.0.0] - 2026-07-17\n\n### Added\n\n- Initial release.\n",
+    )
+    .unwrap();
+
+    let (results, out) = lint_json(dir, &[]);
+    assert!(
+        out.status.success(),
+        "lint exited non-zero: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // No missing-type / no-type error or warning against the bound SKILL.md.
+    let skill_type_issues: Vec<(String, String, String)> = violations_for(&results, "SKILL.md")
+        .into_iter()
+        .filter(|(_, _, msg)| {
+            msg.contains("missing required property \"type\"") || msg.contains("no 'type' property")
+        })
+        .collect();
+    assert!(
+        skill_type_issues.is_empty(),
+        "frontmatter-less bound SKILL.md must not flag missing type: {skill_type_issues:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC: `--profile <name>` flag honors user `[schema] exempt` additions exactly
+// like `[lint] profiles` file activation (mapl BUG-6 flag-vs-file parity).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn profile_flag_honors_user_exempt_like_file_activation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    // User hand-adds an exempt glob before any profile init.
+    fs::write(
+        dir.join(".hyalo.toml"),
+        "[schema]\nexempt = [\"vendored/**\"]\n",
+    )
+    .unwrap();
+
+    // A frontmatter-less file under the user-exempt path — must not error even
+    // though okf's default schema requires `type`.
+    write_md(dir, "vendored/thirdparty.md", "no frontmatter here\n");
+
+    // Schema errors against the exempt file (the thing `[schema] exempt`
+    // controls) — a frontmatter-less file would otherwise error on missing
+    // `type`. Advisory OKF rules are a separate axis and fire regardless; we
+    // assert only that the schema exemption is honored, and identically for
+    // both activation paths.
+    let schema_errors = |r: &serde_json::Value| -> usize {
+        violations_for(r, "vendored/thirdparty.md")
+            .into_iter()
+            .filter(|(_, sev, _)| sev == "error")
+            .count()
+    };
+
+    // Path A: ephemeral `--profile okf` flag.
+    let (results_flag, out_flag) = lint_json(dir, &["--profile", "okf"]);
+    assert!(out_flag.status.success(), "flag lint failed");
+    let flag_errors = schema_errors(&results_flag);
+    assert_eq!(
+        flag_errors, 0,
+        "--profile flag must honor user exempt (no schema error): {results_flag}"
+    );
+
+    // Path B: file activation — init okf (unions the user exempt), then plain lint.
+    assert!(init_profile(dir, "okf").status.success());
+    let (results_file, out_file) = lint_json(dir, &[]);
+    assert!(out_file.status.success(), "file lint failed");
+    let file_errors = schema_errors(&results_file);
+    assert_eq!(
+        file_errors, 0,
+        "file activation must honor user exempt (no schema error): {results_file}"
+    );
+    // Flag and file paths produce identical schema-error behavior (parity).
+    assert_eq!(
+        flag_errors, file_errors,
+        "flag vs file activation must be equivalent for user exempt"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/skills_profile.rs
+++ b/crates/hyalo-cli/tests/e2e/skills_profile.rs
@@ -74,7 +74,10 @@ fn rule_fired(results: &Value, rule_id: &str) -> bool {
 fn init_writes_skills_config() {
     let tmp = init_skills();
     let cfg = std::fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
-    assert!(cfg.contains("profile = \"skills\""), "records lint profile");
+    assert!(
+        cfg.contains("profiles = [\"skills\"]"),
+        "records lint profile"
+    );
     assert!(cfg.contains("[[schema.bind]]"), "writes a bind entry");
     assert!(cfg.contains("**/SKILL.md"), "binds every SKILL.md");
     assert!(

--- a/hyalo-knowledgebase/iterations/iteration-172-profile-composition-semantics.md
+++ b/hyalo-knowledgebase/iterations/iteration-172-profile-composition-semantics.md
@@ -1,5 +1,7 @@
 ---
-title: Iteration 172 — profile composition semantics (smart merge, profiles list, bind typing)
+title: >-
+  Iteration 172 — profile composition semantics (smart merge, profiles list, bind
+  typing)
 type: iteration
 date: 2026-07-17
 tags:
@@ -7,7 +9,7 @@ tags:
   - profiles
   - schema
   - fix-wave
-status: planned
+status: completed
 branch: iter-172/profile-composition-semantics
 ---
 
@@ -35,65 +37,65 @@ and the bind-typing leak from
 
 ### 1. Merge engine (`profiles.rs`)
 
-- [ ] Array keys **union** on merge instead of replace: `[schema] exempt`,
+- [x] Array keys **union** on merge instead of replace: `[schema] exempt`,
   `[lint] ignore`, `[schema.default] required`, and `[[schema.bind]]`
   (dedup bind entries by `(glob, type)`); preserve stable order
   (existing entries first, new appended)
-- [ ] Scalar keys: profile still owns its keys (refresh-on-rerun), but when an
+- [x] Scalar keys: profile still owns its keys (refresh-on-rerun), but when an
   overwrite *changes* an existing differing value, print a
   `conflict: <key> "<old>" -> "<new>" (profile <name>)` line to stderr
-- [ ] Preserve hand-written comments and key order: switch the merge to
+- [x] Preserve hand-written comments and key order: switch the merge to
   `toml_edit` (new dependency; keep `toml` for read-only paths if simpler)
-- [ ] Reconcile the dogfood discrepancy: write a failing test first for the
+- [x] Reconcile the dogfood discrepancy: write a failing test first for the
   4-profile stack (okf+madr+skills+changelog) asserting ALL binds and the
   unioned exempt survive, then make it pass (ff-rdp saw binds compose,
   skills-audit saw them clobbered — find out which path differs)
 
 ### 2. `[lint] profiles` list
 
-- [ ] `[lint] profiles = ["okf", "madr"]` — all listed profiles' native rules
+- [x] `[lint] profiles = ["okf", "madr"]` — all listed profiles' native rules
   are active in plain `hyalo lint`; `profile = "okf"` (singular string) stays
   accepted as a 1-element compat alias, warning that `profiles` is preferred
-- [ ] `init --profile <p>` appends to `profiles` (no duplicates) instead of
+- [x] `init --profile <p>` appends to `profiles` (no duplicates) instead of
   overwriting a scalar
-- [ ] `--profile <p>` CLI flag **adds** an ephemeral overlay composed with the
+- [x] `--profile <p>` CLI flag **adds** an ephemeral overlay composed with the
   file config — it must honor user `[schema] exempt` additions exactly like
   the file path does (fixes mapl BUG-6 flag-vs-file divergence)
 
 ### 3. Bind = typing
 
-- [ ] A `[[schema.bind]]` match satisfies `required = ["type"]` for the bound
+- [x] A `[[schema.bind]]` match satisfies `required = ["type"]` for the bound
   file — a spec-valid frontmatter-less SKILL.md / MADR file lints clean under
   composed okf+skills / okf+madr (fixes df-own-kb B5 / ff-rdp B2)
 
 ### 4. Tests
 
-- [ ] Unit: union semantics per key incl. `required` (user
+- [x] Unit: union semantics per key incl. `required` (user
   `["title","type"]` + profile `["type"]` → both survive), bind dedup,
   comment/order preservation round-trip
-- [ ] e2e: the hoppy regression scenario — `init --profile okf` then
+- [x] e2e: the hoppy regression scenario — `init --profile okf` then
   `init --profile madr` → OKF-CITATIONS rules still fire, reserved files stay
   exempt, lint error count does not regress
-- [ ] e2e: 4-profile stack → every profile's rules fire on a fixture
+- [x] e2e: 4-profile stack → every profile's rules fire on a fixture
   violating each; re-running any `init --profile` is byte-idempotent
-- [ ] e2e: `--profile okf` flag on a vault with user exempt additions honors
+- [x] e2e: `--profile okf` flag on a vault with user exempt additions honors
   them (identical results to `[lint] profiles` file activation)
-- [ ] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
+- [x] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
 
 ### 5. Docs sync (same PR)
 
-- [ ] `init --help` composition claims match the new reality; README profiles
+- [x] `init --help` composition claims match the new reality; README profiles
   section documents `profiles` list + conflict warnings
-- [ ] Bundled skill templates that mention `[lint] profile` updated
-- [ ] Retrospective task: adapt iteration-173..175 plans to what landed here
+- [x] Bundled skill templates that mention `[lint] profile` updated
+- [x] Retrospective task: adapt iteration-173..175 plans to what landed here
 
 ## Acceptance criteria
 
-- [ ] The ff-rdp dogfood branch scenario needs no hand-editing of
+- [x] The ff-rdp dogfood branch scenario needs no hand-editing of
   `.hyalo.toml`: three `init --profile` runs produce a config where all
   reserved-file exemptions and all binds are active simultaneously
-- [ ] No silent loss: any changed scalar prints a conflict line; arrays never
+- [x] No silent loss: any changed scalar prints a conflict line; arrays never
   shrink on profile init
-- [ ] Frontmatter-less bound files (SKILL.md, ADR) lint clean under composed
+- [x] Frontmatter-less bound files (SKILL.md, ADR) lint clean under composed
   profiles
-- [ ] Hand-written TOML comments survive `init --profile`
+- [x] Hand-written TOML comments survive `init --profile`

--- a/hyalo-knowledgebase/iterations/iteration-172-profile-composition-semantics.md
+++ b/hyalo-knowledgebase/iterations/iteration-172-profile-composition-semantics.md
@@ -35,7 +35,7 @@ and the bind-typing leak from
 
 ## Tasks
 
-### 1. Merge engine (`profiles.rs`)
+### 1. Merge engine (`profiles.rs`) [4/4]
 
 - [x] Array keys **union** on merge instead of replace: `[schema] exempt`,
   `[lint] ignore`, `[schema.default] required`, and `[[schema.bind]]`
@@ -51,7 +51,7 @@ and the bind-typing leak from
   unioned exempt survive, then make it pass (ff-rdp saw binds compose,
   skills-audit saw them clobbered — find out which path differs)
 
-### 2. `[lint] profiles` list
+### 2. `[lint] profiles` list [3/3]
 
 - [x] `[lint] profiles = ["okf", "madr"]` — all listed profiles' native rules
   are active in plain `hyalo lint`; `profile = "okf"` (singular string) stays
@@ -62,13 +62,13 @@ and the bind-typing leak from
   file config — it must honor user `[schema] exempt` additions exactly like
   the file path does (fixes mapl BUG-6 flag-vs-file divergence)
 
-### 3. Bind = typing
+### 3. Bind = typing [1/1]
 
 - [x] A `[[schema.bind]]` match satisfies `required = ["type"]` for the bound
   file — a spec-valid frontmatter-less SKILL.md / MADR file lints clean under
   composed okf+skills / okf+madr (fixes df-own-kb B5 / ff-rdp B2)
 
-### 4. Tests
+### 4. Tests [5/5]
 
 - [x] Unit: union semantics per key incl. `required` (user
   `["title","type"]` + profile `["type"]` → both survive), bind dedup,
@@ -82,20 +82,17 @@ and the bind-typing leak from
   them (identical results to `[lint] profiles` file activation)
 - [x] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
 
-### 5. Docs sync (same PR)
+### 5. Docs sync (same PR) [3/3]
 
 - [x] `init --help` composition claims match the new reality; README profiles
   section documents `profiles` list + conflict warnings
 - [x] Bundled skill templates that mention `[lint] profile` updated
 - [x] Retrospective task: adapt iteration-173..175 plans to what landed here
 
-## Acceptance criteria
+## Acceptance Criteria [4/4]
 
-- [x] The ff-rdp dogfood branch scenario needs no hand-editing of
-  `.hyalo.toml`: three `init --profile` runs produce a config where all
-  reserved-file exemptions and all binds are active simultaneously
-- [x] No silent loss: any changed scalar prints a conflict line; arrays never
-  shrink on profile init
+- [x] The ff-rdp dogfood branch scenario needs no hand-editing of `.hyalo.toml`: three `init --profile` runs produce a config where all reserved-file exemptions and all binds are active simultaneously (`three_profile_inits_keep_all_binds_and_exempt`)
+- [x] No silent loss: any changed scalar prints a conflict line (`scalar_conflict_is_reported_not_silent`); arrays never shrink on profile init (`array_change_is_not_reported_as_conflict`)
 - [x] Frontmatter-less bound files (SKILL.md, ADR) lint clean under composed
   profiles
 - [x] Hand-written TOML comments survive `init --profile`

--- a/hyalo-knowledgebase/iterations/iteration-173-generator-safety.md
+++ b/hyalo-knowledgebase/iterations/iteration-173-generator-safety.md
@@ -31,6 +31,18 @@ blocker **RB-2** and the generator half of **RB-3** from
 - **Case handling reuses the `[links] case_insensitive` auto approach**
   (FS-detected), rather than a new knob.
 
+## Note from iter-172
+
+No scope overlap with iter-172's merge-engine/bind-typing work (this
+iteration doesn't touch `profiles.rs`, `.hyalo.toml` merge, or
+`[schema.bind]`). One process lesson carries forward: the `ac-fidelity-check`
+gate requires each ticked Acceptance Criteria bullet to be a single line
+containing a backtick-quoted symbol (test fn name or code identifier) that
+appears in the diff — multi-line prose bullets with no quoted symbol fail the
+gate even when a real test backs the claim. When closing out this iteration,
+write ACs as one-liners naming the backing test/symbol up front rather than
+adding it after the fact.
+
 ## Tasks
 
 ### 1. Non-destructive adoption (RB-2, data loss)


### PR DESCRIPTION
## Summary

Implements iteration 172 — makes profile composition keep its promise ("multiple profiles compose in one vault"). Fixes release blocker RB-1 (5/7 dogfood agents) and the bind-typing leak.

- **Smart merge** (`profiles.rs`, rewritten on `toml_edit`): array config keys **union** instead of clobber — `[schema] exempt`, `[lint] ignore`, `[schema.default] required`, `[lint] profiles`, and `[[schema.bind]]` (deduped by `(glob, type)`). Hand-written comments and key order survive; re-runs are byte-idempotent; a changed **scalar** prints a `conflict: <key> "<old>" -> "<new>" (profile <name>)` line to stderr — nothing is lost silently.
- **`[lint] profiles` list**: the single-profile model (`lint_profile: Option<String>`) becomes `lint_profiles: Vec<String>` across config/dispatch/run, so **all** activated profiles' advisory rules fire together in plain `hyalo lint`. The singular `[lint] profile` scalar stays as a deprecated compat alias (warns). The `--profile` CLI overlay now **composes** with file-activated profiles and honors user `[schema] exempt` additions like file config (mapl BUG-6).
- **Bind = typing**: a path-bound file satisfies `required = ["type"]` through its binding, so a spec-valid frontmatter-less `SKILL.md` / MADR ADR / `CHANGELOG.md` lints clean without an explicit `type:` (df-own-kb B5 / ff-rdp B2). The `--strict` missing-type injection is likewise skipped for bound files; type-specific required properties still fire.
- **`init.rs` Step 1** dir-update switched to `toml_edit` so it no longer strips comments before the profile merge.
- Docs synced: `init`/`lint` help, README profiles + bind sections, `okf`/`skills` skill templates.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace -q` green
- [x] 12 new unit tests: union semantics per key (incl. `required` user+profile), bind dedup, comment/order round-trip, scalar-conflict reporting, bind=typing (frontmatter-less bound file clean + type-specific required still enforced)
- [x] 5-test `profile_composition` e2e module: 4-profile stack unions all binds+exempt, `okf`-after-`madr` regression (OKF rules still fire, reserved files exempt), frontmatter-less bound files lint clean under composed profiles, `--profile` flag vs `[lint] profiles` file exempt parity, byte-idempotent re-runs
- [x] xtask gates: `check-ac-fidelity`, `check-feature-fanout`, `check-help-drift` all pass## Claims vs code
<generated 2026-07-17T11:53:05Z by ralph-loop>

- `release` → ✅ matched in diff