### PR TITLE
fix(links): angle-bracket destinations (L-A1) and escaped link-text brackets (L-A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to
 
 ### Fixed
 
+- **Angle-bracket link destinations are parsed correctly** (L-A1): a
+  CommonMark-valid markdown link destination like `[text](<my dest.md>)` —
+  which hyalo's own generator has emitted since iter-176 — is no longer
+  stored with literal `<>` characters. `find --broken-links` no longer
+  false-positives on these links, and `backlinks` now resolves them.
+- **Escaped brackets in link text no longer drop the link** (L-A2): a label
+  containing an escaped bracket, e.g. `[Contains \[test\] brackets](dest.md)`,
+  no longer terminates the label scan early and silently discards the whole
+  link from `--fields links` and `backlinks` output.
 - **Property-regex parse errors surface the engine detail** (iter-181): an
   invalid `--property 'title~=('` filter now reports the regex engine's own
   message (with caret/position) as the error `cause`, the way `find -e` does,

--- a/crates/hyalo-cli/tests/e2e/backlinks.rs
+++ b/crates/hyalo-cli/tests/e2e/backlinks.rs
@@ -188,6 +188,30 @@ fn backlinks_finds_markdown_links() {
     assert_eq!(json["results"]["backlinks"][0]["source"], "index.md");
 }
 
+// L-A2: escaped brackets in link text (`\[`/`\]`) must not terminate the
+// label scan early — the link must still be found.
+#[test]
+fn backlinks_finds_markdown_link_with_escaped_brackets_in_label() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "dest.md", "# Dest\n");
+    write_md(
+        tmp.path(),
+        "source.md",
+        "See [Contains \\[test\\] brackets](dest.md) for details.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["backlinks", "--file", "dest.md"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1, "backlinks JSON: {json}");
+    assert_eq!(json["results"]["backlinks"][0]["source"], "source.md");
+}
+
 #[test]
 fn backlinks_empty_result() {
     let tmp = TempDir::new().unwrap();

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -342,6 +342,65 @@ fn find_broken_links_combined_with_glob_filter() {
     );
 }
 
+// L-A1: angle-bracket destinations `[text](<my dest.md>)` must not be
+// flagged as broken, and must resolve correctly for `backlinks`.
+#[test]
+fn find_broken_links_ignores_angle_bracket_destination_with_spaces() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+    write_md(tmp.path(), "my dest.md", "# My Dest\n");
+    write_md(
+        tmp.path(),
+        "source.md",
+        "See [spaced link](<my dest.md>) for details.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            tmp.path()
+                .to_str()
+                .expect("temp path should be valid UTF-8"),
+            "find",
+            "--broken-links",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("hyalo find --broken-links should run");
+    assert!(
+        output.status.success(),
+        "find --broken-links exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    let results = json["results"]
+        .as_array()
+        .expect("find output should have a results array");
+    let files: Vec<&str> = results
+        .iter()
+        .map(|r| r["file"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        !files.contains(&"source.md"),
+        "source.md's angle-bracket destination resolves to a real file and \
+         must NOT be reported as broken: {files:?}"
+    );
+
+    // `backlinks` must also resolve the angle-bracket destination.
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["backlinks", "--file", "my dest.md"])
+        .output()
+        .expect("hyalo backlinks should run");
+    assert!(output.status.success());
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["total"], 1, "backlinks JSON: {json}");
+    assert_eq!(json["results"]["backlinks"][0]["source"], "source.md");
+}
+
 // ---------------------------------------------------------------------------
 // links fix: dry run
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -181,6 +181,80 @@ fn is_escaped(bytes: &[u8], pos: usize) -> bool {
     backslashes % 2 == 1
 }
 
