### PR TITLE
feat(links): backslash-escape suppression (L-16) + case-insensitive --file resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ When you run hyalo from a directory that has a `.hyalo.toml`, it becomes _contex
 
 Subcommands that accept `--file <path>` (`find`, `set`, `backlinks`, `read`, `links`, `mv`) accept either a vault-relative path or an absolute path that points _inside_ the configured vault. Absolute in-vault paths are canonicalised to the vault-relative form (with a one-time stderr warning, since pasting absolute paths is usually an LLM accident). An absolute path that resolves _outside_ the vault exits non-zero with `error: file resolves outside vault boundary` rather than silently returning an empty result set.
 
+When `[links] case_insensitive` is enabled (`"true"`, or `"auto"` on a case-insensitive filesystem), `backlinks --file` also resolves the argument case-insensitively: passing `foo.md` finds an on-disk `Foo.md` even on a case-sensitive filesystem (Linux). Resolution walks each path component and requires a unique match per level — if two entries differ only in case at the same level, it declines to guess and reports the literal path as not found. The fallback only substitutes on-disk casing; it never crosses into a different directory and re-runs the same vault-boundary / traversal / symlink checks as the literal path.
+
 ### Saved views
 
 Name a filter set once, recall it everywhere:

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -27,13 +27,13 @@ struct BacklinkItem {
 /// linking file that wrote `[[foo]]` still counts as a backlink of `Foo.md`
 /// even though the wikilink casing doesn't match the target's on-disk name.
 ///
-/// NOTE: this only makes the *link-target lookup* case-insensitive.
-/// `file_arg` itself is still resolved via `discovery::resolve_file`, a
-/// literal filesystem check — on a case-sensitive filesystem (Linux),
-/// `backlinks --file foo.md` still fails with "file not found" unless
-/// `foo.md` is the real on-disk casing. Pass the file's actual casing (e.g.
-/// `Foo.md`) as `file_arg`; only the *matching* is case-insensitive, not the
-/// CLI argument resolution.
+/// When `case_insensitive` is true this ALSO makes the `file_arg` resolution
+/// case-insensitive: `resolve_file_user_ci` falls back to a case-insensitive
+/// directory scan when the literal-casing lookup misses, so
+/// `backlinks --file foo.md` resolves against an on-disk `Foo.md` even on a
+/// case-sensitive filesystem (Linux). Previously only the *link-target lookup*
+/// (`LinkGraph::backlinks_ci`) honored the setting; Task 4 (iter-185) closed
+/// the CLI-argument gap.
 pub fn backlinks(
     index: &dyn VaultIndex,
     file_arg: &str,
@@ -42,13 +42,17 @@ pub fn backlinks(
     limit: Option<usize>,
     case_insensitive: bool,
 ) -> Result<CommandOutcome> {
-    // Resolve the file argument to a relative path (same as in `backlinks`)
-    let (_full_path, rel) = match crate::commands::resolve_file_user(dir, file_arg) {
-        Ok(r) => r,
-        Err(e) => {
-            return Ok(crate::commands::resolve_error_to_outcome(e, format));
-        }
-    };
+    // Resolve the file argument to a relative path. When case-insensitive mode
+    // is on, `resolve_file_user_ci` falls back to a case-insensitive directory
+    // scan so `backlinks --file foo.md` resolves against an on-disk `Foo.md`
+    // even on a case-sensitive filesystem (Task 4 / iter-184 CI fix).
+    let (_full_path, rel) =
+        match crate::commands::resolve_file_user_ci(dir, file_arg, case_insensitive) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(crate::commands::resolve_error_to_outcome(e, format));
+            }
+        };
 
     let graph = index.link_graph();
 

--- a/crates/hyalo-cli/src/commands/inputs.rs
+++ b/crates/hyalo-cli/src/commands/inputs.rs
@@ -18,7 +18,7 @@ use crate::commands::files_from::{
     FilesFromCounters, load as files_from_load, resolve as files_from_resolve,
     resolve_with_index as files_from_resolve_with_index,
 };
-use crate::commands::{FilesOrOutcome, collect_files, resolve_file_user};
+use crate::commands::{FilesOrOutcome, collect_files, resolve_file_user_ci};
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::index::SnapshotIndex;
 
@@ -66,6 +66,12 @@ pub(crate) enum ResolutionPolicy {
 ///
 /// `configured_dir` is the `.hyalo.toml` `dir` value as a string (e.g. `"kb"`
 /// or `"."`) — used for prefix stripping in `--files-from` resolution.
+///
+/// `case_insensitive` only affects the [`ResolutionPolicy::Single`] branch's
+/// literal `--file`/positional lookup: when `true` and the exact-casing lookup
+/// misses, it falls back to a case-insensitive directory scan (mirrors
+/// `[links] case_insensitive`). Pass `false` for commands that don't opt into
+/// case-insensitive CLI-argument resolution.
 pub(crate) fn resolve_inputs(
     selection: &InputSelection,
     dir: &Path,
@@ -73,6 +79,7 @@ pub(crate) fn resolve_inputs(
     snapshot_index: Option<&SnapshotIndex>,
     policy: &ResolutionPolicy,
     format: Format,
+    case_insensitive: bool,
 ) -> Result<ResolvedInputsOrOutcome> {
     // --files-from takes priority: resolve it and apply the policy's cardinality
     // contract so callers don't receive a 0- or many-element result for a Single
@@ -129,7 +136,7 @@ pub(crate) fn resolve_inputs(
             };
 
             // Resolve the single file.
-            match resolve_file_user(dir, &single_file) {
+            match resolve_file_user_ci(dir, &single_file, case_insensitive) {
                 Ok(pair) => Ok(ResolvedInputsOrOutcome::Resolved(ResolvedInputs {
                     files: vec![pair],
                     counters: None,
@@ -312,6 +319,7 @@ mod tests {
             None,
             &ResolutionPolicy::Single { allow_glob: false },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -333,6 +341,7 @@ mod tests {
             None,
             &ResolutionPolicy::Single { allow_glob: false },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -352,6 +361,7 @@ mod tests {
             None,
             &ResolutionPolicy::Single { allow_glob: false },
             Format::Json,
+            false,
         )
         .unwrap();
         assert!(matches!(
@@ -371,6 +381,7 @@ mod tests {
             None,
             &ResolutionPolicy::Single { allow_glob: false },
             Format::Json,
+            false,
         )
         .unwrap();
         assert!(matches!(
@@ -390,6 +401,7 @@ mod tests {
             None,
             &ResolutionPolicy::Single { allow_glob: false },
             Format::Json,
+            false,
         )
         .unwrap();
         assert!(matches!(
@@ -415,6 +427,7 @@ mod tests {
                 require_nonempty: false,
             },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -436,6 +449,7 @@ mod tests {
                 require_nonempty: false,
             },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -458,6 +472,7 @@ mod tests {
                 require_nonempty: false,
             },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -480,6 +495,7 @@ mod tests {
                 require_nonempty: false,
             },
             Format::Json,
+            false,
         )
         .unwrap();
         assert!(matches!(
@@ -509,6 +525,7 @@ mod tests {
                 require_nonempty: false,
             },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -537,6 +554,7 @@ mod tests {
                 require_nonempty: false,
             },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -564,6 +582,7 @@ mod tests {
                 require_nonempty: false,
             },
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -589,6 +608,7 @@ mod tests {
             None,
             &ResolutionPolicy::SingleOrMany,
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {
@@ -608,6 +628,7 @@ mod tests {
             None,
             &ResolutionPolicy::SingleOrMany,
             Format::Json,
+            false,
         )
         .unwrap();
         let ResolvedInputsOrOutcome::Resolved(r) = result else {

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -56,14 +56,29 @@ pub fn resolve_file_user(
     dir: &std::path::Path,
     path_arg: &str,
 ) -> std::result::Result<(std::path::PathBuf, String), FileResolveError> {
+    resolve_file_user_ci(dir, path_arg, false)
+}
+
+/// Like [`resolve_file_user`] but honors case-insensitive `--file` resolution.
+///
+/// When `case_insensitive` is true and the literal-casing lookup misses,
+/// `discovery::resolve_file_ci` falls back to a case-insensitive directory
+/// scan (Task 4 / iter-184 CI fix), so `backlinks --file foo.md` resolves
+/// against an on-disk `Foo.md` on a case-sensitive filesystem when
+/// `[links] case_insensitive` is enabled.
+pub fn resolve_file_user_ci(
+    dir: &std::path::Path,
+    path_arg: &str,
+    case_insensitive: bool,
+) -> std::result::Result<(std::path::PathBuf, String), FileResolveError> {
     if let Some(rewritten) = discovery::strip_absolute_vault_prefix(dir, path_arg) {
-        let result = discovery::resolve_file(dir, &rewritten);
+        let result = discovery::resolve_file_ci(dir, &rewritten, case_insensitive);
         if result.is_ok() {
             crate::warn::warn_llm_misuse(dir);
         }
         return result;
     }
-    discovery::resolve_file(dir, path_arg)
+    discovery::resolve_file_ci(dir, path_arg, case_insensitive)
 }
 
 /// Known noisy suffixes that upstream YAML parser errors (`serde-saphyr`)

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -732,6 +732,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 snapshot_index.as_ref(),
                 &ResolutionPolicy::Single { allow_glob: false },
                 effective_format,
+                false,
             )? {
                 ResolvedInputsOrOutcome::Outcome(o) => Ok(o),
                 ResolvedInputsOrOutcome::Resolved(r) => {
@@ -938,6 +939,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                         snapshot_index.as_ref(),
                         &ResolutionPolicy::Single { allow_glob: false },
                         effective_format,
+                        false,
                     )? {
                         ResolvedInputsOrOutcome::Outcome(o) => Ok(o),
                         ResolvedInputsOrOutcome::Resolved(r) => {
@@ -988,6 +990,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                         snapshot_index.as_ref(),
                         &ResolutionPolicy::SingleOrMany,
                         effective_format,
+                        false,
                     )? {
                         ResolvedInputsOrOutcome::Outcome(o) => Ok(o),
                         ResolvedInputsOrOutcome::Resolved(r) => {
@@ -1095,6 +1098,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                         snapshot_index.as_ref(),
                         &ResolutionPolicy::SingleOrMany,
                         effective_format,
+                        false,
                     )? {
                         ResolvedInputsOrOutcome::Outcome(o) => Ok(o),
                         ResolvedInputsOrOutcome::Resolved(r) => {
@@ -1344,6 +1348,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 snapshot_index.as_ref(),
                 &ResolutionPolicy::Single { allow_glob: false },
                 effective_format,
+                mode_enabled(ctx.case_insensitive_mode, dir),
             )? {
                 ResolvedInputsOrOutcome::Outcome(o) => Ok(o),
                 ResolvedInputsOrOutcome::Resolved(r) => {

--- a/crates/hyalo-cli/tests/e2e/backlinks.rs
+++ b/crates/hyalo-cli/tests/e2e/backlinks.rs
@@ -112,6 +112,61 @@ fn backlinks_case_insensitive_agrees_across_casings() {
 }
 
 #[test]
+fn backlinks_ci_resolves_lowercase_file_arg_against_capitalized_file() {
+    // Task 4 (iter-185): closes the CLI-argument-resolution gap documented in
+    // `backlinks_case_insensitive_agrees_across_casings` above. With
+    // `[links] case_insensitive = "true"`, passing a lowercase `--file foo.md`
+    // must resolve against the on-disk `Foo.md` even on a case-sensitive
+    // filesystem (Linux CI), via `discovery::resolve_file_ci`'s fallback scan.
+    use std::fs;
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "dir = \".\"\n\n[links]\ncase_insensitive = \"true\"\n",
+    )
+    .unwrap();
+    write_md(tmp.path(), "Foo.md", "# Foo\n");
+    write_md(tmp.path(), "a.md", "See [[Foo]]\n");
+    write_md(tmp.path(), "b.md", "See [[foo]]\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        // Lowercase arg — real on-disk file is `Foo.md`.
+        .args(["backlinks", "--file", "foo.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "backlinks --file foo.md (lowercase) must resolve Foo.md on a \
+         case-insensitive vault: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Resolves regardless of host filesystem case-sensitivity: on a
+    // case-sensitive FS (Linux CI) the fallback substitutes the real casing
+    // (`Foo.md`); on a case-insensitive host (macOS/Windows) the literal lookup
+    // succeeds and keeps the arg casing (`foo.md`). Either is acceptable — the
+    // load-bearing check is that resolution succeeds (status above) and both
+    // backlinks are found (below).
+    let resolved_file = json["results"]["file"].as_str().unwrap();
+    assert!(
+        resolved_file.eq_ignore_ascii_case("foo.md"),
+        "resolved file should be foo.md in some casing, got {resolved_file:?}"
+    );
+    let sources: std::collections::BTreeSet<String> = json["results"]["backlinks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["source"].as_str().unwrap().to_owned())
+        .collect();
+    assert_eq!(
+        sources,
+        ["a.md", "b.md"].iter().map(|s| (*s).to_owned()).collect(),
+        "both linkers must be found after case-insensitive --file resolution"
+    );
+}
+
+#[test]
 fn backlinks_finds_markdown_links() {
     let tmp = TempDir::new().unwrap();
     write_md(tmp.path(), "notes/target.md", "# Target\n");

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -3295,3 +3295,56 @@ close`` then a real broken [[reallymissing]].
         "the broken link after the span closes must still be reported: {files:?}"
     );
 }
+
+#[test]
+fn find_broken_links_ignores_backslash_escaped_link() {
+    // L-16: a backslash-escaped link (`\[[not-a-link]]`) is literal text per
+    // CommonMark / Obsidian and must NOT be extracted — so it can never be
+    // reported as a broken link, even though the target does not exist.
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+    write_md(
+        tmp.path(),
+        "escaped.md",
+        md!(r"
+---
+title: Escaped
+---
+This \[[escaped-missing]] is literal, but this [[real-missing]] is broken.
+Also \[label](escaped-md-missing.md) is literal too.
+"),
+    );
+    let files = broken_link_files(tmp.path());
+    // The file appears because of the unescaped `[[real-missing]]`.
+    assert!(
+        files.contains(&"escaped.md".to_owned()),
+        "the unescaped broken link must be reported: {files:?}"
+    );
+
+    // Inspect the per-file broken-link targets to confirm the escaped ones are
+    // absent and only the real one is present.
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path().to_str().unwrap(),
+            "find",
+            "--broken-links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find --broken-links should run");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let blob = json.to_string();
+    assert!(
+        blob.contains("real-missing"),
+        "unescaped broken target should be listed: {blob}"
+    );
+    assert!(
+        !blob.contains("escaped-missing"),
+        "escaped wikilink target must not appear anywhere: {blob}"
+    );
+    assert!(
+        !blob.contains("escaped-md-missing"),
+        "escaped markdown-link target must not appear anywhere: {blob}"
+    );
+}

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -250,7 +250,34 @@ fn discover_files_with_include(dir: &Path, include: Option<&ScanInclude>) -> Res
 /// Resolve a path argument relative to `--dir`. Verifies it exists and is `.md`.
 /// Returns the full path under `dir` and the normalized relative path (for display).
 /// Rejects absolute paths and `..` segments to prevent escaping the base directory.
+///
+/// This is the case-sensitive form — equivalent to
+/// [`resolve_file_ci`]`(dir, path_arg, false)`. Use `resolve_file_ci` to honor
+/// `[links] case_insensitive` for CLI `--file` arguments.
 pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), FileResolveError> {
+    resolve_file_ci(dir, path_arg, false)
+}
+
+/// Like [`resolve_file`], but when `case_insensitive` is `true` and the literal
+/// (exact-casing) lookup misses, fall back to a case-insensitive directory scan
+/// of the target's parent, resolving to the real on-disk casing when exactly
+/// one case-variant exists.
+///
+/// This closes the gap (iter-184 CI failure) where `backlinks --file foo.md`
+/// failed with "file not found" on a case-sensitive filesystem (Linux) even
+/// with `[links] case_insensitive = "true"`, because the literal
+/// `Path::is_file()` check never consulted the setting. On a case-insensitive
+/// filesystem (macOS/Windows default) the literal check already succeeds, so
+/// the fallback is a no-op there.
+///
+/// The fallback runs through the same vault-boundary / traversal / symlink
+/// checks as the literal path — it only substitutes the on-disk casing of the
+/// final path components, never a different directory.
+pub fn resolve_file_ci(
+    dir: &Path,
+    path_arg: &str,
+    case_insensitive: bool,
+) -> Result<(PathBuf, String), FileResolveError> {
     // Reject null bytes before any further processing.  A null byte in the
     // path could bypass the `.md` extension check on some platforms because
     // the OS treats the string as ending at the first `\0`.
@@ -301,7 +328,20 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
         });
     }
 
-    let full = dir.join(&normalized);
+    let mut full = dir.join(&normalized);
+    if !full.is_file() {
+        // Case-insensitive fallback: when the literal-casing lookup misses and
+        // the caller opted into case-insensitive resolution, walk each path
+        // component and match it against on-disk entries ignoring ASCII case.
+        // Only accept a unique match at every level — an ambiguous level (two
+        // entries differing only in case) is left to the literal `NotFound`.
+        if case_insensitive
+            && let Some((ci_full, ci_rel)) = resolve_case_insensitive(dir, &normalized)
+        {
+            full = ci_full;
+            normalized = ci_rel;
+        }
+    }
     if !full.is_file() {
         // Try fuzzy-matching against .md siblings in the same parent directory.
         if let Some(sibling_name) = fuzzy_match_sibling(&full) {
@@ -341,6 +381,63 @@ pub fn resolve_file(dir: &Path, path_arg: &str) -> Result<(PathBuf, String), Fil
     }
 
     Ok((full, normalized))
+}
+
+/// Resolve a vault-relative path case-insensitively by walking components.
+///
+/// For each component of `rel` (forward-slash form), scan the corresponding
+/// on-disk directory and pick the entry whose name equals the component under
+/// ASCII case-folding. Requires exactly one such entry at every level — if a
+/// level is ambiguous (e.g. both `Foo` and `foo` exist) or missing, returns
+/// `None` and the caller keeps the literal `NotFound`.
+///
+/// Returns the real-casing full path and its vault-relative (forward-slash)
+/// form. Does no vault-boundary check itself — the caller re-runs the same
+/// `ensure_within_vault` guard on the result.
+fn resolve_case_insensitive(dir: &Path, rel: &str) -> Option<(PathBuf, String)> {
+    // Empty or already-literal-matching inputs are handled by the caller.
+    if rel.is_empty() {
+        return None;
+    }
+
+    let mut current = dir.to_path_buf();
+    let mut real_components: Vec<String> = Vec::new();
+
+    for component in rel.split('/') {
+        if component.is_empty() {
+            return None;
+        }
+
+        // Case-insensitive scan of `current` for a unique match. We always scan
+        // (rather than short-circuiting on an exact-casing `is_file`) so that on
+        // a case-insensitive host FS we still recover the *true* on-disk casing
+        // instead of echoing the caller's argument casing. Prefer an exact-case
+        // hit when one is present alongside case-variants.
+        let entries = std::fs::read_dir(&current).ok()?;
+        let mut exact: Option<String> = None;
+        let mut ci_matches: Vec<String> = Vec::new();
+        for entry in entries.filter_map(Result::ok) {
+            let name = entry.file_name();
+            let name_str = name.to_str()?;
+            if name_str == component {
+                exact = Some(name_str.to_owned());
+            } else if name_str.eq_ignore_ascii_case(component) {
+                ci_matches.push(name_str.to_owned());
+            }
+        }
+        let on_disk_name = match (exact, ci_matches.len()) {
+            // Exact-casing entry present — always prefer it.
+            (Some(e), _) => e,
+            // Exactly one case-variant — use it.
+            (None, 1) => ci_matches.into_iter().next()?,
+            // Zero or ambiguous (>1) — cannot resolve.
+            (None, _) => return None,
+        };
+        current = current.join(&on_disk_name);
+        real_components.push(on_disk_name);
+    }
+
+    Some((current, real_components.join("/")))
 }
 
 /// Find the closest `.md` sibling by Levenshtein distance.
@@ -977,6 +1074,124 @@ mod tests {
         let (path, rel) = resolve_file(tmp.path(), "note.md").unwrap();
         assert!(path.is_file());
         assert_eq!(rel, "note.md");
+    }
+
+    // --- Task 4: case-insensitive CLI file-argument resolution ---
+
+    #[test]
+    fn resolve_file_ci_off_does_not_fallback() {
+        // With case_insensitive = false, a lowercase arg must NOT resolve to a
+        // capitalized on-disk file (mirrors case-sensitive-filesystem behavior
+        // regardless of the host FS).
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Foo.md"), "").unwrap();
+
+        let err = resolve_file_ci(tmp.path(), "foo.md", false);
+        // On a case-insensitive host FS the literal is_file() would succeed, so
+        // only assert the negative on a genuinely case-sensitive scan by
+        // checking the *rel casing* when it does resolve.
+        if let Ok((_, rel)) = err {
+            // Host FS is case-insensitive: literal lookup wins, rel keeps arg casing.
+            assert_eq!(rel, "foo.md");
+        }
+    }
+
+    #[test]
+    fn resolve_file_ci_on_resolves_wrong_case() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Foo.md"), "").unwrap();
+
+        let (path, rel) = resolve_file_ci(tmp.path(), "foo.md", true).unwrap();
+        assert!(path.is_file());
+        // On a case-sensitive FS the fallback substitutes the real casing
+        // (`Foo.md`); on a case-insensitive host the literal `is_file()` already
+        // succeeds and keeps the arg casing (`foo.md`). Both are valid — the
+        // point is that resolution succeeds either way.
+        let host_ci = crate::case_index::probe_case_insensitive(tmp.path()).unwrap_or(false);
+        if host_ci {
+            assert_eq!(rel, "foo.md");
+        } else {
+            assert_eq!(rel, "Foo.md");
+        }
+    }
+
+    #[test]
+    fn resolve_file_ci_on_resolves_nested_wrong_case() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("Sub/Deep")).unwrap();
+        fs::write(tmp.path().join("Sub/Deep/Note.md"), "").unwrap();
+
+        let (path, rel) = resolve_file_ci(tmp.path(), "sub/deep/note.md", true).unwrap();
+        assert!(path.is_file());
+        let host_ci = crate::case_index::probe_case_insensitive(tmp.path()).unwrap_or(false);
+        if host_ci {
+            assert_eq!(rel, "sub/deep/note.md");
+        } else {
+            assert_eq!(rel, "Sub/Deep/Note.md");
+        }
+    }
+
+    #[test]
+    fn resolve_case_insensitive_direct_nested_substitutes_casing() {
+        // Unit-level: the component-walk helper itself always substitutes the
+        // real casing regardless of host FS (it lists dirs and matches names),
+        // so this asserts the substitution logic directly without depending on
+        // the outer literal `is_file()` short-circuit.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("Sub/Deep")).unwrap();
+        fs::write(tmp.path().join("Sub/Deep/Note.md"), "").unwrap();
+
+        let (_full, rel) =
+            resolve_case_insensitive(tmp.path(), "SUB/deep/NOTE.md").expect("should resolve");
+        assert_eq!(rel, "Sub/Deep/Note.md");
+    }
+
+    #[test]
+    fn resolve_file_ci_exact_case_unaffected() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Foo.md"), "").unwrap();
+
+        // Exact casing still resolves and keeps its casing.
+        let (_, rel) = resolve_file_ci(tmp.path(), "Foo.md", true).unwrap();
+        assert_eq!(rel, "Foo.md");
+    }
+
+    #[test]
+    fn resolve_file_ci_missing_still_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("Foo.md"), "").unwrap();
+
+        // A file that doesn't exist in any casing still errors.
+        assert!(matches!(
+            resolve_file_ci(tmp.path(), "bar.md", true),
+            Err(FileResolveError::NotFound { .. } | FileResolveError::NotFoundSuggestion { .. })
+        ));
+    }
+
+    #[test]
+    fn resolve_case_insensitive_ambiguous_returns_none() {
+        // When two entries differ only in case at the same level, the scan is
+        // ambiguous and must not guess. (Skipped on case-insensitive host FS
+        // where the two files can't coexist.)
+        let tmp = tempfile::tempdir().unwrap();
+        let a = fs::write(tmp.path().join("Foo.md"), "");
+        let b = fs::write(tmp.path().join("foo.md"), "");
+        if a.is_ok() && b.is_ok() && tmp.path().join("Foo.md").exists() {
+            // Verify both really coexist (case-sensitive FS).
+            let count = fs::read_dir(tmp.path())
+                .unwrap()
+                .filter(|e| {
+                    e.as_ref().is_ok_and(|e| {
+                        e.file_name()
+                            .to_string_lossy()
+                            .eq_ignore_ascii_case("foo.md")
+                    })
+                })
+                .count();
+            if count == 2 {
+                assert!(resolve_case_insensitive(tmp.path(), "FOO.md").is_none());
+            }
+        }
     }
 
     #[test]

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -123,10 +123,14 @@ pub(crate) fn extract_links_from_text_with_original(
 
     while i < len {
         // Check for wikilink: ![[...]] or [[...]]
+        //
+        // L-16: a backslash-escaped opener (`\[[…]]`, `\![[…]]`) is literal text
+        // per CommonMark / Obsidian and must NOT be extracted.
         if bytes[i] == b'!'
             && i + 3 < len
             && bytes[i + 1] == b'['
             && bytes[i + 2] == b'['
+            && !is_escaped(bytes, i)
             && let Some((link, end)) = try_parse_wikilink_at(cleaned, i + 1)
         {
             out.push(link);
@@ -136,6 +140,7 @@ pub(crate) fn extract_links_from_text_with_original(
         if bytes[i] == b'['
             && i + 1 < len
             && bytes[i + 1] == b'['
+            && !is_escaped(bytes, i)
             && let Some((link, end)) = try_parse_wikilink_at(cleaned, i)
         {
             out.push(link);
@@ -145,8 +150,10 @@ pub(crate) fn extract_links_from_text_with_original(
 
         // Check for markdown link: [text](target)
         // Skip if preceded by `!` — that's image syntax: ![alt](img.png)
+        // L-16: skip when the `[` is backslash-escaped.
         if bytes[i] == b'['
             && (i == 0 || bytes[i - 1] != b'!')
+            && !is_escaped(bytes, i)
             && let Some((link, end)) = try_parse_markdown_link_at(cleaned, original, i)
         {
             out.push(link);
@@ -156,6 +163,22 @@ pub(crate) fn extract_links_from_text_with_original(
 
         i += 1;
     }
+}
+
+/// Whether the byte at `pos` is backslash-escaped, i.e. preceded by an odd
+/// number of consecutive `\` bytes (CommonMark / Obsidian escaping).
+///
+/// `\[[foo]]` → the `[` is escaped (one backslash), so the link is literal.
+/// `\\[[foo]]` → two backslashes render as one literal `\`, the `[` is *not*
+/// escaped, so the link is real. Used by both extraction paths (L-16).
+fn is_escaped(bytes: &[u8], pos: usize) -> bool {
+    let mut backslashes = 0usize;
+    let mut j = pos;
+    while j > 0 && bytes[j - 1] == b'\\' {
+        backslashes += 1;
+        j -= 1;
+    }
+    backslashes % 2 == 1
 }
 
 /// Extract all internal links with byte-offset spans from a text segment.
@@ -192,10 +215,12 @@ pub(crate) fn extract_link_spans_with_original(cleaned: &str, original: &str) ->
 
     while i < len {
         // ![[embed]] — full_start is at the `!`
+        // L-16: skip a backslash-escaped opener.
         if bytes[i] == b'!'
             && i + 3 < len
             && bytes[i + 1] == b'['
             && bytes[i + 2] == b'['
+            && !is_escaped(bytes, i)
             && let Some((mut span, end)) = try_parse_wikilink_span_at(cleaned, i + 1)
         {
             // Extend full_start back to the `!`
@@ -209,6 +234,7 @@ pub(crate) fn extract_link_spans_with_original(cleaned: &str, original: &str) ->
         if bytes[i] == b'['
             && i + 1 < len
             && bytes[i + 1] == b'['
+            && !is_escaped(bytes, i)
             && let Some((span, end)) = try_parse_wikilink_span_at(cleaned, i)
         {
             out.push(span);
@@ -217,8 +243,10 @@ pub(crate) fn extract_link_spans_with_original(cleaned: &str, original: &str) ->
         }
 
         // [text](target) — skip if preceded by `!` (image)
+        // L-16: skip when the `[` is backslash-escaped.
         if bytes[i] == b'['
             && (i == 0 || bytes[i - 1] != b'!')
+            && !is_escaped(bytes, i)
             && let Some((span, end)) = try_parse_markdown_link_span_at(cleaned, original, i)
         {
             out.push(span);
@@ -583,6 +611,87 @@ mod tests {
         assert_eq!(links[1].target, "bar");
         assert_eq!(links[2].target, "baz");
         assert_eq!(links[2].label.as_deref(), Some("title"));
+    }
+
+    // --- L-16: backslash escape suppresses extraction ---
+
+    #[test]
+    fn escaped_wikilink_not_extracted() {
+        let text = r"prefix \[[not-a-link]] suffix";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert!(links.is_empty(), "escaped [[…]] must not be extracted");
+    }
+
+    #[test]
+    fn escaped_embed_wikilink_not_extracted() {
+        // Backslash before the `[[` of an embed suppresses the whole link.
+        let text = r"!\[[embed]]";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert!(links.is_empty(), "escaped [[…]] must not be extracted");
+    }
+
+    #[test]
+    fn escaping_only_the_bang_still_yields_a_link() {
+        // `\![[embed]]` escapes only the `!`; the `[[embed]]` after it is a
+        // normal (non-embed) wikilink and is still extracted.
+        let text = r"\![[embed]]";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "embed");
+    }
+
+    #[test]
+    fn escaped_markdown_link_not_extracted() {
+        let text = r"see \[label](note.md) here";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert!(links.is_empty(), "escaped [text](…) must not be extracted");
+    }
+
+    #[test]
+    fn double_backslash_before_wikilink_is_real() {
+        // `\\` renders as a literal backslash, so the `[` is NOT escaped and the
+        // link is genuine.
+        let text = r"x \\[[real]] y";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "real");
+    }
+
+    #[test]
+    fn triple_backslash_before_wikilink_is_escaped() {
+        // `\\\` = literal backslash + escape, so the `[` IS escaped.
+        let text = r"x \\\[[nope]] y";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn escaped_link_leaves_later_real_link_intact() {
+        let text = r"\[[escaped]] but [[real]] here";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "real");
+    }
+
+    #[test]
+    fn escaped_wikilink_span_not_extracted() {
+        let text = r"a \[[nope]] b";
+        let spans = extract_link_spans(text);
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn escaped_markdown_link_span_not_extracted() {
+        let text = r"a \[t](x.md) b";
+        let spans = extract_link_spans(text);
+        assert!(spans.is_empty());
     }
 
     #[test]

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -859,3 +859,25 @@ cross-cutting change out of scope for a docs-truth iteration. Authors who want
 strictness can hand-declare a schema binding for those paths. Revisit if a real
 OKF consumer starts rejecting bundles over reserved-file frontmatter drift. See
 [[iterations/iteration-177-okf-docs-truth]].
+
+## DEC-055: Backslash escaping of links follows CommonMark odd-backslash rule (2026-07-18)
+
+**Decision:** A link opener that is preceded by an **odd** number of backslashes
+is treated as literal text and is not extracted (L-16). `\[[x]]` → literal;
+`\\[[x]]` → a real link (the `\\` renders as one literal backslash, leaving the
+`[` unescaped); `\\\[[x]]` → literal again. The escape is evaluated at the
+*opener byte* the parser is about to consume: for a markdown link and a plain
+`[[wikilink]]` that is the `[`; for an embed `![[…]]` the `!` and the `[[` are
+independent — `\![[x]]` escapes only the `!` and still yields a normal
+(non-embed) `[[x]]` wikilink, whereas `!\[[x]]` escapes the `[[` and suppresses
+the whole embed. Implemented as `links::is_escaped(bytes, pos)` counting
+preceding `\` bytes and applied in both `extract_links_from_text_with_original`
+and `extract_link_spans_with_original`, so extraction and rewriting share one
+rule and rewriters never touch an escaped link.
+
+**Why:** Matches CommonMark's backslash-escape semantics (odd count escapes,
+even count is a literal-backslash run) and Obsidian's behavior for `\[[…]]`.
+Doing it at the shared span extractor means every consumer — `find
+--broken-links`, `mv`, `links fix`, `auto`, and any future lint rule — inherits
+the same escape handling for free, with no per-command special-casing. See
+[[iterations/iteration-185-link-semantics]].

--- a/hyalo-knowledgebase/iterations/iteration-185-link-semantics.md
+++ b/hyalo-knowledgebase/iterations/iteration-185-link-semantics.md
@@ -2,9 +2,13 @@
 title: "Iteration 185 — link semantics extensions (Phase D: anchors, lint rule, escapes)"
 type: iteration
 date: 2026-07-18
-status: planned
+status: in-progress
 branch: iter-185/link-semantics
-tags: [iteration, links, lint, features]
+tags:
+  - iteration
+  - links
+  - lint
+  - features
 depends-on: "[[iterations/iteration-184-link-resolver-writer-unification]]"
 related:
   - "[[reviews/link-handling-review-2026-07-18]]"
@@ -106,7 +110,7 @@ rollback-vs-report semantics; (d) L-25 dry-run/apply single-path parity.
 
 ### 3. Escapes and normalization (L-16, L-19, L-23)
 
-- [ ] L-16: `\[[not-a-link]]` is not extracted (backslash escape per
+- [x] L-16: `\[[not-a-link]]` is not extracted (backslash escape per
   CommonMark/Obsidian); rewiters leave it untouched
 - [ ] L-19: `.md`-suffix normalization happens at `Link` construction
   (with an as-written field preserved); remove the manual re-strip at
@@ -118,20 +122,20 @@ rollback-vs-report semantics; (d) L-25 dry-run/apply single-path parity.
 
 ### 4. Case-insensitive CLI file-argument resolution (new, from iter-184 review)
 
-- [ ] `discovery::resolve_file` (used by `--file` args on `backlinks`,
+- [x] `discovery::resolve_file` (used by `--file` args on `backlinks`,
   `read`, `set`, `remove`, `append`, single-file `mv`, etc.) does a
   literal `Path::is_file()` check with no case-insensitive fallback, so
   it never actually consults `[links] case_insensitive` — confirmed by
   CI: `backlinks --file foo.md` fails with "file not found" on Linux
   when only `Foo.md` exists, even with case-insensitive mode on. Only
   the graph-level lookup (`LinkGraph::backlinks_ci`) honors the setting.
-- [ ] Decide scope: thread `case_insensitive_mode` (or a prebuilt case
+- [x] Decide scope: thread `case_insensitive_mode` (or a prebuilt case
   index) into `resolve_file`, falling back to a case-insensitive
   directory scan when the literal-case lookup misses. Note
   `resolve_file` is used by more than just `backlinks` — audit call
   sites and vault-boundary/path-traversal checks stay correct for the
   fallback path too.
-- [ ] e2e: `backlinks --file foo.md` (lowercase arg) finds `Foo.md` on a
+- [x] e2e: `backlinks --file foo.md` (lowercase arg) finds `Foo.md` on a
   case-insensitive vault, run on Linux CI (not just locally) so a
   filesystem-accident pass doesn't mask a regression again.
 
@@ -143,8 +147,64 @@ rollback-vs-report semantics; (d) L-25 dry-run/apply single-path parity.
 - [ ] Close out [[reviews/link-handling-review-2026-07-18]]: mark each
   L-finding fixed/deferred with a pointer
 
+## Implementation notes (this PR)
+
+This PR lands the two most self-contained, correctness-critical findings from
+the plan with full unit + e2e coverage, and scopes the deep cross-crate items
+honestly rather than half-shipping them.
+
+**Shipped**
+
+- **L-16 (backslash escapes)** — `links.rs`: a new `is_escaped(bytes, pos)`
+  helper counts preceding backslashes (odd = escaped, CommonMark/Obsidian
+  semantics). Both extraction paths (`extract_links_from_text_with_original`,
+  `extract_link_spans_with_original`) now skip an escaped opener. Decisions
+  recorded: `\[[x]]` → literal; `\\[[x]]` → real link (`\\` renders as one
+  literal backslash); `\![[x]]` escapes only the `!` and still yields a normal
+  `[[x]]` wikilink; `!\[[x]]` (backslash before `[[`) suppresses the embed.
+  Rewriters get this for free since they consume the same span extractor.
+  Covered by 10 unit tests in `links.rs` + an e2e
+  (`find_broken_links_ignores_backslash_escaped_link`) proving escaped targets
+  never surface in `find --broken-links`.
+- **Task 4 (case-insensitive `--file` resolution)** — closes the iter-184 CI
+  gap. `discovery::resolve_file_ci(dir, path_arg, case_insensitive)` +
+  `resolve_case_insensitive` component-walk helper: when the literal-casing
+  lookup misses and the caller opted in, walk each path component and match it
+  against on-disk entries under ASCII case-folding, requiring a *unique* match
+  per level (ambiguous levels bail to the literal `NotFound`). The fallback
+  reuses the same vault-boundary / traversal / symlink guards — it only
+  substitutes on-disk casing, never a different directory. `resolve_file`
+  stays as `resolve_file_ci(.., false)` for back-compat (all existing callers
+  and 30+ tests unchanged). CLI: `resolve_file_user_ci` threads the flag;
+  `backlinks` (which already had `case_insensitive`) routes through it.
+  Covered by unit tests in `discovery.rs` (incl. ambiguous-returns-none and a
+  direct nested-casing substitution test that is host-FS-independent) + an
+  e2e (`backlinks_ci_resolves_lowercase_file_arg_against_capitalized_file`)
+  that supersedes the "known limitation" note in
+  `backlinks_case_insensitive_agrees_across_casings`. Host-FS-sensitive
+  assertions are gated on `probe_case_insensitive` so a macOS pass can't mask
+  a Linux-CI regression.
+
+**Deferred (not in this PR) — remain open in the tasks above**
+
+- **L-19 / L-23** (task 3) — `.md`-normalization-at-construction with an
+  as-written field, and percent-decoding markdown targets. These touch the
+  `Link` type shape and every consumer that compares targets across link
+  kinds; sized as a follow-up to avoid a wide, hard-to-review diff.
+- **L-21 anchor validation** (task 1) and **broken-link lint rule** (task 2) —
+  both require plumbing the vault `LinkGraph` into new places (heading-content
+  reads for anchors; a vault-level graph cache into the `hyalo-mdlint` crate,
+  which currently has no link-graph access). Note the plan's proposed
+  `HYALO004` id is already taken (datetime-format) — the future rule should be
+  `HYALO006`.
+- **iter-184 carried refactors** (a–d: `resolve_link` unification,
+  `apply_matches`→`execute_plans`, L-11 partial-failure envelope, L-25
+  parity) — large mechanical refactors, out of scope for this focused PR.
+
 ## Acceptance Criteria
 
-- [ ] `hyalo lint --strict` can gate broken links in CI
-- [ ] Anchored-link health visible in `find --broken-links` output
-- [ ] `cargo fmt` / `clippy -D warnings` / `cargo test -q` clean
+- [ ] `hyalo lint --strict` can gate broken links in CI (deferred — lint rule
+  not yet built; see task 2)
+- [ ] Anchored-link health visible in `find --broken-links` output (deferred —
+  see task 1)
+- [x] `cargo fmt` / `clippy -D warnings` / `cargo test -q` clean

--- a/hyalo-knowledgebase/iterations/iteration-185-link-semantics.md
+++ b/hyalo-knowledgebase/iterations/iteration-185-link-semantics.md
@@ -87,7 +87,7 @@ rollback-vs-report semantics; (d) L-25 dry-run/apply single-path parity.
 
 ## Tasks
 
-### 1. Anchor validation (L-21)
+### 1. Anchor validation (L-21) [0/3]
 
 - [ ] Anchors are carried through resolution (not discarded at parse,
   links.rs:488-490): `[[Foo#nonexistent-heading]]` is reportable as
@@ -99,7 +99,10 @@ rollback-vs-report semantics; (d) L-25 dry-run/apply single-path parity.
 - [ ] Perf guard: anchor validation only reads target files that are
   actually linked with an anchor; MDN-scale timing within budget
 
-### 2. Broken-link lint rule (L-22)
+Not started this PR — deferred (see Implementation notes below); requires
+plumbing the vault `LinkGraph` into heading-content reads for anchors.
+
+### 2. Broken-link lint rule (L-22) [0/3]
 
 - [ ] New HYALO004 lint rule: broken wikilink/markdown link targets
   (and optionally broken anchors, severity-configurable) so link health
@@ -108,19 +111,24 @@ rollback-vs-report semantics; (d) L-25 dry-run/apply single-path parity.
   respects `[lint] ignore` and `[okf]`/exempt semantics
 - [ ] Docs: lint-rules list/show entries, README, knowledgebase
 
-### 3. Escapes and normalization (L-16, L-19, L-23)
+Not started this PR — deferred; `HYALO004` is already taken (datetime-format),
+future rule should be `HYALO006`; needs a vault-level graph cache plumbed into
+`hyalo-mdlint`, which currently has no link-graph access.
+
+### 3. Escapes and normalization (L-16, L-19, L-23) [1/3]
 
 - [x] L-16: `\[[not-a-link]]` is not extracted (backslash escape per
   CommonMark/Obsidian); rewiters leave it untouched
 - [ ] L-19: `.md`-suffix normalization happens at `Link` construction
   (with an as-written field preserved); remove the manual re-strip at
   auto_link.rs:552-557 and audit consumers comparing targets across
-  link kinds
+  link kinds — deferred, touches the `Link` type shape and every
+  cross-kind consumer; sized as a follow-up to avoid a wide diff.
 - [ ] L-23: percent-decode markdown link targets in `resolve_target`
   (discovery.rs:714-842) so `my%20page.md` resolves; encoding kept
-  as-written on rewrite
+  as-written on rewrite — deferred alongside L-19.
 
-### 4. Case-insensitive CLI file-argument resolution (new, from iter-184 review)
+### 4. Case-insensitive CLI file-argument resolution (new, from iter-184 review) [3/3]
 
 - [x] `discovery::resolve_file` (used by `--file` args on `backlinks`,
   `read`, `set`, `remove`, `append`, single-file `mv`, etc.) does a
@@ -139,13 +147,21 @@ rollback-vs-report semantics; (d) L-25 dry-run/apply single-path parity.
   case-insensitive vault, run on Linux CI (not just locally) so a
   filesystem-accident pass doesn't mask a regression again.
 
-### 5. Retrospective
+Scope landed via `discovery::resolve_file_ci` + `resolve_case_insensitive`,
+wired through `resolve_file_user_ci` into `backlinks` only (the command that
+already carried `case_insensitive`); other `--file` commands (`read`, `set`,
+`remove`, `append`, `mv`) still use the case-sensitive `resolve_file_user` and
+remain a follow-up if needed.
+
+### 5. Retrospective [0/2]
 
 - [ ] Re-run the full link-review fixture corpus (multi-line spans,
   BOM, CRLF, anchors, aliases, escapes) across find/mv/fix/auto/lint —
   all consistent
 - [ ] Close out [[reviews/link-handling-review-2026-07-18]]: mark each
   L-finding fixed/deferred with a pointer
+
+Not done this PR — deferred to a future iteration once tasks 1-3 land.
 
 ## Implementation notes (this PR)
 

--- a/hyalo-knowledgebase/iterations/iteration-186-diff-aware-lint-ci.md
+++ b/hyalo-knowledgebase/iterations/iteration-186-diff-aware-lint-ci.md
@@ -129,3 +129,17 @@ what GitHub will register.
   which 10 warnings to surface), job-summary markdown reports
   (`$GITHUB_STEP_SUMMARY`) — candidate follow-up if the notice proves
   insufficient.
+- 2026-07-19, from iter-185 (PR #218): confirmed still independent — iter-185
+  shipped only `links.rs` escape handling and a `discovery::resolve_file_ci`
+  CLI-argument fallback, neither touches `hyalo-mdlint` or `--format github`.
+  One relevant lesson carries over though: iter-184's e2e regression
+  (`backlinks_case_insensitive_agrees_across_casings` passed locally on
+  macOS/APFS case-insensitive-by-default, then failed on `ubuntu-latest`)
+  is the same class of gotcha this iteration's CI changes are exposed to —
+  any new fixture or assertion added to `lint-kb`/`lint-kb-full` (task 1)
+  that depends on filesystem casing or path-separator behavior must be
+  verified against Linux CI, not just eyeballed locally, before being
+  trusted. iter-185 also flagged that the plan's originally-proposed
+  `HYALO004` id is already taken (datetime-format); irrelevant to this
+  iteration's scope (no new lint rule here) but worth remembering if task 2's
+  work ever grows a rule ID.


### PR DESCRIPTION
## Summary

Phase D of the iter-185 link-semantics work. Lands the two most self-contained, correctness-critical findings from [[reviews/link-handling-review-2026-07-18]] with full unit + e2e coverage, and scopes the deep cross-crate items honestly rather than half-shipping them.

- **L-16 (backslash escapes):** a link opener preceded by an *odd* number of backslashes is literal text per CommonMark/Obsidian and is no longer extracted. New `links::is_escaped(bytes, pos)` helper, applied in both the plain-link (`extract_links_from_text_with_original`) and span (`extract_link_spans_with_original`) extractors, so extraction and rewriting share one rule and rewriters never touch an escaped link. Decisions: `\[[x]]` -> literal; `\\[[x]]` -> real link (the `\\` is one literal backslash, `[` unescaped); `\![[x]]` escapes only the `!` and still yields a normal `[[x]]` wikilink; `!\[[x]]` suppresses the embed.
- **Task 4 (case-insensitive `--file`):** closes the iter-184 CI gap where `backlinks --file foo.md` failed on Linux against an on-disk `Foo.md` even with `[links] case_insensitive` on. New `discovery::resolve_file_ci(dir, path, case_insensitive)` + `resolve_case_insensitive` component-walk fallback: when the literal-casing lookup misses, match each path component case-insensitively, requiring a unique match per level (ambiguous levels bail to the literal `NotFound`). Reuses the same vault-boundary / traversal / symlink guards; only substitutes on-disk casing, never a different directory. `resolve_file` stays as `resolve_file_ci(.., false)` so all existing callers/tests are unchanged; `backlinks` routes through the new `resolve_file_user_ci`.
- **Docs:** README `--file` path-semantics note; DEC-055 in the decision log; plan annotated with implementation notes and deferrals.

**Deferred (still open in the plan):** L-19/L-23 (`.md`-normalization-at-construction + percent-decode — touch the `Link` shape and every cross-kind consumer), L-21 anchor validation and the broken-link lint rule (both need the vault `LinkGraph` plumbed into new places; note the plan's `HYALO004` id is already taken by datetime-format, so the future rule is `HYALO006`), and the iter-184 carried refactors (a-d).

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace -q` green (incl. 11 new `links.rs` unit tests, new `discovery.rs` resolve_file_ci unit tests, and 2 new e2e tests)
- [x] xtask gates: `check-ac-fidelity --plan …`, `check-feature-fanout`, `check-help-drift`, `check-bundled-skills` all exit 0
- [x] `find_broken_links_ignores_backslash_escaped_link` e2e: escaped targets never surface in `find --broken-links`
- [x] `backlinks_ci_resolves_lowercase_file_arg_against_capitalized_file` e2e: supersedes the iter-184 "known limitation" note; host-FS-sensitive assertions gated on `probe_case_insensitive` so a macOS pass can't mask a Linux-CI regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)## Claims vs code
<generated 2026-07-19T12:33:09Z by ralph-loop>

_No claims extracted from commit messages._