### PR TITLE
iter-201: config trust — --dir keeps .hyalo.toml, malformed config blocks writers, hints marked [writes]

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,5 +2,5 @@
 Use `hyalo` CLI (not Read/Grep/Glob) for all markdown knowledgebase operations.
 Examples: `hyalo find --property status=planned`, `hyalo find "search text"`, `hyalo lint` (add `--strict` to fail on missing-type / undeclared-property warnings), `hyalo types list`.
 Run `hyalo --help` for usage. Output format auto-detects (text on terminals, json when piped); pass `--format text`/`--format json` to override.
-Use `hyalo config` to inspect the effective configuration (effective dir, config path, hints, format, site_prefix) — useful when debugging `.hyalo.toml` resolution. Its JSON is the standard `results`/`hints` envelope, so `hyalo config --jq '.results.dir'` works.
+Use `hyalo config` to inspect the effective configuration (effective dir, config path, hints, format, site_prefix) — useful when debugging `.hyalo.toml` resolution. `--dir` selects a vault, not a config: naming the configured vault keeps `.hyalo.toml` in effect, naming another tree switches to that tree's config (announced on stderr). Its JSON is the standard `results`/`hints` envelope, so `hyalo config --jq '.results.dir'` works.
 <!-- hyalo:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,41 @@ and this project adheres to
 
 ### Changed
 
+- **BREAKING: `--dir` no longer discards `.hyalo.toml`** (iter-201). `--dir`
+  names a *vault*, not a config. When the path it resolves to is the one the
+  working directory's `.hyalo.toml` already points at (`dir = "kb"` +
+  `--dir kb`, the standard repo-root layout), that config now stays in effect;
+  previously hyalo reloaded `.hyalo.toml` from the *vault* directory instead,
+  found nothing there, and silently ran on built-in defaults — dropping the
+  schema, saved views, `[lint] ignore`, per-rule severity overrides,
+  `site_prefix` and the changelog path while printing "--dir is redundant".
+  A `lint --strict` CI gate written that way went vacuously green. When `--dir`
+  names a *different* tree the behaviour is unchanged (that tree's own
+  `.hyalo.toml`, else defaults), but hyalo now says so on stderr, naming the
+  file that took over. `hyalo config --dir <path>` reports the same resolution
+  and no longer returns `config_path: null` while a config is in effect.
+  **Migration:** runs that relied on `--dir` as a way to *ignore* the local
+  config now honor it; pass `--dir` to a directory outside the configured vault,
+  or move/rename the config, to get the old behaviour.
+- **BREAKING: a malformed `.hyalo.toml` blocks mutating commands** (iter-201).
+  One unknown key or type error anywhere in the file — including inside
+  `[links.auto]` — made the whole config unusable and hyalo fell back to *all*
+  defaults, `dir` included. `hyalo links auto --apply -q` could therefore
+  rewrite a completely different tree than the one configured, with the warning
+  suppressed. Writers (`set`, `remove`, `append`, `mv`, `new`, `task toggle`,
+  `views set`, `links fix/auto --apply`, `lint --fix`, …) now exit 1 with the
+  parse diagnostic and touch nothing; `--dry-run` invocations and `init`/`deinit`
+  are unaffected. Read-only commands still run on defaults, but keep the `dir`
+  value when it can be recovered from the file, and their config warning is no
+  longer suppressed by `--quiet`.
+- **Mutating drill-down hints are marked** (iter-201). `hyalo find` with two or
+  more filters suggests saving the query as a view — a command that writes
+  `.hyalo.toml` — and it was rendered in the same `-> hyalo …` list as read-only
+  drill-downs. Writing hints now use a `=>` arrow with a trailing `[writes]`
+  tag in text output and carry `"writes": true` in the JSON envelope, so "run
+  the hints" is safe advice again. An e2e gate runs every hint the CLI marks
+  read-only and fails if it changes a single byte of the vault or the config.
+
 - **`summary --help` now documents the `-n` divergence** (iter-195). `-n` means
   `--recent` on `summary` but `--limit` on `find` and `backlinks`. The semantics
   are deliberately unchanged — `--recent` caps only the "recently modified" list,
@@ -125,6 +160,12 @@ and this project adheres to
 
 ### Fixed
 
+- **`.hyalo.toml` is parsed once per run, not twice** (iter-201). The help
+  banner re-loaded the config the CLI had already resolved, so every invocation
+  paid a second parse and any config warning ended with a spurious
+  "1 additional identical warning(s) suppressed" line. The deprecation check for
+  the kebab-case `required-sections` key also re-parsed the whole file; it now
+  reads the already-parsed `[schema]` value.
 - **`links fix --apply` no longer breaks the links it rewrites** (iter-200).
   The writer emitted the *vault-relative* path of the repaired target, but the
   resolver reads a bare markdown destination as relative to the source file's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Then use target/release/hyalo to work with the documentation in `./hyalo-knowled
 - **Manage schemas**: `hyalo types list`, `hyalo types show <name>`, `hyalo types set <name> --required title,date`
 - Only fall back to Edit for body content changes (markdown prose) that hyalo can't handle
 - **Do NOT pass `--dir hyalo-knowledgebase/`** — `.hyalo.toml` already sets it as the default
-- **Follow hints**: hyalo outputs drill-down hints by default — read and follow them to navigate deeper into the knowledgebase. Use `--no-hints` only when you need raw output.
+- **Follow hints**: hyalo outputs drill-down hints by default — read and follow them to navigate deeper into the knowledgebase. Use `--no-hints` only when you need raw output. Hints prefixed `->` are read-only and safe to run; a `=>` prefix with a `[writes]` tag (JSON: `"writes": true`) means running it modifies the vault or `.hyalo.toml`.
 
 **Iteration file rules:**
 - Always name `iteration-NN-slug.md` — no standalone plan files

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -211,7 +211,21 @@ const LONG_ABOUT_TEMPLATE: &str = "Hyalo — query, filter, and mutate YAML fron
 pub(crate) struct Cli {
     /// Root directory for resolving all file and --glob paths.
     /// Default: "." (Override via .hyalo.toml)
-    #[arg(short, long, global = true)]
+    #[arg(
+        short,
+        long,
+        global = true,
+        long_help = concat!(
+            "Root directory for resolving all file and --glob paths. ",
+            "Default: \".\" (override via .hyalo.toml).\n\n",
+            "--dir names a VAULT, not a config file. Naming the directory .hyalo.toml already ",
+            "resolves to keeps that config in effect (the flag is redundant, and hyalo says so). ",
+            "Naming a different directory switches to that directory's own .hyalo.toml if it has ",
+            "one, else built-in defaults \u{2014} reported on stderr, because the config in your ",
+            "working directory then no longer applies.\n\n",
+            "Run `hyalo config --dir <path>` to see which config file an invocation would use."
+        )
+    )]
     pub dir: Option<PathBuf>,
 
     /// Output format: "json" or "text".