+/// Find the byte offset (relative to `s`) of the closing `]` that terminates
+/// a markdown link label, skipping over backslash-escaped `\]`/`\[` (L-A2).
+///
+/// Unlike a plain `s.find(']')`, this does not stop early on labels like
+/// `[Contains \[test\] brackets](dest.md)` — the escaped brackets are part of
+/// the label text, not delimiters. Returns `None` if no unescaped `]` exists.
+fn find_label_close_bracket(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b']' if !is_escaped(bytes, i) => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Result of parsing a markdown link destination starting right after `(`.
+struct ParsedDestination<'a> {
+    /// The raw target text (angle brackets stripped if the destination used
+    /// the `<...>` form; verbatim otherwise).
+    target_raw: &'a str,
+    /// Byte offset (relative to the start of the destination, i.e. right
+    /// after `(`) of the first byte past the destination (and any title),
+    /// up to and including the closing `)`.
+    end: usize,
+}
+
+/// Parse a markdown link destination starting at `rest` (the text right
+/// after the opening `(`).
+///
+/// Handles both bare destinations (`dest.md`, up to the first `)`) and
+/// CommonMark angle-bracket destinations (`<my dest.md>`, which may contain
+/// spaces and literal `)`), per L-A1. For the angle form, the destination is
+/// closed by the first unescaped `>`; anything between it and the closing
+/// `)` (e.g. a `"title"`) is ignored since this file does not otherwise
+/// track link titles. Returns `None` if no closing `)` can be found for the
+/// destination.
+fn parse_destination(rest: &str) -> Option<ParsedDestination<'_>> {
+    let bytes = rest.as_bytes();
+    if bytes.first() == Some(&b'<') {
+        // Angle-bracket destination: scan for the first unescaped `>`.
+        let mut i = 1;
+        let mut close_angle = None;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'>' if !is_escaped(bytes, i) => {
+                    close_angle = Some(i);
+                    break;
+                }
+                _ => i += 1,
+            }
+        }
+        let close_angle = close_angle?;
+        let target_raw = &rest[1..close_angle];
+
+        // Whatever follows `>` up to `)` (whitespace, optional title) is not
+        // part of the target; just locate the closing `)`.
+        let after_angle = &rest[close_angle + 1..];
+        let close_paren = after_angle.find(')')?;
+        let end = close_angle + 1 + close_paren + 1;
+
+        Some(ParsedDestination { target_raw, end })
+    } else {
+        // Bare destination: up to the first `)`.
+        let close_paren = rest.find(')')?;
+        Some(ParsedDestination {
+            target_raw: &rest[..close_paren],
+            end: close_paren + 1,
+        })
+    }
+}
+
 /// Extract all internal links with byte-offset spans from a text segment.
 ///
 /// Works exactly like [`extract_links_from_text`] but returns [`LinkSpan`]
