### PR TITLE
iter-205: frequency trigger for the links auto noisy-title note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to
 
 ### Added
 
+- **The `links auto` noisy-title note now fires on frequency, not just on an
+  English word list** (iter-205). A title is flagged when it is a common
+  English word **or** when it dominates the run — at least 25 proposed links
+  and at least 2.5% of them, i.e. `max(25, ceil(total / 40))`. The wordlist
+  alone missed the titles that actually matter: on a GitHub Docs slice a page
+  titled `Workflows` produced 502 of 1,179 proposed links (43%) and was never
+  mentioned, while the note named `limits` at 4%. The frequency trigger is
+  arithmetic, so it is also the first version of this note a non-English vault
+  ever sees — the word list is ASCII-only by construction. The note says which
+  trigger fired per title, and quotes the share of the run for frequency hits.
+  `[links.auto] warn_common_titles` and `--no-warn-common-titles` still govern
+  both triggers; there are no configurable thresholds, and stdout stays
+  byte-identical either way.
+
 - **Directory link targets resolve to `<target>/index.md`** (iter-203). A link
   that names a directory now reaches that directory's index file: `/foo`, `foo`
   and `/foo/` all resolve to `foo/index.md`. This is the convention every
@@ -88,6 +102,15 @@ and this project adheres to
   dependency.
 
 ### Changed
+
+- **The `links auto` noisy-title note is honest about truncation and spells
+  titles the way your vault does** (iter-205, dogfood L-12/L-13). With more
+  offenders than it lists, the note now says `showing the 5 noisiest of 7`
+  instead of `+2 more`, and the suggested `--exclude-title` flags cover *every*
+  offender rather than only the listed ones — pasting them back extinguishes
+  the note in one round instead of two. Titles are displayed in their most
+  frequent original casing (`README`, not `readme`), while matching and
+  exclusion stay case-insensitive.
 
 - **`hyalo lint --rule <id>` validates the id, and matches it
   case-insensitively** (iter-204, M-10). A typo'd rule id used to select

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -2045,10 +2045,15 @@ pub(crate) enum LinksAction {
             --exclude-title       Exclude specific titles (repeatable, case-insensitive)\n\
             --exclude-target-glob Exclude target pages by vault-relative path glob (repeatable,\n\
             \u{00a0}                      case-insensitive — 'templates/*' also excludes 'Templates/X.md')\n\n\
-            COMMON-WORD TITLES: when a proposed link comes from a page whose title is an ordinary \
-            English word or a generic doc filename (\"permissions\", \"index\", \"README\"), the run \
-            prints one advisory note on stderr naming those titles with their match counts and the \
-            --exclude-title flags that would skip them. It only names titles that actually produced \
+            NOISY CANDIDATE TITLES: the run prints one advisory note on stderr when a candidate \
+            title looks like a source of over-linking. Two things trigger it: the title is an \
+            ordinary English word or a generic doc filename (\"permissions\", \"index\", \"README\"), \
+            or the title is unusually frequent — at least 25 proposed links and at least 2.5% of \
+            the run. The frequency trigger is language-independent, so non-English titles are \
+            covered too. The note names the offenders with their match counts (plus their share of \
+            the run when frequency is the reason) and the --exclude-title flags that would skip \
+            them; the prose list stops at the five noisiest and says so, but the flags cover every \
+            offender, so one paste-back is enough. It only names titles that actually produced \
             matches, so excluding them makes the note disappear. The note never appears on stdout — \
             the report is unchanged — and -q or --no-warn-common-titles silences it.\n\n\
             PERSISTING THESE: put them in the [links.auto] section of .hyalo.toml so they apply to every run:\n\
@@ -2056,7 +2061,7 @@ pub(crate) enum LinksAction {
             \u{00a0} exclude_titles = [\"permissions\", \"README\"]\n\
             \u{00a0} exclude_target_globs = [\"templates/*\"]\n\
             \u{00a0} first_only = true\n\
-            \u{00a0} warn_common_titles = false   # opt out of the common-word note\n\
+            \u{00a0} warn_common_titles = false   # opt out of the noisy-title note\n\
             The two lists are UNIONED with the flags — --exclude-title/--exclude-target-glob extend the \
             config, they never replace it. --first-only turns first-only on for a single run whatever the \
             config says, and --no-first-only turns it off for a single run whatever the config says. \
@@ -2102,8 +2107,9 @@ pub(crate) enum LinksAction {
         /// (repeatable; matched case-insensitively, mirroring --exclude-title)
         #[arg(long)]
         exclude_target_glob: Vec<String>,
-        /// Do not print the advisory note naming candidate titles that are common
-        /// English words (e.g. "permissions", "index").
+        /// Do not print the advisory note naming noisy candidate titles: common
+        /// English words (e.g. "permissions", "index") and titles that dominate
+        /// the run (at least 25 matches and 2.5% of the proposed links).
         ///
         /// The note goes to stderr only and never changes the report on stdout.
         /// Persist the opt-out with `warn_common_titles = false` under

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -63,7 +63,7 @@ pub(crate) struct LinksAutoReport {
     /// `[links.auto] first_only`.
     pub first_only: bool,
     /// `[links.auto] warn_common_titles` — `true` (the default) means `links
-    /// auto` may print the advisory common-English-word note on stderr.
+    /// auto` may print the advisory noisy-candidate-title note on stderr.
     pub warn_common_titles: bool,
 }
 

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -467,18 +467,88 @@ impl AutoFilters<'_> {
     }
 }
 
-/// How many offending titles the common-title note names before it summarises
-/// the rest as `+N more`. Five keeps the note (and the ready-to-paste flag list
-/// it suggests) inside a terminal line or two.
+/// How many offending titles the common-title note names in its prose list
+/// before it admits it is truncating ("showing the 5 noisiest of 7"). Five
+/// keeps the sentence inside a terminal line or two.
+///
+/// The suggested `--exclude-title` flags are deliberately **not** capped
+/// (dogfood L-12): a truncated flag list needs two paste-backs to extinguish
+/// the note, and flags are cheap.
 const COMMON_TITLE_NOTE_MAX_LISTED: usize = 5;
 
+/// Absolute floor for the frequency trigger: below this many proposed links a
+/// title is never called out on frequency alone, however dominant its share
+/// (DEC-205). It keeps small vaults — where the user simply reads every
+/// proposed link — from being nagged.
+const FREQUENT_TITLE_MIN_MATCHES: usize = 25;
+
+/// Denominator of the frequency trigger's share: `1/40` = 2.5% of a run's
+/// proposed links (DEC-205). Kept as an integer divisor so the threshold is
+/// computed without floating point.
+const FREQUENT_TITLE_SHARE_DIVISOR: usize = 40;
+
+/// Minimum match count at which a title counts as frequency-dominant in a run
+/// of `total` proposed links: `max(25, ceil(total / 40))`.
+///
+/// The two terms cross at exactly 1,000 proposed links: below that the
+/// absolute floor rules, above it the 2.5% share does. Measured against three
+/// corpora in DEC-205 — it flags `workflows` (502/1,179) through `concurrency`
+/// (39/1,179) on a GitHub Docs slice while leaving that slice's 28-match
+/// runner-up alone.
+fn frequent_title_threshold(total: usize) -> usize {
+    total
+        .div_ceil(FREQUENT_TITLE_SHARE_DIVISOR)
+        .max(FREQUENT_TITLE_MIN_MATCHES)
+}
+
+/// `count` as a whole-percent share of `total`, rounded to nearest.
+fn percent_of(count: usize, total: usize) -> usize {
+    if total == 0 {
+        return 0;
+    }
+    (count * 200 + total) / (total * 2)
+}
+
+/// Running tally for one candidate title: how many links it produced, and how
+/// each occurrence was spelled in the prose.
+#[derive(Default)]
+struct TitleTally {
+    count: usize,
+    /// Surface form → occurrences, so the note can display the spelling the
+    /// vault actually uses (dogfood L-13) instead of the lowercased key.
+    surfaces: std::collections::HashMap<String, usize>,
+}
+
+/// One title the note will complain about, with the reason(s) it was flagged.
+struct Offender {
+    /// The `to_ascii_lowercase` key — what `--exclude-title` compares against.
+    key: String,
+    /// The most frequent original spelling; ties broken lexicographically so
+    /// the note is deterministic.
+    display: String,
+    count: usize,
+    /// Flagged because the title is an ordinary English word (wordlist path).
+    common_word: bool,
+    /// Flagged because the title dominates this run (frequency path).
+    frequent: bool,
+}
+
 /// Build the advisory common-title note for a `links auto` run, or `None` when
-/// no proposed link came from a common English word (iter-197).
+/// no proposed link came from a suspicious title (iter-197, widened in
+/// iter-205).
+///
+/// A title is suspicious when it is **either**
+///
+/// - a common English word (`is_common_word`; ASCII-only by construction —
+///   the list is an English word list), **or**
+/// - frequency-dominant for this run (`frequent_title_threshold`), which is
+///   language-independent and therefore the only trigger a non-English vault
+///   ever sees.
 ///
 /// The heuristic runs on the *emitted* matches, not on the title inventory, so
 /// it is self-extinguishing and never speculative:
 ///
-/// - a common-word title that produced no match is not mentioned — nothing to
+/// - a suspicious title that produced no match is not mentioned — nothing to
 ///   act on
 /// - a title already excluded (by `--exclude-title` or `[links.auto]
 ///   exclude_titles`) cannot produce a match, so acting on the note makes it
@@ -496,64 +566,130 @@ fn common_title_note(matches: &[hyalo_core::auto_link::AutoLinkMatch]) -> Option
         return None;
     }
 
