### PR TITLE
iter-175: profile content & tooling polish (RB-4/RB-5/UX-A)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -23,3 +23,5 @@ jobs:
         run: cargo run -p xtask -- check-feature-fanout
       - name: Check help drift
         run: cargo run -p xtask -- check-help-drift
+      - name: Check bundled skills pass the skills profile
+        run: cargo run -p xtask -- check-bundled-skills

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,6 +2520,7 @@ dependencies = [
  "anyhow",
  "clap",
  "serde",
+ "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "walkdir",
 ]

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ The `okf` profile merges a declarative config fragment into `.hyalo.toml`:
 - `[schema] exempt = ["**/index.md", "**/log.md"]` — reserved files skip the required-`type` check.
 - `site_prefix = ""` — bundle-absolute links (`/tables/x.md`, the spec-recommended form) resolve from the bundle root.
 - `validate_on_write = true` — authoring stays conformant.
-- Seed `[schema.types.*]` for common OKF concept types with recommended `# Schema`/`# Citations` sections.
+
+The profile is **vendor-neutral**: it ships **no example `[schema.types.*]`** (a real vault's concept `type` values are domain-specific). Declare your own domain types under `[schema.types."<name>"]` — quoted keys with spaces are supported — with recommended `# Schema` / `# Citations` `required_sections`. The bundled `okf` skill's "Adding domain types" section walks through it.
 
 Profiles are **composable** and **idempotent**: multiple `--profile` runs coexist in one vault. The fragment is deep-merged, and array config keys **union** rather than clobber — each profile's `[schema] exempt` globs, `[[schema.bind]]` entries, `[schema.default] required` fields, and `[lint] profiles` markers all accumulate, so a later `init --profile` never shrinks an earlier one's config or your hand-added entries. Hand-written comments and key order survive the merge, re-running is byte-idempotent, and when a profile overwrites a differing **scalar** value it prints a `conflict: <key> "<old>" -> "<new>"` line to stderr — nothing is lost silently. With `--claude`, the bundled `okf` skill teaches Claude the OKF concept model, reserved-file rules, link forms, and the exact hyalo commands — hyalo owns the deterministic frontmatter/link mechanics while the LLM does the semantic work.
 
@@ -262,6 +263,13 @@ hyalo lint --profile skills                        # validate a directory of ski
 
 Three advisory rules layer on top of the schema pass under `hyalo lint --profile skills`: **`SKILL-RESERVED-NAME`** (**error** — `name` is a reserved word `anthropic`/`claude`, which the slug pattern cannot express without look-around), **`SKILL-NAME-DIRNAME`** (warn — `name` must equal its parent directory), and **`SKILL-LINE-BUDGET`** (warn — the body should stay under 500 lines). All appear in `hyalo lint-rules list` and are toggleable via `hyalo lint-rules set SKILL-… --enabled false`.
 
+**Reaching `.claude/skills/`.** The vault walker skips hidden dot-directories by default, so the canonical Claude Code skill location would be invisible. The `skills` profile therefore ships `[scan] include = [".claude/skills/**"]`, a general walker escape hatch that re-admits specific hidden subtrees (never `.git`, which is always excluded). With it, `hyalo find`/`lint` reach `.claude/skills/**/SKILL.md` in place — no relocation:
+
+```toml
+[scan]
+include = [".claude/skills/**"]   # honored by every command that scans the vault
+```
+
 ## Changelog profile — Keep a Changelog
 
 [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) is a convention for a human-readable `CHANGELOG.md`: a `# Changelog` title, `## [Unreleased]` pinned above dated `## [X.Y.Z] - YYYY-MM-DD` version sections (newest first), `###` subsections limited to six change categories, and a footer of `[x.y.z]: <url>` link references. Unlike the other profiles, `CHANGELOG.md` is **frontmatter-free** — the whole grammar lives in the body.
@@ -288,7 +296,17 @@ hyalo changelog release 1.2.0 --dry-run                                      # C
 hyalo changelog release 1.2.0 --apply                                        # rotate [Unreleased] → [1.2.0]
 ```
 
-**`hyalo changelog release <X.Y.Z>`** rotates the accumulated `## [Unreleased]` content into a dated `## [X.Y.Z] - <date>` section (date defaults to today, override with `--date`), recreates an empty `[Unreleased]` above it, and appends a placeholder `[X.Y.Z]: TBD` footer link reference (replace `TBD` with the real compare/tag URL). It **refuses** to release a version that already exists. **`hyalo changelog add`** appends `- <message>` under the `### <category>` subsection of `[Unreleased]`, creating the subsection if needed. Both default to `--dry-run` and exit non-zero on drift, so they double as CI checks.
+**`hyalo changelog release <X.Y.Z>`** rotates the accumulated `## [Unreleased]` content into a dated `## [X.Y.Z] - <date>` section (date defaults to today, override with `--date`), recreates an empty `[Unreleased]` above it, and appends a placeholder `[X.Y.Z]: TBD` footer link reference (replace `TBD` with the real compare/tag URL). It **refuses** to release a version that already exists. **`hyalo changelog add`** appends `- <message>` under the `### <category>` subsection of `[Unreleased]` — always **inside** the section, before the footer link-reference block, with a single trailing newline — creating the subsection if needed. Both default to `--dry-run` and exit non-zero on drift, so they double as CI checks.
+
+**Repo-root `CHANGELOG.md` with a docs-subdir vault.** When your vault dir is a subdirectory (`dir = "docs"`) but `CHANGELOG.md` lives at the repo root, point the changelog commands at it with `[changelog] path` — resolved relative to the config file's directory (it may sit outside the vault dir, but never above the repo root):
+
+```toml
+dir = "docs"
+[changelog]
+path = "CHANGELOG.md"   # the repo-root file, beside .hyalo.toml
+```
+
+`hyalo init --profile changelog --dir docs` writes this key automatically when a root `CHANGELOG.md` already exists. With it, `hyalo changelog add`/`release` and `hyalo lint --profile changelog` all operate on the root file with no `--dir .` gymnastics.
 
 ### Profiles at a glance
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -837,7 +837,8 @@ Repeatable (AND).\n\
             \u{00a0} hyalo init --profile okf\n\
             \u{00a0} hyalo init --profile okf --claude\n\
             \u{00a0} hyalo init --profile madr\n\
-            \u{00a0} hyalo init --profile skills"
+            \u{00a0} hyalo init --profile skills\n\
+            \u{00a0} hyalo init --profile changelog"
     )]
     Init {
         /// Set up Claude Code integration (skill + CLAUDE.md hint)
@@ -846,8 +847,8 @@ Repeatable (AND).\n\
         /// Set up pi integration (skill + extension)
         #[arg(long)]
         pi: bool,
-        /// Scaffold a preset vault flavour (okf, madr, skills) by merging an
-        /// embedded config fragment into .hyalo.toml
+        /// Scaffold a preset vault flavour (okf, madr, skills, changelog) by
+        /// merging an embedded config fragment into .hyalo.toml
         #[arg(long, value_name = "PROFILE")]
         profile: Option<String>,
     },

--- a/crates/hyalo-cli/src/commands/changelog.rs
+++ b/crates/hyalo-cli/src/commands/changelog.rs
@@ -26,7 +26,67 @@ use crate::commands::changelog_lint::CATEGORIES;
 use crate::output::{CommandOutcome, Format, format_error};
 
 /// Default changelog filename (vault-relative).
