### PR TITLE
fix(changelog): don't split wrapped multi-line bullets on add (LB-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ and this project adheres to
 - Skip-summary pluralization (`1 input path missing`) and YAML parse errors no
   longer leak library-internal advice (`set DuplicateKeyPolicy in Options if
   acceptable`) in `HYALO005` messages and generator skip warnings.
+- **`changelog add` no longer splits a wrapped multi-line bullet** (LB-5): when
+  the last bullet under a `### Category` had hanging-indent continuation
+  lines, the new entry was inserted after only the bullet's first line,
+  stranding its continuation lines below the new entry. The insertion anchor
+  now scans past a bullet's full continuation block before inserting.
 
 ## [0.18.0] - 2026-07-17
 

--- a/crates/hyalo-cli/src/commands/changelog.rs
+++ b/crates/hyalo-cli/src/commands/changelog.rs
@@ -489,8 +489,14 @@ fn insert_entry(cl: &mut Changelog, unreleased_idx: usize, category: &str, messa
 
     let entry = format!("- {message}");
     if let Some(cat_idx) = cat_idx {
-        // Insert after the last bullet under this category (before the next
-        // heading or a trailing blank line).
+        // Insert after the *complete* last bullet block under this category
+        // (before the next heading or a trailing blank line). A bullet block
+        // is its `- ` line plus every immediately-following hanging-indent
+        // continuation line (non-blank, starts with whitespace) — Keep a
+        // Changelog entries routinely wrap prose at ~80 columns, so a bullet's
+        // last line is often a continuation, not the `- ` line itself. Blank
+        // lines never continue a bullet and are never themselves treated as
+        // the insertion point.
         let mut insert_at = cat_idx + 1;
         let mut i = cat_idx + 1;
         while i < section_end {
@@ -499,7 +505,23 @@ fn insert_entry(cl: &mut Changelog, unreleased_idx: usize, category: &str, messa
                 break;
             }
             if l.trim_start().starts_with("- ") {
+                // Found a new bullet: advance past it and all of its
+                // continuation lines (indented, non-blank lines that don't
+                // start a new bullet/heading).
                 insert_at = i + 1;
+                i += 1;
+                while i < section_end {
+                    let cont = &cl.lines[i];
+                    let is_continuation = !cont.trim().is_empty()
+                        && cont.starts_with(char::is_whitespace)
+                        && !cont.trim_start().starts_with("- ");
+                    if !is_continuation {
+                        break;
+                    }
+                    insert_at = i + 1;
+                    i += 1;
+                }
+                continue;
             }
             i += 1;
         }
@@ -708,6 +730,131 @@ mod tests {
             entry_pos < footer_pos,
             "appended entry stays inside the section:\n{out}"
         );
+    }
+
+    /// LB-5: a category whose last bullet is wrapped across several
+    /// hanging-indent continuation lines, with a footer link-ref block at EOF
+    /// (the RB-4 layout). `add` must insert the new entry after the *complete*
+    /// wrapped bullet — not after its first line — leaving the continuation
+    /// lines intact and directly following the `- ` line, and must not
+    /// disturb the footer.
+    const WRAPPED_LAST_BULLET: &str = "\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- **`--format github` annotations are no longer truncated by the file cap**: the
+  regression is now covered by a test that lints 60 files past the default
+  50-file cap and asserts all 60 annotations are emitted.
+
+[Unreleased]: https://x/compare/v1.0.0...HEAD
+[1.0.0]: https://x/tag/v1.0.0
+";
+
+    #[test]
+    fn add_after_wrapped_last_bullet_lb5() {
+        let mut cl = Changelog::parse(WRAPPED_LAST_BULLET);
+        let idx = cl.version_heading_index("Unreleased").unwrap();
+        insert_entry(&mut cl, idx, "Fixed", "New entry.");
+        let out = cl.render();
+
+        // The old wrapped bullet is fully intact: its `- ` line is
+        // immediately followed by both continuation lines, uninterrupted.
+        let old_bullet_pos = out
+            .find("- **`--format github` annotations")
+            .expect("old bullet present");
+        let cont1_pos = out
+            .find("  regression is now covered")
+            .expect("first continuation present");
+        let cont2_pos = out
+            .find("  50-file cap and asserts")
+            .expect("second continuation present");
+        let new_entry_pos = out.find("- New entry.").expect("new entry present");
+        assert!(
+            old_bullet_pos < cont1_pos && cont1_pos < cont2_pos,
+            "old bullet's continuation lines stay in order directly after it:\n{out}"
+        );
+        // Nothing (in particular not the new entry) is stranded between the
+        // bullet's first line and its continuation lines.
+        let between = &out[old_bullet_pos..cont2_pos];
+        assert!(
+            !between.contains("- New entry."),
+            "new entry must not split the wrapped bullet:\n{out}"
+        );
+        // The new entry lands after the complete old bullet block.
+        assert!(
+            cont2_pos < new_entry_pos,
+            "new entry must follow the old bullet's last continuation line:\n{out}"
+        );
+
+        // Footer link refs untouched and still at EOF.
+        let footer_pos = out.find("[Unreleased]:").expect("footer preserved");
+        assert!(new_entry_pos < footer_pos, "new entry stays inside section");
+        assert_eq!(out.matches("[Unreleased]:").count(), 1);
+        assert_eq!(out.matches("[1.0.0]:").count(), 1);
+        assert!(
+            out.trim_end().ends_with("[1.0.0]: https://x/tag/v1.0.0"),
+            "footer remains the last content:\n{out}"
+        );
+
+        // MD047: exactly one trailing newline, no doubled blank lines.
+        assert!(out.ends_with('\n') && !out.ends_with("\n\n"), "MD047 clean");
+    }
+
+    /// LB-5: multiple wrapped bullets in the same category — including a
+    /// blank line between two bullets, the same blank-line separation the
+    /// non-wrapped tests already rely on (see `BASE`/`UNRELEASED_LAST`, which
+    /// separate bullets/subsections with blank lines) — with the *last*
+    /// bullet itself wrapped. The insertion point must land after the last
+    /// bullet's final continuation line, and the blank line between the
+    /// first two bullets must not be mistaken for the insertion point.
+    const MULTI_WRAPPED_BULLETS: &str = "\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- First bug, single line.
+
+- **Second bug, wrapped**: the fix
+  spans two continuation lines
+  before the next entry.
+
+[Unreleased]: https://x/compare/v1.0.0...HEAD
+[1.0.0]: https://x/tag/v1.0.0
+";
+
+    #[test]
+    fn add_after_multiple_wrapped_bullets_lb5() {
+        let mut cl = Changelog::parse(MULTI_WRAPPED_BULLETS);
+        let idx = cl.version_heading_index("Unreleased").unwrap();
+        insert_entry(&mut cl, idx, "Fixed", "Third bug.");
+        let out = cl.render();
+
+        let first_pos = out.find("- First bug, single line.").unwrap();
+        let second_pos = out.find("- **Second bug, wrapped**").unwrap();
+        let last_cont_pos = out.find("  before the next entry.").unwrap();
+        let new_pos = out.find("- Third bug.").unwrap();
+        let footer_pos = out.find("[Unreleased]:").unwrap();
+
+        assert!(first_pos < second_pos, "bullets stay in original order");
+        assert!(
+            second_pos < last_cont_pos && last_cont_pos < new_pos,
+            "new entry lands after the complete last wrapped bullet:\n{out}"
+        );
+        assert!(new_pos < footer_pos, "new entry stays inside the section");
+
+        // The blank line between the two original bullets is preserved
+        // exactly once, and no new blank line was introduced elsewhere.
+        assert!(
+            out.contains("- First bug, single line.\n\n- **Second bug, wrapped**"),
+            "blank line between first and second bullet preserved:\n{out}"
+        );
+
+        assert!(out.ends_with('\n') && !out.ends_with("\n\n"), "MD047 clean");
     }
 
     #[test]

--- a/crates/hyalo-cli/src/commands/changelog.rs
+++ b/crates/hyalo-cli/src/commands/changelog.rs
@@ -507,7 +507,12 @@ fn insert_entry(cl: &mut Changelog, unreleased_idx: usize, category: &str, messa
             if l.trim_start().starts_with("- ") {
                 // Found a new bullet: advance past it and all of its
                 // continuation lines (indented, non-blank lines that don't
-                // start a new bullet/heading).
+                // start a new bullet/heading). A nested `- ` item inside a
+                // bullet also matches here and is deliberately consumed as
+                // its own bullet-with-continuations block — no depth
+                // comparison is needed, because each `- ` line ratchets
+                // `insert_at` past itself the same way, so the anchor still
+                // ends after the last line of the whole list block.
                 insert_at = i + 1;
                 i += 1;
                 while i < section_end {
@@ -752,6 +757,58 @@ mod tests {
 [Unreleased]: https://x/compare/v1.0.0...HEAD
 [1.0.0]: https://x/tag/v1.0.0
 ";
+
+    /// A last bullet that *contains* a nested `- ` sub-list (each nested item
+    /// with its own continuation line). The scan has no indentation-depth
+    /// comparison — nested items are consumed as their own
+    /// bullet-with-continuations blocks — and this test locks in that the
+    /// anchor still ends after the whole list block, keeping the nested list
+    /// attached to its parent bullet.
+    const NESTED_LIST_LAST_BULLET: &str = "\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- **Parent bullet with a nested list**: prose that
+  wraps to a continuation line before the sub-list:
+  - nested item one, whose text also
+    wraps to a deeper continuation line
+  - nested item two
+  and a closing parent continuation line after the sub-list.
+
+[Unreleased]: https://x/compare/v1.0.0...HEAD
+[1.0.0]: https://x/tag/v1.0.0
+";
+
+    #[test]
+    fn add_after_bullet_with_nested_list_lb5() {
+        let mut cl = Changelog::parse(NESTED_LIST_LAST_BULLET);
+        let idx = cl.version_heading_index("Unreleased").unwrap();
+        insert_entry(&mut cl, idx, "Fixed", "New entry.");
+        let out = cl.render();
+
+        let parent_pos = out.find("- **Parent bullet").expect("parent present");
+        let closing_pos = out
+            .find("  and a closing parent continuation line")
+            .expect("closing continuation present");
+        let new_entry_pos = out.find("- New entry.").expect("new entry present");
+        // The whole parent block — nested list included — stays contiguous:
+        // nothing is inserted between the parent's first line and its last
+        // continuation line.
+        assert!(
+            !out[parent_pos..closing_pos].contains("- New entry."),
+            "new entry must not split the parent bullet's block:\n{out}"
+        );
+        assert!(
+            closing_pos < new_entry_pos,
+            "new entry must follow the complete nested-list block:\n{out}"
+        );
+        let footer_pos = out.find("[Unreleased]:").expect("footer preserved");
+        assert!(new_entry_pos < footer_pos, "new entry stays inside section");
+        assert!(out.ends_with('\n') && !out.ends_with("\n\n"), "MD047 clean");
+    }
 
     #[test]
     fn add_after_wrapped_last_bullet_lb5() {

--- a/crates/hyalo-cli/tests/e2e/changelog_profile.rs
+++ b/crates/hyalo-cli/tests/e2e/changelog_profile.rs
@@ -389,6 +389,75 @@ fn add_places_new_category_before_footer_link_refs_rb4() {
 }
 
 #[test]
+fn add_after_wrapped_last_bullet_lb5() {
+    // LB-5: the target category's last bullet wraps across hanging-indent
+    // continuation lines. `add` must insert the new entry after the complete
+    // wrapped bullet (not split it in half), and must not disturb the footer
+    // link-ref block that follows — end-to-end via the CLI binary, mirroring
+    // `add_places_new_category_before_footer_link_refs_rb4`.
+    let tmp = init_changelog();
+    write_changelog(
+        tmp.path(),
+        "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n\
+         - **`--format github` annotations are no longer truncated by the file cap**: the\n\
+         \x20 regression is now covered by a test that lints 60 files past the default\n\
+         \x20 50-file cap and asserts all 60 annotations are emitted.\n\n\
+         [Unreleased]: https://x/compare/v1.0.0...HEAD\n[1.0.0]: https://x/tag/v1.0.0\n",
+    );
+    let (json, out) = run(
+        tmp.path(),
+        &[
+            "changelog",
+            "add",
+            "--category",
+            "Fixed",
+            "--message",
+            "New entry.",
+            "--apply",
+        ],
+    );
+    assert!(out.status.success(), "add succeeds: {json}");
+    let content = std::fs::read_to_string(tmp.path().join("CHANGELOG.md")).unwrap();
+
+    // The old wrapped bullet's continuation lines still directly follow its
+    // `- ` line — nothing stranded between them.
+    let old_bullet = content
+        .find("- **`--format github` annotations")
+        .expect("old bullet present");
+    let cont2 = content
+        .find("50-file cap and asserts")
+        .expect("second continuation present");
+    let new_entry = content.find("- New entry.").expect("new entry present");
+    assert!(
+        !content[old_bullet..cont2].contains("- New entry."),
+        "new entry must not split the wrapped bullet:\n{content}"
+    );
+    assert!(
+        cont2 < new_entry,
+        "new entry follows the complete old bullet:\n{content}"
+    );
+
+    // Footer untouched and still at EOF.
+    let footer = content.find("[Unreleased]:").expect("footer preserved");
+    assert!(new_entry < footer, "new entry stays inside the section");
+    assert_eq!(content.matches("[Unreleased]:").count(), 1);
+    assert_eq!(content.matches("[1.0.0]:").count(), 1);
+
+    // Exactly one trailing newline (MD047), no doubled blank lines.
+    assert!(
+        content.ends_with('\n') && !content.ends_with("\n\n"),
+        "MD047 clean"
+    );
+
+    // Lints clean under the changelog profile.
+    let (lint_json, lint_out) = run(tmp.path(), &["lint", "--profile", "changelog"]);
+    assert!(
+        lint_out.status.success(),
+        "conformant after add: {lint_json}"
+    );
+}
+
+#[test]
 fn root_changelog_reachable_from_docs_subdir_vault() {
     // Task 4 / AC: a repo-root CHANGELOG.md with the vault dir set to a docs
     // subdir must be addressable by `changelog add` and `lint --profile


### PR DESCRIPTION
## Summary
- `changelog add`'s insertion anchor in `insert_entry()` advanced past only a bullet's first `- ` line; with a wrapped (hanging-indent) last bullet under the target `### Category`, the new entry landed mid-bullet, stranding the continuation lines below it and corrupting the file. Found live while adding PR #205's entries to hyalo's own CHANGELOG.md (LB-5 in the re-dogfood report).
- The scan now consumes a bullet's full continuation block (non-blank indented lines that aren't a new bullet/heading) before anchoring. The RB-4 footer-link-ref bounding from iter-175 is untouched.
- CHANGELOG entry for this fix added with the fixed binary itself — self-test on the real file, neighboring bullets and footer refs intact.

## Test plan
- [x] Unit: `add_after_wrapped_last_bullet_lb5`, `add_after_multiple_wrapped_bullets_lb5` (wrapped last bullet + footer refs at EOF → existing bullet intact, new entry after it, MD047-clean)
- [x] e2e: `add_after_wrapped_last_bullet_lb5` (changelog_profile)
- [x] `cargo fmt` / `clippy --workspace --all-targets -D warnings` / `cargo test --workspace -q` all green
- [x] xtask `check-ac-fidelity`, `check-feature-fanout`, `check-help-drift`, `check-bundled-skills` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)