### PR TITLE
iter-202: complete the vault write boundary and dedup the symlink walker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,15 @@ and this project adheres to
   `--apply` as a silent no-op in the first mode hid that asymmetry from anyone
   who learned the batch form first. It now errors with `single-file mv applies
   by default; use --dry-run to preview`. Batch `--apply` is unchanged.
+- **One exit code and one wording for every vault-boundary refusal** (iter-202).
+  `okf log` refused an escaping target with exit 2, the documented
+  internal-error class, while the rest of the family used 1; `mv`,
+  `create-index` and `drop-index` each phrased the same refusal differently.
+  Every boundary refusal now exits 1 and reads `<subject> resolves outside vault
+  boundary: <resolved target>`, with the path the user typed carried in the
+  error's `path` field so both halves are visible. The
+  `set`/`append`/`remove`/`task` family gained the resolved target it previously
+  omitted.
 
 ### Removed
 
@@ -244,6 +253,26 @@ and this project adheres to
   only checked against the body length, so either case sliced a `str` at an
   invalid offset and aborted the run. Such fixes are now reported as conflicts
   and skipped, leaving the file untouched.
+- **Three unchecked writers now refuse to write outside the vault** (iter-202).
+  `madr toc` built `<adr-dir>/README.md` straight from its positional argument,
+  so `../outside` — or an in-vault ADR directory that is a symlink pointing
+  out — created or rewrote a README anywhere on disk at exit 0.
+  `changelog add`/`release` followed a `CHANGELOG.md` symlinked out of the
+  vault; an intentional out-of-vault changelog configured via
+  `[changelog] path` stays allowed, only the silent symlink hop is refused. `new --file` validated its
+  path lexically but never resolved it, so an in-vault `outdir -> ../outside`
+  symlink was a file-creation primitive. All three now resolve the destination
+  before touching the filesystem and refuse at exit 1 with nothing written
+  outside the vault, in dry-run as well as apply.
+- **An in-vault symlink and its target count as one file** (iter-202). The vault
+  walker enumerated both directory entries, so a whole-vault writer processed
+  the same file twice. `links fix --apply` rewrote the note once per spelling
+  and the second write saw the mtime the first had just changed — "modified by
+  another process", exit 1 in CI, even though the fix had landed. The same
+  double-count inflated `find --count`, `summary` totals and glob-write
+  counters, and printed the out-of-vault-symlink skip warning once per internal
+  walk. Enumeration is now deduplicated by canonical path — first spelling in
+  sort order wins, stably across runs — and each skip is warned once per run.
 
 ## [0.20.0] - 2026-07-19
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1380,7 +1380,8 @@ Repeatable (AND).\n\
         /// Document type to scaffold (must exist in `[schema.types.*]`)
         #[arg(long, value_name = "TYPE", required = true)]
         r#type: String,
-        /// Vault-relative path for the new file (must not exist; parent dirs created if missing)
+        /// Vault-relative path for the new file (must not exist; parent dirs created if
+        /// missing; must still resolve inside the vault after symlinks)
         #[arg(long, value_name = "FILE", required = true)]
         file: String,
         /// When `--index` or `--index-file` is set, patch the snapshot index in
@@ -1458,6 +1459,10 @@ Repeatable (AND).\n\
               exists (idempotency guard).\n\n\
             Both default to --dry-run and exit non-zero on drift (a CI signal); pass\n\
             --apply to write.\n\n\
+            The target file is `<vault>/CHANGELOG.md` unless `[changelog] path` names one\n\
+            (resolved against the config directory — that is how a repo-root CHANGELOG.md\n\
+            is used with a docs-subdir vault). Either way the file must still resolve\n\
+            inside that root: a CHANGELOG.md symlinked out of it is refused (exit 1).\n\n\
             VALIDATE: after releasing, replace the `TBD` link target with the real\n\
             compare/tag URL and run `hyalo lint --profile changelog`.\n\n\
             EXAMPLES:\n\