-const CHANGELOG_FILE: &str = "CHANGELOG.md";
+pub(crate) const CHANGELOG_FILE: &str = "CHANGELOG.md";
+
+/// Resolve the effective `CHANGELOG.md` path for the changelog commands.
+///
+/// Precedence:
+/// 1. `config_path` — the raw `[changelog] path` value from `.hyalo.toml`,
+///    resolved *relative to `config_dir`* (the directory the config lives in).
+///    This may point outside the vault `dir` (e.g. `../CHANGELOG.md` for a
+///    repo-root changelog when the vault is a docs subdir).
+/// 2. Otherwise `dir/CHANGELOG.md` (the historical default).
+///
+/// The resolved path is validated to stay within `config_dir`'s repo root: an
+/// absolute `path`, or one that escapes above `config_dir` after normalization,
+/// is rejected — mirroring the `mv` vault-escape guard so a config typo can't
+/// make the tool write to an arbitrary location.
+///
+/// # Errors
+/// Returns an error when `config_path` is absolute or traverses above
+/// `config_dir`.
+pub(crate) fn resolve_changelog_file(
+    dir: &Path,
+    config_dir: &Path,
+    config_path: Option<&str>,
+) -> Result<std::path::PathBuf> {
+    let Some(raw) = config_path else {
+        return Ok(dir.join(CHANGELOG_FILE));
+    };
+    let raw_norm = raw.replace('\\', "/");
+    anyhow::ensure!(
+        !Path::new(&raw_norm).is_absolute() && !raw_norm.starts_with('/'),
+        "[changelog] path must be relative to the config directory, not absolute: {raw}"
+    );
+    // Join onto config_dir, then verify the lexically-normalized result does not
+    // climb above config_dir (bounded `..` back into config_dir is fine; net
+    // escape is not).
+    let joined = config_dir.join(&raw_norm);
+    let mut depth: i32 = 0;
+    let mut escaped = false;
+    for comp in Path::new(&raw_norm).components() {
+        match comp {
+            std::path::Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    escaped = true;
+                    break;
+                }
+            }
+            std::path::Component::Normal(_) => depth += 1,
+            std::path::Component::CurDir => {}
+            _ => {
+                escaped = true;
+                break;
+            }
+        }
+    }
+    anyhow::ensure!(
+        !escaped,
+        "[changelog] path escapes the config directory: {raw}"
+    );
+    Ok(joined)
+}
 
 /// A parsed view of a changelog sufficient for the release/add splices.
 struct Changelog {
@@ -138,18 +198,30 @@ fn is_iso_date(s: &str) -> bool {
         && b[8..].iter().all(u8::is_ascii_digit)
 }
 
+/// A short display name for the changelog file used in messages and JSON
+/// output: the file name (e.g. `CHANGELOG.md`) so output stays stable
+/// regardless of where the file physically lives.
+fn changelog_display(path: &Path) -> String {
+    path.file_name().map_or_else(
+        || CHANGELOG_FILE.to_owned(),
+        |n| n.to_string_lossy().into_owned(),
+    )
+}
+
 /// `hyalo changelog release <X.Y.Z> [--date YYYY-MM-DD] [--apply]`.
 ///
 /// Rotates `## [Unreleased]` content into a new dated version section. Returns
 /// the outcome and an optional exit-code override (1 when a dry run would
 /// change the file, matching the `okf index` / `madr toc` CI convention).
 pub fn run_release(
-    dir: &Path,
+    changelog_file: &Path,
     version: &str,
     date: Option<&str>,
     apply: bool,
+    active_profiles: &[String],
     format: Format,
 ) -> Result<(CommandOutcome, Option<i32>)> {
+    let display = changelog_display(changelog_file);
     if !is_semver(version) {
         return Ok((
             CommandOutcome::UserError(format_error(
@@ -181,21 +253,21 @@ pub fn run_release(
         None => hyalo_core::schema::today_iso8601(),
     };
 
-    let full = dir.join(CHANGELOG_FILE);
+    let full = changelog_file.to_path_buf();
     if !full.is_file() {
         return Ok((
             CommandOutcome::UserError(format_error(
                 format,
-                "CHANGELOG.md not found",
-                Some(CHANGELOG_FILE),
+                &format!("{display} not found"),
+                Some(&display),
                 Some("create a CHANGELOG.md with an `## [Unreleased]` section first"),
                 None,
             )),
             None,
         ));
     }
-    let old_content = std::fs::read_to_string(&full)
-        .with_context(|| format!("failed to read {CHANGELOG_FILE}"))?;
+    let old_content =
+        std::fs::read_to_string(&full).with_context(|| format!("failed to read {display}"))?;
     let mut cl = Changelog::parse(&old_content);
 
     // Idempotency guard: refuse to release an already-present version.
@@ -203,7 +275,7 @@ pub fn run_release(
         return Ok((
             CommandOutcome::UserError(format_error(
                 format,
-                &format!("version `[{version}]` already exists in CHANGELOG.md"),
+                &format!("version `[{version}]` already exists in {display}"),
                 Some(version),
                 Some("bump to a new version, or remove the existing section first"),
                 None,
@@ -216,7 +288,7 @@ pub fn run_release(
         return Ok((
             CommandOutcome::UserError(format_error(
                 format,
-                "no `## [Unreleased]` section found in CHANGELOG.md",
+                &format!("no `## [Unreleased]` section found in {display}"),
                 None,
                 Some("add an `## [Unreleased]` section to accumulate entries into"),
                 None,
@@ -232,17 +304,17 @@ pub fn run_release(
     let changed = new_content != old_content;
     if apply && changed {
         hyalo_core::fs_util::atomic_write(&full, new_content.as_bytes())
-            .with_context(|| format!("failed to write {CHANGELOG_FILE}"))?;
+            .with_context(|| format!("failed to write {display}"))?;
     }
 
     let payload = serde_json::json!({
         "command": "changelog release",
         "apply": apply,
-        "file": CHANGELOG_FILE,
+        "file": display,
         "version": version,
         "date": date_owned,
         "changed": changed,
-        "hint": "hyalo lint --profile changelog  # validate the rotated changelog",
+        "hint": crate::commands::profile_lint_hint("changelog", active_profiles, "validate the rotated changelog"),
     });
     let exit_override = if !apply && changed { Some(1) } else { None };
     Ok((
@@ -311,12 +383,14 @@ fn upsert_release_link_ref(cl: &mut Changelog, version: &str) {
 /// Appends `- <message>` under the `### <category>` subsection of
 /// `## [Unreleased]`, creating the section / subsection when missing.
 pub fn run_add(
-    dir: &Path,
+    changelog_file: &Path,
     category: &str,
     message: &str,
     apply: bool,
+    active_profiles: &[String],
     format: Format,
 ) -> Result<(CommandOutcome, Option<i32>)> {
+    let display = changelog_display(changelog_file);
     let Some(canonical) = CATEGORIES.iter().find(|c| c.eq_ignore_ascii_case(category)) else {
         return Ok((
             CommandOutcome::UserError(format_error(
@@ -342,10 +416,9 @@ pub fn run_add(
         ));
     }
 
-    let full = dir.join(CHANGELOG_FILE);
+    let full = changelog_file.to_path_buf();
     let old_content = if full.is_file() {
-        std::fs::read_to_string(&full)
-            .with_context(|| format!("failed to read {CHANGELOG_FILE}"))?
+        std::fs::read_to_string(&full).with_context(|| format!("failed to read {display}"))?
     } else {
         // Fresh changelog skeleton.
         "# Changelog\n\n## [Unreleased]\n".to_owned()
@@ -369,17 +442,17 @@ pub fn run_add(
     let changed = new_content != old_content;
     if apply && changed {
         hyalo_core::fs_util::atomic_write(&full, new_content.as_bytes())
-            .with_context(|| format!("failed to write {CHANGELOG_FILE}"))?;
+            .with_context(|| format!("failed to write {display}"))?;
     }
 
     let payload = serde_json::json!({
         "command": "changelog add",
         "apply": apply,
-        "file": CHANGELOG_FILE,
+        "file": display,
         "category": canonical,
         "message": message.trim(),
         "changed": changed,
-        "hint": "hyalo lint --profile changelog  # validate the changelog",
+        "hint": crate::commands::profile_lint_hint("changelog", active_profiles, "validate the changelog"),
     });
     let exit_override = if !apply && changed { Some(1) } else { None };
     Ok((
@@ -391,13 +464,20 @@ pub fn run_add(
 /// Insert `- message` under `### <category>` within the `[Unreleased]` section
 /// (heading at `unreleased_idx`), creating the subsection if it is missing.
 fn insert_entry(cl: &mut Changelog, unreleased_idx: usize, category: &str, message: &str) {
-    // Bound of the Unreleased section: up to the next `## ` heading or EOF.
+    // Bound of the Unreleased section: the earliest of the next `## ` heading,
+    // the footer link-reference block, or EOF. Keep-a-Changelog files end with
+    // a block of `[label]: url` link-reference definitions; the `[Unreleased]`
+    // section is frequently the *last* `## ` section, so without stopping at the
+    // footer we would splice a new `### Category` *after* those definitions —
+    // producing a non-conformant file that then fails its own lint (RB-4). We
+    // therefore also stop at the first footer link-ref line so entries always
+    // land inside the section body.
     let section_end = cl
         .lines
         .iter()
         .enumerate()
         .skip(unreleased_idx + 1)
-        .find(|(_, l)| l.starts_with("## "))
+        .find(|(_, l)| l.starts_with("## ") || link_def_label(l).is_some())
         .map_or(cl.lines.len(), |(i, _)| i);
 
     let cat_heading = format!("### {category}");
@@ -526,6 +606,67 @@ mod tests {
         let seg = &out[unrel..v1];
         assert!(seg.contains("### Fixed"));
         assert!(seg.contains("- A bug."));
+    }
+
+    /// RB-4: a conformant KaC file whose `[Unreleased]` is the last `## `
+    /// section (only the footer link-ref block follows) must get new entries
+    /// *inside* the section, never after the link-ref definitions.
+    const UNRELEASED_LAST: &str = "\
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Existing feature.
+
+[Unreleased]: https://x/compare/v1.0.0...HEAD
+[1.0.0]: https://x/tag/v1.0.0
+";
+
+    #[test]
+    fn add_new_category_lands_before_footer_link_refs() {
+        let mut cl = Changelog::parse(UNRELEASED_LAST);
+        let idx = cl.version_heading_index("Unreleased").unwrap();
+        insert_entry(&mut cl, idx, "Fixed", "A bug.");
+        let out = cl.render();
+        let fixed_pos = out.find("### Fixed").expect("Fixed subsection added");
+        let footer_pos = out.find("[Unreleased]:").expect("footer preserved");
+        assert!(
+            fixed_pos < footer_pos,
+            "new category must precede the footer link refs:\n{out}"
+        );
+        // The bug entry lands under Fixed, above the footer.
+        let entry_pos = out.find("- A bug.").unwrap();
+        assert!(entry_pos < footer_pos, "entry before footer:\n{out}");
+        // Footer link refs are intact and not duplicated.
+        assert_eq!(out.matches("[Unreleased]:").count(), 1);
+        assert_eq!(out.matches("[1.0.0]:").count(), 1);
+    }
+
+    #[test]
+    fn add_existing_category_lands_before_footer_link_refs() {
+        let mut cl = Changelog::parse(UNRELEASED_LAST);
+        let idx = cl.version_heading_index("Unreleased").unwrap();
+        insert_entry(&mut cl, idx, "Added", "Second feature.");
+        let out = cl.render();
+        let entry_pos = out.find("- Second feature.").unwrap();
+        let footer_pos = out.find("[Unreleased]:").unwrap();
+        assert!(
+            entry_pos < footer_pos,
+            "appended entry stays inside the section:\n{out}"
+        );
+    }
+
+    #[test]
+    fn add_output_is_md047_clean() {
+        // The rendered file must end with exactly one trailing newline (MD047).
+        let mut cl = Changelog::parse(UNRELEASED_LAST);
+        let idx = cl.version_heading_index("Unreleased").unwrap();
+        insert_entry(&mut cl, idx, "Fixed", "A bug.");
+        let out = cl.render();
+        assert!(out.ends_with('\n'), "file ends with a newline");
+        assert!(!out.ends_with("\n\n"), "no trailing blank line (MD047)");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/commands/changelog.rs
+++ b/crates/hyalo-cli/src/commands/changelog.rs
@@ -563,6 +563,58 @@ mod tests {
     }
 
     #[test]
+    fn resolve_changelog_file_defaults_to_vault_dir() {
+        let dir = Path::new("/repo/docs");
+        let config_dir = Path::new("/repo/docs");
+        let resolved = resolve_changelog_file(dir, config_dir, None).unwrap();
+        assert_eq!(resolved, dir.join("CHANGELOG.md"));
+    }
+
+    #[test]
+    fn resolve_changelog_file_resolves_relative_to_config_dir() {
+        let dir = Path::new("/repo/docs");
+        let config_dir = Path::new("/repo");
+        let resolved = resolve_changelog_file(dir, config_dir, Some("CHANGELOG.md")).unwrap();
+        assert_eq!(resolved, config_dir.join("CHANGELOG.md"));
+    }
+
+    #[test]
+    fn resolve_changelog_file_allows_bounded_parent_traversal() {
+        // `..` that stays net-non-negative relative to config_dir is fine (it
+        // never actually climbs above config_dir).
+        let dir = Path::new("/repo/docs");
+        let config_dir = Path::new("/repo");
+        let resolved =
+            resolve_changelog_file(dir, config_dir, Some("sub/../CHANGELOG.md")).unwrap();
+        assert_eq!(resolved, config_dir.join("sub/../CHANGELOG.md"));
+    }
+
+    #[test]
+    fn resolve_changelog_file_rejects_absolute_path() {
+        let dir = Path::new("/repo/docs");
+        let config_dir = Path::new("/repo");
+        let err = resolve_changelog_file(dir, config_dir, Some("/etc/passwd")).unwrap_err();
+        assert!(err.to_string().contains("must be relative"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_changelog_file_rejects_net_escape() {
+        let dir = Path::new("/repo/docs");
+        let config_dir = Path::new("/repo");
+        let err = resolve_changelog_file(dir, config_dir, Some("../CHANGELOG.md")).unwrap_err();
+        assert!(err.to_string().contains("escapes"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_changelog_file_rejects_deeper_net_escape() {
+        let dir = Path::new("/repo/docs");
+        let config_dir = Path::new("/repo");
+        let err =
+            resolve_changelog_file(dir, config_dir, Some("a/../../CHANGELOG.md")).unwrap_err();
+        assert!(err.to_string().contains("escapes"), "got: {err}");
+    }
+
+    #[test]
     fn release_rotates_unreleased() {
         let mut cl = Changelog::parse(BASE);
         let idx = cl.version_heading_index("Unreleased").unwrap();

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -23,8 +23,11 @@ pub(crate) struct ConfigReport {
     pub raw_contents: Option<String>,
     /// Current working directory.
     pub cwd: PathBuf,
-    /// Resolved vault directory (from `.hyalo.toml` or default `"."`).
+    /// Resolved vault directory: the effective directory the CLI would use —
+    /// a `--dir` override wins over the config's own `dir`.
     pub dir: PathBuf,
+    /// `true` when a `--dir` override replaced the config's `dir` value.
+    pub dir_overridden: bool,
     /// Resolved output format (from config or `None`).
     pub format: Option<String>,
     /// Whether hints are enabled.
@@ -36,8 +39,19 @@ pub(crate) struct ConfigReport {
 }
 
 /// Build and return the config report for `cwd`.
-pub(crate) fn collect_config_report(cwd: &Path) -> anyhow::Result<ConfigReport> {
-    let toml_path = cwd.join(".hyalo.toml");
+///
+/// When `dir_override` is `Some` (the user passed a global `--dir`), the report
+/// loads the config from that directory and reports it as the effective `dir`,
+/// so `hyalo config --dir X` mirrors what the rest of the CLI would use rather
+/// than echoing the CWD config's shadowed `dir` value (ff-rdp B6).
+pub(crate) fn collect_config_report(
+    cwd: &Path,
+    dir_override: Option<&Path>,
+) -> anyhow::Result<ConfigReport> {
+    // The directory whose `.hyalo.toml` we read: the `--dir` override if given,
+    // else the CWD.
+    let config_search_dir = dir_override.unwrap_or(cwd);
+    let toml_path = config_search_dir.join(".hyalo.toml");
     let (config_path, raw_contents) = if toml_path.is_file() {
         let contents = std::fs::read_to_string(&toml_path)
             .with_context(|| format!("reading {}", toml_path.display()))?;
@@ -47,13 +61,21 @@ pub(crate) fn collect_config_report(cwd: &Path) -> anyhow::Result<ConfigReport> 
     };
 
     // Load the full resolved config (handles partial files, malformed TOML, etc.)
-    let resolved = crate::config::load_config_from(cwd);
+    let resolved = crate::config::load_config_from(config_search_dir);
+
+    // A `--dir` override is the effective vault dir regardless of the config's
+    // own `dir` key.
+    let (dir, dir_overridden) = match dir_override {
+        Some(d) => (d.to_path_buf(), true),
+        None => (resolved.dir, false),
+    };
 
     Ok(ConfigReport {
         config_path,
         raw_contents,
         cwd: cwd.to_path_buf(),
-        dir: resolved.dir,
+        dir,
+        dir_overridden,
         format: resolved.format,
         hints: resolved.hints,
         site_prefix: resolved.site_prefix,
@@ -76,6 +98,7 @@ fn run_config_json(report: &ConfigReport) -> CommandOutcome {
         "raw_contents": report.raw_contents,
         "cwd": report.cwd.display().to_string(),
         "dir": report.dir.display().to_string(),
+        "dir_overridden": report.dir_overridden,
         "format": report.format,
         "hints": report.hints,
         "site_prefix": report.site_prefix,
@@ -99,8 +122,16 @@ fn run_config_text(report: &ConfigReport) -> CommandOutcome {
         report.exempt.join(", ")
     };
 
+    // Annotate the dir line when a `--dir` override is in effect, so the report
+    // makes the shadow explicit rather than silently reporting the override.
+    let dir_suffix = if report.dir_overridden {
+        "  (--dir override)"
+    } else {
+        ""
+    };
+
     let mut out = format!(
-        "config: {config_path_str}\ncwd: {cwd}\ndir: {dir}\nformat: {format_str}\nhints: {hints}\nsite_prefix: {site_prefix_str}\nexempt: {exempt_str}\n",
+        "config: {config_path_str}\ncwd: {cwd}\ndir: {dir}{dir_suffix}\nformat: {format_str}\nhints: {hints}\nsite_prefix: {site_prefix_str}\nexempt: {exempt_str}\n",
         cwd = report.cwd.display(),
         dir = report.dir.display(),
         hints = report.hints,

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -27,6 +27,51 @@ Run `hyalo --help` for usage. Use `--format text` for compact LLM-friendly outpu
 const SECTION_START: &str = "<!-- hyalo:start -->";
 const SECTION_END: &str = "<!-- hyalo:end -->";
 
+/// The `.claude/CLAUDE.md` pointer line for an active profile, or `None` for a
+/// profile with no specific reminder. Each line nudges the agent toward the
+/// profile's drift-check / conformance workflow.
+fn profile_pointer_line(profile: &str) -> Option<&'static str> {
+    match profile {
+        "okf" => Some(
+            "OKF vault: run `hyalo okf index --dry-run` to check index drift and \
+             `hyalo lint` for §9 conformance.",
+        ),
+        "madr" => Some(
+            "MADR vault: run `hyalo madr toc --dry-run` to check the ADR table drift and \
+             `hyalo lint` for ADR conformance.",
+        ),
+        "skills" => Some(
+            "Skills vault: run `hyalo lint` to validate SKILL.md files (name/description \
+             rules, `.claude/skills/` is reachable via `[scan] include`).",
+        ),
+        "changelog" => Some(
+            "Changelog vault: use `hyalo changelog add`/`release` to edit CHANGELOG.md and \
+             `hyalo lint` to check Keep-a-Changelog grammar.",
+        ),
+        _ => None,
+    }
+}
+
+/// Read the active `[lint] profiles` list from a written `.hyalo.toml` (empty
+/// on any read/parse failure), in declaration order.
+fn active_profiles_from_config(toml_path: &Path) -> Vec<String> {
+    let Ok(raw) = fs::read_to_string(toml_path) else {
+        return Vec::new();
+    };
+    let Ok(val) = toml::from_str::<toml::Value>(&raw) else {
+        return Vec::new();
+    };
+    val.get("lint")
+        .and_then(|l| l.get("profiles"))
+        .and_then(|p| p.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Common documentation directory names to scan for when no `--dir` is given.
 const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "content", "pages"];
 
@@ -160,6 +205,46 @@ fn run_init_in(
             profile.name
         )
         .unwrap();
+
+        // Changelog profile: when the vault dir is a subdirectory and the repo
+        // root holds the `CHANGELOG.md` (the common layout that hit
+        // user-event-service), point `[changelog] path` at it so
+        // `changelog add`/`release` and `lint --profile changelog` reach the
+        // root file without `--dir .` gymnastics. Only write the key when it is
+        // not already set (idempotent, never clobbers a user override) and the
+        // root file actually exists but the vault-local one does not.
+        if profile.name == "changelog" && dir_value != "." {
+            let root_changelog = cwd.join("CHANGELOG.md");
+            let vault_changelog = cwd.join(&dir_value).join("CHANGELOG.md");
+            if root_changelog.is_file() && !vault_changelog.is_file() {
+                let existing_raw = fs::read_to_string(&toml_path)
+                    .with_context(|| format!("failed to read {}", toml_path.display()))?;
+                if let Ok(mut doc) = existing_raw.parse::<toml_edit::DocumentMut>() {
+                    let already_set = doc.get("changelog").and_then(|c| c.get("path")).is_some();
+                    if !already_set {
+                        // `[changelog] path` is resolved relative to the config
+                        // file's directory (where `.hyalo.toml` lives — the repo
+                        // root here), NOT the vault `dir`. The root `CHANGELOG.md`
+                        // sits right beside `.hyalo.toml`, so the config-dir-
+                        // relative path is simply `CHANGELOG.md` (which differs
+                        // from the default `dir/CHANGELOG.md` and thus points at
+                        // the root file).
+                        let changelog_tbl = doc["changelog"].or_insert(toml_edit::table());
+                        if let Some(tbl) = changelog_tbl.as_table_mut() {
+                            tbl.set_implicit(false);
+                            tbl["path"] = toml_edit::value("CHANGELOG.md");
+                        }
+                        fs::write(&toml_path, doc.to_string())
+                            .with_context(|| format!("failed to write {}", toml_path.display()))?;
+                        writeln!(
+                            summary,
+                            "updated  .hyalo.toml  ([changelog] path = \"CHANGELOG.md\")"
+                        )
+                        .unwrap();
+                    }
+                }
+            }
+        }
     }
 
     if !claude && !pi {
@@ -233,9 +318,22 @@ fn run_init_in(
             writeln!(summary, "created  .claude/rules/knowledgebase.md").unwrap();
         }
 
-        // Step 5: upsert the hyalo managed section in .claude/CLAUDE.md
+        // Step 5: upsert the hyalo managed section in .claude/CLAUDE.md.
+        // Append one profile-specific pointer line per *active* profile (read
+        // from the merged `[lint] profiles` in `.hyalo.toml`), so a vault with
+        // several profiles carries a drift-check reminder for each — and the
+        // lines survive across `init --profile` runs because they are rebuilt
+        // from the config each time, not just from the current `--profile`.
         let claude_md_path = cwd.join(".claude").join("CLAUDE.md");
-        let managed_section = format!("{SECTION_START}\n{CLAUDE_MD_HINT}\n{SECTION_END}");
+        let managed_section = {
+            let active = active_profiles_from_config(&toml_path);
+            let mut body = String::from(CLAUDE_MD_HINT);
+            for pointer in active.iter().filter_map(|p| profile_pointer_line(p)) {
+                body.push('\n');
+                body.push_str(pointer);
+            }
+            format!("{SECTION_START}\n{body}\n{SECTION_END}")
+        };
         if claude_md_path.exists() {
             let existing = fs::read_to_string(&claude_md_path)
                 .with_context(|| format!("failed to read {}", claude_md_path.display()))?;

--- a/crates/hyalo-cli/src/commands/madr.rs
+++ b/crates/hyalo-cli/src/commands/madr.rs
@@ -51,6 +51,8 @@ pub fn run_toc(
     adr_dir: Option<&str>,
     apply: bool,
     replace: bool,
+    schema: &hyalo_core::schema::SchemaConfig,
+    active_profiles: &[String],
     format: Format,
 ) -> Result<(CommandOutcome, Option<i32>)> {
     let adr_rel_normalized = adr_dir.unwrap_or(DEFAULT_ADR_DIR).replace('\\', "/");
@@ -70,7 +72,7 @@ pub fn run_toc(
         ));
     }
 
-    let entries = collect_adrs(&adr_full, adr_rel)?;
+    let entries = collect_adrs(&adr_full, adr_rel, schema)?;
     let body = render_toc_body(&entries);
 
     let toc_rel = format!("{adr_rel}/README.md");
@@ -111,7 +113,7 @@ pub fn run_toc(
         "changed": changed,
         "file": plan.rel_path,
         "action": action,
-        "hint": "hyalo lint --profile madr  # validate ADR conformance",
+        "hint": crate::commands::profile_lint_hint("madr", active_profiles, "validate ADR conformance"),
     });
     if action == "adopt" {
         payload["preserved_lines"] = serde_json::Value::from(plan.old_content.lines().count());
@@ -125,10 +127,28 @@ pub fn run_toc(
     ))
 }
 
-/// Read every `.md` file (except the generated `README.md`) directly under
-/// `adr_full` into an [`AdrEntry`], sorted by number then filename.
-fn collect_adrs(adr_full: &Path, adr_rel: &str) -> Result<Vec<AdrEntry>> {
+/// Read every ADR-typed `.md` file (except the generated `README.md`) directly
+/// under `adr_full` into an [`AdrEntry`], sorted by number then filename.
+///
+/// A file counts as an ADR only when its *effective* type is `adr` — either an
+/// explicit `type: adr` in frontmatter, or a `[[schema.bind]]` that maps its
+/// path to `adr`. This keeps unrelated concept/prose files that happen to live
+/// under the decisions directory out of the dashboard (user-service repro: 13
+/// concept files polluted the TOC).
+fn collect_adrs(
+    adr_full: &Path,
+    adr_rel: &str,
+    schema: &hyalo_core::schema::SchemaConfig,
+) -> Result<Vec<AdrEntry>> {
     let mut entries: Vec<AdrEntry> = Vec::new();
+    // Only filter by effective type when the schema actually knows the `adr`
+    // type (via a `[schema.types.adr]` declaration or a bind that maps to it —
+    // i.e. the madr profile is active). On a plain vault with no ADR schema, the
+    // command has no way to distinguish ADRs from other files, so it keeps the
+    // historical "every .md in the directory" behavior rather than emptying the
+    // dashboard.
+    let filter_by_type =
+        schema.types.contains_key("adr") || schema.bind.entries().iter().any(|(_, t)| t == "adr");
     let read = std::fs::read_dir(adr_full)
         .with_context(|| format!("failed to read ADR directory {adr_rel}"))?;
     for dirent in read.flatten() {
@@ -146,6 +166,9 @@ fn collect_adrs(adr_full: &Path, adr_rel: &str) -> Result<Vec<AdrEntry>> {
             continue;
         }
         let full = dirent.path();
+        if filter_by_type && !is_adr_typed(&full, &format!("{adr_rel}/{name}"), schema)? {
+            continue;
+        }
         entries.push(read_adr_entry(&full, name)?);
     }
     entries.sort_by(|a, b| match (a.number, b.number) {
@@ -155,6 +178,20 @@ fn collect_adrs(adr_full: &Path, adr_rel: &str) -> Result<Vec<AdrEntry>> {
         (None, None) => a.link.cmp(&b.link),
     });
     Ok(entries)
+}
+
+/// Whether the file at `full` (vault-relative `rel`) has effective type `adr`.
+///
+/// Precedence: an explicit `type:` in frontmatter wins; otherwise the schema's
+/// path bindings decide. A file with an explicit *non-`adr`* type, or one bound
+/// to a different type, is excluded from the TOC.
+fn is_adr_typed(full: &Path, rel: &str, schema: &hyalo_core::schema::SchemaConfig) -> Result<bool> {
+    let props = hyalo_core::frontmatter::read_frontmatter(full)
+        .with_context(|| format!("failed to parse frontmatter of {rel}"))?;
+    if let Some(explicit) = props.get("type").and_then(|v| v.as_str()) {
+        return Ok(explicit.trim() == "adr");
+    }
+    Ok(schema.bound_type_for(rel) == Some("adr"))
 }
 
 /// Read one ADR file's frontmatter/heading into an [`AdrEntry`].
@@ -364,7 +401,16 @@ mod tests {
         .unwrap();
 
         // First apply creates the README.
-        let (_out, exit) = run_toc(tmp.path(), None, true, false, Format::Json).unwrap();
+        let (_out, exit) = run_toc(
+            tmp.path(),
+            None,
+            true,
+            false,
+            &hyalo_core::schema::SchemaConfig::default(),
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert_eq!(exit, None, "apply never sets a drift exit code");
         let readme = adr.join("README.md");
         assert!(readme.is_file());
@@ -373,12 +419,30 @@ mod tests {
         assert!(content.contains("<!-- madr:toc:begin -->"));
 
         // Dry-run now reports no drift (exit None).
-        let (_out2, exit2) = run_toc(tmp.path(), None, false, false, Format::Json).unwrap();
+        let (_out2, exit2) = run_toc(
+            tmp.path(),
+            None,
+            false,
+            false,
+            &hyalo_core::schema::SchemaConfig::default(),
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert_eq!(exit2, None, "no drift after apply");
 
         // Re-apply is a no-op (idempotent).
         let before = std::fs::read_to_string(&readme).unwrap();
-        run_toc(tmp.path(), None, true, false, Format::Json).unwrap();
+        run_toc(
+            tmp.path(),
+            None,
+            true,
+            false,
+            &hyalo_core::schema::SchemaConfig::default(),
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         let after = std::fs::read_to_string(&readme).unwrap();
         assert_eq!(before, after);
     }
@@ -390,14 +454,32 @@ mod tests {
         std::fs::create_dir_all(&adr).unwrap();
         std::fs::write(adr.join("0001-x.md"), "---\nstatus: proposed\n---\n# X\n").unwrap();
         // No README yet → dry-run must signal drift (exit 1).
-        let (_out, exit) = run_toc(tmp.path(), None, false, false, Format::Json).unwrap();
+        let (_out, exit) = run_toc(
+            tmp.path(),
+            None,
+            false,
+            false,
+            &hyalo_core::schema::SchemaConfig::default(),
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert_eq!(exit, Some(1));
     }
 
     #[test]
     fn missing_adr_dir_is_user_error() {
         let tmp = tempfile::tempdir().unwrap();
-        let (out, exit) = run_toc(tmp.path(), None, false, false, Format::Json).unwrap();
+        let (out, exit) = run_toc(
+            tmp.path(),
+            None,
+            false,
+            false,
+            &hyalo_core::schema::SchemaConfig::default(),
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert!(matches!(out, CommandOutcome::UserError(_)));
         assert_eq!(exit, None);
     }
@@ -413,10 +495,87 @@ mod tests {
         std::fs::create_dir_all(&adr).unwrap();
         std::fs::write(adr.join("0001-x.md"), "---\nstatus: proposed\n---\n# X\n").unwrap();
 
-        let (out, exit) =
-            run_toc(tmp.path(), Some("docs\\adr"), true, false, Format::Json).unwrap();
+        let (out, exit) = run_toc(
+            tmp.path(),
+            Some("docs\\adr"),
+            true,
+            false,
+            &hyalo_core::schema::SchemaConfig::default(),
+            &[],
+            Format::Json,
+        )
+        .unwrap();
         assert_eq!(exit, None, "apply never sets a drift exit code: {out:?}");
         // The README must land at docs/adr/README.md, not a mixed-separator path.
         assert!(adr.join("README.md").is_file());
+    }
+
+    /// Build a `SchemaConfig` with an `adr` type bound to the decisions subtree,
+    /// mirroring what the madr profile activates.
+    fn adr_schema() -> hyalo_core::schema::SchemaConfig {
+        let merged = crate::commands::profiles::merge_into_config(
+            "",
+            include_str!("../../templates/profile-madr.toml"),
+        )
+        .unwrap();
+        let val: toml::Value = toml::from_str(&merged).unwrap();
+        let raw: hyalo_core::schema::RawSchemaConfig =
+            val.get("schema").unwrap().clone().try_into().unwrap();
+        hyalo_core::schema::SchemaConfig::try_from(raw).unwrap()
+    }
+
+    #[test]
+    fn toc_excludes_non_adr_typed_files_when_schema_present() {
+        // user-service repro: concept/prose files under the decisions dir must
+        // not pollute the TOC when the madr schema is active.
+        let tmp = tempfile::tempdir().unwrap();
+        let adr = tmp.path().join("docs/decisions");
+        std::fs::create_dir_all(&adr).unwrap();
+        // A real ADR (bound to `adr` by path, no explicit type).
+        std::fs::write(
+            adr.join("0001-use-postgres.md"),
+            "---\nstatus: accepted\n---\n# Use Postgres\n",
+        )
+        .unwrap();
+        // A concept file that happens to live here but declares another type.
+        std::fs::write(
+            adr.join("glossary.md"),
+            "---\ntype: concept\n---\n# Glossary\n",
+        )
+        .unwrap();
+
+        let schema = adr_schema();
+        run_toc(tmp.path(), None, true, false, &schema, &[], Format::Json).unwrap();
+        let readme = std::fs::read_to_string(adr.join("README.md")).unwrap();
+        assert!(readme.contains("Use Postgres"), "ADR included:\n{readme}");
+        assert!(
+            !readme.contains("Glossary"),
+            "non-adr concept excluded:\n{readme}"
+        );
+    }
+
+    #[test]
+    fn toc_includes_all_when_no_adr_schema() {
+        // Without the madr schema, `madr toc` can't tell ADRs from other files,
+        // so it keeps the historical "every .md" behavior (no empty dashboard).
+        let tmp = tempfile::tempdir().unwrap();
+        let adr = tmp.path().join("docs/decisions");
+        std::fs::create_dir_all(&adr).unwrap();
+        std::fs::write(adr.join("0001-x.md"), "---\nstatus: proposed\n---\n# X\n").unwrap();
+        std::fs::write(adr.join("0002-y.md"), "---\nstatus: proposed\n---\n# Y\n").unwrap();
+
+        run_toc(
+            tmp.path(),
+            None,
+            true,
+            false,
+            &hyalo_core::schema::SchemaConfig::default(),
+            &[],
+            Format::Json,
+        )
+        .unwrap();
+        let readme = std::fs::read_to_string(adr.join("README.md")).unwrap();
+        assert!(readme.contains("# X") || readme.contains("0001-x"));
+        assert!(readme.contains("# Y") || readme.contains("0002-y"));
     }
 }

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -65,6 +65,25 @@ pub fn resolve_file_user(
     }
     discovery::resolve_file(dir, path_arg)
 }
+
+/// The `hyalo lint --profile <profile>` hint to attach to a generator command's
+/// output — or `None` when it would be redundant.
+///
+/// Commands like `okf index`, `madr toc`, and `changelog add/release` suggest
+/// running `hyalo lint --profile <p>` to validate their output. But on a vault
+/// whose `.hyalo.toml` already activates `<p>` via `[lint] profiles`, plain
+/// `hyalo lint` runs that profile's rules — so the `--profile` flag is
+/// redundant noise (hoppy UX-2). In that case, return the plain
+/// `hyalo lint` form instead (still useful), stripping the redundant flag.
+#[must_use]
+pub(crate) fn profile_lint_hint(profile: &str, active_profiles: &[String], note: &str) -> String {
+    let redundant = active_profiles.iter().any(|p| p == profile);
+    if redundant {
+        format!("hyalo lint  # {note}")
+    } else {
+        format!("hyalo lint --profile {profile}  # {note}")
+    }
+}
 use hyalo_core::index::{ScanOptions, ScannedIndex, ScannedIndexBuild, SnapshotIndex, VaultIndex};
 use std::path::{Path, PathBuf};
 

--- a/crates/hyalo-cli/src/commands/new.rs
+++ b/crates/hyalo-cli/src/commands/new.rs
@@ -94,7 +94,12 @@ pub(crate) fn create_new(
     // Step 4 & 6: synthesise and atomically create the file
     // ------------------------------------------------------------------
     let merged = schema.merged_schema_for_type(type_name);
-    let content = synthesise_content(type_name, &merged, dir);
+    // Normalize the vault-relative path (forward slashes) for bind lookup so a
+    // `[[schema.bind]]` covering this path lets us omit the redundant explicit
+    // `type:` key (the bind already types the file).
+    let rel_for_bind = file_arg.replace('\\', "/");
+    let bound_here = schema.bound_type_for(&rel_for_bind) == Some(type_name);
+    let content = synthesise_content(type_name, &merged, bound_here);
 
     // Pre-flight budget check: reject before touching the filesystem.
     // Extract the YAML content between the --- delimiters.
@@ -176,18 +181,36 @@ pub(crate) fn create_new(
 fn synthesise_content(
     type_name: &str,
     merged: &hyalo_core::schema::TypeSchema,
-    _dir: &Path,
+    omit_type: bool,
 ) -> String {
     // Build an ordered map of frontmatter properties.
-    // `type` always comes first.
+    // `type` comes first — unless a `[[schema.bind]]` already types this file,
+    // in which case the explicit key is redundant (and non-spec for formats like
+    // SKILL.md that carry no `type:`), so we omit it.
     let mut props: IndexMap<String, PropValue> = IndexMap::new();
-    props.insert("type".to_owned(), PropValue::Str(type_name.to_owned()));
+    if !omit_type {
+        props.insert("type".to_owned(), PropValue::Str(type_name.to_owned()));
+    }
 
+    // Emit, in order: required properties (each seeded from its default or a
+    // type-appropriate placeholder), then any *non-required* property that has a
+    // schema `default` (e.g. MADR's `status = "proposed"` / `date = "$today"`),
+    // so the scaffold reflects the schema's declared defaults rather than
+    // leaving those columns blank in downstream views like `madr toc`.
+    let mut emit_order: Vec<String> = Vec::new();
     for prop_name in &merged.required {
         if prop_name == "type" {
-            continue; // already emitted
+            continue;
         }
+        emit_order.push(prop_name.clone());
+    }
+    for prop_name in merged.defaults.keys() {
+        if prop_name != "type" && !emit_order.iter().any(|p| p == prop_name) {
+            emit_order.push(prop_name.clone());
+        }
+    }
 
+    for prop_name in &emit_order {
         // Check if the schema has a default value.
         let default_val = merged.defaults.get(prop_name).map(|d| expand_default(d));
 

--- a/crates/hyalo-cli/src/commands/okf.rs
+++ b/crates/hyalo-cli/src/commands/okf.rs
@@ -31,11 +31,6 @@ use crate::output::{CommandOutcome, Format, format_error};
 const INDEX_BEGIN: &str = "<!-- okf:index:begin -->";
 const INDEX_END: &str = "<!-- okf:index:end -->";
 
-/// Drill-down hint pointing authors from the generators to the conformance
-/// validator. Surfaced in `okf index`/`okf log` JSON payloads and referenced
-/// in the command help.
-const OKF_LINT_HINT: &str = "hyalo lint --profile okf  # validate bundle conformance";
-
 /// The canonical OKF frontmatter key order (`reference_agent`'s `bundle`
 /// package emits keys in this order). Used by [`normalize_key_order`].
 pub const OKF_KEY_ORDER: &[&str] = &[
@@ -114,6 +109,7 @@ impl IndexPlan {
 /// (vault-relative). `apply` writes changes; otherwise this is a dry run and
 /// returns exit code 1 (via `exit_code_override`) when any `index.md` would
 /// change — the CI drift signal.
+#[allow(clippy::too_many_arguments)]
 pub fn run_index(
     dir: &Path,
     scope: Option<&str>,
@@ -121,6 +117,7 @@ pub fn run_index(
     replace: bool,
     ignore: &[String],
     case_insensitive: bool,
+    active_profiles: &[String],
     format: Format,
 ) -> Result<(CommandOutcome, Option<i32>)> {
     // Resolve the optional scope directory to a vault-relative prefix.
@@ -264,7 +261,7 @@ pub fn run_index(
         "changed": changed.len(),
         "skipped_malformed": skipped_malformed,
         "files": results,
-        "hint": OKF_LINT_HINT,
+        "hint": crate::commands::profile_lint_hint("okf", active_profiles, "validate bundle conformance"),
     });
 
     // In dry-run mode, drift (any changed file) is a non-zero exit for CI.
@@ -678,6 +675,7 @@ pub fn run_log(
     message: &str,
     action: Option<&str>,
     apply: bool,
+    active_profiles: &[String],
     format: Format,
 ) -> Result<CommandOutcome> {
     if message.trim().is_empty() {
@@ -726,7 +724,7 @@ pub fn run_log(
         "date": today,
         "entry": entry_line,
         "created": old_content.is_empty(),
-        "hint": OKF_LINT_HINT,
+        "hint": crate::commands::profile_lint_hint("okf", active_profiles, "validate bundle conformance"),
     });
     Ok(CommandOutcome::success(payload.to_string()))
 }

--- a/crates/hyalo-cli/src/commands/profiles.rs
+++ b/crates/hyalo-cli/src/commands/profiles.rs
@@ -138,6 +138,7 @@ const UNION_ARRAY_KEYS: &[&str] = &[
     "lint.ignore",
     "schema.default.required",
     "lint.profiles",
+    "scan.include",
 ];
 
 /// Deep-merge the profile's TOML fragment into an existing (or empty) config
@@ -380,10 +381,8 @@ required = [\"type\", \"status\"]
         let parsed: toml::Table = toml::from_str(&merged).unwrap();
         let types = parsed["schema"]["types"].as_table().unwrap();
         assert!(types.contains_key("madr"), "foreign type preserved");
-        assert!(
-            types.contains_key("BigQuery Table"),
-            "OKF type added alongside"
-        );
+        // The neutral OKF profile ships no example concept types, so the merge
+        // must not have clobbered the foreign `madr` type — it simply survives.
     }
 
     #[test]
@@ -502,7 +501,6 @@ required = [\"type\", \"status\"]
         let types = parsed["schema"]["types"].as_table().unwrap();
         assert!(types.contains_key("changelog"));
         assert!(types.contains_key("adr"));
-        assert!(types.contains_key("BigQuery Table"));
     }
 
     // ---------------------------------------------------------------------------
@@ -717,9 +715,8 @@ exempt = [\"user/only.md\"]
         let parsed: toml::Table = toml::from_str(&both).unwrap();
         let types = parsed["schema"]["types"].as_table().unwrap();
         assert!(types.contains_key("adr"), "madr adr type present");
-        assert!(
-            types.contains_key("BigQuery Table"),
-            "okf types preserved alongside madr"
-        );
+        // OKF adds no example types, so `adr` is the only declared type after
+        // composing okf+madr — the okf merge must not have dropped it.
+        assert_eq!(types.len(), 1, "only madr's adr type declared: {types:?}");
     }
 }

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -884,6 +884,18 @@ fn validate_type_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("type name cannot be empty".to_owned());
     }
+    // `default` is reserved: it names the fallback `[schema.default]` table, not
+    // a concrete type. `hyalo types set default …` would silently create a
+    // phantom `[schema.types.default]` type that never binds to anything
+    // (user-service BUG-A3). Reject it and point at the real table.
+    if name.eq_ignore_ascii_case("default") {
+        return Err(
+            "'default' is a reserved name for the fallback schema — edit \
+             `[schema.default]` in .hyalo.toml directly (it applies to every \
+             untyped file); `types set` only manages concrete `[schema.types.*]` types"
+                .to_owned(),
+        );
+    }
     if !name
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
@@ -1043,6 +1055,47 @@ mod tests {
         assert!(validate_type_name("iteration").is_ok());
         assert!(validate_type_name("my-type").is_ok());
         assert!(validate_type_name("my_type").is_ok());
+    }
+
+    #[test]
+    fn validate_type_name_rejects_reserved_default() {
+        let err = validate_type_name("default").unwrap_err();
+        assert!(
+            err.contains("[schema.default]"),
+            "points at the table: {err}"
+        );
+        // Case-insensitive.
+        assert!(validate_type_name("Default").is_err());
+    }
+
+    #[test]
+    fn set_type_default_is_user_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outcome = set_type(
+            tmp.path(),
+            "default",
+            &["title".to_owned()],
+            &[],
+            &[],
+            &[],
+            None,
+            false,
+            Format::Json,
+        )
+        .unwrap();
+        assert!(
+            matches!(outcome, CommandOutcome::UserError(_)),
+            "types set default must be a user error"
+        );
+        // No phantom type table was written.
+        let toml_path = tmp.path().join(".hyalo.toml");
+        if toml_path.exists() {
+            let contents = std::fs::read_to_string(&toml_path).unwrap();
+            assert!(
+                !contents.contains("[schema.types.default]"),
+                "must not create a phantom default type"
+            );
+        }
     }
 
     #[test]

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -33,6 +33,31 @@ struct LinksConfig {
     case_insensitive: Option<String>,
 }
 
+/// Changelog configuration from `[changelog]` in `.hyalo.toml`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChangelogConfig {
+    /// Path to the `CHANGELOG.md`, resolved relative to the config file's
+    /// directory (`config_dir`). Defaults to `CHANGELOG.md` in the vault dir.
+    /// May point outside the vault dir (e.g. `../CHANGELOG.md` for a repo-root
+    /// changelog when the vault is a docs subdir), but never above the repo
+    /// root — validated at resolution time. Used by `changelog add`,
+    /// `changelog release`, and `lint --profile changelog`.
+    path: Option<String>,
+}
+
+/// Vault-walker configuration from `[scan]` in `.hyalo.toml`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScanConfig {
+    /// Vault-relative globs whose (otherwise-skipped) hidden dot-paths the
+    /// walker descends into. E.g. `[".claude/skills/**"]` makes the canonical
+    /// Claude Code skill location reachable. `.git/**` is never re-included.
+    /// Honored by every command that discovers vault files.
+    #[serde(default)]
+    include: Vec<String>,
+}
+
 /// OKF generator configuration from `[okf]` in `.hyalo.toml`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -128,6 +153,10 @@ struct ConfigFile {
     links: Option<LinksConfig>,
     /// OKF generator configuration (`[okf]` section).
     okf: Option<OkfConfig>,
+    /// Vault-walker configuration (`[scan]` section).
+    scan: Option<ScanConfig>,
+    /// Changelog configuration (`[changelog]` section).
+    changelog: Option<ChangelogConfig>,
     /// When `true`, schema validation runs automatically on every `set`/`append`.
     /// Accepted as a top-level key for backwards compatibility; the documented
     /// location is `[schema] validate_on_write`.
@@ -170,6 +199,14 @@ pub(crate) struct ResolvedDefaults {
     pub(crate) lint_ignore: Vec<String>,
     /// Vault-relative globs the OKF generators skip. From `[okf] ignore`.
     pub(crate) okf_ignore: Vec<String>,
+    /// Vault-relative globs the walker descends into despite being hidden
+    /// dot-paths. From `[scan] include`. Installed process-wide at startup so
+    /// every command's file discovery honors it.
+    pub(crate) scan_include: Vec<String>,
+    /// Raw `[changelog] path` value (config-dir-relative), if set. `None` means
+    /// the default `CHANGELOG.md` in the vault dir. Resolution/validation into
+    /// an absolute path happens in `run.rs` (needs `config_dir`).
+    pub(crate) changelog_path: Option<String>,
     /// Markdown linting config (max caps, per-rule overrides).
     pub(crate) md_lint: hyalo_mdlint::LintConfig,
     /// Parsed schema configuration from `[schema.*]` sections.
@@ -228,6 +265,8 @@ impl ResolvedDefaults {
             validate_on_write: false,
             lint_ignore: Vec::new(),
             okf_ignore: Vec::new(),
+            scan_include: Vec::new(),
+            changelog_path: None,
             md_lint: hyalo_mdlint::LintConfig::default(),
             schema: SchemaConfig::default(),
             default_limit: None,
@@ -415,6 +454,8 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
             .map(|l| l.ignore.clone())
             .unwrap_or_default(),
         okf_ignore: cfg.okf.map(|o| o.ignore).unwrap_or_default(),
+        scan_include: cfg.scan.map(|s| s.include).unwrap_or_default(),
+        changelog_path: cfg.changelog.and_then(|c| c.path),
         md_lint: parse_md_lint_config(cfg.lint.as_ref()),
         schema,
         default_limit: cfg.default_limit,
@@ -604,6 +645,31 @@ pub(crate) fn overlay_profile(
         lint_strict,
         lint_profiles,
     })
+}
+
+/// The `[scan] include` globs contributed by merging the named profile's
+/// fragment into the `.hyalo.toml` found in `config_dir`.
+///
+/// Used to install the walker's dot-dir include list for an ephemeral
+/// `--profile <name>` run (which never writes `.hyalo.toml`) so a profile that
+/// ships `[scan] include` — e.g. `skills` reaching `.claude/skills/` — works
+/// without first running `hyalo init --profile`. On any failure (unknown
+/// profile, unreadable/invalid base config) returns an empty list rather than
+/// erroring: dispatch surfaces the real profile error separately.
+pub(crate) fn overlay_scan_include(config_dir: &Path, profile_name: &str) -> Vec<String> {
+    let Ok(profile) = crate::commands::profiles::lookup(profile_name) else {
+        return Vec::new();
+    };
+    let existing_raw = std::fs::read_to_string(config_dir.join(".hyalo.toml")).unwrap_or_default();
+    let Ok(merged_raw) =
+        crate::commands::profiles::merge_into_config(&existing_raw, profile.toml_fragment)
+    else {
+        return Vec::new();
+    };
+    let Ok(cfg) = toml::from_str::<ConfigFile>(&merged_raw) else {
+        return Vec::new();
+    };
+    cfg.scan.map(|s| s.include).unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -156,6 +156,10 @@ pub(crate) struct CommandContext<'a> {
     pub lint_ignore: &'a [String],
     /// Vault-relative globs the OKF generators skip. From `[okf] ignore` in `.hyalo.toml`.
     pub okf_ignore: &'a [String],
+    /// Raw `[changelog] path` value (config-dir-relative), if set. Resolved
+    /// against `config_dir` by the changelog commands. `None` = default
+    /// `CHANGELOG.md` in the vault dir.
+    pub changelog_path: Option<&'a str>,
     /// Markdown lint configuration from `[lint]` in `.hyalo.toml`.
     pub md_lint: &'a hyalo_mdlint::LintConfig,
     /// Case-insensitive link resolution mode from `[links] case_insensitive`.
@@ -1685,7 +1689,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 glob
             };
 
-            let file_pairs = match crate::commands::collect_files(
+            let mut file_pairs = match crate::commands::collect_files(
                 dir,
                 &files_arg,
                 &effective_glob,
@@ -1694,6 +1698,38 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 crate::commands::FilesOrOutcome::Files(f) => f,
                 crate::commands::FilesOrOutcome::Outcome(o) => return Ok(o),
             };
+
+            // Reach a repo-root CHANGELOG.md that lives *outside* the vault dir.
+            // When the changelog profile is active and `[changelog] path`
+            // resolves to a file the vault walk can't see (the common
+            // docs-subdir layout), add it to the lint set so
+            // `lint --profile changelog` validates the real file without
+            // `--dir .` gymnastics. Only for an unscoped run (no explicit
+            // `--file`/`--glob`), so a targeted lint is never surprised by an
+            // extra file.
+            if files_arg.is_empty()
+                && effective_glob.is_empty()
+                && ctx.lint_profiles.iter().any(|p| p == "changelog")
+                && let Ok(changelog_file) = crate::commands::changelog::resolve_changelog_file(
+                    dir,
+                    ctx.config_dir,
+                    ctx.changelog_path,
+                )
+                && changelog_file.is_file()
+            {
+                let rel = hyalo_core::discovery::relative_path(dir, &changelog_file);
+                // Only inject when the file is outside the vault dir (a relative
+                // path that climbs out, or an absolute one) — an in-vault
+                // CHANGELOG.md was already discovered by the walk.
+                let outside = rel.starts_with("..") || std::path::Path::new(&rel).is_absolute();
+                let already = file_pairs.iter().any(|(p, _)| p == &changelog_file);
+                if outside && !already {
+                    let display = changelog_file
+                        .file_name()
+                        .map_or_else(|| rel.clone(), |n| n.to_string_lossy().into_owned());
+                    file_pairs.push((changelog_file, display));
+                }
+            }
 
             let fix_mode = if fix {
                 if dry_run {
@@ -2265,6 +2301,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     replace,
                     ctx.okf_ignore,
                     case_insensitive,
+                    &ctx.lint_profiles,
                     effective_format,
                 )?;
                 if let Some(code) = exit_override {
@@ -2284,6 +2321,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 &message,
                 log_action.as_deref(),
                 apply,
+                &ctx.lint_profiles,
                 effective_format,
             ),
         },
@@ -2299,6 +2337,8 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     adr_dir.as_deref(),
                     apply,
                     replace,
+                    ctx.schema,
+                    &ctx.lint_profiles,
                     effective_format,
                 )?;
                 if let Some(code) = exit_override {
@@ -2314,11 +2354,17 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 apply,
                 dry_run: _,
             } => {
-                let (outcome, exit_override) = crate::commands::changelog::run_release(
+                let changelog_file = crate::commands::changelog::resolve_changelog_file(
                     ctx.dir,
+                    ctx.config_dir,
+                    ctx.changelog_path,
+                )?;
+                let (outcome, exit_override) = crate::commands::changelog::run_release(
+                    &changelog_file,
                     &version,
                     date.as_deref(),
                     apply,
+                    &ctx.lint_profiles,
                     effective_format,
                 )?;
                 if let Some(code) = exit_override {
@@ -2332,11 +2378,17 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 apply,
                 dry_run: _,
             } => {
-                let (outcome, exit_override) = crate::commands::changelog::run_add(
+                let changelog_file = crate::commands::changelog::resolve_changelog_file(
                     ctx.dir,
+                    ctx.config_dir,
+                    ctx.changelog_path,
+                )?;
+                let (outcome, exit_override) = crate::commands::changelog::run_add(
+                    &changelog_file,
                     &category,
                     &message,
                     apply,
+                    &ctx.lint_profiles,
                     effective_format,
                 )?;
                 if let Some(code) = exit_override {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -18,6 +18,20 @@ use crate::output::{CommandOutcome, Format};
 use crate::output_pipeline::{COUNT_UNSUPPORTED_ERROR, OutputPipeline};
 use hyalo_core::index::SnapshotIndex;
 
+/// The explicit `--profile <name>` from a command, if any. Only `hyalo lint`
+/// accepts an ephemeral `--profile` overlay today; the scan-include installer
+/// consults this so a `--profile skills` run reaches `.claude/skills/` even on
+/// a vault not yet initialized with the profile.
+fn active_profile_name(command: &Commands) -> Option<&str> {
+    match command {
+        Commands::Lint {
+            profile: Some(name),
+            ..
+        } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
 /// Resolve the default output format based on whether stdout is a TTY.
 ///
 /// - TTY (interactive terminal): `Format::Text` — human-readable by default.
@@ -668,8 +682,13 @@ fn run_inner() -> Result<(), AppError> {
                 crate::output::Format::Json
             }
         });
-        let report =
-            crate::commands::config::collect_config_report(&cwd).map_err(AppError::Internal)?;
+        // A `--dir` override wins over the config's own `dir`: report the
+        // effective vault directory the rest of the CLI would use, not the
+        // config-file value it shadows (ff-rdp B6). When `--dir` names a
+        // directory that has its own `.hyalo.toml`, load from there.
+        let dir_override = cli.dir.as_deref();
+        let report = crate::commands::config::collect_config_report(&cwd, dir_override)
+            .map_err(AppError::Internal)?;
         match crate::commands::config::run_config(&report, format) {
             CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output) => {
                 // Sanitized because the text-mode RawOutput branch echoes the raw
@@ -742,6 +761,26 @@ fn run_inner() -> Result<(), AppError> {
     };
     // The directory where .hyalo.toml lives. Views/types are stored there.
     let config_dir = config.config_dir.clone();
+
+    // Install the `[scan] include` globs process-wide so every command's file
+    // discovery descends into the opted-in hidden dot-subtrees. A `--profile`
+    // overlay (below) can add to this via its fragment; union those in now so
+    // an un-initialized vault run with `--profile skills` still reaches
+    // `.claude/skills/`.
+    {
+        let mut include = config.scan_include.clone();
+        if let Some(profile_name) = active_profile_name(&cli.command) {
+            let extra = crate::config::overlay_scan_include(&config_dir, profile_name);
+            for pat in extra {
+                if !include.contains(&pat) {
+                    include.push(pat);
+                }
+            }
+        }
+        for (pat, msg) in hyalo_core::discovery::set_scan_include(&include) {
+            crate::warn::warn(format!("invalid [scan] include glob {pat:?}: {msg}"));
+        }
+    }
 
     // Warn when --dir is redundant: the user passed a dir that matches what
     // .hyalo.toml would have resolved to anyway. Only fires when .hyalo.toml
@@ -1390,6 +1429,7 @@ fn run_inner() -> Result<(), AppError> {
     let mut validate_on_write = config.validate_on_write;
     let lint_ignore = config.lint_ignore;
     let okf_ignore = config.okf_ignore;
+    let changelog_path = config.changelog_path;
     let case_insensitive_mode = config.case_insensitive_mode;
     let mut md_lint = config.md_lint;
     let mut lint_strict_from_config = config.lint_strict;
@@ -1547,6 +1587,7 @@ fn run_inner() -> Result<(), AppError> {
         validate_on_write,
         lint_ignore: &lint_ignore,
         okf_ignore: &okf_ignore,
+        changelog_path: changelog_path.as_deref(),
         md_lint: &md_lint,
         case_insensitive_mode,
         exit_code_override: None,

--- a/crates/hyalo-cli/templates/profile-okf.toml
+++ b/crates/hyalo-cli/templates/profile-okf.toml
@@ -44,14 +44,15 @@ type = "list"
 [schema.default.properties.timestamp]
 type = "datetime-tz"
 
-# Common OKF concept types. Quoted keys (spaces) are supported end-to-end.
-# `required_sections` nudge authors toward the OKF-recommended body structure.
-[schema.types."BigQuery Table"]
-required = ["type", "title"]
-required_sections = ["# Schema", "# Citations"]
-
-[schema.types."BigQuery Dataset"]
-required = ["type", "title"]
-
-[schema.types.Reference]
-required = ["type", "title"]
+# OKF is vendor-neutral: the profile ships no example concept types, because a
+# real vault's `type` values are domain-specific (a data catalog, a research
+# library, an API reference all differ). Declare your own types under
+# `[schema.types.<name>]` so authoring nudges match your domain. Quoted keys
+# (spaces) are supported end-to-end, and `required_sections` steers authors
+# toward the OKF-recommended body structure, e.g.:
+#
+#   [schema.types."Data Table"]
+#   required = ["type", "title"]
+#   required_sections = ["# Schema", "# Citations"]
+#
+# See the bundled `okf` skill ("Adding domain types") for the full recipe.

--- a/crates/hyalo-cli/templates/profile-skills.toml
+++ b/crates/hyalo-cli/templates/profile-skills.toml
@@ -9,6 +9,14 @@
 # Validate skill frontmatter against the schema on write.
 validate_on_write = true
 
+# Reach the canonical Claude Code skill location. The vault walker skips hidden
+# dot-directories by default, so `.claude/skills/**/SKILL.md` would be invisible
+# to every command. This opts that one subtree back in (never `.git`, which is
+# always excluded) so the `**/SKILL.md` bind above can actually see and lint
+# skills where Claude Code stores them — without relocating any files.
+[scan]
+include = [".claude/skills/**"]
+
 # Mark this vault as skills-flavoured so plain `hyalo lint` runs the Agent Skills
 # advisory rules (name↔dirname coupling, 500-line body budget) without
 # `--profile skills` on every invocation. `hyalo lint --profile skills` is then

--- a/crates/hyalo-cli/templates/skill-hyalo-changelog.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-changelog.md
@@ -62,7 +62,10 @@ hyalo changelog release 1.2.0 --date 2026-07-17 --apply            # override th
 ```
 
 - **`changelog add`** appends `- <message>` under the `### <category>` subsection of
-  `## [Unreleased]`, creating the subsection if missing.
+  `## [Unreleased]`, creating the subsection if missing. The entry always lands
+  **inside** the section, before the footer link-reference block, and the file keeps
+  exactly one trailing newline — the output stays Keep-a-Changelog-conformant even when
+  `[Unreleased]` is the last section.
 - **`changelog release <X.Y.Z>`** rotates the accumulated `## [Unreleased]` content into a
   dated `## [X.Y.Z] - <date>` section (date defaults to today), re-creates an empty
   `[Unreleased]` above it, and appends a placeholder `[X.Y.Z]: TBD` footer link reference
@@ -72,3 +75,19 @@ hyalo changelog release 1.2.0 --date 2026-07-17 --apply            # override th
 
 After a release, replace the `TBD` link target with the real compare/tag URL and run
 `hyalo lint --profile changelog` to confirm the result is clean.
+
+## Root `CHANGELOG.md` with a docs-subdir vault
+
+When the vault dir is a subdirectory (`dir = "docs"`) but `CHANGELOG.md` lives at the
+repo root, set `[changelog] path` — resolved relative to the config file's directory —
+so the changelog commands and lint reach the root file:
+
+```toml
+dir = "docs"
+[changelog]
+path = "CHANGELOG.md"   # the repo-root file, beside .hyalo.toml
+```
+
+`hyalo init --profile changelog --dir docs` writes this key automatically when a root
+`CHANGELOG.md` already exists. With it, `hyalo changelog add`/`release` and
+`hyalo lint --profile changelog` all operate on the root file — no `--dir .` needed.

--- a/crates/hyalo-cli/templates/skill-hyalo-okf.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-okf.md
@@ -191,6 +191,33 @@ for bundle-root links, `validate_on_write = true` so authoring stays conformant,
 `[lint] profiles = ["okf"]` so a plain `hyalo lint` runs the §9 conformance + citation rules
 (no `--profile okf` needed on this vault).
 
+## Adding domain types
+
+The OKF profile is **vendor-neutral** and ships **no example concept types** — a
+real bundle's `type` values are domain-specific (a data catalog, a research
+library, and an API reference all differ). Declare the types your bundle uses
+before scaffolding with `hyalo new --type <name>`; the `[schema.default]` block
+above already applies to every concept, so a type only adds what is specific to
+it (extra required fields, `required_sections`). Two ways:
+
+```bash
+# 1) From the CLI (quoted names with spaces are fine end-to-end):
+hyalo types set "Data Table" --required type,title
+# then edit .hyalo.toml to add required_sections for it, e.g.:
+#   [schema.types."Data Table"]
+#   required = ["type", "title"]
+#   required_sections = ["# Schema", "# Citations"]
+
+# 2) By hand in .hyalo.toml (same result), then verify:
+hyalo types list
+hyalo types show "Data Table"
+```
+
+Reserved `default` cannot be used as a type name — it names the fallback
+`[schema.default]` table, which you edit directly. Once a type is declared,
+`hyalo new --type "Data Table" --file tables/blocks.md` scaffolds it. The
+examples below use a `"BigQuery Table"` domain type; substitute your own.
+
 ## Example concept
 
 ```markdown

--- a/crates/hyalo-cli/templates/skill-hyalo-pi.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-pi.md
@@ -2,7 +2,7 @@
 name: hyalo
 user_invocable: false
 description: >
-  Use the hyalo CLI (via the bash tool) instead of read/edit/grep/write when working with markdown (.md) files
+  Use the hyalo CLI instead of read/edit/grep/write when working with markdown (.md) files
   that have YAML frontmatter. This skill MUST be consulted whenever pi is working with
   markdown documentation directories, knowledgebases, wikis, notes, Obsidian-compatible
   collections, Zettelkasten systems, iteration plans, or any collection of .md files with

--- a/crates/hyalo-cli/templates/skill-hyalo-skills.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-skills.md
@@ -3,7 +3,7 @@ name: skills
 user_invocable: false
 description: >
   Author and validate Agent Skills (SKILL.md) with hyalo. Use this skill whenever you are
-  creating or editing a skill — a `<name>/SKILL.md` directory whose frontmatter carries a
+  creating or editing a skill — a name/SKILL.md directory whose frontmatter carries a
   `name` slug and a `description`, per the Agent Skills specification
   (https://agentskills.io/specification). Trigger it when: scaffolding a new skill,
   validating a directory of skills against the spec (name regex/length, reserved words,
@@ -40,7 +40,13 @@ does the semantic work (the instructions the skill contains).
 
 The `skill` schema is bound to `**/SKILL.md` via `[[schema.bind]]`, so any `SKILL.md`
 anywhere in the tree is validated as a skill without needing explicit `type: skill`
-frontmatter. Explicit frontmatter always wins.
+frontmatter (in fact `hyalo new --type skill` omits the redundant `type:` key for a
+bound path, since SKILL.md carries none per the spec). Explicit frontmatter always wins.
+
+The profile also ships `[scan] include = [".claude/skills/**"]`, which re-admits the
+canonical (hidden) Claude Code skill location to the vault walker (`.git` stays
+excluded). Without it, `.claude/skills/**/SKILL.md` would be invisible to `find`/`lint`;
+with it, skills lint in place — no relocation.
 
 ## Validate
 

--- a/crates/hyalo-cli/tests/e2e/changelog_profile.rs
+++ b/crates/hyalo-cli/tests/e2e/changelog_profile.rs
@@ -344,6 +344,121 @@ fn add_rejects_unknown_category() {
 }
 
 #[test]
+fn add_places_new_category_before_footer_link_refs_rb4() {
+    // RB-4: on a conformant KaC file whose `[Unreleased]` is the LAST section
+    // (only the footer link-ref block follows), a new `### Category` must land
+    // inside the section — not after the link-ref definitions — and the result
+    // must lint clean.
+    let tmp = init_changelog();
+    write_changelog(
+        tmp.path(),
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n\n- Existing feature.\n\n\
+         [Unreleased]: https://x/compare/v1.0.0...HEAD\n[1.0.0]: https://x/tag/v1.0.0\n",
+    );
+    let (json, out) = run(
+        tmp.path(),
+        &[
+            "changelog",
+            "add",
+            "--category",
+            "Fixed",
+            "--message",
+            "A bug.",
+            "--apply",
+        ],
+    );
+    assert!(out.status.success(), "add succeeds: {json}");
+    let content = std::fs::read_to_string(tmp.path().join("CHANGELOG.md")).unwrap();
+    let fixed = content.find("### Fixed").expect("Fixed subsection");
+    let footer = content.find("[Unreleased]:").expect("footer");
+    assert!(
+        fixed < footer,
+        "new category before footer link refs:\n{content}"
+    );
+    // Exactly one trailing newline (MD047).
+    assert!(
+        content.ends_with('\n') && !content.ends_with("\n\n"),
+        "MD047 clean"
+    );
+    // And it lints clean under the changelog profile.
+    let (lint_json, lint_out) = run(tmp.path(), &["lint", "--profile", "changelog"]);
+    assert!(
+        lint_out.status.success(),
+        "conformant after add: {lint_json}"
+    );
+}
+
+#[test]
+fn root_changelog_reachable_from_docs_subdir_vault() {
+    // Task 4 / AC: a repo-root CHANGELOG.md with the vault dir set to a docs
+    // subdir must be addressable by `changelog add` and `lint --profile
+    // changelog` without `--dir .` gymnastics.
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("docs")).unwrap();
+    std::fs::write(
+        tmp.path().join("CHANGELOG.md"),
+        "# Changelog\n\n## [Unreleased]\n\n[Unreleased]: https://x/compare/v1.0.0...HEAD\n",
+    )
+    .unwrap();
+    // init from the repo root with the vault dir = docs; the changelog profile
+    // auto-writes `[changelog] path = "CHANGELOG.md"`.
+    let init = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["init", "--profile", "changelog", "--dir", "docs"])
+        .output()
+        .unwrap();
+    assert!(init.status.success(), "init failed");
+    let cfg = std::fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        cfg.contains("path = \"CHANGELOG.md\""),
+        "init wrote the changelog path: {cfg}"
+    );
+
+    // `changelog add` (no --dir) targets the root file.
+    let add = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "changelog",
+            "add",
+            "--category",
+            "Fixed",
+            "--message",
+            "Root bug.",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        add.status.success(),
+        "add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let root = std::fs::read_to_string(tmp.path().join("CHANGELOG.md")).unwrap();
+    assert!(
+        root.contains("- Root bug."),
+        "entry added to root file:\n{root}"
+    );
+    assert!(
+        !tmp.path().join("docs/CHANGELOG.md").exists(),
+        "must not create a vault-local changelog"
+    );
+
+    // `lint --profile changelog` (no --dir) reaches the root file.
+    let lint = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--profile", "changelog", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&lint.stdout);
+    let json: Value = serde_json::from_str(&stdout).unwrap();
+    let checked = json["results"]["files_checked"]
+        .as_u64()
+        .or_else(|| json["total"].as_u64())
+        .unwrap_or(0);
+    assert!(checked >= 1, "root CHANGELOG.md was linted: {stdout}");
+}
+
+#[test]
 fn release_rejects_bad_version() {
     let tmp = init_changelog();
     write_changelog(

--- a/crates/hyalo-cli/tests/e2e/init.rs
+++ b/crates/hyalo-cli/tests/e2e/init.rs
@@ -1167,7 +1167,16 @@ fn init_profile_okf_writes_expected_toml() {
     );
     assert!(content.contains("required = [\"type\"]"), "got: {content}");
     assert!(content.contains("datetime-tz"), "got: {content}");
-    assert!(content.contains("BigQuery Table"), "got: {content}");
+    // The OKF profile is vendor-neutral (iter-175): it must NOT inject example
+    // concept types like the old `BigQuery Table` / `Reference`.
+    assert!(
+        !content.contains("BigQuery"),
+        "neutral OKF profile ships no vendor example types: {content}"
+    );
+    assert!(
+        !content.contains("[schema.types.Reference]"),
+        "neutral OKF profile ships no Reference type: {content}"
+    );
     // Must not emit the deprecated kebab-case section key.
     assert!(
         !stderr.contains("deprecated: 'required-sections'"),

--- a/crates/hyalo-cli/tests/e2e/madr_profile.rs
+++ b/crates/hyalo-cli/tests/e2e/madr_profile.rs
@@ -78,7 +78,19 @@ fn new_adr_scaffolds_required_sections() {
     assert!(output.status.success(), "new adr failed: {json}");
     let content =
         std::fs::read_to_string(tmp.path().join("docs/decisions/0001-use-postgres.md")).unwrap();
-    assert!(content.contains("type: adr"));
+    // The file is path-bound to `adr`, so the scaffold omits the redundant
+    // explicit `type:` key (iter-175) — the bind already types it.
+    assert!(
+        !content.contains("type:"),
+        "bound file omits explicit type: {content}"
+    );
+    // Schema defaults are applied to the scaffold: `status = proposed` and a
+    // `$today`-expanded date.
+    assert!(
+        content.contains("status: proposed"),
+        "status default applied: {content}"
+    );
+    assert!(content.contains("date:"), "date default applied: {content}");
     assert!(content.contains("## Context and Problem Statement"));
     assert!(content.contains("## Considered Options"));
     assert!(content.contains("## Decision Outcome"));

--- a/crates/hyalo-cli/tests/e2e/skills_profile.rs
+++ b/crates/hyalo-cli/tests/e2e/skills_profile.rs
@@ -97,7 +97,13 @@ fn new_skill_scaffolds_and_is_a_skill() {
     );
     assert!(output.status.success(), "new skill failed: {json}");
     let content = std::fs::read_to_string(tmp.path().join("my-skill/SKILL.md")).unwrap();
-    assert!(content.contains("type: skill"));
+    // `**/SKILL.md` binds this path to `skill`, so the scaffold omits the
+    // non-spec explicit `type:` key (SKILL.md carries no `type:` per the Agent
+    // Skills spec) — iter-175.
+    assert!(
+        !content.contains("type:"),
+        "bound SKILL.md omits explicit type: {content}"
+    );
     assert!(content.contains("name:"));
     assert!(content.contains("description:"));
 }
@@ -317,4 +323,67 @@ fn this_repos_own_skills_lint_clean_under_skills_profile() {
         errors, 0,
         "this repo's own skills must lint clean under --profile skills: {json}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// UX-A: [scan] include reaches .claude/skills/
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_include_reaches_claude_skills_dir() {
+    // The skills profile ships `[scan] include = [".claude/skills/**"]`, so a
+    // SKILL.md under the canonical (hidden) Claude Code location is discoverable
+    // and lintable without relocating it (ff-rdp U1 scenario).
+    let tmp = init_skills();
+    let skill = tmp.path().join(".claude/skills/my-skill");
+    std::fs::create_dir_all(&skill).unwrap();
+    std::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: my-skill\ndescription: A discoverable dot-dir skill.\n---\n\n# My Skill\n\nBody.\n",
+    )
+    .unwrap();
+
+    // The config carries the include glob.
+    let cfg = std::fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        cfg.contains(".claude/skills/**"),
+        "skills profile ships the scan include: {cfg}"
+    );
+
+    // `find` sees the hidden-dir skill.
+    let (json, output) = run(
+        tmp.path(),
+        &["find", "--glob", ".claude/skills/**/SKILL.md"],
+    );
+    assert!(output.status.success(), "find failed: {json}");
+    assert_eq!(
+        json["total"].as_u64(),
+        Some(1),
+        "the .claude/skills SKILL.md is discovered: {json}"
+    );
+
+    // And it lints clean (no relocation needed).
+    let (lint_json, lint_out) = run(
+        tmp.path(),
+        &["lint", "--file", ".claude/skills/my-skill/SKILL.md"],
+    );
+    assert!(
+        lint_out.status.success(),
+        "lint reached the file: {lint_json}"
+    );
+}
+
+#[test]
+fn scan_include_never_reaches_git() {
+    // Even with the include list active, `.git/**` stays hard-excluded.
+    let tmp = init_skills();
+    std::fs::create_dir_all(tmp.path().join(".git")).unwrap();
+    std::fs::write(tmp.path().join(".git/config.md"), "# never linted\n").unwrap();
+    let (json, output) = run(tmp.path(), &["find", "--glob", "**/*.md"]);
+    assert!(output.status.success(), "find failed: {json}");
+    let files = json["results"].as_array().cloned().unwrap_or_default();
+    let any_git = files
+        .iter()
+        .any(|f| f["file"].as_str().is_some_and(|p| p.starts_with(".git/")));
+    assert!(!any_git, ".git is never walked: {json}");
 }

--- a/crates/hyalo-cli/tests/e2e/types.rs
+++ b/crates/hyalo-cli/tests/e2e/types.rs
@@ -868,3 +868,39 @@ fn types_set_upsert_does_not_duplicate_type() {
     let set_json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(set_json["results"]["action"], "updated");
 }
+
+#[test]
+fn types_set_default_is_rejected() {
+    // `default` names the fallback `[schema.default]` table, not a concrete
+    // type. `types set default` must be a user error pointing at that table and
+    // must not create a phantom `[schema.types.default]` (user-service BUG-A3).
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "set", "default", "--required", "title"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "types set default must fail: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("[schema.default]"),
+        "error points at the real table: {combined}"
+    );
+    // No phantom type table was written.
+    let cfg = tmp.path().join(".hyalo.toml");
+    if cfg.exists() {
+        let contents = std::fs::read_to_string(&cfg).unwrap();
+        assert!(
+            !contents.contains("[schema.types.default]"),
+            "must not create a phantom default type: {contents}"
+        );
+    }
+}

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -1,40 +1,205 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
-use globset::{GlobBuilder, GlobSetBuilder};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::sync::mpsc;
 
 use crate::case_index::CaseInsensitiveIndex;
 use crate::link_graph::strip_site_prefix;
 use crate::util::levenshtein;
 
+/// Process-global set of `[scan] include` globs.
+///
+/// The vault walker skips hidden (dot-prefixed) paths by default. When a vault
+/// opts a hidden subtree back in via `[scan] include = ["glob", …]`, the CLI
+/// installs the compiled glob set here once at startup (see
+/// [`set_scan_include`]). [`discover_files`] then descends into any otherwise
+/// hidden directory whose vault-relative path is a prefix of, or matches, one
+/// of these globs — so the include list is honored by *every* command that
+/// discovers vault files without threading the config through each call site.
+///
+/// `.git/**` is always hard-excluded regardless of the include list.
+static SCAN_INCLUDE: OnceLock<Option<ScanInclude>> = OnceLock::new();
+
+/// Compiled `[scan] include` configuration.
+#[derive(Clone)]
+struct ScanInclude {
+    /// Full glob set, matched against files to decide inclusion.
+    set: GlobSet,
+    /// Literal directory prefixes of each glob (the path portion before the
+    /// first glob metacharacter). Used to decide whether to *descend* into a
+    /// hidden directory: the walker enters a dir when it lies on the path to,
+    /// or beneath, one of these prefixes.
+    dir_prefixes: Vec<String>,
+}
+
+impl ScanInclude {
+    /// Cheap clone for moving into the parallel-walk `filter_entry` closure
+    /// (`GlobSet` is `Send + Sync` and cheap to clone — it shares compiled
+    /// automata internally).
+    fn clone_shared(&self) -> Self {
+        self.clone()
+    }
+
+    /// Whether the walker should descend into the hidden vault-relative
+    /// directory `rel` (forward-slash, no trailing slash) because a glob reaches
+    /// into or beneath it.
+    fn allows_dir(&self, rel: &str) -> bool {
+        // `.git` is never re-included, even if a glob would match it.
+        if rel == ".git" || rel.starts_with(".git/") {
+            return false;
+        }
+        self.dir_prefixes.iter().any(|p| {
+            p == rel
+                || p.starts_with(&format!("{rel}/")) // rel is an ancestor of the prefix
+                || rel.starts_with(&format!("{p}/")) // rel is inside the prefix
+        })
+    }
+
+    /// Whether the file at vault-relative path `rel` is explicitly re-included.
+    fn allows_file(&self, rel: &str) -> bool {
+        if rel.starts_with(".git/") {
+            return false;
+        }
+        self.set.is_match(rel)
+    }
+}
+
+/// Literal directory prefix of a forward-slash glob: everything up to (but not
+/// including) the segment that first contains a glob metacharacter. E.g.
+/// `.claude/skills/**` → `.claude/skills`, `.config/*.md` → `.config`,
+/// `.obsidian/**/x.md` → `.obsidian`. A glob with metacharacters in its first
+/// segment yields `""`.
+fn glob_dir_prefix(glob: &str) -> String {
+    let mut kept: Vec<&str> = Vec::new();
+    for seg in glob.split('/') {
+        if seg.contains(['*', '?', '[', '{']) {
+            break;
+        }
+        kept.push(seg);
+    }
+    // Drop a trailing filename-looking segment only if the whole glob was
+    // literal (no metachars at all): then the "directory" is its parent.
+    if kept.len() == glob.split('/').count() {
+        kept.pop();
+    }
+    kept.join("/")
+}
+
+/// Install the `[scan] include` glob set for this process.
+///
+/// Idempotent-once: only the first call takes effect (the walker reads it
+/// through a `OnceLock`). The CLI calls this exactly once, right after config
+/// resolution, before any command runs. `patterns` are vault-relative,
+/// forward-slash globs (e.g. `.claude/skills/**`). Invalid globs are skipped
+/// with the returned error list so a single bad pattern doesn't disable the
+/// rest.
+///
+/// # Errors
+/// Never returns `Err`; instead returns the list of `(pattern, message)` pairs
+/// for any globs that failed to compile, so the caller can surface a warning.
+pub fn set_scan_include(patterns: &[String]) -> Vec<(String, String)> {
+    let mut errors = Vec::new();
+    let compiled = if patterns.is_empty() {
+        None
+    } else {
+        let mut builder = GlobSetBuilder::new();
+        let mut dir_prefixes = Vec::new();
+        for pat in patterns {
+            match GlobBuilder::new(pat).literal_separator(true).build() {
+                Ok(g) => {
+                    builder.add(g);
+                    let prefix = glob_dir_prefix(pat);
+                    if !prefix.is_empty() {
+                        dir_prefixes.push(prefix);
+                    }
+                }
+                Err(e) => errors.push((pat.clone(), e.to_string())),
+            }
+        }
+        builder
+            .build()
+            .ok()
+            .map(|set| ScanInclude { set, dir_prefixes })
+    };
+    let _ = SCAN_INCLUDE.set(compiled);
+    errors
+}
+
+/// True when any component of `rel` is a hidden (dot-prefixed) segment.
+fn has_hidden_component(rel: &str) -> bool {
+    rel.split('/')
+        .any(|c| c.starts_with('.') && c != "." && c != "..")
+}
+
 /// Collect all `.md` files under the given directory, respecting `.gitignore` and skipping hidden dirs.
+///
+/// Hidden (dot-prefixed) paths are skipped unless a `[scan] include` glob
+/// (installed via [`set_scan_include`]) re-includes them; `.git/**` is always
+/// excluded.
 pub fn discover_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let include = match SCAN_INCLUDE.get() {
+        Some(Some(inc)) => Some(inc),
+        _ => None,
+    };
+    discover_files_with_include(dir, include)
+}
+
+/// Test-friendly variant of [`discover_files`] with an explicit include
+/// override, bypassing the process-global `OnceLock` (which can only be set
+/// once per process). Production code uses [`discover_files`].
+fn discover_files_with_include(dir: &Path, include: Option<&ScanInclude>) -> Result<Vec<PathBuf>> {
     let (tx, rx) = mpsc::channel();
     let (err_tx, err_rx) = mpsc::channel::<String>();
-    WalkBuilder::new(dir)
-        .hidden(true) // skip hidden files/dirs
-        .git_ignore(true)
-        .build_parallel()
-        .run(|| {
-            let tx = tx.clone();
-            let err_tx = err_tx.clone();
-            Box::new(move |entry| {
-                let entry = match entry {
-                    Ok(e) => e,
-                    Err(e) => {
-                        let _ = err_tx.send(format!("{e}"));
-                        return ignore::WalkState::Continue;
-                    }
-                };
-                let path = entry.path();
-                if path.is_file() && path.extension().is_some_and(|ext| ext == "md") {
-                    let _ = tx.send(path.to_path_buf());
-                }
-                ignore::WalkState::Continue
-            })
+    let walk_root = dir.to_path_buf();
+    let mut builder = WalkBuilder::new(dir);
+    builder.git_ignore(true);
+    if let Some(inc) = include {
+        // Take over hidden-skipping so `[scan] include` can re-admit specific
+        // dot-subtrees. `filter_entry` prunes hidden dirs/files not covered by
+        // the include list while still descending into included ones.
+        builder.hidden(false);
+        let root = walk_root.clone();
+        let inc = inc.clone_shared();
+        builder.filter_entry(move |entry| {
+            let rel = relative_path(&root, entry.path());
+            if rel.is_empty() {
+                return true;
+            }
+            if !has_hidden_component(&rel) {
+                return true;
+            }
+            let is_dir = entry.file_type().is_some_and(|t| t.is_dir());
+            // Hidden path: admit only if the include list reaches it.
+            if is_dir {
+                inc.allows_dir(&rel)
+            } else {
+                inc.allows_file(&rel)
+            }
         });
+    } else {
+        builder.hidden(true); // skip hidden files/dirs
+    }
+    builder.build_parallel().run(|| {
+        let tx = tx.clone();
+        let err_tx = err_tx.clone();
+        Box::new(move |entry| {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    let _ = err_tx.send(format!("{e}"));
+                    return ignore::WalkState::Continue;
+                }
+            };
+            let path = entry.path();
+            if path.is_file() && path.extension().is_some_and(|ext| ext == "md") {
+                let _ = tx.send(path.to_path_buf());
+            }
+            ignore::WalkState::Continue
+        })
+    });
     drop(tx); // close sender so rx iterator terminates
     drop(err_tx); // close error sender so err_rx iterator terminates
 
@@ -704,6 +869,73 @@ mod tests {
         let files = discover_files(tmp.path()).unwrap();
         assert_eq!(files.len(), 1);
         assert!(files[0].ends_with("visible.md"));
+    }
+
+    /// Build a `ScanInclude` directly for testing the include-override path
+    /// without touching the process-global `OnceLock`.
+    fn test_include(patterns: &[&str]) -> ScanInclude {
+        let mut builder = GlobSetBuilder::new();
+        let mut dir_prefixes = Vec::new();
+        for p in patterns {
+            builder.add(GlobBuilder::new(p).literal_separator(true).build().unwrap());
+            let prefix = glob_dir_prefix(p);
+            if !prefix.is_empty() {
+                dir_prefixes.push(prefix);
+            }
+        }
+        ScanInclude {
+            set: builder.build().unwrap(),
+            dir_prefixes,
+        }
+    }
+
+    #[test]
+    fn glob_dir_prefix_cases() {
+        assert_eq!(glob_dir_prefix(".claude/skills/**"), ".claude/skills");
+        assert_eq!(glob_dir_prefix(".config/*.md"), ".config");
+        assert_eq!(glob_dir_prefix(".obsidian/**/x.md"), ".obsidian");
+        assert_eq!(glob_dir_prefix("**/*.md"), "");
+        // A fully-literal glob's "directory" is the parent of the file.
+        assert_eq!(glob_dir_prefix(".claude/skills/a.md"), ".claude/skills");
+    }
+
+    #[test]
+    fn scan_include_reaches_dot_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("visible.md"), "# Visible").unwrap();
+        fs::create_dir_all(tmp.path().join(".claude/skills/foo")).unwrap();
+        fs::write(tmp.path().join(".claude/skills/foo/SKILL.md"), "# Skill").unwrap();
+        // A different hidden dir must stay excluded.
+        fs::create_dir_all(tmp.path().join(".secret")).unwrap();
+        fs::write(tmp.path().join(".secret/leak.md"), "# Leak").unwrap();
+
+        let inc = test_include(&[".claude/skills/**"]);
+        let files = discover_files_with_include(tmp.path(), Some(&inc)).unwrap();
+        let rels: Vec<String> = files.iter().map(|f| relative_path(tmp.path(), f)).collect();
+        assert!(rels.contains(&"visible.md".to_owned()));
+        assert!(
+            rels.contains(&".claude/skills/foo/SKILL.md".to_owned()),
+            "included dot-subtree reachable: {rels:?}"
+        );
+        assert!(
+            !rels.iter().any(|r| r.contains(".secret")),
+            "unrelated hidden dir stays excluded: {rels:?}"
+        );
+    }
+
+    #[test]
+    fn scan_include_never_reaches_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join(".git/config.md"), "# never").unwrap();
+        // Even a permissive glob must not pull `.git` files in.
+        let inc = test_include(&[".git/**", "**/*.md"]);
+        let files = discover_files_with_include(tmp.path(), Some(&inc)).unwrap();
+        let rels: Vec<String> = files.iter().map(|f| relative_path(tmp.path(), f)).collect();
+        assert!(
+            !rels.iter().any(|r| r.starts_with(".git/")),
+            ".git is hard-excluded: {rels:?}"
+        );
     }
 
     #[test]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -14,5 +14,6 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true }
+tempfile = { workspace = true }
 toml = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/xtask/src/bundled_skills.rs
+++ b/crates/xtask/src/bundled_skills.rs
@@ -1,0 +1,188 @@
+//! Gate — Bundled-skill self-conformance.
+//!
+//! RB-5 regression guard: every skill template hyalo ships
+//! (`crates/hyalo-cli/templates/skill-*.md`) must itself pass the `skills`
+//! conformance profile. A profile whose own bundled skill violates the profile
+//! is an embarrassment class of bug, so this gate lints each template *as
+//! installed* — placed at `.claude/skills/<name>/SKILL.md` inside a scratch
+//! vault initialized with `hyalo init --profile skills` — and fails CI on any
+//! error-severity finding.
+//!
+//! Each template is linted in its own scratch vault (keyed on the skill's
+//! `name` frontmatter) so two templates that share a `name` (e.g. the `hyalo`
+//! and `hyalo` pi variants) don't collide on the same directory.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::ac_fidelity::workspace_root;
+
+/// Run the gate: `Ok(true)` when every bundled skill passes, `Ok(false)` when
+/// at least one violates the skills profile (details printed to stderr).
+pub fn run() -> Result<bool> {
+    let root = workspace_root()?;
+    let templates_dir = root.join("crates").join("hyalo-cli").join("templates");
+    let mut skill_files: Vec<PathBuf> = std::fs::read_dir(&templates_dir)
+        .with_context(|| format!("reading templates dir {templates_dir:?}"))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("skill-") && n.ends_with(".md"))
+        })
+        .collect();
+    skill_files.sort();
+
+    if skill_files.is_empty() {
+        eprintln!("check-bundled-skills: no skill-*.md templates found in {templates_dir:?}");
+        return Ok(false);
+    }
+
+    let mut all_ok = true;
+    let mut checked = 0usize;
+    for file in &skill_files {
+        let body = std::fs::read_to_string(file)
+            .with_context(|| format!("reading skill template {file:?}"))?;
+        let name = frontmatter_name(&body)
+            .with_context(|| format!("skill template {file:?} has no `name:` frontmatter field"))?;
+
+        let scratch = tempfile::tempdir().context("creating scratch vault")?;
+        let vault = scratch.path();
+        // Install the skills profile config (writes .hyalo.toml + [scan] include).
+        init_skills_profile(&root, vault)?;
+        // Place the template as installed: `.claude/skills/<name>/SKILL.md`.
+        let skill_dir = vault.join(".claude").join("skills").join(&name);
+        std::fs::create_dir_all(&skill_dir)
+            .with_context(|| format!("creating skill dir {skill_dir:?}"))?;
+        std::fs::write(skill_dir.join("SKILL.md"), &body)
+            .context("writing SKILL.md into scratch vault")?;
+
+        let rel = format!(".claude/skills/{name}/SKILL.md");
+        let (ok, output) = lint_skill(&root, vault, &rel)?;
+        checked += 1;
+        if !ok {
+            all_ok = false;
+            eprintln!(
+                "check-bundled-skills: {} violates the skills profile:\n{}",
+                file.file_name().and_then(|n| n.to_str()).unwrap_or("?"),
+                output.trim()
+            );
+        }
+    }
+
+    if all_ok {
+        println!("check-bundled-skills: {checked} bundled skill(s) pass the skills profile");
+    }
+    Ok(all_ok)
+}
+
+/// Extract the `name:` scalar from a SKILL.md frontmatter block. Handles the
+/// simple `name: value` form used by every bundled template.
+fn frontmatter_name(body: &str) -> Option<String> {
+    let mut lines = body.lines();
+    // First non-empty line must open the frontmatter fence.
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+    for line in lines {
+        let t = line.trim();
+        if t == "---" {
+            break;
+        }
+        if let Some(rest) = t.strip_prefix("name:") {
+            let v = rest.trim().trim_matches(['"', '\'']).to_owned();
+            if !v.is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Build a `cargo run` command for the `hyalo` CLI that executes *inside*
+/// `vault` (so `init` writes `.hyalo.toml` there and never touches the repo's
+/// own config), while still resolving the workspace via `--manifest-path`
+/// (`cargo run` runs the target binary in the caller's CWD, which we set to the
+/// scratch vault).
+fn hyalo_in_vault(root: &Path, vault: &Path) -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.args([
+        "run",
+        "-q",
+        "--manifest-path",
+        &root.join("Cargo.toml").to_string_lossy(),
+        "-p",
+        "hyalo-cli",
+        "--",
+    ])
+    .current_dir(vault);
+    cmd
+}
+
+/// Initialize the skills profile in `vault` via `hyalo init --profile skills`.
+fn init_skills_profile(root: &Path, vault: &Path) -> Result<()> {
+    let out = hyalo_in_vault(root, vault)
+        .args(["--dir", ".", "init", "--profile", "skills"])
+        .output()
+        .context("running hyalo init --profile skills")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "hyalo init --profile skills failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Lint a single skill file with the skills profile. Returns `(passed, output)`.
+fn lint_skill(root: &Path, vault: &Path, rel: &str) -> Result<(bool, String)> {
+    let out = hyalo_in_vault(root, vault)
+        .args([
+            "--dir",
+            ".",
+            "lint",
+            "--profile",
+            "skills",
+            "--file",
+            rel,
+            "--format",
+            "text",
+        ])
+        .output()
+        .context("running hyalo lint --profile skills")?;
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Ok((out.status.success(), combined))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frontmatter_name_simple() {
+        let body = "---\nname: skills\ndescription: x\n---\n# body\n";
+        assert_eq!(frontmatter_name(body), Some("skills".to_owned()));
+    }
+
+    #[test]
+    fn frontmatter_name_quoted() {
+        let body = "---\nname: \"hyalo-tidy\"\n---\n";
+        assert_eq!(frontmatter_name(body), Some("hyalo-tidy".to_owned()));
+    }
+
+    #[test]
+    fn frontmatter_name_missing() {
+        let body = "---\ndescription: x\n---\n";
+        assert_eq!(frontmatter_name(body), None);
+    }
+
+    #[test]
+    fn frontmatter_name_no_fence() {
+        assert_eq!(frontmatter_name("name: skills\n"), None);
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 
 mod ac_fidelity;
+mod bundled_skills;
 mod feature_fanout;
 mod help_drift;
 mod stubs;
@@ -24,6 +25,8 @@ enum Commands {
     CheckFeatureFanout,
     /// Gate 3: verify help text has EXAMPLES blocks and no stale wording.
     CheckHelpDrift,
+    /// Gate: verify every bundled skill template passes the skills profile.
+    CheckBundledSkills,
     /// Stub — not yet implemented (iter-142b).
     CheckDeadPrimitives(stubs::StubArgs),
     /// Stub — not yet implemented (iter-142b).
@@ -36,6 +39,7 @@ fn main() {
         Commands::CheckAcFidelity(args) => ac_fidelity::run(args),
         Commands::CheckFeatureFanout => feature_fanout::run(),
         Commands::CheckHelpDrift => help_drift::run(),
+        Commands::CheckBundledSkills => bundled_skills::run(),
         Commands::CheckDeadPrimitives(_) => stubs::check_dead_primitives(),
         Commands::CheckTodoAnnotations(_) => stubs::check_todo_annotations(),
     };

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0180-iter175-fixwave-retro.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0180-iter175-fixwave-retro.md
@@ -1,0 +1,82 @@
+---
+title: "Iter-175 retrospective — v0.18.0 profile fix-wave (RB-4/RB-5/UX-A + mediums)"
+type: research
+date: 2026-07-17
+status: active
+tags:
+  - dogfooding
+  - iter-175
+  - profiles
+  - retrospective
+related:
+  - "[[dogfood-v0180-okf-profiles-pre-release]]"
+---
+
+# Iter-175 retrospective — v0.18.0 profile fix-wave
+
+Fix-wave iteration closing the pre-release blockers and sharp edges from
+[[dogfood-v0180-okf-profiles-pre-release]] so v0.18.0 is releasable.
+
+## What shipped
+
+### Release blockers
+
+- **RB-4 — `changelog add` placement.** `insert_entry` now bounds the
+  `[Unreleased]` section at the footer link-reference block (not just the next
+  `## ` heading), so a new `### Category` lands inside the section even when
+  `[Unreleased]` is the last section. Output stays MD047-clean (one trailing
+  newline). `changelog add`/`release` also route through a resolved changelog
+  path (see task 4) and their `file` field reports the file's basename.
+- **RB-5 — bundled skills self-conformance.** The `skills` skill description
+  dropped the literal `<`. New `check-bundled-skills` xtask gate lints every
+  `crates/hyalo-cli/templates/skill-*.md` as installed (`.claude/skills/<name>/SKILL.md`)
+  under the skills profile and fails CI on any error-severity finding; wired into
+  `quality-gates.yml`. Also trimmed the pi skill description to ≤1024 chars to
+  pass the gate.
+
+### High-impact UX
+
+- **UX-A — reach `.claude/skills/`.** New `[scan] include = ["glob", …]` config
+  key (`hyalo-core::discovery`): a process-global glob set, installed once at CLI
+  startup, that re-admits specific hidden dot-subtrees to the vault walker via
+  `filter_entry`. `.git` is always hard-excluded. Honored by every command that
+  discovers files. The skills profile ships `[scan] include = [".claude/skills/**"]`,
+  and an ephemeral `--profile skills` run installs it too (via
+  `config::overlay_scan_include`).
+
+### Mediums bundle
+
+- **Root `CHANGELOG.md` reachability.** `[changelog] path`, resolved relative to
+  the config-file directory (validated against config-dir escape). `changelog
+  add`/`release` and `lint --profile changelog` (which injects the resolved file
+  into the lint set when it lives outside the vault dir) all reach a repo-root
+  changelog. `init --profile changelog --dir <sub>` auto-writes the key when a
+  root file exists.
+- **Neutral OKF profile.** Removed the `BigQuery Table`/`BigQuery Dataset`/
+  `Reference` example types from `profile-okf.toml`; documented "Adding domain
+  types" in the okf skill.
+- **Scaffold fidelity.** `hyalo new` now (a) applies `[schema.types.<t>.defaults]`
+  (incl. `$today`) for defaulted non-required properties, and (b) omits the
+  explicit `type:` key when the target path is covered by a `[[schema.bind]]` for
+  that type (fixes the non-spec `type: skill` in SKILL.md scaffolds and empty
+  Status/Date in `madr toc`).
+- **`madr toc` type filter.** Only files whose effective type is `adr` (explicit
+  or bound) enter the TOC when the madr schema is active; a plain vault keeps the
+  historical "every .md" behavior.
+- **`types set default` rejection.** `default` is reserved for `[schema.default]`;
+  `types set default` is now a user error pointing at that table.
+- **Small fixes.** `init --help` lists the `changelog` profile; the `--claude`
+  CLAUDE.md managed section gains one pointer line per active profile; redundant
+  `lint --profile <p>` hints are suppressed when the vault already activates `<p>`
+  (`profile_lint_hint`); `hyalo config` reports the effective dir under a `--dir`
+  override.
+
+## Notes / follow-ups
+
+- UX-B (skip counters in text/github output) was addressed in iter-174, not here.
+- The `[scan] include` glob→directory-descent uses the glob's literal prefix
+  (`glob_dir_prefix`) to decide which hidden dirs to enter, then the full glob to
+  admit files. Deeply-nested include patterns with metacharacters early in the
+  path fall back to descending from the first literal segment.
+- `[changelog] path` deeper than one level is left to the user; init only
+  auto-writes for the common one-level docs-subdir layout.

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0180-okf-profiles-pre-release.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0180-okf-profiles-pre-release.md
@@ -79,12 +79,23 @@ changelog** gets non-conformant output that then fails its own lint.
 `changelog release` places its footer ref correctly; the defect is specific
 to `add`. Minimal repro in the user-event-service agent report.
 
+**Status: FIXED (iter-175).** `changelog add` now bounds the `[Unreleased]`
+section at the footer link-ref block, so new entries land inside the section;
+output stays MD047-clean. Regression tests: unit tests in `changelog.rs`
+(`add_new_category_lands_before_footer_link_refs`, `add_output_is_md047_clean`)
+and e2e `add_places_new_category_before_footer_link_refs_rb4`.
+
 ### RB-5: The bundled `skills` skill fails its own skills profile (HIGH, embarrassment class)
 
 Its `description` contains a literal `<` (from `` `<name>/SKILL.md` ``),
 which the profile's `description` pattern `^[^<]*$` forbids. Fix the wording
 and add a CI/xtask step linting the bundled skill templates with
 `--profile skills` so a self-violation can't ship again.
+
+**Status: FIXED (iter-175).** The `skills` skill description no longer contains
+`<`, and a new `cargo run -p xtask -- check-bundled-skills` gate (wired into
+`quality-gates.yml`) lints every bundled `skill-*.md` as installed under the
+skills profile, failing CI on any error-severity violation.
 
 ## High-impact UX gaps (fix with the blockers if possible)
 
@@ -93,6 +104,12 @@ and add a CI/xtask step linting the bundled skill templates with
   Claude Code skill location (4 of 5 real SKILL.md files in ff-rdp were
   unreachable). Allow-list dot-dirs for bind matching or document the
   limitation prominently.
+  **Status: FIXED (iter-175).** New `[scan] include = ["glob", …]` config key
+  re-admits specific hidden subtrees to the walker (honored by every command;
+  `.git` stays hard-excluded). The skills profile ships
+  `[scan] include = [".claude/skills/**"]`, and an ephemeral `--profile skills`
+  run installs it too, so `.claude/skills/**/SKILL.md` is discoverable and
+  lintable in place. e2e: `scan_include_reaches_claude_skills_dir`.
 - **UX-B: skip counters are JSON-only** — the diff-aware CI pipeline
   (`git diff … | hyalo lint --files-from -`) silently dropped 41 of 43 input
   paths with zero indication in `--format text` or `--format github` output.

--- a/hyalo-knowledgebase/iterations/iteration-175-profile-polish.md
+++ b/hyalo-knowledgebase/iterations/iteration-175-profile-polish.md
@@ -1,12 +1,14 @@
 ---
-title: Iteration 175 — profile content & tooling polish (changelog add, skills reach, neutral okf, scaffold defaults)
+title: >-
+  Iteration 175 — profile content & tooling polish (changelog add, skills reach,
+  neutral okf, scaffold defaults)
 type: iteration
 date: 2026-07-17
 tags:
   - iteration
   - profiles
   - fix-wave
-status: planned
+status: in-progress
 branch: iter-175/profile-polish
 ---
 
@@ -59,92 +61,92 @@ No other scope adaptation needed — this iteration's tasks stand as written.
 
 ### 1. `changelog add` placement (RB-4)
 
-- [ ] Insert the new `### Category` + entry INSIDE `## [Unreleased]`, before
+- [x] Insert the new `### Category` + entry INSIDE `## [Unreleased]`, before
   the footer link-reference block — never after it (user-event-service
   minimal repro becomes the e2e); no trailing-newline damage (MD047 clean)
 
 ### 2. Bundled skills pass their own profile (RB-5)
 
-- [ ] Reword the `skills` skill description to drop the literal `<`
+- [x] Reword the `skills` skill description to drop the literal `<`
   (e.g. "a name/SKILL.md directory") and re-verify all four profile skills
   + base skills pass `lint --profile skills`
-- [ ] New xtask gate `check-bundled-skills`: lints
+- [x] New xtask gate `check-bundled-skills`: lints
   `crates/hyalo-cli/templates/skill-*.md` (as installed) with the skills
   profile; wired into `quality-gates.yml` CI so a self-violation can't ship
 
 ### 3. Reach `.claude/skills/` (UX-A)
 
-- [ ] New `[scan] include = ["glob", ...]` config key: the vault walker
+- [x] New `[scan] include = ["glob", ...]` config key: the vault walker
   descends into otherwise-skipped dot-paths matching the globs (never
   `.git/**` — hard-excluded); honored by all commands
-- [ ] The skills profile fragment ships
+- [x] The skills profile fragment ships
   `[scan] include = [".claude/skills/**"]`
-- [ ] e2e on a fixture repo: SKILL.md files under `.claude/skills/` are
+- [x] e2e on a fixture repo: SKILL.md files under `.claude/skills/` are
   linted by the skills profile without moving them (ff-rdp U1 scenario)
 
 ### 4. Root `CHANGELOG.md` reachability
 
-- [ ] `[changelog] path = "../CHANGELOG.md"` (default `CHANGELOG.md` in the
+- [x] `[changelog] path = "../CHANGELOG.md"` (default `CHANGELOG.md` in the
   vault dir): resolved from the config file's directory; used by
   `lint --profile changelog`, `changelog add`, `changelog release`
-- [ ] Path is validated (no traversal above the config dir's repo root —
+- [x] Path is validated (no traversal above the config dir's repo root —
   reuse the mv vault-escape checks); clear error when the file is absent
-- [ ] The changelog profile's `init` writes the key when a root
+- [x] The changelog profile's `init` writes the key when a root
   `CHANGELOG.md` exists and the vault dir is a subdir (the common case that
   hit user-event-service)
 
 ### 5. Neutral OKF profile + scaffold fidelity
 
-- [ ] Remove `BigQuery Dataset` / `BigQuery Table` / `Reference` example
+- [x] Remove `BigQuery Dataset` / `BigQuery Table` / `Reference` example
   types from `profile-okf.toml` (4 agents flagged them as junk in real
   vaults); document in the okf skill how to add domain types
-- [ ] `hyalo new --type <t>` applies `[schema.types.<t>.defaults]`
+- [x] `hyalo new --type <t>` applies `[schema.types.<t>.defaults]`
   (incl. `$today`) to the scaffold (4 agents; also fixes the empty
   Status/Date columns in `madr toc` and makes the madr skill's claims true)
-- [ ] `hyalo new` omits the explicit `type:` key when the target path is
+- [x] `hyalo new` omits the explicit `type:` key when the target path is
   covered by a `[[schema.bind]]` for that type (relies on iter-172's
   bind-=-typing; fixes the non-spec `type: skill` key in SKILL.md scaffolds)
-- [ ] `madr toc` includes only files typed/bound `adr` (user-service repro:
+- [x] `madr toc` includes only files typed/bound `adr` (user-service repro:
   13 concept files polluted the dashboard)
-- [ ] `types set default` rejects the reserved name with an error pointing at
+- [x] `types set default` rejects the reserved name with an error pointing at
   `[schema.default]` (phantom-type trap, user-service BUG-A3)
 
 ### 6. Small fixes bundle
 
-- [ ] `init --help` lists the `changelog` profile (it works but is
+- [x] `init --help` lists the `changelog` profile (it works but is
   undocumented)
-- [ ] `--claude` CLAUDE.md managed section gains one profile-specific pointer
+- [x] `--claude` CLAUDE.md managed section gains one profile-specific pointer
   line per installed profile (e.g. okf → `hyalo okf index` drift check)
-- [ ] Suppress the redundant `lint --profile <p>` hint when the config's
+- [x] Suppress the redundant `lint --profile <p>` hint when the config's
   `profiles` already activates `<p>` (hoppy UX-2)
-- [ ] `hyalo config` reports the EFFECTIVE dir when `--dir` overrides the
+- [x] `hyalo config` reports the EFFECTIVE dir when `--dir` overrides the
   config (ff-rdp B6)
 
 ### 7. Tests
 
-- [ ] e2e per task group above (changelog placement, xtask gate red/green,
+- [x] e2e per task group above (changelog placement, xtask gate red/green,
   dot-dir include, changelog path, defaults scaffold, toc filter,
   types-set-default rejection)
-- [ ] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
+- [x] `cargo fmt` / clippy `-D warnings` / `cargo test --workspace -q` green
 
 ### 8. Docs sync (same PR)
 
-- [ ] README (profiles at-a-glance, changelog section, skills section),
+- [x] README (profiles at-a-glance, changelog section, skills section),
   affected `--help` texts, and the four profile skill templates all updated
   to the shipped behavior
-- [ ] Retrospective: write the fix-wave summary into the KB and update
+- [x] Retrospective: write the fix-wave summary into the KB and update
   [[dogfood-results/dogfood-v0180-okf-profiles-pre-release]] finding
   statuses (fixed / deferred)
 
 ## Acceptance criteria
 
-- [ ] `changelog add` on a conformant KaC file yields a conformant file, every
+- [x] `changelog add` on a conformant KaC file yields a conformant file, every
   time
-- [ ] CI fails if any bundled skill violates the skills profile
-- [ ] A stock Claude Code repo's `.claude/skills/` is lintable via the skills
+- [x] CI fails if any bundled skill violates the skills profile
+- [x] A stock Claude Code repo's `.claude/skills/` is lintable via the skills
   profile without relocating files
-- [ ] `hyalo --profile changelog` workflows work on a repo-root CHANGELOG.md
+- [x] `hyalo --profile changelog` workflows work on a repo-root CHANGELOG.md
   with the vault dir set to a docs subdir, without `--dir .` gymnastics
-- [ ] `init --profile okf` no longer injects vendor example types
-- [ ] After this iteration, the slim re-dogfood checklist in task #10 passes
+- [x] `init --profile okf` no longer injects vendor example types
+- [x] After this iteration, the slim re-dogfood checklist in task #10 passes
   and v0.18.0 is releasable

--- a/hyalo-knowledgebase/iterations/iteration-175-profile-polish.md
+++ b/hyalo-knowledgebase/iterations/iteration-175-profile-polish.md
@@ -8,7 +8,7 @@ tags:
   - iteration
   - profiles
   - fix-wave
-status: in-progress
+status: completed
 branch: iter-175/profile-polish
 ---
 


### PR DESCRIPTION
## Summary

Closes the remaining v0.18.0 pre-release blockers and profile sharp edges from the OKF/profiles dogfood report.

- **RB-4 — `changelog add` placement.** Entries now insert *inside* `## [Unreleased]`, before the footer link-reference block, with a single trailing newline (MD047-clean) — even when `[Unreleased]` is the last section. `changelog add`/`release` also route through a resolved changelog path and report the file's basename.
- **RB-5 — bundled-skill self-conformance.** The `skills` skill description drops the literal `<`; a new `cargo run -p xtask -- check-bundled-skills` gate lints every `crates/hyalo-cli/templates/skill-*.md` as installed under the skills profile and is wired into `quality-gates.yml`. Trimmed the pi skill description to ≤1024 chars to pass.
- **UX-A — reach `.claude/skills/`.** New `[scan] include = ["glob", …]` config key (a process-global glob set installed at startup) re-admits specific hidden dot-subtrees to the vault walker (`.git` stays hard-excluded); honored by every command. The skills profile ships `[scan] include = [".claude/skills/**"]`, and an ephemeral `--profile skills` run installs it too.
- **Root `CHANGELOG.md` reachability.** `[changelog] path` (config-dir-relative, escape-validated) makes a repo-root changelog addressable from a docs-subdir vault; `init --profile changelog --dir <sub>` auto-writes the key; `lint --profile changelog` injects the file when it lives outside the vault dir.
- **Neutral OKF profile.** Removes the `BigQuery Table`/`BigQuery Dataset`/`Reference` example types; the `okf` skill gains an "Adding domain types" section.
- **Scaffold + toc fidelity.** `hyalo new` applies `[schema.types.<t>.defaults]` (incl. `$today`) and omits the explicit `type:` key for bind-typed paths (fixes non-spec `type: skill` in SKILL.md scaffolds and empty Status/Date in `madr toc`); `madr toc` includes only `adr`-typed files; `types set default` is rejected with a pointer at `[schema.default]`.
- **Small fixes.** `init --help` lists the `changelog` profile; the `--claude` CLAUDE.md managed section gains one pointer line per active profile; redundant `lint --profile <p>` hints are suppressed when the vault already activates `<p>`; `hyalo config` reports the effective dir under a `--dir` override.
- **Docs.** README (skills/changelog/okf sections), the 3 affected profile skill templates, a fix-wave retrospective, and updated dogfood-report finding statuses.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all green (1264 e2e + lib + core + xtask).
- [x] xtask gates: `check-ac-fidelity`, `check-feature-fanout`, `check-help-drift`, `check-bundled-skills` all pass.
- [x] Unit + e2e tests per task group: changelog placement (RB-4), scan-include reaching `.claude/skills/` + `.git` exclusion, root-changelog add/lint, scaffold defaults + type-omission, `madr toc` adr filter, `types set default` rejection.
- [x] Manually verified with the release binary: RB-4 changelog add, UX-A dot-dir reach (init + ephemeral overlay), and repo-root `[changelog] path` add/lint end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)## Claims vs code
<generated 2026-07-17T14:16:21Z by ralph-loop>

_No claims extracted from commit messages._