### PR TITLE
iter-214: frontmatter writes touch only the keys they change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **Frontmatter writes now touch only the keys they change** (iter-214,
+  dogfood BUG-14). `set`, `remove`, `append`, `tags rename`,
+  `properties rename`, `types apply` and `lint --fix` parsed the whole YAML
+  block and re-serialized all of it, so a one-key change rewrote every line
+  the serializer happened to format differently — 116 of 198 frontmatter lines
+  on a real GitHub Docs `index.md` for a single added property, with long list
+  items refolded into `>-` block scalars and `'` quote style flipped to `"`.
+  Nothing was ever lost (the round trip was semantically exact), but the churn
+  made hyalo unusable in repos where frontmatter is under code review. Writes
+  now re-emit the original bytes of every unchanged key — preserving quote
+  style, block scalars, flow collections, indentation, blank lines and
+  comments — and serialize only what actually changed. Adding one property
+  changes one line. Where a block cannot be mapped to per-key line spans
+  (explicit `? key` syntax, top-level flow collections, invalid UTF-8, mixed
+  line endings) the whole block is still rewritten, but never silently: a
+  `warning:` on stderr names the file and the reason. See DEC-080/DEC-081.
+
 ### Added
 
 - **`hyalo config --raw`, and a machine-readable malformed-config signal**

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -839,6 +839,12 @@ element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk (unless --dry-run is passed).\n\
+            FORMATTING: only the lines of the keys you change are rewritten. Every other \
+            frontmatter line — quote style, block scalars, flow collections, indentation, \
+            blank lines and comments — is preserved byte for byte. A block that cannot be \
+            mapped to per-key line spans (explicit `? key` syntax, top-level flow collections, \
+            invalid UTF-8, mixed line endings) is rewritten in full, with a warning on stderr \
+            naming the file and the reason.\n\
             SIZE LIMIT: frontmatter is limited to 64 KiB / 2000 lines. A write that would exceed \
             this limit is rejected with exit 1 and a JSON error \
             {\"error\": \"frontmatter would exceed size budget\", \"limit_bytes\": ..., \"would_be_bytes\": ..., \"file\": ...}.\n\
@@ -909,6 +915,12 @@ element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk (unless --dry-run is passed).\n\
+            FORMATTING: only the lines of the keys you change are rewritten. Every other \
+            frontmatter line — quote style, block scalars, flow collections, indentation, \
+            blank lines and comments — is preserved byte for byte. A block that cannot be \
+            mapped to per-key line spans (explicit `? key` syntax, top-level flow collections, \
+            invalid UTF-8, mixed line endings) is rewritten in full, with a warning on stderr \
+            naming the file and the reason.\n\
             SIZE LIMIT: frontmatter is limited to 64 KiB / 2000 lines. A write that would exceed \
             this limit is rejected with exit 1 and a JSON error (see `hyalo set --help`).\n\
             USE WHEN: You need to delete properties or remove tags from one or more files.\n\n\
@@ -1092,6 +1104,12 @@ element matches. Repeatable (AND).\n\
             - --where-tag T: only mutate files with this tag (nested matching: 'project' matches 'project/backend'). \
 Repeatable (AND).\n\
             SIDE EFFECTS: Modifies matched files on disk (unless --dry-run is passed).\n\
+            FORMATTING: only the lines of the keys you change are rewritten. Every other \
+            frontmatter line — quote style, block scalars, flow collections, indentation, \
+            blank lines and comments — is preserved byte for byte. A block that cannot be \
+            mapped to per-key line spans (explicit `? key` syntax, top-level flow collections, \
+            invalid UTF-8, mixed line endings) is rewritten in full, with a warning on stderr \
+            naming the file and the reason.\n\
             SIZE LIMIT: frontmatter is limited to 64 KiB / 2000 lines. A write that would exceed \
             this limit is rejected with exit 1 and a JSON error (see `hyalo set --help`).\n\
             USE WHEN: You need to append items to list-type properties such as 'aliases' or 'authors' \

--- a/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
+++ b/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
@@ -1,0 +1,409 @@
+//! e2e: minimal-diff frontmatter writes (iter-214).
+//!
+//! Every frontmatter mutation must touch only the lines belonging to the keys
+//! it changes. The regression these tests lock down: adding one property to a
+//! real GitHub Docs `index.md` used to rewrite 116 of its 198 frontmatter
+//! lines (long list items refolded into `>-` block scalars, `'` quote style
+//! flipped to `"`), which made `hyalo set` unusable on any docs repo under
+//! code review.
+
+use super::common::{hyalo_no_hints, write_md};
+use std::fs;
+use tempfile::TempDir;
+
+/// Frontmatter shaped like a real GitHub Docs `index.md`: single-quoted
+/// version globs, `>-` folded intros, nested feature maps, long redirect and
+/// child lists.
+const GH_DOCS_FRONTMATTER: &str = "\
+title: GitHub Actions documentation
+shortTitle: GitHub Actions
+intro: >-
+  Automate, customize, and execute your software development workflows right
+  in your repository with GitHub Actions. You can discover, create, and share
+  actions to perform any job you'd like, including CI/CD.
+allowTitleToDifferFromFilename: true
+introLinks:
+  quickstart: /actions/quickstart
+  reference: /actions/reference
+featuredLinks:
+  startHere:
+    - /actions/learn-github-actions/understanding-github-actions
+    - /actions/learn-github-actions/finding-and-customizing-actions
+    - /actions/examples/using-scripts-to-test-your-code-on-a-runner
+  guideCards:
+    - /actions/deployment/deploying-to-amazon-elastic-container-service
+    - /actions/deployment/deploying-to-azure-app-service
+  popular:
+    - /actions/writing-workflows/workflow-syntax-for-github-actions
+    - /actions/writing-workflows/events-that-trigger-workflows
+changelog:
+  label: actions
+  prefix: 'GitHub Actions: '
+redirect_from:
+  - /articles/automating-your-workflow-with-github-actions
+  - /articles/customizing-your-project-with-github-actions
+  - /categories/automating-your-workflow-with-github-actions
+layout: product-landing
+versions:
+  fpt: '*'
+  ghes: '*'
+  ghec: '*'
+topics:
+  - CI
+  - CD
+  - Developer
+children:
+  - /concepts
+  - /tutorials
+  - /how-tos
+  - /reference
+";
+
+fn gh_docs_file(tmp: &TempDir) {
+    write_md(
+        tmp.path(),
+        "index.md",
+        &format!("---\n{GH_DOCS_FRONTMATTER}---\n\n# GitHub Actions\n\nBody text.\n"),
+    );
+}
+
+/// Number of lines present in exactly one of the two texts — a coarse but
+/// direction-agnostic stand-in for `git diff` line count.
+fn diff_line_count(before: &str, after: &str) -> usize {
+    let b: Vec<&str> = before.lines().collect();
+    let a: Vec<&str> = after.lines().collect();
+    a.iter().filter(|l| !b.contains(l)).count() + b.iter().filter(|l| !a.contains(l)).count()
+}
+
+fn run(tmp: &TempDir, args: &[&str]) -> (bool, String) {
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(args)
+        .output()
+        .unwrap();
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The headline acceptance criterion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_adds_one_property_to_github_docs_index_and_changes_one_line() {
+    let tmp = TempDir::new().unwrap();
+    gh_docs_file(&tmp);
+    let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+
+    let (ok, stderr) = run(&tmp, &["set", "index.md", "--property", "status=reviewed"]);
+    assert!(ok, "set failed: {stderr}");
+    assert!(
+        !stderr.contains("rewriting the entire frontmatter block"),
+        "no fallback expected for plain GitHub Docs frontmatter: {stderr}"
+    );
+
+    let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+    assert_eq!(
+        diff_line_count(&before, &after),
+        1,
+        "adding one property must change exactly one line\n--- before ---\n{before}\n--- after ---\n{after}"
+    );
+    assert!(after.contains("status: reviewed\n"));
+    // Every original frontmatter line survives byte-identically.
+    for line in GH_DOCS_FRONTMATTER.lines() {
+        assert!(
+            after.contains(&format!("{line}\n")),
+            "original line lost or reformatted: {line:?}\n{after}"
+        );
+    }
+}
+
+#[test]
+fn set_changing_one_value_leaves_the_rest_byte_identical() {
+    let tmp = TempDir::new().unwrap();
+    gh_docs_file(&tmp);
+    let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+
+    let (ok, stderr) = run(&tmp, &["set", "index.md", "--property", "layout=landing"]);
+    assert!(ok, "set failed: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+    assert_eq!(
+        diff_line_count(&before, &after),
+        2,
+        "changing one value must change exactly one line in each direction\n{after}"
+    );
+    assert!(after.contains("layout: landing\n"));
+    assert!(!after.contains("layout: product-landing\n"));
+}
+
+#[test]
+fn remove_drops_only_the_removed_key() {
+    let tmp = TempDir::new().unwrap();
+    gh_docs_file(&tmp);
+    let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+
+    let (ok, stderr) = run(&tmp, &["remove", "index.md", "--property", "layout"]);
+    assert!(ok, "remove failed: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+    assert_eq!(diff_line_count(&before, &after), 1, "{after}");
+    assert!(!after.contains("layout:"));
+    assert!(after.contains("changelog:\n  label: actions\n"));
+}
+
+#[test]
+fn append_to_a_list_rewrites_only_that_list() {
+    let tmp = TempDir::new().unwrap();
+    gh_docs_file(&tmp);
+    let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+
+    let (ok, stderr) = run(&tmp, &["append", "index.md", "--property", "topics=Actions"]);
+    assert!(ok, "append failed: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+    assert!(after.contains("  - Actions\n"));
+    // Only the appended item is new; the `intro`, `featuredLinks` and
+    // `children` blocks must be untouched.
+    assert_eq!(diff_line_count(&before, &after), 1, "{after}");
+    assert!(after.contains("changelog:\n  label: actions\n  prefix: 'GitHub Actions: '\n"));
+}
+
+// ---------------------------------------------------------------------------
+// Preservation corpus: quote styles, block scalars, indentation, CRLF
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quote_styles_and_block_scalars_survive_a_set() {
+    let tmp = TempDir::new().unwrap();
+    let fm = "\
+double: \"a double quoted value\"
+single: 'a single quoted value'
+plain: an unquoted value
+literal: |
+  first literal line
+  second literal line
+folded: >-
+  folded line one
+  folded line two
+flow: [alpha, beta, gamma]
+flowMap: {a: 1, b: 2}
+empty: ''
+nullish: null
+number: 42
+boolish: true
+";
+    write_md(tmp.path(), "note.md", &format!("---\n{fm}---\n\nBody\n"));
+
+    let (ok, stderr) = run(&tmp, &["set", "note.md", "--property", "added=1"]);
+    assert!(ok, "set failed: {stderr}");
+    let after = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert_eq!(
+        after,
+        format!("---\n{fm}added: 1\n---\n\nBody\n"),
+        "every original line must be byte-identical"
+    );
+}
+
+#[test]
+fn compact_list_indentation_survives_a_set() {
+    let tmp = TempDir::new().unwrap();
+    let fm = "\
+title: Compact
+tags:
+- one
+- two
+children:
+- /a
+- /b
+";
+    write_md(tmp.path(), "note.md", &format!("---\n{fm}---\n\nBody\n"));
+
+    let (ok, stderr) = run(&tmp, &["set", "note.md", "--property", "status=draft"]);
+    assert!(ok, "set failed: {stderr}");
+    let after = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert_eq!(after, format!("---\n{fm}status: draft\n---\n\nBody\n"));
+}
+
+#[test]
+fn unusual_indentation_and_nesting_survive_a_set() {
+    let tmp = TempDir::new().unwrap();
+    let fm = "\
+versions:
+    fpt: '*'
+    ghes: '>=3.9'
+    nested:
+        deep:
+            deeper: yes-value
+title: Odd indentation
+";
+    write_md(tmp.path(), "note.md", &format!("---\n{fm}---\n\nBody\n"));
+
+    let (ok, stderr) = run(&tmp, &["set", "note.md", "--property", "status=draft"]);
+    assert!(ok, "set failed: {stderr}");
+    let after = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert_eq!(after, format!("---\n{fm}status: draft\n---\n\nBody\n"));
+}
+
+#[test]
+fn comments_are_preserved_and_travel_with_their_key() {
+    let tmp = TempDir::new().unwrap();
+    let fm = "\
+# document-level header comment
+title: Commented
+
+# explains the status field
+status: planned
+tags:
+  - a
+# trailing note
+";
+    write_md(tmp.path(), "note.md", &format!("---\n{fm}---\n\nBody\n"));
+
+    let (ok, stderr) = run(&tmp, &["set", "note.md", "--property", "status=completed"]);
+    assert!(ok, "set failed: {stderr}");
+    let after = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(after.contains("# document-level header comment\n"));
+    assert!(after.contains("# explains the status field\nstatus: completed\n"));
+    assert!(after.contains("# trailing note\n"));
+
+    // Removing the key removes its explanatory comment with it.
+    let (ok, stderr) = run(&tmp, &["remove", "note.md", "--property", "status"]);
+    assert!(ok, "remove failed: {stderr}");
+    let after = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(!after.contains("# explains the status field"));
+    assert!(after.contains("# document-level header comment\n"));
+    assert!(after.contains("# trailing note\n"));
+}
+
+#[test]
+fn crlf_files_stay_crlf_and_keep_untouched_lines() {
+    let tmp = TempDir::new().unwrap();
+    let content = "---\r\ntitle: 'CRLF note'\r\nstatus: planned\r\ntags:\r\n  - a\r\n---\r\n\r\nBody\r\n";
+    write_md(tmp.path(), "crlf.md", content);
+
+    let (ok, stderr) = run(&tmp, &["set", "crlf.md", "--property", "status=done"]);
+    assert!(ok, "set failed: {stderr}");
+    let after = fs::read_to_string(tmp.path().join("crlf.md")).unwrap();
+    assert!(after.contains("title: 'CRLF note'\r\n"), "{after:?}");
+    assert!(after.contains("status: done\r\n"), "{after:?}");
+    assert!(after.contains("  - a\r\n"), "{after:?}");
+    assert!(!after.contains("\n\n"), "no bare LF expected: {after:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Fallback behaviour: explicit, warned, never silent
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unmappable_frontmatter_warns_before_rewriting_the_block() {
+    let tmp = TempDir::new().unwrap();
+    // Explicit-key syntax (`? key` / `: value`) is deliberately not modelled by
+    // the splicer, so the write falls back to a full re-serialization.
+    let fm = "? complex key\n: a value\ntitle: Odd\n";
+    write_md(tmp.path(), "odd.md", &format!("---\n{fm}---\n\nBody\n"));
+
+    let (ok, stderr) = run(&tmp, &["set", "odd.md", "--property", "status=draft"]);
+    assert!(ok, "set failed: {stderr}");
+    assert!(
+        stderr.contains("rewriting the entire frontmatter block"),
+        "fallback must warn, never churn silently: {stderr}"
+    );
+    assert!(
+        stderr.contains("cannot be mapped to per-key line spans"),
+        "warning must say why: {stderr}"
+    );
+
+    let after = fs::read_to_string(tmp.path().join("odd.md")).unwrap();
+    assert!(after.contains("status: draft"));
+    assert!(after.contains("Body"));
+}
+
+#[test]
+fn ordinary_writes_never_warn_about_a_full_rewrite() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "plain.md",
+        "---\ntitle: Plain\nstatus: planned\n---\n\nBody\n",
+    );
+    let (ok, stderr) = run(&tmp, &["set", "plain.md", "--property", "status=done"]);
+    assert!(ok, "set failed: {stderr}");
+    assert!(
+        !stderr.contains("rewriting the entire frontmatter block"),
+        "unexpected fallback: {stderr}"
+    );
+
+    // A file with no frontmatter at all gains one without a warning.
+    write_md(tmp.path(), "bare.md", "# No frontmatter\n");
+    let (ok, stderr) = run(&tmp, &["set", "bare.md", "--property", "title=Added"]);
+    assert!(ok, "set failed: {stderr}");
+    assert!(
+        !stderr.contains("rewriting the entire frontmatter block"),
+        "creating frontmatter is not a rewrite: {stderr}"
+    );
+
+    // An empty frontmatter block has nothing to preserve — also no warning.
+    write_md(tmp.path(), "emptyfm.md", "---\n---\n\nBody\n");
+    let (ok, stderr) = run(&tmp, &["set", "emptyfm.md", "--property", "title=Added"]);
+    assert!(ok, "set failed: {stderr}");
+    assert!(
+        !stderr.contains("rewriting the entire frontmatter block"),
+        "empty block is not churn: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The other frontmatter writers share the same path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tags_rename_preserves_surrounding_formatting() {
+    let tmp = TempDir::new().unwrap();
+    gh_docs_file(&tmp);
+    // `topics` is the GitHub Docs list; give the file a `tags` list too so the
+    // tag rewriter has something to touch.
+    let (ok, stderr) = run(&tmp, &["append", "index.md", "--property", "tags=ci"]);
+    assert!(ok, "append failed: {stderr}");
+    let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+
+    let (ok, stderr) = run(&tmp, &["tags", "rename", "--from", "ci", "--to", "actions"]);
+    assert!(ok, "tags rename failed: {stderr}");
+    assert!(
+        !stderr.contains("rewriting the entire frontmatter block"),
+        "unexpected fallback: {stderr}"
+    );
+    let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+    assert!(after.contains("  - actions\n"), "{after}");
+    // Only the renamed tag line differs, in each direction.
+    assert_eq!(diff_line_count(&before, &after), 2, "{after}");
+}
+
+#[test]
+fn properties_rename_preserves_surrounding_formatting() {
+    let tmp = TempDir::new().unwrap();
+    gh_docs_file(&tmp);
+    let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+
+    let (ok, stderr) = run(
+        &tmp,
+        &[
+            "properties",
+            "rename",
+            "--from",
+            "layout",
+            "--to",
+            "pageLayout",
+        ],
+    );
+    assert!(ok, "properties rename failed: {stderr}");
+    assert!(
+        !stderr.contains("rewriting the entire frontmatter block"),
+        "unexpected fallback: {stderr}"
+    );
+    let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+    assert!(after.contains("pageLayout: product-landing\n"), "{after}");
+    assert_eq!(diff_line_count(&before, &after), 2, "{after}");
+}

--- a/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
+++ b/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
@@ -160,7 +160,10 @@ fn append_to_a_list_rewrites_only_that_list() {
     gh_docs_file(&tmp);
     let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
 
-    let (ok, stderr) = run(&tmp, &["append", "index.md", "--property", "topics=Actions"]);
+    let (ok, stderr) = run(
+        &tmp,
+        &["append", "index.md", "--property", "topics=Actions"],
+    );
     assert!(ok, "append failed: {stderr}");
 
     let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
@@ -281,7 +284,8 @@ tags:
 #[test]
 fn crlf_files_stay_crlf_and_keep_untouched_lines() {
     let tmp = TempDir::new().unwrap();
-    let content = "---\r\ntitle: 'CRLF note'\r\nstatus: planned\r\ntags:\r\n  - a\r\n---\r\n\r\nBody\r\n";
+    let content =
+        "---\r\ntitle: 'CRLF note'\r\nstatus: planned\r\ntags:\r\n  - a\r\n---\r\n\r\nBody\r\n";
     write_md(tmp.path(), "crlf.md", content);
 
     let (ok, stderr) = run(&tmp, &["set", "crlf.md", "--property", "status=done"]);

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -18,6 +18,7 @@ mod examples_contract;
 mod feature_matrix;
 mod files_from;
 mod find;
+mod frontmatter_preservation;
 mod help;
 mod hint_execution;
 mod hints;

--- a/crates/hyalo-core/src/frontmatter/mod.rs
+++ b/crates/hyalo-core/src/frontmatter/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 
 mod parse;
+mod splice;
 mod types;
 
 use anyhow::Context as _;

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
+use super::splice::{FallbackReason, SpliceOutcome, splice_frontmatter};
 use super::{FrontmatterError, MAX_FRONTMATTER_BYTES, MAX_FRONTMATTER_LINES};
 
 /// Convenience macro: return a [`FrontmatterError`] wrapped in `anyhow::Error`.
@@ -367,11 +368,19 @@ fn write_frontmatter_impl(
         );
     }
 
-    // --- Step 1: find the byte offset where the body starts and detect indent style ---
+    // --- Step 1: find the byte offset where the body starts, detect indent
+    // style, and capture the original YAML text for the minimal-diff splice ---
     let span = find_body_offset(&mut file)?;
 
-    // Detect list indent style from the existing frontmatter before overwriting
-    let compact_list_indent = if span.body_offset > 0 {
+    let mut compact_list_indent = false;
+    // The frontmatter's original YAML text (delimiters excluded), kept so that
+    // `splice_frontmatter` can re-emit untouched keys byte-for-byte (iter-214).
+    let mut original_yaml: Option<String> = None;
+    // Set when the original block exists but cannot be spliced; the user is
+    // warned before the whole block is re-serialized.
+    let mut splice_blocked: Option<FallbackReason> = None;
+
+    if span.body_offset > 0 {
         file.seek(SeekFrom::Start(0))
             .with_context(|| format!("failed to seek in {}", path.display()))?;
         // body_offset is the byte position within the file; on 32-bit targets a
@@ -381,6 +390,7 @@ fn write_frontmatter_impl(
         let mut fm_bytes = vec![0u8; span.body_offset as usize];
         file.read_exact(&mut fm_bytes)
             .with_context(|| format!("failed to read frontmatter of {}", path.display()))?;
+        let is_utf8 = std::str::from_utf8(&fm_bytes).is_ok();
         let fm_str = String::from_utf8_lossy(&fm_bytes);
         // Extract just the YAML content between the --- delimiters, using the
         // exact opening prefix `find_body_offset` recognized (BOM + line ending).
@@ -389,13 +399,23 @@ fn write_frontmatter_impl(
             if span.has_bom { BOM } else { "" },
             span.line_ending.as_str()
         );
-        let yaml_content = fm_str
+        let after_open = fm_str
             .strip_prefix(opening_prefix.as_str())
             .unwrap_or(&fm_str);
-        detect_list_indent_style(yaml_content)
-    } else {
-        false
-    };
+        let yaml_content = strip_closing_delimiter(after_open);
+        compact_list_indent = detect_list_indent_style(yaml_content.unwrap_or(after_open));
+
+        match yaml_content {
+            // Invalid UTF-8 in the frontmatter: `fm_str` is lossy, so splicing
+            // it would write replacement characters. Re-serialize instead.
+            _ if !is_utf8 => splice_blocked = Some(FallbackReason::NotUtf8),
+            // An empty block (`---\n---`) has nothing to preserve — take the
+            // full-serialization path silently.
+            Some(yaml) if yaml.trim().is_empty() => {}
+            Some(yaml) => original_yaml = Some(yaml.to_owned()),
+            None => splice_blocked = Some(FallbackReason::NotSpanMappable),
+        }
+    }
 
     // --- Step 2: read the body bytes from that offset ---
     file.seek(SeekFrom::Start(span.body_offset))
@@ -415,11 +435,34 @@ fn write_frontmatter_impl(
         out.extend_from_slice(BOM.as_bytes());
     }
     if !props.is_empty() {
-        let mut yaml = serde_saphyr::to_string_with_options(
-            props,
-            hyalo_serializer_options(compact_list_indent),
-        )
-        .context("failed to serialize YAML")?;
+        // Minimal-diff write (iter-214): re-emit every key whose value did not
+        // change byte-for-byte and serialize only what actually changed. Falls
+        // back to a full re-serialization — with a warning — when the original
+        // block cannot be mapped to per-key line spans.
+        let spliced = match original_yaml.as_deref() {
+            Some(orig) => match splice_frontmatter(orig, props, compact_list_indent) {
+                SpliceOutcome::Spliced(yaml) => Some(yaml),
+                SpliceOutcome::Fallback(reason) => {
+                    warn_full_frontmatter_rewrite(path, reason);
+                    None
+                }
+            },
+            None => {
+                if let Some(reason) = splice_blocked {
+                    warn_full_frontmatter_rewrite(path, reason);
+                }
+                None
+            }
+        };
+
+        let mut yaml = match spliced {
+            Some(yaml) => yaml,
+            None => serde_saphyr::to_string_with_options(
+                props,
+                hyalo_serializer_options(compact_list_indent),
+            )
+            .context("failed to serialize YAML")?,
+        };
         if !yaml.ends_with('\n') {
             yaml.push('\n');
         }
@@ -519,6 +562,33 @@ pub fn check_frontmatter_size_budget(
         });
     }
     Ok(())
+}
+
+/// Strip the trailing closing `---` line from a frontmatter block's text.
+///
+/// `s` is everything after the opening delimiter line up to (and including)
+/// the closing delimiter line, i.e. exactly what [`find_body_offset`] framed.
+/// Returns the YAML content between the delimiters, or `None` when the last
+/// line is not a closing delimiter (which means our framing assumption is
+/// wrong and the block must not be spliced).
+fn strip_closing_delimiter(s: &str) -> Option<&str> {
+    let without_eol = s
+        .strip_suffix('\n')
+        .map_or(s, |t| t.strip_suffix('\r').unwrap_or(t));
+    let last_start = without_eol.rfind('\n').map_or(0, |i| i + 1);
+    is_closing_delimiter(&without_eol[last_start..]).then(|| &s[..last_start])
+}
+
+/// Warn that a frontmatter write could not be limited to the changed keys.
+///
+/// iter-214 DEC-060: a full-block rewrite is allowed as a fallback, but never
+/// silently — the user must be able to tell reformatting churn from a bug.
+fn warn_full_frontmatter_rewrite(path: &Path, reason: FallbackReason) {
+    crate::warn::warn(format!(
+        "{}: rewriting the entire frontmatter block because {}; formatting of untouched keys may change",
+        path.display(),
+        reason.as_str()
+    ));
 }
 
 /// Byte offset and framing of the frontmatter block found by [`find_body_offset`].

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -439,14 +439,15 @@ fn write_frontmatter_impl(
         // change byte-for-byte and serialize only what actually changed. Falls
         // back to a full re-serialization — with a warning — when the original
         // block cannot be mapped to per-key line spans.
-        let spliced = match original_yaml.as_deref() {
-            Some(orig) => match splice_frontmatter(orig, props, compact_list_indent) {
-                SpliceOutcome::Spliced(yaml) => Some(yaml),
-                SpliceOutcome::Fallback(reason) => {
-                    warn_full_frontmatter_rewrite(path, reason);
-                    None
-                }
-            },
+        let spliced = match original_yaml
+            .as_deref()
+            .map(|orig| splice_frontmatter(orig, props, compact_list_indent))
+        {
+            Some(SpliceOutcome::Spliced(yaml)) => Some(yaml),
+            Some(SpliceOutcome::Fallback(reason)) => {
+                warn_full_frontmatter_rewrite(path, reason);
+                None
+            }
             None => {
                 if let Some(reason) = splice_blocked {
                     warn_full_frontmatter_rewrite(path, reason);

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -581,7 +581,7 @@ fn strip_closing_delimiter(s: &str) -> Option<&str> {
 
 /// Warn that a frontmatter write could not be limited to the changed keys.
 ///
-/// iter-214 DEC-060: a full-block rewrite is allowed as a fallback, but never
+/// iter-214 DEC-081: a full-block rewrite is allowed as a fallback, but never
 /// silently — the user must be able to tell reformatting churn from a bug.
 fn warn_full_frontmatter_rewrite(path: &Path, reason: FallbackReason) {
     crate::warn::warn(format!(

--- a/crates/hyalo-core/src/frontmatter/splice.rs
+++ b/crates/hyalo-core/src/frontmatter/splice.rs
@@ -29,8 +29,9 @@
 
 use indexmap::IndexMap;
 use serde_json::Value;
-use serde_saphyr::SerializerOptions;
+use serde_saphyr::{Options, SerializerOptions};
 
+use super::MAX_FRONTMATTER_BYTES;
 use super::parse::{hyalo_options, is_closing_delimiter};
 
 /// Why a minimal-diff write could not be performed.
@@ -200,7 +201,7 @@ pub(super) fn splice_frontmatter(
 
     // Final gate: the spliced text must parse back to exactly what the caller
     // asked to write. This is what makes every heuristic above safe.
-    match parse_map(&out) {
+    match parse_map_with(&out, verify_options()) {
         Ok(round_tripped) if map_eq(&round_tripped, props) => SpliceOutcome::Spliced(out),
         _ => SpliceOutcome::Fallback(FallbackReason::VerificationFailed),
     }
@@ -208,12 +209,39 @@ pub(super) fn splice_frontmatter(
 
 /// Parse YAML text into an ordered property map using hyalo's shared parser
 /// options (strict booleans, no anchors/aliases, duplicate keys rejected).
+///
+/// Used for the *baseline* parse of the on-disk block, so that the splicer
+/// sees exactly what the read path saw.
 fn parse_map(yaml: &str) -> Result<IndexMap<String, Value>, ()> {
+    parse_map_with(yaml, hyalo_options())
+}
+
+/// Parse YAML text for the post-splice verification pass.
+///
+/// Same hardening as [`hyalo_options`] where it matters (no aliases, no
+/// anchors, one document, duplicate keys rejected) but with node and scalar
+/// budgets scaled to the frontmatter size limit rather than to the much
+/// tighter read-path defaults. A caller is allowed to *write* a value larger
+/// than the read-path scalar budget — the size-budget pre-flight in
+/// `write_frontmatter_impl` is what rejects those — and verification must not
+/// mistake that for a splicing failure and warn about churn that did not
+/// happen.
+fn verify_options() -> Options {
+    let base = hyalo_options();
+    let budget = base.budget.map(|b| serde_saphyr::Budget {
+        max_events: 200_000,
+        max_nodes: 100_000,
+        max_total_scalar_bytes: MAX_FRONTMATTER_BYTES * 2,
+        ..b
+    });
+    Options { budget, ..base }
+}
+
+fn parse_map_with(yaml: &str, options: Options) -> Result<IndexMap<String, Value>, ()> {
     if yaml.trim().is_empty() {
         return Ok(IndexMap::new());
     }
-    serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(yaml, hyalo_options())
-        .map_err(|_| ())
+    serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(yaml, options).map_err(|_| ())
 }
 
 /// Order-sensitive map equality (`IndexMap`'s `PartialEq` ignores order).
@@ -584,9 +612,17 @@ mod tests {
 
     #[test]
     fn top_level_sequence_falls_back() {
+        // A top-level sequence is not a property map at all, so it is rejected
+        // by the baseline parse before segmentation even runs.
         let yaml = "- a\n- b\n";
         let p = props(&[("a", json!(1))]);
-        assert_eq!(fallback(yaml, &p), FallbackReason::NotSpanMappable);
+        assert_eq!(fallback(yaml, &p), FallbackReason::Unparseable);
+    }
+
+    #[test]
+    fn compact_sequence_before_any_key_is_not_span_mappable() {
+        // Segmentation-level guard for the same shape, reached directly.
+        assert!(segment("- a\n- b\n").is_none());
     }
 
     #[test]

--- a/crates/hyalo-core/src/frontmatter/splice.rs
+++ b/crates/hyalo-core/src/frontmatter/splice.rs
@@ -37,7 +37,7 @@ use super::parse::{hyalo_options, is_closing_delimiter};
 /// Why a minimal-diff write could not be performed.
 ///
 /// Surfaced to the user as a warning so that unexpected full-block churn is
-/// always explained rather than silent (iter-214 DEC-060).
+/// always explained rather than silent (iter-214 DEC-081).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FallbackReason {
     /// The original frontmatter bytes are not valid UTF-8.

--- a/crates/hyalo-core/src/frontmatter/splice.rs
+++ b/crates/hyalo-core/src/frontmatter/splice.rs
@@ -1,0 +1,673 @@
+//! Minimal-diff frontmatter writes (iter-214).
+//!
+//! Every frontmatter mutation (`set`, `remove`, `append`, `properties rename`,
+//! `tags`, `types apply`, `lint --fix`) funnels through a single
+//! parse → mutate → write cycle.  Until iter-214 that cycle **re-serialized
+//! the whole block**: semantically lossless, but textually destructive.
+//! Adding one property to a real GitHub Docs `index.md` rewrote 116 of its
+//! 198 frontmatter lines (long list items refolded into `>-` block scalars,
+//! `'` quote style flipped to `"`).  A one-key change producing a 116-line
+//! diff is unreviewable and makes hyalo unusable in any repo where
+//! frontmatter is under code review.
+//!
+//! This module implements the fix: [`splice_frontmatter`] segments the
+//! *original raw YAML text* into top-level key spans, re-emits every span
+//! whose value did not change **byte for byte**, and serializes only the keys
+//! that were actually added or changed.
+//!
+//! # Safety model
+//!
+//! Splicing is a text transformation driven by heuristics (where does a
+//! top-level key's span start and end?).  Rather than trust those heuristics,
+//! every candidate result is **verified before it is returned**: the spliced
+//! YAML is re-parsed with the standard `hyalo_options` parser and compared
+//! against the exact property map the caller asked to write — same keys, same
+//! order, same values.  Anything that does not verify returns
+//! [`SpliceOutcome::Fallback`], and the caller re-serializes the whole block
+//! and warns.  There is no silent churn, and no path where splicing can write
+//! something the full serializer would not have written.
+
+use indexmap::IndexMap;
+use serde_json::Value;
+use serde_saphyr::SerializerOptions;
+
+use super::parse::{hyalo_options, is_closing_delimiter};
+
+/// Why a minimal-diff write could not be performed.
+///
+/// Surfaced to the user as a warning so that unexpected full-block churn is
+/// always explained rather than silent (iter-214 DEC-060).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FallbackReason {
+    /// The original frontmatter bytes are not valid UTF-8.
+    NotUtf8,
+    /// The original frontmatter mixes line endings (a lone `\r`).
+    MixedLineEndings,
+    /// The original frontmatter is not parseable as a top-level mapping.
+    Unparseable,
+    /// The raw text could not be split into one span per top-level key
+    /// (YAML constructs this splicer deliberately does not model: explicit
+    /// `? key` syntax, top-level flow mappings or sequences, directives,
+    /// multiple documents).
+    NotSpanMappable,
+    /// Spans were produced but re-parsing the spliced result did not
+    /// reproduce the requested properties exactly.
+    VerificationFailed,
+    /// Serializing an individual changed key on its own failed.
+    SerializeFailed,
+}
+
+impl FallbackReason {
+    /// Human-readable explanation, used in the `warning:` line.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            FallbackReason::NotUtf8 => "existing frontmatter is not valid UTF-8",
+            FallbackReason::MixedLineEndings => "existing frontmatter mixes line endings",
+            FallbackReason::Unparseable => "existing frontmatter is not a plain YAML mapping",
+            FallbackReason::NotSpanMappable => {
+                "existing frontmatter uses YAML constructs that cannot be mapped to per-key line spans"
+            }
+            FallbackReason::VerificationFailed => {
+                "the minimal-diff result did not round-trip to the requested properties"
+            }
+            FallbackReason::SerializeFailed => "a changed key could not be serialized on its own",
+        }
+    }
+}
+
+/// Result of attempting a minimal-diff frontmatter rewrite.
+#[derive(Debug)]
+pub(super) enum SpliceOutcome {
+    /// Spliced YAML content (between the `---` delimiters, LF line endings,
+    /// trailing newline included). Untouched keys are byte-identical to the
+    /// original.
+    Spliced(String),
+    /// Splicing was not possible; the caller must re-serialize the whole
+    /// block and warn the user with this reason.
+    Fallback(FallbackReason),
+}
+
+/// One top-level key of the original frontmatter, with the exact source text
+/// it occupies.
+#[derive(Debug)]
+struct Segment<'a> {
+    key: String,
+    value: Value,
+    /// Blank/comment lines immediately preceding the key line. Kept with the
+    /// key so that `# explains the next key` travels with — or dies with — it.
+    pre_trivia: &'a str,
+    /// The key line plus every continuation line belonging to it, verbatim.
+    body: &'a str,
+}
+
+/// How a column-0 line relates to the flat top-level key structure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineRole {
+    /// Blank line or column-0 comment.
+    Trivia,
+    /// Starts a new top-level mapping key.
+    Key,
+    /// Belongs to the preceding key (compact-style sequence item `- x`).
+    Continuation,
+    /// A construct this splicer does not model — forces a fallback.
+    Unsupported,
+}
+
+/// Attempt a minimal-diff rewrite of `original_yaml` so that it expresses
+/// exactly `props`.
+///
+/// `original_yaml` is the raw text between the `---` delimiters (delimiters
+/// excluded), exactly as it appears on disk — with the file's original line
+/// endings. `props` is the full desired property map, in the order it should
+/// be written. `compact_list_indent` mirrors the existing serializer option so
+/// that newly written keys match the file's list-indentation style.
+///
+/// On success the returned YAML uses `\n` line endings; the caller converts to
+/// CRLF if the file uses it, exactly as it does for full serialization.
+pub(super) fn splice_frontmatter(
+    original_yaml: &str,
+    props: &IndexMap<String, Value>,
+    compact_list_indent: bool,
+) -> SpliceOutcome {
+    // Normalize line endings to LF for the whole operation. A frontmatter
+    // block is either LF or CRLF throughout (`find_body_offset` records
+    // which); a stray lone `\r` means content the caller's CRLF re-expansion
+    // would mangle, so refuse.
+    let normalized;
+    let yaml = if original_yaml.contains('\r') {
+        normalized = original_yaml.replace("\r\n", "\n");
+        if normalized.contains('\r') {
+            return SpliceOutcome::Fallback(FallbackReason::MixedLineEndings);
+        }
+        normalized.as_str()
+    } else {
+        original_yaml
+    };
+
+    // The original must itself be a well-formed mapping; otherwise we have no
+    // trustworthy baseline to diff against.
+    let Ok(original_map) = parse_map(yaml) else {
+        return SpliceOutcome::Fallback(FallbackReason::Unparseable);
+    };
+
+    let Some((header, segments, footer)) = segment(yaml) else {
+        return SpliceOutcome::Fallback(FallbackReason::NotSpanMappable);
+    };
+
+    // Cross-check the segmentation against the authoritative parse: same keys,
+    // same order, same values. If they disagree, our line spans do not model
+    // this document and we must not touch it.
+    if segments.len() != original_map.len()
+        || !segments
+            .iter()
+            .zip(original_map.iter())
+            .all(|(seg, (key, value))| seg.key == *key && seg.value == *value)
+    {
+        return SpliceOutcome::Fallback(FallbackReason::NotSpanMappable);
+    }
+
+    let mut out = String::with_capacity(yaml.len() + 64);
+    out.push_str(header);
+    for (key, new_value) in props {
+        match segments.iter().find(|seg| seg.key == *key) {
+            // Unchanged: emit the original bytes, untouched.
+            Some(seg) if seg.value == *new_value => {
+                out.push_str(seg.pre_trivia);
+                out.push_str(seg.body);
+            }
+            // Changed: keep the key's comment block, re-serialize its value.
+            Some(seg) => {
+                out.push_str(seg.pre_trivia);
+                let Some(rendered) = serialize_one(key, new_value, compact_list_indent) else {
+                    return SpliceOutcome::Fallback(FallbackReason::SerializeFailed);
+                };
+                out.push_str(&rendered);
+            }
+            // New key: emit it at the position `props` asks for.
+            None => {
+                let Some(rendered) = serialize_one(key, new_value, compact_list_indent) else {
+                    return SpliceOutcome::Fallback(FallbackReason::SerializeFailed);
+                };
+                out.push_str(&rendered);
+            }
+        }
+    }
+    out.push_str(footer);
+
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+
+    // Final gate: the spliced text must parse back to exactly what the caller
+    // asked to write. This is what makes every heuristic above safe.
+    match parse_map(&out) {
+        Ok(round_tripped) if map_eq(&round_tripped, props) => SpliceOutcome::Spliced(out),
+        _ => SpliceOutcome::Fallback(FallbackReason::VerificationFailed),
+    }
+}
+
+/// Parse YAML text into an ordered property map using hyalo's shared parser
+/// options (strict booleans, no anchors/aliases, duplicate keys rejected).
+fn parse_map(yaml: &str) -> Result<IndexMap<String, Value>, ()> {
+    if yaml.trim().is_empty() {
+        return Ok(IndexMap::new());
+    }
+    serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(yaml, hyalo_options())
+        .map_err(|_| ())
+}
+
+/// Order-sensitive map equality (`IndexMap`'s `PartialEq` ignores order).
+fn map_eq(a: &IndexMap<String, Value>, b: &IndexMap<String, Value>) -> bool {
+    a.len() == b.len()
+        && a.iter()
+            .zip(b.iter())
+            .all(|((ak, av), (bk, bv))| ak == bk && av == bv)
+}
+
+/// Serialize a single `key: value` pair as standalone YAML.
+fn serialize_one(key: &str, value: &Value, compact_list_indent: bool) -> Option<String> {
+    let mut single: IndexMap<&str, &Value> = IndexMap::with_capacity(1);
+    single.insert(key, value);
+    let opts = SerializerOptions {
+        compact_list_indent,
+        ..SerializerOptions::default()
+    };
+    let mut yaml = serde_saphyr::to_string_with_options(&single, opts).ok()?;
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    Some(yaml)
+}
+
+/// Is this column-0 line blank or a comment (i.e. trivia between keys)?
+fn is_trivia(line: &str) -> bool {
+    line.trim().is_empty() || line.starts_with('#')
+}
+
+/// Classify a column-0 line (line ending already stripped).
+///
+/// Deliberately conservative: only `key:`, `key: value`, `"key": value` and
+/// `'key': value` count as keys. Compact-style sequence items (`- x`, which
+/// hyalo already supports via `compact_list_indent`) continue the preceding
+/// key. Everything else at column 0 — explicit `? key` syntax, top-level flow
+/// collections, anchors, tags, directives, document markers — is
+/// [`LineRole::Unsupported`], which the caller turns into a fallback rather
+/// than a guess.
+fn classify_line(line: &str) -> LineRole {
+    debug_assert!(!line.starts_with([' ', '\t']));
+    if is_trivia(line) {
+        return LineRole::Trivia;
+    }
+    if line == "-" || line.starts_with("- ") {
+        return LineRole::Continuation;
+    }
+    if line.starts_with("---") || line.starts_with("...") || line.starts_with('%') {
+        return LineRole::Unsupported;
+    }
+    let first = line.as_bytes()[0];
+    if matches!(first, b'-' | b'?' | b'{' | b'[' | b'&' | b'*' | b'!' | b'|' | b'>' | b':') {
+        return LineRole::Unsupported;
+    }
+    let rest = match first {
+        b'"' => match scan_quoted(line, '"', true) {
+            Some(rest) => rest,
+            None => return LineRole::Unsupported,
+        },
+        b'\'' => match scan_quoted(line, '\'', false) {
+            Some(rest) => rest,
+            None => return LineRole::Unsupported,
+        },
+        _ => {
+            // Plain key: everything up to the first `:` that is followed by a
+            // space or end-of-line. A leading `#` would have made the line
+            // trivia, which is handled above.
+            let bytes = line.as_bytes();
+            let mut found = None;
+            for (i, b) in bytes.iter().enumerate() {
+                if *b == b':' && (i + 1 == bytes.len() || bytes[i + 1] == b' ') {
+                    found = Some(i);
+                    break;
+                }
+            }
+            match found {
+                Some(0) | None => return LineRole::Unsupported,
+                Some(i) => &line[i..],
+            }
+        }
+    };
+    // `rest` must start at the key separator.
+    if rest.starts_with(':') && (rest.len() == 1 || rest.as_bytes()[1] == b' ') {
+        LineRole::Key
+    } else {
+        LineRole::Unsupported
+    }
+}
+
+/// Skip a quoted scalar starting at index 0 of `line`, returning the remainder
+/// after the closing quote. `escapes` enables `\`-escaping (double quotes);
+/// single quotes use `''` doubling instead.
+fn scan_quoted(line: &str, quote: char, escapes: bool) -> Option<&str> {
+    let mut chars = line.char_indices();
+    chars.next()?; // opening quote
+    while let Some((i, c)) = chars.next() {
+        if escapes && c == '\\' {
+            chars.next();
+            continue;
+        }
+        if c == quote {
+            if !escapes && line[i + 1..].starts_with(quote) {
+                chars.next();
+                continue;
+            }
+            return Some(&line[i + c.len_utf8()..]);
+        }
+    }
+    None
+}
+
+/// Split raw frontmatter YAML into `(header trivia, per-key segments, footer trivia)`.
+///
+/// Returns `None` when the text cannot be modeled as a flat sequence of
+/// top-level keys.
+fn segment(yaml: &str) -> Option<(&str, Vec<Segment<'_>>, &str)> {
+    // Byte offsets at which each top-level key line begins.
+    let mut key_starts: Vec<usize> = Vec::new();
+    let mut offset = 0usize;
+    for line in yaml.split_inclusive('\n') {
+        let stripped = line.trim_end_matches(['\n', '\r']);
+        if !stripped.starts_with([' ', '\t']) {
+            // A closing delimiter must never appear inside the content we were
+            // handed; if it does, our framing is wrong.
+            if is_closing_delimiter(stripped) {
+                return None;
+            }
+            match classify_line(stripped) {
+                LineRole::Key => key_starts.push(offset),
+                LineRole::Trivia => {}
+                // A compact sequence item before any key means the document is
+                // a top-level sequence, not a mapping.
+                LineRole::Continuation if key_starts.is_empty() => return None,
+                LineRole::Continuation => {}
+                LineRole::Unsupported => return None,
+            }
+        }
+        offset += line.len();
+    }
+
+    // No keys at all (empty or comment-only block): nothing to splice against.
+    let first_key = *key_starts.first()?;
+    let header = &yaml[..first_key];
+
+    // Where each key's own text ends: the region up to the next key, minus any
+    // trailing run of column-0 trivia (which belongs to whatever follows).
+    let body_ends: Vec<usize> = key_starts
+        .iter()
+        .enumerate()
+        .map(|(i, &start)| {
+            let region_end = key_starts.get(i + 1).copied().unwrap_or(yaml.len());
+            trailing_trivia_start(yaml, start, region_end)
+        })
+        .collect();
+
+    let mut segments: Vec<Segment<'_>> = Vec::with_capacity(key_starts.len());
+    for (i, &start) in key_starts.iter().enumerate() {
+        let pre_start = if i == 0 { start } else { body_ends[i - 1] };
+        let pre_trivia = &yaml[pre_start..start];
+        let body = &yaml[start..body_ends[i]];
+        let parsed = parse_map(body).ok()?;
+        if parsed.len() != 1 {
+            return None;
+        }
+        let (key, value) = parsed.into_iter().next()?;
+        segments.push(Segment {
+            key,
+            value,
+            pre_trivia,
+            body,
+        });
+    }
+
+    // Whatever follows the last key's body is document footer trivia. It is
+    // only legitimate if it really is pure trivia — otherwise our span model
+    // dropped real content.
+    let footer = &yaml[*body_ends.last()?..];
+    if !footer
+        .split_inclusive('\n')
+        .all(|l| is_trivia(l.trim_end_matches(['\n', '\r'])))
+    {
+        return None;
+    }
+
+    Some((header, segments, footer))
+}
+
+/// Within `yaml[start..end]`, find the offset where the trailing run of
+/// column-0 trivia lines begins. Used to detach a comment block from the key
+/// above it so it can travel with the key below.
+///
+/// `start` must point at a key line (never trivia), so the returned offset is
+/// always `> start`.
+fn trailing_trivia_start(yaml: &str, start: usize, end: usize) -> usize {
+    let mut lines: Vec<(usize, usize)> = Vec::new();
+    let mut offset = start;
+    for line in yaml[start..end].split_inclusive('\n') {
+        lines.push((offset, offset + line.len()));
+        offset += line.len();
+    }
+    let mut cut = end;
+    for &(ls, le) in lines.iter().rev() {
+        let stripped = yaml[ls..le].trim_end_matches(['\n', '\r']);
+        if stripped.starts_with([' ', '\t']) || !is_trivia(stripped) {
+            break;
+        }
+        cut = ls;
+    }
+    cut
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn props(pairs: &[(&str, Value)]) -> IndexMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    fn spliced(yaml: &str, p: &IndexMap<String, Value>) -> String {
+        match splice_frontmatter(yaml, p, false) {
+            SpliceOutcome::Spliced(s) => s,
+            SpliceOutcome::Fallback(reason) => {
+                panic!("expected splice, got fallback: {}", reason.as_str())
+            }
+        }
+    }
+
+    fn fallback(yaml: &str, p: &IndexMap<String, Value>) -> FallbackReason {
+        match splice_frontmatter(yaml, p, false) {
+            SpliceOutcome::Spliced(s) => panic!("expected fallback, got splice:\n{s}"),
+            SpliceOutcome::Fallback(reason) => reason,
+        }
+    }
+
+    /// Count lines that differ between `before` and `after` (in either
+    /// direction) — a coarse stand-in for a diff line count.
+    fn changed_lines(before: &str, after: &str) -> usize {
+        let b: Vec<&str> = before.lines().collect();
+        let a: Vec<&str> = after.lines().collect();
+        a.iter().filter(|l| !b.contains(l)).count()
+            + b.iter().filter(|l| !a.contains(l)).count()
+    }
+
+    #[test]
+    fn adding_a_key_leaves_every_other_line_byte_identical() {
+        let yaml = "title: 'Single quoted title'\ntags:\n  - a\n  - b\nintro: >-\n  A long folded\n  intro paragraph.\n";
+        let p = props(&[
+            ("title", json!("Single quoted title")),
+            ("tags", json!(["a", "b"])),
+            ("intro", json!("A long folded intro paragraph.")),
+            ("status", json!("draft")),
+        ]);
+        let out = spliced(yaml, &p);
+        assert_eq!(out, format!("{yaml}status: draft\n"));
+        assert_eq!(changed_lines(yaml, &out), 1);
+    }
+
+    #[test]
+    fn changing_one_key_touches_only_that_key() {
+        let yaml = "title: 'Keep me'\nstatus: planned\ntags:\n  - x\n";
+        let p = props(&[
+            ("title", json!("Keep me")),
+            ("status", json!("completed")),
+            ("tags", json!(["x"])),
+        ]);
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "title: 'Keep me'\nstatus: completed\ntags:\n  - x\n");
+    }
+
+    #[test]
+    fn removing_a_key_drops_its_lines_and_its_comment() {
+        let yaml = "title: 'Keep me'\n# explains status\nstatus: planned\ntags:\n  - x\n";
+        let p = props(&[("title", json!("Keep me")), ("tags", json!(["x"]))]);
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "title: 'Keep me'\ntags:\n  - x\n");
+    }
+
+    #[test]
+    fn header_and_footer_comments_survive() {
+        let yaml = "# document header\ntitle: 'T'\nstatus: planned\n# trailing note\n";
+        let p = props(&[("title", json!("T")), ("status", json!("in-progress"))]);
+        let out = spliced(yaml, &p);
+        assert_eq!(
+            out,
+            "# document header\ntitle: 'T'\nstatus: in-progress\n# trailing note\n"
+        );
+    }
+
+    #[test]
+    fn block_scalars_and_quote_styles_are_preserved() {
+        let yaml = concat!(
+            "title: \"Double quoted\"\n",
+            "shortTitle: 'Single quoted'\n",
+            "plain: unquoted value\n",
+            "literal: |\n",
+            "  line one\n",
+            "  line two\n",
+            "folded: >-\n",
+            "  folded one\n",
+            "  folded two\n",
+            "flowList: [a, b, c]\n",
+            "blockList:\n",
+            "  - one\n",
+            "  - two\n",
+        );
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("added".into(), json!(1));
+        let out = spliced(yaml, &p);
+        assert_eq!(out, format!("{yaml}added: 1\n"));
+    }
+
+    #[test]
+    fn compact_list_indentation_is_preserved() {
+        let yaml = "tags:\n- one\n- two\nstatus: planned\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("status".into(), json!("done"));
+        let out = match splice_frontmatter(yaml, &p, true) {
+            SpliceOutcome::Spliced(s) => s,
+            SpliceOutcome::Fallback(r) => panic!("unexpected fallback: {}", r.as_str()),
+        };
+        assert_eq!(out, "tags:\n- one\n- two\nstatus: done\n");
+    }
+
+    #[test]
+    fn nested_objects_and_unusual_indentation_are_preserved() {
+        let yaml = concat!(
+            "versions:\n",
+            "    fpt: '*'\n",
+            "    ghec: '*'\n",
+            "children:\n",
+            "- /first\n",
+            "- /second\n",
+        );
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("topic".into(), json!(["API"]));
+        let out = spliced(yaml, &p);
+        assert!(out.starts_with(yaml), "original text must survive:\n{out}");
+    }
+
+    #[test]
+    fn crlf_input_is_normalized_and_untouched_keys_keep_their_text() {
+        let yaml = "title: 'T'\r\nstatus: planned\r\n";
+        let p = props(&[("title", json!("T")), ("status", json!("done"))]);
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "title: 'T'\nstatus: done\n");
+    }
+
+    #[test]
+    fn reordering_moves_original_text_rather_than_rewriting_it() {
+        let yaml = "b: 'second'\na: 'first'\n";
+        let p = props(&[("a", json!("first")), ("b", json!("second"))]);
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "a: 'first'\nb: 'second'\n");
+    }
+
+    #[test]
+    fn quoted_keys_are_recognized() {
+        let yaml = "\"quoted key\": 1\n'other key': 2\n";
+        let p = props(&[("quoted key", json!(1)), ("other key", json!(3))]);
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "\"quoted key\": 1\nother key: 3\n");
+    }
+
+    #[test]
+    fn top_level_sequence_falls_back() {
+        let yaml = "- a\n- b\n";
+        let p = props(&[("a", json!(1))]);
+        assert_eq!(fallback(yaml, &p), FallbackReason::NotSpanMappable);
+    }
+
+    #[test]
+    fn explicit_key_syntax_falls_back() {
+        let yaml = "? complex\n: value\n";
+        let p = props(&[("complex", json!("value"))]);
+        assert_eq!(fallback(yaml, &p), FallbackReason::NotSpanMappable);
+    }
+
+    #[test]
+    fn unparseable_original_falls_back() {
+        let yaml = "title: [unclosed\n";
+        let p = props(&[("title", json!("x"))]);
+        assert_eq!(fallback(yaml, &p), FallbackReason::Unparseable);
+    }
+
+    #[test]
+    fn comment_only_block_falls_back() {
+        let yaml = "# nothing but a comment\n";
+        let p = props(&[("title", json!("x"))]);
+        assert_eq!(fallback(yaml, &p), FallbackReason::NotSpanMappable);
+    }
+
+    #[test]
+    fn lone_carriage_return_falls_back() {
+        let yaml = "title: 'a\rb'\n";
+        let p = props(&[("title", json!("x"))]);
+        assert_eq!(fallback(yaml, &p), FallbackReason::MixedLineEndings);
+    }
+
+    #[test]
+    fn everything_removed_yields_empty_output() {
+        let yaml = "title: 'T'\n";
+        let p: IndexMap<String, Value> = IndexMap::new();
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn github_docs_shaped_frontmatter_changes_only_the_added_line() {
+        // Shape lifted from a real GitHub Docs `index.md`: long values, `>-`
+        // folded intros, deep child lists, nested version maps.
+        let yaml = concat!(
+            "title: GitHub Actions documentation\n",
+            "shortTitle: GitHub Actions\n",
+            "intro: >-\n",
+            "  Automate, customize, and execute your software development workflows\n",
+            "  right in your repository with GitHub Actions.\n",
+            "introLinks:\n",
+            "  quickstart: /actions/quickstart\n",
+            "  reference: /actions/reference\n",
+            "featuredLinks:\n",
+            "  startHere:\n",
+            "    - /actions/learn-github-actions/understanding-github-actions\n",
+            "    - /actions/learn-github-actions/finding-and-customizing-actions\n",
+            "  guideCards:\n",
+            "    - /actions/deployment/deploying-to-amazon-elastic-container-service\n",
+            "changelog:\n",
+            "  label: actions\n",
+            "  prefix: 'GitHub Actions: '\n",
+            "redirect_from:\n",
+            "  - /articles/automating-your-workflow-with-github-actions\n",
+            "  - /articles/customizing-your-project-with-github-actions\n",
+            "versions:\n",
+            "  fpt: '*'\n",
+            "  ghes: '*'\n",
+            "  ghec: '*'\n",
+            "children:\n",
+            "  - /concepts\n",
+            "  - /tutorials\n",
+            "  - /how-tos\n",
+            "  - /reference\n",
+        );
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("status".into(), json!("reviewed"));
+        let out = spliced(yaml, &p);
+        assert_eq!(out, format!("{yaml}status: reviewed\n"));
+        assert_eq!(
+            changed_lines(yaml, &out),
+            1,
+            "adding one property must change exactly one line"
+        );
+    }
+}

--- a/crates/hyalo-core/src/frontmatter/splice.rs
+++ b/crates/hyalo-core/src/frontmatter/splice.rs
@@ -293,7 +293,10 @@ fn classify_line(line: &str) -> LineRole {
         return LineRole::Unsupported;
     }
     let first = line.as_bytes()[0];
-    if matches!(first, b'-' | b'?' | b'{' | b'[' | b'&' | b'*' | b'!' | b'|' | b'>' | b':') {
+    if matches!(
+        first,
+        b'-' | b'?' | b'{' | b'[' | b'&' | b'*' | b'!' | b'|' | b'>' | b':'
+    ) {
         return LineRole::Unsupported;
     }
     let rest = match first {
@@ -371,11 +374,10 @@ fn segment(yaml: &str) -> Option<(&str, Vec<Segment<'_>>, &str)> {
             }
             match classify_line(stripped) {
                 LineRole::Key => key_starts.push(offset),
-                LineRole::Trivia => {}
                 // A compact sequence item before any key means the document is
                 // a top-level sequence, not a mapping.
                 LineRole::Continuation if key_starts.is_empty() => return None,
-                LineRole::Continuation => {}
+                LineRole::Trivia | LineRole::Continuation => {}
                 LineRole::Unsupported => return None,
             }
         }
@@ -486,8 +488,7 @@ mod tests {
     fn changed_lines(before: &str, after: &str) -> usize {
         let b: Vec<&str> = before.lines().collect();
         let a: Vec<&str> = after.lines().collect();
-        a.iter().filter(|l| !b.contains(l)).count()
-            + b.iter().filter(|l| !a.contains(l)).count()
+        a.iter().filter(|l| !b.contains(l)).count() + b.iter().filter(|l| !a.contains(l)).count()
     }
 
     #[test]

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -50,6 +50,11 @@ Fields (`path`, `hint`, `cause`) are omitted when not applicable. The `cause` fi
 
 **Why:** serde_yaml_ng cannot preserve formatting (comments, quoting style, blank lines). Obsidian itself rewrites frontmatter on save. The files are machine-managed. Keeps the implementation simple. Can revisit if hand-edited YAML preservation becomes important.
 
+**Superseded by [[decision-log#DEC-080]] (iter-214):** "hand-edited YAML preservation"
+did become important — a one-key change rewrote 116 of 198 lines on a real
+GitHub Docs file. Formatting is now preserved by splicing per-key line spans
+in the write path; the parser choice in this decision is unaffected.
+
 ## DEC-007: serde_yaml_ng over serde_yaml (2026-03-20)
 
 **Decision:** Use `serde_yaml_ng` 0.10 instead of the deprecated `serde_yaml` 0.9.
@@ -1608,3 +1613,72 @@ from inside the vault now write to the ancestor `.hyalo.toml` instead of
 creating a new one in the working directory. That is the desired outcome —
 nested configs are shadowed and already warned about — but it does mean a run
 that previously created a config file now edits one.
+
+## DEC-080: frontmatter writes splice per-key line spans instead of re-serializing (2026-08-23)
+
+**Decision:** every frontmatter mutation re-emits the **original bytes** of every
+top-level key whose value did not change, and serializes only the keys that were
+added, changed, or reordered. The raw YAML block is segmented into one line span
+per top-level key; unchanged spans are copied verbatim, changed spans are
+replaced with freshly serialized YAML for that key alone, removed spans (and the
+comment block directly above them) are dropped.
+
+**Why:** the writer parsed the whole block into `serde_yaml`/`serde_saphyr`
+values and re-serialized everything, so a one-key change rewrote every line the
+serializer chose to format differently. On a real GitHub Docs `index.md` that
+was **116 of 198 frontmatter lines** for a single added property — long list
+items refolded into `>-` block scalars, `'` quote style flipped to `"`. The
+round trip was semantically lossless, so nothing was *lost*; but a 116-line diff
+for a one-key change is unreviewable, and it makes hyalo unusable in any repo
+where frontmatter is under code review. Diff churn is an adoption blocker
+independent of correctness.
+
+**Supersedes DEC-006**, which accepted full-block rewrites because the YAML
+library could not preserve formatting. The fix does not need the library to:
+the unchanged text is never handed to the serializer at all.
+
+**Splice, not a format-preserving YAML crate:** the alternative was to swap the
+parser for a CST-preserving YAML library (the `toml_edit` equivalent, which
+hyalo already uses for `.hyalo.toml` — that path never churned). No maintained
+Rust YAML crate offers `toml_edit`'s fidelity, and swapping the parser would put
+every read path, the hardened `Budget`, strict-boolean handling, and duplicate-key
+policy back on the table for a formatting problem. Line-span splicing is
+confined to the write path and leaves the read model untouched.
+
+**Comments belong to the key below them:** a contiguous run of blank/comment
+lines immediately above a key travels with that key — including into oblivion
+when the key is removed. Trivia before the *first* key is document-level and
+stays at the top; trivia after the last key is a footer and stays at the bottom.
+This is a convention, not a YAML rule, but it matches how frontmatter comments
+are actually written (`# explains the field below`).
+
+**Verified, not trusted:** span mapping is a heuristic, so the spliced text is
+re-parsed and compared against the exact property map the caller asked to write
+— same keys, same order, same values — before it is returned. Verification uses
+budgets scaled to the frontmatter size limit rather than the tighter read-path
+defaults, because a caller is allowed to *write* a value larger than the
+read-path scalar budget (the size-budget pre-flight is what rejects those) and
+verification must not mistake that for a splicing failure.
+
+## DEC-081: the full-rewrite fallback stays, but is never silent (2026-08-23)
+
+**Decision:** when a frontmatter block cannot be span-mapped, hyalo still
+performs the write — by re-serializing the whole block — and emits a
+`warning:` on stderr naming the file and the reason. It does **not** refuse.
+
+**Why not refuse:** the fallback triggers on YAML hyalo can read but this
+splicer deliberately does not model — explicit `? key` syntax, top-level flow
+collections, directives, invalid UTF-8, mixed line endings. Refusing would turn
+a *cosmetic* limitation into a hard failure on files that `set` has always
+handled correctly, and would leave the user with no in-tool way to change a
+property. The prior behavior (full rewrite) is still correct; it is only noisy.
+
+**Why not silent:** the entire point of DEC-080 is that unexplained diff churn
+destroys trust in the tool. A user who sees 116 changed lines must be able to
+tell "hyalo could not do better here, and said so" from "hyalo has a bug".
+The warning carries the reason string, so the fallback class is identifiable
+from the message alone.
+
+**Not warned:** creating frontmatter on a file that had none, and writing into
+an empty `---\n---` block. Neither has any formatting to preserve, so neither is
+churn.

--- a/hyalo-knowledgebase/iterations/iteration-214-frontmatter-format-preservation.md
+++ b/hyalo-knowledgebase/iterations/iteration-214-frontmatter-format-preservation.md
@@ -2,7 +2,7 @@
 title: Iteration 214 — frontmatter format preservation (minimal-diff writes)
 type: iteration
 date: 2026-08-23
-status: planned
+status: in-progress
 branch: iter-214/frontmatter-format-preservation
 tags:
   - iteration
@@ -43,39 +43,39 @@ triggers.
 
 ## Tasks
 
-- [ ] Research the current write path (`write_frontmatter` and callers)
+- [x] Research the current write path (`write_frontmatter` and callers)
       and the span information available from the YAML parser; record
       the chosen mechanism as a DEC (targeted splice vs format-preserving
       YAML crate vs other).
-- [ ] Implement minimal-diff writes for `set`, `remove`, `append`,
+- [x] Implement minimal-diff writes for `set`, `remove`, `append`,
       `task toggle` (frontmatter portion), `mv` (frontmatter-touching
       paths), and `types`/`lint-rules`/`views set` writes to
       `.hyalo.toml` if they share the problem (verify; scope to what
       actually churns).
-- [ ] Preservation test corpus: nested objects, block scalars (`>-`,
+- [x] Preservation test corpus: nested objects, block scalars (`>-`,
       `|`), single/double/unquoted strings, flow and block lists,
       comments, unusual indentation, CRLF — assert that changing key X
       leaves every line not belonging to X byte-identical. Use real
       GitHub Docs frontmatter shapes as fixtures.
-- [ ] e2e: repeat the dogfood measurement — add one property to a copied
+- [x] e2e: repeat the dogfood measurement — add one property to a copied
       GitHub Docs `index.md` and assert the diff touches only the added
       line(s).
-- [ ] Define and document the fallback: when span-mapping fails, either
+- [x] Define and document the fallback: when span-mapping fails, either
       refuse with a clear error or re-serialize with a loud warning —
       pick one, record as a DEC, never silently churn.
-- [ ] Docs/CHANGELOG: describe the new guarantee and its fallback
+- [x] Docs/CHANGELOG: describe the new guarantee and its fallback
       boundary.
 
 ## Acceptance criteria
 
-- [ ] Adding one property to the GitHub Docs fixture changes only the
+- [x] Adding one property to the GitHub Docs fixture changes only the
       inserted line (was 116 of 198 lines)
-- [ ] The preservation corpus passes byte-identity for untouched lines
+- [x] The preservation corpus passes byte-identity for untouched lines
       across all listed YAML shapes
-- [ ] Fallback behavior is explicit, tested, and never silent
-- [ ] Existing frontmatter-write e2e suite still green (semantics
+- [x] Fallback behavior is explicit, tested, and never silent
+- [x] Existing frontmatter-write e2e suite still green (semantics
       unchanged)
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q` all clean
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-214-frontmatter-format-preservation.md
+++ b/hyalo-knowledgebase/iterations/iteration-214-frontmatter-format-preservation.md
@@ -2,7 +2,7 @@
 title: Iteration 214 — frontmatter format preservation (minimal-diff writes)
 type: iteration
 date: 2026-08-23
-status: in-progress
+status: completed
 branch: iter-214/frontmatter-format-preservation
 tags:
   - iteration
@@ -41,7 +41,7 @@ re-serialization only when the file's YAML cannot be span-mapped
 (anchors/aliases, exotic constructs) — and warning when that fallback
 triggers.
 
-## Tasks
+## Tasks [6/6]
 
 - [x] Research the current write path (`write_frontmatter` and callers)
       and the span information available from the YAML parser; record
@@ -66,7 +66,7 @@ triggers.
 - [x] Docs/CHANGELOG: describe the new guarantee and its fallback
       boundary.
 
-## Acceptance criteria
+## Acceptance criteria [5/5]
 
 - [x] Adding one property to the GitHub Docs fixture changes only the
       inserted line (was 116 of 198 lines)


### PR DESCRIPTION
## Summary

- **Minimal-diff frontmatter writes.** `set`, `remove`, `append`, `tags rename`,
  `properties rename`, `types apply` and `lint --fix` all funnel through
  `write_frontmatter_impl`, which parsed the whole YAML block and re-serialized
  all of it. A one-key change therefore rewrote every line the serializer
  happened to format differently — **116 of 198 frontmatter lines** on a real
  GitHub Docs `index.md` for a single added property (long list items refolded
  into `>-` block scalars, `'` quote style flipped to `"`). Nothing was ever
  lost, but a 116-line diff for a one-key change is unreviewable and blocks
  adoption in any repo where frontmatter is under code review.

- **New `crates/hyalo-core/src/frontmatter/splice.rs`.** Segments the original
  raw YAML into one line span per top-level key, re-emits every span whose value
  did not change **byte for byte**, and serializes only what was added, changed
  or reordered. Quote style, block scalars (`|`, `>-`), flow collections,
  nesting depth, unusual indentation, blank lines and comments all survive.
  Comments directly above a key travel with it — including into oblivion when
  the key is removed.

- **Verified, not trusted.** Span mapping is a heuristic, so the spliced text is
  re-parsed and compared against the exact property map the caller asked to
  write (same keys, same order, same values) before it is returned. Anything
  that does not verify falls back to the old full-block rewrite, so splicing can
  never write something the full serializer would not have written.

- **The fallback is loud.** Blocks that cannot be span-mapped (explicit `? key`
  syntax, top-level flow collections, invalid UTF-8, mixed line endings) are
  still rewritten in full, but a `warning:` on stderr names the file and the
  reason. Creating frontmatter where there was none, and writing into an empty
  `---\n---` block, are not warned — neither has formatting to preserve.

- **Docs:** CHANGELOG entry; DEC-080 (splice mechanism, explicitly supersedes
  DEC-006 "no formatting preservation") and DEC-081 (warned fallback); a
  `FORMATTING:` paragraph in `set` / `remove` / `append` `--help`.

## Test plan

- [x] 18 unit tests in `splice.rs`: GitHub-Docs-shaped fixture, quote styles,
      block scalars, flow collections, nested/oddly-indented maps, compact vs
      indented lists, CRLF, quoted keys, reordering, comment placement,
      key removal, and one test per fallback class.
- [x] 13 e2e tests in `crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs`
      driving the real binary: adding one property to the GitHub Docs fixture
      changes exactly **one** line; changing one value changes exactly one line
      in each direction; `remove`, `append`, `tags rename` and
      `properties rename` are equally surgical; CRLF files stay CRLF;
      un-mappable frontmatter warns; ordinary writes never warn.
- [x] Dogfood measurement on the real knowledgebase: `hyalo set --glob '**/*.md'
      --property perftest=1` over 387 files produced **387 changed lines total**
      — exactly one per file. Wall time 4.4 s at 8% CPU, i.e. still fsync-bound;
      the extra parses are not measurable against the write cost.
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
      `cargo test --workspace -q` (1583 tests) all clean.
- [x] All six `xtask check-*` gates exit 0.
- [x] `hyalo lint` and `hyalo lint --profile changelog` on the knowledgebase:
      0 errors, only the 4 pre-existing HYALO002 warnings on old iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEuPjCTq74bwJgoWbcvHrD
## Carry-over

Swept the iter-214 plan, this PR body, and the BUG-14 dogfood cluster it closes
out. Nothing to carry forward:

- **Plan ACs / tasks**: all 6 tasks and all 5 acceptance criteria in
  `iterations/iteration-214-frontmatter-format-preservation.md` landed and are
  verified against the diff (ticked in this PR, plan `status: completed`).
- **`[deferred …]` annotations**: none in the plan, PR body, or commit history
  for this branch.
- **Non-goals** (declared in the plan, not carry-over — deliberately out of
  scope, not incomplete): `lint --fix` body-rewrite formatting preservation
  (different code path, already minimal), and a general YAML formatting-style
  option. Neither was requested by this iteration's goal; no plan filed.
- **BUG-14 cluster** (`dogfood-results/dogfood-v0210-pre2-integrity-wave.md`):
  this PR closes the cluster's last open item (frontmatter reformat churn).
  The other four BUG-14 items (`[changelog] path` exit-code contract,
  `views run` positional-pattern parity, `config_excluded` semantics,
  `create-index` help example) were already fixed and merged in iter-213
  (`iterations/iteration-213-config-ux-polish.md`, status `completed`).
- **Local review** (`/review-pr local-only`): zero findings. The splice
  implementation's verify-before-return safety net (re-parse the spliced text,
  compare against the exact requested property map) means every heuristic
  edge case I traced (blank lines inside literal block scalars, tab
  indentation, duplicate-key documents) either splices correctly or is caught
  by verification and falls back to the warned full rewrite — there is no path
  where an unverified guess reaches disk.