@@ -274,6 +288,10 @@ pub(crate) struct Cli {
     /// Useful in scripts or CI pipelines where warning noise is undesirable.
     /// Identical warnings are always deduplicated regardless of this flag;
     /// use `--quiet` to suppress them entirely.
+    ///
+    /// One exception: a `.hyalo.toml` that could not be parsed is always
+    /// reported. That warning means the run is using a different vault and a
+    /// different rule set than the config asked for, which is not noise.
     #[arg(short = 'q', long, global = true)]
     pub quiet: bool,
 

--- a/crates/hyalo-cli/src/cli/banner.rs
+++ b/crates/hyalo-cli/src/cli/banner.rs
@@ -10,10 +10,15 @@
 ///
 /// The public entry-point reads the process CWD; the inner `_for` variant accepts
 /// an explicit path so unit tests can exercise it without mutating the process state.
-pub(crate) fn cwd_help_banner() -> Option<String> {
+/// `resolved_dir` is the `dir` value from the already-loaded CWD config. It is
+/// threaded in rather than re-derived: loading `.hyalo.toml` a second time here
+/// is what made every invocation parse the config twice and print
+/// "1 additional identical warning(s) suppressed" on any malformed file
+/// (iter-201, M-2).
+pub(crate) fn cwd_help_banner(resolved_dir: &std::path::Path) -> Option<String> {
     let cwd = std::env::current_dir().ok()?;
     let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
-    cwd_help_banner_for_tty(&cwd, is_tty)
+    cwd_help_banner_for_tty(&cwd, resolved_dir, is_tty)
 }
 
 /// Inner implementation that accepts an explicit CWD path.
@@ -22,7 +27,8 @@ pub(crate) fn cwd_help_banner() -> Option<String> {
 /// working directory.
 #[cfg(test)]
 pub(crate) fn cwd_help_banner_for(cwd: &std::path::Path) -> Option<String> {
-    cwd_help_banner_for_tty(cwd, true)
+    let resolved_dir = crate::config::load_config_from(cwd).dir;
+    cwd_help_banner_for_tty(cwd, &resolved_dir, true)
 }
 
 /// Variant that controls emoji rendering based on TTY.
@@ -30,19 +36,21 @@ pub(crate) fn cwd_help_banner_for(cwd: &std::path::Path) -> Option<String> {
 /// When `is_tty` is `false` (stdout is piped/redirected), emoji prefixes are
 /// suppressed so that `hyalo --help | cat` produces clean ASCII text. The
 /// banner content is otherwise unchanged.
-pub(crate) fn cwd_help_banner_for_tty(cwd: &std::path::Path, is_tty: bool) -> Option<String> {
+pub(crate) fn cwd_help_banner_for_tty(
+    cwd: &std::path::Path,
+    resolved_dir: &std::path::Path,
+    is_tty: bool,
+) -> Option<String> {
     let info_prefix = if is_tty { "\u{2139}\u{fe0f}  " } else { "" };
     let warn_prefix = if is_tty { "\u{26a0}\u{fe0f}  " } else { "" };
 
     // Case 1: CWD contains .hyalo.toml — banner tells the user which dir is active.
     let local_toml = cwd.join(".hyalo.toml");
     if local_toml.is_file() {
-        // Use the same loader as the rest of the CLI so the banner reflects
-        // the effective `dir` (and falls back gracefully on malformed configs).
-        let dir_value = crate::config::load_config_from(cwd)
-            .dir
-            .display()
-            .to_string();
+        // The caller already resolved this through the normal loader, so the
+        // banner reflects the effective `dir` (and its malformed-config
+        // fallback) without re-reading the file.
+        let dir_value = resolved_dir.display().to_string();
         return Some(format!(
             "{info_prefix}hyalo runs against `{dir_value}` (from ./.hyalo.toml). \
              Don't `cd` into it; pass paths relative to `{dir_value}`.\n"
@@ -217,8 +225,9 @@ mod tests {
         fs::create_dir_all(tmp.path().join("kb")).unwrap();
         fs::write(tmp.path().join(".hyalo.toml"), "dir = \"kb\"\n").unwrap();
 
-        let tty = cwd_help_banner_for_tty(tmp.path(), true).expect("tty banner");
-        let piped = cwd_help_banner_for_tty(tmp.path(), false).expect("piped banner");
+        let dir = crate::config::load_config_from(tmp.path()).dir;
+        let tty = cwd_help_banner_for_tty(tmp.path(), &dir, true).expect("tty banner");
+        let piped = cwd_help_banner_for_tty(tmp.path(), &dir, false).expect("piped banner");
 
         assert!(tty.contains('\u{2139}'), "TTY banner should keep emoji");
         assert!(
@@ -238,8 +247,9 @@ mod tests {
         fs::write(tmp.path().join(".hyalo.toml"), "dir = \"kb\"\n").unwrap();
         let cwd = tmp.path().join("kb");
 
-        let tty = cwd_help_banner_for_tty(&cwd, true).expect("tty warn banner");
-        let piped = cwd_help_banner_for_tty(&cwd, false).expect("piped warn banner");
+        let dir = crate::config::load_config_from(&cwd).dir;
+        let tty = cwd_help_banner_for_tty(&cwd, &dir, true).expect("tty warn banner");
+        let piped = cwd_help_banner_for_tty(&cwd, &dir, false).expect("piped warn banner");
 
         assert!(tty.contains('\u{26a0}'), "TTY warn banner keeps emoji");
         assert!(

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -73,34 +73,28 @@ impl Default for LinksAutoReport {
 
 /// Build and return the config report for `cwd`.
 ///
-/// When `dir_override` is `Some` (the user passed a global `--dir`), the report
-/// loads the config from that directory and reports it as the effective `dir`,
-/// so `hyalo config --dir X` mirrors what the rest of the CLI would use rather
-/// than echoing the CWD config's shadowed `dir` value (ff-rdp B6).
+/// `effective` comes from [`crate::config::resolve_effective`] — the same
+/// resolution every other command goes through — so `hyalo config` reports what
+/// the CLI would actually use. It used to answer the `--dir` question on its
+/// own by reloading `.hyalo.toml` from the target directory, which reported
+/// `config_path: null` while a config *was* in effect (iter-201, H-4).
 pub(crate) fn collect_config_report(
     cwd: &Path,
-    dir_override: Option<&Path>,
+    effective: crate::config::EffectiveConfig,
+    dir_overridden: bool,
 ) -> anyhow::Result<ConfigReport> {
-    // The directory whose `.hyalo.toml` we read: the `--dir` override if given,
-    // else the CWD.
-    let config_search_dir = dir_override.unwrap_or(cwd);
-    let toml_path = config_search_dir.join(".hyalo.toml");
-    let (config_path, raw_contents) = if toml_path.is_file() {
-        let contents = std::fs::read_to_string(&toml_path)
-            .with_context(|| format!("reading {}", toml_path.display()))?;
-        (Some(toml_path), Some(contents))
-    } else {
-        (None, None)
-    };
+    let crate::config::EffectiveConfig {
+        config: resolved,
+        dir,
+        config_path,
+        ..
+    } = effective;
 
-    // Load the full resolved config (handles partial files, malformed TOML, etc.)
-    let resolved = crate::config::load_config_from(config_search_dir);
-
-    // A `--dir` override is the effective vault dir regardless of the config's
-    // own `dir` key.
-    let (dir, dir_overridden) = match dir_override {
-        Some(d) => (d.to_path_buf(), true),
-        None => (resolved.dir, false),
+    let raw_contents = match &config_path {
+        Some(path) => Some(
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?,
+        ),
+        None => None,
     };
 
     Ok(ConfigReport {
@@ -130,12 +124,14 @@ pub(crate) fn collect_config_report(
 /// execution-based hint gate (`tests/e2e/hint_execution.rs`) can run them.
 pub(crate) fn config_hints(report: &ConfigReport) -> Vec<crate::hints::Hint> {
     let dir = report.dir.display().to_string();
-    // Only pass --dir when it is not the implicit default; a bare `hyalo summary`
-    // reads the same .hyalo.toml this report came from.
-    let suffix = if dir == "." {
-        String::new()
-    } else {
+    // Only pass --dir when the caller passed one. When `dir` came from the
+    // config file, a bare `hyalo summary` run from the same CWD reads that very
+    // file — re-emitting `--dir <configured>` adds nothing and, before
+    // iter-201, actively changed which config applied (H-4).
+    let suffix = if report.dir_overridden && dir != "." {
         format!(" --dir {}", crate::hints::shell_quote(&dir))
+    } else {
+        String::new()
     };
     vec![
         crate::hints::Hint::new(
@@ -165,7 +161,7 @@ pub(crate) fn config_hints(report: &ConfigReport) -> Vec<crate::hints::Hint> {
 pub(crate) fn config_envelope(report: &ConfigReport) -> serde_json::Value {
     let hints: Vec<serde_json::Value> = config_hints(report)
         .iter()
-        .map(|h| json!({"description": &h.description, "cmd": &h.cmd}))
+        .map(|h| json!({"description": &h.description, "cmd": &h.cmd, "writes": h.writes}))
         .collect();
     json!({
         "results": {

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -204,7 +204,7 @@ struct ConfigFile {
 }
 
 /// Resolved configuration with all defaults applied.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct ResolvedDefaults {
     pub(crate) dir: PathBuf,
     /// The directory where `.hyalo.toml` was found.  Views and types are stored
@@ -272,6 +272,16 @@ pub(crate) struct ResolvedDefaults {
     /// `false` when the file was missing, unreadable, or malformed (in which
     /// case all other fields are hardcoded defaults).
     pub(crate) loaded_from_file: bool,
+    /// The parse/read diagnostic when a `.hyalo.toml` **existed** but could not
+    /// be used, `None` otherwise (iter-201, M-2).
+    ///
+    /// A missing file is not an error — it is the "no config" case and leaves
+    /// this `None`. A file that is present but unusable is different in kind:
+    /// every setting the user wrote (`dir`, `[lint] ignore`, schema, views) is
+    /// gone, so a mutating command run in that state would operate on a vault
+    /// and a rule set the user never configured. Callers use this to refuse the
+    /// run instead of silently proceeding on defaults.
+    pub(crate) malformed: Option<String>,
     /// Active conformance profiles from `[lint] profiles` (or the deprecated
     /// `[lint] profile` alias) in `.hyalo.toml` (e.g. `["okf", "madr"]`).
     /// Enables every listed profile's advisory lint rules for plain
@@ -323,6 +333,7 @@ impl ResolvedDefaults {
             auto_link_warn_common_titles: true,
             lint_strict: false,
             loaded_from_file: false,
+            malformed: None,
             lint_profiles: Vec::new(),
         }
     }
@@ -334,6 +345,32 @@ impl ResolvedDefaults {
             ..Self::hardcoded()
         }
     }
+
+    /// Defaults for a directory whose `.hyalo.toml` exists but is unusable.
+    ///
+    /// Records `diagnostic` in [`ResolvedDefaults::malformed`] so writers can
+    /// refuse the run, and salvages the `dir` key when a lenient re-read can
+    /// still find it. Salvaging `dir` matters even though every other setting
+    /// is lost: it keeps read-only commands pointed at the vault the user
+    /// configured instead of silently re-rooting them at the config directory.
+    fn unusable_for(dir: &Path, diagnostic: String, salvaged_dir: Option<PathBuf>) -> Self {
+        Self {
+            dir: salvaged_dir.unwrap_or_else(|| PathBuf::from(".")),
+            malformed: Some(diagnostic),
+            ..Self::defaults_for(dir)
+        }
+    }
+}
+
+/// Best-effort extraction of the `dir` key from a `.hyalo.toml` that failed the
+/// strict parse.
+///
+/// Used only on the error path. Returns `None` when the text is not even valid
+/// TOML syntax, or when `dir` is absent or not a string.
+fn salvage_dir(contents: &str) -> Option<PathBuf> {
+    let raw: toml::Value = toml::from_str(contents).ok()?;
+    let dir = raw.get("dir")?.as_str()?;
+    Some(PathBuf::from(dir))
 }
 
 /// Load configuration from `.hyalo.toml` in the current working directory.
@@ -368,13 +405,16 @@ fn parse_case_insensitive_mode(raw: Option<&str>) -> anyhow::Result<CaseInsensit
 
 /// Load configuration from `.hyalo.toml` inside `dir`.
 ///
-/// Walks `[schema.types.*]` tables in a parsed `.hyalo.toml` looking for a real
-/// `required-sections` key (the deprecated kebab-case alias). Used to gate the
-/// deprecation warning so we don't false-positive on the string appearing in a
-/// comment, doc string, or unrelated value.
-fn schema_table_has_required_sections_key(raw: &toml::Value) -> bool {
-    let Some(types) = raw
-        .get("schema")
+/// Walks `types.*` tables inside the already-parsed `[schema]` value looking for
+/// a real `required-sections` key (the deprecated kebab-case alias). Used to
+/// gate the deprecation warning so we don't false-positive on the string
+/// appearing in a comment, doc string, or unrelated value.
+///
+/// Takes the `[schema]` value out of the parsed [`ConfigFile`] rather than a
+/// second `toml::from_str` of the file text: the loader used to parse every
+/// `.hyalo.toml` twice just to run this check (iter-201, M-2 double-parse).
+fn schema_table_has_required_sections_key(schema: Option<&toml::Value>) -> bool {
+    let Some(types) = schema
         .and_then(|s| s.get("types"))
         .and_then(toml::Value::as_table)
     else {
@@ -397,30 +437,33 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
             return ResolvedDefaults::defaults_for(dir);
         }
         Err(e) => {
-            crate::warn::warn(format!("could not read .hyalo.toml: {e}"));
-            return ResolvedDefaults::defaults_for(dir);
+            // The file exists but cannot be read — a config-integrity problem,
+            // so the warning is not suppressible by `-q` (iter-201, M-2).
+            let diagnostic = format!("could not read .hyalo.toml: {e}");
+            crate::warn::warn_always(&diagnostic);
+            return ResolvedDefaults::unusable_for(dir, diagnostic, None);
         }
     };
-
-    // Deprecation: warn when the kebab-case `required-sections` key is used.
-    // The canonical key is `required_sections`; the alias is kept for one release.
-    // Parse as generic TOML so a string value or comment containing the literal
-    // text "required-sections" doesn't trigger a false positive.
-    if let Ok(raw) = toml::from_str::<toml::Value>(&contents)
-        && schema_table_has_required_sections_key(&raw)
-    {
-        crate::warn::warn(
-            "deprecated: 'required-sections' in .hyalo.toml — rename to 'required_sections'",
-        );
-    }
 
     let mut cfg: ConfigFile = match toml::from_str(&contents) {
         Ok(c) => c,
         Err(e) => {
-            crate::warn::warn(format!("malformed .hyalo.toml: {e}"));
-            return ResolvedDefaults::defaults_for(dir);
+            let diagnostic = format!("malformed .hyalo.toml: {e}");
+            crate::warn::warn_always(&diagnostic);
+            return ResolvedDefaults::unusable_for(dir, diagnostic, salvage_dir(&contents));
         }
     };
+
+    // Deprecation: warn when the kebab-case `required-sections` key is used.
+    // The canonical key is `required_sections`; the alias is kept for one
+    // release. Checked against the already-parsed `[schema]` value (which the
+    // loader keeps as raw TOML), so a string value or comment containing the
+    // literal text "required-sections" still cannot trigger a false positive.
+    if schema_table_has_required_sections_key(cfg.schema.as_ref()) {
+        crate::warn::warn(
+            "deprecated: 'required-sections' in .hyalo.toml — rename to 'required_sections'",
+        );
+    }
 
     // Warn when the resolved config points its `dir` at a subdirectory that
     // itself contains a `.hyalo.toml`. The inner file is shadowed by this
@@ -523,6 +566,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         auto_link_warn_common_titles: links_auto.warn_common_titles.unwrap_or(true),
         lint_strict,
         loaded_from_file: true,
+        malformed: None,
         lint_profiles,
     }
 }
@@ -731,6 +775,124 @@ pub(crate) fn overlay_scan_include(config_dir: &Path, profile_name: &str) -> Vec
         return Vec::new();
     };
     cfg.scan.map(|s| s.include).unwrap_or_default()
+}
+
+/// Where a run's effective configuration came from, and what an explicit
+/// `--dir` did to it.
+///
+/// Built by [`resolve_effective`], which is the single place that answers "which
+/// `.hyalo.toml` governs this invocation?". Before iter-201 that question had
+/// two different answers — one in `run.rs` and one in `hyalo config` — and both
+/// of them discarded the caller's config whenever `--dir` was present.
+pub(crate) struct EffectiveConfig {
+    /// The settings the run must use.
+    pub(crate) config: ResolvedDefaults,
+    /// The vault directory to operate on.
+    pub(crate) dir: PathBuf,
+    /// The `.hyalo.toml` actually in effect, or `None` when the run is on
+    /// built-in defaults. Never `None` while a config file was read — that
+    /// mismatch is exactly what made `hyalo config --dir X` lie.
+    pub(crate) config_path: Option<PathBuf>,
+    /// `true` when `--dir` named precisely the vault the CWD config already
+    /// resolves to. The config still applies; the flag was just noise.
+    pub(crate) dir_redundant: bool,
+    /// `true` when `--dir` selected a *different* vault and the CWD did have a
+    /// `.hyalo.toml`, so that file no longer applies to this run.
+    pub(crate) cwd_config_shadowed: bool,
+}
+
+/// Path of the `.hyalo.toml` in `dir`, or `None` when there is no file there.
+fn config_file_in(dir: &Path) -> Option<PathBuf> {
+    let path = dir.join(".hyalo.toml");
+    path.is_file().then_some(path)
+}
+
+/// Resolve the configuration that governs a run.
+///
+/// `cwd_config` is the already-loaded config for the process working directory;
+/// `cli_dir` is the explicit `--dir` value, if any.
+///
+/// The `--dir` semantics (iter-201, H-4):
+///
+/// - **No `--dir`** — the CWD config applies, vault = its `dir`.
+/// - **`--dir` naming the same directory the CWD config resolves to** — the CWD
+///   config *still applies*. Previously hyalo reloaded `.hyalo.toml` from the
+///   vault directory instead, which for the overwhelmingly common layout
+///   (`dir = "docs"`, config at the repo root) meant no config at all: schema,
+///   views, `[lint] ignore`, severity overrides and `site_prefix` were dropped
+///   while the CLI printed "--dir is redundant". `lint --dir <same> --strict`
+///   went vacuously green in CI as a result.
+/// - **`--dir` naming a different directory** — that directory's own
+///   `.hyalo.toml` applies if it has one, else built-in defaults. The caller
+///   announces which, because this is the case where the user's config really
+///   does stop applying.
+pub(crate) fn resolve_effective(
+    cwd_config: ResolvedDefaults,
+    cli_dir: Option<&Path>,
+) -> EffectiveConfig {
+    let cwd_config_path = config_file_in(&cwd_config.config_dir);
+
+    let Some(cli_dir) = cli_dir else {
+        let dir = cwd_config.dir.clone();
+        return EffectiveConfig {
+            config: cwd_config,
+            dir,
+            config_path: cwd_config_path,
+            dir_redundant: false,
+            cwd_config_shadowed: false,
+        };
+    };
+
+    // "Same vault" is decided on canonicalized paths so `--dir ./kb`,
+    // `--dir kb/` and an absolute path all count as the configured vault.
+    let cwd_vault = cwd_config.config_dir.join(&cwd_config.dir);
+    let same_vault = cwd_config.loaded_from_file
+        && match (dunce::canonicalize(cli_dir), dunce::canonicalize(&cwd_vault)) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        };
+
+    if same_vault {
+        return EffectiveConfig {
+            config: cwd_config,
+            dir: cli_dir.to_path_buf(),
+            config_path: cwd_config_path,
+            dir_redundant: true,
+            cwd_config_shadowed: false,
+        };
+    }
+
+    let target = load_config_from(cli_dir);
+    EffectiveConfig {
+        config: target,
+        dir: cli_dir.to_path_buf(),
+        config_path: config_file_in(cli_dir),
+        dir_redundant: false,
+        cwd_config_shadowed: cwd_config_path.is_some(),
+    }
+}
+
+/// The stderr note that names the configuration a `--dir` override switched to.
+///
+/// Returns `None` when nothing was switched away from (no `--dir`, a redundant
+/// `--dir`, or a CWD with no config to lose). Kept as a pure function so the
+/// exact wording is unit-testable without spawning a process.
+pub(crate) fn dir_override_note(effective: &EffectiveConfig) -> Option<String> {
+    if !effective.cwd_config_shadowed {
+        return None;
+    }
+    let dir = effective.dir.display();
+    Some(match &effective.config_path {
+        Some(path) => format!(
+            "--dir {dir} selects a different vault: ./.hyalo.toml does not apply, \
+             {} is in effect",
+            path.display()
+        ),
+        None => format!(
+            "--dir {dir} selects a different vault: ./.hyalo.toml does not apply and \
+             {dir} has no .hyalo.toml — running on built-in defaults"
+        ),
+    })
 }
 
 #[cfg(test)]

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -1285,13 +1285,19 @@ site_prefix = "docs"
         .unwrap();
 
         // Same behaviour as every other unknown key: warn, then fall back to
-        // hardcoded defaults for the whole file (deny_unknown_fields).
+        // hardcoded defaults for the whole file (deny_unknown_fields) — except
+        // `dir`, which is salvaged so read-only commands stay pointed at the
+        // configured vault instead of silently re-rooting (iter-201).
         let _guard = crate::warn::WARN_TEST_LOCK.lock().unwrap();
         crate::warn::reset_for_test();
         crate::warn::init(false);
         let resolved = load_config_from(dir.path());
         assert!(resolved.auto_link_exclude_titles.is_empty());
-        assert_eq!(resolved.dir, PathBuf::from("."));
+        assert_eq!(resolved.dir, PathBuf::from("vault"));
+        assert!(
+            resolved.malformed.is_some(),
+            "an unusable config must be flagged so writers can refuse"
+        );
         assert!(crate::warn::any_tracked_starts_with(
             "malformed .hyalo.toml"
         ));

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -910,6 +910,125 @@ mod tests {
         tempfile::tempdir().expect("failed to create temp dir")
     }
 
+    // ---------------------------------------------------------------------------
+    // resolve_effective / dir_override_note (iter-201, H-4)
+    // ---------------------------------------------------------------------------
+
+    /// A repo-root config pointing at a `kb/` subdirectory — the layout the
+    /// `--dir` bug was worst on.
+    fn make_project() -> TempDir {
+        let dir = make_temp();
+        fs::create_dir_all(dir.path().join("kb")).unwrap();
+        fs::write(
+            dir.path().join(".hyalo.toml"),
+            "dir = \"kb\"\nhints = false\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn resolve_without_dir_keeps_the_cwd_config() {
+        let project = make_project();
+        let effective = resolve_effective(load_config_from(project.path()), None);
+        assert_eq!(effective.dir, PathBuf::from("kb"));
+        assert!(!effective.config.hints, "the config must apply");
+        assert!(effective.config_path.is_some());
+        assert!(!effective.dir_redundant);
+        assert!(!effective.cwd_config_shadowed);
+    }
+
+    #[test]
+    fn resolve_with_dir_naming_the_configured_vault_keeps_the_config() {
+        let project = make_project();
+        let cli_dir = project.path().join("kb");
+        let effective = resolve_effective(load_config_from(project.path()), Some(&cli_dir));
+        assert!(
+            !effective.config.hints,
+            "the CWD config must survive a redundant --dir"
+        );
+        assert_eq!(
+            effective.config_path,
+            Some(project.path().join(".hyalo.toml"))
+        );
+        assert!(effective.dir_redundant);
+        assert!(!effective.cwd_config_shadowed);
+        assert_eq!(dir_override_note(&effective), None);
+    }
+
+    #[test]
+    fn resolve_with_dir_naming_another_tree_drops_the_cwd_config() {
+        let project = make_project();
+        let other = project.path().join("other");
+        fs::create_dir_all(&other).unwrap();
+        let effective = resolve_effective(load_config_from(project.path()), Some(&other));
+        assert!(
+            effective.config.hints,
+            "a different vault must not inherit hints = false"
+        );
+        assert_eq!(effective.config_path, None);
+        assert!(!effective.dir_redundant);
+        assert!(effective.cwd_config_shadowed);
+        let note = dir_override_note(&effective).expect("the switch must be announced");
+        assert!(note.contains("built-in defaults"), "note was: {note}");
+    }
+
+    #[test]
+    fn resolve_with_dir_naming_a_tree_with_its_own_config_uses_that_file() {
+        let project = make_project();
+        let other = project.path().join("other");
+        fs::create_dir_all(&other).unwrap();
+        fs::write(other.join(".hyalo.toml"), "site_prefix = \"other\"\n").unwrap();
+        let effective = resolve_effective(load_config_from(project.path()), Some(&other));
+        assert_eq!(
+            effective.config.site_prefix.as_deref(),
+            Some("other"),
+            "the target's own config must apply"
+        );
+        assert_eq!(effective.config_path, Some(other.join(".hyalo.toml")));
+        let note = dir_override_note(&effective).expect("the switch must be announced");
+        assert!(
+            note.contains(".hyalo.toml is in effect"),
+            "note was: {note}"
+        );
+    }
+
+    #[test]
+    fn resolve_without_a_cwd_config_announces_nothing() {
+        // Nothing is being shadowed, so a `--dir` elsewhere is not news.
+        let dir = make_temp();
+        let other = dir.path().join("other");
+        fs::create_dir_all(&other).unwrap();
+        let effective = resolve_effective(load_config_from(dir.path()), Some(&other));
+        assert!(!effective.cwd_config_shadowed);
+        assert_eq!(dir_override_note(&effective), None);
+    }
+
+    #[test]
+    fn resolve_with_a_malformed_cwd_config_does_not_claim_redundancy() {
+        // A config that did not parse resolves no vault, so `--dir` cannot be
+        // "the same as" anything and must not be called redundant.
+        let dir = make_temp();
+        fs::create_dir_all(dir.path().join("kb")).unwrap();
+        fs::write(dir.path().join(".hyalo.toml"), "dir = \"kb\"\nnope = 1\n").unwrap();
+        let _guard = crate::warn::WARN_TEST_LOCK.lock().unwrap();
+        crate::warn::reset_for_test();
+        crate::warn::init(false);
+        let cli_dir = dir.path().join("kb");
+        let effective = resolve_effective(load_config_from(dir.path()), Some(&cli_dir));
+        assert!(!effective.dir_redundant);
+    }
+
+    #[test]
+    fn salvage_dir_recovers_dir_from_an_otherwise_unusable_file() {
+        assert_eq!(
+            salvage_dir("dir = \"kb\"\nnope = 1\n"),
+            Some(PathBuf::from("kb"))
+        );
+        assert_eq!(salvage_dir("this is not { toml"), None);
+        assert_eq!(salvage_dir("nope = 1\n"), None);
+    }
+
     #[test]
     fn missing_config_returns_defaults() {
         let dir = make_temp();

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -847,7 +847,10 @@ pub(crate) fn resolve_effective(
     // `--dir kb/` and an absolute path all count as the configured vault.
     let cwd_vault = cwd_config.config_dir.join(&cwd_config.dir);
     let same_vault = cwd_config.loaded_from_file
-        && match (dunce::canonicalize(cli_dir), dunce::canonicalize(&cwd_vault)) {
+        && match (
+            dunce::canonicalize(cli_dir),
+            dunce::canonicalize(&cwd_vault),
+        ) {
             (Ok(a), Ok(b)) => a == b,
             _ => false,
         };

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -38,13 +38,24 @@ const SITE_URL_BROKEN_PERCENT: u64 = 95;
 pub struct Hint {
     pub(crate) description: String,
     pub(crate) cmd: String,
+    /// `true` when running `cmd` would modify the vault or `.hyalo.toml`.
+    ///
+    /// Derived from the command text by
+    /// [`crate::mutation::command_line_writes`] rather than set by each hint
+    /// builder, so a new hint cannot be added *without* being classified. The
+    /// `views set …` suggestion sat unmarked among read-only drill-downs until
+    /// iter-201; renderers now separate the two (see
+    /// [`crate::output::format_envelope`]).
+    pub(crate) writes: bool,
 }
 
 impl Hint {
     pub(crate) fn new(description: impl Into<String>, cmd: String) -> Self {
+        let writes = crate::mutation::command_line_writes(&cmd);
         Self {
             description: description.into(),
             cmd,
+            writes,
         }
     }
 
@@ -55,6 +66,7 @@ impl Hint {
         Self {
             description: description.into(),
             cmd: String::new(),
+            writes: false,
         }
     }
 }

--- a/crates/hyalo-cli/src/lib.rs
+++ b/crates/hyalo-cli/src/lib.rs
@@ -6,6 +6,7 @@ mod dispatch;
 mod error;
 pub mod hints;
 mod list_commands;
+mod mutation;
 pub mod output;
 mod output_pipeline;
 mod run;

--- a/crates/hyalo-cli/src/mutation.rs
+++ b/crates/hyalo-cli/src/mutation.rs
@@ -1,0 +1,456 @@
+//! Does this invocation write anything? (iter-201)
+//!
+//! Two features need the same answer and must never disagree:
+//!
+//! - **Config trust (M-2)** — a `.hyalo.toml` that failed to parse leaves the
+//!   run on built-in defaults: a different vault root, no schema, no
+//!   `[lint] ignore`. Reads may proceed on that (loudly); a write must not.
+//! - **Hint marking (M-7)** — the `-> hyalo …` drill-down list mixed a
+//!   `views set …` command, which *writes `.hyalo.toml`*, in among read-only
+//!   suggestions with nothing to distinguish it.
+//!
+//! [`Commands::writes`] answers it from parsed arguments (exact, used by the
+//! config gate). [`command_line_writes`] answers it from a command *string*
+//! (used to mark hints, which are built as text). The two are kept in sync by
+//! `writes_agrees_with_command_line_classifier` in the tests below, which runs
+//! a corpus of command lines through both.
+
+use crate::cli::args::{
+    ChangelogAction, Commands, LinksAction, LintRulesAction, MadrAction, OkfAction,
+    PropertiesAction, TagsAction, TaskAction, TypesAction, ViewsAction,
+};
+
+impl Commands {
+    /// `true` when this invocation will modify the vault, `.hyalo.toml`, or a
+    /// snapshot index on disk.
+    ///
+    /// `--dry-run` makes an otherwise-writing command return `false`: it
+    /// reports what *would* change and touches nothing. Commands that only
+    /// write behind `--apply` (`links fix`, `links auto`, the `okf`/`madr`/
+    /// `changelog` generators) likewise return `false` in their preview form.
+    ///
+    /// `init` and `deinit` are deliberately **not** writers here even though
+    /// they write: they are how a broken `.hyalo.toml` gets repaired, so the
+    /// config gate must never block them. They also short-circuit before the
+    /// gate runs.
+    pub(crate) fn writes(&self) -> bool {
+        match self {
+            // Read-only.
+            Self::Find { .. }
+            | Self::Read { .. }
+            | Self::Summary { .. }
+            | Self::Backlinks { .. }
+            | Self::Config
+            | Self::Completion { .. }
+            | Self::Init { .. }
+            | Self::Deinit => false,
+
+            // Snapshot index files live outside the vault but are still bytes
+            // on disk chosen by config (`dir` decides what gets indexed).
+            Self::CreateIndex { .. } | Self::DropIndex { .. } => true,
+
+            // Scaffolds a new file from a schema type; there is no preview mode.
+            Self::New { .. } => true,
+
+            Self::Set { dry_run, .. }
+            | Self::Remove { dry_run, .. }
+            | Self::Append { dry_run, .. }
+            | Self::Mv { dry_run, .. } => !dry_run,
+
+            Self::Lint {
+                fix,
+                fix_rule,
+                dry_run,
+                ..
+            } => (*fix || fix_rule.is_some()) && !dry_run,
+
+            Self::Task { action } => match action {
+                TaskAction::Read { .. } => false,
+                TaskAction::Toggle { dry_run, .. } | TaskAction::Set { dry_run, .. } => !dry_run,
+            },
+
+            Self::Properties { action } => match action {
+                PropertiesAction::Summary { .. } => false,
+                PropertiesAction::Rename { dry_run, .. } => !dry_run,
+            },
+
+            Self::Tags { action } => match action {
+                TagsAction::Summary { .. } => false,
+                TagsAction::Rename { dry_run, .. } => !dry_run,
+            },
+
+            Self::Views { action } => match action {
+                ViewsAction::List | ViewsAction::Run { .. } => false,
+                ViewsAction::Set { .. } | ViewsAction::Remove { .. } => true,
+            },
+
+            Self::Types { action } => match action {
+                TypesAction::List | TypesAction::Show { .. } => false,
+                TypesAction::Set { dry_run, .. } => !dry_run,
+                TypesAction::Remove { .. } => true,
+            },
+
+            Self::LintRules { action } => match action {
+                LintRulesAction::List { .. } | LintRulesAction::Show { .. } => false,
+                LintRulesAction::Set { dry_run, .. } | LintRulesAction::Remove { dry_run, .. } => {
+                    !dry_run
+                }
+            },
+
+            Self::Links { action } => match action {
+                LinksAction::Fix { apply, dry_run, .. }
+                | LinksAction::Auto { apply, dry_run, .. } => *apply && !dry_run,
+            },
+
+            Self::Okf { action } => match action {
+                OkfAction::Index { apply, dry_run, .. } | OkfAction::Log { apply, dry_run, .. } => {
+                    *apply && !dry_run
+                }
+            },
+
+            Self::Madr { action } => match action {
+                MadrAction::Toc { apply, dry_run, .. } => *apply && !dry_run,
+            },
+
+            Self::Changelog { action } => match action {
+                ChangelogAction::Release { apply, dry_run, .. }
+                | ChangelogAction::Add { apply, dry_run, .. } => *apply && !dry_run,
+            },
+        }
+    }
+}
+
+/// Top-level subcommands (and `group sub` pairs) that write unconditionally.
+///
+/// Kept as data rather than a `match` so the string classifier stays a table a
+/// reviewer can read against `hyalo --help`.
+const ALWAYS_WRITING: &[&[&str]] = &[
+    &["set"],
+    &["remove"],
+    &["append"],
+    &["mv"],
+    &["new"],
+    &["create-index"],
+    &["drop-index"],
+    &["task", "toggle"],
+    &["task", "set"],
+    &["properties", "rename"],
+    &["tags", "rename"],
+    &["views", "set"],
+    &["views", "remove"],
+    &["types", "set"],
+    &["types", "remove"],
+    &["lint-rules", "set"],
+    &["lint-rules", "remove"],
+];
+
+/// Subcommand paths that write only when `--apply` is present.
+const APPLY_GATED: &[&[&str]] = &[
+    &["links", "fix"],
+    &["links", "auto"],
+    &["okf", "index"],
+    &["okf", "log"],
+    &["madr", "toc"],
+    &["changelog", "release"],
+    &["changelog", "add"],
+];
+
+/// Global and subcommand options that take a separate value argument.
+///
+/// Needed so `--dir writes` or `--property status=set` cannot be mistaken for a
+/// subcommand name while scanning for the command path.
+const VALUE_OPTIONS: &[&str] = &[
+    "-d",
+    "--dir",
+    "--format",
+    "--jq",
+    "--site-prefix",
+    "--files-from",
+    "--index",
+    "--index-file",
+    "-f",
+    "--file",
+    "-g",
+    "--glob",
+    "-p",
+    "--property",
+    "-t",
+    "--tag",
+    "--section",
+    "--lines",
+    "--line",
+    "--limit",
+    "--sort",
+    "--task",
+    "--title",
+    "--view",
+    "--status",
+    "--rule",
+    "--rule-prefix",
+    "--fix-rule",
+    "--max-per-rule",
+    "--profile",
+    "--to",
+    "--from",
+    "--threshold",
+    "--min-confidence",
+    "--min-length",
+    "--exclude-title",
+    "--exclude-target-glob",
+    "--ignore-target",
+    "--on-conflict",
+    "--depth",
+    "--recent",
+    "--fields",
+    "--where-property",
+    "--where-tag",
+    "--date",
+    "--category",
+    "--message",
+    "--wrap",
+    "--scope",
+    "--adr-dir",
+    "--severity",
+    "--required",
+    "--default",
+    "--property-type",
+    "--property-values",
+    "--filename-template",
+    "--output",
+    "--target",
+    "--action",
+];
+
+/// Classify an already-tokenized `hyalo …` command line.
+///
+/// `tokens` is the full argv including the leading `hyalo`; quoting must already
+/// be undone. Unknown or unparseable input is reported as writing — a hint the
+/// classifier cannot understand must not be presented as safe.
+#[must_use]
+pub(crate) fn tokens_write(tokens: &[String]) -> bool {
+    let mut path: Vec<&str> = Vec::new();
+    let mut has_apply = false;
+    let mut has_dry_run = false;
+    let mut has_fix = false;
+    let mut skip_value = false;
+
+    for tok in tokens.iter().skip(usize::from(
+        tokens.first().is_some_and(|t| t == "hyalo" || t == "hyalo.exe"),
+    )) {
+        if skip_value {
+            skip_value = false;
+            continue;
+        }
+        if let Some(name) = tok.split('=').next().filter(|_| tok.starts_with('-')) {
+            // `--opt=value` carries its value inline; only the bare form
+            // consumes the next token.
+            if VALUE_OPTIONS.contains(&name) && !tok.contains('=') {
+                skip_value = true;
+            }
+            match name {
+                "--apply" => has_apply = true,
+                "--dry-run" => has_dry_run = true,
+                "--fix" => has_fix = true,
+                "--fix-rule" => has_fix = true,
+                _ => {}
+            }
+            continue;
+        }
+        // Only the first two bare words can form the subcommand path; anything
+        // after that is a positional argument.
+        if path.len() < 2 {
+            path.push(tok);
+        }
+    }
+
+    if has_dry_run {
+        return false;
+    }
+    if path.first() == Some(&"lint") {
+        return has_fix;
+    }
+    let matches = |table: &[&[&str]]| {
+        table
+            .iter()
+            .any(|entry| entry.len() <= path.len() && entry.iter().zip(&path).all(|(a, b)| a == b))
+    };
+    if matches(ALWAYS_WRITING) {
+        return true;
+    }
+    if matches(APPLY_GATED) {
+        return has_apply;
+    }
+    false
+}
+
+/// Classify a `hyalo …` command *string* (as hints carry them).
+///
+/// Undoes shell quoting, then defers to [`tokens_write`].
+#[must_use]
+pub(crate) fn command_line_writes(cmd: &str) -> bool {
+    tokens_write(&split_command_line(cmd))
+}
+
+/// Minimal POSIX-ish tokenizer: splits on whitespace, honoring `'…'` and `"…"`.
+///
+/// The inverse of `hints::shell_quote`, which is the only quoter that produces
+/// the strings this ever sees.
+fn split_command_line(cmd: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut started = false;
+    let mut quote: Option<char> = None;
+    let mut chars = cmd.chars().peekable();
+    while let Some(c) = chars.next() {
+        match quote {
+            Some(q) if c == q => quote = None,
+            Some('\'') if c == '\\' => {
+                // Inside single quotes a backslash is literal, except for the
+                // `'\''` escape shell_quote emits, which the `Some(q)` arm
+                // above already closed.
+                cur.push(c);
+            }
+            Some(_) => cur.push(c),
+            None if c == '\'' || c == '"' => {
+                started = true;
+                quote = Some(c);
+            }
+            None if c == '\\' => {
+                if let Some(next) = chars.next() {
+                    started = true;
+                    cur.push(next);
+                }
+            }
+            None if c.is_whitespace() => {
+                if started {
+                    out.push(std::mem::take(&mut cur));
+                    started = false;
+                }
+            }
+            None => {
+                started = true;
+                cur.push(c);
+            }
+        }
+    }
+    if started {
+        out.push(cur);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::Cli;
+    use clap::Parser as _;
+
+    /// Command lines exercised by both classifiers, with the expected verdict.
+    const CORPUS: &[(&str, bool)] = &[
+        ("hyalo find --property status=draft", false),
+        ("hyalo find 'set the property'", false),
+        ("hyalo summary", false),
+        ("hyalo read notes/a.md --section Tasks", false),
+        ("hyalo backlinks notes/a.md", false),
+        ("hyalo config", false),
+        ("hyalo views list", false),
+        ("hyalo views run planned", false),
+        ("hyalo types list", false),
+        ("hyalo types show iteration", false),
+        ("hyalo lint-rules list", false),
+        ("hyalo lint-rules show MD013", false),
+        ("hyalo tags summary", false),
+        ("hyalo properties summary", false),
+        ("hyalo task read notes/a.md --line 5", false),
+        ("hyalo lint", false),
+        ("hyalo lint --detailed --rule MD013", false),
+        ("hyalo lint --fix --dry-run", false),
+        ("hyalo links fix", false),
+        ("hyalo links auto", false),
+        ("hyalo okf index", false),
+        ("hyalo madr toc", false),
+        ("hyalo changelog release 1.2.0", false),
+        ("hyalo set --property status=done --file notes/a.md", true),
+        (
+            "hyalo set --property status=done --file notes/a.md --dry-run",
+            false,
+        ),
+        ("hyalo remove --property owner --file notes/a.md", true),
+        ("hyalo append --property aliases=Alt --file notes/a.md", true),
+        ("hyalo mv notes/a.md notes/b.md", true),
+        ("hyalo new --file notes/c.md", true),
+        ("hyalo create-index", true),
+        ("hyalo task toggle notes/a.md --line 5", true),
+        ("hyalo task set notes/a.md --line 5 --status doing", true),
+        ("hyalo properties rename --from a --to b", true),
+        ("hyalo tags rename --from a --to b", true),
+        ("hyalo views set my-view --property status=draft", true),
+        ("hyalo views remove my-view", true),
+        ("hyalo types set note --required title", true),
+        ("hyalo lint-rules set MD013 --enabled false", true),
+        ("hyalo lint --fix", true),
+        ("hyalo lint --fix-rule HYALO001", true),
+        ("hyalo links fix --apply", true),
+        ("hyalo links auto --apply", true),
+        ("hyalo okf index --apply", true),
+        ("hyalo madr toc --apply", true),
+        ("hyalo changelog release 1.2.0 --apply", true),
+        ("hyalo --dir kb views set v --tag shared", true),
+        ("hyalo --dir kb --format json find --tag shared", false),
+    ];
+
+    #[test]
+    fn command_line_classifier_matches_the_corpus() {
+        for (cmd, expected) in CORPUS {
+            assert_eq!(
+                command_line_writes(cmd),
+                *expected,
+                "command_line_writes({cmd:?})"
+            );
+        }
+    }
+
+    /// The two classifiers must never disagree: the hint marker would then
+    /// promise "read-only" for something the config gate treats as a write.
+    #[test]
+    fn writes_agrees_with_command_line_classifier() {
+        for (cmd, expected) in CORPUS {
+            let argv = split_command_line(cmd);
+            let Ok(cli) = Cli::try_parse_from(&argv) else {
+                panic!("corpus entry does not parse: {cmd}");
+            };
+            assert_eq!(
+                cli.command.writes(),
+                *expected,
+                "Commands::writes() for {cmd:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_arguments_do_not_leak_into_the_subcommand_path() {
+        // A body search whose *pattern* is the word "set" must stay read-only.
+        assert!(!command_line_writes("hyalo find 'set'"));
+        assert!(!command_line_writes(r#"hyalo find "views set""#));
+    }
+
+    #[test]
+    fn option_values_are_not_mistaken_for_subcommands() {
+        assert!(!command_line_writes("hyalo --dir set find"));
+        assert!(!command_line_writes("hyalo find --property title~=set"));
+    }
+
+    #[test]
+    fn inline_option_values_are_handled() {
+        assert!(!command_line_writes("hyalo --dir=set find"));
+        assert!(command_line_writes("hyalo --dir=kb views set v"));
+    }
+
+    #[test]
+    fn split_command_line_undoes_quoting() {
+        assert_eq!(
+            split_command_line("hyalo find --property 'status=in progress'"),
+            vec!["hyalo", "find", "--property", "status=in progress"]
+        );
+    }
+}

--- a/crates/hyalo-cli/src/mutation.rs
+++ b/crates/hyalo-cli/src/mutation.rs
@@ -45,12 +45,10 @@ impl Commands {
             | Self::Init { .. }
             | Self::Deinit => false,
 
-            // Snapshot index files live outside the vault but are still bytes
-            // on disk chosen by config (`dir` decides what gets indexed).
-            Self::CreateIndex { .. } | Self::DropIndex { .. } => true,
-
-            // Scaffolds a new file from a schema type; there is no preview mode.
-            Self::New { .. } => true,
+            // `create-index`/`drop-index` write a snapshot index file, `new`
+            // scaffolds a markdown file from a schema type. None of the three
+            // has a preview mode.
+            Self::CreateIndex { .. } | Self::DropIndex { .. } | Self::New { .. } => true,
 
             Self::Set { dry_run, .. }
             | Self::Remove { dry_run, .. }
@@ -62,44 +60,50 @@ impl Commands {
                 fix_rule,
                 dry_run,
                 ..
-            } => (*fix || fix_rule.is_some()) && !dry_run,
+            } => (*fix || !fix_rule.is_empty()) && !dry_run,
 
             Self::Task { action } => match action {
                 TaskAction::Read { .. } => false,
                 TaskAction::Toggle { dry_run, .. } | TaskAction::Set { dry_run, .. } => !dry_run,
             },
 
+            // Groups whose `action` is optional default to their read-only
+            // aggregate (`summary` / `list`) when omitted.
             Self::Properties { action } => match action {
-                PropertiesAction::Summary { .. } => false,
-                PropertiesAction::Rename { dry_run, .. } => !dry_run,
+                None | Some(PropertiesAction::Summary { .. }) => false,
+                Some(PropertiesAction::Rename { dry_run, .. }) => !dry_run,
             },
 
             Self::Tags { action } => match action {
-                TagsAction::Summary { .. } => false,
-                TagsAction::Rename { dry_run, .. } => !dry_run,
+                None | Some(TagsAction::Summary { .. }) => false,
+                Some(TagsAction::Rename { dry_run, .. }) => !dry_run,
             },
 
             Self::Views { action } => match action {
-                ViewsAction::List | ViewsAction::Run { .. } => false,
-                ViewsAction::Set { .. } | ViewsAction::Remove { .. } => true,
+                None | Some(ViewsAction::List | ViewsAction::Run { .. }) => false,
+                Some(ViewsAction::Set { .. } | ViewsAction::Remove { .. }) => true,
             },
 
             Self::Types { action } => match action {
-                TypesAction::List | TypesAction::Show { .. } => false,
-                TypesAction::Set { dry_run, .. } => !dry_run,
-                TypesAction::Remove { .. } => true,
+                None | Some(TypesAction::List | TypesAction::Show { .. }) => false,
+                Some(TypesAction::Set { dry_run, .. }) => !dry_run,
+                Some(TypesAction::Remove { .. }) => true,
             },
 
             Self::LintRules { action } => match action {
-                LintRulesAction::List { .. } | LintRulesAction::Show { .. } => false,
-                LintRulesAction::Set { dry_run, .. } | LintRulesAction::Remove { dry_run, .. } => {
-                    !dry_run
-                }
+                None | Some(LintRulesAction::List { .. } | LintRulesAction::Show { .. }) => false,
+                Some(
+                    LintRulesAction::Set { dry_run, .. } | LintRulesAction::Remove { dry_run, .. },
+                ) => !dry_run,
             },
 
+            // `hyalo links` with no subcommand defaults to the `fix` preview.
             Self::Links { action } => match action {
-                LinksAction::Fix { apply, dry_run, .. }
-                | LinksAction::Auto { apply, dry_run, .. } => *apply && !dry_run,
+                None => false,
+                Some(
+                    LinksAction::Fix { apply, dry_run, .. }
+                    | LinksAction::Auto { apply, dry_run, .. },
+                ) => *apply && !dry_run,
             },
 
             Self::Okf { action } => match action {
@@ -235,7 +239,9 @@ pub(crate) fn tokens_write(tokens: &[String]) -> bool {
     let mut skip_value = false;
 
     for tok in tokens.iter().skip(usize::from(
-        tokens.first().is_some_and(|t| t == "hyalo" || t == "hyalo.exe"),
+        tokens
+            .first()
+            .is_some_and(|t| t == "hyalo" || t == "hyalo.exe"),
     )) {
         if skip_value {
             skip_value = false;
@@ -250,8 +256,7 @@ pub(crate) fn tokens_write(tokens: &[String]) -> bool {
             match name {
                 "--apply" => has_apply = true,
                 "--dry-run" => has_dry_run = true,
-                "--fix" => has_fix = true,
-                "--fix-rule" => has_fix = true,
+                "--fix" | "--fix-rule" => has_fix = true,
                 _ => {}
             }
             continue;
@@ -376,7 +381,10 @@ mod tests {
             false,
         ),
         ("hyalo remove --property owner --file notes/a.md", true),
-        ("hyalo append --property aliases=Alt --file notes/a.md", true),
+        (
+            "hyalo append --property aliases=Alt --file notes/a.md",
+            true,
+        ),
         ("hyalo mv notes/a.md notes/b.md", true),
         ("hyalo new --file notes/c.md", true),
         ("hyalo create-index", true),

--- a/crates/hyalo-cli/src/mutation.rs
+++ b/crates/hyalo-cli/src/mutation.rs
@@ -223,6 +223,7 @@ const VALUE_OPTIONS: &[&str] = &[
     "--output",
     "--target",
     "--action",
+    "--type",
 ];
 
 /// Classify an already-tokenized `hyalo …` command line.
@@ -386,7 +387,7 @@ mod tests {
             true,
         ),
         ("hyalo mv notes/a.md notes/b.md", true),
-        ("hyalo new --file notes/c.md", true),
+        ("hyalo new --type note --file notes/c.md", true),
         ("hyalo create-index", true),
         ("hyalo task toggle notes/a.md --line 5", true),
         ("hyalo task set notes/a.md --line 5 --status doing", true),
@@ -397,7 +398,7 @@ mod tests {
         ("hyalo types set note --required title", true),
         ("hyalo lint-rules set MD013 --enabled false", true),
         ("hyalo lint --fix", true),
-        ("hyalo lint --fix-rule HYALO001", true),
+        ("hyalo lint --fix --fix-rule HYALO001", true),
         ("hyalo links fix --apply", true),
         ("hyalo links auto --apply", true),
         ("hyalo okf index --apply", true),

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -157,6 +157,51 @@ pub fn format_output<T: Serialize>(format: Format, value: &T) -> String {
     format_success(format, &json)
 }
 
+/// Serialize one hint for the JSON envelope.
+///
+/// `writes` is always present (never omitted when `false`) so a consumer can
+/// filter on it without having to distinguish "absent" from "read-only"
+/// (iter-201, M-7).
+fn hint_to_json(hint: &crate::hints::Hint) -> serde_json::Value {
+    serde_json::json!({
+        "description": &hint.description,
+        "cmd": &hint.cmd,
+        "writes": hint.writes,
+    })
+}
+
+/// Append the `-> hyalo …` drill-down block to text output.
+///
+/// Mutating suggestions are rendered with a distinct `=>` arrow and a trailing
+/// `[writes]` tag. Before iter-201 a `views set …` command — which rewrites
+/// `.hyalo.toml` — appeared in the same `->` list as read-only drill-downs,
+/// so "run the hints" was not a safe instruction to give an agent.
+fn append_hint_lines(text: &mut String, hints: &[crate::hints::Hint]) {
+    if hints.is_empty() {
+        return;
+    }
+    text.push('\n');
+    for hint in hints {
+        if hint.cmd.is_empty() {
+            // Advice-only hint (no follow-up command). Render the
+            // description directly without the `cmd  # desc` layout.
+            text.push_str("\n  -> ");
+            text.push_str(&hint.description);
+        } else if hint.writes {
+            text.push_str("\n  => ");
+            text.push_str(&hint.cmd);
+            text.push_str("  # ");
+            text.push_str(&hint.description);
+            text.push_str(" [writes]");
+        } else {
+            text.push_str("\n  -> ");
+            text.push_str(&hint.cmd);
+            text.push_str("  # ");
+            text.push_str(&hint.description);
+        }
+    }
+}
+
 /// Build the JSON envelope value: `{"results": ..., "total": <optional>, "hints": [...]}`.
 ///
 /// The envelope is always present even when hints is empty (hints becomes `[]`).
@@ -167,10 +212,7 @@ pub fn build_envelope_value(
     total: Option<u64>,
     hints: &[crate::hints::Hint],
 ) -> serde_json::Value {
-    let hints_json: Vec<serde_json::Value> = hints
-        .iter()
-        .map(|h| serde_json::json!({"description": &h.description, "cmd": &h.cmd}))
-        .collect();
+    let hints_json: Vec<serde_json::Value> = hints.iter().map(hint_to_json).collect();
     let mut envelope = serde_json::json!({
         "results": value,
         "hints": hints_json,
@@ -218,22 +260,7 @@ pub fn format_envelope(
         Format::Text => {
             let mut cache = JaqFilterCache::new();
             let mut text = format_results_as_text(value, total, &mut cache);
-            if !hints.is_empty() {
-                text.push('\n');
-                for hint in hints {
-                    if hint.cmd.is_empty() {
-                        // Advice-only hint (no follow-up command). Render the
-                        // description directly without the `cmd  # desc` layout.
-                        text.push_str("\n  -> ");
-                        text.push_str(&hint.description);
-                    } else {
-                        text.push_str("\n  -> ");
-                        text.push_str(&hint.cmd);
-                        text.push_str("  # ");
-                        text.push_str(&hint.description);
-                    }
-                }
-            }
+            append_hint_lines(&mut text, hints);
             sanitize_control_chars(&text)
         }
     }
@@ -259,22 +286,7 @@ pub fn format_prebuilt_envelope(
         Format::Text => {
             let mut cache = JaqFilterCache::new();
             let mut text = format_results_as_text(results_value, total, &mut cache);
-            if !hints.is_empty() {
-                text.push('\n');
-                for hint in hints {
-                    if hint.cmd.is_empty() {
-                        // Advice-only hint (no follow-up command). Render the
-                        // description directly without the `cmd  # desc` layout.
-                        text.push_str("\n  -> ");
-                        text.push_str(&hint.description);
-                    } else {
-                        text.push_str("\n  -> ");
-                        text.push_str(&hint.cmd);
-                        text.push_str("  # ");
-                        text.push_str(&hint.description);
-                    }
-                }
-            }
+            append_hint_lines(&mut text, hints);
             sanitize_control_chars(&text)
         }
     }

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -740,22 +740,14 @@ fn run_inner() -> Result<(), AppError> {
     let cli_dir_str: Option<String> = cli.dir.as_deref().map(|p| p.to_string_lossy().into_owned());
     let format_from_cli = cli.format.is_some();
     let hints_from_cli = cli.hints;
-    // Save the CWD-derived vault dir for the redundant-dir warning below.
-    // We need this before `config` is potentially shadowed by the target config.
-    let cwd_config_resolved_dir = config.config_dir.join(&config.dir);
+    // Save the CWD config's own `dir` string for the redundant-`--dir` note.
+    // We need it before `config` is potentially shadowed by the target config.
     let cwd_config_dir_str = config.dir.display().to_string();
-    // Whether the CWD `.hyalo.toml` was actually parsed cleanly. Used to gate
-    // the redundant-`--dir` warning so we don't claim a malformed/ignored config
-    // "already sets dir = ...".
-    let cwd_config_parsed_ok = config.loaded_from_file;
-    // Determine the effective vault directory and the config to use:
-    //
-    // - When --dir is explicitly provided on the CLI, validate first, then
-    //   reload .hyalo.toml from the target directory so its schema, format,
-    //   hints, site_prefix, and search config apply — not the caller's CWD
-    //   config.
-    // - Otherwise, keep the CWD config (already loaded) and use its dir.
-    let (dir, config) = if let Some(cli_dir) = cli.dir {
+    // Determine the effective vault directory and the config to use. The
+    // `--dir` semantics live in `config::resolve_effective` so `hyalo config`
+    // and every other command answer "which .hyalo.toml applies?" identically
+    // (iter-201, H-4).
+    if let Some(cli_dir) = cli.dir.as_deref() {
         // Validate before loading config to avoid misleading file-read warnings.
         if !cli_dir.exists() {
             let fmt = early_format(cli.format, cli.jq.is_some(), config.format.as_deref());
@@ -780,12 +772,43 @@ fn run_inner() -> Result<(), AppError> {
                 None,
             )));
         }
-        let target_config = crate::config::load_config_from(&cli_dir);
-        (cli_dir, target_config)
-    } else {
-        let vault_dir = config.dir.clone();
-        (vault_dir, config)
-    };
+    }
+    let effective = crate::config::resolve_effective(config, cli.dir.as_deref());
+    // Announce a `--dir` that switched to a different configuration before the
+    // command runs, so the change of rules is visible in the same stream as the
+    // results it shaped.
+    if let Some(note) = crate::config::dir_override_note(&effective) {
+        crate::warn::note(note);
+    }
+    let crate::config::EffectiveConfig {
+        config,
+        dir,
+        dir_redundant,
+        ..
+    } = effective;
+
+    // A `.hyalo.toml` that exists but could not be parsed leaves the run on
+    // built-in defaults: a different vault root, no schema, no `[lint] ignore`,
+    // no views. Reads may proceed on those defaults (the warning is
+    // `-q`-proof), but a command that *writes* must not — it would edit files
+    // the user did not configure hyalo to touch, using rules they did not
+    // write. Refuse with the parse diagnostic and exit 1 (iter-201, M-2).
+    if let Some(diagnostic) = config.malformed.as_deref()
+        && cli.command.writes()
+    {
+        let fmt = early_format(cli.format, cli.jq.is_some(), config.format.as_deref());
+        return Err(AppError::User(crate::output::format_error(
+            fmt,
+            &format!(
+                "refusing to run a mutating command with an unusable .hyalo.toml \
+                 ({}/.hyalo.toml): {diagnostic}",
+                config.config_dir.display()
+            ),
+            None,
+            Some("Fix the config file, or pass --dir to target a vault whose config parses."),
+            None,
+        )));
+    }
     // The directory where .hyalo.toml lives. Views/types are stored there.
     let config_dir = config.config_dir.clone();
 
@@ -809,22 +832,13 @@ fn run_inner() -> Result<(), AppError> {
         }
     }
 
-    // Warn when --dir is redundant: the user passed a dir that matches what
-    // .hyalo.toml would have resolved to anyway. Only fires when .hyalo.toml
-    // is present AND parsed successfully — otherwise the loader fell back to
-    // defaults and the message would be misleading.
-    if dir_from_cli && cwd_has_config && cwd_config_parsed_ok {
-        // Compare the CLI-provided dir against what the CWD config resolved to.
-        // `cwd_config_resolved_dir` was captured before `config` was shadowed.
-        if let (Ok(a), Ok(b)) = (
-            dunce::canonicalize(&dir),
-            dunce::canonicalize(&cwd_config_resolved_dir),
-        ) && a == b
-        {
-            crate::warn::note(format!(
-                "--dir is redundant; .hyalo.toml already sets dir = \"{cwd_config_dir_str}\""
-            ));
-        }
+    // Note when --dir is redundant: the user passed the dir .hyalo.toml already
+    // resolves to. The config still applies (iter-201) — the flag is simply
+    // noise, which is all this note now claims.
+    if dir_redundant {
+        crate::warn::note(format!(
+            "--dir is redundant; .hyalo.toml already sets dir = \"{cwd_config_dir_str}\""
+        ));
     }
 
     // Validate that the resolved dir exists and is a directory (for the

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -480,7 +480,7 @@ fn run_inner() -> Result<(), AppError> {
 
     // Prepend CWD-aware banner when relevant (info if .hyalo.toml in CWD,
     // warning if running from inside the vault). Shown by both -h and --help.
-    if let Some(banner) = cwd_help_banner() {
+    if let Some(banner) = cwd_help_banner(&config.dir) {
         cmd = cmd.before_help(banner.clone()).before_long_help(banner);
     }
 
@@ -684,13 +684,18 @@ fn run_inner() -> Result<(), AppError> {
                 crate::output::Format::Json
             }
         });
-        // A `--dir` override wins over the config's own `dir`: report the
-        // effective vault directory the rest of the CLI would use, not the
-        // config-file value it shadows (ff-rdp B6). When `--dir` names a
-        // directory that has its own `.hyalo.toml`, load from there.
+        // Report exactly what the rest of the CLI would use, by going through
+        // the shared `--dir` resolution rather than a second, divergent one
+        // (iter-201, H-4). `config` is the command users reach for to *check*
+        // which `.hyalo.toml` applies, so it must not have its own answer.
         let dir_override = cli.dir.as_deref();
-        let report = crate::commands::config::collect_config_report(&cwd, dir_override)
-            .map_err(AppError::Internal)?;
+        let effective = crate::config::resolve_effective(config.clone(), dir_override);
+        if let Some(note) = crate::config::dir_override_note(&effective) {
+            crate::warn::note(note);
+        }
+        let report =
+            crate::commands::config::collect_config_report(&cwd, effective, dir_override.is_some())
+                .map_err(AppError::Internal)?;
 
         // `--jq` operates on the full envelope, exactly as it does for pipeline
         // commands. Before iter-192 the filter was accepted and silently

--- a/crates/hyalo-cli/src/warn.rs
+++ b/crates/hyalo-cli/src/warn.rs
@@ -68,13 +68,48 @@ pub fn note(msg: impl AsRef<str>) {
     emit_with_prefix("note", msg.as_ref());
 }
 
+/// Emit a warning that `--quiet` cannot suppress.
+///
+/// Reserved for **config-integrity** problems (iter-201): a `.hyalo.toml` that
+/// could not be parsed silently changes *which vault* and *which rules* apply.
+/// Letting `-q` hide that turns the flag into "run against a configuration you
+/// did not ask for", which is how `links auto --apply -q` ended up able to
+/// rewrite a different tree than `dir` configured. Dedup still applies, so the
+/// message is printed at most once per run.
+pub fn warn_always(msg: impl AsRef<str>) {
+    emit(&Emit {
+        prefix: "warning",
+        msg: msg.as_ref(),
+        force: true,
+    });
+}
+
 /// Shared backend for [`warn`] and [`note`].
 ///
 /// The dedup key combines `prefix` with `msg` so that a `warn("x")` does not
 /// suppress a later `note("x")` (and vice versa) — the surface forms differ
 /// and a user reading stderr expects to see both.
 fn emit_with_prefix(prefix: &str, msg: &str) {
-    if QUIET.load(Ordering::Relaxed) {
+    emit(&Emit {
+        prefix,
+        msg,
+        force: false,
+    });
+}
+
+/// Arguments for [`emit`], grouped so the function keeps a single parameter and
+/// call sites read as named fields rather than a row of bare positionals.
+struct Emit<'a> {
+    prefix: &'a str,
+    msg: &'a str,
+    /// When `true`, quiet mode does not suppress the message (dedup still does).
+    force: bool,
+}
+
+/// Shared backend for every stderr channel.
+fn emit(args: &Emit<'_>) {
+    let Emit { prefix, msg, force } = *args;
+    if !force && QUIET.load(Ordering::Relaxed) {
         return;
     }
 

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -9,6 +9,12 @@ Prefer `hyalo` CLI for operations on files in this directory:
 - **Inspect config**: `hyalo config` — shows effective dir, config path, hints, format, site_prefix,
   and the `[links.auto]` auto-link settings.
   JSON uses the standard envelope: `hyalo config --jq '.results.dir'`
+- **`--dir` is a vault, not a config**: `--dir <configured-vault>` keeps `.hyalo.toml` in effect
+  (the flag is just redundant); `--dir <other-tree>` switches to that tree's own `.hyalo.toml` — or
+  built-in defaults — and says so on stderr. A `.hyalo.toml` that fails to parse blocks every
+  mutating command with exit 1 (reads continue on defaults, with a `-q`-proof warning).
+- **Hints marked `[writes]`** (`=>` prefix in text, `"writes": true` in JSON) modify the vault or
+  `.hyalo.toml`; `->` hints are read-only and safe to run unattended.
 - **Read frontmatter/metadata**: `hyalo find --file <path>`, `hyalo properties`, `hyalo tags`
 - **Read content/sections**: `hyalo read <path>` or `hyalo read <path> --section "Heading"`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append`

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -121,6 +121,14 @@ lines in text mode, a `"hints"` array in the JSON envelope). Read and follow the
 concrete next commands to explore deeper. Use `--no-hints` to suppress them, or `--jq` which
 suppresses hints automatically.
 
+**Check the `writes` marker before running a hint.** Read-only suggestions are prefixed `->`;
+a suggestion that modifies the vault or `.hyalo.toml` is prefixed `=>` and tagged `[writes]`
+(JSON: `"writes": true` on the hint object). Only the `->` ones are safe to run unattended:
+
+```bash
+hyalo find --tag rust --jq '[.hints[] | select(.writes | not) | .cmd]'
+```
+
 Pipe through `--jq` to reshape output into anything — dashboards, burndowns, reports.
 `--jq` requires JSON output; piping naturally produces JSON, so `--jq` works without
 an explicit `--format json` in most contexts:

--- a/crates/hyalo-cli/tests/e2e/config_trust.rs
+++ b/crates/hyalo-cli/tests/e2e/config_trust.rs
@@ -1,0 +1,495 @@
+//! Config-trust e2e gates (iter-201).
+//!
+//! Three ways a user's `.hyalo.toml` used to stop applying without a signal
+//! strong enough to notice — two of which made CI go vacuously green:
+//!
+//! - **H-4** — an explicit `--dir` naming the *configured* vault discarded the
+//!   whole config (schema, views, `[lint] ignore`, severity overrides) while
+//!   printing "--dir is redundant".
+//! - **M-2** — one malformed key anywhere in the file fell back to *all*
+//!   defaults, including `dir`, and `-q` hid the warning; a mutating command
+//!   would then happily rewrite a tree the config never pointed at.
+//! - **truthfulness** — `hyalo config --dir X` reported `config_path: null`
+//!   while a config was in effect.
+
+use super::common::{hyalo, hyalo_no_hints, md, write_md};
+use std::fs;
+use tempfile::TempDir;
+
+/// A project laid out the way `.hyalo.toml` is normally used: config at the
+/// repo root, vault in a subdirectory, a schema and a `[lint] ignore` entry
+/// that only apply if the config is honored.
+fn build_project(tmp: &TempDir) {
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        md!(r#"
+dir = "kb"
+
+[schema.types.note]
+required = ["title", "type", "status"]
+
+[lint]
+ignore = ["archive/**"]
+
+[views.drafts]
+properties = ["status=draft"]
+"#),
+    )
+    .unwrap();
+
+    let kb = tmp.path().join("kb");
+    // Two notes missing the required `status`: lint findings that only appear
+    // when the schema is loaded.
+    write_md(&kb, "a.md", "---\ntitle: A\ntype: note\n---\n# A\n");
+    write_md(&kb, "b.md", "---\ntitle: B\ntype: note\n---\n# B\n");
+    // Ignored by `[lint] ignore`, so a config-less run reports *more*, not less.
+    write_md(
+        &kb,
+        "archive/old.md",
+        "---\ntitle: Old\ntype: note\n---\n# Old\n",
+    );
+}
+
+/// Parse a JSON envelope from stdout, failing loudly with both streams.
+fn envelope(stdout: &[u8], stderr: &[u8]) -> serde_json::Value {
+    serde_json::from_slice(stdout).unwrap_or_else(|e| {
+        panic!(
+            "not a JSON envelope ({e})\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(stdout),
+            String::from_utf8_lossy(stderr)
+        )
+    })
+}
+
+// ---------------------------------------------------------------------------
+// H-4 — an explicit --dir naming the configured vault keeps the config
+// ---------------------------------------------------------------------------
+
+#[test]
+fn redundant_dir_keeps_the_config_for_lint() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+
+    let without = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--format", "json"])
+        .output()
+        .unwrap();
+    let with = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--dir", "kb", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let a = envelope(&without.stdout, &without.stderr);
+    let b = envelope(&with.stdout, &with.stderr);
+
+    for key in [
+        "errors",
+        "warnings",
+        "files_checked",
+        "files_with_violations",
+    ] {
+        assert_eq!(
+            a["results"][key], b["results"][key],
+            "`lint --dir kb` must report the same `{key}` as a bare `lint`; \
+             without: {a}\nwith: {b}"
+        );
+    }
+    // Not vacuous: the schema really did produce findings.
+    assert!(
+        a["results"]["total"].as_u64().unwrap_or(0) > 0,
+        "fixture stopped producing lint findings: {a}"
+    );
+}
+
+#[test]
+fn redundant_dir_keeps_lint_ignore() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--dir", "kb", "--detailed", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = envelope(&output.stdout, &output.stderr);
+    let text = json.to_string();
+    assert!(
+        !text.contains("archive/old.md"),
+        "`[lint] ignore` must still apply under --dir; got: {text}"
+    );
+}
+
+#[test]
+fn redundant_dir_keeps_schema_types_and_views() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+
+    let types = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["types", "list", "--dir", "kb", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = envelope(&types.stdout, &types.stderr);
+    assert_eq!(
+        json["total"].as_u64(),
+        Some(1),
+        "the `note` type must survive --dir: {json}"
+    );
+
+    let views = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["views", "list", "--dir", "kb", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = envelope(&views.stdout, &views.stderr);
+    assert_eq!(
+        json["total"].as_u64(),
+        Some(1),
+        "the `drafts` view must survive --dir: {json}"
+    );
+}
+
+#[test]
+fn redundant_dir_still_says_so_but_no_longer_claims_the_config_is_gone() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["summary", "--dir", "kb", "--format", "json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--dir is redundant"),
+        "the redundancy note stays; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("does not apply"),
+        "a redundant --dir does not shadow anything; stderr: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// H-4 — a --dir naming a *different* vault says which config is in effect
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dir_to_another_tree_announces_that_the_cwd_config_no_longer_applies() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+    let other = tmp.path().join("other");
+    write_md(&other, "c.md", "---\ntitle: C\n---\n# C\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["summary", "--dir", "other", "--format", "json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not apply") && stderr.contains("built-in defaults"),
+        "switching vaults must name the config in effect; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn dir_to_a_tree_with_its_own_config_names_that_file() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+    let other = tmp.path().join("other");
+    fs::create_dir_all(&other).unwrap();
+    fs::write(other.join(".hyalo.toml"), "hints = false\n").unwrap();
+    write_md(&other, "c.md", "---\ntitle: C\n---\n# C\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["summary", "--dir", "other", "--format", "json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not apply") && stderr.contains(".hyalo.toml is in effect"),
+        "the target's own config must be named; stderr: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// H-4 — `hyalo config` tells the truth and emits runnable hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_reports_the_config_path_under_a_redundant_dir() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["config", "--dir", "kb", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = envelope(&output.stdout, &output.stderr);
+    let path = json["results"]["config_path"]
+        .as_str()
+        .unwrap_or_else(|| panic!("config_path must not be null while a config applies: {json}"));
+    assert!(
+        path.ends_with(".hyalo.toml"),
+        "unexpected config_path: {path}"
+    );
+}
+
+#[test]
+fn config_hints_omit_dir_when_it_was_not_overridden() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["config", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = envelope(&output.stdout, &output.stderr);
+    let hints = json["hints"].as_array().cloned().unwrap_or_default();
+    assert!(!hints.is_empty(), "config must emit hints: {json}");
+    for hint in &hints {
+        let cmd = hint["cmd"].as_str().unwrap_or_default();
+        assert!(
+            !cmd.contains("--dir"),
+            "a non-overridden config must not suggest --dir: {cmd}"
+        );
+        assert_eq!(
+            hint["writes"].as_bool(),
+            Some(false),
+            "config drill-downs are read-only: {hint}"
+        );
+    }
+}
+
+#[test]
+fn config_hints_run_and_return_non_degraded_results() {
+    let tmp = TempDir::new().unwrap();
+    build_project(&tmp);
+
+    let output = hyalo()
+        .current_dir(tmp.path())
+        .args(["config", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = envelope(&output.stdout, &output.stderr);
+    for hint in json["hints"].as_array().cloned().unwrap_or_default() {
+        let cmd = hint["cmd"].as_str().unwrap_or_default();
+        let argv: Vec<&str> = cmd.split_whitespace().skip(1).collect();
+        let run = hyalo()
+            .current_dir(tmp.path())
+            .args(&argv)
+            .args(["--format", "json"])
+            .output()
+            .unwrap();
+        let result = envelope(&run.stdout, &run.stderr);
+        assert!(
+            result.get("error").is_none(),
+            "config hint `{cmd}` failed: {result}"
+        );
+        // "Non-degraded" concretely: `types list` must still see the schema.
+        if cmd.contains("types list") {
+            assert_eq!(
+                result["total"].as_u64(),
+                Some(1),
+                "config hint `{cmd}` returned a config-less result: {result}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// M-2 — a malformed .hyalo.toml blocks writes and cannot be silenced
+// ---------------------------------------------------------------------------
+
+/// A project whose config has one unknown key — everything else is valid.
+fn build_malformed_project(tmp: &TempDir) {
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "dir = \"kb\"\nbogus_key = 1\n",
+    )
+    .unwrap();
+    write_md(
+        &tmp.path().join("kb"),
+        "a.md",
+        "---\ntitle: A\n---\n# A\n\n- [ ] open\n",
+    );
+}
+
+#[test]
+fn malformed_config_refuses_a_mutating_command_and_touches_nothing() {
+    let tmp = TempDir::new().unwrap();
+    build_malformed_project(&tmp);
+    let note = tmp.path().join("kb").join("a.md");
+    let before = fs::read(&note).unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "set",
+            "--property",
+            "status=done",
+            "--file",
+            "a.md",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a writer on an unusable config must exit 1; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // User errors are emitted as a JSON object on stderr; the config warning
+    // precedes it, so parse from the first `{`.
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let json: serde_json::Value = serde_json::from_str(
+        &stderr[stderr
+            .find('{')
+            .unwrap_or_else(|| panic!("no JSON error on stderr: {stderr}"))..],
+    )
+    .unwrap_or_else(|e| panic!("stderr is not a JSON error ({e}): {stderr}"));
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("unusable .hyalo.toml"),
+        "unexpected error: {json}"
+    );
+    assert_eq!(
+        fs::read(&note).unwrap(),
+        before,
+        "the refused command must not have written"
+    );
+}
+
+#[test]
+fn malformed_config_refuses_links_auto_apply_even_under_quiet() {
+    let tmp = TempDir::new().unwrap();
+    build_malformed_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["links", "auto", "--apply", "-q", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "`links auto --apply -q` must not proceed on defaults; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("malformed .hyalo.toml"),
+        "the config diagnostic must survive -q; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn malformed_config_still_warns_on_a_read_under_quiet() {
+    let tmp = TempDir::new().unwrap();
+    build_malformed_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["summary", "-q", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "reads still work on a malformed config"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("malformed .hyalo.toml"),
+        "config-integrity warnings are not chatter; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn malformed_config_allows_a_dry_run() {
+    let tmp = TempDir::new().unwrap();
+    build_malformed_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "set",
+            "--property",
+            "status=done",
+            "--file",
+            "a.md",
+            "--dry-run",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--dry-run writes nothing, so it is not gated; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn malformed_config_keeps_the_configured_dir_for_reads() {
+    // `dir` is salvaged from an otherwise-unusable file, so a read does not
+    // silently re-root at the config directory and scan the whole repo.
+    let tmp = TempDir::new().unwrap();
+    build_malformed_project(&tmp);
+    write_md(
+        tmp.path(),
+        "outside.md",
+        "---\ntitle: Outside\n---\n# Outside\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = envelope(&output.stdout, &output.stderr);
+    let text = json.to_string();
+    assert!(
+        !text.contains("outside.md"),
+        "a salvaged `dir` must keep reads inside the vault: {text}"
+    );
+}
+
+#[test]
+fn malformed_config_reports_once_not_twice() {
+    // The loader used to parse `.hyalo.toml` twice per invocation, so every run
+    // ended with "1 additional identical warning(s) suppressed" (dogfood L-14).
+    let tmp = TempDir::new().unwrap();
+    build_malformed_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("malformed .hyalo.toml").count(),
+        1,
+        "the diagnostic must be emitted exactly once; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("additional identical warning"),
+        "no suppression notice means no double parse; stderr: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/hint_execution.rs
+++ b/crates/hyalo-cli/tests/e2e/hint_execution.rs
@@ -118,6 +118,11 @@ const SEED_COMMANDS: &[&[&str]] = &[
     &["find", "--task", "todo"],
     &["find", "--property", "status=draft"],
     &["find", "--tag", "shared"],
+    // Two view-serializable filter dimensions on a single-file result set, so
+    // the "Save this query as a view" hint fires without being crowded out of
+    // the MAX_HINTS budget — that hint is the one that writes `.hyalo.toml`
+    // (iter-201, M-7).
+    &["find", "--property", "status=draft", "--tag", "topic-3"],
     &["tags", "summary"],
     &["properties", "summary"],
     &["backlinks", "notes/note-1.md"],
@@ -166,6 +171,8 @@ struct Harvested {
     seed: String,
     description: String,
     cmd: String,
+    /// The `writes` marker the CLI attached to the hint (iter-201, M-7).
+    writes: bool,
 }
 
 /// Run one seed command and collect the hints from its JSON envelope.
@@ -206,6 +213,14 @@ fn harvest(seed: &[&str]) -> Vec<Harvested> {
                             .unwrap_or_default()
                             .to_owned(),
                         cmd: cmd.to_owned(),
+                        // Absent `writes` is a bug in the envelope, not a
+                        // read-only hint: default to `true` so a missing marker
+                        // surfaces as an unexpected mutation rather than a
+                        // silently skipped check.
+                        writes: h
+                            .get("writes")
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(true),
                     })
                 })
                 .collect()
@@ -375,5 +390,180 @@ fn to_argv_injects_dir_when_the_hint_omits_it() {
             "--limit",
             "0"
         ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Side-effect gate (iter-201, M-7)
+// ---------------------------------------------------------------------------
+//
+// The gate above proves every hint *runs*. It says nothing about what running
+// it does. `hyalo find --property … --tag …` used to suggest a `views set …`
+// command that rewrites `.hyalo.toml`, rendered in the same `-> hyalo …` list
+// as read-only drill-downs — so "run the hints to explore" was not safe advice
+// to give an agent. Hints now carry a `writes` flag; this gate holds the flag
+// honest by running every hint marked read-only and diffing the vault.
+
+/// A content fingerprint of every file under `root`, including `.hyalo.toml`.
+///
+/// Sorted vault-relative paths paired with their bytes, so the comparison
+/// catches creations, deletions, and in-place edits alike.
+fn snapshot(root: &Path) -> Vec<(String, Vec<u8>)> {
+    fn walk(dir: &Path, root: &Path, out: &mut Vec<(String, Vec<u8>)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, root, out);
+            } else if let Ok(bytes) = std::fs::read(&path) {
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                out.push((rel, bytes));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// Describe how two snapshots differ, or `None` when they are identical.
+fn describe_diff(before: &[(String, Vec<u8>)], after: &[(String, Vec<u8>)]) -> Option<String> {
+    let mut changes: Vec<String> = Vec::new();
+    for (path, bytes) in after {
+        match before.iter().find(|(p, _)| p == path) {
+            None => changes.push(format!("created {path}")),
+            Some((_, old)) if old != bytes => changes.push(format!("modified {path}")),
+            Some(_) => {}
+        }
+    }
+    for (path, _) in before {
+        if !after.iter().any(|(p, _)| p == path) {
+            changes.push(format!("deleted {path}"));
+        }
+    }
+    (!changes.is_empty()).then(|| changes.join(", "))
+}
+
+/// Every hint the CLI presents as read-only must leave the vault byte-identical.
+#[test]
+fn unmarked_hints_have_no_side_effects() {
+    let harvested: Vec<Harvested> = SEED_COMMANDS.iter().flat_map(|s| harvest(s)).collect();
+    let read_only: Vec<&Harvested> = harvested.iter().filter(|h| !h.writes).collect();
+
+    assert!(
+        read_only.len() >= 20,
+        "only {} read-only hints harvested — the gate would be near-vacuous",
+        read_only.len()
+    );
+
+    let mut failures: Vec<String> = Vec::new();
+    for h in read_only {
+        let tmp = TempDir::new().unwrap();
+        build_fixture(tmp.path());
+        let before = snapshot(tmp.path());
+        let argv = to_argv(&h.cmd, tmp.path());
+        let _ = hyalo().args(&argv).output().unwrap();
+        let after = snapshot(tmp.path());
+        if let Some(diff) = describe_diff(&before, &after) {
+            failures.push(format!(
+                "  hint from `hyalo {}`\n    description: {}\n    command:     {}\n    changed:     {diff}",
+                h.seed, h.description, h.cmd
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} hint(s) presented as read-only modified the vault:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// At least one hint must actually be *marked* as writing, otherwise
+/// `unmarked_hints_have_no_side_effects` could pass by the marker being applied
+/// to everything.
+#[test]
+fn the_views_set_hint_is_marked_as_writing() {
+    let harvested: Vec<Harvested> =
+        harvest(&["find", "--property", "status=draft", "--tag", "topic-3"]);
+    let views_set = harvested
+        .iter()
+        .find(|h| h.cmd.contains("views set"))
+        .unwrap_or_else(|| {
+            panic!(
+                "the save-as-view hint stopped firing; harvested: {:?}",
+                harvested.iter().map(|h| &h.cmd).collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        views_set.writes,
+        "`{}` writes .hyalo.toml but is not marked",
+        views_set.cmd
+    );
+}
+
+/// The marker must reach text output too — JSON consumers are not the only
+/// audience, and the plain `->` list is what a human reads.
+#[test]
+fn text_output_distinguishes_writing_hints() {
+    let tmp = TempDir::new().unwrap();
+    build_fixture(tmp.path());
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=draft",
+            "--tag",
+            "topic-3",
+            "--format",
+            "text",
+            "--hints",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let writing_line = stdout
+        .lines()
+        .find(|l| l.contains("views set"))
+        .unwrap_or_else(|| panic!("no views-set hint in text output:\n{stdout}"));
+    assert!(
+        writing_line.trim_start().starts_with("=>"),
+        "writing hint must use the `=>` arrow, got: {writing_line}"
+    );
+    assert!(
+        writing_line.ends_with("[writes]"),
+        "writing hint must be tagged [writes], got: {writing_line}"
+    );
+    assert!(
+        stdout.lines().any(|l| l.trim_start().starts_with("-> ")),
+        "read-only hints must keep the `->` arrow:\n{stdout}"
+    );
+}
+
+/// The snapshot helper must notice a change, or the gate above is decorative.
+#[test]
+fn snapshot_diff_detects_a_write() {
+    let tmp = TempDir::new().unwrap();
+    build_fixture(tmp.path());
+    let before = snapshot(tmp.path());
+    let argv = to_argv(
+        "hyalo set --property touched=true --file notes/note-1.md",
+        tmp.path(),
+    );
+    let _ = hyalo().args(&argv).output().unwrap();
+    let after = snapshot(tmp.path());
+    let diff = describe_diff(&before, &after).expect("a write must show up as a diff");
+    assert!(
+        diff.contains("modified notes/note-1.md"),
+        "unexpected diff: {diff}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -9,6 +9,7 @@ mod changelog_profile;
 mod completion;
 mod config;
 mod config_dir;
+mod config_trust;
 mod count;
 mod cwd_features;
 mod errors;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,58 @@ type = "enum"
 values = ["planned", "in-progress", "completed", "superseded"]
 ```
 
+## Config resolution: which `.hyalo.toml` applies
+
+hyalo reads **one** `.hyalo.toml` per run — the one in the current working
+directory. It does not merge configs and does not walk up the directory tree.
+`dir` inside that file names the vault, resolved relative to the config file, so
+the standard layout is a config at the repo root and a vault in a subdirectory:
+
+```text
+my-project/
+  .hyalo.toml        # dir = "kb"  → this is the config in effect
+  kb/                # the vault
+```
+
+### What `--dir` does
+
+| Invocation | Config in effect | Vault |
+| --- | --- | --- |
+| `hyalo lint` (from `my-project/`) | `my-project/.hyalo.toml` | `kb/` |
+| `hyalo lint --dir kb` | `my-project/.hyalo.toml` | `kb/` |
+| `hyalo lint --dir other` | `other/.hyalo.toml` if it exists, else built-in defaults | `other/` |
+
+`--dir` names a **vault**, not a config. When it resolves to the directory the
+config already points at, the config keeps applying and hyalo emits a one-time
+`note:` that the flag is redundant. When it names a different tree, the CWD
+config no longer applies and hyalo says so on stderr, naming the config file
+that took over (or reporting that it is running on built-in defaults).
+
+> **Changed in 0.21.0.** `--dir <configured-vault>` used to *discard* the
+> config: schema, saved views, `[lint] ignore`, per-rule severity overrides and
+> `site_prefix` were all silently dropped, which could turn a `lint --strict` CI
+> gate vacuously green. Run `hyalo config --dir <path>` to see exactly which
+> file is in effect for any invocation.
+
+### When `.hyalo.toml` cannot be parsed
+
+An unknown key or a type error anywhere in the file — including inside
+`[links.auto]` or `[schema.*]` — makes the whole file unusable. hyalo then:
+
+- prints the parse diagnostic (with line, column and the accepted key names).
+  This warning is **not** suppressed by `--quiet`: a config that stopped
+  applying changes which vault and which rules a command uses, so it is not
+  chatter;
+- **refuses mutating commands** (`set`, `remove`, `append`, `mv`, `new`,
+  `task toggle`, `views set`, `links auto --apply`, `lint --fix`, …) with exit
+  code 1, writing nothing. `--dry-run` invocations are unaffected;
+- lets read-only commands continue on built-in defaults, keeping the `dir` value
+  if it can still be recovered from the file, so reads stay inside the vault you
+  configured.
+
+`hyalo init` and `hyalo deinit` are never blocked — they are how a broken config
+gets repaired.
+
 ## Case-insensitive link resolution
 
 `[links] case_insensitive` controls whether a link whose target differs only in
@@ -162,7 +214,25 @@ When you run hyalo from a directory that has a `.hyalo.toml`, it becomes _contex
 - **`hyalo summary`** includes the resolved `kb dir:` as its first output line. The `--format json` envelope exposes the same value as a top-level `dir` field alongside `total`, `tags`, `properties`, etc.
 - **`hyalo config`** prints the full resolved configuration — handy for debugging `.hyalo.toml` resolution or feeding config into an LLM context. `--format json` uses the standard envelope, so `hyalo config --jq '.results.dir'` works like it does everywhere else; the config's own hints switch is reported as `results.hints_enabled` so it never collides with the envelope's `hints` array. `dir` is also hoisted to the envelope root.
 - Running from _inside_ the vault directory emits a warning banner suggesting you `cd ..` to the project root so hyalo can find `.hyalo.toml`.
-- Passing `--dir <path>` when it already matches `.hyalo.toml` emits a one-time `note:` that `--dir` is redundant.
+- Passing `--dir <path>` when it already matches `.hyalo.toml` emits a one-time `note:` that `--dir` is redundant. The config still applies — see [Config resolution](#config-resolution-which-hyalotoml-applies).
+
+## Drill-down hints
+
+Commands append a short list of follow-up commands unless `hints = false` (or
+`--no-hints`) is set. Read-only suggestions use `->`; a suggestion that would
+**write** to the vault or to `.hyalo.toml` uses `=>` and is tagged `[writes]`:
+
+```text
+  -> hyalo find --property status=draft --tag rust  # Narrow by tag: rust (3 files)
+  => hyalo views set draft-rust --property status=draft --tag rust  # Save this query as a view [writes]
+```
+
+In `--format json` every hint object carries a boolean `writes` field, so an
+agent can execute the read-only ones unattended:
+
+```sh
+hyalo find --tag rust --format json --jq '[.hints[] | select(.writes | not) | .cmd]'
+```
 
 ## Snapshot index
 

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -1237,3 +1237,94 @@ run.
 **Not done:** counter-flags for `exclude_titles` / `exclude_target_globs`. They
 are unioned lists, so "ignore the config's list for this run" is a different
 and larger question (partial vs. total override) with no demand behind it.
+
+## DEC-069: `--dir` selects a vault, not a config (2026-08-22)
+
+**Decision:** `--dir <path>` names the *vault* to operate on and never decides,
+on its own, which `.hyalo.toml` applies. Resolution is now a single function,
+`config::resolve_effective`, used by every command including `hyalo config`:
+
+1. **No `--dir`** — the CWD's `.hyalo.toml` applies; the vault is its `dir`.
+2. **`--dir` canonicalizing to the vault that config already resolves to** — the
+   CWD config *still applies*. The existing `note: --dir is redundant` stays,
+   because the flag genuinely adds nothing.
+3. **`--dir` naming a different directory** — that directory's own
+   `.hyalo.toml` applies if present, else built-in defaults. Either way hyalo
+   writes a `note:` on stderr naming the file that took over, because this is
+   the case where the user's config really does stop applying.
+
+`hyalo config --dir X` reports exactly this, so `config_path` is never `null`
+while a config was read.
+
+**Why:** [[dogfood-results/dogfood-v0210-pre-release-iters-191-198]] H-4. Case 2
+is the overwhelmingly common layout — config at the repo root with
+`dir = "hyalo-knowledgebase"` — and hyalo's behaviour there was to reload
+`.hyalo.toml` from *inside* the vault, find nothing, and run on built-in
+defaults: no schema, no views, no `[lint] ignore`, no severity overrides, no
+`site_prefix`, no changelog path. Measured on this repo, `lint --dir
+hyalo-knowledgebase --strict` reported 125 files/694 warnings against the
+config-honoring run's 4 warnings — a CI gate written with the flag was
+inspecting a different rule set than the one the project maintains, and hyalo's
+own hint output emitted `--dir`-bearing commands that walked users into it. The
+"redundant" note made it worse by asserting the two forms were equivalent.
+
+**Why not "always load the target dir's config":** that is what the code did,
+and it is only coherent if `--dir` is understood as "switch projects". But
+`--dir` is documented as "root directory for resolving all file and --glob
+paths" and is what `hyalo config`'s own hints emit — it reads as a path
+argument, not a project switch. Making case 2 a no-op restores the property the
+flag's name implies.
+
+**Why not walk ancestors for a config in case 3:** hyalo has never merged or
+inherited configs, and an ancestor walk would make `--dir /tmp/scratch` silently
+pick up whatever config sits above `/tmp`. Case 3 keeps the existing rule (own
+file or defaults) and only adds the stderr note.
+
+**Consequence:** breaking for anyone who used `--dir <configured-vault>` as a
+way to *ignore* the local config. Called out in the changelog with the
+migration (point `--dir` outside the configured vault instead).
+
+## DEC-070: unusable `.hyalo.toml` is fatal for writers, advisory for readers (2026-08-22)
+
+**Decision:** A `.hyalo.toml` that exists but does not parse sets
+`ResolvedDefaults::malformed`. Commands that would actually write — per
+`Commands::writes()`, which excludes `--dry-run` and preview-only forms — exit 1
+with the parse diagnostic and touch nothing. Read-only commands continue on
+built-in defaults, except that `dir` is salvaged from the file when a lenient
+re-read can still find it. The diagnostic is emitted through
+`warn::warn_always`, which `--quiet` cannot suppress. `init`/`deinit` are never
+blocked.
+
+**Why:** dogfood M-2. One unknown key anywhere in the file discarded everything
+including `dir`, so `hyalo links auto --apply -q` could rewrite a tree the
+config never pointed at, with no output at all. The asymmetry is deliberate: a
+read on the wrong defaults produces a confusing answer the user can discard; a
+write produces edits they have to find and undo. Salvaging `dir` narrows even
+the read case to "wrong rules" rather than "wrong tree".
+
+**Why `-q` does not apply:** `--quiet` exists to suppress per-file chatter in
+scripts. A config that stopped applying is not chatter — it changes which vault
+and which rules the command used, which is precisely the thing a script author
+must not miss.
+
+## DEC-071: hints carry a `writes` flag, derived not declared (2026-08-22)
+
+**Decision:** `Hint` gains a `writes: bool`, computed inside `Hint::new` from
+the command string by `mutation::command_line_writes` rather than passed in by
+each hint builder. Text output renders writing hints with a `=>` arrow and a
+trailing `[writes]` tag; the JSON envelope always includes `"writes"`. An e2e
+gate harvests every hint the CLI emits, runs the ones marked read-only, and
+fails on any byte-level change to the vault or `.hyalo.toml`.
+
+**Why:** dogfood M-7. `hyalo find` with two or more filters suggests
+`hyalo views set …`, which rewrites `.hyalo.toml`, in the same `-> hyalo …`
+list as read-only drill-downs. "Follow the hints" is standing instruction in
+this repo's `CLAUDE.md`, so an unmarked mutation is a trap for exactly the
+audience hints are written for.
+
+**Why derived rather than declared:** a `Hint::writing(…)` constructor is one
+that a future hint site can forget to use, and the failure mode is silent. A
+classifier in `Hint::new` cannot be bypassed. Its risk — misclassification —
+is covered two ways: `mutation::tests` runs a command corpus through both the
+string classifier and the typed `Commands::writes()` and asserts they agree, and
+the e2e gate independently proves the read-only marker by executing the hints.

--- a/hyalo-knowledgebase/iterations/iteration-201-config-trust.md
+++ b/hyalo-knowledgebase/iterations/iteration-201-config-trust.md
@@ -2,7 +2,7 @@
 title: Iteration 201 — config trust (no silent config discard)
 type: iteration
 date: 2026-08-18
-status: planned
+status: completed
 branch: iter-201/config-trust
 tags:
   - iteration
@@ -49,44 +49,44 @@ Repros in [[dogfood-results/dogfood-v0210-pre-release-iters-191-198]]
 
 ## Tasks
 
-- [ ] H-4 decision first, recorded as a DEC entry: when `--dir` equals the
+- [x] H-4 decision first, recorded as a DEC entry: when `--dir` equals the
       configured dir, the config MUST apply (the note stays, minus the
       lie). When `--dir` names a different directory, pick one semantic
       and implement it everywhere: load that directory's own
       `.hyalo.toml` if present, else defaults — and say which config file
       is in effect on stderr. `hyalo config --dir X` must report the truth
       (`config_path` never silently null while a config was read).
-- [ ] H-4: stop emitting `--dir` in hints when the flag would change which
+- [x] H-4: stop emitting `--dir` in hints when the flag would change which
       config applies (hint builders already thread flags — reuse that).
-- [ ] M-2: a malformed `.hyalo.toml` must NOT fall back to all-defaults
+- [x] M-2: a malformed `.hyalo.toml` must NOT fall back to all-defaults
       for mutating commands — hard error, exit 1, with today's excellent
       parse diagnostics. Read-only commands may keep the
       warn-and-defaults behavior, but the warning must survive `-q`
       (config-integrity warnings are not chatter).
-- [ ] M-2: fix the double-parse (config parsed twice per invocation per
+- [x] M-2: fix the double-parse (config parsed twice per invocation per
       the dedup notice).
-- [ ] M-7: mutating hints get a distinct marker (e.g. `=> … # writes
+- [x] M-7: mutating hints get a distinct marker (e.g. `=> … # writes
       .hyalo.toml`) or move to a separate labelled block. The iter-192
       hint-execution e2e gate must then assert that every UNMARKED hint is
       side-effect-free (run it, snapshot-diff the vault + config).
-- [ ] e2e: `--dir` same-dir keeps schema/views/lint config (assert the 4
+- [x] e2e: `--dir` same-dir keeps schema/views/lint config (assert the 4
       HYALO002 warnings appear WITH the flag); malformed-config mutation
       refusal; `-q` still shows the config warning on reads.
-- [ ] Docs: configuration.md section on config resolution order and the
+- [x] Docs: configuration.md section on config resolution order and the
       `--dir` semantics; CHANGELOG (breaking if H-4 changes `--dir`
       behavior — call it out).
 
 ## Acceptance criteria
 
-- [ ] `hyalo lint --dir hyalo-knowledgebase --strict` reports the same
+- [x] `hyalo lint --dir hyalo-knowledgebase --strict` reports the same
       findings as without the flag (repo KB: 4 warnings, not vacuous
       green)
-- [ ] Every hint emitted by `hyalo config` runs and returns non-degraded
+- [x] Every hint emitted by `hyalo config` runs and returns non-degraded
       results
-- [ ] `hyalo set`/`links auto`/any writer exits 1 on a malformed
+- [x] `hyalo set`/`links auto`/any writer exits 1 on a malformed
       `.hyalo.toml` and touches nothing
-- [ ] No unmarked hint mutates anything (gate-enforced)
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] No unmarked hint mutates anything (gate-enforced)
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q` all clean
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-201-config-trust.md
+++ b/hyalo-knowledgebase/iterations/iteration-201-config-trust.md
@@ -47,7 +47,7 @@ Repros in [[dogfood-results/dogfood-v0210-pre-release-iters-191-198]]
   `.hyalo.toml`, emitted in the same `-> hyalo …` list as read-only
   drill-downs when 2+ filters combine.
 
-## Tasks
+## Tasks [7/7]
 
 - [x] H-4 decision first, recorded as a DEC entry: when `--dir` equals the
       configured dir, the config MUST apply (the note stays, minus the
@@ -76,7 +76,7 @@ Repros in [[dogfood-results/dogfood-v0210-pre-release-iters-191-198]]
       `--dir` semantics; CHANGELOG (breaking if H-4 changes `--dir`
       behavior — call it out).
 
-## Acceptance criteria
+## Acceptance criteria [5/5]
 
 - [x] `hyalo lint --dir hyalo-knowledgebase --strict` reports the same
       findings as without the flag (repo KB: 4 warnings, not vacuous


### PR DESCRIPTION
## Summary

Closes the "config silently discarded" family from the v0.21.0-pre dogfood report (H-4, M-2, M-7, L-14). Common thread: the user's `.hyalo.toml` stopped applying with no signal strong enough to notice, and in two cases CI went vacuously green.

- **H-4 — `--dir` no longer discards the config (BREAKING).** `--dir` names a *vault*, not a config. When it resolves to the directory `.hyalo.toml` already points at (the standard repo-root layout: config at the root, `dir = "kb"`), that config now stays in effect. Previously hyalo reloaded `.hyalo.toml` from *inside* the vault, found nothing, and ran on built-in defaults — dropping schema, saved views, `[lint] ignore`, severity overrides, `site_prefix` and the changelog path, while printing "--dir is redundant". Measured on this repo: `lint --dir hyalo-knowledgebase --strict` reported **125 files / 694 warnings** before, **4 warnings** (matching the bare `lint`) after. When `--dir` names a *different* tree, behaviour is unchanged but hyalo now names the config that took over on stderr. All of this comes from one new function, `config::resolve_effective`, which `hyalo config` also uses — so `config_path` is never `null` while a config is in effect, and `config`'s own hints no longer emit a `--dir` that would change which config applies. Recorded as **DEC-069**.
- **M-2 — a malformed `.hyalo.toml` blocks writers (BREAKING).** One unknown key or type error anywhere in the file discarded *everything* including `dir`, so `links auto --apply -q` could rewrite a different tree than the one configured, silently. Writers now exit 1 with the parse diagnostic and touch nothing (`--dry-run` and `init`/`deinit` unaffected); reads continue on defaults but keep a salvaged `dir`, and the warning is emitted through a new `warn::warn_always` that `--quiet` cannot suppress. Recorded as **DEC-070**.
- **M-7 — mutating hints are marked.** `hyalo find` with 2+ filters suggests `views set …`, which writes `.hyalo.toml`, rendered in the same `-> hyalo …` list as read-only drill-downs. Writing hints now render `=> … [writes]` in text and carry `"writes": true` in JSON. The flag is *derived* in `Hint::new` from the command string, not declared per call site, so a new hint cannot be added unclassified. Recorded as **DEC-071**.
- **L-14 — `.hyalo.toml` is parsed once per run.** The help banner re-loaded the config the CLI had already resolved, and the `required-sections` deprecation check re-parsed the whole file; every run with a config warning ended in a spurious "1 additional identical warning(s) suppressed".

New: `crates/hyalo-cli/src/mutation.rs` — `Commands::writes()` (typed, used by the config gate) plus a string classifier (used to mark hints), cross-checked against each other on a 47-command corpus so the hint marker can never promise "read-only" for something the config gate treats as a write.

## Test plan

- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` — all clean
- [x] All four xtask gates (`check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`) exit 0
- [x] `tests/e2e/config_trust.rs` (15 new tests): `--dir <configured>` keeps lint findings / `[lint] ignore` / schema types / views; the redundancy note stays but no longer claims a shadow; switching trees names the config in effect; `hyalo config --dir` reports a non-null `config_path`; every `hyalo config` hint runs and `types list` still sees the schema; malformed config refuses `set` and `links auto --apply -q` with exit 1 and no file change; `-q` still shows the warning on reads; `--dry-run` is not gated; the diagnostic is printed exactly once
- [x] `tests/e2e/hint_execution.rs`: new `unmarked_hints_have_no_side_effects` gate byte-diffs the whole vault (including `.hyalo.toml`) after running every hint marked read-only; `snapshot_diff_detects_a_write` proves the differ is not decorative; text and JSON marker assertions
- [x] Unit tests for `resolve_effective` / `dir_override_note` / `salvage_dir` and the mutation classifiers
- [x] Manual: `hyalo lint --dir hyalo-knowledgebase --strict` on this repo returns the same 4 warnings as the bare form
- [ ] Reviewer: confirm the two BREAKING changes are acceptable pre-0.21.0 (both are documented with migration notes in `CHANGELOG.md`)

Docs: `docs/configuration.md` gains a "Config resolution: which `.hyalo.toml` applies" section (with a `--dir` table and the malformed-config rules) and a "Drill-down hints" section; `--dir` and `--quiet` long help updated; `CLAUDE.md`, `.claude/CLAUDE.md`, and both bundled templates (`rule-knowledgebase.md`, `skill-hyalo.md`) updated; `CHANGELOG.md` carries two BREAKING entries plus the double-parse fix.

Plan: `hyalo-knowledgebase/iterations/iteration-201-config-trust.md` (status: completed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEuPjCTq74bwJgoWbcvHrD

## Carry-over

Sweep of iter-201's Non-goals and this PR's scope for anything not landed here:

| Item | Source | Disposition |
| --- | --- | --- |
| Boundary checks for `madr toc`, `changelog add/release`, `new --file` (dogfood H-3, M-3, M-4) | iteration-201 Non-goals | Already scoped into [[iteration-202-boundary-completion]] (existing plan, tasks H-3/M-3/M-4 present) — no new plan needed |
| Symlink walker double-enumeration (dogfood M-5) and boundary-refusal UX unification (L-16) | iteration-201 Non-goals (implicit, same dogfood report) | Already scoped into [[iteration-202-boundary-completion]] (tasks M-5 and "Unify refusal UX" present) |
| `chmod 444` / hardlink atomic-write semantics (L-3) and `mv` onto dangling symlink (L-4) | dogfood report, out of scope for both 201 and 202 | Already scoped into [[iteration-204-dogfood-low-batch]] per iteration-202's own Non-goals |
| `[links.auto]` key semantics changes | iteration-201 Non-goals | Deliberate scope boundary, not a deferred bug — iter-195a semantics are settled; no follow-up needed |

No unticked ACs, no `[deferred …]` annotations, and no new out-of-scope findings surfaced during this PR's review — all Tasks [7/7] and Acceptance criteria [5/5] in [[iteration-201-config-trust]] landed and were verified against the diff before ticking.