@@ -315,7 +389,9 @@ fn try_parse_markdown_link_span_at(
 ) -> Option<(LinkSpan, usize)> {
     let rest = &text[start..];
 
-    let close_bracket = rest.find(']')?;
+    // L-A2: skip escaped `\]`/`\[` so labels like
+    // `[Contains \[test\] brackets]` don't terminate the scan early.
+    let close_bracket = find_label_close_bracket(rest)?;
     // Read label from `original` so backtick-wrapped content is not lost when
     // `text` has had inline code spans replaced with spaces.
     // Use `.get()` to avoid panic if `original` has a different byte layout.
@@ -326,10 +402,11 @@ fn try_parse_markdown_link_span_at(
         return None;
     }
 
-    let paren_start = after_bracket + 1; // first byte of raw target
+    let paren_start = after_bracket + 1; // first byte after `(`
     let rest_after_paren = &text[paren_start..];
-    let close_paren = rest_after_paren.find(')')?;
-    let target_raw = &rest_after_paren[..close_paren];
+    // L-A1: handle both bare and angle-bracket (`<my dest.md>`) destinations.
+    let dest = parse_destination(rest_after_paren)?;
+    let target_raw = dest.target_raw;
 
     if is_external(target_raw) || target_raw.is_empty() {
         return None;
@@ -337,17 +414,25 @@ fn try_parse_markdown_link_span_at(
 
     let link = parse_markdown_link(label_text, target_raw)?;
 
-    // target_end stops at `#` if a fragment is present, otherwise at `)`.
+    // target_end stops at `#` if a fragment is present, otherwise at the end
+    // of the (unwrapped) target text. `target_start` is offset past the `<`
+    // when the angle form was used, so the writer's splice naturally
+    // preserves the angle brackets around a rewritten target.
+    let target_start = if text.as_bytes().get(paren_start).copied() == Some(b'<') {
+        paren_start + 1
+    } else {
+        paren_start
+    };
     let target_end_in_raw = target_raw.find('#').unwrap_or(target_raw.len());
 
-    let full_end = paren_start + close_paren + 1;
+    let full_end = paren_start + dest.end;
 
     Some((
         LinkSpan {
             link,
             kind: LinkKind::Markdown,
-            target_start: paren_start,
-            target_end: paren_start + target_end_in_raw,
+            target_start,
+            target_end: target_start + target_end_in_raw,
             full_start: start,
             full_end,
         },
@@ -441,8 +526,9 @@ pub(crate) fn strip_wikilink_md_suffix(target: &str) -> &str {
 fn try_parse_markdown_link_at(text: &str, original: &str, start: usize) -> Option<(Link, usize)> {
     let rest = &text[start..];
 
-    // Find the closing ]
-    let close_bracket = rest.find(']')?;
+    // Find the closing ] (L-A2: skip escaped `\]`/`\[` so labels like
+    // `[Contains \[test\] brackets]` don't terminate the scan early).
+    let close_bracket = find_label_close_bracket(rest)?;
     // Read label from `original` so backtick-wrapped content is not lost when
     // `text` has had inline code spans replaced with spaces.
     // Use `.get()` to avoid panic if `original` has a different byte layout.
@@ -454,11 +540,12 @@ fn try_parse_markdown_link_at(text: &str, original: &str, start: usize) -> Optio
         return None;
     }
 
-    // Find closing )
+    // Parse the destination, handling both bare and angle-bracket
+    // (`<my dest.md>`) forms (L-A1).
     let paren_start = after_bracket + 1;
     let rest_after_paren = &text[paren_start..];
-    let close_paren = rest_after_paren.find(')')?;
-    let target_raw = &rest_after_paren[..close_paren];
+    let dest = parse_destination(rest_after_paren)?;
+    let target_raw = dest.target_raw;
 
     // Skip external links
     if is_external(target_raw) {
@@ -471,7 +558,7 @@ fn try_parse_markdown_link_at(text: &str, original: &str, start: usize) -> Optio
     }
 
     let link = parse_markdown_link(label_text, target_raw)?;
-    let end_pos = paren_start + close_paren + 1;
+    let end_pos = paren_start + dest.end;
     Some((link, end_pos))
 }
 
@@ -1087,5 +1174,122 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].label.as_deref(), Some("`mod.rs`"));
         assert_eq!(links[0].target, "src/mod.rs");
+    }
+
+    // --- L-A1: angle-bracket destinations ---
+
+    #[test]
+    fn angle_bracket_destination_with_spaces_strips_brackets() {
+        let text = "[spaced link](<my dest.md>)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "my dest.md");
+        assert_eq!(links[0].label.as_deref(), Some("spaced link"));
+    }
+
+    #[test]
+    fn angle_bracket_destination_without_spaces_still_works() {
+        let text = "[link](<dest.md>)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "dest.md");
+    }
+
+    #[test]
+    fn angle_bracket_destination_empty_does_not_panic() {
+        // `<>` — empty angle destination. Falls through to the standard
+        // empty-target rejection (mirrors bare `()`), so no link is
+        // extracted, but parsing must not panic.
+        let text = "[link](<>)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert!(links.is_empty(), "empty angle destination yields no link");
+    }
+
+    #[test]
+    fn angle_bracket_destination_unclosed_does_not_panic() {
+        // No matching `>` — not parseable as an angle destination. There is
+        // no closing `)` before end-of-string either (the `)` that follows
+        // `dest.md` is inside the unterminated `<...`), so this also fails to
+        // parse as a link at all, consistent with the rest of this file
+        // treating unparseable link syntax as "no link" rather than a panic
+        // or a partial/garbled match.
+        let text = "[link](<dest.md) trailing";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert!(
+            links.is_empty(),
+            "unclosed angle destination must not panic and must not parse as a link"
+        );
+    }
+
+    #[test]
+    fn angle_bracket_destination_with_fragment() {
+        let text = "[link](<my dest.md#heading>)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "my dest.md");
+    }
+
+    #[test]
+    fn angle_bracket_destination_span_target_excludes_brackets() {
+        let text = "[spaced link](<my dest.md>)";
+        let spans = extract_link_spans(text);
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        assert_eq!(span.link.target, "my dest.md");
+        // target_start/target_end must point at the unwrapped text so a
+        // writer splice re-emits the angle brackets around a new target.
+        assert_eq!(&text[span.target_start..span.target_end], "my dest.md");
+    }
+
+    // --- L-A2: escaped brackets in link text ---
+
+    #[test]
+    fn escaped_brackets_in_label_are_not_terminators() {
+        let text = r"[Contains \[test\] brackets](dest.md)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "dest.md");
+        assert_eq!(
+            links[0].label.as_deref(),
+            Some(r"Contains \[test\] brackets")
+        );
+    }
+
+    #[test]
+    fn escaped_bracket_at_start_of_label() {
+        let text = r"[\[leading](dest.md)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "dest.md");
+        assert_eq!(links[0].label.as_deref(), Some(r"\[leading"));
+    }
+
+    #[test]
+    fn escaped_bracket_at_end_of_label() {
+        let text = r"[trailing\]](dest.md)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "dest.md");
+        assert_eq!(links[0].label.as_deref(), Some(r"trailing\]"));
+    }
+
+    #[test]
+    fn escaped_brackets_in_label_span_variant() {
+        let text = r"[Contains \[test\] brackets](dest.md)";
+        let spans = extract_link_spans(text);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].link.target, "dest.md");
+        assert_eq!(
+            spans[0].link.label.as_deref(),
+            Some(r"Contains \[test\] brackets")
+        );
     }
 }

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -205,9 +205,43 @@ struct ParsedDestination<'a> {
     /// the `<...>` form; verbatim otherwise).
     target_raw: &'a str,
     /// Byte offset (relative to the start of the destination, i.e. right