-    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut tallies: HashMap<String, TitleTally> = HashMap::new();
     for m in matches {
-        // Key on the lowercased matched text: `--exclude-title` compares
-        // case-insensitively, so "Permissions" and "permissions" are one title
-        // and the note must not split them into two entries.
-        let key = m.matched_text.trim().to_ascii_lowercase();
-        if key.is_empty() {
+        // Key on the ASCII-lowercased matched text: `auto_link` compares
+        // `exclude_titles` with `to_ascii_lowercase` too, so "Permissions" and
+        // "permissions" are one title here exactly as they are one exclusion
+        // there. A Unicode-aware lowercase would merge titles the exclusion
+        // would then fail to cover, and the note would suggest a flag that
+        // does not work.
+        let surface = m.matched_text.trim();
+        if surface.is_empty() {
             continue;
         }
-        *counts.entry(key).or_insert(0) += 1;
+        let tally = tallies.entry(surface.to_ascii_lowercase()).or_default();
+        tally.count += 1;
+        *tally.surfaces.entry(surface.to_owned()).or_insert(0) += 1;
     }
 
-    let mut offenders: Vec<(String, usize)> = counts
+    let frequent_at = frequent_title_threshold(total);
+    let mut offenders: Vec<Offender> = tallies
         .into_iter()
-        .filter(|(title, _)| hyalo_core::common_words::is_common_word(title))
+        .filter_map(|(key, tally)| {
+            let common_word = hyalo_core::common_words::is_common_word(&key);
+            let frequent = tally.count >= frequent_at;
+            if !common_word && !frequent {
+                return None;
+            }
+            // Most frequent spelling wins; equal counts resolve alphabetically
+            // so the same vault always produces the same note.
+            let display = tally
+                .surfaces
+                .into_iter()
+                .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))
+                .map_or_else(|| key.clone(), |(surface, _)| surface);
+            Some(Offender {
+                key,
+                display,
+                count: tally.count,
+                common_word,
+                frequent,
+            })
+        })
         .collect();
     if offenders.is_empty() {
         return None;
     }
     // Most-noisy first; ties broken alphabetically so the note is deterministic.
-    offenders.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    offenders.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.key.cmp(&b.key)));
 
-    let affected: usize = offenders.iter().map(|(_, count)| *count).sum();
+    let affected: usize = offenders.iter().map(|o| o.count).sum();
     let listed = offenders.len().min(COMMON_TITLE_NOTE_MAX_LISTED);
-    let mut names: Vec<String> = offenders[..listed]
-        .iter()
-        .map(|(title, count)| format!("\"{title}\" ({count}×)"))
-        .collect();
-    if offenders.len() > listed {
-        names.push(format!("+{} more", offenders.len() - listed));
-    }
 
