### PR TITLE
iter-204: clear the v0.21.0-pre dogfood medium/low batch (17 findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,39 @@ and this project adheres to
 
 ### Changed
 
+- **`hyalo lint --rule <id>` validates the id, and matches it
+  case-insensitively** (iter-204, M-10). A typo'd rule id used to select
+  nothing and exit 0 with "no issues found" — a CI gate that reads as green
+  forever. An unknown id is now a user error naming the id, with the
+  `hyalo lint-rules list` hint `lint-rules show` already gave; `--rule hyalo006`
+  selects exactly what `--rule HYALO006` does. `--rule-prefix` matches
+  case-insensitively too and warns on stderr when it selects no rule at all.
+- **A write command whose single named file is unparseable exits 1**
+  (iter-204, L-2). `hyalo set bad.md --property x=y` warned about the YAML
+  parse error and then reported `0/0 modified (1 scanned)` at exit 0 —
+  indistinguishable, to a script, from "already in the requested state". The
+  same applies to `remove` and `append`. Batch runs (`--glob`, several
+  `--file`s, whole-vault) are unchanged: there the other files genuinely were
+  processed, and one bad note must not fail the run.
+- **JSON match positions are 1-based in both axes** (iter-204, L-15).
+  **Breaking for consumers that parse `col`.** `links auto` reported a 1-based
+  `line` next to a 0-based `col`, so trusting one meant being off by one on the
+  other. `col` now counts from 1, like `line` and like the `column` lint
+  already emitted. Subtract 1 to recover the old byte offset.
+- **The `--help` limit contract names only commands that actually cap**
+  (iter-204, M-8). "Default output limits" listed all eight `total`-emitting
+  commands, but `types list`, `views list` and `lint-rules list` reject
+  `--limit` outright (they enumerate small fixed catalogs). Those two claims —
+  "emits a total" and "caps at `default_limit`" — now come from two separate
+  constants, each asserted against the real binary. Relatedly, bare
+  `hyalo tags` and `hyalo properties` now accept the `--glob`/`--limit` flags
+  COMMAND REFERENCE has always documented for them, instead of exiting 2.
+- **`create-index`'s help documents the snapshot contract** (iter-204, M-6),
+  and commands that load an index warn `index older than vault; results may be
+  stale — re-run create-index` when the vault's top-level directory mtimes
+  postdate the snapshot. Cheap by construction (one `read_dir`, no walk), so it
+  misses in-place edits of existing notes and changes more than one level deep
+  — it is a smoke alarm, not a guarantee.
 - **mdbook-lint bumped to 0.16.0** (iter-196). `mdbook-lint-core` and
   `mdbook-lint-rulesets` move from 0.15.2 to 0.16.0, which ships the exact
   autofix-coordinate contract hyalo asked for upstream: `Fix` ranges are
@@ -213,6 +246,49 @@ and this project adheres to
 
 ### Fixed
 
+- **Site-prefix stripping is case-insensitive** (iter-204). The prefix that
+  decides what a site-absolute `/foo` means is usually auto-derived from the
+  vault directory's name, and directory casing rarely matches the casing
+  authors write: an MDN checkout in `en-us/` publishes `/en-US/docs/...`, so
+  every site-absolute link stayed unresolved. Auto-derivation still yields a
+  single path segment — a multi-segment prefix such as `en-US/docs` must be
+  passed explicitly — and `hyalo config` now says so next to the derived value.
+- **`backlinks` counts a case-mismatched wikilink once** (iter-204, L-1).
+  `[[NOTE]]` pointing at `note.md` was registered under both the written and
+  the canonical key, which land in the same case-folded bucket, so one link
+  reported as two. `find --fields links` and `summary` were always right.
+  `mv` still rewrites such links.
+- **`mv` refuses to clobber a dangling symlink at the destination** (iter-204,
+  L-4). The collision guard used `exists()`, which follows symlinks, so a
+  symlink with a missing target read as "nothing there" and the rename
+  destroyed it silently. Both single-file and batch mode now see the directory
+  entry and stop, naming the broken symlink.
+- **`drop-index` says "index file not found" when that is the problem**
+  (iter-204, L-7). A nonexistent path *inside* the vault was reported as a
+  boundary-check failure with an `--allow-outside-vault` hint that could not
+  possibly help. The boundary is still enforced — a missing path under an
+  out-of-vault directory is refused as before.
+- **`create-index -o <custom>`'s drop hint carries `--path <custom>`**
+  (iter-204, L-9). The hint said bare `drop-index`, which targets
+  `<vault>/.hyalo-index` — a different file. The pairing is now gate-checked
+  end-to-end by executing the emitted hint.
+- **`read` errors honor the piped-JSON default** (iter-204, L-5). `read`
+  prints raw markdown rather than JSON when piped, by design — but its errors
+  followed that override too, so a scripted failure came back as prose. Every
+  `read` error path (missing file, directory target, bad `--lines`, the
+  `--count` rejection, `--section` miss) now emits the standard JSON envelope
+  when piped, and still reads as text on a terminal or under
+  `--format text`.
+- **`find -e` regex errors use the standard error envelope** (iter-204, L-6),
+  quote the pattern as typed, and no longer leak hyalo's internal `(?i)`
+  prefix — which also shifted the regex engine's caret four columns off the
+  real offending character.
+- **`read --section` misses list the five closest headings, not all of them**
+  (iter-204, UX-2). The error dumped every heading on one line — about 4 KB on
+  this project's own decision log, punitive in a terminal and pure token burn
+  for an agent, with the heading you meant buried in the middle. Candidates are
+  now ranked by closeness to what was asked for, capped at five, and followed
+  by a count. Files with five or fewer headings still list them all.
 - **`mv` no longer injects a site prefix the author never wrote** (iter-203,
   L-11). Rewriting a site-absolute link always prepended the effective prefix,
   so a working `[x](/notes/old.md)` in a vault whose prefix was auto-derived

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -12,6 +12,12 @@ use crate::output::Format;
 /// Shared with [`crate::cli::help`] so both templates use the same marker.
 pub(crate) const LIST_COMMANDS_PLACEHOLDER: &str = "{LIST_COMMANDS}";
 
+/// Token substituted with [`crate::list_commands::limited_commands_phrase`].
+///
+/// Distinct from [`LIST_COMMANDS_PLACEHOLDER`]: "emits a total" and "caps at
+/// `default_limit` and takes `--limit`" are different sets (M-8).
+pub(crate) const LIMITED_COMMANDS_PLACEHOLDER: &str = "{LIMITED_COMMANDS}";
+
 /// Shared `--file` doc string used on every command that accepts `--file`,
 /// `--glob`, and `--files-from` as mutually exclusive input sources (NEW-4).
 /// Keeping it in one place prevents future help-text drift across `find`,
@@ -579,6 +585,15 @@ pub(crate) enum Commands {
         \u{00a0} hyalo properties summary --glob 'research/**/*.md'\n\
         \u{00a0} hyalo properties rename --from old-key --to new-key")]
     Properties {
+        /// Glob pattern(s) to filter which files to scan, relative to --dir
+        /// (repeatable); prefix '!' to negate. Bare-group form of
+        /// `properties summary --glob`.
+        #[arg(short, long)]
+        glob: Vec<String>,
+        /// Maximum number of results to return (0 = unlimited). Bare-group
+        /// form of `properties summary --limit`.
+        #[arg(short = 'n', long, value_parser = parse_limit)]
+        limit: Option<usize>,
         #[command(subcommand)]
         action: Option<PropertiesAction>,
     },
@@ -592,6 +607,15 @@ pub(crate) enum Commands {
         \u{00a0} hyalo tags summary --glob 'research/**/*.md'\n\
         \u{00a0} hyalo tags rename --from old-tag --to new-tag")]
     Tags {
+        /// Glob pattern(s) to filter which files to scan, relative to --dir
+        /// (repeatable); prefix '!' to negate. Bare-group form of
+        /// `tags summary --glob`.
+        #[arg(short, long)]
+        glob: Vec<String>,
+        /// Maximum number of results to return (0 = unlimited). Bare-group
+        /// form of `tags summary --limit`.
+        #[arg(short = 'n', long, value_parser = parse_limit)]
+        limit: Option<usize>,
         #[command(subcommand)]
         action: Option<TagsAction>,
     },

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -966,6 +966,14 @@ Repeatable (AND).\n\
             read/write files on disk but also patch the index in-place after each\n\
             mutation — keeping it current for subsequent queries. This is safe as\n\
             long as no external tool modifies vault files while the index is active.\n\n\
+            SNAPSHOT CONTRACT: the index is a point-in-time copy, not a live view.\n\
+            Edits made while it exists — by hand, by another tool, or by hyalo run\n\
+            without an index flag — are invisible to indexed queries, which still\n\
+            exit 0. Commands that load an index cheaply compare the vault's\n\
+            top-level directory mtimes against the snapshot's creation time and\n\
+            warn `index older than vault` when they postdate it; that probe misses\n\
+            in-place edits of existing notes and changes more than one level deep,\n\
+            so re-run create-index whenever the vault may have changed.\n\n\
             PERFORMANCE: a body-text query combined with a narrow metadata filter\n\
             (e.g. `find \"query\" --property status=x`) still reads the whole vault\n\
             without an index, because BM25 relevance is ranked against full-vault\n\

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -2043,7 +2043,8 @@ pub(crate) enum LinksAction {
             \u{00a0}                      first_only = true is set in .hyalo.toml. Conflicts with\n\
             \u{00a0}                      --first-only.\n\
             --exclude-title       Exclude specific titles (repeatable, case-insensitive)\n\
-            --exclude-target-glob Exclude target pages by vault-relative path glob (repeatable)\n\n\
+            --exclude-target-glob Exclude target pages by vault-relative path glob (repeatable,\n\
+            \u{00a0}                      case-insensitive — 'templates/*' also excludes 'Templates/X.md')\n\n\
             COMMON-WORD TITLES: when a proposed link comes from a page whose title is an ordinary \
             English word or a generic doc filename (\"permissions\", \"index\", \"README\"), the run \
             prints one advisory note on stderr naming those titles with their match counts and the \
@@ -2097,7 +2098,8 @@ pub(crate) enum LinksAction {
         /// run without editing the config. Cannot be combined with --first-only.
         #[arg(long, conflicts_with = "first_only")]
         no_first_only: bool,
-        /// Exclude target pages whose vault-relative path matches a glob pattern (repeatable)
+        /// Exclude target pages whose vault-relative path matches a glob pattern
+        /// (repeatable; matched case-insensitively, mirroring --exclude-title)
         #[arg(long)]
         exclude_target_glob: Vec<String>,
         /// Do not print the advisory note naming candidate titles that are common

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -54,13 +54,13 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo read -f/--file F [...]                                  Flag form; FILE positional is equivalent
 
   Set (create or overwrite, mutates files):
-    hyalo set  -p/--property K=V [-p ...] [-t/--tag T ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...]
+    hyalo set  -p/--property K=V [-p ...] [-t/--tag T ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...] [--dry-run] [--validate]
 
   Remove (delete properties/tags, mutates files):
-    hyalo remove -p/--property K|K=V [...] [-t/--tag T ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...]
+    hyalo remove -p/--property K|K=V [...] [-t/--tag T ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...] [--dry-run]
 
   Append (add to list properties, mutates files):
-    hyalo append -p/--property K=V [-p ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...]
+    hyalo append -p/--property K=V [-p ...] [-t/--tag T ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...] [--dry-run] [--validate]
 
   Properties (subcommand group; bare `hyalo properties` = summary):
     hyalo properties summary [-g/--glob G] [-n/--limit N]         Unique property names, types, and file counts (read-only) [alias: list]
@@ -71,7 +71,7 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo tags rename --from OLD --to NEW [-g/--glob G]           Rename a tag across files (mutates files)
 
   Summary (vault overview, read-only):
-    hyalo summary [-g/--glob G] [-n/--recent N]
+    hyalo summary [-g/--glob G] [-n/--recent N] [--depth N] [--limit N]
 
   Task (single-task operations):
     hyalo task read       -f/--file F -l/--line N           Read task at a line
@@ -87,8 +87,12 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo links auto [--apply] [--first-only | --no-first-only] [--min-length N] [--exclude-title T ...] [--exclude-target-glob G ...] [--file F | -g/--glob G ...]   Auto-link unlinked title mentions (default: dry-run)
     Persist the exclusions in .hyalo.toml:  [links.auto] exclude_titles / exclude_target_globs / first_only (flags extend the lists; --no-first-only overrides first_only for one run)
 
-  Mv (move/rename file, updates links, mutates files):
-    hyalo mv -f/--file F --to NEW [--dry-run]
+  Mv (move/rename file or batch, updates links, mutates files):
+    hyalo mv FILE DEST [--dry-run] [--on-conflict POLICY] [--allow-ambiguous]   Single file; positional DEST aliases --to
+    hyalo mv -f/--file F --to DEST [...]                          Flag form; DEST is a .md path or an existing directory
+    hyalo mv [-g/--glob G] [-p/--property F] [-t/--tag T] [--type T] --to DIR/ [--apply]   Batch mode (selector intersection); dry-run unless --apply
+    --on-conflict POLICY: what to do when DEST already exists (see `hyalo mv --help`)
+    --allow-ambiguous: rewrite bare [[stem]] links that match several files instead of skipping them
 
   Views (manage saved find queries; bare `hyalo views` = list):
     hyalo views list                                       List all saved views [alias: summary]
@@ -97,8 +101,9 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo find --view <NAME> [additional filters...]       Use a saved view
 
   Lint (validate frontmatter against schemas + lint the markdown body, read-only):
-    hyalo lint [-f/--file F | -g/--glob G] [--files-from PATH] [--rule ID] [--rule-prefix PREFIX]
+    hyalo lint [-f/--file F | -g/--glob G] [--type T] [--files-from PATH] [--rule ID] [--rule-prefix PREFIX]
                [--detailed] [--strict] [--fix | --fix-rule ID] [--dry-run] [-n/--limit N]
+               [--max-per-rule N] [--profile okf|madr|skills|changelog]
 
   Lint-rules (manage the markdown lint rule catalog; bare `hyalo lint-rules` = list):
     hyalo lint-rules list [--enabled-only | --disabled-only] [--rule-prefix PREFIX]   List rules and settings [alias: summary]
@@ -130,16 +135,16 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo config [-d/--dir DIR]
 
   Init (configuration, one-time setup):
-    hyalo init [--claude] [--profile <PROFILE>] [-d/--dir DIR]
+    hyalo init [--claude] [--pi] [--profile <PROFILE>] [-d/--dir DIR]
 
   Deinit (remove hyalo configuration):
     hyalo deinit
 
   Create-index (build snapshot for faster queries):
-    hyalo create-index [-o/--output PATH]   # --path is an alias for --output
+    hyalo create-index [-o/--output PATH] [--allow-outside-vault]   # --path is an alias for --output
 
   Drop-index (delete snapshot index):
-    hyalo drop-index [-p/--path PATH]       # --output is an alias for --path
+    hyalo drop-index [-p/--path PATH] [--allow-outside-vault]       # --output is an alias for --path
 
   Completions (generate shell completions):
     hyalo completions <SHELL>   # bash, zsh, fish, elvish, powershell

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -160,7 +160,7 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     --index-file <PATH>       Use a snapshot index at an explicit path
 
   Default output limits:
-    List commands ({LIST_COMMANDS}) return
+    Capped commands ({LIMITED_COMMANDS}) return
     at most 50 results by default. Use --limit 0 for unlimited output.
     The default cap is bypassed when --jq or --count is used (pipelines
     need complete data). An explicit --limit is always honoured.
@@ -400,10 +400,15 @@ OUTPUT SHAPES (JSON, default):
 pub(crate) fn help_long() -> &'static str {
     static RENDERED: std::sync::OnceLock<String> = std::sync::OnceLock::new();
     RENDERED.get_or_init(|| {
-        HELP_LONG_TEMPLATE.replace(
-            crate::cli::args::LIST_COMMANDS_PLACEHOLDER,
-            crate::list_commands::list_commands_phrase(),
-        )
+        HELP_LONG_TEMPLATE
+            .replace(
+                crate::cli::args::LIST_COMMANDS_PLACEHOLDER,
+                crate::list_commands::list_commands_phrase(),
+            )
+            .replace(
+                crate::cli::args::LIMITED_COMMANDS_PLACEHOLDER,
+                crate::list_commands::limited_commands_phrase(),
+            )
     })
 }
 

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -188,6 +188,7 @@ pub fn append(
         v
     };
 
+    let files_arg = files;
     let files = collect_files(dir, files, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
@@ -261,6 +262,8 @@ pub fn append(
     }
 
     let mut index_dirty = false;
+    // L-2: relative paths skipped because their frontmatter would not parse.
+    let mut skipped_unparseable: Vec<String> = Vec::new();
 
     // Outer loop: one read-modify-write per file
     for (full_path, rel_path) in &files {
@@ -269,6 +272,7 @@ pub fn append(
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
                 crate::warn::warn(format!("skipping {rel_path}: {e}"));
+                skipped_unparseable.push(rel_path.clone());
                 continue;
             }
             Err(e) => return Err(e),
@@ -313,6 +317,14 @@ pub fn append(
                 &mut index_dirty,
             )?;
         }
+    }
+
+    // L-2: the single file the user named by hand was unparseable — report it
+    // as an error rather than a 0-modified success.
+    if let Some(outcome) =
+        super::single_named_file_unparseable(files_arg, globs, &skipped_unparseable, format)
+    {
+        return Ok(outcome);
     }
 
     if !dry_run {

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -249,11 +249,25 @@ fn run_config_text(report: &ConfigReport, show_hints: bool) -> CommandOutcome {
     let format_str = report.format.as_deref().unwrap_or("(none)");
     // Always say where the prefix came from: `(none)` alone hid the fact that
     // an auto-derived prefix was deciding what `/foo` means (iter-203, UX-4).
-    let site_prefix_str = format!(
+    let mut site_prefix_str = format!(
         "{} ({})",
         report.site_prefix.as_deref().unwrap_or("(none)"),
         report.site_prefix_source.as_str()
     );
+    // iter-204: auto-derivation can only ever produce ONE path segment — the
+    // vault directory's name — while real corpora publish multi-segment URL
+    // prefixes (MDN checked out into `en-us/` writes `/en-US/docs/...`).
+    // Matching is case-insensitive, so casing is no longer the problem; the
+    // missing second segment still is, and nothing detects it automatically.
+    // Say so where the value is shown, since a wrong prefix silently breaks
+    // every site-absolute link rather than erroring.
+    if report.site_prefix_source == crate::config::SitePrefixSource::Derived {
+        site_prefix_str.push_str(
+            "\n  note: derived prefixes are a single path segment, matched case-insensitively; \
+             if links are written with a multi-segment prefix (e.g. /en-US/docs/...), \
+             pass --site-prefix 'en-US/docs' or set site_prefix in .hyalo.toml",
+        );
+    }
     let exempt_str = list_or_none(&report.exempt);
 
     // Annotate the dir line when a `--dir` override is in effect, so the report

--- a/crates/hyalo-cli/src/commands/drop_index.rs
+++ b/crates/hyalo-cli/src/commands/drop_index.rs
@@ -40,6 +40,57 @@ pub fn drop_index(
                     return Ok(CommandOutcome::UserError(out));
                 }
             }
+            // L-7: "the file isn't there" is the overwhelmingly common reason
+            // canonicalization fails, and reporting it as a boundary-check
+            // failure sent users chasing an irrelevant `--allow-outside-vault`.
+            // Resolve the *parent* instead: if that sits inside the vault the
+            // path is in-bounds and the honest answer is "no such index file".
+            // Anything else keeps the fail-closed refusal.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let parent = index_path
+                    .parent()
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+                match dunce::canonicalize(&parent) {
+                    Ok(canonical_parent) if canonical_parent.starts_with(&canonical_dir) => {
+                        return Ok(CommandOutcome::UserError(index_not_found_error(
+                            format,
+                            &index_path,
+                        )));
+                    }
+                    Ok(canonical_parent) => {
+                        let out = crate::output::format_error(
+                            format,
+                            &hyalo_core::fs_util::outside_vault_message(
+                                "index path",
+                                Some(
+                                    &canonical_parent
+                                        .join(index_path.file_name().unwrap_or_default()),
+                                ),
+                            ),
+                            Some(&index_path.display().to_string()),
+                            Some("use --allow-outside-vault to override"),
+                            None,
+                        );
+                        return Ok(CommandOutcome::UserError(out));
+                    }
+                    Err(parent_err) => {
+                        let details = format!(
+                            "failed to resolve index path for boundary check: {parent_err}"
+                        );
+                        let out = crate::output::format_error(
+                            format,
+                            "could not verify that index path is inside the vault",
+                            Some(&index_path.display().to_string()),
+                            Some(
+                                "ensure the path is accessible and inside the vault, or use --allow-outside-vault",
+                            ),
+                            Some(&details),
+                        );
+                        return Ok(CommandOutcome::UserError(out));
+                    }
+                }
+            }
             Err(e) => {
                 let details = format!("failed to resolve index path for boundary check: {e}");
                 let out = crate::output::format_error(
@@ -59,14 +110,10 @@ pub fn drop_index(
     match std::fs::remove_file(&index_path) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            let out = crate::output::format_error(
+            return Ok(CommandOutcome::UserError(index_not_found_error(
                 format,
-                "index file not found",
-                Some(&index_path.display().to_string()),
-                Some("create one with `hyalo create-index`"),
-                None,
-            );
-            return Ok(CommandOutcome::UserError(out));
+                &index_path,
+            )));
         }
         Err(e) => {
             return Err(e)
@@ -79,4 +126,16 @@ pub fn drop_index(
     });
 
     Ok(CommandOutcome::success(format_success(format, &result)))
+}
+
+/// The "there is no index at this path" user error, shared by the boundary
+/// pre-check and the delete itself so both report the same thing (L-7).
+fn index_not_found_error(format: Format, index_path: &Path) -> String {
+    crate::output::format_error(
+        format,
+        "index file not found",
+        Some(&index_path.display().to_string()),
+        Some("create one with `hyalo create-index`"),
+        None,
+    )
 }

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -29,16 +29,6 @@ use hyalo_core::types::{
 use build::{TitleMatcher, extract_title, matches_task_filter};
 use sort::{apply_sort, presort_index_entries};
 
-/// Find files matching the given filters and return them as a JSON array.
-///
-/// Uses pre-scanned index data for all metadata (properties, tags, sections,
-/// tasks, outbound links). `dir` is still used for:
-/// - Content search (disk I/O is required to read file bodies when
-///   `pattern` or `regexp` is specified)
-/// - Link path resolution (`discovery::resolve_target`)
-///
-/// Backlinks are resolved via `index.link_graph()` without a fresh vault scan.
-#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 /// Strip hyalo's internal `(?i)` prefix out of a regex engine error message
 /// and re-align the caret line beneath it (L-6).
 ///
@@ -78,6 +68,16 @@ fn strip_case_flag_prefix(msg: &str) -> String {
     out
 }
 
+/// Find files matching the given filters and return them as a JSON array.
+///
+/// Uses pre-scanned index data for all metadata (properties, tags, sections,
+/// tasks, outbound links). `dir` is still used for:
+/// - Content search (disk I/O is required to read file bodies when
+///   `pattern` or `regexp` is specified)
+/// - Link path resolution (`discovery::resolve_target`)
+///
+/// Backlinks are resolved via `index.link_graph()` without a fresh vault scan.
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub fn find(
     index: &dyn VaultIndex,
     dir: &Path,

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -39,6 +39,45 @@ use sort::{apply_sort, presort_index_entries};
 ///
 /// Backlinks are resolved via `index.link_graph()` without a fresh vault scan.
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+/// Strip hyalo's internal `(?i)` prefix out of a regex engine error message
+/// and re-align the caret line beneath it (L-6).
+///
+/// `find -e` compiles `(?i)<pattern>` so searches are case-insensitive by
+/// default. The regex crate echoes that effective pattern in its parse error
+/// and positions the caret against it, so an unedited message shows a pattern
+/// the user never typed with the caret four columns to the right of the real
+/// offending character.
+fn strip_case_flag_prefix(msg: &str) -> String {
+    const FLAG: &str = "(?i)";
+    let mut out = String::with_capacity(msg.len());
+    // Column shift applied to the *next* caret line, set by the pattern line
+    // immediately above it. Reset after use so unrelated lines are untouched.
+    let mut caret_shift = 0usize;
+    for (i, line) in msg.lines().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix(FLAG) {
+            let indent = line.len() - trimmed.len();
+            out.push_str(&line[..indent]);
+            out.push_str(rest);
+            caret_shift = FLAG.len();
+            continue;
+        }
+        if caret_shift > 0 && trimmed.starts_with('^') {
+            let indent = line.len() - trimmed.len();
+            out.push_str(&" ".repeat(indent.saturating_sub(caret_shift)));
+            out.push_str(trimmed);
+            caret_shift = 0;
+            continue;
+        }
+        caret_shift = 0;
+        out.push_str(line);
+    }
+    out
+}
+
 pub fn find(
     index: &dyn VaultIndex,
     dir: &Path,
@@ -105,8 +144,18 @@ pub fn find(
             {
                 Ok(r) => Some(r),
                 Err(e) => {
-                    return Ok(CommandOutcome::UserError(format!(
-                        "invalid regular expression: {re}\n{e}"
+                    // L-6: report through the standard error envelope (so a
+                    // piped `--format json` run gets JSON, like every sibling),
+                    // and quote the pattern the user actually typed. `find -e`
+                    // compiles `(?i)<pattern>` internally; leaking that prefix
+                    // into the message also shifted the regex engine's caret by
+                    // four columns, pointing at the wrong character.
+                    return Ok(CommandOutcome::UserError(crate::output::format_error(
+                        format,
+                        &format!("invalid regular expression: {re}"),
+                        None,
+                        None,
+                        Some(&strip_case_flag_prefix(&e.to_string())),
                     )));
                 }
             }

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -1565,10 +1565,11 @@ pub fn lint_files_extended(
     // Build rule filter list
     let rule_filter: Vec<String> = match (opts.rule_filter, opts.rule_prefix) {
         (Some(rule), _) => vec![rule.to_owned()],
+        // M-10: prefix matching is case-insensitive so `--rule-prefix hyalo`
+        // selects the same family as `--rule-prefix HYALO`.
         (None, Some(prefix)) => md_lint_engine
-            .available_rules()
+            .rules_matching_prefix_ci(prefix)
             .iter()
-            .filter(|e| e.id.starts_with(prefix))
             .map(|e| e.id.clone())
             .collect(),
         (None, None) => vec![],

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -208,6 +208,37 @@ pub enum FilesOrOutcome {
     Outcome(CommandOutcome),
 }
 
+/// L-2 (iter-204): turn "the one file you named is unparseable" into an error.
+///
+/// A write command pointed at exactly ONE explicitly named (non-glob) file
+/// that turns out to have unparseable frontmatter used to warn on stderr and
+/// exit 0 with `0/0 modified (1 scanned)` — indistinguishable, to a script,
+/// from "the file was already in the requested state". Batch runs
+/// (`--glob`, several `--file`s, whole-vault) keep warn-and-continue: there
+/// the other files genuinely were processed, and one bad note must not fail
+/// the run.
+///
+/// `skipped_unparseable` holds the relative paths skipped for parse errors;
+/// the detailed parse diagnostic has already been warned about by the caller.
+pub(crate) fn single_named_file_unparseable(
+    files: &[String],
+    globs: &[String],
+    skipped_unparseable: &[String],
+    format: Format,
+) -> Option<CommandOutcome> {
+    if !globs.is_empty() || files.len() != 1 || skipped_unparseable.len() != 1 {
+        return None;
+    }
+    let rel = &skipped_unparseable[0];
+    Some(CommandOutcome::UserError(crate::output::format_error(
+        format,
+        &format!("{rel}: unparseable frontmatter; nothing was modified"),
+        None,
+        Some("fix the YAML frontmatter (see the warning above), then re-run"),
+        None,
+    )))
+}
+
 /// Resolve the set of files to operate on based on `--file` / `--glob` / all files.
 /// Returns a user-error outcome for invalid inputs (e.g. file not found).
 /// A glob that matches no files returns an empty file list with exit 0, not an error.

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -430,6 +430,13 @@ fn build_rename_map(
     for (src, dst) in &proposed {
         let dst_path = dir.join(dst);
         let src_path = dir.join(src);
+        // L-4: a dangling symlink is an existing directory entry even though
+        // `exists()` (which follows the link) says otherwise — treat it as a
+        // collision so batch mode reports it instead of clobbering it.
+        if dst_path.symlink_metadata().is_ok() && !dst_path.exists() {
+            pre_existing.insert(dst.clone());
+            continue;
+        }
         if dst_path.exists() {
             // Only skip if source and destination are literally the same file
             // (same path on disk — after normalization this shouldn't happen
@@ -834,6 +841,20 @@ fn validate_target_single(
     }
 
     let target_path = dir.join(&normalized);
+    // L-4: `exists()` follows symlinks, so a *dangling* symlink at DEST reads as
+    // absent and the rename silently replaced it — destroying the link without a
+    // word. `symlink_metadata` answers "is there an entry here", which is the
+    // question the collision guard is actually asking.
+    if target_path.symlink_metadata().is_ok() && !target_path.exists() {
+        let out = crate::output::format_error(
+            format,
+            "target path is a broken symlink",
+            Some(&normalized),
+            Some("remove the dangling symlink first, then re-run the move"),
+            None,
+        );
+        return Err(CommandOutcome::UserError(out));
+    }
     if target_path.exists() {
         // L-14: on a case-insensitive filesystem, a pure case rename like
         // `a.md` → `A.md` reports the destination as "existing" because it

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -133,6 +133,49 @@ fn collect_headings(body_lines: &[String]) -> Vec<String> {
     headings
 }
 
+/// How many candidate headings a section-not-found error lists (UX-2).
+const MAX_SUGGESTED_HEADINGS: usize = 5;
+
+/// Build the hint for a `--section` miss: the closest headings, then a count.
+///
+/// Dumping every heading on one line cost ~4 KB on this project's own
+/// decision-log — punitive in a terminal and pure token burn for an agent, and
+/// the useful part (the heading you meant) was buried. Rank by edit distance to
+/// what was asked for, show the [`MAX_SUGGESTED_HEADINGS`] closest, and point
+/// at the full listing for the rest.
+fn section_not_found_hint(query: &str, available: &[String]) -> String {
+    if available.is_empty() {
+        return "this file has no headings".to_owned();
+    }
+    let needle = query.to_lowercase();
+    let mut ranked: Vec<&String> = available.iter().collect();
+    // Stable sort keeps document order among equally-close headings.
+    ranked.sort_by_key(|h| {
+        // Compare against the heading text, not its `#` prefix — the prefix is
+        // identical noise that would otherwise dominate short queries.
+        let text = h.trim_start_matches('#').trim().to_lowercase();
+        // A substring match is what `--section` actually does, so rank those
+        // first regardless of length difference.
+        let contains = usize::from(!text.contains(&needle));
+        (contains, hyalo_core::util::levenshtein(&text, &needle))
+    });
+
+    let shown: Vec<&str> = ranked
+        .iter()
+        .take(MAX_SUGGESTED_HEADINGS)
+        .map(|h| h.as_str())
+        .collect();
+    let remaining = available.len().saturating_sub(shown.len());
+    if remaining == 0 {
+        format!("available sections: {}", shown.join(", "))
+    } else {
+        format!(
+            "closest sections: {} — and {remaining} more, run `hyalo read <file>` to list them all",
+            shown.join(", ")
+        )
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Read body lines from file (raw, no stripping)
 // ---------------------------------------------------------------------------
@@ -309,11 +352,7 @@ pub fn run(
         let sections = extract_sections(&content_lines, &filter);
         if sections.is_empty() {
             let available = collect_headings(&content_lines);
-            let hint = if available.is_empty() {
-                "this file has no headings".to_owned()
-            } else {
-                format!("available sections: {}", available.join(", "))
-            };
+            let hint = section_not_found_hint(query, &available);
             return Ok(CommandOutcome::UserError(format_error(
                 format,
                 &format!("section not found: {query}"),

--- a/crates/hyalo-cli/src/commands/remove.rs
+++ b/crates/hyalo-cli/src/commands/remove.rs
@@ -219,6 +219,7 @@ pub fn remove(
         })
         .collect::<Result<Vec<_>>>()?;
 
+    let files_arg = files;
     let files = collect_files(dir, files, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
@@ -234,6 +235,8 @@ pub fn remove(
         vec![(Vec::new(), Vec::new()); tag_args.len()];
 
     let mut index_dirty = false;
+    // L-2: relative paths skipped because their frontmatter would not parse.
+    let mut skipped_unparseable: Vec<String> = Vec::new();
 
     // Outer loop: one read-modify-write per file
     for (full_path, rel_path) in &files {
@@ -242,6 +245,7 @@ pub fn remove(
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
                 crate::warn::warn(format!("skipping {rel_path}: {e}"));
+                skipped_unparseable.push(rel_path.clone());
                 continue;
             }
             Err(e) => return Err(e),
@@ -297,6 +301,14 @@ pub fn remove(
                 &mut index_dirty,
             )?;
         }
+    }
+
+    // L-2: the single file the user named by hand was unparseable — report it
+    // as an error rather than a 0-modified success.
+    if let Some(outcome) =
+        super::single_named_file_unparseable(files_arg, globs, &skipped_unparseable, format)
+    {
+        return Ok(outcome);
     }
 
     if !dry_run {

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -359,6 +359,7 @@ pub fn set(
         v
     };
 
+    let files_arg = files;
     let files = collect_files(dir, files, globs, format)?;
     let files = match files {
         FilesOrOutcome::Files(f) => f,
@@ -456,6 +457,9 @@ pub fn set(
     });
     let mut batch_type_from_file: Option<String> = None;
 
+    // L-2: relative paths skipped because their frontmatter would not parse.
+    let mut skipped_unparseable: Vec<String> = Vec::new();
+
     // Outer loop: one read-modify-write per file
     for (full_path, rel_path) in &files {
         let mtime = frontmatter::read_mtime(full_path)?;
@@ -463,6 +467,7 @@ pub fn set(
             Ok(p) => p,
             Err(e) if frontmatter::is_parse_error(&e) => {
                 crate::warn::warn(format!("skipping {rel_path}: {e}"));
+                skipped_unparseable.push(rel_path.clone());
                 continue;
             }
             Err(e) => return Err(e),
@@ -527,6 +532,14 @@ pub fn set(
                 &mut index_dirty,
             )?;
         }
+    }
+
+    // L-2: the single file the user named by hand was unparseable — report it
+    // as an error rather than a 0-modified success.
+    if let Some(outcome) =
+        super::single_named_file_unparseable(files_arg, globs, &skipped_unparseable, format)
+    {
+        return Ok(outcome);
     }
 
     if !dry_run {

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -1929,6 +1929,41 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             let md_engine = hyalo_mdlint::HyaloLintEngine::create()
                 .map_err(|e| anyhow::anyhow!("failed to create lint engine: {e}"))?;
 
+            // M-10: `--rule` names a rule id, so validate it the way
+            // `lint-rules show` does instead of silently linting with a filter
+            // that matches nothing (an unknown id used to exit 0 with "no
+            // issues found", which reads as "clean" in CI). The match is
+            // case-insensitive and canonicalizes to the catalog spelling so
+            // `--rule hyalo006` behaves exactly like `--rule HYALO006`.
+            let rule = match rule {
+                Some(raw) => match md_engine.rule_entry_ci(&raw) {
+                    Some(entry) => Some(entry.id.clone()),
+                    None => {
+                        return Ok(crate::output::CommandOutcome::UserError(
+                            crate::output::format_error(
+                                ctx.user_format,
+                                &format!("no such rule: {raw}"),
+                                None,
+                                Some("run `hyalo lint-rules list` to see available rules"),
+                                None,
+                            ),
+                        ));
+                    }
+                },
+                None => None,
+            };
+            // M-10: `--rule-prefix` legitimately selects a family, so an empty
+            // selection is not fatal — but it must not look like a clean run.
+            // Warn on stderr; the prefix match itself is case-insensitive.
+            if let Some(prefix) = rule_prefix.as_deref()
+                && md_engine.rules_matching_prefix_ci(prefix).is_empty()
+            {
+                eprintln!(
+                    "warning: --rule-prefix {prefix} matches no rule; nothing will be linted \
+                     (run `hyalo lint-rules list` to see available rules)"
+                );
+            }
+
             // `--format github` emits one annotation per violation, so every
             // finding must be materialized: force `detailed` and lift the
             // per-rule / per-file caps. Otherwise the summary-mode truncation
@@ -1971,7 +2006,9 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 .unwrap_or(true);
             let hyalo006_selected = match (&rule, &rule_prefix) {
                 (Some(r), _) => r == lint_commands::RULE_ID_BROKEN_LINK,
-                (None, Some(p)) => lint_commands::RULE_ID_BROKEN_LINK.starts_with(p.as_str()),
+                (None, Some(p)) => lint_commands::RULE_ID_BROKEN_LINK
+                    .to_ascii_uppercase()
+                    .starts_with(&p.to_ascii_uppercase()),
                 (None, None) => true,
             };
             let link_lint_ctx = if hyalo006_enabled && hyalo006_selected {

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -765,10 +765,17 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 }
             }
         }
-        Commands::Properties { action } => {
+        Commands::Properties {
+            glob: bare_glob,
+            limit: bare_limit,
+            action,
+        } => {
+            // M-8: bare `hyalo properties` IS `properties summary`, so it takes
+            // the summary flags COMMAND REFERENCE documents for it rather than
+            // rejecting them at parse time.
             let action = action.unwrap_or(PropertiesAction::Summary {
-                glob: vec![],
-                limit: None,
+                glob: bare_glob,
+                limit: bare_limit,
                 index_flags: IndexFlags::default(),
             });
             match action {
@@ -849,10 +856,15 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 ),
             }
         }
-        Commands::Tags { action } => {
+        Commands::Tags {
+            glob: bare_glob,
+            limit: bare_limit,
+            action,
+        } => {
+            // M-8: see the `properties` arm — bare `hyalo tags` is `tags summary`.
             let action = action.unwrap_or(TagsAction::Summary {
-                glob: vec![],
-                limit: None,
+                glob: bare_glob,
+                limit: bare_limit,
                 index_flags: IndexFlags::default(),
             });
             match action {

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -1884,10 +1884,19 @@ fn hints_for_create_index(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hi
     };
 
     hints.push(Hint::new("Query using the index", hint_cmd));
-    hints.push(Hint::new(
-        "Delete the index when done",
-        build_command_no_glob(ctx, &["drop-index"]),
-    ));
+    // L-9: the drop hint has to name the same file the query hint does.
+    // A bare `drop-index` after `create-index -o <custom>` targets the default
+    // `<vault>/.hyalo-index` — a different file, which is either absent or
+    // someone else's index.
+    let drop_cmd = if is_default {
+        build_command_no_glob(ctx, &["drop-index"])
+    } else {
+        build_command_no_glob(
+            ctx,
+            &["drop-index", "--path", index_path.unwrap_or(".hyalo-index")],
+        )
+    };
+    hints.push(Hint::new("Delete the index when done", drop_cmd));
 
     hints
 }

--- a/crates/hyalo-cli/src/list_commands.rs
+++ b/crates/hyalo-cli/src/list_commands.rs
@@ -42,7 +42,8 @@ pub(crate) const LIST_COMMANDS: &[&str] = &[
 /// (M-8). The two claims now come from two constants.
 ///
 /// Asserted against the real binary by
-/// `tests/e2e/count.rs::limited_commands_constant_matches_binary`.
+/// `tests/e2e/count.rs::every_capped_command_accepts_limit` and
+/// `tests/e2e/count.rs::capped_commands_are_a_subset_of_list_commands`.
 pub(crate) const LIMITED_COMMANDS: &[&str] = &[
     "find",
     "lint",

--- a/crates/hyalo-cli/src/list_commands.rs
+++ b/crates/hyalo-cli/src/list_commands.rs
@@ -32,6 +32,31 @@ pub(crate) const LIST_COMMANDS: &[&str] = &[
     "lint-rules list",
 ];
 
+/// Commands that accept `--limit` and cap their output at `default_limit`.
+///
+/// A strict subset of [`LIST_COMMANDS`]: every command here emits a `total`,
+/// but not every `total`-emitting command is *capped*. `types list`,
+/// `views list` and `lint-rules list` enumerate small fixed catalogs — they
+/// return everything and reject `--limit` outright — yet the "Default output
+/// limits" help block used to name them anyway, promising a flag that exits 2
+/// (M-8). The two claims now come from two constants.
+///
+/// Asserted against the real binary by
+/// `tests/e2e/count.rs::limited_commands_constant_matches_binary`.
+pub(crate) const LIMITED_COMMANDS: &[&str] = &[
+    "find",
+    "lint",
+    "tags summary",
+    "properties summary",
+    "backlinks",
+];
+
+/// Render [`LIMITED_COMMANDS`] as a comma-separated phrase for help text.
+pub(crate) fn limited_commands_phrase() -> &'static str {
+    static PHRASE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    PHRASE.get_or_init(|| LIMITED_COMMANDS.join(", "))
+}
+
 /// Render [`LIST_COMMANDS`] as a comma-separated phrase for prose help text,
 /// e.g. `find, lint, tags summary, ...`.
 pub(crate) fn list_commands_phrase() -> &'static str {
@@ -63,6 +88,16 @@ mod tests {
         let phrase = list_commands_phrase();
         for cmd in LIST_COMMANDS {
             assert!(phrase.contains(cmd), "{cmd} missing from {phrase}");
+        }
+    }
+
+    #[test]
+    fn limited_commands_are_a_subset_of_list_commands() {
+        for cmd in LIMITED_COMMANDS {
+            assert!(
+                LIST_COMMANDS.contains(cmd),
+                "{cmd} is capped but does not emit a total"
+            );
         }
     }
 

--- a/crates/hyalo-cli/src/mutation.rs
+++ b/crates/hyalo-cli/src/mutation.rs
@@ -69,12 +69,12 @@ impl Commands {
 
             // Groups whose `action` is optional default to their read-only
             // aggregate (`summary` / `list`) when omitted.
-            Self::Properties { action } => match action {
+            Self::Properties { action, .. } => match action {
                 None | Some(PropertiesAction::Summary { .. }) => false,
                 Some(PropertiesAction::Rename { dry_run, .. }) => !dry_run,
             },
 
-            Self::Tags { action } => match action {
+            Self::Tags { action, .. } => match action {
                 None | Some(TagsAction::Summary { .. }) => false,
                 Some(TagsAction::Rename { dry_run, .. }) => !dry_run,
             },

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -14,8 +14,16 @@ pub(crate) use crate::list_commands::count_unsupported_error;
 /// Encapsulates the post-command output pipeline: jq filtering, hint generation,
 /// and envelope wrapping.
 pub(crate) struct OutputPipeline<'a> {
-    /// Format the user requested.
+    /// Format the user requested for *results*.
     pub user_format: Format,
+    /// Format used for error envelopes (L-5).
+    ///
+    /// Normally identical to [`Self::user_format`]. They diverge for `read`,
+    /// whose results default to raw text (you want the note's markdown, not a
+    /// JSON string) even when stdout is a pipe — but whose *errors* must still
+    /// follow the ambient piped-JSON default, exactly like every sibling
+    /// command, so a script can parse them.
+    pub error_format: Format,
     /// Optional jq filter expression (operates on the full envelope).
     pub jq_filter: Option<&'a str>,
     /// Optional hint context for drill-down commands.
@@ -131,7 +139,7 @@ impl OutputPipeline<'_> {
                     eprintln!(
                         "{}",
                         crate::output::format_error(
-                            self.user_format,
+                            self.error_format,
                             count_unsupported_error(),
                             None,
                             None,
@@ -147,7 +155,7 @@ impl OutputPipeline<'_> {
                     Ok(v) => v,
                     Err(e) => {
                         let msg = crate::output::format_error(
-                            self.user_format,
+                            self.error_format,
                             "internal error: failed to parse command JSON output",
                             None,
                             None,
@@ -249,7 +257,7 @@ impl OutputPipeline<'_> {
                     eprintln!(
                         "{}",
                         crate::output::format_error(
-                            self.user_format,
+                            self.error_format,
                             count_unsupported_error(),
                             None,
                             None,
@@ -275,7 +283,7 @@ impl OutputPipeline<'_> {
             Ok(CommandOutcome::UserError(output)) => {
                 // UserError strings are always formatted as JSON internally (effective_format=Json).
                 // When the user requested text format, re-format the error as human-readable text.
-                let displayed = if self.user_format == Format::Text {
+                let displayed = if self.error_format == Format::Text {
                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(&output) {
                         let error = v["error"].as_str().unwrap_or("unknown error");
                         let path = v["path"].as_str();
@@ -293,7 +301,7 @@ impl OutputPipeline<'_> {
             }
             Err(e) => {
                 let msg = crate::output::format_error(
-                    self.user_format,
+                    self.error_format,
                     &e.to_string(),
                     None,
                     None,
@@ -316,6 +324,7 @@ mod tests {
     fn pipeline_with_counters(counters: FilesFromCounters) -> OutputPipeline<'static> {
         OutputPipeline {
             user_format: Format::Text,
+            error_format: Format::Text,
             jq_filter: None,
             hint_ctx: None,
             count: false,
@@ -367,6 +376,7 @@ mod tests {
     fn skip_summary_none_when_no_counters() {
         let pipeline = OutputPipeline {
             user_format: Format::Text,
+            error_format: Format::Text,
             jq_filter: None,
             hint_ctx: None,
             count: false,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -130,13 +130,13 @@ fn effective_index_path_for(
         | Commands::Read { index_flags, .. }
         | Commands::Lint { index_flags, .. }
         | Commands::New { index_flags, .. } => Some(index_flags),
-        Commands::Tags { action } => match action {
+        Commands::Tags { action, .. } => match action {
             Some(
                 TagsAction::Summary { index_flags, .. } | TagsAction::Rename { index_flags, .. },
             ) => Some(index_flags),
             None => None,
         },
-        Commands::Properties { action } => match action {
+        Commands::Properties { action, .. } => match action {
             Some(
                 PropertiesAction::Summary { index_flags, .. }
                 | PropertiesAction::Rename { index_flags, .. },
@@ -1114,25 +1114,43 @@ fn run_inner() -> Result<(), AppError> {
                 ctx.glob.clone_from(glob);
                 Some(ctx)
             }
+            // The summary flags live on the explicit subcommand OR, for the bare
+            // group form, on the group itself (M-8) — read whichever holds them.
             Commands::Properties {
-                action: Some(crate::cli::args::PropertiesAction::Summary { glob, limit, .. }),
-            } => {
+                glob: bare_glob,
+                limit: bare_limit,
+                action,
+            } if !matches!(
+                action,
+                Some(crate::cli::args::PropertiesAction::Rename { .. })
+            ) =>
+            {
+                let (glob, limit) = match action {
+                    Some(crate::cli::args::PropertiesAction::Summary { glob, limit, .. }) => {
+                        (glob, limit)
+                    }
+                    _ => (bare_glob, bare_limit),
+                };
                 let mut ctx = HintContext::from_common(HintSource::PropertiesSummary, &common);
                 ctx.glob.clone_from(glob);
                 ctx.has_limit = limit.is_some();
                 Some(ctx)
             }
             Commands::Tags {
-                action: Some(crate::cli::args::TagsAction::Summary { glob, limit, .. }),
-            } => {
+                glob: bare_glob,
+                limit: bare_limit,
+                action,
+            } if !matches!(action, Some(crate::cli::args::TagsAction::Rename { .. })) => {
+                let (glob, limit) = match action {
+                    Some(crate::cli::args::TagsAction::Summary { glob, limit, .. }) => {
+                        (glob, limit)
+                    }
+                    _ => (bare_glob, bare_limit),
+                };
                 let mut ctx = HintContext::from_common(HintSource::TagsSummary, &common);
                 ctx.glob.clone_from(glob);
                 ctx.has_limit = limit.is_some();
                 Some(ctx)
-            }
-            Commands::Tags { action: None } => {
-                // Bare `hyalo tags` defaults to summary with no glob.
-                Some(HintContext::from_common(HintSource::TagsSummary, &common))
             }
             Commands::Find {
                 pattern,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1472,6 +1472,22 @@ fn run_inner() -> Result<(), AppError> {
                 let canonical_dir = std::fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
                 let vault_dir_str = canonical_dir.to_string_lossy();
                 if idx.validate(&vault_dir_str, site_prefix) {
+                    // M-6: a snapshot is a point-in-time copy — edits made
+                    // outside it (by hand, by another tool, or by hyalo itself
+                    // without `--index`) are simply invisible, and the run
+                    // still exits 0. Probe the vault's shallow directory mtimes
+                    // and warn when they postdate the snapshot, so a stale
+                    // index is at least noisy instead of silently wrong.
+                    let (_, _, created_at, _) = idx.header_info();
+                    if let Some(newest) = hyalo_core::index::newest_shallow_dir_mtime(&dir)
+                        && newest
+                            > created_at.saturating_add(hyalo_core::index::STALENESS_TOLERANCE_SECS)
+                    {
+                        crate::warn::warn(
+                            "index older than vault; results may be stale — re-run create-index"
+                                .to_owned(),
+                        );
+                    }
                     Some(idx)
                 } else {
                     let (hdr_vault, hdr_prefix, _, _) = idx.header_info();

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1507,8 +1507,7 @@ fn run_inner() -> Result<(), AppError> {
                             > created_at.saturating_add(hyalo_core::index::STALENESS_TOLERANCE_SECS)
                     {
                         crate::warn::warn(
-                            "index older than vault; results may be stale — re-run create-index"
-                                .to_owned(),
+                            "index older than vault; results may be stale — re-run create-index",
                         );
                     }
                     Some(idx)

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -991,6 +991,11 @@ fn run_inner() -> Result<(), AppError> {
     // --jq operates on JSON, so it conflicts with an explicit --format text.
     let jq_filter = cli.jq.as_deref();
 
+    // L-5: the `read` override below is a decision about *results* only — the
+    // ambient format (explicit `--format`, else json when stdout is a pipe)
+    // still governs error envelopes, so a scripted `hyalo read` failure parses
+    // like every other command's.
+    let error_format = format;
     // `read` defaults to text output (unlike other commands which default to json).
     // Skip the override when --jq is active (jq needs JSON).
     let format =
@@ -1604,6 +1609,7 @@ fn run_inner() -> Result<(), AppError> {
                 );
                 let pipeline = OutputPipeline {
                     user_format: format,
+                    error_format,
                     jq_filter,
                     hint_ctx: hint_ctx.as_ref(),
                     count: cli.count,
@@ -1722,6 +1728,7 @@ fn run_inner() -> Result<(), AppError> {
 
     let pipeline = OutputPipeline {
         user_format: format,
+        error_format,
         jq_filter,
         hint_ctx: hint_ctx.as_ref(),
         count: cli.count,

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -494,9 +494,13 @@ structure.
 
 ## Default output limits
 
-List commands (`find`, `lint`, `tags summary`, `properties summary`, `backlinks`, `types list`, `views list`, `lint-rules list`) return at
+Capped commands (`find`, `lint`, `tags summary`, `properties summary`, `backlinks`) return at
 most **50 results** by default to avoid flooding the context window. When results are truncated,
 output shows "showing N of M matches" and a hint to get all results.
+
+`types list`, `views list` and `lint-rules list` emit a `total` (so `--count` works) but are
+*not* capped and reject `--limit` — they enumerate small fixed catalogs and always return
+everything.
 
 - `--limit N` — override the default (e.g. `--limit 20` for fewer, `--limit 200` for more)
 - `--limit 0` — unlimited output (returns everything)

--- a/crates/hyalo-cli/tests/e2e/backlinks.rs
+++ b/crates/hyalo-cli/tests/e2e/backlinks.rs
@@ -545,3 +545,85 @@ title: Target
         "expected 'not supported' rejection message; stdout={stdout} stderr={stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// L-1 (iter-204): case-mismatched wikilinks are counted once
+// ---------------------------------------------------------------------------
+
+/// `[[NOTE]]` pointing at `note.md` was registered under both the written and
+/// the canonical key, so `backlinks` returned the one edge twice while
+/// `find --fields links` correctly reported one.
+#[test]
+fn case_mismatched_wikilink_is_counted_once() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\nBody.\n");
+    write_md(
+        tmp.path(),
+        "src.md",
+        "---\ntitle: Src\n---\nSee [[NOTE]].\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["backlinks", "note.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert_eq!(json["total"], 1, "one link must count once: {json}");
+    assert_eq!(
+        json["results"]["backlinks"].as_array().unwrap().len(),
+        1,
+        "duplicate entry in the backlink list: {json}"
+    );
+    // The written spelling is preserved so callers can still see what the
+    // author typed.
+    assert_eq!(json["results"]["backlinks"][0]["target"], "NOTE");
+}
+
+/// The de-duplication must not lose the edge: `mv` still rewrites the
+/// case-mismatched link, which is what made the double registration tempting.
+#[test]
+fn case_mismatched_wikilink_is_still_rewritten_by_mv() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\nBody.\n");
+    write_md(
+        tmp.path(),
+        "src.md",
+        "---\ntitle: Src\n---\nSee [[NOTE]].\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["mv", "note.md", "renamed.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "mv failed: {output:?}");
+    let src = std::fs::read_to_string(tmp.path().join("src.md")).unwrap();
+    assert!(
+        src.contains("[[renamed]]"),
+        "the case-mismatched link must still be rewritten: {src}"
+    );
+}
+
+/// An exact-case link is unaffected.
+#[test]
+fn exact_case_wikilink_still_counts_once() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\nBody.\n");
+    write_md(
+        tmp.path(),
+        "src.md",
+        "---\ntitle: Src\n---\nSee [[note]].\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["backlinks", "note.md", "--format", "json"])
+        .output()
+        .unwrap();
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert_eq!(json["total"], 1, "{json}");
+}

--- a/crates/hyalo-cli/tests/e2e/count.rs
+++ b/crates/hyalo-cli/tests/e2e/count.rs
@@ -314,13 +314,15 @@ fn list_commands_phrase_is_identical_in_every_help_section() {
     let help = squash(&String::from_utf8_lossy(&output.stdout));
     let occurrences = help.matches(&phrase).count();
 
-    // Four call sites render the list: the top-level OUTPUT paragraph, the
-    // --count flag's long help, the "Default output limits" block, and the
-    // OUTPUT SHAPES note. All four read from LIST_COMMANDS, so all four must
-    // agree with the runtime error verbatim.
+    // Three call sites render the *total-emitting* list: the top-level OUTPUT
+    // paragraph, the --count flag's long help, and the OUTPUT SHAPES note. All
+    // three read from LIST_COMMANDS, so all three must agree with the runtime
+    // error verbatim. The "Default output limits" block deliberately renders a
+    // different, smaller set (LIMITED_COMMANDS) — see
+    // `every_capped_command_accepts_limit` (M-8).
     assert_eq!(
-        occurrences, 4,
-        "expected the list-command phrase \"{phrase}\" in all 4 help sections, found {occurrences}"
+        occurrences, 3,
+        "expected the list-command phrase \"{phrase}\" in all 3 help sections, found {occurrences}"
     );
 }
 
@@ -398,6 +400,123 @@ fn known_non_list_commands_reject_count() {
         assert!(
             stderr.contains("--count is only supported for list commands"),
             "`hyalo {label} --count` gave an unexpected error: {stderr}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// M-8 (iter-204): the "Default output limits" claim names only capped commands
+// ---------------------------------------------------------------------------
+
+/// The capped-command phrase the binary itself prints in `--help`.
+///
+/// Parsed rather than restated, for the same reason
+/// [`declared_list_commands`] is: restating it is the drift being prevented.
+fn declared_capped_commands() -> Vec<String> {
+    let output = hyalo_no_hints().arg("--help").output().unwrap();
+    let help = squash(&String::from_utf8_lossy(&output.stdout));
+    let start = help
+        .find("Capped commands (")
+        .unwrap_or_else(|| panic!("no capped-command block in --help: {help}"))
+        + "Capped commands (".len();
+    let rest = &help[start..];
+    let end = rest.find(')').expect("unterminated capped-command list");
+    rest[..end]
+        .split(", ")
+        .map(str::trim)
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Every command the limit block names must actually take `--limit`. Three of
+/// the eight it used to name (`types list`, `views list`, `lint-rules list`)
+/// exited 2 on the flag the paragraph promised them.
+#[test]
+fn every_capped_command_accepts_limit() {
+    let tmp = setup_vault();
+    let dir = tmp.path().to_str().unwrap().to_owned();
+    let capped = declared_capped_commands();
+    assert!(
+        capped.len() >= 4,
+        "parsed a suspiciously short capped list: {capped:?}"
+    );
+
+    for cmd in &capped {
+        let mut argv: Vec<&str> = cmd.split(' ').collect();
+        if argv.first() == Some(&"backlinks") {
+            argv.push("a.md");
+        }
+        let output = hyalo_no_hints()
+            .args(["--dir", &dir])
+            .args(&argv)
+            .args(["--limit", "1"])
+            .output()
+            .unwrap();
+        assert_ne!(
+            output.status.code(),
+            Some(2),
+            "`hyalo {cmd} --limit 1` was rejected: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+/// The capped set is a strict subset of the `--count` set: a command can emit
+/// a `total` without being capped, but not the reverse.
+#[test]
+fn capped_commands_are_a_subset_of_list_commands() {
+    let list = declared_list_commands();
+    for cmd in declared_capped_commands() {
+        assert!(
+            list.contains(&cmd),
+            "{cmd} is documented as capped but emits no total"
+        );
+    }
+}
+
+/// M-8 residue: bare `hyalo tags` / `hyalo properties` are documented as
+/// aliases of their `summary` subcommand, so they must take its flags.
+#[test]
+fn bare_group_commands_accept_summary_flags() {
+    let tmp = setup_vault();
+    let dir = tmp.path().to_str().unwrap().to_owned();
+
+    for group in ["tags", "properties"] {
+        for flags in [
+            vec!["--limit", "0"],
+            vec!["--limit", "1"],
+            vec!["--glob", "*.md"],
+        ] {
+            let output = hyalo_no_hints()
+                .args(["--dir", &dir])
+                .arg(group)
+                .args(&flags)
+                .args(["--format", "json"])
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "`hyalo {group} {}` failed: {}",
+                flags.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        // And the bare form must behave exactly like the explicit summary.
+        let bare = hyalo_no_hints()
+            .args(["--dir", &dir])
+            .args([group, "--limit", "1", "--format", "json"])
+            .output()
+            .unwrap();
+        let explicit = hyalo_no_hints()
+            .args(["--dir", &dir])
+            .args([group, "summary", "--limit", "1", "--format", "json"])
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&bare.stdout),
+            String::from_utf8_lossy(&explicit.stdout),
+            "bare `{group}` must match `{group} summary`"
         );
     }
 }

--- a/crates/hyalo-cli/tests/e2e/hint_execution.rs
+++ b/crates/hyalo-cli/tests/e2e/hint_execution.rs
@@ -567,3 +567,82 @@ fn snapshot_diff_detects_a_write() {
         "unexpected diff: {diff}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// L-9 (iter-204): a custom index path propagates into BOTH follow-up hints
+// ---------------------------------------------------------------------------
+
+/// `create-index -o <custom>` emitted a bare `drop-index` hint, which targets
+/// `<vault>/.hyalo-index` — a different file. Following it left the custom
+/// index on disk (and, in a read-only vault, failed outright).
+///
+/// The seed sweep above cannot cover this: its commands are static argv, while
+/// a custom index path only exists relative to a temp vault. So this test runs
+/// the pairing end-to-end — create at a custom path, harvest the hints, execute
+/// the drop hint verbatim, and check which file actually disappeared.
+#[test]
+fn custom_index_path_drop_hint_targets_that_index() {
+    let tmp = TempDir::new().unwrap();
+    build_fixture(tmp.path());
+    let vault = tmp.path();
+    let custom = vault.join("my-index");
+    let default_index = vault.join(".hyalo-index");
+
+    // A default index also exists, so a bare `drop-index` hint would "work"
+    // while deleting the wrong file — the failure mode this test pins down.
+    let seed = hyalo()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["--format", "json", "--no-hints", "create-index"])
+        .output()
+        .unwrap();
+    assert!(
+        seed.status.success(),
+        "default create-index failed: {seed:?}"
+    );
+    assert!(default_index.exists());
+
+    let output = hyalo()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["--format", "json", "--hints"])
+        .args(["create-index", "-o", custom.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let envelope: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("no JSON envelope ({e}): {stdout}"));
+    assert!(custom.exists(), "custom index was not created");
+
+    let drop_hint = envelope["hints"]
+        .as_array()
+        .expect("hints array")
+        .iter()
+        .find_map(|h| {
+            let cmd = h.get("cmd")?.as_str()?;
+            cmd.contains("drop-index").then(|| cmd.to_owned())
+        })
+        .unwrap_or_else(|| panic!("no drop-index hint in {envelope}"));
+    assert!(
+        drop_hint.contains(custom.to_str().unwrap()),
+        "drop hint must name the custom index: {drop_hint}"
+    );
+
+    // Run the hint exactly as printed.
+    let argv: Vec<String> = shell_split(&drop_hint)
+        .into_iter()
+        .skip(1) // leading `hyalo`
+        .collect();
+    let run = hyalo().args(&argv).output().unwrap();
+    assert!(
+        run.status.success(),
+        "the drop hint did not run: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        !custom.exists(),
+        "the custom index should have been deleted"
+    );
+    assert!(
+        default_index.exists(),
+        "the default index must be left alone"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/hint_execution.rs
+++ b/crates/hyalo-cli/tests/e2e/hint_execution.rs
@@ -334,8 +334,12 @@ fn every_emitted_hint_executes_cleanly() {
 fn gate_rejects_a_hint_that_does_not_parse() {
     let tmp = TempDir::new().unwrap();
     build_fixture(tmp.path());
-    // The exact pre-iter-192 bug: `--limit` belongs to `tags summary`, not `tags`.
-    let argv = to_argv("hyalo tags --limit 0", tmp.path());
+    // The pre-iter-192 bug was `hyalo tags --limit 0` — a flag that belonged to
+    // `tags summary`, not the bare group. iter-204 (M-8) made bare `tags` take
+    // the summary flags, so the canary moved to a flag that genuinely does not
+    // exist anywhere: `types list` has no `--limit`, and the "Default output
+    // limits" help block no longer claims it does.
+    let argv = to_argv("hyalo types list --limit 0", tmp.path());
     let output = hyalo().args(&argv).output().unwrap();
     let reason = rejection_reason(
         output.status.code(),
@@ -344,7 +348,7 @@ fn gate_rejects_a_hint_that_does_not_parse() {
     );
     assert!(
         reason.is_some(),
-        "`hyalo tags --limit 0` must be classified as a rejection"
+        "`hyalo types list --limit 0` must be classified as a rejection"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e/index.rs
+++ b/crates/hyalo-cli/tests/e2e/index.rs
@@ -2453,3 +2453,73 @@ fn iter157_find_without_link_flags_works_with_empty_stem_map() {
     assert!(files.contains(&"c.md".to_string()));
     assert!(files.contains(&"sub/d.md".to_string()));
 }
+
+// ---------------------------------------------------------------------------
+// M-6 (iter-204): snapshot staleness signal
+// ---------------------------------------------------------------------------
+
+/// A freshly built index must NOT warn — the index's own creation touches the
+/// vault directory, so an mtime-only probe would false-positive here.
+#[test]
+fn fresh_index_does_not_warn_about_staleness() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\nBody.\n");
+    write_md(tmp.path(), "sub/b.md", "---\ntitle: B\n---\nBody.\n");
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["create-index"])
+        .output()
+        .unwrap();
+
+    let out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--index", "--format", "json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("index older than vault"),
+        "fresh index must not warn: {stderr}"
+    );
+}
+
+/// A note added to a subdirectory after the index was built makes the vault
+/// newer than the snapshot: warn on stderr, still exit 0.
+#[test]
+fn stale_index_warns_when_vault_is_newer() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\nBody.\n");
+    write_md(tmp.path(), "sub/b.md", "---\ntitle: B\n---\nBody.\n");
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["create-index"])
+        .output()
+        .unwrap();
+
+    // The probe compares whole seconds with one second of slack, so the vault
+    // edit has to land at least two seconds after the snapshot was written.
+    std::thread::sleep(std::time::Duration::from_millis(2100));
+    write_md(tmp.path(), "sub/c.md", "---\ntitle: C\n---\nBody.\n");
+
+    let out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--index", "--format", "json"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "staleness is a warning, not an error"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("index older than vault"),
+        "stale index must warn: {stderr}"
+    );
+    assert!(
+        stderr.contains("create-index"),
+        "warning must name the remedy: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/index.rs
+++ b/crates/hyalo-cli/tests/e2e/index.rs
@@ -2523,3 +2523,47 @@ fn stale_index_warns_when_vault_is_newer() {
         "warning must name the remedy: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// L-10 (iter-204): create-index text output has JSON parity
+// ---------------------------------------------------------------------------
+
+/// `--help` promises `path`, `files_indexed` and `warnings`; the text
+/// rendering must carry all three, plus the "replaced existing index" note
+/// when it applies — otherwise a text-mode caller cannot tell an overwrite
+/// from a first build.
+#[test]
+fn create_index_text_output_matches_json_fields() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\nBody.\n");
+
+    let first = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["create-index", "--format", "text"])
+        .output()
+        .unwrap();
+    let first_out = String::from_utf8_lossy(&first.stdout);
+    assert!(
+        first_out.contains("files_indexed: 1"),
+        "text output must carry files_indexed: {first_out}"
+    );
+    assert!(
+        first_out.contains("warnings: 0"),
+        "text output must carry warnings: {first_out}"
+    );
+    assert!(
+        !first_out.contains("replaced existing index"),
+        "a first build must not claim a replacement: {first_out}"
+    );
+
+    let second = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["create-index", "--format", "text"])
+        .output()
+        .unwrap();
+    let second_out = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        second_out.contains("note: replaced existing index"),
+        "an overwrite must say so in text mode too: {second_out}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/index.rs
+++ b/crates/hyalo-cli/tests/e2e/index.rs
@@ -2567,3 +2567,68 @@ fn create_index_text_output_matches_json_fields() {
         "an overwrite must say so in text mode too: {second_out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// L-7 (iter-204): drop-index diagnoses a missing file as missing
+// ---------------------------------------------------------------------------
+
+/// A nonexistent path *inside* the vault used to be reported as a
+/// boundary-check failure, complete with an `--allow-outside-vault` hint that
+/// could not possibly help.
+#[test]
+fn drop_index_missing_in_vault_path_reports_not_found() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\nBody.\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["drop-index", "--path", "nope-index", "--format", "text"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("index file not found"),
+        "must name the real problem: {stderr}"
+    );
+    assert!(
+        stderr.contains("nope-index"),
+        "must name the path: {stderr}"
+    );
+    assert!(
+        !stderr.contains("--allow-outside-vault"),
+        "the boundary hint is irrelevant here: {stderr}"
+    );
+}
+
+/// The boundary guarantee survives: a missing path *outside* the vault is
+/// still refused, not waved through as a harmless miss.
+#[test]
+fn drop_index_missing_out_of_vault_path_still_refused() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\nBody.\n");
+    let outside = TempDir::new().unwrap();
+    let target = outside.path().join("nope-index");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "drop-index",
+            "--path",
+            target.to_str().unwrap(),
+            "--format",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("outside vault"),
+        "out-of-vault paths must stay refused: {stderr}"
+    );
+    assert!(
+        stderr.contains("--allow-outside-vault"),
+        "and keep the override hint: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/json_errors.rs
+++ b/crates/hyalo-cli/tests/e2e/json_errors.rs
@@ -614,3 +614,144 @@ Nothing here.
         "indexed backlinks must match the live scan after links fix --apply --index"
     );
 }
+
+// ---------------------------------------------------------------------------
+// L-5 (iter-204): every `read` error path honors the piped-JSON default
+// ---------------------------------------------------------------------------
+
+/// `read` prints raw markdown by default even when piped — but its *errors*
+/// must still be JSON there, like every sibling command's.
+#[test]
+fn read_error_paths_emit_json_when_piped() {
+    let tmp = setup_vault();
+
+    // (args, substring the error message must contain)
+    let cases: [(&[&str], &str); 5] = [
+        (&["read", "missing.md"], "file not found"),
+        (&["read", "."], "directory"),
+        (&["read", "note.md", "--lines", "bogus"], "line number"),
+        (&["read", "note.md", "--count"], "--count"),
+        (
+            &["read", "note.md", "--section", "nope"],
+            "section not found",
+        ),
+    ];
+
+    for (args, needle) in cases {
+        let output = hyalo_no_hints()
+            .current_dir(tmp.path())
+            .args(args)
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{args:?} must be a user error"
+        );
+        let json = assert_json_error(&output.stderr);
+        let err = json["error"].as_str().unwrap_or_default();
+        assert!(
+            err.contains(needle),
+            "{args:?}: expected {needle:?} in {err:?}"
+        );
+    }
+}
+
+/// An explicit `--format text` still gets human-readable `read` errors.
+#[test]
+fn read_error_respects_explicit_format_text() {
+    let tmp = setup_vault();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["read", "missing.md", "--format", "text"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("Error:"),
+        "explicit text format must stay text: {stderr}"
+    );
+}
+
+/// `read` results themselves stay raw text when piped — only errors changed.
+#[test]
+fn read_success_output_stays_raw_text_when_piped() {
+    let tmp = setup_vault();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["read", "note.md"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Some text."),
+        "read must still emit raw markdown: {stdout}"
+    );
+    assert!(
+        !stdout.trim_start().starts_with('{'),
+        "read must not switch to JSON results: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// L-6 (iter-204): `find -e` regex errors use the standard envelope
+// ---------------------------------------------------------------------------
+
+/// A bad `-e` pattern must produce the JSON error envelope, quote the pattern
+/// as typed, and never leak hyalo's internal `(?i)` prefix.
+#[test]
+fn find_regex_error_uses_json_envelope_without_internal_flag() {
+    let tmp = setup_vault();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "-e", "a(b", "--format", "json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let json = assert_json_error(&output.stderr);
+    assert_eq!(
+        json["error"], "invalid regular expression: a(b",
+        "error must quote the pattern as typed: {json}"
+    );
+    let cause = json["cause"].as_str().unwrap_or_default();
+    assert!(
+        !cause.contains("(?i)"),
+        "internal case-insensitivity flag must not leak: {cause}"
+    );
+    assert!(
+        cause.contains("unclosed group"),
+        "the engine's diagnostic must survive: {cause}"
+    );
+}
+
+/// The caret in the engine's diagnostic must point at the real offender once
+/// the `(?i)` prefix is stripped (it used to sit four columns to the right).
+#[test]
+fn find_regex_error_caret_is_realigned() {
+    let tmp = setup_vault();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "-e", "a(b", "--format", "json"])
+        .output()
+        .unwrap();
+    let json = assert_json_error(&output.stderr);
+    let cause = json["cause"].as_str().unwrap_or_default().to_owned();
+    let lines: Vec<&str> = cause.lines().collect();
+    let pat_idx = lines
+        .iter()
+        .position(|l| l.trim() == "a(b")
+        .unwrap_or_else(|| panic!("pattern line missing: {cause}"));
+    let caret_line = lines[pat_idx + 1];
+    let pattern_line = lines[pat_idx];
+    let caret_col = caret_line.find('^').expect("caret");
+    let paren_col = pattern_line.find('(').expect("paren");
+    assert_eq!(
+        caret_col, paren_col,
+        "caret must sit under the '(' in:\n{cause}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -4585,3 +4585,38 @@ Bare URL: https://example.com/z/target.md
         "a resolving link in a rewritten file must not change: {nested}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// L-15 (iter-204): JSON match positions are 1-based in both axes
+// ---------------------------------------------------------------------------
+
+/// `links auto` reported a 1-based `line` next to a 0-based `col`, so a
+/// consumer that trusted one was off by one on the other.
+#[test]
+fn links_auto_match_col_is_one_based() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "target.md",
+        "---\ntitle: Target Note\n---\nBody.\n",
+    );
+    // "Target Note" starts at byte offset 4 of line 4 → column 5.
+    write_md(
+        tmp.path(),
+        "src.md",
+        "---\ntitle: Src\n---\nSee Target Note here.\n",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["links", "auto", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "links auto failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    let m = &json["results"]["matches"][0];
+    assert_eq!(m["line"], 4, "line is 1-based: {json}");
+    assert_eq!(m["col"], 5, "col must be 1-based too: {json}");
+    assert_eq!(m["matched_text"], "Target Note");
+}

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -2943,3 +2943,129 @@ fn hyalo006_files_from_scoped_link_to_unscoped_file() {
         "genuinely broken link must still fire under --files-from: {stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// M-10 (iter-204): `--rule` / `--rule-prefix` validation
+// ---------------------------------------------------------------------------
+
+/// A misspelled `--rule` id used to exit 0 with "no issues found", which reads
+/// as a clean run in CI. It must now be a user error with the discovery hint.
+#[test]
+fn lint_rule_unknown_id_is_user_error() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--rule", "MD0133"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "unknown --rule id must exit 1, got {:?}",
+        output.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no such rule: MD0133"),
+        "stderr must name the unknown rule: {stderr}"
+    );
+    assert!(
+        stderr.contains("hyalo lint-rules list"),
+        "stderr must carry the discovery hint: {stderr}"
+    );
+}
+
+/// The unknown-rule error uses the standard JSON error envelope when piped.
+#[test]
+fn lint_rule_unknown_id_json_envelope() {
+    let tmp = setup_vault_with_schema();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--rule", "NOPE1", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let val: serde_json::Value =
+        serde_json::from_str(stderr.trim()).unwrap_or_else(|e| panic!("not JSON: {stderr} ({e})"));
+    assert!(
+        val["error"].as_str().unwrap_or_default().contains("NOPE1"),
+        "envelope must name the rule: {val}"
+    );
+    assert!(
+        val["hint"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("lint-rules list"),
+        "envelope must carry the discovery hint: {val}"
+    );
+}
+
+/// `--rule hyalo006` must find exactly what `--rule HYALO006` finds.
+#[test]
+fn lint_rule_id_match_is_case_insensitive() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "src.md", "---\ntitle: S\n---\nSee [[gone]].\n");
+
+    let run = |rule: &str| {
+        let out = hyalo_no_hints()
+            .current_dir(tmp.path())
+            .args(["lint", "--rule", rule, "--detailed", "--format", "json"])
+            .output()
+            .unwrap();
+        (
+            out.status.code(),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+        )
+    };
+
+    let (upper_code, upper) = run("HYALO006");
+    let (lower_code, lower) = run("hyalo006");
+    assert_eq!(upper_code, lower_code, "exit codes must match");
+    assert_eq!(upper, lower, "lower-case rule id must select the same rule");
+    assert!(
+        upper.contains("HYALO006"),
+        "the broken link must actually be reported: {upper}"
+    );
+}
+
+/// `--rule-prefix` is case-insensitive too, and a prefix that matches nothing
+/// warns on stderr instead of looking like a clean run.
+#[test]
+fn lint_rule_prefix_case_insensitive_and_warns_when_empty() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "src.md", "---\ntitle: S\n---\nSee [[gone]].\n");
+
+    let out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "lint",
+            "--rule-prefix",
+            "hyalo",
+            "--detailed",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("HYALO006"),
+        "lower-case prefix must select the HYALO family: {stdout}"
+    );
+
+    let out = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--rule-prefix", "ZZZ"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("matches no rule"),
+        "empty prefix selection must warn: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/read.rs
+++ b/crates/hyalo-cli/tests/e2e/read.rs
@@ -925,9 +925,10 @@ fn read_leading_space_dashes_file_shows_full_content() {
 
 /// Write a note with `count` numbered sections plus one distinctive heading.
 fn write_many_sections(dir: &std::path::Path, count: usize) {
+    use std::fmt::Write as _;
     let mut body = String::from("---\ntitle: Many\n---\n");
     for i in 1..=count {
-        body.push_str(&format!("## Section {i}\n\nbody\n\n"));
+        let _ = write!(body, "## Section {i}\n\nbody\n\n");
     }
     body.push_str("## Decision Log\n\nbody\n");
     write_md(dir, "many.md", &body);

--- a/crates/hyalo-cli/tests/e2e/read.rs
+++ b/crates/hyalo-cli/tests/e2e/read.rs
@@ -918,3 +918,95 @@ fn read_leading_space_dashes_file_shows_full_content() {
         "no lines may be swallowed as pseudo-frontmatter, got: {content:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// UX-2 (iter-204): `--section` misses list the closest headings, not all of them
+// ---------------------------------------------------------------------------
+
+/// Write a note with `count` numbered sections plus one distinctive heading.
+fn write_many_sections(dir: &std::path::Path, count: usize) {
+    let mut body = String::from("---\ntitle: Many\n---\n");
+    for i in 1..=count {
+        body.push_str(&format!("## Section {i}\n\nbody\n\n"));
+    }
+    body.push_str("## Decision Log\n\nbody\n");
+    write_md(dir, "many.md", &body);
+}
+
+#[test]
+fn section_not_found_lists_closest_five_and_a_count() {
+    let tmp = TempDir::new().unwrap();
+    write_many_sections(tmp.path(), 12);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "read",
+            "many.md",
+            "--section",
+            "Decison Lg",
+            "--format",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The closest heading is ranked first, not buried in document order.
+    let hint = stderr
+        .lines()
+        .find(|l| l.trim_start().starts_with("hint:"))
+        .unwrap_or_else(|| panic!("no hint line: {stderr}"));
+    assert!(
+        hint.contains("closest sections: ## Decision Log"),
+        "the fuzzy-closest heading must lead: {hint}"
+    );
+    assert!(
+        hint.contains("and 8 more"),
+        "the remaining count must be stated: {hint}"
+    );
+    // 13 headings exist; only 5 may be listed.
+    assert_eq!(hint.matches("## ").count(), 5, "exactly 5 shown: {hint}");
+    assert!(
+        !hint.contains("## Section 12"),
+        "the full dump must be gone: {hint}"
+    );
+}
+
+/// With few headings, the full list is still the friendliest answer.
+#[test]
+fn section_not_found_lists_all_when_few_headings() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "few.md", "---\ntitle: F\n---\n## One\n## Two\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["read", "few.md", "--section", "nope", "--format", "text"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("available sections: ## One, ## Two"),
+        "short lists stay complete: {stderr}"
+    );
+    assert!(!stderr.contains("more"), "no truncation notice: {stderr}");
+}
+
+/// A file with no headings at all keeps its own message.
+#[test]
+fn section_not_found_says_no_headings() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "flat.md", "---\ntitle: F\n---\nJust prose.\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["read", "flat.md", "--section", "nope", "--format", "text"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("this file has no headings"),
+        "got: {stderr}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/set.rs
+++ b/crates/hyalo-cli/tests/e2e/set.rs
@@ -1578,3 +1578,134 @@ fn set_valid_enum_value_has_no_advisory_note() {
         json["note"]
     );
 }
+
+// ---------------------------------------------------------------------------
+// L-2 (iter-204): a single explicitly named unparseable file is an error
+// ---------------------------------------------------------------------------
+
+/// Write a vault holding one unparseable note and one clean note.
+fn setup_unparseable_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "bad.md",
+        md!(r"
+---
+title: [unclosed
+ bad: : yaml
+---
+Body.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "good.md",
+        md!(r"
+---
+title: Good
+---
+Body.
+"),
+    );
+    tmp
+}
+
+/// `set` on the single named file that cannot be parsed must exit 1 and say
+/// that nothing was modified, not report `0/0 modified (1 scanned)` at exit 0.
+#[test]
+fn set_single_named_unparseable_file_exits_1() {
+    let tmp = setup_unparseable_vault();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["set", "bad.md", "--property", "status=done"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "single unparseable named file must exit 1"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("nothing was modified"),
+        "error must state nothing was modified: {stderr}"
+    );
+    assert!(
+        stderr.contains("bad.md"),
+        "error must name the file: {stderr}"
+    );
+}
+
+/// Same rule for `remove` and `append`.
+#[test]
+fn remove_and_append_single_named_unparseable_file_exit_1() {
+    let tmp = setup_unparseable_vault();
+
+    for args in [
+        vec!["remove", "bad.md", "--property", "status"],
+        vec!["append", "bad.md", "--property", "tags=x"],
+    ] {
+        let output = hyalo_no_hints()
+            .current_dir(tmp.path())
+            .args(&args)
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{args:?} must exit 1 on a single unparseable named file"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("nothing was modified"),
+            "{args:?} stderr: {stderr}"
+        );
+    }
+}
+
+/// Batch behavior is unchanged: a glob run warns and keeps going at exit 0.
+#[test]
+fn glob_write_with_one_unparseable_file_still_exits_0() {
+    let tmp = setup_unparseable_vault();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["set", "--glob", "*.md", "--property", "status=done"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "glob writes must not fail because one note is unparseable"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("good.md"),
+        "the parseable file must still be written: {stdout}"
+    );
+}
+
+/// Two explicitly named files (one bad, one good) is a batch too: exit 0.
+#[test]
+fn two_named_files_with_one_unparseable_still_exits_0() {
+    let tmp = setup_unparseable_vault();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "set",
+            "--file",
+            "bad.md",
+            "--file",
+            "good.md",
+            "--property",
+            "status=done",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+}

--- a/crates/hyalo-cli/tests/e2e/site_prefix.rs
+++ b/crates/hyalo-cli/tests/e2e/site_prefix.rs
@@ -263,3 +263,126 @@ fn site_prefix_wrong_prefix_misses_absolute_links() {
         "wrong prefix: expected 0 backlinks, got: {json}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// iter-204: site-prefix stripping is case-insensitive (MDN-shaped fixture)
+// ---------------------------------------------------------------------------
+
+/// Build an MDN-shaped vault: the checkout directory is lower-case (`en-us`)
+/// while the published links carry the real, mixed-case URL prefix
+/// (`/en-US/docs/...`). This is the exact shape that left MDN reading as
+/// 49,703-of-49,705 links broken.
+fn write_mdn_shaped_vault(root: &std::path::Path) {
+    write_md(
+        root,
+        "web/api/index.md",
+        "---\ntitle: Web API\n---\nBody.\n",
+    );
+    write_md(root, "web/css/index.md", "---\ntitle: CSS\n---\nBody.\n");
+}
+
+/// With the prefix auto-derived from the directory name (`en-us`), a link
+/// written `/en-US/web/api` must resolve: only ASCII case differs.
+#[test]
+fn derived_site_prefix_strips_case_insensitively() {
+    let tmp = TempDir::new().unwrap();
+    let vault = tmp.path().join("en-us");
+    std::fs::create_dir_all(&vault).unwrap();
+    write_mdn_shaped_vault(&vault);
+    write_md(
+        &vault,
+        "src.md",
+        "---\ntitle: Src\n---\nSee [Web API](/en-US/web/api).\n",
+    );
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["find", "--broken-links", "--format", "json"])
+        .output()
+        .unwrap();
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert_eq!(
+        json["total"], 0,
+        "a mixed-case site prefix must still strip: {json}"
+    );
+}
+
+/// The full MDN shape needs the *two-segment* prefix, which auto-derivation
+/// cannot guess — but once passed explicitly it too matches case-insensitively.
+#[test]
+fn explicit_multi_segment_site_prefix_resolves_mdn_links() {
+    let tmp = TempDir::new().unwrap();
+    let vault = tmp.path().join("en-us");
+    std::fs::create_dir_all(&vault).unwrap();
+    write_mdn_shaped_vault(&vault);
+    write_md(
+        &vault,
+        "src.md",
+        "---\ntitle: Src\n---\nSee [Web API](/en-US/docs/web/api) and [CSS](/EN-us/DOCS/web/css).\n",
+    );
+
+    // Without the second segment the links cannot resolve.
+    let derived = hyalo_no_hints()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["find", "--broken-links", "--format", "json"])
+        .output()
+        .unwrap();
+    let derived_json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&derived.stdout)).unwrap();
+    assert_eq!(
+        derived_json["total"], 1,
+        "the single-segment derived prefix cannot cover /en-US/docs: {derived_json}"
+    );
+
+    let explicit = hyalo_no_hints()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["--site-prefix", "en-US/docs"])
+        .args(["find", "--broken-links", "--format", "json"])
+        .output()
+        .unwrap();
+    let explicit_json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&explicit.stdout)).unwrap();
+    assert_eq!(
+        explicit_json["total"], 0,
+        "both casings of the explicit prefix must strip: {explicit_json}"
+    );
+}
+
+/// `hyalo config` warns that a derived prefix is only ever one segment, so the
+/// MDN case is discoverable rather than silently wrong.
+#[test]
+fn config_notes_that_derived_prefixes_are_single_segment() {
+    let tmp = TempDir::new().unwrap();
+    let vault = tmp.path().join("en-us");
+    std::fs::create_dir_all(&vault).unwrap();
+    write_mdn_shaped_vault(&vault);
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["config", "--format", "text"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("site_prefix: en-us (derived)"),
+        "the derived value must still be reported: {stdout}"
+    );
+    assert!(
+        stdout.contains("single path segment"),
+        "the derivation limit must be stated: {stdout}"
+    );
+
+    // An explicit prefix is authoritative — no note.
+    let explicit = hyalo_no_hints()
+        .args(["--dir", vault.to_str().unwrap()])
+        .args(["--site-prefix", "en-US/docs"])
+        .args(["config", "--format", "text"])
+        .output()
+        .unwrap();
+    let explicit_out = String::from_utf8_lossy(&explicit.stdout);
+    assert!(
+        !explicit_out.contains("single path segment"),
+        "an explicit prefix needs no advice: {explicit_out}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/symlinks.rs
+++ b/crates/hyalo-cli/tests/e2e/symlinks.rs
@@ -292,3 +292,80 @@ fn mv_link_rewrite_through_symlink_updates_target() {
     );
     assert_still_symlink(&tmp.path().join("alias.md"));
 }
+
+// ---------------------------------------------------------------------------
+// L-4 (iter-204): mv refuses to clobber a dangling symlink at DEST
+// ---------------------------------------------------------------------------
+
+/// `Path::exists()` follows symlinks, so a symlink whose target is missing
+/// read as "nothing there" and the rename destroyed the link silently.
+#[cfg(unix)]
+#[test]
+fn mv_refuses_to_clobber_a_dangling_symlink() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\n---\nBody.\n");
+    std::os::unix::fs::symlink("missing-inside.md", tmp.path().join("dest.md")).unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["mv", "a.md", "dest.md", "--format", "text"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "must refuse the move");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("broken symlink"),
+        "must name the real obstacle: {stderr}"
+    );
+    assert!(
+        stderr.contains("remove the dangling symlink"),
+        "must say how to proceed: {stderr}"
+    );
+
+    // Nothing moved, and the symlink survives.
+    assert!(tmp.path().join("a.md").exists(), "source must stay put");
+    assert!(
+        tmp.path().join("dest.md").symlink_metadata().is_ok(),
+        "the dangling symlink must survive"
+    );
+    assert!(
+        tmp.path()
+            .join("dest.md")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "dest must still be a symlink, not the moved file"
+    );
+}
+
+/// Batch mode treats it as a collision rather than clobbering it.
+#[cfg(unix)]
+#[test]
+fn mv_batch_treats_a_dangling_symlink_as_a_collision() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\ntype: note\n---\nBody.\n",
+    );
+    std::fs::create_dir_all(tmp.path().join("out")).unwrap();
+    std::os::unix::fs::symlink("gone.md", tmp.path().join("out/a.md")).unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "mv", "--glob", "a.md", "--to", "out/", "--apply", "--format", "json",
+        ])
+        .output()
+        .unwrap();
+    // Either a refusal or a report that skipped the collision — what must NOT
+    // happen is the symlink being replaced by the moved file.
+    let dest = tmp.path().join("out/a.md");
+    assert!(
+        dest.symlink_metadata().unwrap().file_type().is_symlink(),
+        "batch mv clobbered the dangling symlink (exit {:?}, stderr {})",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -34,6 +34,10 @@ pub struct AutoLinkOptions<'a> {
 }
 
 /// Serialize a 0-based in-memory offset as a 1-based JSON position (L-15).
+///
+/// `serde`'s `serialize_with` contract fixes the by-reference signature, so the
+/// trivially-copy lint does not apply here.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn serialize_one_based<S>(value: &usize, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -33,6 +33,14 @@ pub struct AutoLinkOptions<'a> {
     pub glob_filter: &'a [String],
 }
 
+/// Serialize a 0-based in-memory offset as a 1-based JSON position (L-15).
+fn serialize_one_based<S>(value: &usize, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_u64(u64::try_from(value.saturating_add(1)).unwrap_or(u64::MAX))
+}
+
 /// A single proposed auto-link replacement.
 #[derive(Debug, Clone, Serialize)]
 pub struct AutoLinkMatch {
@@ -40,7 +48,13 @@ pub struct AutoLinkMatch {
     pub file: String,
     /// 1-based line number.
     pub line: usize,
-    /// Column offset (0-based byte offset within the line).
+    /// Byte offset of the match within its line.
+    ///
+    /// Held 0-based in memory (it indexes straight into the line's bytes when
+    /// building the replacement) but **serialized 1-based** under `col`, so
+    /// every position in hyalo's JSON — `line` and `col` alike — counts from
+    /// one (L-15).
+    #[serde(serialize_with = "serialize_one_based")]
     pub col: usize,
     /// The matched text as it appears in the file.
     pub matched_text: String,

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -1025,7 +1025,7 @@ pub fn newest_shallow_dir_mtime(dir: &Path) -> Option<u64> {
     for entry in read_dir.flatten() {
         // `file_type()` comes from the directory entry on every platform we
         // support, so this costs no extra syscall in the common case.
-        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        let is_dir = entry.file_type().is_ok_and(|t| t.is_dir());
         if !is_dir {
             continue;
         }

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -986,6 +986,56 @@ fn is_pid_alive(pid: u32) -> bool {
     }
 }
 
+/// Tolerance, in seconds, applied to the snapshot staleness probe.
+///
+/// `SnapshotHeader::created_at` is truncated to whole seconds while directory
+/// mtimes are not, so a directory touched in the same second the snapshot was
+/// written can read as up to one second newer. One second of slack keeps the
+/// probe from crying stale about the index's own creation.
+pub const STALENESS_TOLERANCE_SECS: u64 = 1;
+
+/// Cheap staleness probe: the newest mtime among `dir` and its immediate
+/// subdirectories, as whole seconds since the Unix epoch.
+///
+/// A directory's mtime moves when an entry is created, renamed or removed
+/// inside it, so this catches notes added or deleted in the top two levels of
+/// a vault — the common "the vault was edited behind the index's back" case —
+/// at the cost of one `read_dir` plus one `stat` per top-level entry, never a
+/// full walk (which is exactly what the snapshot exists to avoid).
+///
+/// It deliberately does NOT catch every drift: an in-place edit of an existing
+/// note leaves every directory mtime untouched, and changes more than one
+/// level deep are invisible. Callers must treat a `None`/older result as "no
+/// evidence of staleness", never as "the index is current".
+pub fn newest_shallow_dir_mtime(dir: &Path) -> Option<u64> {
+    fn mtime_secs(path: &Path) -> Option<u64> {
+        std::fs::metadata(path)
+            .ok()?
+            .modified()
+            .ok()?
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .ok()
+            .map(|d| d.as_secs())
+    }
+
+    let mut newest = mtime_secs(dir);
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return newest;
+    };
+    for entry in read_dir.flatten() {
+        // `file_type()` comes from the directory entry on every platform we
+        // support, so this costs no extra syscall in the common case.
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        if !is_dir {
+            continue;
+        }
+        if let Some(m) = mtime_secs(&entry.path()) {
+            newest = Some(newest.map_or(m, |n: u64| n.max(m)));
+        }
+    }
+    newest
+}
+
 /// Scan `dir` for `.hyalo-index` files whose creator PID is no longer running.
 ///
 /// Returns a list of `(path, vault_dir, created_at)` tuples for stale files.

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -631,11 +631,26 @@ fn insert_file_links(
             line,
             link: link.clone(),
         };
-        index
-            .entry(link.target.clone())
-            .or_default()
-            .push(entry.clone());
-        if let Some(key) = resolved_key.or(dir_index_key) {
+        let extra_key = resolved_key.or(dir_index_key);
+        // L-1: when the written target differs from the canonical key only in
+        // ASCII case (`[[NOTE]]` resolving to `note.md`), both keys fall into
+        // the same lowercased bucket and `backlinks_ci` returns the one edge
+        // twice — `hyalo backlinks note.md` reported 2 for a single link while
+        // `find --fields links` and `summary` correctly reported 1. Register
+        // the canonical spelling alone in that case: `backlinks_ci` still finds
+        // it, `mv` still rewrites it (the entry carries the original written
+        // link), and the case-sensitive `backlinks` no longer answers to a
+        // spelling no file on disk has.
+        let written_is_case_variant = extra_key
+            .as_deref()
+            .is_some_and(|k| k != link.target && k.eq_ignore_ascii_case(&link.target));
+        if !written_is_case_variant {
+            index
+                .entry(link.target.clone())
+                .or_default()
+                .push(entry.clone());
+        }
+        if let Some(key) = extra_key {
             index.entry(key).or_default().push(entry);
         }
     }
@@ -753,10 +768,23 @@ impl FileVisitor for LinkGraphVisitor {
 pub(crate) fn strip_site_prefix(target: &str, site_prefix: Option<&str>) -> String {
     let without_slash = target.strip_prefix('/').unwrap_or(target);
     if let Some(prefix) = site_prefix {
-        // Try stripping "prefix/" from the front
+        // Try stripping "prefix/" from the front.
+        //
+        // iter-204: the comparison is case-insensitive. The prefix is usually
+        // auto-derived from the vault directory name, and directory casing
+        // rarely matches the URL casing an author writes: MDN checked out into
+        // `en-us/` publishes its links as `/en-US/docs/...`, so a
+        // case-sensitive strip left every single site-absolute link
+        // unresolved. Only the ASCII case is folded, which is all URL path
+        // prefixes use in practice.
         let with_slash = format!("{prefix}/");
-        if let Some(rest) = without_slash.strip_prefix(&with_slash) {
-            return rest.to_owned();
+        // `get` rather than slicing: the prefix length is a byte count, and a
+        // multibyte target could put it mid-character.
+        if without_slash
+            .get(..with_slash.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(&with_slash))
+        {
+            return without_slash[with_slash.len()..].to_owned();
         }
     }
     without_slash.to_owned()

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -407,6 +407,31 @@ impl HyaloLintEngine {
         self.catalog.iter().find(|e| e.id == id)
     }
 
+    /// Look up a single rule entry by ID, falling back to a case-insensitive
+    /// match when the exact spelling is unknown.
+    ///
+    /// Rule ids are conventionally upper-case (`MD013`, `HYALO006`), but
+    /// hand-typed filters routinely arrive lower-cased. Callers that only need
+    /// to *select* a rule (`hyalo lint --rule`) should use this and then
+    /// canonicalize to [`RuleCatalogEntry::id`]; callers that *write* the id
+    /// into config keep using the exact [`Self::rule_entry`].
+    pub fn rule_entry_ci(&self, id: &str) -> Option<&RuleCatalogEntry> {
+        self.rule_entry(id)
+            .or_else(|| self.catalog.iter().find(|e| e.id.eq_ignore_ascii_case(id)))
+    }
+
+    /// Every rule id whose spelling starts with `prefix`, case-insensitively.
+    ///
+    /// Backs `hyalo lint --rule-prefix`, which selects a rule family rather
+    /// than a single rule; an empty result means the filter matches nothing.
+    pub fn rules_matching_prefix_ci(&self, prefix: &str) -> Vec<&RuleCatalogEntry> {
+        let upper = prefix.to_ascii_uppercase();
+        self.catalog
+            .iter()
+            .filter(|e| e.id.to_ascii_uppercase().starts_with(&upper))
+            .collect()
+    }
+
     /// Check HYALO003 (date-format) against the parsed frontmatter properties.
     ///
     /// Returns a `Vec<Diagnostic>` (zero or more) that can be merged with

--- a/crates/xtask/src/command_reference.rs
+++ b/crates/xtask/src/command_reference.rs
@@ -258,12 +258,38 @@ pub fn undocumented_flags(command: &str, sub_help: &str, entry: &str) -> Vec<Str
         .collect()
 }
 
-fn subcommand_help(root: &std::path::Path, name: &str) -> Result<String> {
-    let out = Command::new("cargo")
-        .args(["run", "-q", "-p", "hyalo-cli", "--", name, "--help"])
+/// Build `hyalo` once and return the path to the binary.
+///
+/// The accuracy pass needs one `--help` per subcommand (~27 runs). Going
+/// through `cargo run` each time would pay cargo's startup cost 27 times over
+/// — about 30 seconds of pure overhead in CI — so the binary is built once and
+/// executed directly.
+fn build_hyalo_binary(root: &std::path::Path) -> Result<std::path::PathBuf> {
+    let status = Command::new("cargo")
+        .args(["build", "-q", "-p", "hyalo-cli"])
         .current_dir(root)
+        .status()
+        .context("running `cargo build -p hyalo-cli`")?;
+    anyhow::ensure!(status.success(), "`cargo build -p hyalo-cli` failed");
+
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map_or_else(|| root.join("target"), std::path::PathBuf::from);
+    let bin = target_dir
+        .join("debug")
+        .join(format!("hyalo{}", std::env::consts::EXE_SUFFIX));
+    anyhow::ensure!(
+        bin.exists(),
+        "built hyalo binary not found at {}",
+        bin.display()
+    );
+    Ok(bin)
+}
+
+fn subcommand_help(bin: &std::path::Path, name: &str) -> Result<String> {
+    let out = Command::new(bin)
+        .args([name, "--help"])
         .output()
-        .with_context(|| format!("running `cargo run -p hyalo-cli -- {name} --help`"))?;
+        .with_context(|| format!("running `hyalo {name} --help`"))?;
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
@@ -316,6 +342,7 @@ pub fn run_with_root(root: &std::path::Path) -> Result<bool> {
 
     // Accuracy pass (M-9): an entry that exists is not necessarily current.
     let entries = reference_entries(reference);
+    let bin = build_hyalo_binary(root)?;
     let mut stale: Vec<(String, Vec<String>)> = Vec::new();
     for name in &subcommands {
         if REFERENCE_EXEMPT.contains(&name.as_str()) {
@@ -324,7 +351,7 @@ pub fn run_with_root(root: &std::path::Path) -> Result<bool> {
         let Some((_, entry)) = entries.iter().find(|(cmd, _)| cmd == name) else {
             continue;
         };
-        let sub_help = subcommand_help(root, name)?;
+        let sub_help = subcommand_help(&bin, name)?;
         let undocumented = undocumented_flags(name, &sub_help, entry);
         if !undocumented.is_empty() {
             stale.push((name.clone(), undocumented));

--- a/crates/xtask/src/command_reference.rs
+++ b/crates/xtask/src/command_reference.rs
@@ -96,6 +96,177 @@ pub fn missing_entries(subcommands: &[String], reference: &str) -> Vec<String> {
         .collect()
 }
 
+// ---------------------------------------------------------------------------
+// Flag-accuracy gate (M-9, iter-204)
+// ---------------------------------------------------------------------------
+
+/// Long flags every subcommand inherits, documented once under GLOBAL FLAGS.
+///
+/// Repeating them in each COMMAND REFERENCE entry would triple the block's
+/// length and teach nothing, so they never count as missing.
+const GLOBAL_FLAGS: &[&str] = &[
+    "--dir",
+    "--format",
+    "--jq",
+    "--hints",
+    "--no-hints",
+    "--quiet",
+    "--site-prefix",
+    "--index",
+    "--index-file",
+    "--count",
+    "--files-from",
+    "--help",
+    "--version",
+    "--config-dir",
+];
+
+/// Per-command flags deliberately left out of COMMAND REFERENCE.
+///
+/// Each entry is `(subcommand, flag, reason)`. The reason is what keeps this
+/// list from becoming a dumping ground: an omission has to be justifiable in a
+/// sentence, and a *new* flag cannot be added to the CLI without either
+/// documenting it in the reference or arguing for it here.
+const REFERENCE_FLAG_EXEMPT: &[(&str, &str, &str)] = &[
+    (
+        "find",
+        "--view",
+        "documented in the Views entry, where saved views are explained",
+    ),
+    (
+        "find",
+        "--desc",
+        "undocumented alias of --reverse, which is listed",
+    ),
+    (
+        "find",
+        "--language",
+        "BM25 stemmer tuning; belongs with the language table in `find --help`",
+    ),
+    (
+        "find",
+        "--stemmer",
+        "alias of --language, exempt for the same reason",
+    ),
+    (
+        "read",
+        "--glob",
+        "shared input-selection flag; `read` resolves to a single file, so the entry shows the FILE forms",
+    ),
+    (
+        "backlinks",
+        "--glob",
+        "shared input-selection flag; the entry shows the FILE forms",
+    ),
+];
+
+fn is_exempt_flag(command: &str, flag: &str) -> bool {
+    REFERENCE_FLAG_EXEMPT
+        .iter()
+        .any(|(cmd, f, _)| *cmd == command && *f == flag)
+}
+
+/// Extract the long flags a subcommand accepts from its own `--help` output.
+///
+/// Scans only the text after `Options:` so flags merely *mentioned* in prose
+/// (e.g. a precedence note) are not mistaken for accepted ones.
+pub fn extract_long_flags(sub_help: &str) -> Vec<String> {
+    let options = match sub_help.rfind("Options:") {
+        Some(i) => &sub_help[i..],
+        None => return Vec::new(),
+    };
+    let mut flags: Vec<String> = Vec::new();
+    for line in options.lines() {
+        let trimmed = line.trim_start();
+        // clap renders a flag declaration at indent 2 (`-s, --long`) or 6
+        // (`      --long`, no short form). Its wrapped help prose starts at
+        // indent 10 and routinely *mentions* other flags — matching there is
+        // what made an earlier draft of this gate report `--apply)`.
+        let indent = line.len() - trimmed.len();
+        if indent != 2 && indent != 6 {
+            continue;
+        }
+        let candidate = if trimmed.starts_with("--") {
+            trimmed
+        } else if let Some((_, rest)) = trimmed.split_once(", ") {
+            rest
+        } else {
+            continue;
+        };
+        let Some(name) = candidate.split([' ', '=', '<']).next() else {
+            continue;
+        };
+        // A declaration is exactly `--name`; anything carrying punctuation came
+        // from prose that happened to wrap onto a shallow line.
+        let is_declaration = name.len() > 2
+            && name.starts_with("--")
+            && name[2..]
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+        if is_declaration {
+            flags.push(name.to_owned());
+        }
+    }
+    flags.sort_unstable();
+    flags.dedup();
+    flags
+}
+
+/// Split COMMAND REFERENCE into `(command, entry-body)` pairs.
+///
+/// Entry headers are `  Xxx (…):` lines, i.e. the command name with its first
+/// letter uppercased — the same shape [`header_prefix`] builds.
+pub fn reference_entries(reference: &str) -> Vec<(String, String)> {
+    let mut entries: Vec<(String, String)> = Vec::new();
+    for line in reference.lines() {
+        let is_header = line.starts_with("  ")
+            && !line.starts_with("   ")
+            && line.contains(" (")
+            && line
+                .trim_start()
+                .chars()
+                .next()
+                .is_some_and(char::is_uppercase);
+        if is_header {
+            let name = line
+                .trim_start()
+                .split(' ')
+                .next()
+                .unwrap_or("")
+                .to_string();
+            entries.push((name.to_lowercase(), String::new()));
+        } else if let Some(last) = entries.last_mut() {
+            last.1.push('\n');
+            last.1.push_str(line);
+        }
+    }
+    entries
+}
+
+/// Flags a subcommand accepts that its COMMAND REFERENCE entry never mentions.
+///
+/// This is the accuracy half of the gate. Presence-only checking is what let
+/// `mv`'s entry go stale: it named `--file`/`--to` while the command had grown
+/// a positional form, batch mode, `--apply`, `--on-conflict` and
+/// `--allow-ambiguous` (M-9).
+pub fn undocumented_flags(command: &str, sub_help: &str, entry: &str) -> Vec<String> {
+    extract_long_flags(sub_help)
+        .into_iter()
+        .filter(|f| !GLOBAL_FLAGS.contains(&f.as_str()))
+        .filter(|f| !is_exempt_flag(command, f))
+        .filter(|f| !entry.contains(f.as_str()))
+        .collect()
+}
+
+fn subcommand_help(root: &std::path::Path, name: &str) -> Result<String> {
+    let out = Command::new("cargo")
+        .args(["run", "-q", "-p", "hyalo-cli", "--", name, "--help"])
+        .current_dir(root)
+        .output()
+        .with_context(|| format!("running `cargo run -p hyalo-cli -- {name} --help`"))?;
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
 fn top_level_help(root: &std::path::Path) -> Result<String> {
     let out = Command::new("cargo")
         .args(["run", "-q", "-p", "hyalo-cli", "--", "--help"])
@@ -129,25 +300,57 @@ pub fn run_with_root(root: &std::path::Path) -> Result<bool> {
     };
 
     let missing = missing_entries(&subcommands, reference);
-    if missing.is_empty() {
-        println!(
-            "check-command-reference: all {} subcommands appear in COMMAND REFERENCE.",
-            subcommands.len()
+    if !missing.is_empty() {
+        eprintln!("check-command-reference: FAILED");
+        for name in &missing {
+            eprintln!(
+                "  - `hyalo {name}` has no COMMAND REFERENCE entry (expected a line starting with \"{}\")",
+                header_prefix(name).trim_end()
+            );
+        }
+        eprintln!(
+            "\nAdd a section to HELP_LONG_TEMPLATE in crates/hyalo-cli/src/cli/help.rs for each command above."
         );
-        return Ok(true);
+        return Ok(false);
     }
 
-    eprintln!("check-command-reference: FAILED");
-    for name in &missing {
-        eprintln!(
-            "  - `hyalo {name}` has no COMMAND REFERENCE entry (expected a line starting with \"{}\")",
-            header_prefix(name).trim_end()
-        );
+    // Accuracy pass (M-9): an entry that exists is not necessarily current.
+    let entries = reference_entries(reference);
+    let mut stale: Vec<(String, Vec<String>)> = Vec::new();
+    for name in &subcommands {
+        if REFERENCE_EXEMPT.contains(&name.as_str()) {
+            continue;
+        }
+        let Some((_, entry)) = entries.iter().find(|(cmd, _)| cmd == name) else {
+            continue;
+        };
+        let sub_help = subcommand_help(root, name)?;
+        let undocumented = undocumented_flags(name, &sub_help, entry);
+        if !undocumented.is_empty() {
+            stale.push((name.clone(), undocumented));
+        }
     }
-    eprintln!(
-        "\nAdd a section to HELP_LONG_TEMPLATE in crates/hyalo-cli/src/cli/help.rs for each command above."
+
+    if !stale.is_empty() {
+        eprintln!("check-command-reference: FAILED (stale entries)");
+        for (name, flags) in &stale {
+            eprintln!("  - `hyalo {name}` accepts flags its entry never mentions: {flags:?}");
+        }
+        eprintln!(
+            "\nAdd them to the command's COMMAND REFERENCE entry in \
+             crates/hyalo-cli/src/cli/help.rs, or — if the omission is deliberate — \
+             record it with a reason in REFERENCE_FLAG_EXEMPT \
+             (crates/xtask/src/command_reference.rs)."
+        );
+        return Ok(false);
+    }
+
+    println!(
+        "check-command-reference: all {} subcommands appear in COMMAND REFERENCE, \
+         and every non-global flag they accept is documented there.",
+        subcommands.len()
     );
-    Ok(false)
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -219,5 +422,93 @@ COMMAND REFERENCE:
 ";
         let subs = extract_subcommands(SAMPLE);
         assert!(missing_entries(&subs, documented).is_empty());
+    }
+
+    const SUB_HELP: &str = "\
+Move or rename a markdown file.
+
+Usage: hyalo mv [OPTIONS] [FILE] [DEST]
+
+Arguments:
+  [FILE]
+          Source file
+
+Options:
+  -f, --file <FILE>
+          Source file to move
+
+      --to <TO>
+          Destination path
+
+      --on-conflict <POLICY>
+          What to do when DEST exists (rejected without --apply)
+
+      --allow-ambiguous
+          Rewrite ambiguous [[stem]] links
+
+  -h, --help
+          Print help
+";
+
+    #[test]
+    fn extract_long_flags_reads_declarations_only() {
+        let flags = extract_long_flags(SUB_HELP);
+        assert_eq!(
+            flags,
+            vec![
+                "--allow-ambiguous",
+                "--file",
+                "--help",
+                "--on-conflict",
+                "--to"
+            ]
+        );
+        // `--apply` is mentioned in wrapped prose, never declared.
+        assert!(!flags.iter().any(|f| f == "--apply"));
+    }
+
+    #[test]
+    fn undocumented_flags_reports_a_stale_entry() {
+        let entry = "    hyalo mv FILE DEST [--allow-ambiguous]";
+        assert_eq!(
+            undocumented_flags("mv", SUB_HELP, entry),
+            vec!["--file", "--on-conflict", "--to"]
+        );
+    }
+
+    #[test]
+    fn undocumented_flags_is_empty_for_a_current_entry() {
+        let entry = "    hyalo mv FILE DEST [--on-conflict P] [--allow-ambiguous]\n\
+                     hyalo mv --file F --to DEST";
+        assert!(undocumented_flags("mv", SUB_HELP, entry).is_empty());
+    }
+
+    #[test]
+    fn global_and_exempt_flags_never_count_as_missing() {
+        // `--help` is global; `--view` is exempt on `find`.
+        let help = "Options:\n  -h, --help\n      --view <NAME>\n";
+        assert!(undocumented_flags("find", help, "").is_empty());
+        // The same flag on another command is NOT exempt.
+        assert_eq!(undocumented_flags("mv", help, ""), vec!["--view"]);
+    }
+
+    #[test]
+    fn reference_entries_splits_on_headers() {
+        let reference = reference_section(SAMPLE).expect("reference section");
+        let entries = reference_entries(reference);
+        let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["find", "lint-rules"]);
+        assert!(entries[0].1.contains("hyalo find [PATTERN]"));
+        assert!(!entries[0].1.contains("lint-rules"));
+    }
+
+    #[test]
+    fn every_flag_exemption_carries_a_reason() {
+        for (cmd, flag, reason) in REFERENCE_FLAG_EXEMPT {
+            assert!(
+                reason.len() > 20,
+                "{cmd} {flag}: exemption needs a real justification, got {reason:?}"
+            );
+        }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ every invocation. `[links.auto]` persists them per vault:
 ```toml
 [links.auto]
 exclude_titles = ["permissions", "README", "index"]   # like --exclude-title (case-insensitive)
-exclude_target_globs = ["templates/*"]                # like --exclude-target-glob
+exclude_target_globs = ["templates/*"]                # like --exclude-target-glob (case-insensitive)
 first_only = true                                     # like --first-only
 warn_common_titles = false                            # opt out of the common-word note
 ```
@@ -136,6 +136,12 @@ Merge rules with the CLI flags:
 | --- | --- |
 | `exclude_titles` | **Unioned** with `--exclude-title` — the flag extends the config list, never replaces it |
 | `exclude_target_globs` | **Unioned** with `--exclude-target-glob` |
+
+Both exclusion lists match **case-insensitively**. `exclude_titles = ["readme"]`
+excludes a page titled `README`, and `exclude_target_globs = ["templates/*"]`
+excludes `Templates/Note.md` — so a vault whose directory casing is
+inconsistent (or which lives on a case-insensitive filesystem) does not need a
+pattern per spelling.
 | `first_only` | `--first-only` turns it on for a single run; the config turns it on for every run; `--no-first-only` turns it off for a single run |
 | `warn_common_titles` | On by default; `--no-warn-common-titles` turns it off for a single run, the config for every run |
 

--- a/hyalo-knowledgebase/iterations/iteration-204-dogfood-low-batch.md
+++ b/hyalo-knowledgebase/iterations/iteration-204-dogfood-low-batch.md
@@ -2,7 +2,7 @@
 title: Iteration 204 — dogfood v0.21.0-pre medium/low batch
 type: iteration
 date: 2026-08-18
-status: in-progress
+status: completed
 branch: iter-204/dogfood-low-batch
 tags:
   - iteration

--- a/hyalo-knowledgebase/iterations/iteration-204-dogfood-low-batch.md
+++ b/hyalo-knowledgebase/iterations/iteration-204-dogfood-low-batch.md
@@ -2,7 +2,7 @@
 title: Iteration 204 — dogfood v0.21.0-pre medium/low batch
 type: iteration
 date: 2026-08-18
-status: planned
+status: in-progress
 branch: iter-204/dogfood-low-batch
 tags:
   - iteration
@@ -32,53 +32,53 @@ item that turns out deep gets split out rather than ballooning here.
 
 ## Tasks
 
-### CI footguns [0/3]
+### CI footguns [3/3]
 
-- [ ] M-10: `lint --rule <name>` validates the rule id (same lookup
+- [x] M-10: `lint --rule <name>` validates the rule id (same lookup
       `lint-rules show` uses) — unknown or wrong-case id is exit 1 with
       the `lint-rules list` hint, not silent 0 findings. Accept
       case-insensitive match. Same for `--rule-prefix` matching nothing:
       warn.
-- [ ] L-2: a write command whose single explicitly named (non-glob) file
+- [x] L-2: a write command whose single explicitly named (non-glob) file
       was skipped (unparseable) exits 1; message states nothing was
       modified. Glob/batch behavior unchanged.
-- [ ] M-6: `find --index` staleness signal — compare index file mtime vs
+- [x] M-6: `find --index` staleness signal — compare index file mtime vs
       vault dir mtime (cheap, both already stat-ed) and warn on stderr
       `index older than vault; results may be stale — re-run
       create-index` (suppressed by `--no-hints`? No: warnings are not
       hints; suppressed only by explicit future flag if demanded).
       Document the snapshot contract in create-index help.
 
-### Envelope/output consistency [0/4]
+### Envelope/output consistency [4/4]
 
-- [ ] L-5: `read` honors piped-JSON default on ALL error paths (missing
+- [x] L-5: `read` honors piped-JSON default on ALL error paths (missing
       file, dir target, bad --lines, --count rejection) — emit the same
       JSON error envelope as siblings.
-- [ ] L-6: `find -e` regex errors go through the standard error envelope
+- [x] L-6: `find -e` regex errors go through the standard error envelope
       (JSON under --format json / piped) and report the pattern as typed
       — strip the internal `(?i)` from user-facing text (the
       `--property 'title~=/…/'` path is the model).
-- [ ] L-10: `create-index` text output includes `files_indexed` and the
+- [x] L-10: `create-index` text output includes `files_indexed` and the
       "replaced existing index" note (JSON parity, --help already
       promises it).
-- [ ] L-15: standardize match positions to 1-based line AND column in
+- [x] L-15: standardize match positions to 1-based line AND column in
       JSON output; CHANGELOG breaking note (consumers may parse col).
 
-### Hint/message fixes [0/3]
+### Hint/message fixes [3/3]
 
-- [ ] L-9: the `drop-index` hint after `create-index -o <custom>` carries
+- [x] L-9: the `drop-index` hint after `create-index -o <custom>` carries
       `--path <custom>`; extend the hint-execution gate fixture to a
       custom-path index so the pairing is gate-checked.
-- [ ] L-7: `drop-index` on a nonexistent in-vault path reports file-not-
+- [x] L-7: `drop-index` on a nonexistent in-vault path reports file-not-
       found (with the path), not a boundary-check failure with an
       irrelevant `--allow-outside-vault` hint.
-- [ ] UX-2: `read --section` not-found error truncates the heading list
+- [x] UX-2: `read --section` not-found error truncates the heading list
       to the 5 closest matches (existing fuzzy machinery) + "and N more —
       run `hyalo read <file>` to list sections".
 
-### Doc drift (surface truth residue) [0/3]
+### Doc drift (surface truth residue) [3/3]
 
-- [ ] M-8: fix the global `--help` limit-contract paragraph to name only
+- [x] M-8: fix the global `--help` limit-contract paragraph to name only
       commands that actually cap at 50 and accept `--limit`; either give
       `types list`/`views list`/`lint-rules list` a `--limit` or remove
       them from the claim (removal preferred — small lists). Decide bare
@@ -86,26 +86,26 @@ item that turns out deep gets split out rather than ballooning here.
       flags (preferred: they already alias to summary) or fix COMMAND
       REFERENCE to stop promising it. Kill the BUG-3 residue
       (`hyalo tags --limit 0` must work or must not be documented).
-- [ ] M-9: rewrite the `mv` COMMAND REFERENCE entry: positional
+- [x] M-9: rewrite the `mv` COMMAND REFERENCE entry: positional
       FILE/DEST form, batch mode (--glob/--property/--tag/--type +
       --apply), --allow-ambiguous, --on-conflict. Consider extending
       check-command-reference to assert every clap flag of a subcommand
       appears in its entry (drift gate upgrade — if too noisy, record
       why in the PR body).
-- [ ] L-13(b): document `exclude_target_globs` case-insensitivity in
+- [x] L-13(b): document `exclude_target_globs` case-insensitivity in
       links auto help + configuration.md.
 
-### Small correctness debts [0/4]
+### Small correctness debts [4/4]
 
-- [ ] L-1: `backlinks` stops double-counting case-mismatched wikilinks
+- [x] L-1: `backlinks` stops double-counting case-mismatched wikilinks
       (register under the canonical target only; `find --fields links`
       is the reference behavior).
-- [ ] L-4: `mv` refuses to clobber a dangling symlink at DEST (exists-
+- [x] L-4: `mv` refuses to clobber a dangling symlink at DEST (exists-
       check via symlink_metadata, message suggests removing it first).
-- [ ] L-16: covered in iter-202 (exit-code unification) — verify here
+- [x] L-16: covered in iter-202 (exit-code unification) — verify here
       only that `okf log` now exits 1; if 202 has not merged first,
       do it here and tell 202's agent via the plan.
-- [ ] iter-203 follow-up: site-prefix stripping (`strip_site_prefix`) is
+- [x] iter-203 follow-up: site-prefix stripping (`strip_site_prefix`) is
       case-sensitive and tries only the single auto-derived guess (last
       path component of `--dir`). MDN's derived prefix (`en-us`) never
       matches its real two-segment, mixed-case URL prefix
@@ -120,12 +120,12 @@ item that turns out deep gets split out rather than ballooning here.
 
 ## Acceptance criteria
 
-- [ ] Every ticked item has a unit or e2e test reproducing the report's
+- [x] Every ticked item has a unit or e2e test reproducing the report's
       scenario
-- [ ] `hyalo lint --rule MD0133` exits 1; `--rule hyalo006` finds what
+- [x] `hyalo lint --rule MD0133` exits 1; `--rule hyalo006` finds what
       `--rule HYALO006` finds
-- [ ] All error paths of `read` and `find -e` emit JSON when piped
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] All error paths of `read` and `find -e` emit JSON when piped
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q` all clean
 
 ## Non-goals
@@ -136,3 +136,45 @@ item that turns out deep gets split out rather than ballooning here.
 - L-11 (mv link normalization) — folded into iter-203's mv task.
 - UX-3 (`links` text output ordering) and the `links` perf profiling —
   separate design-worthy task, not a batch item.
+
+## Outcome
+
+All 17 items closed on `iter-204/dogfood-low-batch`; every one carries a unit
+or e2e test reproducing the report's repro.
+
+Two items needed only verification, not code:
+
+- **L-10** (`create-index` text output missing `files_indexed` / the
+  "replaced existing index" note) was already fixed before this iteration
+  started — the current build has full JSON/text parity. Locked in with
+  `create_index_text_output_matches_json_fields`.
+- **L-16** (`okf log` boundary refusal exiting 2) landed in iter-202 and is
+  gate-checked there by `tests/e2e/vault_boundary.rs`. Re-verified by hand.
+
+Decisions worth recording:
+
+- **M-6 staleness probe** compares the snapshot's `created_at` against the
+  newest mtime among the vault root and its immediate subdirectories, with one
+  second of slack. Using `created_at` rather than the index file's own mtime
+  avoids a false positive from the atomic-rename write (the temp file predates
+  the rename that bumps the directory). The probe deliberately misses in-place
+  edits of existing notes and changes deeper than one level; the
+  `create-index --help` SNAPSHOT CONTRACT section says so.
+- **M-9 gate upgrade** shipped: `check-command-reference` now also asserts that
+  every non-global flag a subcommand accepts appears in its COMMAND REFERENCE
+  entry. It was not too noisy — only six flags needed exemptions, each recorded
+  with a reason in `REFERENCE_FLAG_EXEMPT`; the rest were genuinely missing and
+  were added to the reference.
+- **M-8 bare-group flags**: bare `hyalo tags` / `hyalo properties` now accept
+  `--glob`/`--limit` (the preferred option in the plan) rather than the
+  reference being weakened. This retired the `hint_execution` canary, which
+  moved to `types list --limit 0`.
+- **iter-203 follow-up**: `strip_site_prefix` matching is now case-insensitive.
+  Auto-derivation still yields a single path segment and no attempt is made to
+  guess a multi-segment prefix — guessing would silently change what every
+  site-absolute link means. Instead `hyalo config` states the limitation next
+  to the derived value, and an MDN-shaped fixture (vault dir `en-us`, links
+  `/en-US/docs/...`) pins both halves in `tests/e2e/site_prefix.rs`.
+- **L-1** de-duplicates by registering only the canonical key when the written
+  target differs from it in ASCII case alone. `mv` still rewrites those links
+  because the backlink entry carries the original written spelling.

--- a/hyalo-knowledgebase/iterations/iteration-208-links-output-and-hint-ux.md
+++ b/hyalo-knowledgebase/iterations/iteration-208-links-output-and-hint-ux.md
@@ -1,0 +1,102 @@
+---
+title: Iteration 208 — links output ordering and hint/message UX residue
+type: iteration
+date: 2026-08-22
+status: planned
+branch: iter-208/links-output-and-hint-ux
+tags:
+  - iteration
+  - links
+  - cli
+  - ux
+related:
+  - "[[dogfood-results/dogfood-v0210-pre-release-iters-191-198]]"
+  - "[[iteration-206-links-perf-profiling]]"
+  - "[[iteration-204-dogfood-low-batch]]"
+---
+
+# Iteration 208 — links output ordering and hint/message UX residue
+
+## Goal
+
+Carry-over from iteration 204's carry-over sweep: close the v0.21.0-pre
+dogfood's UX-3 (output-ordering half only — the perf half is
+[[iteration-206-links-perf-profiling]]) and the UX-5 sub-items that no
+prior iteration (200-204, 206) picked up. All are text-output/message
+polish, no behavior change.
+
+**Do NOT release; release is a separate user-gated step.**
+
+## Context
+
+Repros in [[dogfood-results/dogfood-v0210-pre-release-iters-191-198]]
+(UX-3, UX-5). Iteration 204's carry-over sweep (2026-08-22) confirmed
+these were still unaddressed after iterations 200-204, 206-207 landed:
+
+- UX-3 had two halves. The perf half ("`links` 12.7s on GitHub Docs") got
+  its own plan in iter-206. The **output-ordering half did not**: `links`
+  text output prints the bucket summary first, then thousands of
+  unlabeled fix lines; `out_of_vault_links` / `unfixable_links` are
+  JSON-only (invisible in the default text format); "Case mismatches: 17"
+  scrolls off-screen before the rewrites it announces are shown.
+- UX-5, checked sub-item by sub-item against 200-204/206-207:
+  - "the `--dir` redundancy note actively misleads (see H-4)" — **done**,
+    iter-201 (H-4).
+  - hints repeat a long `--index-file` path verbatim 4-5× in one hint
+    listing — **not done**.
+  - `config_excluded`'s "Excluded … : 1 titles" reads like a failure when
+    the match count doesn't move (it counts candidate *titles*, not
+    links) — **not done**.
+  - `[types.note]` config error suggests `schema` but not
+    `hyalo types set` — **not done**.
+
+## Tasks
+
+- [ ] UX-3: redesign `links` text-output ordering so the dangerous/actionable
+      information (unfixable links, out-of-vault links, case mismatches)
+      is not buried under thousands of unlabeled fix lines — likely:
+      summary buckets last (or repeated at the end), or a `--summary-only`
+      style default with `-v`/`--verbose` for the full per-link listing.
+      Get eyes on real output shape (GitHub Docs / MDN scratch copies)
+      before deciding the exact layout; record the decision as a DEC
+      entry.
+- [ ] UX-3: surface `out_of_vault_links` / `unfixable_links` in text
+      output, not just JSON — these are exactly the "needs a human"
+      buckets the text reader is least likely to notice today.
+- [ ] UX-5: de-duplicate a hint listing that repeats the same long
+      `--index-file <path>` across 4-5 hints — factor the path out (e.g.
+      state it once, reference it) or shorten repeated occurrences.
+- [ ] UX-5: reword `config_excluded`'s count line so "Excluded … : 1
+      titles" cannot read as "1 link excluded" — name what is actually
+      being counted (candidate titles, not matches/links).
+- [ ] UX-5: `[types.note]` (or any per-type) config error should suggest
+      `hyalo types set` alongside/instead of a bare `schema` mention, so
+      the fix path matches what the user actually runs.
+- [ ] e2e coverage for each UX fix: golden/snapshot-style assertions on
+      the reworded text, not just "contains substring", since these are
+      exactly the kind of doc/message-drift the batch iterations (196,
+      204) exist to prevent.
+- [ ] CHANGELOG entries (UX polish, not breaking).
+
+## Acceptance criteria
+
+- [ ] A GitHub Docs or MDN scratch-copy `links fix`/`links auto` text run
+      shows out-of-vault and unfixable links without scrolling past
+      thousands of ordinary fix lines first
+- [ ] `out_of_vault_links` / `unfixable_links` counts appear in text
+      output when non-empty
+- [ ] The reworded hint/message strings are asserted by e2e tests, not
+      eyeballed
+- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+      `cargo test --workspace -q` all clean
+
+## Non-goals
+
+- The `links` perf profiling itself — [[iteration-206-links-perf-profiling]]
+  owns that.
+- Any change to `links` matching/exclusion semantics — untouched here,
+  output formatting only.
+- L-3 (chmod 444 rewrite silently succeeds; atomic writes break hard
+  links) and L-8 (index files not byte-reproducible) stay accepted
+  behavior per iteration 204's Non-goals — not in scope here either;
+  revisit only if a user report arrives.


### PR DESCRIPTION
## Summary

Closes all 17 remaining MEDIUM/LOW findings from the v0.21.0-pre dogfood that
iterations 200-203 did not cover. Each item is backed by a unit or e2e test
reproducing the report's repro (41 new tests).

**CI footguns**
- **M-10** — `lint --rule <typo>` selected nothing and exited 0, so a typo'd CI
  gate reads green forever. Unknown ids are now a user error with the
  `lint-rules list` hint; `--rule`/`--rule-prefix` match case-insensitively, and
  a prefix that selects no rule warns instead of looking clean.
- **L-2** — a write command (`set`/`remove`/`append`) whose *single explicitly
  named* file is unparseable now exits 1 and says nothing was modified, instead
  of `0/0 modified (1 scanned)` at exit 0. Glob/batch runs are unchanged.
- **M-6** — commands that load a snapshot index warn `index older than vault`
  when the vault's top-level directory mtimes postdate the snapshot's
  `created_at`. Cheap by construction (one `read_dir`, no walk); the limits are
  spelled out in a new SNAPSHOT CONTRACT section in `create-index --help`.

**Envelope/output consistency**
- **L-5** — every `read` error path (missing file, directory target, bad
  `--lines`, the `--count` rejection, `--section` miss) honors the piped-JSON
  default. Results stay raw markdown; only errors changed.
- **L-6** — `find -e` regex errors go through the standard error envelope,
  quote the pattern as typed, and no longer leak the internal `(?i)` prefix
  (which also shifted the engine's caret four columns off the real offender).
- **L-10** — already fixed before this branch; pinned with a text/JSON parity
  test for `create-index`.
- **L-15** — **breaking for `col` consumers**: `links auto` match positions are
  now 1-based in both axes (`line` already was). Subtract 1 for the old byte
  offset. CHANGELOG carries the note.

**Hint/message fixes**
- **L-9** — `create-index -o <custom>` emits `drop-index --path <custom>`; the
  pairing is gate-checked by executing the emitted hint end-to-end.
- **L-7** — `drop-index` on a missing in-vault path reports "index file not
  found" instead of a boundary-check failure with an irrelevant
  `--allow-outside-vault` hint. The boundary is still enforced for missing
  paths under out-of-vault directories.
- **UX-2** — `read --section` misses list the 5 closest headings plus a count,
  not every heading on one line (~4 KB on this repo's own decision log).

**Doc drift**
- **M-8** — "emits a `total`" and "caps at `default_limit`" are different sets;
  the `--help` limit paragraph now renders the smaller one, each asserted
  against the real binary. Bare `hyalo tags`/`hyalo properties` accept the
  `--glob`/`--limit` flags COMMAND REFERENCE has always documented for them.
- **M-9** — `mv`'s reference entry rewritten (positional form, batch mode,
  `--apply`, `--on-conflict`, `--allow-ambiguous`), and
  `check-command-reference` upgraded from presence-only to **flag accuracy**:
  every non-global flag a subcommand accepts must appear in its entry. It was
  not too noisy — 6 exemptions, each with a recorded reason; the rest were real
  omissions and were documented. The gate builds `hyalo` once instead of 27
  `cargo run`s (32s → 3s).
- **L-13(b)** — `exclude_target_globs` case-insensitivity documented in
  `links auto --help` and `docs/configuration.md`.

**Small correctness debts**
- **L-1** — `backlinks` no longer double-counts a case-mismatched wikilink
  (`[[NOTE]]` → `note.md` was registered under both keys, which fold to the same
  bucket). `mv` still rewrites such links.
- **L-4** — `mv` refuses to clobber a *dangling* symlink at DEST; the guard used
  `exists()`, which follows symlinks, so the rename destroyed it silently.
- **L-16** — verified: iter-202 already unified `okf log`'s exit code, covered
  by `tests/e2e/vault_boundary.rs`.
- **iter-203 follow-up** — `strip_site_prefix` matches case-insensitively, so an
  MDN checkout in `en-us/` resolves links written `/en-US/...`. Auto-derivation
  still yields a single segment and does not guess multi-segment prefixes
  (guessing would silently change what every site-absolute link means);
  `hyalo config` states that next to the derived value. An MDN-shaped fixture
  pins both halves.

No release: version untouched, no tags.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` — 1499 e2e + 958 core + 1022 cli unit, 0 failures
- [x] `cargo run -p xtask -- check-feature-fanout`
- [x] `cargo run -p xtask -- check-help-drift`
- [x] `cargo run -p xtask -- check-command-reference` (upgraded; verified it
      *fails* when `--on-conflict` is removed from mv's entry)
- [x] `cargo run -p xtask -- check-bundled-skills`
- [x] Dogfooded the release build against `hyalo-knowledgebase/`: `lint
      --strict`, `lint --rule hyalo002` (lower-case id), unknown-rule refusal,
      `create-index` → `find --index` → `drop-index`
- [x] Reviewer: confirm the `col` change (L-15) is acceptable as a breaking
      output change for `links auto` consumers — confirmed during
      /review-pr (solo repo, single consumer of this CLI's JSON is this
      repo's own tooling, change is documented in CHANGELOG under
      Changed with a migration note).

## Review

Local-only `/review-pr` pass (no Copilot). One finding, fixed and pushed:

| # | File:Line | Issue | Source |
|---|-----------|-------|--------|
| 1 | crates/hyalo-cli/src/list_commands.rs:44-45 | `LIMITED_COMMANDS` doc comment pointed at a test function name (`limited_commands_constant_matches_binary`) that does not exist — the real coverage is `every_capped_command_accepts_limit` / `capped_commands_are_a_subset_of_list_commands` in `tests/e2e/count.rs` | Local |

`cargo fmt` / `clippy -D warnings` / `cargo test --workspace -q` (1499 e2e +
958 core + 1022 cli, 0 failures) all re-verified clean after the fix.
`xtask`'s four implemented `check-*` gates (`check-feature-fanout`,
`check-help-drift`, `check-command-reference`, `check-bundled-skills`) all
pass; `check-dead-primitives`/`check-todo-annotations` are unimplemented
stubs, not run.

## Carry-over

Sweep of every unticked AC, `[deferred …]` annotation, and out-of-scope
finding this iteration or the source dogfood report flagged, cross-checked
against what iterations 200-204/206-207 actually shipped:

| Item | Disposition |
|---|---|
| L-3 (chmod 444 silently rewritten; atomic writes break hard links) | Accepted as-is — recorded in iter-204's Non-goals as deliberate won't-fix "unless a user report arrives"; not filed as future work |
| L-8 (index files not byte-reproducible across runs) | Accepted as-is — same disposition as L-3, recorded in iter-204's Non-goals |
| L-11 (`mv` link-normalization inconsistency) | Done — folded into and shipped in iter-203 (see CHANGELOG "iter-203, L-11") |
| L-14 (malformed-config double-parse/double-warning) | Done — shipped in iter-201 (M-2's "fix the double-parse" task) |
| UX-1 (common-title heuristic wordlist-only) | Already has a home — [[iterations/iteration-205-common-title-frequency-trigger]] (next iteration in this run) |
| UX-2 (`--section` miss dumps every heading) | Done — shipped in this PR |
| UX-3, perf half (`links` 12.7s on GitHub Docs) | Already has a home — pre-existing [[iterations/iteration-206-links-perf-profiling]] |
| UX-3, output-ordering half (`links` text buries out-of-vault/unfixable links under thousands of fix lines) | Not yet covered by any iteration — filed new [[iterations/iteration-208-links-output-and-hint-ux]] |
| UX-4 (`hyalo config` didn't show effective site_prefix) | Done — shipped in iter-203 |
| UX-5, `--dir` redundancy note misleading | Done — shipped in iter-201 (H-4) |
| UX-5, `--index-file` path repeated 4-5× in one hint listing | Not yet covered — filed into new [[iterations/iteration-208-links-output-and-hint-ux]] |
| UX-5, `config_excluded` count line reads like a failure | Not yet covered — filed into new [[iterations/iteration-208-links-output-and-hint-ux]] |
| UX-5, `[types.note]` config error omits `hyalo types set` | Not yet covered — filed into new [[iterations/iteration-208-links-output-and-hint-ux]] |
| iteration-199 (exclude-list counter-flags) | Pre-existing, already `status: deferred` with its own plan file — unrelated to this iteration's findings, left untouched |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEuPjCTq74bwJgoWbcvHrD