-    /// after `(`) of the first byte past the destination (and any title),
-    /// up to and including the closing `)`.
+    /// after `(`) of the first byte past the `)` that closes the link
+    /// (skipping any intervening title, which may itself contain `)`).
     end: usize,
+}
+
+/// Locate the `)` that closes a markdown link, given the text immediately
+/// after an angle-bracket destination's closing `>`. Skips leading
+/// whitespace and an optional CommonMark title (`"…"`, `'…'`, or `(…)`,
+/// escape-aware), so a `)` inside the title is not mistaken for the closing
+/// paren. Returns the byte offset of the closing `)` within `s`, or `None`
+/// if what follows is neither a title nor the closing paren (per CommonMark
+/// the construct is then not a link).
+fn find_close_paren_after_destination(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        i += 1;
+    }
+    match bytes.get(i) {
+        Some(b')') => Some(i),
+        Some(&open @ (b'"' | b'\'' | b'(')) => {
+            let close = if open == b'(' { b')' } else { open };
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == close && !is_escaped(bytes, i) {
+                    i += 1;
+                    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+                        i += 1;
+                    }
+                    return (bytes.get(i) == Some(&b')')).then_some(i);
+                }
+                i += 1;
+            }
+            None
+        }
+        _ => None,
+    }
 }
 
 /// Parse a markdown link destination starting at `rest` (the text right
@@ -216,10 +250,15 @@ struct ParsedDestination<'a> {
 /// Handles both bare destinations (`dest.md`, up to the first `)`) and
 /// CommonMark angle-bracket destinations (`<my dest.md>`, which may contain
 /// spaces and literal `)`), per L-A1. For the angle form, the destination is
-/// closed by the first unescaped `>`; anything between it and the closing
-/// `)` (e.g. a `"title"`) is ignored since this file does not otherwise
+/// closed by the first unescaped `>`; an optional title between it and the
+/// closing `)` is skipped (escape-aware, so a `)` inside the title does not
+/// truncate the span) but not stored, since this file does not otherwise
 /// track link titles. Returns `None` if no closing `)` can be found for the
 /// destination.
