### PR TITLE
fix(find): case-insensitive inbound for --orphan/--dead-end (L-6 tail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,8 +118,6 @@ and this project adheres to
   The "Apply N fixes" hint count now discounts would-be-stale fixes so it
   matches what `--apply` actually writes.
 
-### Internal
-
 - **Classify-side link resolution collapsed onto the shared resolver** (iter-189,
   refactor only): the `links fix` verdict logic (`resolve_and_classify_link`,
   `classify_link`, `classify_short_form_wikilink`, plus the `LinkResolution` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to
 
 ### Fixed
 
+- **`find --orphan` / `--dead-end` / `--fields backlinks` count
+  case-insensitive inbound links** (L-6 tail): `[[foo]]` pointing at `Foo.md`
+  now counts as inbound in `find`, matching the `backlinks` command and
+  `summary` (all three route through the same case-insensitive graph lookup).
+  Previously `find --orphan` could list a file that `summary` and `backlinks`
+  agreed had inbound links.
 - **Percent-encoded markdown link destinations now resolve** (iter-188, L-23):
   `[x](my%20dest.md)` previously never resolved (the `%20` was compared
   literally against the on-disk filename `my dest.md`), so `find --broken-links`

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -810,9 +810,12 @@ pub fn find(
         };
 
         // --- Backlinks from pre-built link graph ---
+        // Case-insensitive lookup (L-6): keeps `find --fields backlinks`,
+        // `--orphan`, and `--dead-end` consistent with the `backlinks`
+        // command and `summary`, which route through `backlinks_ci`.
         let backlinks = if fields.backlinks {
             let entries_bl = link_graph_ref
-                .map(|graph| graph.backlinks(&entry.rel_path))
+                .map(|graph| graph.backlinks_ci(&entry.rel_path))
                 .unwrap_or_default();
             Some(
                 entries_bl

--- a/crates/hyalo-cli/tests/e2e/find.rs
+++ b/crates/hyalo-cli/tests/e2e/find.rs
@@ -3549,6 +3549,43 @@ fn find_orphan_returns_isolated_files() {
     assert!(results[0]["backlinks"].is_array());
 }
 
+/// L-6 alignment: a case-insensitive inbound link (`[[foo]]` → `Foo.md`)
+/// counts as inbound for `--orphan`/`--dead-end`, consistent with the
+/// `backlinks` command and `summary` (both route through `backlinks_ci`).
+#[test]
+fn find_orphan_counts_case_insensitive_inbound() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\n[[foo]]\n");
+    write_md(tmp.path(), "Foo.md", "---\ntitle: Foo\n---\nContent.\n");
+
+    for (flag, expected) in [("--orphan", Vec::new()), ("--dead-end", vec!["Foo.md"])] {
+        let output = hyalo_no_hints()
+            .args([
+                "--dir",
+                tmp.path().to_str().unwrap(),
+                "find",
+                flag,
+                "--format",
+                "json",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let files: Vec<&str> = json["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["file"].as_str().unwrap())
+            .collect();
+        assert_eq!(files, expected, "{flag} files: {files:?}");
+    }
+}
+
 #[test]
 fn find_dead_end_returns_files_with_inbound_only() {
     let tmp = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- Completes the L-6 case-insensitivity family: `find`'s backlinks source now uses `LinkGraph::backlinks_ci`, so `--fields backlinks`, `--orphan`, and `--dead-end` agree with the `backlinks` command and `summary` (aligned in iter-184/189). Previously `find --orphan` could list `Foo.md` while `summary` and `backlinks` agreed `[[foo]]` linked to it.
- This was the explicitly documented follow-up from iter-189 task 3's audit note.

## Test plan
- [x] New e2e `find_orphan_counts_case_insensitive_inbound`: `[[foo]]` → `Foo.md` — not an orphan, is a dead-end
- [x] Existing orphan/dead-end e2e unchanged and green
- [x] Full workspace suite, fmt, clippy -D warnings clean; changelog profile lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)