@@ -1640,13 +1645,17 @@ pub(crate) enum MadrAction {
             instead. Running with --apply twice is a no-op (idempotent). In --dry-run (the\n\
             default) the command exits non-zero when the TOC would change — use this in CI.\n\n\
             SIDE EFFECTS: writes `<adr-dir>/README.md` only with --apply.\n\n\
+            DIR must stay inside the vault once symlinks are resolved: a `../` traversal\n\
+            or a symlinked ADR directory pointing out is refused (exit 1) in dry-run and\n\
+            apply alike.\n\n\
             EXAMPLES:\n\
             \u{00a0} hyalo madr toc --dry-run\n\
             \u{00a0} hyalo madr toc --apply\n\
             \u{00a0} hyalo madr toc docs/adr --apply"
     )]
     Toc {
-        /// ADR directory (vault-relative); defaults to `docs/decisions`
+        /// ADR directory (vault-relative, must resolve inside the vault);
+        /// defaults to `docs/decisions`
         #[arg(value_name = "DIR")]
         adr_dir: Option<String>,
         /// Write changes to disk. Without this flag the command is a dry run.

--- a/crates/hyalo-cli/src/commands/changelog.rs
+++ b/crates/hyalo-cli/src/commands/changelog.rs
@@ -88,6 +88,49 @@ pub(crate) fn resolve_changelog_file(
     Ok(joined)
 }
 
+/// The directory a resolved changelog must stay inside.
+///
+/// With no `[changelog] path` the changelog is `dir/CHANGELOG.md` and the vault
+/// is the boundary. With a configured path the boundary is the *config*
+/// directory: [`resolve_changelog_file`] already bounds the lexical path there,
+/// so an intentional repo-root `CHANGELOG.md` for a docs-subdir vault stays
+/// allowed (that is a documented setup, not an escape). Passing this root to
+/// the write gate makes the same bound survive symlink resolution — M-3
+/// (iter-202), where a `CHANGELOG.md` symlinked out of the vault was followed
+/// silently.
+pub(crate) fn changelog_boundary_root(
+    dir: &Path,
+    config_dir: &Path,
+    config_path: Option<&str>,
+) -> std::path::PathBuf {
+    if config_path.is_some() {
+        config_dir.to_path_buf()
+    } else {
+        dir.to_path_buf()
+    }
+}
+
+/// Refuse a changelog write whose target resolves outside `boundary_root`.
+///
+/// Shared by `release` and `add` so both refuse identically, in dry-run as
+/// well as apply — a mode that reports a change it would refuse to make is
+/// worse than useless in CI.
+fn boundary_refusal(
+    boundary_root: &Path,
+    changelog_file: &Path,
+    display: &str,
+    format: Format,
+) -> Result<Option<CommandOutcome>> {
+    crate::commands::refuse_escaping_write(
+        boundary_root,
+        changelog_file,
+        "changelog",
+        display,
+        Some("point [changelog] path at a file inside the repository, or remove the symlink"),
+        format,
+    )
+}
+
 /// A parsed view of a changelog sufficient for the release/add splices.
 struct Changelog {
     /// Raw lines with both the trailing `\n` and any trailing `\r` stripped;
@@ -215,6 +258,7 @@ fn changelog_display(path: &Path) -> String {
 /// change the file, matching the `okf index` / `madr toc` CI convention).
 pub fn run_release(
     changelog_file: &Path,
+    boundary_root: &Path,
     version: &str,
     date: Option<&str>,
     apply: bool,
@@ -222,6 +266,9 @@ pub fn run_release(
     format: Format,
 ) -> Result<(CommandOutcome, Option<i32>)> {
     let display = changelog_display(changelog_file);
+    if let Some(outcome) = boundary_refusal(boundary_root, changelog_file, &display, format)? {
+        return Ok((outcome, None));
+    }
     if !is_semver(version) {
         return Ok((
             CommandOutcome::UserError(format_error(
@@ -303,9 +350,10 @@ pub fn run_release(
     let new_content = cl.render();
     let changed = new_content != old_content;
     if apply && changed {
-        // No vault root here: `changelog` targets an arbitrary CHANGELOG.md
-        // path (often the repo root), so there is no boundary to check against.
-        hyalo_core::fs_util::atomic_write(&full, new_content.as_bytes())
+        // Defense in depth: the early `boundary_refusal` gate already ran, but
+        // re-check against the same root right before the write so the
+        // invariant survives future refactors.
+        hyalo_core::fs_util::atomic_write_within(boundary_root, &full, new_content.as_bytes())
             .with_context(|| format!("failed to write {display}"))?;
     }
 
@@ -386,6 +434,7 @@ fn upsert_release_link_ref(cl: &mut Changelog, version: &str) {
 /// `## [Unreleased]`, creating the section / subsection when missing.
 pub fn run_add(
     changelog_file: &Path,
+    boundary_root: &Path,
     category: &str,
     message: &str,
     wrap: Option<usize>,
@@ -394,6 +443,9 @@ pub fn run_add(
     format: Format,
 ) -> Result<(CommandOutcome, Option<i32>)> {
     let display = changelog_display(changelog_file);
+    if let Some(outcome) = boundary_refusal(boundary_root, changelog_file, &display, format)? {
+        return Ok((outcome, None));
+    }
     let Some(canonical) = CATEGORIES.iter().find(|c| c.eq_ignore_ascii_case(category)) else {
         return Ok((
             CommandOutcome::UserError(format_error(
@@ -461,9 +513,10 @@ pub fn run_add(
     let new_content = cl.render();
     let changed = new_content != old_content;
     if apply && changed {
-        // No vault root here: `changelog` targets an arbitrary CHANGELOG.md
-        // path (often the repo root), so there is no boundary to check against.
-        hyalo_core::fs_util::atomic_write(&full, new_content.as_bytes())
+        // Defense in depth: the early `boundary_refusal` gate already ran, but
+        // re-check against the same root right before the write so the
+        // invariant survives future refactors.
+        hyalo_core::fs_util::atomic_write_within(boundary_root, &full, new_content.as_bytes())
             .with_context(|| format!("failed to write {display}"))?;
     }
 

--- a/crates/hyalo-cli/src/commands/changelog.rs
+++ b/crates/hyalo-cli/src/commands/changelog.rs
@@ -432,6 +432,7 @@ fn upsert_release_link_ref(cl: &mut Changelog, version: &str) {
 ///
 /// Appends `- <message>` under the `### <category>` subsection of
 /// `## [Unreleased]`, creating the section / subsection when missing.
+#[allow(clippy::too_many_arguments)]
 pub fn run_add(
     changelog_file: &Path,
     boundary_root: &Path,

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -50,7 +50,10 @@ pub fn create_index(
         if !canonical_parent.starts_with(&canonical_dir) {
             let out = crate::output::format_error(
                 format,
-                "output path is outside the vault boundary",
+                &hyalo_core::fs_util::outside_vault_message(
+                    "output path",
+                    Some(&canonical_parent),
+                ),
                 Some(&index_path.display().to_string()),
                 Some("use --allow-outside-vault to override"),
                 None,

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -50,10 +50,7 @@ pub fn create_index(
         if !canonical_parent.starts_with(&canonical_dir) {
             let out = crate::output::format_error(
                 format,
-                &hyalo_core::fs_util::outside_vault_message(
-                    "output path",
-                    Some(&canonical_parent),
-                ),
+                &hyalo_core::fs_util::outside_vault_message("output path", Some(&canonical_parent)),
                 Some(&index_path.display().to_string()),
                 Some("use --allow-outside-vault to override"),
                 None,

--- a/crates/hyalo-cli/src/commands/drop_index.rs
+++ b/crates/hyalo-cli/src/commands/drop_index.rs
@@ -29,7 +29,10 @@ pub fn drop_index(
                 if !canonical_path.starts_with(&canonical_dir) {
                     let out = crate::output::format_error(
                         format,
-                        "index path is outside the vault boundary",
+                        &hyalo_core::fs_util::outside_vault_message(
+                            "index path",
+                            Some(&canonical_path),
+                        ),
                         Some(&index_path.display().to_string()),
                         Some("use --allow-outside-vault to override"),
                         None,

--- a/crates/hyalo-cli/src/commands/madr.rs
+++ b/crates/hyalo-cli/src/commands/madr.rs
@@ -58,6 +58,24 @@ pub fn run_toc(
     let adr_rel_normalized = adr_dir.unwrap_or(DEFAULT_ADR_DIR).replace('\\', "/");
     let adr_rel = adr_rel_normalized.trim_end_matches('/');
     let adr_full = dir.join(adr_rel);
+    let toc_rel = format!("{adr_rel}/README.md");
+
+    // H-3 (iter-202): `--adr-dir` is user input joined straight onto the vault
+    // root. Without this gate a plain `../` — or an in-vault ADR directory that
+    // is a symlink pointing out — made `--apply` create/rewrite a README.md
+    // anywhere on disk at exit 0. Checked before the `is_dir` probe so a
+    // traversal attempt is always reported as a boundary refusal, and in
+    // dry-run as well as apply so the two modes agree.
+    if let Some(outcome) = crate::commands::refuse_escaping_write(
+        dir,
+        &dir.join(&toc_rel),
+        "TOC path",
+        &toc_rel,
+        Some("pass an ADR directory inside the vault"),
+        format,
+    )? {
+        return Ok((outcome, None));
+    }
 
     if !adr_full.is_dir() {
         return Ok((
@@ -75,7 +93,6 @@ pub fn run_toc(
     let entries = collect_adrs(&adr_full, adr_rel, schema)?;
     let body = render_toc_body(&entries);
 
-    let toc_rel = format!("{adr_rel}/README.md");
     let old_content = read_old_content(dir, &toc_rel)?;
     let markers = Markers::new(TOC_PREFIX);
     let mode = if replace {

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -64,13 +64,15 @@ pub(crate) fn refuse_escaping_write(
     let Some(target) = hyalo_core::fs_util::escaping_write_target(dir, full)? else {
         return Ok(None);
     };
-    Ok(Some(CommandOutcome::UserError(crate::output::format_error(
-        format,
-        &hyalo_core::fs_util::outside_vault_message(subject, Some(&target)),
-        Some(display),
-        hint,
-        None,
-    ))))
+    Ok(Some(CommandOutcome::UserError(
+        crate::output::format_error(
+            format,
+            &hyalo_core::fs_util::outside_vault_message(subject, Some(&target)),
+            Some(display),
+            hint,
+            None,
+        ),
+    )))
 }
 
 /// Wrap `discovery::resolve_file` with the LLM-misuse warning.

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -41,6 +41,38 @@ use crate::output::{CommandOutcome, Format};
 use anyhow::Result;
 use hyalo_core::discovery::{self, FileResolveError};
 
+/// Refuse a write whose destination resolves outside the vault.
+///
+/// One gate for the whole boundary family (iter-202): every writer that builds
+/// a destination from user input — `madr toc`, `changelog add/release`,
+/// `new --file`, `okf index/log` — calls this *before* touching the
+/// filesystem, so an escape is a user error (exit 1) with the unified
+/// two-path wording rather than a mid-write `anyhow` bail (exit 2).
+///
+/// `subject` names what is being refused (`"TOC path"`, `"changelog"`, …) and
+/// `display` is the path as the user expressed it, surfaced as the error's
+/// `path` field. Returns `Some(outcome)` when the write must be refused and
+/// `None` when it may proceed.
+pub(crate) fn refuse_escaping_write(
+    dir: &std::path::Path,
+    full: &std::path::Path,
+    subject: &str,
+    display: &str,
+    hint: Option<&str>,
+    format: Format,
+) -> Result<Option<CommandOutcome>> {
+    let Some(target) = hyalo_core::fs_util::escaping_write_target(dir, full)? else {
+        return Ok(None);
+    };
+    Ok(Some(CommandOutcome::UserError(crate::output::format_error(
+        format,
+        &hyalo_core::fs_util::outside_vault_message(subject, Some(&target)),
+        Some(display),
+        hint,
+        None,
+    ))))
+}
+
 /// Wrap `discovery::resolve_file` with the LLM-misuse warning.
 ///
 /// If `path_arg` is an absolute path that lies inside the canonical vault,
@@ -213,6 +245,12 @@ pub fn collect_files(
                     }
                     FileResolveError::IsDirectory { hint, .. } => {
                         format!("path is a directory, not a file: {path} (try {hint})")
+                    }
+                    FileResolveError::OutsideVault {
+                        resolved: Some(target),
+                        ..
+                    } => {
+                        format!("file resolves outside vault boundary: {path} -> {target}")
                     }
                     FileResolveError::OutsideVault { .. } => {
                         format!("file resolves outside vault boundary: {path}")
@@ -500,10 +538,13 @@ pub fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> Comman
                 None,
             ))
         }
-        FileResolveError::OutsideVault { path } => {
+        FileResolveError::OutsideVault { path, resolved } => {
             CommandOutcome::UserError(crate::output::format_error(
                 format,
-                "file resolves outside vault boundary",
+                &hyalo_core::fs_util::outside_vault_message(
+                    "file",
+                    resolved.as_deref().map(std::path::Path::new),
+                ),
                 Some(&path),
                 None,
                 None,

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -733,54 +733,34 @@ fn rollback_renames(applied: &[(PathBuf, PathBuf)]) {
 // Validation helpers
 // ---------------------------------------------------------------------------
 
-/// Walk up from `path` to find the nearest ancestor that exists on disk.
-///
-/// Used to find a safe point to canonicalize when the destination itself
-/// (and possibly several of its parent directories) doesn't exist yet.
-fn nearest_existing_ancestor(path: &Path) -> PathBuf {
-    let mut current = path;
-    loop {
-        if current.exists() {
-            return current.to_path_buf();
-        }
-        match current.parent() {
-            Some(parent) if !parent.as_os_str().is_empty() => current = parent,
-            _ => return current.to_path_buf(),
-        }
-    }
-}
-
 /// Verify that a prospective destination `new_rel` (relative to `dir`) stays
 /// within the vault, even when its parent directories don't exist yet or an
 /// in-vault path component is a symlink that resolves outside the vault
 /// (H-3).
 ///
-/// `fs::create_dir_all` only ever creates plain directories — never symlinks
-/// — so canonicalizing the nearest *existing* ancestor of the destination and
-/// checking it resolves inside `canonical_vault` is sufficient to guarantee
-/// every path component that would be created below it also stays in the
-/// vault. Must be called before any `fs::create_dir_all`/`fs::rename` on the
-/// destination.
+/// Delegates to [`hyalo_core::fs_util::escaping_write_target`], which anchors
+/// on the nearest existing ancestor: `fs::create_dir_all` only ever creates
+/// plain directories — never symlinks — so an in-vault anchor guarantees every
+/// component created below it also stays in the vault. Must be called before
+/// any `fs::create_dir_all`/`fs::rename` on the destination.
+///
+/// `canonical_vault` is accepted (rather than re-derived) so callers that
+/// already canonicalized the vault keep a single source of truth for it.
 fn ensure_dest_within_vault(
     canonical_vault: &Path,
     dir: &Path,
     new_rel: &str,
 ) -> std::result::Result<(), String> {
     let dst = dir.join(new_rel);
-    let start = dst.parent().unwrap_or(dir);
-    let ancestor = nearest_existing_ancestor(start);
-    let canonical_ancestor = dunce::canonicalize(&ancestor).map_err(|e| {
-        format!(
-            "failed to verify destination {} stays within the vault: {e}",
-            ancestor.display()
-        )
-    })?;
-    if canonical_ancestor.starts_with(canonical_vault) {
-        Ok(())
-    } else {
-        Err(format!(
-            "target path resolves outside vault boundary: {new_rel}"
-        ))
+    match hyalo_core::fs_util::escaping_write_target(canonical_vault, &dst) {
+        Ok(None) => Ok(()),
+        Ok(Some(target)) => Err(hyalo_core::fs_util::outside_vault_message(
+            "target path",
+            Some(&target),
+        )),
+        Err(e) => Err(format!(
+            "failed to verify destination {new_rel} stays within the vault: {e}"
+        )),
     }
 }
 

--- a/crates/hyalo-cli/src/commands/new.rs
+++ b/crates/hyalo-cli/src/commands/new.rs
@@ -81,6 +81,24 @@ pub(crate) fn create_new(
     let full_path: PathBuf = dir.join(file_arg);
 
     // ------------------------------------------------------------------
+    // Step 2b: the lexical checks above are not enough (M-4, iter-202)
+    // ------------------------------------------------------------------
+    // `outdir -> ../outside` inside the vault contains neither `..` nor a root
+    // component, so the component walk waves it through; only resolution
+    // catches it. Must run before `create_dir_all`, which would otherwise
+    // fabricate directories out of the vault before anything refused.
+    if let Some(outcome) = crate::commands::refuse_escaping_write(
+        dir,
+        &full_path,
+        "file",
+        file_arg,
+        Some("provide a path that stays inside the vault after symlinks are resolved"),
+        format,
+    )? {
+        return Ok(outcome);
+    }
+
+    // ------------------------------------------------------------------
     // Step 3: ensure parent directory exists (create if needed)
     // ------------------------------------------------------------------
     if let Some(parent) = full_path.parent()

--- a/crates/hyalo-cli/src/commands/okf.rs
+++ b/crates/hyalo-cli/src/commands/okf.rs
@@ -962,6 +962,22 @@ pub fn run_log(
     };
     let full = dir.join(&rel_path);
 
+    // L-16 (iter-202): `atomic_write_within` already refuses a `log.md`
+    // symlinked out of the vault, but it does so with an `anyhow` bail, which
+    // the CLI reports as exit 2 — the "internal error" class — while every
+    // other boundary refusal exits 1. Gate here instead so the whole family
+    // agrees on exit code and wording, and so `--dry-run` refuses too.
+    if let Some(outcome) = crate::commands::refuse_escaping_write(
+        dir,
+        &full,
+        "log path",
+        &rel_path,
+        Some("log into a file inside the vault, or remove the escaping symlink"),
+        format,
+    )? {
+        return Ok(outcome);
+    }
+
     // The target must be a regular file or absent — a directory named `log.md`
     // (or any non-file at that path) can't be written; reject it in both
     // dry-run and apply so they agree (BUG-11 parity for `okf log`).
@@ -1225,7 +1241,10 @@ fn normalize_vault_rel(dir: &Path, raw: &str) -> std::result::Result<String, Str
         || Path::new(normalized).is_absolute()
         || discovery::has_parent_traversal(normalized)
     {
-        return Err(format!("path resolves outside the vault boundary: {raw}"));
+        return Err(format!(
+            "{}: {raw}",
+            hyalo_core::fs_util::outside_vault_message("path", None)
+        ));
     }
     Ok(normalized.to_owned())
 }

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -2503,8 +2503,14 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     ctx.config_dir,
                     ctx.changelog_path,
                 )?;
+                let boundary_root = crate::commands::changelog::changelog_boundary_root(
+                    ctx.dir,
+                    ctx.config_dir,
+                    ctx.changelog_path,
+                );
                 let (outcome, exit_override) = crate::commands::changelog::run_release(
                     &changelog_file,
+                    &boundary_root,
                     &version,
                     date.as_deref(),
                     apply,
@@ -2528,8 +2534,14 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                     ctx.config_dir,
                     ctx.changelog_path,
                 )?;
+                let boundary_root = crate::commands::changelog::changelog_boundary_root(
+                    ctx.dir,
+                    ctx.config_dir,
+                    ctx.changelog_path,
+                );
                 let (outcome, exit_override) = crate::commands::changelog::run_add(
                     &changelog_file,
+                    &boundary_root,
                     &category,
                     &message,
                     wrap,

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -54,6 +54,7 @@ mod symlinks;
 mod tags;
 mod task;
 mod types;
+mod vault_boundary;
 mod vault_side_effects;
 mod version;
 mod views;

--- a/crates/hyalo-cli/tests/e2e/symlinks.rs
+++ b/crates/hyalo-cli/tests/e2e/symlinks.rs
@@ -20,10 +20,12 @@ use tempfile::TempDir;
 ///
 /// The target lives under `.store/` on purpose. The discovery walker skips
 /// hidden directories, so the vault contains exactly *one* discoverable
-/// markdown file. Without that, both the symlink and its target would be
-/// walked as two separate files backed by one inode, and any whole-vault
-/// command would write the same inode twice — a fixture artefact, not the
-/// behaviour under test.
+/// markdown file and these tests exercise the write path through a symlink
+/// without also exercising enumeration. (Since iteration 202 the walker also
+/// deduplicates a symlink against its target by canonical path — see
+/// `vault_boundary::links_fix_apply_rewrites_an_aliased_note_once` — so an
+/// unhidden target would no longer produce a double write either. The hidden
+/// directory keeps the two concerns in separate tests.)
 fn vault_with_symlink(content: &str) -> (TempDir, std::path::PathBuf) {
     let tmp = TempDir::new().unwrap();
     fs::create_dir(tmp.path().join(".store")).unwrap();

--- a/crates/hyalo-cli/tests/e2e/vault_boundary.rs
+++ b/crates/hyalo-cli/tests/e2e/vault_boundary.rs
@@ -1,0 +1,531 @@
+//! Vault-boundary refusals across the whole write path (iteration 202).
+//!
+//! Iteration 191 gave the `set`/`append`/`remove`/`task`/`mv` family a
+//! boundary-checked write. The v0.21.0-pre dogfood then found three writers it
+//! had missed — `madr toc` (H-3), `changelog add`/`release` (M-3) and
+//! `new --file` (M-4) — plus an inconsistent exit code and message shape
+//! (L-16). This suite pins all of that down:
+//!
+//! - every escape vector refuses at **exit 1**, never 0 and never 2;
+//! - nothing outside the vault is created or modified;
+//! - every refusal carries the same two-path wording — the path the user typed
+//!   in the error's `path` field, and where it really resolves in the message.
+//!
+//! Unix only: creating a symlink on Windows needs developer mode or
+//! elevation. The `../` traversal vectors need no symlink, but they live here
+//! with the rest of the family rather than being split across two files.
+#![cfg(unix)]
+
+use super::common::{hyalo_no_hints, write_md};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Run `hyalo --dir <vault> <args...>` and return `(exit code, stdout+stderr)`.
+fn run(vault: &Path, args: &[&str]) -> (i32, String) {
+    let out = hyalo_no_hints()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(args)
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.code().unwrap_or(-1), combined)
+}
+
+/// Assert a boundary refusal: exit 1 and the shared wording.
+///
+/// Exit 1 is the whole point of L-16 — `okf log` used to escape via an
+/// `anyhow` bail and surface as exit 2, the documented "internal error" class,
+/// which tells a caller to file a bug rather than to fix its path.
+fn assert_boundary_refusal(code: i32, combined: &str, context: &str) {
+    assert_eq!(code, 1, "{context}: expected exit 1, got {code}: {combined}");
+    assert!(
+        combined.contains("resolves outside vault boundary"),
+        "{context}: expected the shared boundary wording, got: {combined}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// H-3 — `madr toc` built `<adr-dir>/README.md` from unvalidated user input
+// ---------------------------------------------------------------------------
+
+#[test]
+fn madr_toc_refuses_parent_traversal_adr_dir() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(vault.join("docs")).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("README.md"), "PRECIOUS\n").unwrap();
+
+    let (code, combined) = run(&vault, &["madr", "toc", "../outside", "--apply"]);
+    assert_boundary_refusal(code, &combined, "madr toc ../outside");
+    assert_eq!(
+        fs::read_to_string(outside.join("README.md")).unwrap(),
+        "PRECIOUS\n",
+        "the out-of-vault README must be byte-for-byte untouched"
+    );
+}
+
+#[test]
+fn madr_toc_refuses_symlinked_adr_dir() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    write_md(
+        &outside,
+        "0001-thing.md",
+        "---\ntitle: Thing\ntype: adr\n---\n# Thing\n",
+    );
+    std::os::unix::fs::symlink(&outside, vault.join("decisions")).unwrap();
+
+    let (code, combined) = run(&vault, &["madr", "toc", "decisions", "--apply"]);
+    assert_boundary_refusal(code, &combined, "madr toc via symlinked dir");
+    assert!(
+        !outside.join("README.md").exists(),
+        "no README.md may be fabricated outside the vault"
+    );
+}
+
+/// Dry-run and apply must agree. A dry-run that cheerfully reports the TOC it
+/// would write, followed by an apply that refuses, is the disagreement
+/// iteration 191 spent its time eliminating elsewhere.
+#[test]
+fn madr_toc_refuses_escaping_adr_dir_in_dry_run_too() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+
+    let (code, combined) = run(&vault, &["madr", "toc", "../outside", "--dry-run"]);
+    assert_boundary_refusal(code, &combined, "madr toc --dry-run");
+}
+
+#[test]
+fn madr_toc_still_works_inside_the_vault() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    fs::create_dir_all(&vault).unwrap();
+    write_md(
+        &vault,
+        "docs/decisions/0001-thing.md",
+        "---\ntitle: Thing\ntype: adr\nstatus: accepted\n---\n# Thing\n",
+    );
+
+    let (code, combined) = run(&vault, &["madr", "toc", "--apply"]);
+    assert_eq!(code, 0, "in-vault TOC generation must succeed: {combined}");
+    let toc = fs::read_to_string(vault.join("docs/decisions/README.md")).unwrap();
+    assert!(toc.contains("Thing"), "TOC should list the ADR: {toc}");
+}
+
+// ---------------------------------------------------------------------------
+// M-3 — `changelog` followed a CHANGELOG.md symlink out of the vault
+// ---------------------------------------------------------------------------
+
+/// Vault whose `CHANGELOG.md` is a symlink to a changelog outside it.
+fn vault_with_escaping_changelog() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    let escapee = outside.join("CHANGELOG.md");
+    fs::write(&escapee, "# Changelog\n\n## [Unreleased]\n").unwrap();
+    std::os::unix::fs::symlink(&escapee, vault.join("CHANGELOG.md")).unwrap();
+    (root, vault, escapee)
+}
+
+#[test]
+fn changelog_add_refuses_symlink_escaping_vault() {
+    let (_root, vault, escapee) = vault_with_escaping_changelog();
+
+    let (code, combined) = run(
+        &vault,
+        &[
+            "changelog",
+            "add",
+            "--category",
+            "Added",
+            "--message",
+            "injected",
+            "--apply",
+        ],
+    );
+    assert_boundary_refusal(code, &combined, "changelog add");
+    assert!(
+        !fs::read_to_string(&escapee).unwrap().contains("injected"),
+        "the out-of-vault changelog must be untouched"
+    );
+}
+
+#[test]
+fn changelog_release_refuses_symlink_escaping_vault() {
+    let (_root, vault, escapee) = vault_with_escaping_changelog();
+
+    let (code, combined) = run(&vault, &["changelog", "release", "1.0.0", "--apply"]);
+    assert_boundary_refusal(code, &combined, "changelog release");
+    assert!(
+        !fs::read_to_string(&escapee).unwrap().contains("1.0.0"),
+        "the out-of-vault changelog must be untouched"
+    );
+}
+
+/// An *intentional* out-of-vault changelog — configured via `[changelog] path`
+/// for the common repo-root-changelog / docs-subdir-vault layout — is a
+/// documented setup, not an escape. Only the silent symlink hop is refused.
+#[test]
+fn changelog_add_allows_configured_repo_root_path() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("docs");
+    fs::create_dir_all(&vault).unwrap();
+    fs::write(
+        root.path().join(".hyalo.toml"),
+        "dir = \"docs\"\n\n[changelog]\npath = \"CHANGELOG.md\"\n",
+    )
+    .unwrap();
+    fs::write(
+        root.path().join("CHANGELOG.md"),
+        "# Changelog\n\n## [Unreleased]\n",
+    )
+    .unwrap();
+
+    let out = hyalo_no_hints()
+        .current_dir(root.path())
+        .args([
+            "changelog",
+            "add",
+            "--category",
+            "Added",
+            "--message",
+            "intentional",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a configured repo-root changelog must stay allowed: {combined}"
+    );
+    assert!(
+        fs::read_to_string(root.path().join("CHANGELOG.md"))
+            .unwrap()
+            .contains("intentional"),
+        "the configured changelog should have been written"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// M-4 — `new --file` validated lexically but never resolved
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_refuses_symlinked_output_directory() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(
+        vault.join(".hyalo.toml"),
+        "[schema.types.note]\nrequired = [\"title\"]\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&outside, vault.join("outdir")).unwrap();
+
+    let (code, combined) = run(
+        &vault,
+        &["new", "--type", "note", "--file", "outdir/planted.md"],
+    );
+    assert_boundary_refusal(code, &combined, "new --file through symlinked dir");
+    assert!(
+        !outside.join("planted.md").exists(),
+        "no file may be created outside the vault"
+    );
+}
+
+/// The symlink may sit several levels above the new file: the check anchors on
+/// the nearest ancestor that exists, so directories that would be *created*
+/// below an escaping ancestor are refused before `create_dir_all` runs.
+#[test]
+fn new_refuses_nested_path_below_symlinked_directory() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(
+        vault.join(".hyalo.toml"),
+        "[schema.types.note]\nrequired = [\"title\"]\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&outside, vault.join("outdir")).unwrap();
+
+    let (code, combined) = run(
+        &vault,
+        &["new", "--type", "note", "--file", "outdir/a/b/planted.md"],
+    );
+    assert_boundary_refusal(code, &combined, "new --file nested below symlink");
+    assert!(
+        !outside.join("a").exists(),
+        "create_dir_all must not fabricate directories outside the vault"
+    );
+}
+
+#[test]
+fn new_still_creates_files_inside_the_vault() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    fs::create_dir_all(&vault).unwrap();
+    fs::write(
+        vault.join(".hyalo.toml"),
+        "[schema.types.note]\nrequired = [\"title\"]\n",
+    )
+    .unwrap();
+
+    let (code, combined) = run(
+        &vault,
+        &["new", "--type", "note", "--file", "nested/fine.md"],
+    );
+    assert_eq!(code, 0, "in-vault creation must succeed: {combined}");
+    assert!(vault.join("nested/fine.md").is_file());
+}
+
+// ---------------------------------------------------------------------------
+// L-16 — one exit code and one message shape for the whole family
+// ---------------------------------------------------------------------------
+
+/// `okf log` used to refuse correctly but with exit 2, because the refusal
+/// came from `atomic_write_within`'s `anyhow` bail rather than a user error.
+#[test]
+fn okf_log_refuses_symlink_escaping_vault_at_exit_one() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    let escapee = outside.join("log.md");
+    fs::write(&escapee, "# Log\n").unwrap();
+    std::os::unix::fs::symlink(&escapee, vault.join("log.md")).unwrap();
+
+    let (code, combined) = run(&vault, &["okf", "log", "--message", "injected", "--apply"]);
+    assert_boundary_refusal(code, &combined, "okf log");
+    assert!(
+        !fs::read_to_string(&escapee).unwrap().contains("injected"),
+        "the out-of-vault log must be untouched"
+    );
+}
+
+/// The refusals must not just each be exit 1 — they must read the same way.
+/// Every one of them names where the path *resolves to*, so a caller that has
+/// been handed a symlinked vault can see what actually happened.
+#[test]
+fn boundary_refusals_share_exit_code_and_message_shape() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(
+        vault.join(".hyalo.toml"),
+        "[schema.types.note]\nrequired = [\"title\"]\n",
+    )
+    .unwrap();
+    fs::write(outside.join("secret.md"), "---\ntitle: S\n---\nBody\n").unwrap();
+    fs::write(outside.join("CHANGELOG.md"), "# Changelog\n\n## [Unreleased]\n").unwrap();
+    fs::write(outside.join("log.md"), "# Log\n").unwrap();
+    std::os::unix::fs::symlink(outside.join("secret.md"), vault.join("escape.md")).unwrap();
+    std::os::unix::fs::symlink(outside.join("CHANGELOG.md"), vault.join("CHANGELOG.md")).unwrap();
+    std::os::unix::fs::symlink(outside.join("log.md"), vault.join("log.md")).unwrap();
+    std::os::unix::fs::symlink(&outside, vault.join("outdir")).unwrap();
+
+    let escape_target = fs::canonicalize(outside.join("secret.md")).unwrap();
+    let vectors: Vec<(&str, Vec<&str>)> = vec![
+        (
+            "set",
+            vec!["set", "--file", "escape.md", "--property", "status=done"],
+        ),
+        (
+            "append",
+            vec!["append", "--file", "escape.md", "--property", "tags=x"],
+        ),
+        (
+            "remove",
+            vec!["remove", "--file", "escape.md", "--property", "title"],
+        ),
+        (
+            "changelog add",
+            vec![
+                "changelog", "add", "--category", "Added", "--message", "x", "--apply",
+            ],
+        ),
+        (
+            "okf log",
+            vec!["okf", "log", "--message", "x", "--apply"],
+        ),
+        (
+            "new",
+            vec!["new", "--type", "note", "--file", "outdir/x.md"],
+        ),
+        ("madr toc", vec!["madr", "toc", "../outside", "--apply"]),
+    ];
+
+    for (name, args) in vectors {
+        let (code, combined) = run(&vault, &args);
+        assert_boundary_refusal(code, &combined, name);
+    }
+
+    // The `set` family now names the resolved target as well as the typed
+    // path — the two-path form `okf log` had and iteration 191's writers did
+    // not (L-16).
+    let (_, combined) = run(
+        &vault,
+        &["set", "--file", "escape.md", "--property", "status=done"],
+    );
+    assert!(
+        combined.contains(&escape_target.display().to_string()),
+        "the refusal must name the resolved target, got: {combined}"
+    );
+    assert!(
+        combined.contains("escape.md"),
+        "the refusal must also name the path the user typed, got: {combined}"
+    );
+    assert!(
+        fs::read_to_string(outside.join("secret.md"))
+            .unwrap()
+            .contains("Body"),
+        "nothing outside the vault may be modified"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// M-5 — an in-vault symlink and its target are one file, not two
+// ---------------------------------------------------------------------------
+
+/// Vault holding one real note plus an in-vault symlink to it.
+fn vault_with_intra_vault_alias() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "target.md", "---\ntitle: Target\n---\nx\n");
+    write_md(
+        tmp.path(),
+        "hub.md",
+        "---\ntitle: Hub\n---\nSee [[Target]].\n",
+    );
+    std::os::unix::fs::symlink("hub.md", tmp.path().join("alias.md")).unwrap();
+    tmp
+}
+
+#[test]
+fn summary_counts_an_aliased_note_once() {
+    let tmp = vault_with_intra_vault_alias();
+    let out = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+    let val: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        val["results"]["files"]["total"], 2,
+        "hub.md and target.md are two files; the alias must not make three: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn find_count_counts_an_aliased_note_once() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "real.md", "---\ntitle: Real\n---\nx\n");
+    std::os::unix::fs::symlink("real.md", tmp.path().join("alias.md")).unwrap();
+
+    let out = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--count", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "1",
+        "one file reachable under two spellings is still one file: {stdout}"
+    );
+}
+
+/// The regression that made this a HIGH-value fix: `links fix --apply` rewrote
+/// the same note once per spelling, and the second write saw the mtime the
+/// first one had just changed — "modified by another process", exit 1, even
+/// though the fix had landed.
+#[test]
+fn links_fix_apply_rewrites_an_aliased_note_once() {
+    let tmp = vault_with_intra_vault_alias();
+    let out = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["links", "fix", "--apply"])
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "the double write used to trip the concurrency guard: {combined}"
+    );
+    assert!(
+        !combined.contains("modified by another process"),
+        "no concurrent-modification false positive: {combined}"
+    );
+    let hub = fs::read_to_string(tmp.path().join("hub.md")).unwrap();
+    assert_eq!(
+        hub.matches("[[target]]").count(),
+        1,
+        "the note must be rewritten exactly once: {hub}"
+    );
+    assert!(
+        fs::symlink_metadata(tmp.path().join("alias.md"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the alias must survive as a symlink"
+    );
+}
+
+/// The skip warning for a symlink pointing *out* of the vault is emitted from
+/// the walker, and a single CLI run walks the vault more than once. It must
+/// still be reported once.
+#[test]
+fn out_of_vault_symlink_warning_is_printed_once() {
+    let root = TempDir::new().unwrap();
+    let vault = root.path().join("vault");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&vault).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("secret.md"), "---\ntitle: S\n---\nx\n").unwrap();
+    write_md(&vault, "in.md", "---\ntitle: In\n---\nx\n");
+    std::os::unix::fs::symlink(outside.join("secret.md"), vault.join("escape.md")).unwrap();
+
+    let out = hyalo_no_hints()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["summary", "--format", "json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        stderr.matches("symlink target resolves outside vault").count(),
+        1,
+        "the skip warning must be emitted once per run, got: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/vault_boundary.rs
+++ b/crates/hyalo-cli/tests/e2e/vault_boundary.rs
@@ -42,7 +42,10 @@ fn run(vault: &Path, args: &[&str]) -> (i32, String) {
 /// `anyhow` bail and surface as exit 2, the documented "internal error" class,
 /// which tells a caller to file a bug rather than to fix its path.
 fn assert_boundary_refusal(code: i32, combined: &str, context: &str) {
-    assert_eq!(code, 1, "{context}: expected exit 1, got {code}: {combined}");
+    assert_eq!(
+        code, 1,
+        "{context}: expected exit 1, got {code}: {combined}"
+    );
     assert!(
         combined.contains("resolves outside vault boundary"),
         "{context}: expected the shared boundary wording, got: {combined}"
@@ -344,7 +347,11 @@ fn boundary_refusals_share_exit_code_and_message_shape() {
     )
     .unwrap();
     fs::write(outside.join("secret.md"), "---\ntitle: S\n---\nBody\n").unwrap();
-    fs::write(outside.join("CHANGELOG.md"), "# Changelog\n\n## [Unreleased]\n").unwrap();
+    fs::write(
+        outside.join("CHANGELOG.md"),
+        "# Changelog\n\n## [Unreleased]\n",
+    )
+    .unwrap();
     fs::write(outside.join("log.md"), "# Log\n").unwrap();
     std::os::unix::fs::symlink(outside.join("secret.md"), vault.join("escape.md")).unwrap();
     std::os::unix::fs::symlink(outside.join("CHANGELOG.md"), vault.join("CHANGELOG.md")).unwrap();
@@ -368,13 +375,16 @@ fn boundary_refusals_share_exit_code_and_message_shape() {
         (
             "changelog add",
             vec![
-                "changelog", "add", "--category", "Added", "--message", "x", "--apply",
+                "changelog",
+                "add",
+                "--category",
+                "Added",
+                "--message",
+                "x",
+                "--apply",
             ],
         ),
-        (
-            "okf log",
-            vec!["okf", "log", "--message", "x", "--apply"],
-        ),
+        ("okf log", vec!["okf", "log", "--message", "x", "--apply"]),
         (
             "new",
             vec!["new", "--type", "note", "--file", "outdir/x.md"],
@@ -437,7 +447,8 @@ fn summary_counts_an_aliased_note_once() {
         .unwrap();
     let val: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(
-        val["results"]["files"]["total"], 2,
+        val["results"]["files"]["total"],
+        2,
         "hub.md and target.md are two files; the alias must not make three: {}",
         String::from_utf8_lossy(&out.stdout)
     );
@@ -524,7 +535,9 @@ fn out_of_vault_symlink_warning_is_printed_once() {
         .unwrap();
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert_eq!(
-        stderr.matches("symlink target resolves outside vault").count(),
+        stderr
+            .matches("symlink target resolves outside vault")
+            .count(),
         1,
         "the skip warning must be emitted once per run, got: {stderr}"
     );

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -326,7 +326,10 @@ pub fn resolve_file_ci(
         || has_parent_traversal(&normalized)
         || Path::new(&normalized).is_absolute()
     {
-        return Err(FileResolveError::OutsideVault { path: normalized });
+        return Err(FileResolveError::OutsideVault {
+            path: normalized,
+            resolved: None,
+        });
     }
 
     if !std::path::Path::new(&normalized)
@@ -391,8 +394,14 @@ pub fn resolve_file_ci(
     match ensure_within_vault(&canonical_dir, &full) {
         Ok(true) => {}
         Ok(false) => {
+            // Report where the path really lands, not just what the user typed
+            // (iter-202 L-16): a symlink escape is far easier to understand
+            // with both halves shown.
             return Err(FileResolveError::OutsideVault {
                 path: normalized.clone(),
+                resolved: dunce::canonicalize(&full)
+                    .ok()
+                    .map(|p| p.display().to_string()),
             });
         }
         Err(_) => {
@@ -788,7 +797,12 @@ pub enum FileResolveError {
     NotFoundSuggestion { path: String, suggestion: String },
     MissingExtension { path: String, hint: String },
     IsDirectory { path: String, hint: String },
-    OutsideVault { path: String },
+    OutsideVault {
+        path: String,
+        /// Canonical destination the path escaped to, when resolution (symlink
+        /// following) produced one. `None` for a purely lexical rejection.
+        resolved: Option<String>,
+    },
     InvalidPath { path: String, reason: &'static str },
 }
 
@@ -805,7 +819,16 @@ impl std::fmt::Display for FileResolveError {
             Self::IsDirectory { path, hint } => {
                 write!(f, "path is a directory, not a file: {path} (try {hint})")
             }
-            Self::OutsideVault { path } => {
+            Self::OutsideVault {
+                path,
+                resolved: Some(target),
+            } => {
+                write!(f, "file resolves outside vault boundary: {path} -> {target}")
+            }
+            Self::OutsideVault {
+                path,
+                resolved: None,
+            } => {
                 write!(f, "file resolves outside vault boundary: {path}")
             }
             Self::InvalidPath { path, reason } => {

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -810,17 +810,31 @@ pub fn relative_path(dir: &Path, file: &Path) -> String {
 /// Errors specific to file resolution.
 #[derive(Debug)]
 pub enum FileResolveError {
-    NotFound { path: String },
-    NotFoundSuggestion { path: String, suggestion: String },
-    MissingExtension { path: String, hint: String },
-    IsDirectory { path: String, hint: String },
+    NotFound {
+        path: String,
+    },
+    NotFoundSuggestion {
+        path: String,
+        suggestion: String,
+    },
+    MissingExtension {
+        path: String,
+        hint: String,
+    },
+    IsDirectory {
+        path: String,
+        hint: String,
+    },
     OutsideVault {
         path: String,
         /// Canonical destination the path escaped to, when resolution (symlink
         /// following) produced one. `None` for a purely lexical rejection.
         resolved: Option<String>,
     },
-    InvalidPath { path: String, reason: &'static str },
+    InvalidPath {
+        path: String,
+        reason: &'static str,
+    },
 }
 
 impl std::fmt::Display for FileResolveError {
@@ -840,7 +854,10 @@ impl std::fmt::Display for FileResolveError {
                 path,
                 resolved: Some(target),
             } => {
-                write!(f, "file resolves outside vault boundary: {path} -> {target}")
+                write!(
+                    f,
+                    "file resolves outside vault boundary: {path} -> {target}"
+                )
             }
             Self::OutsideVault {
                 path,
@@ -1558,6 +1575,63 @@ mod tests {
         let files = discover_files(tmp.path()).unwrap();
         assert_eq!(files.len(), 2);
         assert!(files.iter().all(|f| f.extension().unwrap() == "md"));
+    }
+
+    /// M-5 (iter-202): a symlink and its target are two directory entries but
+    /// one file. Enumerating both made whole-vault writers rewrite the same
+    /// note twice — the second write tripping the concurrent-modification
+    /// guard — and inflated every count the CLI reports.
+    #[cfg(unix)]
+    #[test]
+    fn discover_dedups_intra_vault_symlink_and_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("real.md"), "# Real").unwrap();
+        std::os::unix::fs::symlink("real.md", tmp.path().join("alias.md")).unwrap();
+
+        let files = discover_files(tmp.path()).unwrap();
+        assert_eq!(files.len(), 1, "one file, two spellings: {files:?}");
+        assert!(
+            files[0].ends_with("alias.md"),
+            "the first spelling in sort order wins: {files:?}"
+        );
+    }
+
+    /// The surviving spelling must not depend on walk order, which is
+    /// non-deterministic (the walker is parallel).
+    #[cfg(unix)]
+    #[test]
+    fn discover_dedup_is_stable_across_runs() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("zzz")).unwrap();
+        fs::write(tmp.path().join("zzz/real.md"), "# Real").unwrap();
+        std::os::unix::fs::symlink("zzz/real.md", tmp.path().join("aaa.md")).unwrap();
+        fs::write(tmp.path().join("other.md"), "# Other").unwrap();
+
+        let first = discover_files(tmp.path()).unwrap();
+        for _ in 0..5 {
+            assert_eq!(
+                discover_files(tmp.path()).unwrap(),
+                first,
+                "dedup must pick the same spelling every run"
+            );
+        }
+        assert_eq!(first.len(), 2, "aaa.md + other.md: {first:?}");
+        assert!(first[0].ends_with("aaa.md"), "{first:?}");
+    }
+
+    /// Two distinct notes that merely *look* similar must both survive — the
+    /// dedup key is the canonical path, not the file name or content.
+    #[cfg(unix)]
+    #[test]
+    fn discover_keeps_distinct_files_with_symlinks_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("a.md"), "# A").unwrap();
+        fs::write(tmp.path().join("b.md"), "# B").unwrap();
+        std::os::unix::fs::symlink("a.md", tmp.path().join("c.md")).unwrap();
+
+        let files = discover_files(tmp.path()).unwrap();
+        assert_eq!(files.len(), 2, "a.md (as a.md) and b.md: {files:?}");
+        assert!(files.iter().any(|f| f.ends_with("b.md")), "{files:?}");
     }
 
     #[test]

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -2,6 +2,7 @@
 use anyhow::{Context, Result};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::sync::mpsc;
@@ -209,42 +210,63 @@ fn discover_files_with_include(dir: &Path, include: Option<&ScanInclude>) -> Res
 
     let mut files: Vec<PathBuf> = rx.into_iter().collect();
 
-    // Filter out symlinks whose target resolves outside the vault boundary.
-    // Only canonicalize paths that are actually symlinks to avoid unnecessary
-    // syscalls on the common (non-symlink) path.
+    // Sort before filtering so the dedup below is deterministic: when a file is
+    // reachable under two spellings, the lexicographically first one wins on
+    // every platform and every run.
+    files.sort();
+
+    // Two jobs in one pass:
+    //
+    // 1. Drop symlinks whose target resolves outside the vault boundary.
+    // 2. Drop duplicate spellings of the same file (iter-202 M-5). An in-vault
+    //    symlink and its target are two directory entries but one file; left
+    //    unmerged they make `links fix --apply` rewrite the same note twice
+    //    (the second write trips the concurrent-modification guard) and
+    //    double-count `find --count`, `summary` and glob-write totals.
+    //
+    // Only paths that are actually symlinks are canonicalized — the common
+    // (non-symlink) case pays one `symlink_metadata` call and no more. A
+    // non-symlink entry's canonical form is just the canonical vault root
+    // joined with its vault-relative path, because the walker never descends
+    // through directory symlinks.
     let canonical_dir = canonicalize_vault_dir(dir)?;
-    files.retain(|path| {
+    let mut seen: HashSet<PathBuf> = HashSet::with_capacity(files.len());
+    let mut kept: Vec<PathBuf> = Vec::with_capacity(files.len());
+    for path in files {
         let is_symlink = path
             .symlink_metadata()
             .is_ok_and(|m| m.file_type().is_symlink());
-        if !is_symlink {
-            return true;
-        }
-        match dunce::canonicalize(path) {
-            Ok(canonical) => {
-                if canonical.starts_with(&canonical_dir) {
-                    true
-                } else {
+        let canonical = if is_symlink {
+            match dunce::canonicalize(&path) {
+                Ok(canonical) if canonical.starts_with(&canonical_dir) => canonical,
+                Ok(_) => {
                     eprintln!(
                         "warning: skipping {}: symlink target resolves outside vault",
                         path.display()
                     );
-                    false
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "warning: skipping {}: failed to resolve path: {}",
+                        path.display(),
+                        e
+                    );
+                    continue;
                 }
             }
-            Err(e) => {
-                eprintln!(
-                    "warning: skipping {}: failed to resolve path: {}",
-                    path.display(),
-                    e
-                );
-                false
+        } else {
+            match path.strip_prefix(dir) {
+                Ok(rel) => canonical_dir.join(rel),
+                Err(_) => path.clone(),
             }
+        };
+        if seen.insert(canonical) {
+            kept.push(path);
         }
-    });
+    }
 
-    files.sort();
-    Ok(files)
+    Ok(kept)
 }
 
 /// Resolve a path argument relative to `--dir`. Verifies it exists and is `.md`.

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -4,8 +4,8 @@ use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 use std::sync::mpsc;
+use std::sync::{LazyLock, Mutex, OnceLock};
 
 use crate::case_index::CaseInsensitiveIndex;
 use crate::link_graph::strip_site_prefix;
@@ -129,6 +129,30 @@ pub fn set_scan_include(patterns: &[String]) -> Vec<(String, String)> {
     errors
 }
 
+/// Paths already reported as skipped by [`discover_files`], so a command that
+/// walks the vault more than once per run does not repeat itself.
+///
+/// A single `hyalo` invocation calls `discover_files` several times (counting,
+/// then collecting, then hinting), which made every out-of-vault symlink skip
+/// print two or three identical warnings (iter-202 M-5). The set is
+/// process-global and never cleared: one process is one CLI run.
+static WARNED_SKIPS: LazyLock<Mutex<HashSet<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Emit `message` for `path` unless the same path was already reported.
+///
+/// A poisoned lock is treated as "not yet warned" — a duplicate warning is a
+/// far better outcome than aborting a walk over it.
+fn warn_skip_once(path: &Path, message: &str) {
+    let first = match WARNED_SKIPS.lock() {
+        Ok(mut seen) => seen.insert(path.to_path_buf()),
+        Err(_) => true,
+    };
+    if first {
+        eprintln!("warning: skipping {}: {message}", path.display());
+    }
+}
+
 /// True when any component of `rel` is a hidden (dot-prefixed) segment.
 fn has_hidden_component(rel: &str) -> bool {
     rel.split('/')
@@ -240,18 +264,11 @@ fn discover_files_with_include(dir: &Path, include: Option<&ScanInclude>) -> Res
             match dunce::canonicalize(&path) {
                 Ok(canonical) if canonical.starts_with(&canonical_dir) => canonical,
                 Ok(_) => {
-                    eprintln!(
-                        "warning: skipping {}: symlink target resolves outside vault",
-                        path.display()
-                    );
+                    warn_skip_once(&path, "symlink target resolves outside vault");
                     continue;
                 }
                 Err(e) => {
-                    eprintln!(
-                        "warning: skipping {}: failed to resolve path: {}",
-                        path.display(),
-                        e
-                    );
+                    warn_skip_once(&path, &format!("failed to resolve path: {e}"));
                     continue;
                 }
             }

--- a/crates/hyalo-core/src/fs_util.rs
+++ b/crates/hyalo-core/src/fs_util.rs
@@ -43,6 +43,81 @@ fn resolve_write_target(path: &Path) -> Result<PathBuf> {
     )
 }
 
+/// Walk up from `path` to the nearest ancestor that exists on disk.
+///
+/// Used to find a canonicalizable anchor when the destination of a prospective
+/// write (and possibly several of its parent directories) does not exist yet.
+fn nearest_existing_ancestor(path: &Path) -> PathBuf {
+    let mut current = path;
+    loop {
+        if current.exists() {
+            return current.to_path_buf();
+        }
+        match current.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => current = parent,
+            _ => return current.to_path_buf(),
+        }
+    }
+}
+
+/// The one wording every vault-boundary refusal in hyalo uses (iter-202 L-16).
+///
+/// `subject` names what was refused — `"file"`, `"target path"`, `"output
+/// path"`, … — and `resolved` is the canonical destination the path escaped
+/// to. Pass `Some(target)` whenever an actual resolution happened (symlink or
+/// `..` following) so the user sees both halves of the story: the path they
+/// typed and where it really lands. Pass `None` for a purely lexical rejection,
+/// where no resolved target exists.
+#[must_use]
+pub fn outside_vault_message(subject: &str, resolved: Option<&Path>) -> String {
+    match resolved {
+        Some(target) => format!(
+            "{subject} resolves outside vault boundary: {}",
+            target.display()
+        ),
+        None => format!("{subject} resolves outside vault boundary"),
+    }
+}
+
+/// Report where a prospective write to `path` would really land, when that is
+/// outside `vault_root`.
+///
+/// Resolves `path` through any symlink chain, then anchors on the nearest
+/// ancestor that exists on disk (the destination itself, its parent, or higher
+/// for a brand-new nested file) and canonicalizes that. Because
+/// `fs::create_dir_all` only ever creates plain directories — never symlinks —
+/// an in-vault anchor guarantees every component created below it also stays
+/// in the vault.
+///
+/// Returns:
+/// - `Ok(None)` — the write stays inside the vault
+/// - `Ok(Some(target))` — the write would land at `target`, outside the vault
+/// - `Err(_)` — the vault root or the anchor could not be canonicalized
+///
+/// Call this *before* any `create_dir_all`/`OpenOptions::create_new`/rename so
+/// the refusal is a user error (exit 1) rather than a mid-write failure.
+pub fn escaping_write_target(vault_root: &Path, path: &Path) -> Result<Option<PathBuf>> {
+    let canonical_root = dunce::canonicalize(vault_root).with_context(|| {
+        format!(
+            "failed to canonicalize vault dir {} while checking a write destination",
+            vault_root.display()
+        )
+    })?;
+    let dest = resolve_write_target(path)?;
+    let anchor = nearest_existing_ancestor(&dest);
+    let canonical_anchor = dunce::canonicalize(&anchor)
+        .with_context(|| format!("failed to resolve write destination {}", anchor.display()))?;
+    if canonical_anchor.starts_with(&canonical_root) {
+        return Ok(None);
+    }
+    // Re-attach the not-yet-existing components so the reported target names
+    // the real file rather than the deepest directory that happens to exist.
+    // The boundary decision itself is made on the anchor alone, so a `..` in
+    // the suffix cannot widen what is accepted.
+    let suffix = dest.strip_prefix(&anchor).unwrap_or(Path::new(""));
+    Ok(Some(canonical_anchor.join(suffix)))
+}
+
 /// Verify that a symlink-resolved destination is still inside `vault_root`.
 ///
 /// Called only when resolution actually changed the path, so ordinary
@@ -71,9 +146,8 @@ fn ensure_resolved_within(vault_root: &Path, original: &Path, resolved: &Path) -
     };
     if !canonical_target.starts_with(&canonical_root) {
         bail!(
-            "refusing to write through symlink: {} resolves outside vault boundary: {}",
-            original.display(),
-            canonical_target.display()
+            "refusing to write through symlink: {}",
+            outside_vault_message(&original.display().to_string(), Some(&canonical_target))
         );
     }
     Ok(())

--- a/crates/hyalo-core/src/fs_util.rs
+++ b/crates/hyalo-core/src/fs_util.rs
@@ -461,6 +461,109 @@ mod tests {
     }
 
     #[test]
+    fn outside_vault_message_two_path_form() {
+        let msg = outside_vault_message("file", Some(Path::new("/elsewhere/secret.md")));
+        assert_eq!(
+            msg,
+            "file resolves outside vault boundary: /elsewhere/secret.md"
+        );
+    }
+
+    #[test]
+    fn outside_vault_message_without_resolved_target() {
+        assert_eq!(
+            outside_vault_message("path", None),
+            "path resolves outside vault boundary"
+        );
+    }
+
+    #[test]
+    fn escaping_write_target_accepts_plain_in_vault_path() {
+        let vault = tempfile::tempdir().unwrap();
+        let dest = vault.path().join("note.md");
+        std::fs::write(&dest, "x").unwrap();
+        assert!(
+            escaping_write_target(vault.path(), &dest)
+                .unwrap()
+                .is_none(),
+            "an ordinary in-vault file must not be refused"
+        );
+    }
+
+    #[test]
+    fn escaping_write_target_accepts_not_yet_existing_nested_path() {
+        let vault = tempfile::tempdir().unwrap();
+        let dest = vault.path().join("a").join("b").join("new.md");
+        assert!(
+            escaping_write_target(vault.path(), &dest)
+                .unwrap()
+                .is_none(),
+            "a brand-new nested destination anchors on the vault root"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn escaping_write_target_reports_symlink_escape() {
+        let outside = tempfile::tempdir().unwrap();
+        let escapee = outside.path().join("secret.md");
+        std::fs::write(&escapee, "untouched").unwrap();
+        let vault = tempfile::tempdir().unwrap();
+        let link = vault.path().join("alias.md");
+        std::os::unix::fs::symlink(&escapee, &link).unwrap();
+
+        let target = escaping_write_target(vault.path(), &link)
+            .unwrap()
+            .expect("the escape must be reported");
+        assert_eq!(
+            target,
+            dunce::canonicalize(&escapee).unwrap(),
+            "the reported target must be the canonical destination"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn escaping_write_target_reports_escape_through_symlinked_directory() {
+        let outside = tempfile::tempdir().unwrap();
+        let vault = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), vault.path().join("outdir")).unwrap();
+
+        // Neither the file nor its intermediate directories exist yet: the
+        // check must anchor on the symlinked directory, which already does.
+        let dest = vault.path().join("outdir").join("a").join("planted.md");
+        let target = escaping_write_target(vault.path(), &dest)
+            .unwrap()
+            .expect("a write below a symlinked-out directory must be refused");
+        assert!(
+            target.ends_with("a/planted.md"),
+            "the reported target keeps the not-yet-created components: {}",
+            target.display()
+        );
+        assert!(
+            !outside.path().join("a").exists(),
+            "the check must not create anything"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn escaping_write_target_accepts_intra_vault_symlink() {
+        let vault = tempfile::tempdir().unwrap();
+        let real = vault.path().join("real.md");
+        std::fs::write(&real, "x").unwrap();
+        let link = vault.path().join("alias.md");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert!(
+            escaping_write_target(vault.path(), &link)
+                .unwrap()
+                .is_none(),
+            "a symlink that stays inside the vault is fine"
+        );
+    }
+
+    #[test]
     fn atomic_write_fails_if_parent_missing() {
         let tmp = tempfile::tempdir().unwrap();
         // The "missing" subdirectory does not exist, so the temp file cannot be created.

--- a/crates/hyalo-core/src/fs_util.rs
+++ b/crates/hyalo-core/src/fs_util.rs
@@ -115,6 +115,11 @@ pub fn escaping_write_target(vault_root: &Path, path: &Path) -> Result<Option<Pa
     // The boundary decision itself is made on the anchor alone, so a `..` in
     // the suffix cannot widen what is accepted.
     let suffix = dest.strip_prefix(&anchor).unwrap_or(Path::new(""));
+    if suffix.as_os_str().is_empty() {
+        // `join("")` would append a trailing separator; the anchor *is* the
+        // destination here.
+        return Ok(Some(canonical_anchor));
+    }
     Ok(Some(canonical_anchor.join(suffix)))
 }
 

--- a/hyalo-knowledgebase/iterations/iteration-202-boundary-completion.md
+++ b/hyalo-knowledgebase/iterations/iteration-202-boundary-completion.md
@@ -2,7 +2,7 @@
 title: Iteration 202 — vault boundary completion and symlink walker dedup
 type: iteration
 date: 2026-08-18
-status: planned
+status: completed
 branch: iter-202/boundary-completion
 tags:
   - iteration
@@ -52,42 +52,42 @@ Repros in [[dogfood-results/dogfood-v0210-pre-release-iters-191-198]]
 
 ## Tasks
 
-- [ ] H-3: `madr toc` canonicalizes the ADR dir (following symlinks) and
+- [x] H-3: `madr toc` canonicalizes the ADR dir (following symlinks) and
       refuses when the resolved `README.md` falls outside the vault —
       same `atomic_write_within` path the iter-191 writers use. e2e for
       the `../` and symlinked-dir vectors.
-- [ ] M-3: `changelog add`/`release --apply` resolve `CHANGELOG.md`
+- [x] M-3: `changelog add`/`release --apply` resolve `CHANGELOG.md`
       through symlinks and refuse an out-of-vault target, mirroring
       `okf log`. Note: an INTENTIONAL out-of-vault changelog is
       configured via `[changelog] path` — that documented path stays
       allowed; only the silent symlink escape is refused.
-- [ ] M-4: `new --file` canonicalizes the parent directory after the
+- [x] M-4: `new --file` canonicalizes the parent directory after the
       lexical checks and refuses out-of-vault resolution with the same
       message `set` gives.
-- [ ] M-5: dedup vault enumeration by canonical path (first spelling
+- [x] M-5: dedup vault enumeration by canonical path (first spelling
       wins, stable order). Asserts: `links fix --apply` with an in-vault
       symlink exits 0 and rewrites once; `find --count` counts one file;
       the skip warning prints once. Watch Windows: canonicalize via the
       existing helpers, no `\\?\` surprises (CI covers it).
-- [ ] Unify refusal UX: one exit code (1) and one message shape for the
+- [x] Unify refusal UX: one exit code (1) and one message shape for the
       whole boundary family, adopting the two-path phrasing ("path X
       resolves outside vault Y"). Update the e2e escape-refusal suite.
-- [ ] Sweep for other unchecked writers: grep every `--apply`/write
+- [x] Sweep for other unchecked writers: grep every `--apply`/write
       command for missing canonicalize+boundary (okf index, lint --fix,
       task, set/append/remove already covered — verify and list in the
       PR body).
 
 ## Acceptance criteria
 
-- [ ] All H-3/M-3/M-4 repros from the report refuse at exit 1 with
+- [x] All H-3/M-3/M-4 repros from the report refuse at exit 1 with
       nothing written outside the vault
-- [ ] `links fix --apply` on the M-5 repro vault exits 0; the note is
+- [x] `links fix --apply` on the M-5 repro vault exits 0; the note is
       rewritten exactly once
-- [ ] `summary` on a vault with an in-vault symlink to one note reports
+- [x] `summary` on a vault with an in-vault symlink to one note reports
       1 file
-- [ ] Boundary refusals share exit code and message shape (asserted in
+- [x] Boundary refusals share exit code and message shape (asserted in
       e2e)
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q` all clean
 
 ## Non-goals


### PR DESCRIPTION
## Summary

Closes the three writers iteration 191's boundary work missed, plus the walker
bug that made `links fix --apply` false-fail in CI. Plan:
`hyalo-knowledgebase/iterations/iteration-202-boundary-completion.md`
(dogfood findings H-3, M-3, M-4, M-5, L-16).

- **New shared gate in `hyalo-core::fs_util`.** `escaping_write_target(root, path)`
  resolves a prospective destination through its symlink chain, anchors on the
  nearest ancestor that exists (so a brand-new nested file is checked too, before
  `create_dir_all` can fabricate anything), and reports the canonical target when
  it lands outside `root`. `outside_vault_message(subject, resolved)` is the single
  wording. `commands::refuse_escaping_write` wraps both into a `UserError`, so an
  escape is exit 1 rather than a mid-write `anyhow` bail.
- **H-3 — `madr toc`.** `<adr-dir>/README.md` was built straight from the positional
  `DIR`, so `../outside` (or an in-vault ADR directory that is a symlink pointing
  out) created or rewrote a README anywhere on disk at exit 0. Now gated before the
  `is_dir` probe, in dry-run as well as apply.
- **M-3 — `changelog add`/`release`.** Both wrote via `atomic_write` with no vault
  root at all, so a `CHANGELOG.md` symlinked out of the vault was followed silently.
  The boundary root is now the vault, or the *config* directory when `[changelog] path`
  is set — the documented repo-root-changelog / docs-subdir-vault layout stays
  allowed; only the silent symlink hop is refused. Writes also switched to
  `atomic_write_within` as defense in depth.
- **M-4 — `new --file`.** Lexical checks rejected `..` and absolute paths but nothing
  resolved the path, so an in-vault `outdir -> ../outside` symlink was a file-creation
  primitive. Gated before `create_dir_all`.
- **M-5 — walker dedup.** An in-vault symlink and its target were two directory
  entries for one file, so whole-vault writers processed it twice: `links fix --apply`
  rewrote the note once per spelling and the second write saw the mtime the first had
  just changed ("modified by another process", exit 1, though the fix had landed).
  The same double-count inflated `find --count`, `summary` and glob-write counters.
  Enumeration is now deduplicated by canonical path (sort first, first spelling wins,
  stable across runs), and the out-of-vault skip warning is emitted once per run
  instead of once per internal walk.
- **L-16 — one exit code, one shape.** `okf log` refused at exit 2 (the documented
  internal-error class) while everything else used 1; `mv`, `create-index` and
  `drop-index` each phrased the refusal differently. All now exit 1 and read
  `<subject> resolves outside vault boundary: <resolved target>`, with the path the
  user typed in the error's `path` field. `FileResolveError::OutsideVault` gained the
  resolved target, so the `set`/`append`/`remove`/`task` family shows both paths too.

### Writer sweep (plan task 6)

Every write path was checked for canonicalize + boundary:

| Command | Status |
| --- | --- |
| `set` / `append` / `remove` | `resolve_file` + `write_frontmatter_within(dir, …)` — already covered |
| `task toggle` | `tasks.rs` → `atomic_write_within(vault_root, …)` — already covered |
| `mv` (single + batch) | `ensure_dest_within_vault` before rename; `atomic_write_within` for link rewrites — already covered, now reusing the shared helper |
| `links fix --apply` | `link_rewrite.rs` → `atomic_write_within` — already covered |
| `lint --fix` | `write_frontmatter_within(vault_dir, …)` + `atomic_write_within(vault_dir, …)` — already covered |
| `okf index --apply` | `atomic_write_within(dir, …)`; per-file failures warn and set a non-zero exit — already covered |
| `okf log --apply` | **fixed** (exit 2 → 1, refuses in dry-run too) |
| `madr toc --apply` | **fixed** (H-3) |
| `changelog add` / `release` | **fixed** (M-3) |
| `new --file` | **fixed** (M-4) |
| `create-index` / `drop-index` | explicit boundary check with an `--allow-outside-vault` opt-out — already covered, wording unified |
| `init` | writes into the directory the user names; that directory *is* the operand, there is no vault to escape |
| `types set` / `lint-rules set` | write the resolved `.hyalo.toml`, not a user-supplied path |

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
      `cargo test --workspace -q` — all clean (3500+ tests)
- [x] All six xtask gates exit 0 (`check-feature-fanout`, `check-help-drift`,
      `check-command-reference`, `check-bundled-skills`, and the two stubs)
- [x] 16 new e2e tests in `crates/hyalo-cli/tests/e2e/vault_boundary.rs`: every escape
      vector refuses at exit 1 with nothing written outside the vault; a configured
      repo-root changelog still works; in-vault `madr toc` / `new` still work; the
      whole family asserted to share exit code and message shape in one test
- [x] 6 new `fs_util` unit tests (in-vault paths, not-yet-existing nested paths,
      symlink escape, escape through a symlinked directory, intra-vault symlink) and
      3 new `discovery` unit tests (dedup, stability across runs, distinct files kept)
- [x] Manually reproduced all five dogfood repros against the built binary before and
      after: `madr toc ../outside --apply` now exits 1 (was exit 0 + write),
      `links fix --apply` on the aliased-note vault exits 0 and rewrites once, and
      the out-of-vault skip warning prints once instead of twice
- [x] Docs synced in the same PR: three CHANGELOG entries (added with `hyalo changelog
      add` itself), `madr toc` / `new --file` / `changelog` help texts, and the
      iteration plan marked completed via `hyalo set` / `hyalo task toggle`

No release is cut by this PR.

## Carry-over

`/review-pr` (local-only) found no issues on this diff — `cargo fmt`, clippy
(`-D warnings`), `cargo test --workspace -q` (2542 tests) and all six xtask
`check-*` subcommands (four real gates plus the two not-yet-implemented
stubs, all exit 0) were already clean before and after the review pass, so
nothing was fixed here. All six iteration-202 plan tasks and all five
acceptance criteria are ticked in
`hyalo-knowledgebase/iterations/iteration-202-boundary-completion.md`,
verified against this PR's actual diff — nothing was ticked speculatively.

The plan's only deferrals are its two Non-goals, both already filed (not by
this PR — they predate it, from the `iter-196` iteration-200-through-205
planning pass):

| Item | Disposition |
| --- | --- |
| L-3 (chmod 444 / hardlink semantics of atomic writes) | Recorded as accepted behavior in `iteration-204-dogfood-low-batch.md`'s Non-goals, unless a user report arrives |
| L-4 (`mv` onto a dangling symlink at DEST) | Task item in `iteration-204-dogfood-low-batch.md` (`status: planned`) |

Iteration 202 is the last iteration of this run; no further carry-over items
were raised by the review or by the implementation commits (no `defer`,
`TODO`, or "out of scope" annotations found in this branch's history beyond
the plan's own Non-goals section, which is the table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEuPjCTq74bwJgoWbcvHrD
