### PR TITLE
fix(lint): case-insensitive exempt/reserved matching + re-dogfood polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ A required property whose value is YAML null (`tags: ~`) or an empty array (`tag
 
 **Exempt (reserved) files:** `[schema] exempt = ["**/index.md", "**/log.md"]` lists vault-relative globs for files that are bound to no schema. They skip the missing-`type` warning, required-property checks, and undeclared-property warnings — useful for reserved files such as an [Open Knowledge Format](https://openknowledge.foundation/) bundle's `index.md`/`log.md`. Glob matching is vault-relative and cross-platform (paths are normalized to forward slashes). For bundle-root absolute links (`/x/y.md` resolved from the vault root), set `site_prefix = ""` so only the leading `/` is stripped — this also avoids mis-stripping when a subdirectory shares its name with the vault directory.
 
+Exempt-glob matching honors the vault's resolved `[links] case_insensitive` mode (see below): on a case-insensitive filesystem (the macOS/Windows default, or `case_insensitive = "true"`), a literally-named `INDEX.md` is exempted by `**/index.md` the same way `hyalo okf index` already treats `INDEX.md` as the reserved index file. On a case-sensitive filesystem (or `case_insensitive = "false"`), `INDEX.md` and `index.md` are distinct files and only the latter matches.
+
 See `hyalo types --help` for managing schemas from the CLI, and `hyalo lint` to validate your vault against them.
 
 ### CWD-aware behaviour

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1043,7 +1043,10 @@ Repeatable (AND).\n\
             EXEMPT FILES: `[schema] exempt = [\"**/index.md\", \"**/log.md\"]` lists vault-relative\n\
             globs for reserved files that are bound to no schema — they skip the missing-`type`\n\
             warning, required-property checks, and undeclared-property warnings (useful for OKF\n\
-            bundle reserved files). Matching is cross-platform (forward-slash normalized).\n\n\
+            bundle reserved files). Matching is cross-platform (forward-slash normalized) and\n\
+            honors the resolved `[links] case_insensitive` mode: on a case-insensitive filesystem\n\
+            (macOS/Windows default, or `case_insensitive = \"true\"`), `INDEX.md` is exempted by\n\
+            `**/index.md` the same way `hyalo okf index` treats it as the reserved index file.\n\n\
             REQUIRED EMPTINESS: a required property whose value is YAML null (`tags: ~`) or\n\
             an empty array (`tags: []`) is treated as semantically equivalent to absent and\n\
             reported as an error (e.g. `required property \"tags\" must not be empty`). The\n\

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -2691,6 +2691,7 @@ fn lint_one_file_extended(
             okf_doc_type,
             &is_enabled,
             vault_dir,
+            case_insensitive,
         );
         for f in findings {
             // Apply per-rule severity override; OKF rules default to warn.

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -30,6 +30,7 @@ use hyalo_core::schema::{
 use hyalo_core::util::is_iso8601_date;
 
 use crate::commands::section_scanner::SectionScanner;
+use crate::commands::terse_root_cause;
 
 use crate::output::{CommandOutcome, Format, format_success};
 
@@ -76,17 +77,6 @@ pub const VIOLATION_KIND_MISSING_REQUIRED_NO_DEFAULT: &str = "schema/missing-req
 /// (`lint-rules list`) so its severity is user-configurable via
 /// `[lint.rules.HYALO005]`, but it is never silently downgraded by a profile.
 pub const RULE_ID_FRONTMATTER_PARSE_ERROR: &str = "HYALO005";
-
-/// Deepest error message in an anyhow chain, condensed to its first line.
-///
-/// The YAML parser attaches a multi-line source snippet to its error; for a
-/// one-line lint message we keep only the leading line so the `HYALO005`
-/// violation stays terse. The full detail is still available in the file
-/// itself. Reused shape from `commands::okf::root_cause`.
-fn terse_root_cause(err: &anyhow::Error) -> String {
-    let root = err.root_cause().to_string();
-    root.lines().next().unwrap_or(&root).trim().to_owned()
-}
 
 /// A single lint violation found in a file.
 #[derive(Debug, Clone, Serialize)]
@@ -187,8 +177,17 @@ pub struct LintCounts {
 pub fn lint_files(
     files: &[(std::path::PathBuf, String)],
     schema: &SchemaConfig,
+    case_insensitive: bool,
 ) -> Result<(CommandOutcome, LintCounts)> {
-    lint_files_with_options(files, schema, FixMode::Off, None, &mut None, None)
+    lint_files_with_options(
+        files,
+        schema,
+        FixMode::Off,
+        None,
+        &mut None,
+        None,
+        case_insensitive,
+    )
 }
 
 /// Prepend an additional `FileLintResult` (e.g. `.hyalo.toml` view violations)
@@ -372,6 +371,7 @@ pub fn lint_files_with_options(
     limit: Option<usize>,
     snapshot_index: &mut Option<hyalo_core::index::SnapshotIndex>,
     index_path: Option<&Path>,
+    case_insensitive: bool,
 ) -> Result<(CommandOutcome, LintCounts)> {
     let mut results: Vec<FileLintResult> = Vec::new();
     let mut counts = LintCounts::default();
@@ -379,7 +379,8 @@ pub fn lint_files_with_options(
     let mut index_dirty = false;
 
     for (full_path, rel_path) in files {
-        let (file_result, file_fixes) = lint_file_with_fix(full_path, rel_path, schema, fix)?;
+        let (file_result, file_fixes) =
+            lint_file_with_fix(full_path, rel_path, schema, fix, case_insensitive)?;
         for v in &file_result.violations {
             match v.severity {
                 Severity::Error => counts.errors += 1,
@@ -443,10 +444,11 @@ pub fn lint_files_with_options(
 pub fn lint_counts_only(
     files: &[(std::path::PathBuf, String)],
     schema: &SchemaConfig,
+    case_insensitive: bool,
 ) -> Result<LintCounts> {
     let mut counts = LintCounts::default();
     for (full_path, rel_path) in files {
-        let file_result = lint_file(full_path, rel_path, schema)?;
+        let file_result = lint_file(full_path, rel_path, schema, case_insensitive)?;
         for v in &file_result.violations {
             match v.severity {
                 Severity::Error => counts.errors += 1,
@@ -467,10 +469,11 @@ pub fn lint_counts_only(
 pub(crate) fn lint_counts_from_properties<'a>(
     entries: impl Iterator<Item = (&'a str, &'a IndexMap<String, Value>)>,
     schema: &SchemaConfig,
+    case_insensitive: bool,
 ) -> LintCounts {
     let mut counts = LintCounts::default();
     for (rel_path, properties) in entries {
-        let violations = validate_properties(rel_path, properties, schema);
+        let violations = validate_properties(rel_path, properties, schema, case_insensitive);
         for v in &violations {
             match v.severity {
                 Severity::Error => counts.errors += 1,
@@ -488,8 +491,14 @@ pub(crate) fn lint_counts_from_properties<'a>(
 // Per-file validation
 // ---------------------------------------------------------------------------
 
-fn lint_file(full_path: &Path, rel_path: &str, schema: &SchemaConfig) -> Result<FileLintResult> {
-    let (result, _) = lint_file_with_fix(full_path, rel_path, schema, FixMode::Off)?;
+fn lint_file(
+    full_path: &Path,
+    rel_path: &str,
+    schema: &SchemaConfig,
+    case_insensitive: bool,
+) -> Result<FileLintResult> {
+    let (result, _) =
+        lint_file_with_fix(full_path, rel_path, schema, FixMode::Off, case_insensitive)?;
     Ok(result)
 }
 
@@ -499,6 +508,7 @@ fn lint_file_with_fix(
     rel_path: &str,
     schema: &SchemaConfig,
     fix: FixMode,
+    case_insensitive: bool,
 ) -> Result<(FileLintResult, FileFixResult)> {
     let properties = match read_frontmatter(full_path) {
         Ok(props) => props,
@@ -535,7 +545,7 @@ fn lint_file_with_fix(
         (properties, Vec::new())
     };
 
-    let mut violations = validate_properties(rel_path, &final_props, schema);
+    let mut violations = validate_properties(rel_path, &final_props, schema, case_insensitive);
 
     // Validate required_sections against the body outline. The effective type is
     // the explicit `type:` else the `[schema.bind]` path binding, so a bound ADR
@@ -552,7 +562,9 @@ fn lint_file_with_fix(
         None => schema.default_schema().clone(),
     };
 
-    if !effective_schema.required_sections.is_empty() && !schema.exempt.is_exempt(rel_path) {
+    if !effective_schema.required_sections.is_empty()
+        && !schema.exempt.is_exempt_ci(rel_path, case_insensitive)
+    {
         let section_violations =
             validate_required_sections(full_path, rel_path, &effective_schema.required_sections)?;
         violations.extend(section_violations);
@@ -888,13 +900,17 @@ fn validate_properties(
     rel_path: &str,
     properties: &IndexMap<String, Value>,
     schema: &SchemaConfig,
+    case_insensitive: bool,
 ) -> Vec<Violation> {
     let mut violations: Vec<Violation> = Vec::new();
 
     // Reserved / exempt files (e.g. OKF `index.md`, `log.md`) are bound to no
     // schema: they skip the missing-`type` warning, required-property checks,
     // undeclared-property warnings, and per-property constraint validation.
-    if schema.exempt.is_exempt(rel_path) {
+    // `case_insensitive` mirrors the vault's resolved `[links]
+    // case_insensitive` mode so `INDEX.md` is exempted the same way `hyalo
+    // okf index` treats it on case-folding filesystems (macOS/Windows).
+    if schema.exempt.is_exempt_ci(rel_path, case_insensitive) {
         return violations;
     }
 
@@ -1519,6 +1535,11 @@ pub struct ExtLintOptions<'a> {
     /// cross-check default to warn) in addition to the schema pass. Set by
     /// `hyalo lint --profile changelog`.
     pub changelog_profile: bool,
+    /// Resolved `[links] case_insensitive` mode for `vault_dir` (see
+    /// [`hyalo_core::case_index::mode_enabled`]). Used so `[schema] exempt`
+    /// globs (e.g. `**/index.md`) fold case the same way `hyalo okf index`
+    /// does on case-insensitive filesystems.
+    pub case_insensitive: bool,
 }
 
 /// Run the extended lint (frontmatter + body) and return the new output shape.
@@ -1554,6 +1575,7 @@ pub fn lint_files_extended(
     let skills_profile = opts.skills_profile;
     let changelog_profile = opts.changelog_profile;
     let vault_dir = opts.vault_dir;
+    let case_insensitive = opts.case_insensitive;
 
     // Process files in parallel. Each worker lints one file.
     let lint_file = |(full_path, rel_path): &(std::path::PathBuf, String)| {
@@ -1574,6 +1596,7 @@ pub fn lint_files_extended(
             skills_profile,
             changelog_profile,
             vault_dir,
+            case_insensitive,
         )
     };
     #[cfg(not(miri))]
@@ -2121,6 +2144,7 @@ fn lint_one_file_extended(
     skills_profile: bool,
     changelog_profile: bool,
     vault_dir: &Path,
+    case_insensitive: bool,
 ) -> Result<PerFileLintResult> {
     // One rule's fix can expose a fresh violation for another rule (e.g. a
     // trimmed line changing what counts as a duplicate blank line), so a
@@ -2244,7 +2268,8 @@ fn lint_one_file_extended(
             .iter()
             .any(|r| r.starts_with("FRONTMATTER") || r == "SCHEMA");
     if should_include_frontmatter {
-        let mut fm_violations = validate_properties(rel_path, &properties, schema);
+        let mut fm_violations =
+            validate_properties(rel_path, &properties, schema, case_insensitive);
 
         // Under --strict, the missing-type warning is promoted to an error.
         // `validate_properties` only emits it when the schema is non-empty, but
@@ -2260,7 +2285,7 @@ fn lint_one_file_extended(
         if strict
             && !already_has_missing_type
             && !properties.contains_key("type")
-            && !schema.exempt.is_exempt(rel_path)
+            && !schema.exempt.is_exempt_ci(rel_path, case_insensitive)
             && schema.bound_type_for(rel_path).is_none()
         {
             fm_violations.push(Violation {
@@ -2416,7 +2441,7 @@ fn lint_one_file_extended(
                 // `fix_actions.len()`, which is not 1:1 with resolved
                 // diagnostics (one fix action can clear multiple violations,
                 // or insert defaults that don't clear any).
-                let post = validate_properties(rel_path, &mutable, schema);
+                let post = validate_properties(rel_path, &mutable, schema, case_insensitive);
                 let remaining: Vec<InternalViolation> = post
                     .into_iter()
                     .map(|v| {
@@ -3259,7 +3284,7 @@ mod tests {
         std::fs::write(&path, "---\ntitle: Hello\n---\nBody\n").unwrap();
 
         let schema = make_schema(&["title", "date"], "note", &[], HashMap::new());
-        let result = lint_file(&path, "note.md", &schema).unwrap();
+        let result = lint_file(&path, "note.md", &schema, false).unwrap();
         // date is in default required, but only "title" is present.
         // No type -> warn about no type. date missing -> error.
         assert!(
@@ -3277,7 +3302,7 @@ mod tests {
         // be synthesized by --fix, so its violation is tagged not-autofixable.
         let schema = make_schema(&["title", "date"], "note", &[], HashMap::new());
         let props: IndexMap<String, Value> = IndexMap::new(); // nothing present
-        let violations = validate_properties("note.md", &props, &schema);
+        let violations = validate_properties("note.md", &props, &schema, false);
         let date_v = violations
             .iter()
             .find(|v| v.message.contains("missing required property \"date\""))
@@ -3305,7 +3330,7 @@ mod tests {
             ..Default::default()
         };
         let props: IndexMap<String, Value> = IndexMap::new();
-        let violations = validate_properties("note.md", &props, &schema);
+        let violations = validate_properties("note.md", &props, &schema, false);
         let status_v = violations
             .iter()
             .find(|v| v.message.contains("missing required property \"status\""))
@@ -3324,7 +3349,7 @@ mod tests {
         std::fs::write(&path, "---\ntitle: Hello\n---\nBody\n").unwrap();
 
         let schema = make_schema(&["title"], "note", &[], HashMap::new());
-        let result = lint_file(&path, "note.md", &schema).unwrap();
+        let result = lint_file(&path, "note.md", &schema, false).unwrap();
         assert!(
             result
                 .violations
@@ -3372,7 +3397,7 @@ type = \"skill\"
         )
         .unwrap();
 
-        let result = lint_file(&path, "foo/SKILL.md", &schema).unwrap();
+        let result = lint_file(&path, "foo/SKILL.md", &schema, false).unwrap();
         assert!(
             !result
                 .violations
@@ -3423,7 +3448,7 @@ type = \"skill\"
         // Missing `description` (a skill-required field).
         std::fs::write(&path, "---\nname: my-skill\n---\nBody\n").unwrap();
 
-        let result = lint_file(&path, "foo/SKILL.md", &schema).unwrap();
+        let result = lint_file(&path, "foo/SKILL.md", &schema, false).unwrap();
         assert!(
             result
                 .violations
@@ -3447,7 +3472,7 @@ type = \"skill\"
         .unwrap();
 
         let schema = make_schema(&["title"], "note", &[], HashMap::new());
-        let result = lint_file(&path, "note.md", &schema).unwrap();
+        let result = lint_file(&path, "note.md", &schema, false).unwrap();
         assert!(result.violations.is_empty());
     }
 
@@ -3459,7 +3484,7 @@ type = \"skill\"
 
         let schema = SchemaConfig::default();
         let files = vec![(path, "note.md".to_owned())];
-        let (_, counts) = lint_files(&files, &schema).unwrap();
+        let (_, counts) = lint_files(&files, &schema, false).unwrap();
         assert_eq!(counts.errors, 0);
         assert_eq!(counts.warnings, 0);
     }
@@ -3477,7 +3502,7 @@ type = \"skill\"
         .unwrap();
 
         let schema = SchemaConfig::default();
-        let result = lint_file(&path, "note.md", &schema).unwrap();
+        let result = lint_file(&path, "note.md", &schema, false).unwrap();
         let comma_warn = result
             .violations
             .iter()
@@ -3529,6 +3554,7 @@ type = \"skill\"
             madr_profile: false,
             skills_profile: false,
             changelog_profile: false,
+            case_insensitive: false,
         };
         lint_files_extended(&files, schema, &engine, &md_config, &mut opts).unwrap()
     }
@@ -3733,9 +3759,16 @@ type = \"skill\"
 
         let schema = SchemaConfig::default();
         let files = vec![(path.clone(), "note.md".to_owned())];
-        let (_, counts) =
-            lint_files_with_options(&files, &schema, FixMode::Apply, None, &mut None, None)
-                .unwrap();
+        let (_, counts) = lint_files_with_options(
+            &files,
+            &schema,
+            FixMode::Apply,
+            None,
+            &mut None,
+            None,
+            false,
+        )
+        .unwrap();
 
         // After fix, the comma-joined tag warning should be gone.
         assert_eq!(counts.warnings, 0, "comma-tag warning should be fixed");
@@ -3906,7 +3939,7 @@ type = \"skill\"
         .unwrap();
 
         let schema = make_schema_with_sections(vec!["# Goal".to_owned(), "## Tasks".to_owned()]);
-        let result = lint_file(&path, "doc.md", &schema).unwrap();
+        let result = lint_file(&path, "doc.md", &schema, false).unwrap();
         let section_viols: Vec<_> = result
             .violations
             .iter()
@@ -3929,7 +3962,7 @@ type = \"skill\"
         .unwrap();
 
         let schema = make_schema_with_sections(vec!["# Goal".to_owned(), "## Tasks".to_owned()]);
-        let result = lint_file(&path, "doc.md", &schema).unwrap();
+        let result = lint_file(&path, "doc.md", &schema, false).unwrap();
         let section_viols: Vec<_> = result
             .violations
             .iter()
@@ -3960,7 +3993,7 @@ type = \"skill\"
 
         // Required: Goal then Tasks (but in body: Tasks then Goal).
         let schema = make_schema_with_sections(vec!["# Goal".to_owned(), "## Tasks".to_owned()]);
-        let result = lint_file(&path, "doc.md", &schema).unwrap();
+        let result = lint_file(&path, "doc.md", &schema, false).unwrap();
         let section_viols: Vec<_> = result
             .violations
             .iter()
@@ -3984,7 +4017,7 @@ type = \"skill\"
         .unwrap();
 
         let schema = make_schema_with_sections(vec!["# Goal".to_owned(), "## Tasks".to_owned()]);
-        let result = lint_file(&path, "doc.md", &schema).unwrap();
+        let result = lint_file(&path, "doc.md", &schema, false).unwrap();
         let section_viols: Vec<_> = result
             .violations
             .iter()

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -69,7 +69,7 @@ pub fn resolve_file_user(
 /// Known noisy suffixes that upstream YAML parser errors (`serde-saphyr`)
 /// append to otherwise-useful messages — internal-API advice ("set
 /// `DuplicateKeyPolicy` in `Options`...") that means nothing to a user
-/// looking at a `HYALO005` lint violation or an OKF/MADR generator skip
+/// looking at a `HYALO005` lint violation or an OKF generator skip
 /// warning. Stripped by [`terse_root_cause`] before the message reaches the
 /// user; the line/column info and the actual cause (e.g. "duplicate mapping
 /// key: type") are left intact.
@@ -85,19 +85,28 @@ const NOISY_ERROR_SUFFIXES: &[&str] = &[", set DuplicateKeyPolicy in Options if 
 /// file itself.
 ///
 /// Shared by the `HYALO005` (`RULE_ID_FRONTMATTER_PARSE_ERROR`) lint
-/// violation message and the OKF/MADR generator skip warnings — both surface
+/// violation message and the OKF generator skip warnings — both surface
 /// a YAML parse error's root cause to the user.
 #[must_use]
 pub(crate) fn terse_root_cause(err: &anyhow::Error) -> String {
     let root = err.root_cause().to_string();
     let first_line = root.lines().next().unwrap_or(&root).trim();
-    let mut msg = first_line.to_owned();
-    for suffix in NOISY_ERROR_SUFFIXES {
-        if let Some(stripped) = msg.strip_suffix(suffix) {
-            msg = stripped.to_owned();
+    // Strip to a fixed point so one suffix's removal can expose another
+    // (matters once NOISY_ERROR_SUFFIXES grows past a single entry).
+    let mut msg = first_line;
+    loop {
+        let mut stripped_any = false;
+        for suffix in NOISY_ERROR_SUFFIXES {
+            if let Some(stripped) = msg.strip_suffix(suffix) {
+                msg = stripped;
+                stripped_any = true;
+            }
+        }
+        if !stripped_any {
+            break;
         }
     }
-    msg
+    msg.trim_end().to_owned()
 }
 
 /// The `hyalo lint --profile <profile>` hint to attach to a generator command's

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -66,6 +66,40 @@ pub fn resolve_file_user(
     discovery::resolve_file(dir, path_arg)
 }
 
+/// Known noisy suffixes that upstream YAML parser errors (`serde-saphyr`)
+/// append to otherwise-useful messages — internal-API advice ("set
+/// `DuplicateKeyPolicy` in `Options`...") that means nothing to a user
+/// looking at a `HYALO005` lint violation or an OKF/MADR generator skip
+/// warning. Stripped by [`terse_root_cause`] before the message reaches the
+/// user; the line/column info and the actual cause (e.g. "duplicate mapping
+/// key: type") are left intact.
+const NOISY_ERROR_SUFFIXES: &[&str] = &[", set DuplicateKeyPolicy in Options if acceptable"];
+
+/// Deepest error message in an `anyhow` chain, condensed to its first line and
+/// stripped of known-noisy upstream advisory suffixes (see
+/// [`NOISY_ERROR_SUFFIXES`]).
+///
+/// The YAML parser attaches a multi-line source snippet to its error; for a
+/// one-line lint message or generator skip warning we keep only the leading
+/// line so the message stays terse. The full detail is still available in the
+/// file itself.
+///
+/// Shared by the `HYALO005` (`RULE_ID_FRONTMATTER_PARSE_ERROR`) lint
+/// violation message and the OKF/MADR generator skip warnings — both surface
+/// a YAML parse error's root cause to the user.
+#[must_use]
+pub(crate) fn terse_root_cause(err: &anyhow::Error) -> String {
+    let root = err.root_cause().to_string();
+    let first_line = root.lines().next().unwrap_or(&root).trim();
+    let mut msg = first_line.to_owned();
+    for suffix in NOISY_ERROR_SUFFIXES {
+        if let Some(stripped) = msg.strip_suffix(suffix) {
+            msg = stripped.to_owned();
+        }
+    }
+    msg
+}
+
 /// The `hyalo lint --profile <profile>` hint to attach to a generator command's
 /// output — or `None` when it would be redundant.
 ///
@@ -498,5 +532,51 @@ mod tests {
     #[test]
     fn iso8601_known_date() {
         assert_eq!(format_iso8601(1_705_314_600), "2024-01-15T10:30:00Z");
+    }
+
+    // --- terse_root_cause ---
+
+    /// A real duplicate-mapping-key YAML error, produced through the same
+    /// frontmatter-parsing entry point `HYALO005` and the OKF/MADR skip
+    /// warnings use, must not leak the upstream `serde-saphyr` internal-API
+    /// advice ("set DuplicateKeyPolicy in Options if acceptable") — but must
+    /// keep the actual cause and its line/column location.
+    #[test]
+    fn terse_root_cause_strips_duplicate_key_policy_advice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("corrupt.md");
+        std::fs::write(&path, "---\ntitle: A\ntitle: B\n---\n# Body\n").unwrap();
+        let err = hyalo_core::frontmatter::read_frontmatter(&path).unwrap_err();
+
+        let msg = terse_root_cause(&err);
+
+        assert!(
+            !msg.contains("DuplicateKeyPolicy"),
+            "must not leak the Rust type name: {msg:?}"
+        );
+        assert!(
+            !msg.contains("set DuplicateKeyPolicy in Options if acceptable"),
+            "must not leak the internal-API advice suffix: {msg:?}"
+        );
+        assert!(
+            msg.contains("duplicate mapping key"),
+            "must keep the actual cause: {msg:?}"
+        );
+        assert!(
+            msg.contains("line 2 column 1"),
+            "must keep line/column info: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn terse_root_cause_condenses_to_first_line() {
+        let err = anyhow::anyhow!("first line\nsecond line\nthird line");
+        assert_eq!(terse_root_cause(&err), "first line");
+    }
+
+    #[test]
+    fn terse_root_cause_leaves_unrelated_messages_untouched() {
+        let err = anyhow::anyhow!("plain error with no noisy suffix");
+        assert_eq!(terse_root_cause(&err), "plain error with no noisy suffix");
     }
 }

--- a/crates/hyalo-cli/src/commands/okf.rs
+++ b/crates/hyalo-cli/src/commands/okf.rs
@@ -196,7 +196,10 @@ pub fn run_index(
             }
             Err(err) => {
                 skipped_malformed += 1;
-                eprintln!("warning: skipping {rel}: {}", root_cause(&err));
+                eprintln!(
+                    "warning: skipping {rel}: {}",
+                    crate::commands::terse_root_cause(&err)
+                );
             }
         }
     }
@@ -647,13 +650,6 @@ fn build_ignore_globset(patterns: &[String]) -> Option<globset::GlobSet> {
         return None;
     }
     builder.build().ok()
-}
-
-/// The deepest error message in an `anyhow` chain, for a terse one-line stderr
-/// warning (the `root_cause` is the concrete parse/IO failure, not the wrapping
-/// "failed to parse frontmatter of X" context we add ourselves).
-fn root_cause(err: &anyhow::Error) -> String {
-    err.root_cause().to_string()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/src/commands/okf_lint.rs
+++ b/crates/hyalo-cli/src/commands/okf_lint.rs
@@ -57,15 +57,29 @@ const INDEX_BEGIN: &str = "<!-- okf:index:begin -->";
 const INDEX_END: &str = "<!-- okf:index:end -->";
 
 /// Is `rel_path` a reserved `index.md` (root or any subdirectory)?
-fn is_index_file(rel_path: &str) -> bool {
+///
+/// When `case_insensitive` is set (mirrors the vault's resolved `[links]
+/// case_insensitive` mode, same as `ExemptGlobs::is_exempt_ci`), the match
+/// folds case so an adopted `INDEX.md` is recognized as reserved exactly
+/// like `hyalo okf index` and the SCHEMA exempt-glob pass already do.
+fn is_index_file(rel_path: &str, case_insensitive: bool) -> bool {
     let norm = rel_path.replace('\\', "/");
-    norm == "index.md" || norm.ends_with("/index.md")
+    if case_insensitive {
+        norm.eq_ignore_ascii_case("index.md") || norm.to_ascii_lowercase().ends_with("/index.md")
+    } else {
+        norm == "index.md" || norm.ends_with("/index.md")
+    }
 }
 
-/// Is `rel_path` a reserved `log.md`?
-fn is_log_file(rel_path: &str) -> bool {
+/// Is `rel_path` a reserved `log.md`? See [`is_index_file`] for the
+/// `case_insensitive` contract.
+fn is_log_file(rel_path: &str, case_insensitive: bool) -> bool {
     let norm = rel_path.replace('\\', "/");
-    norm == "log.md" || norm.ends_with("/log.md")
+    if case_insensitive {
+        norm.eq_ignore_ascii_case("log.md") || norm.to_ascii_lowercase().ends_with("/log.md")
+    } else {
+        norm == "log.md" || norm.ends_with("/log.md")
+    }
 }
 
 /// Strip a trailing `\r` (CRLF tolerance) and any trailing `\n` already removed
@@ -98,6 +112,10 @@ fn ends_with_md(s: &str) -> bool {
 /// * `doc_type` — the frontmatter `type`, if any.
 /// * `is_enabled` — predicate deciding whether a given rule id runs (honors
 ///   `[lint.rules]` overrides and `--rule`/`--rule-prefix` filters).
+/// * `case_insensitive` — resolved `[links] case_insensitive` mode for the
+///   vault, mirroring `ExemptGlobs::is_exempt_ci` so a case-folded `INDEX.md`
+///   / `LOG.md` is recognized as the reserved file the same way the SCHEMA
+///   exempt-glob pass and `hyalo okf index` already do.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_okf_rules(
     rel_path: &str,
@@ -108,17 +126,18 @@ pub(crate) fn run_okf_rules(
     doc_type: Option<&str>,
     is_enabled: &dyn Fn(&str) -> bool,
     vault_dir: &Path,
+    case_insensitive: bool,
 ) -> Vec<OkfFinding> {
     let mut out = Vec::new();
 
-    if is_index_file(rel_path) {
+    if is_index_file(rel_path, case_insensitive) {
         if is_enabled("OKF-INDEX-STRUCTURE") {
             check_index_structure(content, body, body_line_offset, &mut out);
         }
         // Reserved files are not concept docs — no citation/augmentation checks.
         return out;
     }
-    if is_log_file(rel_path) {
+    if is_log_file(rel_path, case_insensitive) {
         if is_enabled("OKF-LOG-STRUCTURE") {
             check_log_structure(body, body_line_offset, &mut out);
         }
@@ -592,6 +611,42 @@ mod tests {
         true
     }
 
+    // -------------------------------------------------------------------
+    // is_index_file / is_log_file: case-sensitivity contract
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn is_index_file_case_sensitive_by_default() {
+        assert!(!is_index_file("INDEX.md", false));
+        assert!(is_index_file("index.md", false));
+        assert!(is_index_file("sub/index.md", false));
+        assert!(!is_index_file("sub/INDEX.md", false));
+    }
+
+    #[test]
+    fn is_index_file_case_insensitive_when_enabled() {
+        assert!(is_index_file("INDEX.md", true));
+        assert!(is_index_file("index.md", true));
+        assert!(is_index_file("sub/INDEX.md", true));
+        assert!(is_index_file("sub\\INDEX.md", true), "Windows separator");
+    }
+
+    #[test]
+    fn is_log_file_case_sensitive_by_default() {
+        assert!(!is_log_file("LOG.md", false));
+        assert!(is_log_file("log.md", false));
+        assert!(is_log_file("sub/log.md", false));
+        assert!(!is_log_file("sub/LOG.md", false));
+    }
+
+    #[test]
+    fn is_log_file_case_insensitive_when_enabled() {
+        assert!(is_log_file("LOG.md", true));
+        assert!(is_log_file("log.md", true));
+        assert!(is_log_file("sub/LOG.md", true));
+        assert!(is_log_file("sub\\LOG.md", true), "Windows separator");
+    }
+
     #[test]
     fn every_emitted_rule_id_is_registered() {
         // Any rule id the runtime can emit must appear in OKF_RULE_IDS so the
@@ -606,6 +661,7 @@ mod tests {
             Some("BigQuery Table"),
             &always_enabled,
             Path::new("/vault"),
+            false,
         );
         for f in &out {
             assert!(
@@ -760,6 +816,7 @@ mod tests {
             Some("BigQuery Table"),
             &always_enabled,
             Path::new("/vault"),
+            false,
         );
         assert!(
             out.iter()

--- a/crates/hyalo-cli/src/commands/okf_lint.rs
+++ b/crates/hyalo-cli/src/commands/okf_lint.rs
@@ -63,22 +63,27 @@ const INDEX_END: &str = "<!-- okf:index:end -->";
 /// folds case so an adopted `INDEX.md` is recognized as reserved exactly
 /// like `hyalo okf index` and the SCHEMA exempt-glob pass already do.
 fn is_index_file(rel_path: &str, case_insensitive: bool) -> bool {
-    let norm = rel_path.replace('\\', "/");
-    if case_insensitive {
-        norm.eq_ignore_ascii_case("index.md") || norm.to_ascii_lowercase().ends_with("/index.md")
-    } else {
-        norm == "index.md" || norm.ends_with("/index.md")
-    }
+    has_reserved_name(rel_path, "index.md", case_insensitive)
 }
 
 /// Is `rel_path` a reserved `log.md`? See [`is_index_file`] for the
 /// `case_insensitive` contract.
 fn is_log_file(rel_path: &str, case_insensitive: bool) -> bool {
-    let norm = rel_path.replace('\\', "/");
+    has_reserved_name(rel_path, "log.md", case_insensitive)
+}
+
+/// Basename comparison behind the reserved-file predicates, allocation-free
+/// (runs once per file per lint invocation). Case folding is ASCII-only
+/// (`eq_ignore_ascii_case`) while the SCHEMA exempt-glob pass folds via
+/// globset's Unicode-aware `(?i)`; the reserved names are pure ASCII, so the
+/// two can only diverge on pathological non-ASCII lookalikes (e.g. U+212A
+/// KELVIN SIGN case-folding to `k`) — accepted, not worth matching exactly.
+fn has_reserved_name(rel_path: &str, name: &str, case_insensitive: bool) -> bool {
+    let base = rel_path.rsplit(['/', '\\']).next().unwrap_or(rel_path);
     if case_insensitive {
-        norm.eq_ignore_ascii_case("log.md") || norm.to_ascii_lowercase().ends_with("/log.md")
+        base.eq_ignore_ascii_case(name)
     } else {
-        norm == "log.md" || norm.ends_with("/log.md")
+        base == name
     }
 }
 

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -200,6 +200,7 @@ pub fn set(
     dry_run: bool,
     validate: bool,
     schema: Option<&SchemaConfig>,
+    case_insensitive_mode: hyalo_core::case_index::CaseInsensitiveMode,
 ) -> Result<CommandOutcome> {
     // At least one mutation target required
     if property_args.is_empty() && tag_args.is_empty() {
@@ -313,10 +314,15 @@ pub fn set(
     //     validation, no files are written. The schema is chosen from the merged
     //     `type` property (post-mutation), so `--property type=X` selects X's schema.
     if validate && let Some(schema) = schema {
+        // Resolved once for the whole batch (not re-probed per file) so
+        // `[schema] exempt` globs fold case the same way `hyalo okf index`
+        // treats `INDEX.md` on case-insensitive filesystems (macOS/Windows
+        // default).
+        let case_insensitive = hyalo_core::case_index::mode_enabled(case_insensitive_mode, dir);
         for (full_path, rel_path) in &files {
             // Reserved / exempt files (e.g. OKF `index.md`, `log.md`) are not
             // subject to schema validation.
-            if schema.exempt.is_exempt(rel_path) {
+            if schema.exempt.is_exempt_ci(rel_path, case_insensitive) {
                 continue;
             }
             let props = match frontmatter::read_frontmatter(full_path) {
@@ -571,6 +577,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let out = match outcome {
@@ -615,6 +622,7 @@ status: draft
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
 
@@ -650,6 +658,7 @@ status: done
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -688,6 +697,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -729,6 +739,7 @@ tags:
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -765,6 +776,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -792,6 +804,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -814,6 +827,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -837,6 +851,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -860,6 +875,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -889,6 +905,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
 
@@ -925,6 +942,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -971,6 +989,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -1011,6 +1030,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -1050,6 +1070,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         let CommandOutcome::Success { output: out, .. } = outcome else {
@@ -1087,6 +1108,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         match outcome {
@@ -1115,6 +1137,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -1138,6 +1161,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -1161,6 +1185,7 @@ title: Note
             false,
             false,
             None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::UserError(_)));
@@ -1227,6 +1252,7 @@ type: post
             false,
             true, // validate = true
             Some(&schema),
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(
@@ -1291,6 +1317,7 @@ type: post
             false,
             true, // validate = true
             Some(&schema),
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -332,7 +332,14 @@ pub fn summary(
         // extract_tags, so passing properties alone is sufficient for the
         // lint pass — there is no `tags` data unreachable through properties.
         let lint_entries = entries.iter().map(|e| (e.rel_path.as_str(), &e.properties));
-        let counts = lint_counts_from_properties(lint_entries, schema);
+        // Mirror the vault's resolved `[links] case_insensitive` mode so
+        // `[schema] exempt` globs (e.g. `**/index.md`) fold case the same way
+        // `hyalo okf index` does on case-insensitive filesystems. `case_index`
+        // already resolved the mode via `mode_enabled` when it was built, so
+        // reading it back here costs nothing extra.
+        let case_insensitive =
+            case_index.is_some_and(CaseInsensitiveIndex::case_insensitive_paths_enabled);
+        let counts = lint_counts_from_properties(lint_entries, schema, case_insensitive);
         Some(LintSummary {
             errors: counts.errors,
             warnings: counts.warnings,

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -213,6 +213,7 @@ pub(crate) fn set_type(
     filename_template: Option<&str>,
     dry_run: bool,
     format: Format,
+    case_insensitive_mode: hyalo_core::case_index::CaseInsensitiveMode,
 ) -> Result<CommandOutcome> {
     // Validate type name before anything else.
     if let Err(msg) = validate_type_name(type_name) {
@@ -542,7 +543,15 @@ pub(crate) fn set_type(
             })
             .collect();
 
-        let counts = crate::commands::lint::lint_counts_only(&file_pairs, &updated_schema)?;
+        // Resolved once here (only when a violation check is actually
+        // needed) rather than probing the filesystem unconditionally on
+        // every `hyalo types set` invocation.
+        let case_insensitive = hyalo_core::case_index::mode_enabled(case_insensitive_mode, dir);
+        let counts = crate::commands::lint::lint_counts_only(
+            &file_pairs,
+            &updated_schema,
+            case_insensitive,
+        )?;
 
         if counts.errors > 0 || counts.warnings > 0 {
             constraint_violations.push(serde_json::json!({
@@ -1081,6 +1090,7 @@ mod tests {
             None,
             false,
             Format::Json,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(
@@ -1170,6 +1180,7 @@ mod tests {
             None,
             false,
             Format::Json,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
         assert!(matches!(outcome, CommandOutcome::Success { .. }));
@@ -1197,6 +1208,7 @@ mod tests {
             None,
             false,
             Format::Json,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         )
         .unwrap();
 
@@ -1257,6 +1269,7 @@ mod tests {
             None,
             false,
             Format::Json,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
         );
         // Should return an error about malformed TOML, not panic
         assert!(

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -1210,6 +1210,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 dry_run,
                 do_validate,
                 if do_validate { Some(ctx.schema) } else { None },
+                ctx.case_insensitive_mode,
             )
         }
         Commands::Remove {
@@ -1870,6 +1871,11 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 madr_profile: madr_profile_active,
                 skills_profile: skills_profile_active,
                 changelog_profile: changelog_profile_active,
+                // Resolved once per `hyalo lint` invocation (not re-probed
+                // per file) so `[schema] exempt` globs fold case the same way
+                // `hyalo okf index` treats `INDEX.md` on case-insensitive
+                // filesystems (macOS/Windows default).
+                case_insensitive: mode_enabled(ctx.case_insensitive_mode, dir),
             };
 
             let (outcome, mut counts) = lint_commands::lint_files_extended(
@@ -2270,6 +2276,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     filename_template.as_deref(),
                     dry_run,
                     effective_format,
+                    ctx.case_insensitive_mode,
                 ),
             }
         }

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -94,7 +94,12 @@ impl OutputPipeline<'_> {
         let c = self.files_from_counters.as_ref()?;
         let mut parts: Vec<String> = Vec::new();
         if c.files_missing > 0 {
-            parts.push(format!("{} input paths missing", c.files_missing));
+            let noun = if c.files_missing == 1 {
+                "path"
+            } else {
+                "paths"
+            };
+            parts.push(format!("{} input {noun} missing", c.files_missing));
         }
         if c.files_skipped_non_md > 0 {
             parts.push(format!("{} non-markdown skipped", c.files_skipped_non_md));
@@ -299,5 +304,83 @@ impl OutputPipeline<'_> {
                 2
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pipeline_with_counters(counters: FilesFromCounters) -> OutputPipeline<'static> {
+        OutputPipeline {
+            user_format: Format::Text,
+            jq_filter: None,
+            hint_ctx: None,
+            count: false,
+            files_from_counters: Some(counters),
+            github_path_prefix: String::new(),
+        }
+    }
+
+    #[test]
+    fn skip_summary_singular_missing_path() {
+        let pipeline = pipeline_with_counters(FilesFromCounters {
+            files_missing: 1,
+            files_skipped_non_md: 0,
+            files_skipped_outside_vault: 0,
+        });
+        assert_eq!(
+            pipeline.skip_summary().as_deref(),
+            Some("1 input path missing")
+        );
+    }
+
+    #[test]
+    fn skip_summary_plural_missing_paths() {
+        let pipeline = pipeline_with_counters(FilesFromCounters {
+            files_missing: 2,
+            files_skipped_non_md: 0,
+            files_skipped_outside_vault: 0,
+        });
+        assert_eq!(
+            pipeline.skip_summary().as_deref(),
+            Some("2 input paths missing")
+        );
+    }
+
+    #[test]
+    fn skip_summary_combines_all_counters() {
+        let pipeline = pipeline_with_counters(FilesFromCounters {
+            files_missing: 1,
+            files_skipped_non_md: 3,
+            files_skipped_outside_vault: 1,
+        });
+        assert_eq!(
+            pipeline.skip_summary().as_deref(),
+            Some("1 input path missing, 3 non-markdown skipped, 1 outside vault skipped")
+        );
+    }
+
+    #[test]
+    fn skip_summary_none_when_no_counters() {
+        let pipeline = OutputPipeline {
+            user_format: Format::Text,
+            jq_filter: None,
+            hint_ctx: None,
+            count: false,
+            files_from_counters: None,
+            github_path_prefix: String::new(),
+        };
+        assert_eq!(pipeline.skip_summary(), None);
+    }
+
+    #[test]
+    fn skip_summary_none_when_all_zero() {
+        let pipeline = pipeline_with_counters(FilesFromCounters {
+            files_missing: 0,
+            files_skipped_non_md: 0,
+            files_skipped_outside_vault: 0,
+        });
+        assert_eq!(pipeline.skip_summary(), None);
     }
 }

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -2554,3 +2554,101 @@ fn lint_exempt_glob_case_insensitive_false_does_not_exempt_uppercase_index() {
         String::from_utf8_lossy(&output2.stdout)
     );
 }
+
+// ---------------------------------------------------------------------------
+// OKF profile: reserved-file predicates (is_index_file/is_log_file) honor
+// `[links] case_insensitive` too (same fix-wave, okf_lint.rs half of the bug).
+//
+// The SCHEMA exempt-glob pass (tested above) is one of two independent
+// reserved-file checks; `--profile okf`'s own `is_index_file`/`is_log_file`
+// used to be hard-coded case-sensitive, so an adopted `INDEX.md` was exempt
+// from SCHEMA but still fell through to the concept-doc rules (spurious
+// `OKF-CITATIONS-PRESENT`) instead of being treated as the reserved index.
+// ---------------------------------------------------------------------------
+
+/// `[links] case_insensitive = "true"` + `--profile okf`: an `INDEX.md` with
+/// no `# Citations` section must NOT get `OKF-CITATIONS-PRESENT` (it is now
+/// recognized as the reserved index, not a concept doc) — it may still warn
+/// `OKF-INDEX-STRUCTURE` because its body is prose, not a link list.
+#[test]
+fn lint_okf_profile_case_insensitive_true_index_skips_citations_present() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        "dir = \".\"\n\n[links]\ncase_insensitive = \"true\"\n",
+    );
+    // Prose body, no link list and no `# Citations` — would trip both
+    // OKF-INDEX-STRUCTURE (not a link list) and, if misclassified as a
+    // concept doc, OKF-CITATIONS-PRESENT.
+    write_md(
+        tmp.path(),
+        "INDEX.md",
+        "---\ntype: BigQuery Table\n---\nThis is prose, not a link list.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json", "--profile", "okf"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let rule_ids: Vec<&str> = json["results"]["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|f| f["rule_groups"].as_array())
+        .flatten()
+        .filter_map(|g| g["rule"].as_str())
+        .collect();
+
+    assert!(
+        !rule_ids.contains(&"OKF-CITATIONS-PRESENT"),
+        "case-folded INDEX.md must not be treated as a concept doc: stdout={stdout}"
+    );
+    assert!(
+        rule_ids.contains(&"OKF-INDEX-STRUCTURE"),
+        "case-folded INDEX.md should still get OKF-INDEX-STRUCTURE for its prose body: stdout={stdout}"
+    );
+}
+
+/// `[links] case_insensitive = "false"` + `--profile okf`: behavior is
+/// unchanged from before this whole fix wave — `INDEX.md` is treated as an
+/// ordinary concept doc and DOES get `OKF-CITATIONS-PRESENT` when it lacks a
+/// `# Citations` section.
+#[test]
+fn lint_okf_profile_case_insensitive_false_index_keeps_citations_present() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        "dir = \".\"\n\n[links]\ncase_insensitive = \"false\"\n",
+    );
+    write_md(
+        tmp.path(),
+        "INDEX.md",
+        "---\ntype: BigQuery Table\n---\nThis is prose, not a link list.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json", "--profile", "okf"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let rule_ids: Vec<&str> = json["results"]["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|f| f["rule_groups"].as_array())
+        .flatten()
+        .filter_map(|g| g["rule"].as_str())
+        .collect();
+
+    assert!(
+        rule_ids.contains(&"OKF-CITATIONS-PRESENT"),
+        "with case_insensitive=false, INDEX.md must remain an ordinary concept doc: stdout={stdout}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -2331,6 +2331,44 @@ fn lint_skip_summary_text_and_github() {
     );
 }
 
+/// A single missing input path is reported as singular ("1 input path
+/// missing"), not "1 input paths missing" (redogfood fix-wave v0.18.0).
+#[test]
+fn lint_skip_summary_singular_missing_path() {
+    let tmp = setup_vault_with_corrupt_file();
+    write_md(tmp.path(), "ok.md", "---\ntitle: Fine\n---\n# Body\n");
+
+    // Exactly 1 real .md + 1 missing path.
+    let list = write_list_file(&["ok.md", "gone.md"]);
+    let list_path = list.path().to_str().unwrap();
+
+    let text = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "text", "--files-from", list_path])
+        .output()
+        .unwrap();
+    let text_err = std::str::from_utf8(&text.stderr).unwrap();
+    assert!(
+        text_err.contains("note: 1 input path missing"),
+        "singular count must say 'path', not 'paths'; got stderr:\n{text_err}"
+    );
+    assert!(
+        !text_err.contains("1 input paths missing"),
+        "must not use the plural form for count=1; got stderr:\n{text_err}"
+    );
+
+    let gh = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "github", "--files-from", list_path])
+        .output()
+        .unwrap();
+    let gh_out = std::str::from_utf8(&gh.stdout).unwrap();
+    assert!(
+        gh_out.contains("::notice::1 input path missing"),
+        "github format must also use the singular form; got:\n{gh_out}"
+    );
+}
+
 /// An explicitly named `--file` that is excluded by `[lint] ignore` prints a
 /// notice instead of silently reporting `0 files checked`.
 #[test]
@@ -2403,5 +2441,116 @@ fn lint_github_fix_dry_run_distinguishable() {
     assert_ne!(
         stdout, plain_out,
         "fix --dry-run github output must differ from plain lint output"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Exempt globs honor `[links] case_insensitive` (redogfood fix-wave v0.18.0)
+// ---------------------------------------------------------------------------
+//
+// `hyalo okf index` already treats `INDEX.md` as the reserved index file on a
+// case-insensitive filesystem (auto-detected or forced via `[links]
+// case_insensitive`); `hyalo lint`'s `[schema] exempt` globs must agree, or a
+// literally-named `INDEX.md` spuriously fails the required-`type` check that
+// `**/index.md` was supposed to exempt it from.
+//
+// Both tests below force the mode explicitly via config rather than relying
+// on host detection, so they pass identically on Linux, macOS, and Windows.
+
+fn exempt_index_schema_toml() -> &'static str {
+    r#"dir = "."
+
+[schema]
+exempt = ["**/index.md"]
+
+[schema.default]
+required = ["type"]
+"#
+}
+
+/// `[links] case_insensitive = "true"` forces exempt-glob matching to fold
+/// case: a literal `INDEX.md` is treated the same as `index.md` and is
+/// exempt from the `required = ["type"]` default schema.
+#[test]
+fn lint_exempt_glob_case_insensitive_true_exempts_uppercase_index() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        &format!(
+            "{}\n[links]\ncase_insensitive = \"true\"\n",
+            exempt_index_schema_toml()
+        ),
+    );
+    // No `type` property — would fail `required = ["type"]` unless exempt.
+    write_md(tmp.path(), "INDEX.md", "---\n---\nBody.\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "INDEX.md must be exempt under case_insensitive = true; stdout: {stdout}, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        json["results"]["files_with_violations"]
+            .as_u64()
+            .unwrap_or(99),
+        0,
+        "expected zero violations for exempt INDEX.md; stdout: {stdout}"
+    );
+}
+
+/// `[links] case_insensitive = "false"` keeps exempt-glob matching strict:
+/// `INDEX.md` does NOT match `**/index.md` and the missing-`type` violation
+/// still fires. This is the inverse of the test above and guards against a
+/// fix that makes exempt matching unconditionally case-insensitive.
+#[test]
+fn lint_exempt_glob_case_insensitive_false_does_not_exempt_uppercase_index() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(
+        tmp.path(),
+        &format!(
+            "{}\n[links]\ncase_insensitive = \"false\"\n",
+            exempt_index_schema_toml()
+        ),
+    );
+    write_md(tmp.path(), "INDEX.md", "---\n---\nBody.\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !output.status.success(),
+        "INDEX.md must NOT be exempt under case_insensitive = false; stdout: {stdout}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        json["results"]["files_with_violations"]
+            .as_u64()
+            .unwrap_or(0),
+        1,
+        "expected the missing-type violation on INDEX.md; stdout: {stdout}"
+    );
+
+    // The genuinely-exempt lowercase `index.md` still lints clean regardless
+    // of case_insensitive mode.
+    write_md(tmp.path(), "index.md", "---\n---\nBody.\n");
+    let output2 = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json", "index.md"])
+        .output()
+        .unwrap();
+    assert!(
+        output2.status.success(),
+        "lowercase index.md must remain exempt; stdout: {}",
+        String::from_utf8_lossy(&output2.stdout)
     );
 }

--- a/crates/hyalo-core/src/schema.rs
+++ b/crates/hyalo-core/src/schema.rs
@@ -122,13 +122,18 @@ impl SchemaBind {
 
 /// Compiled set of vault-relative exempt globs.
 ///
-/// Wraps the raw patterns plus a lazily-built [`globset::GlobSet`]. An empty
-/// set matches nothing. Cheap to clone (the underlying `GlobSet` is `Arc`-free
-/// but small, and patterns are shared by clone).
+/// Wraps the raw patterns plus lazily-built [`globset::GlobSet`]s: one
+/// case-sensitive, one case-insensitive. An empty set matches nothing. Cheap
+/// to clone (the underlying `GlobSet`s are `Arc`-free but small, and patterns
+/// are shared by clone).
 #[derive(Debug, Clone, Default)]
 pub struct ExemptGlobs {
     patterns: Vec<String>,
     set: Option<globset::GlobSet>,
+    /// Same patterns compiled with `.case_insensitive(true)`, used by
+    /// [`is_exempt_ci`](Self::is_exempt_ci) on filesystems that fold case
+    /// (e.g. `INDEX.md` matching `**/index.md` on macOS/Windows).
+    set_ci: Option<globset::GlobSet>,
 }
 
 impl ExemptGlobs {
@@ -141,6 +146,7 @@ impl ExemptGlobs {
             return Self::default();
         }
         let mut builder = globset::GlobSetBuilder::new();
+        let mut builder_ci = globset::GlobSetBuilder::new();
         let mut valid = Vec::with_capacity(patterns.len());
         for pat in patterns {
             // Skip invalid globs but keep the rest usable; config-load already
@@ -150,19 +156,32 @@ impl ExemptGlobs {
                 .build()
             {
                 builder.add(g);
-                valid.push(pat);
+                valid.push(pat.clone());
+            }
+            if let Ok(g) = globset::GlobBuilder::new(&pat)
+                .literal_separator(true)
+                .case_insensitive(true)
+                .build()
+            {
+                builder_ci.add(g);
             }
         }
         let set = builder.build().ok();
+        let set_ci = builder_ci.build().ok();
         Self {
             patterns: valid,
             set,
+            set_ci,
         }
     }
 
     /// Returns `true` when `rel_path` (a vault-relative path) matches any
     /// exempt glob. The path is normalized to forward slashes so Windows
     /// backslash-separated paths match the same globs as Unix paths.
+    ///
+    /// Matching is always case-sensitive here; use
+    /// [`is_exempt_ci`](Self::is_exempt_ci) when the vault's filesystem folds
+    /// case (e.g. under the resolved `[links] case_insensitive` mode).
     #[must_use]
     pub fn is_exempt(&self, rel_path: &str) -> bool {
         let Some(set) = &self.set else {
@@ -170,6 +189,30 @@ impl ExemptGlobs {
         };
         let normalized = rel_path.replace('\\', "/");
         set.is_match(normalized.as_str())
+    }
+
+    /// Returns `true` when `rel_path` matches any exempt glob, honoring
+    /// filesystem case-folding when `case_insensitive` is `true`.
+    ///
+    /// On a case-insensitive filesystem (macOS/Windows default), a file named
+    /// `INDEX.md` and a pattern `**/index.md` refer to the same path on disk,
+    /// so exempt matching should fold case too — otherwise `hyalo lint` and
+    /// `hyalo okf index` disagree about which file is the reserved index file
+    /// (`hyalo okf index` already treats `INDEX.md` as `index.md` via
+    /// [`crate::case_index::mode_enabled`]). On a case-sensitive filesystem,
+    /// pass `case_insensitive = false` — `INDEX.md` and `index.md` are
+    /// genuinely different files there and only the latter should match.
+    #[must_use]
+    pub fn is_exempt_ci(&self, rel_path: &str, case_insensitive: bool) -> bool {
+        if case_insensitive {
+            let Some(set) = &self.set_ci else {
+                return false;
+            };
+            let normalized = rel_path.replace('\\', "/");
+            set.is_match(normalized.as_str())
+        } else {
+            self.is_exempt(rel_path)
+        }
     }
 
     /// Returns `true` when no exempt patterns are configured.
@@ -745,6 +788,47 @@ impl SchemaConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---------------------------------------------------------------------
+    // ExemptGlobs case-(in)sensitivity
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn exempt_globs_case_sensitive_by_default() {
+        let globs = ExemptGlobs::new(vec!["**/index.md".to_owned()]);
+        assert!(globs.is_exempt("index.md"));
+        assert!(globs.is_exempt("sub/index.md"));
+        assert!(!globs.is_exempt("INDEX.md"));
+    }
+
+    #[test]
+    fn is_exempt_ci_false_matches_only_exact_case() {
+        let globs = ExemptGlobs::new(vec!["**/index.md".to_owned()]);
+        assert!(globs.is_exempt_ci("index.md", false));
+        assert!(!globs.is_exempt_ci("INDEX.md", false));
+    }
+
+    #[test]
+    fn is_exempt_ci_true_folds_case() {
+        let globs = ExemptGlobs::new(vec!["**/index.md".to_owned()]);
+        assert!(globs.is_exempt_ci("INDEX.md", true), "uppercase must match");
+        assert!(
+            globs.is_exempt_ci("Index.Md", true),
+            "mixed case must match"
+        );
+        assert!(
+            globs.is_exempt_ci("index.md", true),
+            "lowercase must still match"
+        );
+        assert!(!globs.is_exempt_ci("other.md", true));
+    }
+
+    #[test]
+    fn is_exempt_ci_normalizes_windows_separators() {
+        let globs = ExemptGlobs::new(vec!["**/index.md".to_owned()]);
+        assert!(globs.is_exempt_ci(r"sub\INDEX.md", true));
+        assert!(!globs.is_exempt_ci(r"sub\INDEX.md", false));
+    }
 
     #[test]
     fn empty_schema_is_empty() {

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0180-redogfood-fix-wave.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0180-redogfood-fix-wave.md
@@ -23,7 +23,7 @@ fixed mediums, and a quick own-KB regression + perf pass. Scratch vaults
 gate per the iteration-170 ignore policy).
 
 **Verdict: release v0.18.0.** All five blockers and both UX gaps are fixed
-and behave well under the original repros. Three leftovers found (1 MEDIUM,
+and behave well under the original repros. Four leftovers found (2 MEDIUM,
 2 LOW), all fixed in the follow-up PR from this session — none blocks the
 release on its own.
 
@@ -123,6 +123,17 @@ OKF vaults. Root cause: `ExemptGlobs::is_exempt`
 iter-173's case handling covered only the generator's reserved-file
 targeting. Fix: exempt matching honors the same effective
 `[links] case_insensitive` setting (auto-detected) the generator uses.
+
+### LB-4: OKF reserved-file predicates also case-sensitive (MEDIUM)
+
+Same bug class as LB-1, second site: `okf_lint.rs`'s own
+`is_index_file`/`is_log_file` predicates compare case-sensitively, so an
+adopted `INDEX.md` — exempted from SCHEMA after the LB-1 fix — was still
+classified as a concept doc and warned `OKF-CITATIONS-PRESENT` under
+`--profile okf`; lowercase `index.md` got zero findings. Fixed by threading
+the same effective flag and case-folding the predicates; under
+case-insensitivity `INDEX.md` now takes the reserved-file path
+(`OKF-INDEX-STRUCTURE` applies, concept-doc rules don't).
 
 ### LB-2: skip-summary pluralization (LOW)
 

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0180-redogfood-fix-wave.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0180-redogfood-fix-wave.md
@@ -1,0 +1,156 @@
+---
+title: "Dogfood v0.18.0 re-check — fix-wave 172-175 verification (slim)"
+type: research
+date: 2026-07-17
+status: active
+tags: [dogfooding, release-readiness, profiles, okf]
+related:
+  - "[[dogfood-results/dogfood-v0180-okf-profiles-pre-release]]"
+  - "[[iterations/iteration-172-profile-composition-semantics]]"
+  - "[[iterations/iteration-173-generator-safety]]"
+  - "[[iterations/iteration-174-lint-ci-trust]]"
+  - "[[iterations/iteration-175-profile-polish]]"
+---
+
+# Dogfood v0.18.0 re-check — fix-wave 172-175 verification (slim)
+
+Single-session slim pass on binary `hyalo 0.18.0 (fe42578e6a6f)` (main after
+PRs #201–#204). Scope: re-run the original repro scenarios for the five
+release blockers + two UX gaps from
+[[dogfood-results/dogfood-v0180-okf-profiles-pre-release]], spot-check the
+fixed mediums, and a quick own-KB regression + perf pass. Scratch vaults
+(okf+madr composed, changelog, skills) + own KB (337 files, 25 in the lint
+gate per the iteration-170 ignore policy).
+
+**Verdict: release v0.18.0.** All five blockers and both UX gaps are fixed
+and behave well under the original repros. Three leftovers found (1 MEDIUM,
+2 LOW), all fixed in the follow-up PR from this session — none blocks the
+release on its own.
+
+## Release-blocker regression testing
+
+### RB-1: profile composition clobbers config — FIXED
+
+`init --profile okf` then `init --profile madr` in one vault:
+`[lint] profiles = ["okf", "madr"]` (list — both rule sets fire),
+`[schema] exempt` is the union of both profiles' globs,
+`[schema.default] required` survives, `[[schema.bind]]` entries persist,
+hand-written comments and okf's own comments survive the second merge
+(toml_edit). Only cosmetic: merged tables interleave (`schema.default.
+properties.*` between `schema.types.adr.*` blocks) — valid TOML, slightly
+harder to read.
+
+### RB-2: first `okf index --apply` destroys unmarked index files — FIXED
+
+Hand-written marker-less `INDEX.md` (curated intro, links, extra section) on
+case-insensitive macOS FS: dry-run reports `action: "adopt"` with
+`preserved_lines: 9`; apply keeps the entire hand-written body and appends
+the managed region with blank lines around markers (MD022-clean). Second
+apply: `0 files wrote` (idempotent). Case-insensitive targeting picks up
+`INDEX.md` as *the* reserved file — no sibling `index.md` created.
+
+### RB-3: lint silently excludes unparseable-frontmatter files — FIXED
+
+Duplicate-YAML-key file now yields
+`error HYALO005 line 1 could not parse frontmatter: …` and lint exits 1.
+Generators no longer hard-abort: `okf index` prints a stderr warning with a
+code frame and reports `1 skipped (malformed frontmatter)` in the summary,
+exit 0. (LOW leftover: the message leaks yaml-library advice —
+"set DuplicateKeyPolicy in Options if acceptable" — meaningless to users.)
+
+### RB-4: `changelog add` places entries outside `[Unreleased]` — FIXED
+
+On a conformant KaC file ending in link-reference definitions,
+`changelog add --category Fixed --message … --apply` inserts
+`### Fixed` inside `[Unreleased]`, above `[1.0.0]`, footer refs untouched,
+file lints clean (incl. MD047). Note: `add` defaults to `--dry-run`
+(documented in `--help`, `"apply": false` in the JSON) — mildly surprising
+for an "add" verb but consistent with the generators.
+
+### RB-5: bundled `skills` skill fails its own profile — FIXED
+
+`cargo run -p xtask -- check-bundled-skills` → "8 bundled skill(s) pass the
+skills profile", exit 0; wired into quality-gates.yml.
+
+## UX-gap regression testing
+
+### UX-A: walker can't reach `.claude/skills/` — FIXED
+
+The skills profile writes `[scan] include = [".claude/skills/**"]`;
+`find` and `lint` both see `.claude/skills/my-skill/SKILL.md`. Bonus
+(iter-172 bind=typing): the SKILL.md carries no `type:` frontmatter and
+still lints clean under `required = ["type"]`.
+
+### UX-B: skip counters JSON-only — FIXED
+
+`lint --files-from` with a missing path and a non-md path:
+text prints `note: 1 input paths missing, 1 non-markdown skipped`;
+github prints the same as `::notice::`. (LOW leftover: pluralization —
+"1 input paths".)
+
+## Fixed mediums spot-checked
+
+- Bind-typed frontmatter-less files satisfy `required = ["type"]` — WORKING
+  (SKILL.md above; ADR below).
+- `new --type adr` honors `[schema.types.adr.defaults]` (`status: proposed`,
+  `date: $today` → 2026-07-17), scaffolds required sections, omits the
+  bind-implied `type:` key — WORKING.
+- `madr toc` excludes explicitly non-adr-typed files (`type: concept` file
+  in `docs/decisions/` dropped from the table; bind-typed files included) —
+  WORKING.
+- `types set default` rejected with a precise message pointing at
+  `[schema.default]`, exit 1 — WORKING.
+- `lint --limit 0` = unlimited; counts identical across `--limit` values
+  (pre-truncation counting) — WORKING.
+- lint/`okf index` ping-pong: generated region is MD022-clean, lint finds
+  nothing to fix inside it, second apply is a no-op — WORKING.
+- `[changelog] path = "CHANGELOG.md"` reaches the repo-root changelog when
+  the vault is a subdir — WORKING.
+- Neutral OKF profile: no BigQuery example types in the merged config —
+  WORKING.
+
+## Leftovers found (all fixed in this session's follow-up PR)
+
+### LB-1: exempt globs still case-sensitive (MEDIUM)
+
+`[schema] exempt = ["**/index.md"]` does not match `INDEX.md` on a
+case-insensitive FS — while `okf index` (iter-173) *does* treat `INDEX.md`
+as the reserved file there. Net effect: the generator adopts/maintains
+`INDEX.md`, then `lint` flags that same file
+`error SCHEMA missing required property "type"` → red CI on macOS/Windows
+OKF vaults. Root cause: `ExemptGlobs::is_exempt`
+(crates/hyalo-core/src/schema.rs:167) normalizes backslashes but never case;
+iter-173's case handling covered only the generator's reserved-file
+targeting. Fix: exempt matching honors the same effective
+`[links] case_insensitive` setting (auto-detected) the generator uses.
+
+### LB-2: skip-summary pluralization (LOW)
+
+`note: 1 input paths missing` → "1 input path missing".
+
+### LB-3: HYALO005 / generator warnings leak yaml-library internals (LOW)
+
+`…duplicate mapping key: type, set DuplicateKeyPolicy in Options if
+acceptable` — the trailing library advice refers to a Rust API the user
+cannot touch. Trim it from user-facing messages.
+
+## What worked well
+
+- The adopt path is genuinely safe: dry-run names the action (`adopt`) and
+  the preserved line count before anything is written.
+- `changelog add --dry-run` default + drift-nonzero exit makes the CI story
+  coherent across generators.
+- Error message quality is high (`types set default` explains *where* to do
+  it instead; redundant `--dir` gets a note).
+- Own KB: 0 errors under `--strict` (660 warnings, all MD013-class in
+  frozen-adjacent files).
+
+## Performance (own KB, 337 files)
+
+| command | time |
+| --- | --- |
+| `summary` | 0.05 s |
+| `find --property status=completed` | 0.03 s |
+| `find "profile composition"` (BM25) | 0.11 s |
+
+No regressions vs. the pre-release fleet baselines.


### PR DESCRIPTION
## Summary
- **LB-1/LB-4 (MEDIUM)**: exempt globs and OKF reserved-file predicates now honor the effective `[links] case_insensitive` setting (auto-detected, same flag `okf index` already uses). Previously on macOS/Windows the generator adopted `INDEX.md` but lint then flagged that same file with `SCHEMA missing required property "type"` and `OKF-CITATIONS-PRESENT` — the generator's own output failed CI. `ExemptGlobs` gains `is_exempt_ci` (second case-insensitive globset, built once); `okf_lint`'s `is_index_file`/`is_log_file` case-fold under the flag. Case-sensitive filesystems keep exact-case behavior.
- **LB-2 (LOW)**: `lint --files-from` skip summary pluralizes correctly ("1 input path missing").
- **LB-3 (LOW)**: user-facing YAML parse errors (HYALO005, generator skip warnings) no longer leak saphyr library advice ("set DuplicateKeyPolicy in Options if acceptable"); the two near-duplicate root-cause helpers are consolidated into one shared `commands::terse_root_cause`.
- Adds the slim re-dogfood report (`dogfood-results/dogfood-v0180-redogfood-fix-wave.md`): all 5 v0.18.0 release blockers + UX-A/B verified fixed under the original repros; these four leftovers were the only findings. Verdict: release v0.18.0.

## Test plan
- [x] Unit: `is_exempt_ci` both modes + Windows separators; `is_index_file`/`is_log_file` both modes; `terse_root_cause` suffix stripping; `skip_summary` singular/plural/combined
- [x] e2e (FS-independent, mode forced via `[links] case_insensitive` config): INDEX.md exempted under `true` / not under `false`; no `OKF-CITATIONS-PRESENT` on INDEX.md under `true` / unchanged under `false`; skip-summary singular
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` (3,000+ tests green)
- [x] `xtask check-help-drift`, `check-feature-fanout`
- [x] Live repro re-verified on macOS with the release binary (adopted INDEX.md: zero findings; corrupt file still errors HYALO005, exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)