+///
+/// Known CommonMark deviation: an unescaped `<` inside the angle form
+/// (`<foo<bar.md>`) should invalidate the destination per spec, but is
+/// accepted here; hyalo is not a full CommonMark parser elsewhere either.
 fn parse_destination(rest: &str) -> Option<ParsedDestination<'_>> {
     let bytes = rest.as_bytes();
     if bytes.first() == Some(&b'<') {
@@ -238,10 +277,11 @@ fn parse_destination(rest: &str) -> Option<ParsedDestination<'_>> {
         let close_angle = close_angle?;
         let target_raw = &rest[1..close_angle];
 
-        // Whatever follows `>` up to `)` (whitespace, optional title) is not
-        // part of the target; just locate the closing `)`.
+        // Whatever follows `>` (whitespace, optional title) is not part of
+        // the target; locate the `)` that actually closes the link — a bare
+        // `find(')')` would stop inside a title containing `)`.
         let after_angle = &rest[close_angle + 1..];
-        let close_paren = after_angle.find(')')?;
+        let close_paren = find_close_paren_after_destination(after_angle)?;
         let end = close_angle + 1 + close_paren + 1;
 
         Some(ParsedDestination { target_raw, end })
@@ -1244,6 +1284,45 @@ mod tests {
         // target_start/target_end must point at the unwrapped text so a
         // writer splice re-emits the angle brackets around a new target.
         assert_eq!(&text[span.target_start..span.target_end], "my dest.md");
+    }
+
+    #[test]
+    fn angle_bracket_destination_with_title_containing_paren() {
+        // A `)` inside the title must not truncate the span: full_end has to
+        // land past the real closing paren or a writer splice corrupts the
+        // line during `mv`/`links fix --apply`.
+        let text = r#"[text](<dest.md> "a (note)") tail"#;
+        let spans = extract_link_spans(text);
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        assert_eq!(span.link.target, "dest.md");
+        assert_eq!(
+            &text[span.full_start..span.full_end],
+            r#"[text](<dest.md> "a (note)")"#
+        );
+    }
+
+    #[test]
+    fn angle_bracket_destination_with_single_quote_and_paren_titles() {
+        for text in [
+            r"[text](<dest.md> 'a (note)')",
+            r"[text](<dest.md> (a note))",
+        ] {
+            let mut links = Vec::new();
+            extract_links_from_text(text, &mut links);
+            assert_eq!(links.len(), 1, "failed for {text}");
+            assert_eq!(links[0].target, "dest.md", "failed for {text}");
+        }
+    }
+
+    #[test]
+    fn angle_bracket_destination_followed_by_garbage_is_not_a_link() {
+        // Per CommonMark, only whitespace and an optional title may sit
+        // between the closing `>` and the `)`.
+        let text = "[text](<dest.md> junk)";
+        let mut links = Vec::new();
+        extract_links_from_text(text, &mut links);
+        assert!(links.is_empty());
     }
 
     // --- L-A2: escaped brackets in link text ---

--- a/hyalo-knowledgebase/reviews/link-handling-review-2026-07-18.md
+++ b/hyalo-knowledgebase/reviews/link-handling-review-2026-07-18.md
@@ -277,6 +277,13 @@ not fixed pre-release:
   `[Contains \[test\] brackets](<dest.md>)` is entirely absent from
   `--fields links` and `backlinks` output.
 
+**Resolved 2026-07-19** (post-run fix-forward, branch
+`fix/link-parser-angle-escapes`): L-A1 via `parse_destination` (strips
+`<...>` per CommonMark, spaces allowed inside, unclosed `<` is not a link)
+and L-A2 via `find_label_close_bracket` (escape-aware label scan reusing
+the L-16 `is_escaped` helper). Applied to both the byte-offset and
+span-based parse paths; covered by 10 unit + 2 e2e tests.
+
 Minor related: `okf index --dry-run` exits 1 on marker-skip vaults with
 `changed: 0`, contradicting the documented "non-zero when any index.md
 would change" contract (possibly intentional — surface skips in CI — but


### PR DESCRIPTION
## Summary
- Fix **L-A1**: markdown link destinations wrapped in angle brackets (`[text](<spaced dest.md>)`, emitted by hyalo's own generator since iter-176) are now parsed per CommonMark — `<>` stripped, spaces allowed inside, unclosed `<` is not a link. Previously the literal `<...>` was stored, so `find --broken-links` false-positived on generator output and `backlinks` missed the links.
- Fix **L-A2**: escaped brackets in link text (`[Contains \[test\] brackets](dest.md)`) no longer blind the parser — the label scan is escape-aware, reusing the odd-backslash `is_escaped` helper from the L-16 fix. Previously such links were dropped entirely.
- Both fixes applied identically to the byte-offset (`try_parse_markdown_link_at`) and span-based (`try_parse_markdown_link_span_at`) paths so `find`/`backlinks` and `links fix`/rewrites see the same link set; span offsets target the text inside `<...>` so rewrites preserve the angle-bracket form.
- Closes out the L-A1/L-A2 addendum of `reviews/link-handling-review-2026-07-18.md` (fix-forward after the 183–185 chain; see PR #218 discussion).

## Test plan
- [x] 10 new unit tests in `links.rs`: angle brackets (spaces / no spaces / empty / unclosed / fragment / span-target) and escaped brackets (mid-label / start / end / span variant)
- [x] e2e: `find --broken-links` does not flag `[text](<my dest.md>)` when the target exists
- [x] e2e: `backlinks` finds the escaped-label link
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace -q` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)