### PR TITLE
fix(output): broken-anchor marker missing from find text output

### DIFF
--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -868,10 +868,13 @@ fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) ->
         parts.push(r#""  score: \(.score)""#.to_owned());
     }
 
-    // Links: header then each as "    \"target\" → \"path\"" or "    \"target\" (unresolved)"
+    // Links: header then each as "    \"target\" → \"path\"" or "    \"target\" (unresolved)".
+    // Anchored links (L-21) append "#fragment" to the target and, when the
+    // heading is missing, " (broken anchor)" after the path — keep in sync
+    // with LINK_INFO_ANCHORED_FILTER, which renders the standalone shape.
     if map.contains_key("links") {
         parts.push(
-            r#"if (.links | length) > 0 then "  links:\n\(.links | map("    \"\(.target)\"\(if .path then " → \"\(.path)\"" else " (unresolved)" end)") | join("\n"))" else empty end"#.to_owned(),
+            r##"if (.links | length) > 0 then "  links:\n\(.links | map("    \"\(.target)\(if .fragment then "#\(.fragment)" else "" end)\"\(if .path then " → \"\(.path)\"\(if .broken_anchor then " (broken anchor)" else "" end)" else " (unresolved)" end)") | join("\n"))" else empty end"##.to_owned(),
         );
     }
 

--- a/crates/hyalo-cli/tests/e2e/anchors.rs
+++ b/crates/hyalo-cli/tests/e2e/anchors.rs
@@ -297,6 +297,42 @@ fn anchor_matrix_indexed() {
     assert_matrix(&json, "index");
 }
 
+/// Text output renders the fragment on the target and marks a missing
+/// heading as `(broken anchor)` — in the nested `links:` section of find
+/// results, not just the standalone LinkInfo shape the doc tests cover.
+#[test]
+fn anchor_text_output_marks_broken_anchor() {
+    let tmp = setup_anchor_vault();
+    let dir = tmp.path().to_str().expect("utf-8 path");
+    let output = hyalo_no_hints()
+        .args([
+            "--dir",
+            dir,
+            "find",
+            "--broken-links",
+            "--fields",
+            "links",
+            "--format",
+            "text",
+        ])
+        .output()
+        .expect("hyalo find --broken-links should run");
+    assert!(output.status.success());
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        text.contains("\"Foo#nope\" → \"Foo.md\" (broken anchor)"),
+        "broken anchor must be visible in text output, got:\n{text}"
+    );
+    assert!(
+        !text.contains("\"Foo#Real\" → \"Foo.md\" (broken anchor)"),
+        "resolved anchor must not be marked broken, got:\n{text}"
+    );
+    assert!(
+        text.contains("\"Nope#x\" (unresolved)"),
+        "broken target keeps the unresolved marker (with fragment shown), got:\n{text}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // `links fix` headline counts are NOT inflated by broken anchors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `find --broken-links` text output rendered anchored links as plainly resolved: the nested `links:` section in `build_file_object_filter` has its own jq template, which iter-190 (PR #224) did not update — only the standalone LinkInfo filters got the anchor rendering, so the CHANGELOG's text-output claim was false on the path users actually see.
- The nested template now appends `#fragment` to the target and ` (broken anchor)` after the path, matching `LINK_INFO_ANCHORED_FILTER`.
- New e2e (`anchor_text_output_marks_broken_anchor`) asserts the *text* path — the existing 9 anchor e2e only asserted JSON, which is how this slipped through.

## Test plan
- [x] New e2e: broken anchor marked, resolved anchor not marked, broken target keeps `(unresolved)` with fragment shown
- [x] Full workspace suite green (1352+905 tests, 0 failures); fmt + clippy -D warnings clean
- [x] Live smoke on a scratch vault renders `"Foo#Nope" → "Foo.md" (broken anchor)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)