-    let subject = if offenders.len() == 1 {
-        "1 auto-link candidate title is a common English word and accounts for".to_owned()
+    // When every offender was flagged for the same reason the subject line can
+    // state it once; a mixed set has to label each entry instead, because the
+    // user's judgment differs per cause.
+    let mixed = offenders
+        .iter()
+        .any(|o| o.common_word != offenders[0].common_word || o.frequent != offenders[0].frequent);
+    let plural = offenders.len() != 1;
+    let reason_clause = if mixed {
+        "are common English words or unusually frequent".to_owned()
     } else {
-        format!(
-            "{} auto-link candidate titles are common English words and account for",
-            offenders.len()
-        )
+        let first = &offenders[0];
+        match (first.common_word, first.frequent, plural) {
+            (true, true, false) => "is a common English word and unusually frequent".to_owned(),
+            (true, true, true) => "are common English words and unusually frequent".to_owned(),
+            (true, false, false) => "is a common English word".to_owned(),
+            (true, false, true) => "are common English words".to_owned(),
+            (false, _, false) => "is unusually frequent".to_owned(),
+            (false, _, true) => "are unusually frequent".to_owned(),
+        }
     };
+    let subject = format!(
+        "{count} auto-link candidate title{s} {reason_clause} and account{verb} for",
+        count = offenders.len(),
+        s = if plural { "s" } else { "" },
+        verb = if plural { "" } else { "s" },
+    );
+
+    // L-12: the prose list is capped, and says so; the flag list below is not.
+    let truncation = if offenders.len() > listed {
+        format!(" (showing the {listed} noisiest of {})", offenders.len())
+    } else {
+        String::new()
+    };
+
+    let names: Vec<String> = offenders[..listed]
+        .iter()
+        .map(|o| {
+            let mut detail = format!("{}×", o.count);
+            if o.frequent {
+                use std::fmt::Write as _;
+                let _ = write!(detail, ", {}%", percent_of(o.count, total));
+            }
+            if mixed {
+                detail.push_str(match (o.common_word, o.frequent) {
+                    (true, true) => ", common English word + unusually frequent",
+                    (true, false) => ", common English word",
+                    (false, _) => ", unusually frequent",
+                });
+            }
+            format!("\"{}\" ({detail})", o.display)
+        })
+        .collect();
+
     let mut flags = String::new();
-    for (title, _) in &offenders[..listed] {
+    for o in &offenders {
         use std::fmt::Write as _;
         // Writing into a String is infallible; the Result only exists to satisfy
         // the `fmt::Write` signature. Reuse the same shell-quoting the other
         // suggested-flag hints use (`hints::shell_quote`) rather than a
         // bespoke whitespace-only check — titles can contain apostrophes,
         // `$`, backticks, or double quotes, none of which a naive
-        // whitespace check would escape.
+        // whitespace check would escape. The displayed spelling is used
+        // verbatim: `--exclude-title` matches case-insensitively, so it works
+        // either way and stays greppable in the user's own files.
         let _ = write!(
             flags,
             " --exclude-title {}",
-            crate::hints::shell_quote(title)
+            crate::hints::shell_quote(&o.display)
         );
     }
 
     Some(format!(
-        "{subject} {affected} of {total} proposed links: {names}. \
+        "{subject} {affected} of {total} proposed links{truncation}: {names}. \
          If those are prose mentions rather than deliberate references, skip them with{flags} \
          — or persist them once under [links.auto] exclude_titles in .hyalo.toml. \
          Silence this note with --no-warn-common-titles.",

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -823,7 +823,10 @@ pub fn links_auto(
 
 #[cfg(test)]
 mod tests {
-    use super::{AutoFilters, COMMON_TITLE_NOTE_MAX_LISTED, common_title_note};
+    use super::{
+        AutoFilters, COMMON_TITLE_NOTE_MAX_LISTED, common_title_note, frequent_title_threshold,
+        percent_of,
+    };
     use hyalo_core::auto_link::AutoLinkMatch;
 
     fn strings(values: &[&str]) -> Vec<String> {
@@ -844,6 +847,11 @@ mod tests {
 
     fn matches_for(surface_forms: &[&str]) -> Vec<AutoLinkMatch> {
         surface_forms.iter().map(|t| match_for(t)).collect()
+    }
+
+    /// `n` proposed links that all share the same surface form.
+    fn repeated(surface: &str, n: usize) -> Vec<AutoLinkMatch> {
+        (0..n).map(|_| match_for(surface)).collect()
     }
 
     // -----------------------------------------------------------------------
@@ -1079,7 +1087,44 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // iter-197: note text
+    // iter-205: the frequency threshold itself (DEC-205)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn frequency_threshold_is_the_absolute_floor_for_small_runs() {
+        assert_eq!(frequent_title_threshold(1), 25);
+        // The own knowledgebase, measured in DEC-205.
+        assert_eq!(frequent_title_threshold(195), 25);
+        assert_eq!(frequent_title_threshold(999), 25);
+    }
+
+    #[test]
+    fn frequency_threshold_switches_to_the_share_at_a_thousand_links() {
+        // 2.5% overtakes the 25-match floor exactly at 1,000 proposed links.
+        assert_eq!(frequent_title_threshold(1_000), 25);
+        assert_eq!(frequent_title_threshold(1_040), 26);
+        // The two corpora DEC-205 was tuned against.
+        assert_eq!(frequent_title_threshold(1_179), 30);
+        assert_eq!(frequent_title_threshold(33_859), 847);
+    }
+
+    #[test]
+    fn frequency_threshold_rounds_the_share_up() {
+        // ceil, not floor: a title has to clear the share outright.
+        assert_eq!(frequent_title_threshold(1_001), 26);
+    }
+
+    #[test]
+    fn percent_rounds_to_nearest_and_survives_an_empty_run() {
+        assert_eq!(percent_of(502, 1_179), 43);
+        assert_eq!(percent_of(1, 3), 33);
+        assert_eq!(percent_of(2, 3), 67);
+        assert_eq!(percent_of(1, 1), 100);
+        assert_eq!(percent_of(0, 0), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // iter-197: note text (wordlist trigger)
     // -----------------------------------------------------------------------
 
     #[test]
@@ -1089,6 +1134,7 @@ mod tests {
 
     #[test]
     fn domain_specific_titles_produce_no_note() {
+        // Neither an English word nor anywhere near the frequency floor.
         let matches = matches_for(&["Kubernetes", "hyalo", "frontmatter"]);
         assert!(common_title_note(&matches).is_none());
     }
@@ -1110,6 +1156,10 @@ mod tests {
             "the offender should be named with its count: {note}"
         );
         assert!(
+            !note.contains('%'),
+            "a wordlist-only offender has no share to report: {note}"
+        );
+        assert!(
             note.contains("--exclude-title permissions"),
             "the note should suggest the flag: {note}"
         );
@@ -1122,7 +1172,7 @@ mod tests {
         let note = common_title_note(&matches).expect("common words should be flagged");
         let pos = |needle: &str| note.find(needle).expect("offender should be listed");
         assert!(
-            pos("\"note\" (3×)") < pos("\"index\" (1×)"),
+            pos("(3×)") < pos("\"index\" (1×)"),
             "highest count first: {note}"
         );
         assert!(
@@ -1138,7 +1188,9 @@ mod tests {
     #[test]
     fn case_variants_of_one_title_are_counted_once() {
         // `--exclude-title` is case-insensitive, so the note must not split
-        // "Note" and "note" into two separate offenders.
+        // "Note" and "note" into two separate offenders. With the two
+        // spellings equally frequent the display form is the alphabetically
+        // first one, so the note is deterministic (L-13).
         let matches = matches_for(&["Note", "note"]);
         let note = common_title_note(&matches).expect("common word should be flagged");
         assert!(
@@ -1146,38 +1198,213 @@ mod tests {
             "case variants are one title: {note}"
         );
         assert!(
-            note.contains("\"note\" (2×)"),
-            "counts should be merged under the lowercased title: {note}"
+            note.contains("\"Note\" (2×)"),
+            "counts should be merged under one spelling: {note}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // iter-205 / L-13: the displayed spelling is the vault's, not the key's
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn the_note_displays_the_most_frequent_original_spelling() {
+        // A page titled README, mentioned mostly as "README": the note has to
+        // say README, not the lowercased lookup key (dogfood L-13).
+        let mut matches = repeated("README", 3);
+        matches.extend(repeated("readme", 1));
+        let note = common_title_note(&matches).expect("common word should be flagged");
+        assert!(
+            note.contains("\"README\" (4×)"),
+            "the dominant spelling should be displayed: {note}"
+        );
+        assert!(
+            note.contains("--exclude-title README"),
+            "the suggested flag uses the same spelling: {note}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // iter-205: the frequency trigger (dogfood UX-1)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_dominant_title_is_flagged_even_when_it_is_not_an_english_word() {
+        // The UX-1 repro in miniature: "Workflows" drove 43% of a GitHub Docs
+        // run and the wordlist trigger never mentioned it.
+        let mut matches = repeated("Workflows", 30);
+        matches.extend(repeated("Kubernetes", 10));
+        let note = common_title_note(&matches).expect("a dominant title should be flagged");
+        assert!(
+            note.starts_with("1 auto-link candidate title is unusually frequent"),
+            "the reason should be frequency, not the wordlist: {note}"
+        );
+        assert!(
+            note.contains("\"Workflows\" (30×, 75%)"),
+            "a frequency offender reports its share of the run: {note}"
+        );
+        assert!(
+            note.contains("--exclude-title Workflows"),
+            "the note should suggest the flag: {note}"
+        );
+        assert!(
+            !note.contains("Kubernetes"),
+            "the quiet title is nobody's business: {note}"
         );
     }
 
     #[test]
-    fn long_offender_lists_are_capped_with_a_remainder_count() {
+    fn a_title_under_the_absolute_floor_is_never_flagged_on_frequency() {
+        // 24 of 25 links is a 96% share, but on a run this small the user
+        // simply reads them — the floor keeps the note quiet.
+        let mut matches = repeated("Workflows", 24);
+        matches.extend(repeated("Kubernetes", 1));
+        assert!(
+            common_title_note(&matches).is_none(),
+            "the 25-match floor should hold on tiny runs"
+        );
+    }
+
+    #[test]
+    fn a_title_under_the_share_is_not_flagged_in_a_large_run() {
+        // 2,000 proposed links → the threshold is 50, not the floor's 25.
+        let filler: Vec<AutoLinkMatch> = (0..49)
+            .flat_map(|i| repeated(&format!("filler-{i}"), 40))
+            .collect();
+
+        let mut quiet = repeated("Workflows", 40);
+        quiet.extend(filler.iter().cloned());
+        assert_eq!(quiet.len(), 2_000);
+        assert!(
+            common_title_note(&quiet).is_none(),
+            "40 of 2,000 links is under 2.5% — the floor must not carry it"
+        );
+
+        let mut loud = repeated("Workflows", 60);
+        loud.extend(filler);
+        let note = common_title_note(&loud).expect("60 of 2,020 links clears the share");
+        assert!(
+            note.contains("\"Workflows\" (60×"),
+            "the dominant title should be named: {note}"
+        );
+    }
+
+    #[test]
+    fn non_ascii_titles_reach_the_frequency_trigger() {
+        // The wordlist is English and ASCII-gated, which left non-English
+        // vaults with no note at all; the frequency path has no such gate.
+        let mut matches = repeated("Übersicht", 30);
+        matches.extend(repeated("Kubernetes", 10));
+        let note = common_title_note(&matches).expect("a German title should still be flagged");
+        assert!(
+            note.contains("\"Übersicht\" (30×, 75%)"),
+            "the non-ASCII title should be named with its share: {note}"
+        );
+        assert!(
+            note.contains("--exclude-title 'Übersicht'"),
+            "the suggested flag should be shell-safe: {note}"
+        );
+    }
+
+    #[test]
+    fn a_mixed_offender_set_labels_every_entry_with_its_reason() {
+        let mut matches = repeated("Workflows", 30); // frequency only
+        matches.extend(repeated("README", 26)); // both triggers
+        matches.extend(repeated("permissions", 2)); // wordlist only
+        matches.extend(repeated("Kubernetes", 10)); // neither
+        let note = common_title_note(&matches).expect("three offenders should be flagged");
+        assert!(
+            note.starts_with(
+                "3 auto-link candidate titles are common English words or unusually frequent \
+                 and account for 58 of 68 proposed links"
+            ),
+            "a mixed set names both reasons in the subject: {note}"
+        );
+        assert!(
+            note.contains("\"Workflows\" (30×, 44%, unusually frequent)"),
+            "frequency-only offender should be labelled: {note}"
+        );
+        assert!(
+            note.contains("\"README\" (26×, 38%, common English word + unusually frequent)"),
+            "a doubly-flagged offender should say so: {note}"
+        );
+        assert!(
+            note.contains("\"permissions\" (2×, common English word)"),
+            "wordlist-only offender should be labelled and carry no share: {note}"
+        );
+    }
+
+    #[test]
+    fn a_homogeneous_offender_set_states_the_reason_once() {
+        let mut matches = repeated("Workflows", 30);
+        matches.extend(repeated("Übersicht", 30));
+        let note = common_title_note(&matches).expect("two dominant titles should be flagged");
+        assert!(
+            note.starts_with("2 auto-link candidate titles are unusually frequent"),
+            "plural frequency phrasing expected: {note}"
+        );
+        assert!(
+            !note.contains(", unusually frequent)"),
+            "no per-entry label is needed when every offender shares a reason: {note}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // iter-205 / L-12: honest truncation, complete flag list
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn long_offender_lists_are_truncated_in_prose_but_not_in_flags() {
         let matches = matches_for(&[
             "access", "account", "action", "active", "address", "agree", "answer",
         ]);
         let note = common_title_note(&matches).expect("common words should be flagged");
         assert!(
-            note.contains(&format!("+{} more", 7 - COMMON_TITLE_NOTE_MAX_LISTED)),
-            "the tail should be summarised, not listed: {note}"
+            note.contains(&format!(
+                "(showing the {COMMON_TITLE_NOTE_MAX_LISTED} noisiest of 7)"
+            )),
+            "the note should admit that it is truncating: {note}"
+        );
+        assert!(
+            !note.contains("more"),
+            "the old '+N more' phrasing is gone: {note}"
         );
         assert_eq!(
             note.matches("--exclude-title ").count(),
-            COMMON_TITLE_NOTE_MAX_LISTED,
-            "only the named offenders get a suggested flag: {note}"
+            7,
+            "every offender gets a flag so one paste-back extinguishes the note: {note}"
+        );
+        assert_eq!(
+            note.matches('"').count(),
+            COMMON_TITLE_NOTE_MAX_LISTED * 2,
+            "only the named offenders appear in the prose list: {note}"
         );
     }
 
     #[test]
-    fn multiword_titles_are_shell_quoted_in_the_suggestion() {
-        // "state of the art" is not a title we would flag, but a common word
-        // *is* reachable as a multi-word title via frontmatter aliases, and the
-        // suggested flag has to survive a copy-paste into a shell. Uses the
-        // same `hints::shell_quote` every other suggested-flag hint uses, so
-        // it also escapes apostrophes/`$`/backticks/double quotes, not just
-        // whitespace.
-        let quoted = crate::hints::shell_quote("data model");
-        assert_eq!(quoted, "'data model'");
+    fn multiword_frequent_titles_are_shell_quoted_in_the_suggestion() {
+        // "runner groups" (45 links on the GitHub Docs slice) is the real-data
+        // case: a frequency offender whose title contains a space, so the
+        // suggested flag has to survive a copy-paste into a shell.
+        let mut matches = repeated("runner groups", 30);
+        matches.extend(repeated("Kubernetes", 10));
+        let note = common_title_note(&matches).expect("a dominant title should be flagged");
+        assert!(
+            note.contains("\"runner groups\" (30×, 75%)"),
+            "the multi-word title should be named: {note}"
+        );
+        assert!(
+            note.contains("--exclude-title 'runner groups'"),
+            "the suggested flag should be quoted: {note}"
+        );
+    }
+
+    #[test]
+    fn suggested_flags_use_the_shared_shell_quoting_helper() {
+        // Uses the same `hints::shell_quote` every other suggested-flag hint
+        // uses, so it also escapes apostrophes/`$`/backticks/double quotes,
+        // not just whitespace.
+        assert_eq!(crate::hints::shell_quote("data model"), "'data model'");
         assert_eq!(crate::hints::shell_quote("permissions"), "permissions");
         assert_eq!(
             crate::hints::shell_quote("it's a trap"),

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -1349,6 +1349,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn excluding_the_dominant_title_can_reveal_the_next_tier() {
+        // A share-relative trigger re-scales when the run shrinks: excluding a
+        // 74% title leaves a much smaller run in which the runner-up clears
+        // the threshold it previously missed. That is the trigger working as
+        // designed, not a nag loop — the 25-match floor bounds it, because
+        // every round removes at least 25 links from the run.
+        let filler: Vec<AutoLinkMatch> = (0..19)
+            .flat_map(|i| repeated(&format!("filler-{i}"), 20))
+            .collect();
+
+        // Round 1: 1,620 links, threshold 41. Only the dominant title clears it.
+        let mut round1 = repeated("Workflows", 1_200);
+        round1.extend(repeated("runner groups", 40));
+        round1.extend(filler.iter().cloned());
+        assert_eq!(round1.len(), 1_620);
+        let note = common_title_note(&round1).expect("the dominant title should be flagged");
+        assert!(
+            note.starts_with("1 auto-link candidate title is unusually frequent"),
+            "the 40-match runner-up is under 2.5% of 1,620: {note}"
+        );
+
+        // Round 2: the same vault with "Workflows" excluded — 420 links, so
+        // the threshold falls back to the floor and the runner-up surfaces.
+        let mut round2 = repeated("runner groups", 40);
+        round2.extend(filler.iter().cloned());
+        let note = common_title_note(&round2).expect("the next tier should surface");
+        assert!(
+            note.contains("\"runner groups\" (40×, 10%)"),
+            "the runner-up is now the dominant title: {note}"
+        );
+
+        // Round 3: nothing left clears the 25-match floor. The process ends.
+        assert!(
+            common_title_note(&filler).is_none(),
+            "the floor terminates the cascade"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // iter-205 / L-12: honest truncation, complete flag list
     // -----------------------------------------------------------------------

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -56,8 +56,9 @@ struct AutoLinksConfig {
     /// When `true`, behaves as if `--first-only` had been passed.
     #[serde(default)]
     first_only: Option<bool>,
-    /// When `false`, suppresses the advisory stderr note that names candidate
-    /// titles which are common English words (iter-197). Defaults to `true`;
+    /// When `false`, suppresses the advisory stderr note that names noisy
+    /// candidate titles — common English words (iter-197) and titles that
+    /// dominate the run (iter-205). Defaults to `true`;
     /// `--no-warn-common-titles` turns it off for a single run.
     #[serde(default)]
     warn_common_titles: Option<bool>,
@@ -259,10 +260,10 @@ pub(crate) struct ResolvedDefaults {
     /// when the config says `false`.
     pub(crate) auto_link_first_only: bool,
     /// `[links.auto] warn_common_titles`, default `true`. When `false`, `hyalo
-    /// links auto` never emits the advisory note naming candidate titles that are
-    /// common English words (iter-197). `--no-warn-common-titles` turns it off for
-    /// a single run; there is no flag to turn it back on, because the default
-    /// already does.
+    /// links auto` never emits the advisory note naming noisy candidate titles —
+    /// common English words (iter-197) or titles that dominate the run
+    /// (iter-205). `--no-warn-common-titles` turns it off for a single run; there
+    /// is no flag to turn it back on, because the default already does.
     pub(crate) auto_link_warn_common_titles: bool,
     /// When `true`, "no 'type' property" and "undeclared property in frontmatter"
     /// warnings are promoted to errors.  From `[lint] strict = true` in `.hyalo.toml`.

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -173,7 +173,8 @@ pub(crate) struct CommandContext<'a> {
     /// `[links.auto] first_only` — `--first-only` for every run.
     pub auto_link_first_only: bool,
     /// `[links.auto] warn_common_titles` (default `true`) — whether `links auto`
-    /// may emit the advisory note naming common-English-word candidate titles.
+    /// may emit the advisory note naming noisy candidate titles (common English
+    /// words, or titles that dominate the run).
     pub auto_link_warn_common_titles: bool,
     /// Optional exit code override set by commands that need a non-0/2 exit code
     /// (e.g. `lint` returns 1 when errors are found). The output pipeline uses this

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -23,8 +23,10 @@ Prefer `hyalo` CLI for operations on files in this directory:
   `exclude_target_globs = [...]`, `first_only = true` in `.hyalo.toml`. Flags extend those lists
   rather than replacing them, and a run whose config exclusions removed candidates reports
   `config_excluded`. `--no-first-only` forces first-only OFF for one run when the config
-  persists `first_only = true`. When a proposed link comes from a page titled with a common English word,
-  a stderr `note:` names it with its match count — act on it or silence it with
+  persists `first_only = true`. When a candidate title looks noisy — an ordinary English word,
+  or unusually frequent (>= 25 matches and >= 2.5% of the run, which also catches non-English
+  titles) — a stderr `note:` names it with its match count and share, and suggests
+  `--exclude-title` for every offender; act on it or silence it with
   `--no-warn-common-titles` / `[links.auto] warn_common_titles = false`
 - **Move/rename (single file)**: `hyalo mv old.md --to new.md` (rewrites links across the vault)
 - **Move/rename (batch)**: `hyalo mv --glob 'iterations/*.md' --property status=completed --to iterations/done/` (dry-run by default; add `--apply` to commit; builds link graph once for all files; use `--on-conflict=skip` to skip collisions)

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -4487,12 +4487,13 @@ fn links_auto_note_truncates_the_prose_list_but_not_the_flags() {
     ];
     let mut guide = String::from("---\ntitle: Guide\n---\n");
     for word in words {
+        use std::fmt::Write as _;
         write_md(
             tmp.path(),
             &format!("{word}.md"),
             &format!("---\ntitle: {word}\n---\nA page.\n"),
         );
-        guide.push_str(&format!("The {word} page is over there.\n"));
+        let _ = writeln!(guide, "The {word} page is over there.");
     }
     write_md(tmp.path(), "guide.md", &guide);
 

--- a/crates/hyalo-cli/tests/e2e/links.rs
+++ b/crates/hyalo-cli/tests/e2e/links.rs
@@ -4131,11 +4131,12 @@ fn links_auto_notes_common_word_titles_on_stderr() {
         "note should explain why the titles are flagged: {stderr}"
     );
     assert!(
-        stderr.contains("\"permissions\" (2×)"),
-        "note should name the offending title with its match count: {stderr}"
+        stderr.contains("\"Permissions\" (2×)"),
+        "note should name the offending title, in the vault's own spelling \
+         (L-13), with its match count: {stderr}"
     );
     assert!(
-        stderr.contains("--exclude-title permissions"),
+        stderr.contains("--exclude-title Permissions"),
         "note should hand the user a ready-to-paste flag: {stderr}"
     );
     assert!(
@@ -4257,6 +4258,254 @@ We deploy on Kubernetes twice a week.
     assert!(
         stderr.is_empty(),
         "no common-word title means no note at all: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// iter-205: frequency trigger for the common-title note (dogfood UX-1)
+// ---------------------------------------------------------------------------
+
+/// Run `links auto` in `dir` with an explicit output format and return
+/// `(stdout, stderr)` verbatim.
+fn run_links_auto_capturing_format(
+    dir: &std::path::Path,
+    format: &str,
+    extra_args: &[&str],
+) -> (String, String) {
+    let output = hyalo_no_hints()
+        .current_dir(dir)
+        .args(["links", "auto", "--format", format])
+        .args(extra_args)
+        .output()
+        .expect("hyalo links auto should run");
+    assert!(
+        output.status.success(),
+        "links auto exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// A GitHub-Docs-shaped vault: one page whose title dominates the run without
+/// being an English word (`mentions` prose mentions), plus a quiet
+/// domain-specific title. This is the shape UX-1 was invisible on.
+fn setup_frequent_title_vault(config: &str, title: &str, mentions: usize) -> TempDir {
+    use std::fmt::Write as _;
+
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+    fs::write(tmp.path().join(".hyalo.toml"), config).expect("config should be writable");
+
+    write_md(
+        tmp.path(),
+        "dominant.md",
+        &format!("---\ntitle: {title}\n---\nThe page everything mentions.\n"),
+    );
+    write_md(
+        tmp.path(),
+        "kubernetes.md",
+        md!(r"
+---
+title: Kubernetes
+---
+Container orchestration.
+"),
+    );
+
+    let mut guide = String::from("---\ntitle: Guide\n---\n");
+    for i in 0..mentions {
+        let _ = writeln!(guide, "Step {i}: {title} is configured in the usual place.");
+    }
+    for i in 0..10 {
+        let _ = writeln!(guide, "Note {i}: Kubernetes schedules the run.");
+    }
+    write_md(tmp.path(), "guide.md", &guide);
+
+    tmp
+}
+
+#[test]
+fn links_auto_notes_a_dominant_title_that_is_not_an_english_word() {
+    // Dogfood UX-1: on GitHub Docs a page titled "Workflows" produced 43% of
+    // all proposed links and the wordlist-only trigger never mentioned it.
+    let tmp = setup_frequent_title_vault("", "Workflows", 30);
+
+    let (_stdout, stderr) = run_links_auto_capturing(tmp.path(), &[]);
+
+    assert!(
+        stderr.contains("note:"),
+        "the advisory should be a note, not a warning: {stderr}"
+    );
+    assert!(
+        stderr.contains("unusually frequent"),
+        "the note should name frequency as the reason: {stderr}"
+    );
+    assert!(
+        !stderr.contains("common English word"),
+        "\"Workflows\" is not a wordlist hit — the reason must not claim it is: {stderr}"
+    );
+    assert!(
+        stderr.contains("\"Workflows\" (30×, 75%)"),
+        "the note should quote the count and the share of the run: {stderr}"
+    );
+    assert!(
+        stderr.contains("--exclude-title Workflows"),
+        "the note should hand the user a ready-to-paste flag: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Kubernetes"),
+        "the quiet title should not be mentioned: {stderr}"
+    );
+}
+
+#[test]
+fn links_auto_frequency_note_disappears_after_one_paste_back() {
+    // The whole point of the suggestion: one round, not two.
+    let tmp = setup_frequent_title_vault("", "Workflows", 30);
+
+    let (_stdout, stderr) = run_links_auto_capturing(tmp.path(), &["--exclude-title", "Workflows"]);
+
+    assert!(
+        stderr.is_empty(),
+        "excluding the dominant title should extinguish the note: {stderr}"
+    );
+}
+
+#[test]
+fn links_auto_frequency_note_never_touches_the_stdout_report() {
+    // Same contract as the wordlist path: the note is stderr-only, in every
+    // output format.
+    let tmp = setup_frequent_title_vault("", "Workflows", 30);
+
+    for format in ["json", "text"] {
+        let (with_note, stderr) = run_links_auto_capturing_format(tmp.path(), format, &[]);
+        let (without_note, silent_stderr) =
+            run_links_auto_capturing_format(tmp.path(), format, &["--no-warn-common-titles"]);
+
+        assert!(
+            stderr.contains("unusually frequent"),
+            "the control run should actually have emitted the note ({format}): {stderr}"
+        );
+        assert!(
+            silent_stderr.is_empty(),
+            "--no-warn-common-titles should leave stderr empty ({format}): {silent_stderr}"
+        );
+        assert_eq!(
+            with_note, without_note,
+            "the note must not change the stdout envelope ({format})"
+        );
+        assert!(
+            !with_note.contains("unusually frequent"),
+            "the advisory text must never leak into stdout ({format}): {with_note}"
+        );
+    }
+}
+
+#[test]
+fn links_auto_config_opt_out_also_silences_the_frequency_note() {
+    let tmp = setup_frequent_title_vault(
+        "[links.auto]\nwarn_common_titles = false\n",
+        "Workflows",
+        30,
+    );
+
+    let (_stdout, stderr) = run_links_auto_capturing(tmp.path(), &[]);
+
+    assert!(
+        stderr.is_empty(),
+        "warn_common_titles = false governs both triggers: {stderr}"
+    );
+}
+
+#[test]
+fn links_auto_multiword_frequent_title_round_trips_through_the_suggested_flag() {
+    // "runner groups" (45 links on the dogfood's GitHub Docs slice) is the
+    // real-data case for the shell-quoting path: paste the flag back verbatim
+    // and the note has to go away.
+    let tmp = setup_frequent_title_vault("", "runner groups", 30);
+
+    let (_stdout, stderr) = run_links_auto_capturing(tmp.path(), &[]);
+    assert!(
+        stderr.contains("--exclude-title 'runner groups'"),
+        "a title with a space must be shell-quoted in the suggestion: {stderr}"
+    );
+
+    // What the shell hands back after stripping the quotes.
+    let (_stdout, quiet) =
+        run_links_auto_capturing(tmp.path(), &["--exclude-title", "runner groups"]);
+    assert!(
+        quiet.is_empty(),
+        "pasting the quoted flag should extinguish the note: {quiet}"
+    );
+}
+
+#[test]
+fn links_auto_notes_a_dominant_non_ascii_title() {
+    // The wordlist is ASCII-gated, so before iter-205 a German vault never saw
+    // the note at all however dominant its titles were.
+    let tmp = setup_frequent_title_vault("", "Übersicht", 30);
+
+    let (_stdout, stderr) = run_links_auto_capturing(tmp.path(), &[]);
+
+    assert!(
+        stderr.contains("\"Übersicht\" (30×, 75%)"),
+        "a non-ASCII title should reach the frequency trigger: {stderr}"
+    );
+    assert!(
+        stderr.contains("--exclude-title 'Übersicht'"),
+        "the suggested flag should be shell-safe: {stderr}"
+    );
+}
+
+#[test]
+fn links_auto_stays_silent_when_no_title_clears_the_frequency_floor() {
+    // The knowledgebase-shaped case: a handful of domain-specific titles, none
+    // of them an English word and none anywhere near 25 matches.
+    let tmp = setup_frequent_title_vault("", "Workflows", 20);
+
+    let (stdout, stderr) = run_links_auto_capturing(tmp.path(), &[]);
+
+    assert!(
+        stdout.contains("Workflows"),
+        "the links themselves should still be proposed: {stdout}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "20 matches is under the floor — no note: {stderr}"
+    );
+}
+
+#[test]
+fn links_auto_note_truncates_the_prose_list_but_not_the_flags() {
+    // Dogfood L-12: with more offenders than the note lists, the flag list
+    // still has to cover all of them, and the note has to admit it truncated.
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+    let words = [
+        "access", "account", "action", "active", "address", "agree", "answer",
+    ];
+    let mut guide = String::from("---\ntitle: Guide\n---\n");
+    for word in words {
+        write_md(
+            tmp.path(),
+            &format!("{word}.md"),
+            &format!("---\ntitle: {word}\n---\nA page.\n"),
+        );
+        guide.push_str(&format!("The {word} page is over there.\n"));
+    }
+    write_md(tmp.path(), "guide.md", &guide);
+
+    let (_stdout, stderr) = run_links_auto_capturing(tmp.path(), &[]);
+
+    assert!(
+        stderr.contains("showing the 5 noisiest of 7"),
+        "the note should admit that its prose list is capped: {stderr}"
+    );
+    assert_eq!(
+        stderr.matches("--exclude-title ").count(),
+        7,
+        "every offender needs a flag so one paste-back extinguishes the note: {stderr}"
     );
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ case_insensitive = "auto"                             # "auto", "true", or "fals
 exclude_titles = ["permissions", "README"]            # titles hyalo links auto never links
 exclude_target_globs = ["templates/*"]                # pages hyalo links auto never links to
 first_only = true                                     # link only the first mention per file
-warn_common_titles = true                             # note when a candidate title is a common word
+warn_common_titles = true                             # note when a candidate title looks noisy
 
 [schema.default]
 required = ["title"]
@@ -127,7 +127,7 @@ every invocation. `[links.auto]` persists them per vault:
 exclude_titles = ["permissions", "README", "index"]   # like --exclude-title (case-insensitive)
 exclude_target_globs = ["templates/*"]                # like --exclude-target-glob (case-insensitive)
 first_only = true                                     # like --first-only
-warn_common_titles = false                            # opt out of the common-word note
+warn_common_titles = false                            # opt out of the noisy-title note
 ```
 
 Merge rules with the CLI flags:
@@ -161,20 +161,40 @@ line in text output. `hyalo config` prints the effective settings as
 `links.auto.first_only` / `links.auto.warn_common_titles` (and
 `results.links_auto` in JSON).
 
-### The common-word title note
+### The noisy candidate title note
 
 Exclusions only help once you have noticed the noise. On a first run, `hyalo
-links auto` also checks whether any proposed link came from a page whose title
-is an ordinary English word or a generic doc filename (`permissions`, `index`,
-`notes`, `README`) and, if so, prints one advisory line on stderr:
+links auto` also looks at the links it is about to propose and, if any of them
+come from a title that looks like a source of over-linking, prints one advisory
+line on stderr:
 
 ```text
-note: 2 auto-link candidate titles are common English words and account for 31 of 33
-proposed links: "permissions" (24×), "index" (7×). If those are prose mentions rather
-than deliberate references, skip them with --exclude-title permissions
---exclude-title index — or persist them once under [links.auto] exclude_titles in
-.hyalo.toml. Silence this note with --no-warn-common-titles.
+note: 3 auto-link candidate titles are common English words or unusually frequent and
+account for 588 of 1179 proposed links (showing the 5 noisiest of 7): "Workflows"
+(502×, 43%, unusually frequent), "limits" (46×, common English word), "runner groups"
+(45×, 4%, unusually frequent). If those are prose mentions rather than deliberate
+references, skip them with --exclude-title Workflows --exclude-title limits
+--exclude-title 'runner groups' — or persist them once under [links.auto]
+exclude_titles in .hyalo.toml. Silence this note with --no-warn-common-titles.
 ```
+
+Two independent triggers put a title in that list:
+
+- **Common English word.** The title is an ordinary English word or a generic
+  doc filename (`permissions`, `index`, `notes`, `README`). The list lives in
+  `hyalo-core::common_words` — bundled, no dependency — and covers regular
+  plurals, so `permissions` matches the stored `permission`. Titles shorter
+  than 3 characters are never classified; `--min-length` already excludes them.
+  Being an English word list, it only ever matches ASCII titles.
+- **Unusually frequent.** The title produced at least **25** proposed links
+  *and* at least **2.5%** of the run — `max(25, ceil(total / 40))` matches, so
+  the absolute floor governs runs below 1,000 links and the share governs
+  larger ones. This trigger is purely arithmetic and therefore
+  language-independent: a German or Japanese vault gets the note too.
+
+A title flagged by both is labelled as both. When every offender was flagged
+for the same reason the note states it once in the opening clause instead of
+repeating it per entry.
 
 Properties of the check, all deliberate:
 
@@ -184,13 +204,15 @@ Properties of the check, all deliberate:
   run are named. Excluding them — by flag or config — removes the note.
 - **Match-count honest.** The counts quoted are the links being offered, not an
   estimate over the title inventory.
+- **One paste-back is enough.** The prose list stops at the five noisiest and
+  says so (`showing the 5 noisiest of 7`), but the suggested `--exclude-title`
+  flags cover *every* offender.
+- **Spelled the way your vault spells it.** A title is displayed in its most
+  frequent original casing (`README`, not `readme`), while matching and
+  exclusion stay case-insensitive.
 - **Silenced by `-q`** like every other note, or permanently by
-  `warn_common_titles = false`.
-- **Bundled word list, no dependency.** The list lives in
-  `hyalo-core::common_words` and covers high-frequency English words (plus
-  regular plurals, so `permissions` matches the stored `permission`) and generic
-  doc filenames. Titles shorter than 3 characters are never classified —
-  `--min-length` already excludes them.
+  `warn_common_titles = false`. One key governs both triggers; there are no
+  configurable thresholds.
 
 `hyalo links fix` has a similar per-invocation filter spelled
 `--ignore-target <substring>`. It matches link *targets* by substring rather

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,6 +214,13 @@ Properties of the check, all deliberate:
   `warn_common_titles = false`. One key governs both triggers; there are no
   configurable thresholds.
 
+Because the share is measured against *this* run, excluding a dominant title
+can bring the next tier above the threshold: on a large vault the second run
+may name titles the first one did not, simply because the run it is measured
+against is now much smaller. That converges rather than nagging — every round
+removes at least 25 links, and once nothing clears the 25-match floor the note
+stops for good.
+
 `hyalo links fix` has a similar per-invocation filter spelled
 `--ignore-target <substring>`. It matches link *targets* by substring rather
 than page titles or paths, so it is deliberately not part of `[links.auto]` and

--- a/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
+++ b/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
@@ -91,13 +91,21 @@ lowercase would let the note suggest a flag that does not actually exclude.
 The *display* form (L-13) is the most frequent original surface spelling,
 ties broken lexicographically.
 
+**Cascade, measured.** Excluding the seven GitHub Docs offenders shrinks that
+run from 1,179 to 265 links, which drops the threshold from 30 to the floor of
+25 — and two titles that were previously quiet (`actions-runner-controller`
+28, `runner-groups` 27) now cross it. This is inherent to a share-relative
+trigger and it terminates: every round removes at least 25 links, so the
+cascade is bounded by `total / 25` rounds (two, here). Documented in
+`docs/configuration.md` and covered by a unit test rather than smoothed over.
+
 **Non-goal reaffirmed.** No new config key and no user-configurable
 thresholds; `[links.auto] warn_common_titles` keeps governing both triggers.
 Revisit only on demand.
 
 ## Tasks
 
-- [ ] Design the trigger and record it in the plan before coding (a DEC
+- [x] Design the trigger and record it in the plan before coding (a DEC
       entry): a candidate title is flagged when wordlist-common OR
       frequency-dominant. Starting point to validate against the
       report's data: matches >= max(15, 20% of total proposed links),
@@ -107,46 +115,49 @@ Revisit only on demand.
       the own KB (192 candidates, 22 titles — currently zero notes, keep
       it that way; tune thresholds against both corpora and record the
       chosen values + measured outcomes here).
-- [ ] Non-ASCII titles participate in the frequency path (drop the ASCII
+- [x] Non-ASCII titles participate in the frequency path (drop the ASCII
       gate for frequency; keep it for the wordlist, whose entries are
       ASCII by construction).
-- [ ] Note wording distinguishes the reason: "common English words" vs
+- [x] Note wording distinguishes the reason: "common English words" vs
       "unusually frequent" (or a merged phrasing naming both) — the
       user's judgment differs per cause.
-- [ ] L-12: when offenders exceed the listing cap, say so ("showing the
+- [x] L-12: when offenders exceed the listing cap, say so ("showing the
       5 noisiest of 7") AND include --exclude-title flags for ALL
       offenders (flags are cheap; the cap is for the prose list only) so
       one paste-back fully extinguishes.
-- [ ] L-13: display the most frequent original casing ("README (3x)")
+- [x] L-13: display the most frequent original casing ("README (3x)")
       while matching stays case-insensitive; the suggested flag value
       keeps working either way.
-- [ ] Frequency titles containing spaces/quotes now make the
+- [x] Frequency titles containing spaces/quotes now make the
       shell-quoting path (hints::shell_quote, #232 review fix) live —
       add an e2e proving a multi-word frequent title round-trips through
       the suggested flag ("runner groups" is the real-data case).
-- [ ] e2e: GitHub Docs-shaped fixture where the dominant title is NOT a
+- [x] e2e: GitHub Docs-shaped fixture where the dominant title is NOT a
       wordlist word; own-KB-shaped fixture asserting silence; stdout
       byte-identity re-asserted for the frequency path; opt-outs cover
       both trigger kinds.
-- [ ] Docs: links auto --help, configuration.md ([links.auto]
+- [x] Docs: links auto --help, configuration.md ([links.auto]
       warn_common_titles covers both triggers — confirm the key name
       still fits or add a separate key ONLY if user-configurable
       thresholds are demanded; default: no new config).
-- [ ] CHANGELOG entry.
+- [x] CHANGELOG entry.
 
 ## Acceptance criteria
 
-- [ ] The report's GitHub Docs scenario names Workflows first with its
-      count/share; pasting the suggestion extinguishes the note in one
-      round
-- [ ] Own KB emits exactly one note, naming `backlinks` (130 of 195,
+- [x] The report's GitHub Docs scenario names `workflows` first with its
+      count and share (502×, 43%); pasting the suggested flags back removes
+      all seven named offenders in one round. The now-much-smaller run then
+      surfaces the next tier (`actions-runner-controller` 28,
+      `runner-groups` 27) — inherent to a share-relative trigger, bounded by
+      the 25-match floor, documented and unit-tested rather than hidden
+- [x] Own KB emits exactly one note, naming `backlinks` (130 of 195,
       67%) — amended from "note-free" by DEC-205, which shows the
       original criterion is unachievable and the note is a true positive
-- [ ] A German-titled scratch vault with one dominant title gets the
+- [x] A German-titled scratch vault with one dominant title gets the
       note (ASCII gate no longer total)
-- [ ] stdout remains byte-identical with/without the note in both
+- [x] stdout remains byte-identical with/without the note in both
       formats
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q` all clean
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
+++ b/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
@@ -2,7 +2,7 @@
 title: Iteration 205 — frequency trigger for the common-title note
 type: iteration
 date: 2026-08-18
-status: in-progress
+status: completed
 branch: iter-205/common-title-frequency-trigger
 tags:
   - iteration

--- a/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
+++ b/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
@@ -103,7 +103,7 @@ cascade is bounded by `total / 25` rounds (two, here). Documented in
 thresholds; `[links.auto] warn_common_titles` keeps governing both triggers.
 Revisit only on demand.
 
-## Tasks
+## Tasks [9/9]
 
 - [x] Design the trigger and record it in the plan before coding (a DEC
       entry): a candidate title is flagged when wordlist-common OR
@@ -142,7 +142,7 @@ Revisit only on demand.
       thresholds are demanded; default: no new config).
 - [x] CHANGELOG entry.
 
-## Acceptance criteria
+## Acceptance criteria [5/5]
 
 - [x] The report's GitHub Docs scenario names `workflows` first with its
       count and share (502×, 43%); pasting the suggested flags back removes

--- a/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
+++ b/hyalo-knowledgebase/iterations/iteration-205-common-title-frequency-trigger.md
@@ -2,7 +2,7 @@
 title: Iteration 205 — frequency trigger for the common-title note
 type: iteration
 date: 2026-08-18
-status: planned
+status: in-progress
 branch: iter-205/common-title-frequency-trigger
 tags:
   - iteration
@@ -38,6 +38,62 @@ L-13). Anchors at `931a226`: trigger + note assembly in
 plumbing (stderr-only, byte-identical stdout, self-extinguishing,
 opt-outs) is verified correct and must not change — this iteration only
 widens WHAT triggers the note.
+
+## DEC-205 — the frequency trigger (recorded before coding)
+
+**Rule.** A candidate title is an offender when it is wordlist-common
+**OR** frequency-dominant. Frequency-dominant means
+
+```text
+count >= max(25, ceil(0.025 * total_proposed_links))
+```
+
+i.e. an absolute floor of 25 matches, overtaken by a 2.5% share once a run
+exceeds 1,000 proposed links. The two curves cross exactly at 1,000, so the
+floor protects small vaults from being nagged about a title the user can
+simply read, and the share keeps the note selective on large ones.
+
+**Why not the plan's 20%-of-total starting point.** It flags nothing but
+`Workflows` on the GitHub Docs slice: 20% of 1,179 is 236, so `metrics`
+(62), `runner groups` (45) and `concurrency` (39) — all named in the
+dogfood as must-flag — stay silent. A share that low needs the absolute
+floor to carry small and mid-size runs.
+
+**Measured outcomes** (v0.20.0 binary, 2026-08-22, `links auto` with no
+flags):
+
+| corpus | total links | titles | threshold | flagged |
+|---|---|---|---|---|
+| own KB (`hyalo-knowledgebase`) | 195 | 22 | 25 | `backlinks` (130, 67%) |
+| GitHub Docs `actions`+`repositories`+`get-started` | 1,179 | 52 | 30 | `workflows` 502, `oidc` 177, `metrics` 62, `limits` 46, `runner groups` 45, `powershell` 43, `concurrency` 39 |
+| `vscode-docs` | 33,859 | 144 | 847 | 10 titles, `command` 4,149 (12%) down to `configure` 932 (2.8%) |
+
+Nearest non-flagged neighbours: own KB `decision log` 19; GitHub Docs
+`actions-runner-controller` 28; vscode-docs `markdown` 829. No corpus sits
+on a knife edge.
+
+**Deviation from the plan's "own KB stays note-free" acceptance criterion.**
+It is unachievable and the criterion was written from a wrong premise. The
+own KB's dominant title is `backlinks` at **130 of 195 links (67%)** across
+56 files — a project about a CLI whose command is called `backlinks`, whose
+every prose mention would be linked. No threshold can flag GitHub Docs'
+`concurrency` (39 links, 3.3%) while staying silent about a title with 130
+links at 67%: it is larger on both the absolute and the relative axis. The
+own-KB note is therefore a **true positive** of exactly the class UX-1 asks
+us to catch, and the AC is amended to: the own KB emits exactly one note,
+naming `backlinks`, extinguished in one paste-back. A vault-size gate (only
+warn above N total links) would restore the silence but contradicts the
+German-scratch-vault criterion, which needs the note on a small vault.
+
+**Casing and keying.** Offender keys stay `to_ascii_lowercase`, matching the
+comparison `auto_link` itself uses for `exclude_titles` — a Unicode-aware
+lowercase would let the note suggest a flag that does not actually exclude.
+The *display* form (L-13) is the most frequent original surface spelling,
+ties broken lexicographically.
+
+**Non-goal reaffirmed.** No new config key and no user-configurable
+thresholds; `[links.auto] warn_common_titles` keeps governing both triggers.
+Revisit only on demand.
 
 ## Tasks
 
@@ -83,7 +139,9 @@ widens WHAT triggers the note.
 - [ ] The report's GitHub Docs scenario names Workflows first with its
       count/share; pasting the suggestion extinguishes the note in one
       round
-- [ ] Own KB stays note-free
+- [ ] Own KB emits exactly one note, naming `backlinks` (130 of 195,
+      67%) — amended from "note-free" by DEC-205, which shows the
+      original criterion is unachievable and the note is a true positive
 - [ ] A German-titled scratch vault with one dominant title gets the
       note (ASCII gate no longer total)
 - [ ] stdout remains byte-identical with/without the note in both

--- a/hyalo-knowledgebase/iterations/iteration-209-links-auto-configurable-noise-thresholds.md
+++ b/hyalo-knowledgebase/iterations/iteration-209-links-auto-configurable-noise-thresholds.md
@@ -1,0 +1,76 @@
+---
+type: iteration
+title: Iteration 209 — configurable thresholds for the links auto noisy-title note
+date: 2026-08-22
+status: deferred
+tags:
+  - iteration
+  - links
+  - auto-link
+branch: iter-209/links-auto-configurable-noise-thresholds
+related:
+  - "[[iterations/iteration-205-common-title-frequency-trigger]]"
+  - "[[iterations/iteration-199-links-auto-exclude-list-counter-flags]]"
+---
+
+# Iteration 209 — configurable thresholds for the links auto noisy-title note
+
+## Goal
+
+Carried over from iteration 205's Non-goals (DEC-205, 2026-08-22): "Per-vault
+configurable thresholds (wait for demand — DEC it)." Iteration 205 hardcoded
+the frequency trigger's constants — `FREQUENT_TITLE_MIN_MATCHES = 25` and
+`FREQUENT_TITLE_SHARE_DIVISOR = 40` (2.5%) — tuned against three measured
+corpora (own KB, a GitHub Docs slice, `vscode-docs`). No corpus in that
+measurement sat on a knife edge, so there was no evidence a fixed constant
+would misfire elsewhere. This plan exists so "wait for demand" is a tracked,
+revisitable position rather than a sentence buried in a completed iteration's
+Non-goals section — matching the precedent [[iterations/iteration-199-links-auto-exclude-list-counter-flags]]
+set for exactly this situation.
+
+## Context
+
+- The two constants live in `crates/hyalo-cli/src/commands/links.rs`
+  (`FREQUENT_TITLE_MIN_MATCHES`, `FREQUENT_TITLE_SHARE_DIVISOR`), feeding
+  `frequent_title_threshold(total) = max(25, ceil(total / 40))`.
+- `[links.auto] warn_common_titles` already exists as a single on/off switch
+  governing both the wordlist and frequency triggers. A configurable
+  threshold would need new key(s) — e.g. `frequent_title_min_matches` /
+  `frequent_title_share` — under the same `[links.auto]` table, plus CLI
+  flag equivalents if per-run overrides are wanted (mirroring the
+  `exclude_titles` config-vs-flag precedent from iter-195a).
+- DEC-205's measurement is the evidence base to re-check before touching
+  this: own KB (195 links, threshold 25, flags `backlinks` at 67%), GitHub
+  Docs slice (1,179 links, threshold 30), `vscode-docs` (33,859 links,
+  threshold 847). If a future corpus needs a threshold outside what those
+  three could justify, that is the demand signal this plan is waiting for.
+
+## Tasks
+
+- [ ] Re-evaluate demand: has any user or dogfood session hit a corpus where
+      the fixed 25-match / 2.5%-share constants produce a wrong call (a true
+      offender under the floor, or a false positive the share shouldn't have
+      caught) since iter-205 shipped? If not, close this `wont-do` with the
+      evidence rather than force a decision.
+- [ ] If proceeding: decide the config surface — new `[links.auto]` keys
+      only, or also CLI flags for a single-run override (precedent:
+      `--min-length` is CLI-only with no config key, by iter-205's own
+      design note; `exclude_titles` is both).
+- [ ] If proceeding: decide whether the floor and the share get independent
+      overrides or must move together.
+- [ ] If proceeding: unit tests for the chosen semantics (mirroring the
+      `frequent_title_threshold` coverage style from iter-205).
+- [ ] If proceeding: e2e coverage plus docs — `links auto --help`,
+      `docs/configuration.md`, `CHANGELOG.md`, `rule-knowledgebase.md`.
+
+## Acceptance criteria
+
+- [ ] TBD once the re-evaluation task above concludes proceed vs. wont-do,
+      and — if proceeding — once the config-surface question is settled.
+
+## Non-goals
+
+- Revisiting the frequency trigger's already-shipped default values
+  (iter-205, DEC-205) absent a concrete counter-example.
+- Revisiting the wordlist trigger (`is_common_word`) or its own thresholds
+  (title-length floor, plural stemming) — out of scope for this plan.


### PR DESCRIPTION
## Summary

- **The `links auto` advisory note now fires on frequency, not just on an English word list** (dogfood UX-1). A candidate title is flagged when it is a common English word **or** when it dominates the run: `count >= max(25, ceil(total / 40))` — an absolute floor of 25 proposed links, overtaken by a 2.5% share once a run exceeds 1,000 links. The wordlist alone missed the titles that actually matter: on a GitHub Docs slice a page titled `Workflows` produced 502 of 1,179 proposed links (43%) and was never mentioned, while the note named `limits` at 4%.
- **Non-English vaults finally see the note.** The word list is ASCII-gated by construction, so it was dead on every non-English vault; the frequency path is pure arithmetic and has no such gate. Verified against a German scratch vault (`"Übersicht" (30×, 100%)`).
- **The note says which trigger fired.** A homogeneous offender set states the reason once in the opening clause; a mixed set labels each entry (`common English word`, `unusually frequent`, or both), and frequency hits quote their share of the run.
- **L-12 — honest truncation, complete flag list.** `showing the 5 noisiest of 7` replaces `+2 more`, and the suggested `--exclude-title` flags now cover *every* offender, not just the listed ones, so one paste-back is enough.
- **L-13 — the vault's own spelling.** Titles display in their most frequent original casing (`README`, not `readme`); matching and exclusion stay case-insensitive, and the suggested flag works either way.
- No new config key: `[links.auto] warn_common_titles` / `--no-warn-common-titles` still govern both triggers, and stdout stays byte-identical with or without the note.

## Threshold, tuned against real corpora (DEC-205)

| corpus | links | titles | threshold | flagged |
|---|---|---|---|---|
| own knowledgebase | 195 | 22 | 25 | `backlinks` 130 (67%) — next below: 19 |
| GitHub Docs `actions`+`repositories`+`get-started` | 1,179 | 52 | 30 | `workflows` 502, `oidc` 177, `metrics` 62, `limits` 46, `runner groups` 45, `powershell` 43, `concurrency` 39 — next below: 28 |
| `vscode-docs` | 33,859 | 144 | 847 | 10 titles, `command` 4,149 (12%) … `configure` 932 (2.8%) — next below: 829 |

Two deviations from the plan, both recorded in the iteration file with evidence:

1. **The plan's `max(15, 20% of total)` starting point does not work** — 20% of 1,179 is 236, so `metrics`/`runner groups`/`concurrency`, all named in the dogfood as must-flag, stay silent. A low share needs an absolute floor to carry small and mid-size runs.
2. **"Own KB stays note-free" is unachievable and the criterion was wrong.** The own KB's dominant title is `backlinks` at 130 of 195 links (67%) across 56 files. No threshold can flag GitHub Docs' `concurrency` (39 links, 3.3%) while staying silent about a title that is larger on *both* the absolute and the relative axis. That note is a true positive of exactly the class UX-1 asks us to catch; the AC was amended rather than the threshold bent.

Also measured and documented rather than hidden: excluding the seven GitHub Docs offenders shrinks the run to 265 links, dropping the threshold to the floor, so two previously quiet titles surface. That is inherent to a share-relative trigger and it terminates — every round removes at least 25 links — so it is bounded by `total / 25` rounds and covered by a unit test.

## Test plan

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` — all clean
- All four xtask gates (`check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`) exit 0; the two stubs report unimplemented
- 17 new unit tests: threshold arithmetic (floor, share, the crossing point at 1,000, ceil rounding), percent rounding, frequency-only / wordlist-only / mixed offender sets, display-casing selection and its tie-break, the under-floor and under-share silences, and the exclusion cascade
- 8 new e2e tests: a GitHub-Docs-shaped vault whose dominant title is not a wordlist word, one-paste-back extinguish, stdout byte-identity in **both** `json` and `text`, `--no-warn-common-titles` and `[links.auto] warn_common_titles = false` against the frequency trigger, a non-ASCII (`Übersicht`) dominant title, the multi-word `runner groups` shell-quote round-trip, and L-12 truncation with all 7 flags present
- Manual verification with the release binary against three real corpora and a German scratch vault (numbers above)
- Docs updated in the same PR: `links auto --help`, `docs/configuration.md`, the bundled knowledgebase rule template, `CHANGELOG.md`, and the iteration plan. README untouched by design.

## Carry-over

Sweep of iter-205's plan (Tasks/ACs/Non-goals), this PR body, and the
review milestones — every unticked AC, `[deferred …]` annotation, and
out-of-scope finding, with its disposition. This is the last iteration of
this run, so every item below either was already filed before this PR or
gets a brand-new plan file (no next iteration to fold into):

| Item | Source | Disposition |
|---|---|---|
| Acceptance criteria / Tasks | iteration-205 plan | All 9 tasks and 5 ACs ticked and verified against the real diff — nothing unticked to carry over |
| "Per-vault configurable thresholds (wait for demand)" | iter-205 Non-goals (DEC-205) | New plan filed: [[iterations/iteration-209-links-auto-configurable-noise-thresholds]] (`status: deferred`) |
| "iteration-199 (exclude-list counter-flags) stays deferred" | iter-205 Non-goals | Already has its own plan, `status: deferred` since 2026-08-18 — no new action needed, referenced for traceability |
| "Any change to match/exclusion semantics of links auto itself" | iter-205 Non-goals | Owned by [[iterations/iteration-200-links-apply-integrity]], already merged — not this PR's concern |

No unaddressed local-review findings: the review pass found the
implementation, tests, and docs consistent with the diff and DEC-205's
measurements, and made no code changes beyond restoring the repo's
`[N/M]` heading-count convention on the iteration plan itself.
