### PR TITLE
iter-218: lint --fix counter truth, scalar columns, fuzzy hint honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ and this project adheres to
 
 ### Fixed
 
+- **`lint --fix` totals now describe the whole run, not the display-capped
+  listing** (iter-218, dogfood NEW-6). `total_fixed`, `total_remaining`,
+  and `total_conflicts` — in both the text footer and JSON — were
+  accumulated inside the same per-file loop that builds the (`--limit`-capped)
+  `files[]` array, so a low `--limit` silently under-reported them. On a
+  GitHub Docs corpus, the default limit printed `conflicts 0` while
+  `--limit 100000` showed `conflicts 12` — a user who dry-ran at the
+  default limit saw a clean preview and then hit conflicts on `--apply`.
+  Writes were always complete (the trees produced with and without
+  `--limit 0` were byte-identical); only the report lied. The totals are
+  now accumulated over every result before the display list is truncated,
+  exactly like plain `lint`'s `total`/`errors`/`warnings` already were.
+- **MD010, MD042, and (when enabled) MD052 report Unicode-scalar columns,
+  not byte columns** (iter-218, dogfood NEW-11). Per DEC-073, `lint`
+  columns are 1-based Unicode scalars; these three upstream
+  `mdbook-lint-rulesets` rules compute their reported column from a byte
+  offset (`str::find`, a byte cursor, or comrak's byte-indexed AST
+  `sourcepos`) instead. A line reading `àéî<TAB>` reported column 7 for the
+  tab (the byte offset) instead of column 4 (the scalar offset); an emoji
+  line reported column 5 instead of 2. Every other default-on rule was
+  audited against a multibyte fixture and found already correct (MD009,
+  MD011, MD034 index a `Vec<char>`; the rest report either a constant
+  column 1 or a length measured only over ASCII indentation/hashes, which
+  cannot diverge from bytes). The fix converts the reported column for
+  these three rule IDs after the fact, using the same line text upstream
+  measured against — it does not touch `mdbook-lint-rulesets`.
+- **The `links`/`links fix` `[writes]` fuzzy hint no longer promises an
+  apply it will not perform** (iter-218, dogfood NEW-14). The hint counted
+  every fuzzy candidate found, including ones below the confidence floor
+  that `--apply-fuzzy` never writes — on GitHub Docs it read
+  `# Review then apply 3253 lower-confidence fuzzy fixes [writes]`, and
+  running that command verbatim applied 0 files because none of the 3,253
+  cleared the floor. The hint now counts only candidates at or above the
+  effective floor; when none clear it, the hint instead points at
+  `--min-confidence` to review the below-floor candidates, and no longer
+  claims to write anything.
 - **`links auto --apply` no longer corrupts wrapped wikilinks, wrapped
   markdown links, multi-line HTML tags, or any bracketed text**
   (iter-217, dogfood NEW-1/NEW-2/NEW-10). The zone scan that decides what is
@@ -43,6 +79,17 @@ and this project adheres to
 
 ### Changed
 
+- **`lint --fix` JSON reports `remaining_errors`/`remaining_warnings`
+  instead of `errors`/`warnings`** (iter-218, dogfood NEW-6b — **BREAKING
+  JSON shape change**). Both plain `lint` and `lint --fix` used the same
+  `errors`/`warnings` keys for two different quantities: plain `lint`
+  counts whole-run severity totals, `lint --fix` counted only what was
+  left unfixed after the run. A script reading `.errors` off both command's
+  output got answers to two different questions under one key name. The
+  fix-mode shape now uses `remaining_errors`/`remaining_warnings`, which is
+  what those counts have always actually meant; plain `lint`'s
+  `errors`/`warnings` are unchanged. Update any script or `--jq` filter
+  that reads `.errors`/`.warnings` from `lint --fix` JSON.
 - **`links auto`'s heading skip now uses the same CommonMark ATX-heading
   rule as the rest of the zone scan** (iter-217, review follow-up), instead
   of "the trimmed line starts with `#`". A line like `#nothash` (no space

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1334,7 +1334,14 @@ Repeatable (AND).\n\
             typos, normalize dates, infer type) and body fixes from autofixable rules. Body fixes\n\
             are applied in `(start, end, rule_id)` order; overlapping fixes are deferred and\n\
             reported as conflicts. Use --fix-rule <ID> (repeatable) to limit which rules autofix,\n\
-            or --dry-run to preview without writing.\n\n\
+            or --dry-run to preview without writing. JSON under --fix uses `total_fixed`,\n\
+            `total_remaining`, and `total_conflicts` in place of plain lint's `total` —\n\
+            all three, like every counter above, describe the WHOLE run and are identical at\n\
+            any --limit; only the displayed `files[]` list shrinks. `remaining_errors`/\n\
+            `remaining_warnings` replace `errors`/`warnings` in this shape (they count what is\n\
+            left unfixed, not the whole-run count those keys mean on plain lint) so a script\n\
+            reading the same key off both shapes never silently answers two different\n\
+            questions.\n\n\
             EXIT CODES: 0 = clean (after fixes), 1 = errors remain, 2 = internal error.\n\n\
             EXAMPLES:\n\
             \u{00a0} hyalo lint\n\

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -1491,7 +1491,14 @@ pub struct ExtLintOutput {
 }
 
 /// Full extended lint output in fix-mode.
-#[derive(Debug, serde::Serialize)]
+///
+/// `Default` backs the empty-result shape `run.rs` emits when
+/// `--files-from` resolves to zero files (review finding #5) — serializing
+/// `Self::default()` (with only `dry_run` overridden) keeps that shape from
+/// drifting out of sync with the real field set as fields are added or
+/// removed here, and its `#[serde(skip_serializing_if)]` on `dry_run`
+/// applies the same way it does on the non-empty path.
+#[derive(Debug, Default, serde::Serialize)]
 pub struct ExtLintFixOutput {
     pub files: Vec<ExtFileLintFixResult>,
     pub total_fixed: usize,
@@ -2174,11 +2181,16 @@ fn fix_mode_file_totals(r: &PerFileLintResult) -> (usize, usize, usize) {
 /// Count the error- and warning-severity violations across every result,
 /// independent of the `max_files` display cap.
 ///
-/// In read-only mode this is simply every violation. In fix mode it counts the
+/// In read-only mode this is simply every violation, reported as
+/// [`ExtLintOutput::errors`]/`::warnings`. In fix mode it counts the
 /// violations that *remain* after fixing — SCHEMA remainders come from
-/// `post_fix_schema_remaining`, body remainders from `!v.fixed` — so the
-/// reported `errors`/`warnings` (and the exit code they drive) reflect the true
-/// post-fix state of the whole vault, not just the first `max_files` shown.
+/// `post_fix_schema_remaining`, body remainders from `!v.fixed` — reported as
+/// [`ExtLintFixOutput::remaining_errors`]/`::remaining_warnings` (renamed
+/// from `errors`/`warnings` in iter-218 NEW-6b, since this mode's count means
+/// something different from the read-only mode's despite the pre-rename JSON
+/// using the same key for both). Either way, the exit code they drive
+/// reflects the true whole-vault state, not just the first `max_files`
+/// shown.
 fn count_errors_warnings(results: &[PerFileLintResult], is_fix_mode: bool) -> (usize, usize) {
     let mut errors = 0usize;
     let mut warnings = 0usize;

--- a/crates/hyalo-cli/src/commands/lint.rs
+++ b/crates/hyalo-cli/src/commands/lint.rs
@@ -12,7 +12,7 @@
 ///
 /// Exit code: 0 = clean, 1 = errors found, 2 = internal error.
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -1501,8 +1501,17 @@ pub struct ExtLintFixOutput {
     pub files_with_violations: usize,
     pub files_checked: usize,
     pub files_truncated: bool,
-    pub errors: usize,
-    pub warnings: usize,
+    /// Error-severity violations left unfixed after this run.
+    ///
+    /// Named `remaining_errors`/`remaining_warnings` (not `errors`/
+    /// `warnings`, iter-218 NEW-6b) because those keys mean something
+    /// different on [`ExtLintOutput`]: whole-run severity counts, not a
+    /// remaining-after-fix count. The two commands used to share a key name
+    /// for two different quantities — a script reading `.errors` off both
+    /// `lint` and `lint --fix` JSON silently got answers to different
+    /// questions.
+    pub remaining_errors: usize,
+    pub remaining_warnings: usize,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub dry_run: bool,
 }
@@ -1682,6 +1691,26 @@ pub fn lint_files_extended(
         seen.len()
     };
 
+    // Fix-mode totals, computed over EVERY result *before* the display cap,
+    // exactly like `authoritative_total`/`authoritative_rules_fired` above.
+    // The per-file display loop below only builds the (possibly truncated)
+    // `files[]` array for fix-mode too — deriving `total_fixed` /
+    // `total_remaining` / `total_conflicts` from it (as this did before
+    // iter-218) made `--limit` silently understate `conflicts`, hiding
+    // apply-time surprises from anyone who dry-ran at the default limit
+    // (NEW-6).
+    let (authoritative_total_fixed, authoritative_total_remaining, authoritative_total_conflicts) =
+        if is_fix_mode {
+            all_results
+                .iter()
+                .fold((0, 0, 0), |(fixed, remaining, conflicts), r| {
+                    let (f, rem, c) = fix_mode_file_totals(r);
+                    (fixed + f, remaining + rem, conflicts + c)
+                })
+        } else {
+            (0, 0, 0)
+        };
+
     // Cap the display list (0 == unlimited is normalized to `usize::MAX` by the
     // caller, so truncation here is a no-op for `--limit 0`).
     all_results.truncate(opts.max_files);
@@ -1691,9 +1720,6 @@ pub fn lint_files_extended(
         // Fix-mode output: fixed_groups / remaining_groups / conflicts shape.
         // -------------------------------------------------------------------
         let mut output_fix_files: Vec<ExtFileLintFixResult> = Vec::new();
-        let mut grand_total_fixed = 0usize;
-        let mut grand_total_remaining = 0usize;
-        let mut grand_total_conflicts = 0usize;
 
         for r in &all_results {
             // Build a set of (rule_id, order-within-rule) → FixOutcome from
@@ -1735,7 +1761,6 @@ pub fn lint_files_extended(
             // fixed_groups: rules with at least one applied fix + SCHEMA if fixed.
             let mut fixed_groups: Vec<FixedGroup> = Vec::new();
             if schema_fix_count > 0 {
-                grand_total_fixed += schema_fix_count;
                 fixed_groups.push(FixedGroup {
                     rule: "SCHEMA".to_owned(),
                     count: schema_fix_count,
@@ -1769,7 +1794,6 @@ pub fn lint_files_extended(
                     .get(rule_id)
                     .map_or(0, |vs| vs.iter().filter(|v| v.fixed).count());
                 if count > 0 {
-                    grand_total_fixed += count;
                     fixed_groups.push(FixedGroup {
                         rule: rule_id.clone(),
                         count,
@@ -1818,7 +1842,6 @@ pub fn lint_files_extended(
                     if remaining == 0 {
                         continue;
                     }
-                    grand_total_remaining += remaining;
                     let shown = remaining.min(opts.max_per_rule);
                     let truncated = remaining > shown;
                     let body_violations = remaining_owned
@@ -1855,7 +1878,6 @@ pub fn lint_files_extended(
                 if remaining_count == 0 {
                     continue;
                 }
-                grand_total_remaining += remaining_count;
 
                 let autofixable = md_lint_engine
                     .available_rules()
@@ -1893,7 +1915,6 @@ pub fn lint_files_extended(
             // conflicts: rules with at least one conflicting fix.
             let mut conflicts: Vec<ConflictEntry> = Vec::new();
             for (rule_id, blocking_rule) in &conflict_by_rule {
-                grand_total_conflicts += 1;
                 conflicts.push(ConflictEntry {
                     rule: rule_id.clone(),
                     reason: format!("range overlap with {blocking_rule}"),
@@ -1913,15 +1934,15 @@ pub fn lint_files_extended(
 
         let fix_output = ExtLintFixOutput {
             files: output_fix_files,
-            total_fixed: grand_total_fixed,
-            total_remaining: grand_total_remaining,
-            total_conflicts: grand_total_conflicts,
+            total_fixed: authoritative_total_fixed,
+            total_remaining: authoritative_total_remaining,
+            total_conflicts: authoritative_total_conflicts,
             rules_fired: authoritative_rules_fired,
             files_with_violations: total_files_with_violations,
             files_checked: files_checked_total,
             files_truncated,
-            errors: authoritative_errors,
-            warnings: authoritative_warnings,
+            remaining_errors: authoritative_errors,
+            remaining_warnings: authoritative_warnings,
             dry_run: matches!(opts.fix, FixMode::DryRun),
         };
         serde_json::to_value(&fix_output).context("failed to serialize fix lint output")?
@@ -2101,6 +2122,53 @@ struct PerFileLintResult {
     /// `None` means fix-mode was off or no SCHEMA pass ran. Body rules use
     /// `InternalViolation.fixed` instead.
     post_fix_schema_remaining: Option<Vec<InternalViolation>>,
+}
+
+/// Compute one file's fix-mode totals — (fixed, remaining, conflicts) —
+/// without building the display groups (`fixed_groups`/`remaining_groups`/
+/// `conflicts`). Mirrors the per-file accounting the display loop in
+/// [`run_ext_lint`] does inline, but is called separately over the *full*
+/// `all_results` before the `--limit` display cap is applied, so
+/// `total_fixed`/`total_remaining`/`total_conflicts` describe the whole run
+/// even when the listing is truncated (iter-218 NEW-6).
+fn fix_mode_file_totals(r: &PerFileLintResult) -> (usize, usize, usize) {
+    let mut applied_rules: HashSet<&str> = HashSet::new();
+    let mut conflict_rules: HashSet<&str> = HashSet::new();
+    for (rule_id, outcome) in &r.body_fix_outcomes {
+        match outcome {
+            FixOutcome::Applied => {
+                applied_rules.insert(rule_id.as_str());
+            }
+            FixOutcome::Conflict { .. } => {
+                conflict_rules.insert(rule_id.as_str());
+            }
+            FixOutcome::NoFix => {}
+        }
+    }
+
+    let schema_before = r
+        .violations_by_rule
+        .get("SCHEMA")
+        .map_or(0, std::vec::Vec::len);
+    let schema_after = r
+        .post_fix_schema_remaining
+        .as_ref()
+        .map_or(schema_before, std::vec::Vec::len);
+    let mut fixed = schema_before.saturating_sub(schema_after);
+    let mut remaining = 0usize;
+
+    for (rule_id, violations) in &r.violations_by_rule {
+        if rule_id == "SCHEMA" {
+            remaining += schema_after;
+            continue;
+        }
+        if applied_rules.contains(rule_id.as_str()) {
+            fixed += violations.iter().filter(|v| v.fixed).count();
+        }
+        remaining += violations.iter().filter(|v| !v.fixed).count();
+    }
+
+    (fixed, remaining, conflict_rules.len())
 }
 
 /// Count the error- and warning-severity violations across every result,

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -377,19 +377,29 @@ fn inject_ext_file_result(
                 _ => extra_warnings += n,
             }
         }
+        // Fix-mode renamed these to `remaining_errors`/`remaining_warnings`
+        // (iter-218 NEW-6b) since they mean something different there than
+        // on the read-only shape's `errors`/`warnings` (remaining-after-fix
+        // vs whole-run severity counts) — bump whichever key this payload
+        // actually carries.
+        let (errors_key, warnings_key) = if is_fix_mode {
+            ("remaining_errors", "remaining_warnings")
+        } else {
+            ("errors", "warnings")
+        };
         if extra_errors > 0
-            && let Some(n) = obj.get_mut("errors").and_then(|v| v.as_u64())
+            && let Some(n) = obj.get_mut(errors_key).and_then(|v| v.as_u64())
         {
             obj.insert(
-                "errors".to_string(),
+                errors_key.to_string(),
                 serde_json::Value::from(n + extra_errors),
             );
         }
         if extra_warnings > 0
-            && let Some(n) = obj.get_mut("warnings").and_then(|v| v.as_u64())
+            && let Some(n) = obj.get_mut(warnings_key).and_then(|v| v.as_u64())
         {
             obj.insert(
-                "warnings".to_string(),
+                warnings_key.to_string(),
                 serde_json::Value::from(n + extra_warnings),
             );
         }

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -1083,6 +1083,24 @@ fn slugify(s: &str) -> String {
     out.trim_matches('-').to_owned()
 }
 
+/// Format a confidence floor (0.0-1.0) as a `--min-confidence` CLI argument.
+///
+/// Rounds to 3 decimal places and trims trailing zeros/the decimal point, so
+/// `0.8` stays `"0.8"` rather than growing float-repr noise like
+/// `"0.8000000000000001"`, and `0.5` doesn't print as `"0.500"`.
+fn format_confidence(v: f64) -> String {
+    let mut s = format!("{v:.3}");
+    if s.contains('.') {
+        while s.ends_with('0') {
+            s.pop();
+        }
+        if s.ends_with('.') {
+            s.pop();
+        }
+    }
+    s
+}
+
 /// Derive a short, human-readable name from the active filters.
 fn auto_view_name(ctx: &HintContext) -> String {
     let mut parts: Vec<String> = Vec::new();
@@ -1828,9 +1846,32 @@ fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
     if applicable_fuzzy > 0 && !fuzzy_applied {
+        // `applicable_fuzzy` is counted against THIS run's effective floor
+        // (`fuzzy_min_confidence`), which may differ from
+        // `DEFAULT_FUZZY_MIN_CONFIDENCE` — either because this run passed
+        // `--min-confidence` or because `.hyalo.toml` sets
+        // `[links] fuzzy_min_confidence`. The hinted command must carry the
+        // same floor, or a dry run at a lower floor promises a count the
+        // hinted apply (which would silently fall back to the default 0.8)
+        // does not deliver (review finding #1). Appending it whenever the
+        // floor is non-default is simpler than tracking whether it came
+        // from the flag or the config file, and is harmless when it came
+        // from the config (the flag just repeats what the config would
+        // have applied anyway).
+        let floor = data
+            .get("fuzzy_min_confidence")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(hyalo_core::link_score::DEFAULT_FUZZY_MIN_CONFIDENCE);
+        let mut cmd_parts = vec!["links", "fix", "--apply", "--apply-fuzzy"];
+        let floor_arg;
+        if (floor - hyalo_core::link_score::DEFAULT_FUZZY_MIN_CONFIDENCE).abs() > f64::EPSILON {
+            floor_arg = format_confidence(floor);
+            cmd_parts.push("--min-confidence");
+            cmd_parts.push(&floor_arg);
+        }
         hints.push(Hint::new(
             format!("Review then apply {applicable_fuzzy} lower-confidence fuzzy fixes"),
-            build_command_with_glob(ctx, &["links", "fix", "--apply", "--apply-fuzzy"]),
+            build_command_with_glob(ctx, &cmd_parts),
         ));
     } else if fuzzy > 0 && !fuzzy_applied {
         // Every candidate is below the floor — `--apply-fuzzy` would apply 0

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -1808,19 +1808,44 @@ fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint>
     }
 
     // Fuzzy-match fixes are excluded from --apply by default. Surface the
-    // opt-in when a dry-run turned up fuzzy candidates that were not applied.
+    // opt-in when a dry-run turned up fuzzy candidates that were not applied
+    // — but only count candidates that actually clear the confidence floor
+    // (NEW-14, iter-218). `fuzzy` is every candidate found, including ones
+    // below the floor that `--apply-fuzzy` would never write; promising to
+    // apply all of `fuzzy` produced a hint like "apply 3253 fixes" that
+    // applied 0 files when every one of them was below-floor.
     let fuzzy = data
         .get("fuzzy")
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
+    let fuzzy_below_floor = data
+        .get("fuzzy_below_floor")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let applicable_fuzzy = fuzzy.saturating_sub(fuzzy_below_floor);
     let fuzzy_applied = data
         .get("fuzzy_applied")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
-    if fuzzy > 0 && !fuzzy_applied {
+    if applicable_fuzzy > 0 && !fuzzy_applied {
         hints.push(Hint::new(
-            format!("Review then apply {fuzzy} lower-confidence fuzzy fixes"),
+            format!("Review then apply {applicable_fuzzy} lower-confidence fuzzy fixes"),
             build_command_with_glob(ctx, &["links", "fix", "--apply", "--apply-fuzzy"]),
+        ));
+    } else if fuzzy > 0 && !fuzzy_applied {
+        // Every candidate is below the floor — `--apply-fuzzy` would apply 0
+        // of them. Point at reviewing with a lower floor instead of a
+        // command that reads as an apply but writes nothing.
+        let floor = data
+            .get("fuzzy_min_confidence")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(0.0);
+        hints.push(Hint::new(
+            format!(
+                "{fuzzy} fuzzy candidates found, all below the confidence floor \
+                 {floor} — review with a lower --min-confidence before applying"
+            ),
+            build_command_with_glob(ctx, &["links", "fix", "--min-confidence", "0"]),
         ));
     }
 
@@ -3912,8 +3937,8 @@ mod tests {
             "files_with_violations": 0,
             "files_checked": 3,
             "files_truncated": false,
-            "errors": 0,
-            "warnings": 0,
+            "remaining_errors": 0,
+            "remaining_warnings": 0,
             "dry_run": false,
         });
         let hints = generate_hints(&c, &data, None);

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -1466,6 +1466,42 @@ fn format_lint_fix_output_text(map: &serde_json::Map<String, serde_json::Value>)
         }
     }
 
+    // `files_truncated` gates a "(showing N of M files with issues)" line,
+    // mirroring `format_lint_output_text`'s. Without it, the summary line
+    // below — whose fixed/remaining/conflicts counts describe the WHOLE run
+    // since iter-218 (NEW-6) — read as if the file listing above it were
+    // complete too, when `--limit` had silently capped it (review finding
+    // #2).
+    let files_truncated = map
+        .get("files_truncated")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if files_truncated {
+        let files_with_violations = map
+            .get("files_with_violations")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let shown_files = files.map_or(0, |arr| {
+            arr.iter()
+                .filter(|f| {
+                    f.get("fixed_groups")
+                        .and_then(|g| g.as_array())
+                        .is_some_and(|a| !a.is_empty())
+                        || f.get("remaining_groups")
+                            .and_then(|g| g.as_array())
+                            .is_some_and(|a| !a.is_empty())
+                        || f.get("conflicts")
+                            .and_then(|c| c.as_array())
+                            .is_some_and(|a| !a.is_empty())
+                })
+                .count()
+        });
+        let _ = writeln!(
+            s,
+            "… (showing {shown_files} of {files_with_violations} files with issues)"
+        );
+    }
+
     // Summary line.
     let files_checked = map
         .get("files_checked")

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -253,20 +253,22 @@ fn empty_result_for_command(cmd: &Commands) -> CommandOutcome {
             // non-empty counterpart would, letting `output.rs`'s
             // `format_lint_fix_output_text` detection and any JSON consumer
             // reading `.total_fixed`/`.remaining_errors` see a consistent
-            // key set regardless of whether any file matched.
-            let payload = serde_json::json!({
-                "files": [],
-                "total_fixed": 0,
-                "total_remaining": 0,
-                "total_conflicts": 0,
-                "rules_fired": 0,
-                "files_with_violations": 0,
-                "files_checked": 0,
-                "files_truncated": false,
-                "remaining_errors": 0,
-                "remaining_warnings": 0,
-                "dry_run": *dry_run,
-            });
+            // key set regardless of whether any file matched. Serializing
+            // `ExtLintFixOutput::default()` (review finding #5) instead of a
+            // hand-written `json!` literal means this can never drift out of
+            // sync with the real struct's field set, and its own
+            // `#[serde(skip_serializing_if)]` on `dry_run` applies here too
+            // (finding #6) — the key is present only when `*dry_run` is true,
+            // exactly like the non-empty path.
+            let empty = crate::commands::lint::ExtLintFixOutput {
+                dry_run: *dry_run,
+                ..Default::default()
+            };
+            // `ExtLintFixOutput` has no maps or floats, so this cannot
+            // actually fail; the fallback keeps the "no unwrap/expect
+            // outside tests" rule rather than assuming infallibility.
+            let payload = serde_json::to_value(&empty)
+                .unwrap_or_else(|_| serde_json::json!({"files": [], "dry_run": *dry_run}));
             CommandOutcome::success_with_total(payload.to_string(), 0)
         }
         Commands::Lint { .. } => {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -245,6 +245,30 @@ fn empty_result_for_command(cmd: &Commands) -> CommandOutcome {
         Commands::Find { .. } => {
             CommandOutcome::success_with_total(serde_json::json!([]).to_string(), 0)
         }
+        Commands::Lint { fix, dry_run, .. } if *fix => {
+            // Fix-mode shape: `total_fixed`/`total_remaining`/`total_conflicts`
+            // plus `remaining_errors`/`remaining_warnings` (iter-218 NEW-6b) —
+            // distinct from the read-only shape below so a `--files-from`
+            // run that resolves to zero files still reports the shape its
+            // non-empty counterpart would, letting `output.rs`'s
+            // `format_lint_fix_output_text` detection and any JSON consumer
+            // reading `.total_fixed`/`.remaining_errors` see a consistent
+            // key set regardless of whether any file matched.
+            let payload = serde_json::json!({
+                "files": [],
+                "total_fixed": 0,
+                "total_remaining": 0,
+                "total_conflicts": 0,
+                "rules_fired": 0,
+                "files_with_violations": 0,
+                "files_checked": 0,
+                "files_truncated": false,
+                "remaining_errors": 0,
+                "remaining_warnings": 0,
+                "dry_run": *dry_run,
+            });
+            CommandOutcome::success_with_total(payload.to_string(), 0)
+        }
         Commands::Lint { .. } => {
             let payload = serde_json::json!({
                 "files": [],

--- a/crates/hyalo-cli/tests/e2e/files_from.rs
+++ b/crates/hyalo-cli/tests/e2e/files_from.rs
@@ -286,6 +286,80 @@ fn lint_files_from_empty_exits_zero() {
     assert_eq!(envelope["results"]["files_missing"].as_u64().unwrap(), 0);
 }
 
+/// `lint --fix --files-from` resolving to zero files must emit the
+/// fix-mode shape (`total_fixed`/`total_remaining`/`total_conflicts`,
+/// `remaining_errors`/`remaining_warnings`), not the read-only shape —
+/// otherwise a JSON consumer or the text renderer's shape-detection sees a
+/// different payload depending on whether any file happened to match
+/// (iter-218 review finding #5). `dry_run` must be present (and `true`)
+/// only under `--dry-run`, matching the non-empty path's
+/// `#[serde(skip_serializing_if)]` behavior (finding #6).
+#[test]
+fn lint_fix_files_from_empty_emits_fix_mode_shape() {
+    let tmp = setup_vault();
+    let list = write_list_file(&["nonexistent.md"]);
+
+    let mut cmd = hyalo_no_hints();
+    cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    cmd.args([
+        "lint",
+        "--fix",
+        "--files-from",
+        list.path().to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    let out = cmd.output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let envelope: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = &envelope["results"];
+    for key in [
+        "total_fixed",
+        "total_remaining",
+        "total_conflicts",
+        "remaining_errors",
+        "remaining_warnings",
+    ] {
+        assert_eq!(
+            results[key].as_u64(),
+            Some(0),
+            "expected fix-mode key {key} present and 0: {envelope}"
+        );
+    }
+    assert!(
+        results.get("total").is_none() && results.get("errors").is_none(),
+        "must not carry the read-only shape's keys: {envelope}"
+    );
+    assert!(
+        results.get("dry_run").is_none(),
+        "dry_run must be absent (not `false`) without --dry-run: {envelope}"
+    );
+
+    let mut dry_run_cmd = hyalo_no_hints();
+    dry_run_cmd.args(["--dir", tmp.path().to_str().unwrap()]);
+    dry_run_cmd.args([
+        "lint",
+        "--fix",
+        "--dry-run",
+        "--files-from",
+        list.path().to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    let dry_out = dry_run_cmd.output().unwrap();
+    assert!(dry_out.status.success());
+    let dry_envelope: serde_json::Value = serde_json::from_slice(&dry_out.stdout).unwrap();
+    assert_eq!(
+        dry_envelope["results"]["dry_run"].as_bool(),
+        Some(true),
+        "dry_run must be present and true under --dry-run: {dry_envelope}"
+    );
+}
+
 #[test]
 fn lint_files_from_mutual_exclusion_with_type_fails() {
     let tmp = setup_vault();

--- a/crates/hyalo-cli/tests/e2e/hints.rs
+++ b/crates/hyalo-cli/tests/e2e/hints.rs
@@ -1273,6 +1273,101 @@ title: ActualNote
 }
 
 // ---------------------------------------------------------------------------
+// links fix --hints: 0 fuzzy candidates clear the confidence floor
+// (iter-218 NEW-11 / NEW-14)
+// ---------------------------------------------------------------------------
+
+/// When every fuzzy candidate is below the confidence floor, `links`/
+/// `links fix` must not emit a hint that promises an apply it will not
+/// perform. Before iter-218, the hint counted every fuzzy candidate
+/// regardless of confidence, so a vault whose fuzzy bucket was entirely
+/// below-floor still got `"Review then apply N lower-confidence fuzzy
+/// fixes" [writes]` — running that command verbatim applied 0 files
+/// (dogfood NEW-14).
+#[test]
+fn links_fix_hints_below_floor_only_fuzzy_does_not_promise_apply() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "target.md",
+        md!(r"
+---
+title: Target
+---
+# Target
+"),
+    );
+    // "target-x" is similar enough to fuzzy-match "target" but well below
+    // the default 0.8 confidence floor (confirmed empirically: ~0.67).
+    write_md(
+        tmp.path(),
+        "source.md",
+        md!(r"
+---
+title: Source
+---
+See [[target-x]] for more.
+"),
+    );
+
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["links", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "invalid JSON: {e}\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    let results = &parsed["results"];
+    assert_eq!(
+        results["fuzzy"].as_u64(),
+        Some(1),
+        "one fuzzy candidate found: {parsed}"
+    );
+    assert_eq!(
+        results["fuzzy_below_floor"].as_u64(),
+        Some(1),
+        "the one candidate must be below the confidence floor for this test \
+         fixture to exercise the 0-applicable case: {parsed}"
+    );
+
+    let hints = parsed["hints"].as_array().expect("hints array");
+    assert!(
+        !hints.iter().any(|h| h["cmd"]
+            .as_str()
+            .is_some_and(|c| c.contains("--apply-fuzzy"))),
+        "must not suggest --apply-fuzzy when 0 candidates clear the floor: {hints:?}"
+    );
+    let review_hint = hints
+        .iter()
+        .find(|h| {
+            h["description"]
+                .as_str()
+                .is_some_and(|d| d.contains("below the confidence floor"))
+        })
+        .unwrap_or_else(|| panic!("expected a below-floor review hint: {hints:?}"));
+    assert_eq!(
+        review_hint["writes"].as_bool(),
+        Some(false),
+        "the review hint must not claim to write anything: {review_hint}"
+    );
+    assert!(
+        review_hint["cmd"]
+            .as_str()
+            .is_some_and(|c| c.contains("--min-confidence") && !c.contains("--apply")),
+        "the review hint should point at --min-confidence, not an apply: {review_hint}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // create-index --hints
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -3262,3 +3262,120 @@ fn lint_json_files_truncated_tracks_list_truncation() {
         "`--limit 0` lists everything, so nothing is truncated: {unlimited}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// NEW-6 / NEW-6b (iter-218): `lint --fix` totals describe the whole run, and
+// fix-mode's `errors`/`warnings` are renamed so they never mean something
+// different than the same keys on plain `lint`.
+// ---------------------------------------------------------------------------
+
+/// Build a vault with `dirty` files that each get 4 autofixed MD012
+/// (multiple-blank-lines) violations — no conflicts — plus one additional
+/// file whose only violation is a genuine cross-rule conflict: a line ending
+/// in a hard tab trips both MD009 (trailing whitespace) and MD010 (hard
+/// tab), and their fixes overlap the same byte range, so exactly one of them
+/// is reported as `conflicts` and the other as `fixed`.
+///
+/// The conflict file has only 2 violations against 4 for every dirty file,
+/// so the worst-offenders-first sort (`lint.rs`'s `all_results.sort_by_key`)
+/// always places it last — a `--limit` low enough to truncate the display
+/// truncates it out first, making it the ideal canary for whether
+/// `total_conflicts` is computed before or after that truncation.
+fn setup_fix_counter_vault(dirty: usize) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    for i in 0..dirty {
+        write_md(
+            tmp.path(),
+            &format!("dirty-{i:03}.md"),
+            "---\ntitle: T\ntype: note\n---\n\nA\n\n\n\nB\n\n\n\nC\n\n\n\nD\n\n\n\nE\n",
+        );
+    }
+    // Sorts last: only 2 violations (MD009 + MD010 on the same trailing tab,
+    // one of which becomes a conflict), versus 4 for every dirty-*.md file.
+    write_md(
+        tmp.path(),
+        "zzz-conflict.md",
+        "---\ntitle: Conflict\ntype: note\n---\n\nHello\t\nWorld\n",
+    );
+    tmp
+}
+
+fn lint_fix_json(dir: &std::path::Path, extra: &[&str]) -> serde_json::Value {
+    let mut args = vec!["lint", "--fix", "--dry-run", "--format", "json"];
+    args.extend_from_slice(extra);
+    let out = hyalo_no_hints()
+        .current_dir(dir)
+        .args(&args)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("lint --fix {extra:?} did not emit JSON: {stdout} ({e})"))
+}
+
+/// `lint --fix --dry-run` totals (`total_fixed`/`total_remaining`/
+/// `total_conflicts`) must be identical at `--limit 1`, `--limit 50`
+/// (default), and `--limit 100000` — `--limit` may only ever shrink the
+/// `files[]` listing, never the summary counters. Before iter-218 these were
+/// accumulated inside the same per-file loop that builds the (display-capped)
+/// `files[]` array, so `--limit 1` silently reported `conflicts: 0` on a
+/// vault that actually had one (dogfood NEW-6: GH Docs showed `conflicts 0`
+/// at the default limit vs 12 at `--limit 100000`).
+#[test]
+fn lint_fix_totals_invariant_across_limit_on_conflict_vault() {
+    let tmp = setup_fix_counter_vault(55);
+
+    let at_1 = lint_fix_json(tmp.path(), &["--limit", "1"]);
+    let at_50 = lint_fix_json(tmp.path(), &["--limit", "50"]);
+    let at_100000 = lint_fix_json(tmp.path(), &["--limit", "100000"]);
+
+    for key in ["total_fixed", "total_remaining", "total_conflicts"] {
+        assert_eq!(
+            at_1["results"][key], at_50["results"][key],
+            "{key} must not depend on --limit (1 vs 50): {at_1} vs {at_50}"
+        );
+        assert_eq!(
+            at_50["results"][key], at_100000["results"][key],
+            "{key} must not depend on --limit (50 vs 100000): {at_50} vs {at_100000}"
+        );
+    }
+    assert_eq!(
+        at_1["results"]["total_conflicts"].as_u64(),
+        Some(1),
+        "the conflict file's MD009/MD010 overlap must be counted even though \
+         --limit 1 excludes it from the displayed files[] list: {at_1}"
+    );
+    // Sanity: the display list itself really is capped at each limit.
+    assert_eq!(
+        at_1["results"]["files"].as_array().map(Vec::len),
+        Some(1),
+        "display list capped at 1: {at_1}"
+    );
+    assert_eq!(
+        at_50["results"]["files"].as_array().map(Vec::len),
+        Some(50),
+        "display list capped at 50: {at_50}"
+    );
+}
+
+/// `lint --fix` JSON reports `remaining_errors`/`remaining_warnings`, not
+/// `errors`/`warnings` — those key names are reserved for plain `lint`'s
+/// whole-run severity counts (NEW-6b). A consumer must not be able to read
+/// `.errors` off both `lint` and `lint --fix` output and silently get
+/// answers to two different questions under one key name.
+#[test]
+fn lint_fix_json_uses_remaining_errors_warnings_keys() {
+    let tmp = setup_fix_counter_vault(2);
+
+    let val = lint_fix_json(tmp.path(), &[]);
+    let results = &val["results"];
+    assert!(
+        results.get("errors").is_none() && results.get("warnings").is_none(),
+        "fix-mode JSON must not carry the ambiguous errors/warnings keys: {val}"
+    );
+    assert!(
+        results["remaining_errors"].is_u64() && results["remaining_warnings"].is_u64(),
+        "fix-mode JSON must carry remaining_errors/remaining_warnings: {val}"
+    );
+}

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -660,9 +660,18 @@ impl HyaloLintEngine {
                     // A handful of upstream rules report `column` as a byte
                     // offset, not a Unicode scalar one — see
                     // `BYTE_COLUMN_RULE_IDS` (DEC-073, iter-218 NEW-11).
+                    //
+                    // `checked_sub` (not `saturating_sub`, review finding
+                    // #7): `v.line` is 1-based, so a well-formed diagnostic
+                    // never reports 0. If one somehow does, `saturating_sub`
+                    // would silently convert the column against line 1's
+                    // bytes — the wrong line — instead of the nonexistent
+                    // "line 0". `checked_sub` makes that case look up
+                    // nothing, so `map_or` falls back to the raw column.
                     let column = if BYTE_COLUMN_RULE_IDS.contains(rule_id) {
-                        doc.lines
-                            .get(v.line.saturating_sub(1))
+                        v.line
+                            .checked_sub(1)
+                            .and_then(|i| doc.lines.get(i))
                             .map_or(v.column, |line| byte_col_to_scalar_col(line, v.column))
                     } else {
                         v.column
@@ -743,6 +752,18 @@ impl HyaloLintEngine {
 /// MD031, MD040, MD047) are unaffected and must not be added here — passing
 /// an already-scalar column through [`byte_col_to_scalar_col`] would corrupt
 /// it on any line with multibyte content before the flagged position.
+///
+/// Not filed upstream (unlike the CRLF gap `md047_fix` compensates for) — the
+/// three rules here each compute the byte offset a different way, so there is
+/// no single upstream fix to track. Re-check this table on every
+/// `mdbook-lint-rulesets` version bump: if a rule listed here switches to a
+/// `Vec<char>`/scalar computation upstream (as MD011/MD034 already do) and
+/// stays in this list, its column gets converted twice and silently comes
+/// out wrong again — the opposite failure mode from the one this table
+/// fixes, and just as invisible without a test. The
+/// `md010_reports_byte_column_before_conversion` test below pins the
+/// pre-conversion assumption for MD010 so a silent upstream fix breaks the
+/// test instead of double-converting unnoticed.
 const BYTE_COLUMN_RULE_IDS: &[&str] = &["MD010", "MD042", "MD052"];
 
 /// Convert a rule's 1-based **byte** column to a 1-based Unicode-scalar
@@ -1050,6 +1071,95 @@ mod tests {
         assert_eq!(
             d.column, 2,
             "expected scalar column 2 (1 char + 1), not the byte column 5"
+        );
+    }
+
+    #[test]
+    fn md042_reports_unicode_scalar_column_not_byte_offset() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+
+        // MD042 (no-empty-links, default-on) computes its column from
+        // comrak's byte-indexed AST `sourcepos`. Nested inside a blockquote
+        // so the fixture also proves the conversion uses the *raw* line text
+        // (block marker included) rather than content stripped of it —
+        // comrak's sourcepos is relative to the raw line, and so is
+        // `Document::lines`, so they must agree.
+        let body = "> àéî []()\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD042")
+            .expect("MD042 should fire on the empty link");
+        // "> àéî " is 6 Unicode scalars (`>`, space, à, é, î, space) — 9 UTF-8
+        // bytes. Scalar column is 7; byte column would be 10.
+        assert_eq!(
+            d.column, 7,
+            "expected scalar column 7 (6 chars + 1), not the byte column 10"
+        );
+    }
+
+    #[test]
+    fn md052_reports_unicode_scalar_column_not_byte_offset_when_enabled() {
+        // MD052 (undefined reference link) is opt-in — enable it via the
+        // same `[lint.rules]` override path `.hyalo.toml` uses.
+        use crate::config::RuleOverride;
+        let mut config = LintConfig::default();
+        config
+            .rules
+            .insert("MD052".to_owned(), RuleOverride::Enabled(true));
+        let engine = HyaloLintEngine::create().unwrap();
+
+        // MD052 computes its column from a byte cursor
+        // (`self.pos - self.line_start`) into its own `&[u8]` input.
+        let body = "àéî [ref][undefined]\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD052")
+            .expect("MD052 should fire on the undefined reference label");
+        // "àéî " is 4 Unicode scalars, 7 UTF-8 bytes. Scalar column is 5;
+        // byte column would be 8.
+        assert_eq!(
+            d.column, 5,
+            "expected scalar column 5 (4 chars + 1), not the byte column 8"
+        );
+    }
+
+    /// Pins the *pre-conversion* assumption `BYTE_COLUMN_RULE_IDS` documents:
+    /// MD010's raw upstream `Violation.column` is a byte offset. Calls the
+    /// upstream `mdbook_lint_rulesets::standard::md010::MD010` rule directly
+    /// — bypassing `lint_body`'s conversion entirely — so a future
+    /// `mdbook-lint-rulesets` release that switches MD010 to a scalar
+    /// computation (as MD011/MD034 already do) fails this test loudly
+    /// instead of silently getting double-converted by
+    /// `byte_col_to_scalar_col` and coming out wrong again (review finding
+    /// #3).
+    #[test]
+    fn md010_reports_byte_column_before_conversion() {
+        use mdbook_lint_core::rule::Rule as _;
+        use mdbook_lint_rulesets::standard::md010::MD010;
+
+        let body = "àéî\tTAB\n";
+        let doc = Document::new(body.to_owned(), PathBuf::from("test.md")).unwrap();
+        let violations = MD010::default().check(&doc).unwrap();
+        let v = violations
+            .iter()
+            .find(|v| v.rule_id == "MD010")
+            .expect("MD010 should fire on the hard tab");
+        // "àéî" is 6 UTF-8 bytes (2 per char); the tab's 1-based byte column
+        // is 7. If this ever becomes 4 (the scalar column), MD010 has moved
+        // off byte offsets upstream and must come out of
+        // `BYTE_COLUMN_RULE_IDS`.
+        assert_eq!(
+            v.column, 7,
+            "MD010's raw upstream column is expected to still be byte-indexed; \
+             if this fails because it's now 4, remove MD010 from \
+             BYTE_COLUMN_RULE_IDS instead of updating this assertion"
         );
     }
 

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -657,12 +657,22 @@ impl HyaloLintEngine {
                     } else {
                         convert_fix(&v, body_content)
                     };
+                    // A handful of upstream rules report `column` as a byte
+                    // offset, not a Unicode scalar one — see
+                    // `BYTE_COLUMN_RULE_IDS` (DEC-073, iter-218 NEW-11).
+                    let column = if BYTE_COLUMN_RULE_IDS.contains(rule_id) {
+                        doc.lines
+                            .get(v.line.saturating_sub(1))
+                            .map_or(v.column, |line| byte_col_to_scalar_col(line, v.column))
+                    } else {
+                        v.column
+                    };
                     diagnostics.push(Diagnostic {
                         rule_id: rule_id.to_string(),
                         rule_name: v.rule_name.clone(),
                         message: v.message.clone(),
                         line: v.line,
-                        column: v.column,
+                        column,
                         severity: sev,
                         fix,
                     });
@@ -716,6 +726,39 @@ impl HyaloLintEngine {
 
         Ok(diagnostics)
     }
+}
+
+/// Rule IDs whose upstream `Violation.column` (the *reported* diagnostic
+/// position, distinct from the `Fix` range `convert_fix` handles above) is
+/// computed from a byte offset rather than a Unicode-scalar one.
+///
+/// Confirmed by reading each rule's source in `mdbook-lint-rulesets` 0.16.0
+/// and reproducing on a multibyte fixture (iter-218, dogfood NEW-11):
+/// MD010 (`line.find('\t')`, a byte offset) and MD042 (comrak AST
+/// `sourcepos.start.column`, byte-based) are both default-on; MD052
+/// (`self.pos - self.line_start`, a byte cursor into `self.input: &[u8]`) is
+/// opt-in but wrong the same way once enabled. Rules that already index a
+/// `Vec<char>` (MD009, MD011, MD034) or only ever report column 1 or an
+/// ASCII-whitespace-prefix length (MD001, MD012, MD018, MD019, MD022, MD023,
+/// MD031, MD040, MD047) are unaffected and must not be added here — passing
+/// an already-scalar column through [`byte_col_to_scalar_col`] would corrupt
+/// it on any line with multibyte content before the flagged position.
+const BYTE_COLUMN_RULE_IDS: &[&str] = &["MD010", "MD042", "MD052"];
+
+/// Convert a rule's 1-based **byte** column to a 1-based Unicode-scalar
+/// column, matching `lint`'s DEC-073 convention.
+///
+/// `line` must be the exact line text the upstream rule measured against
+/// (no terminator) — `Document::lines` splits the same way upstream rules
+/// do, via `str::lines()`. A column that does not land on a char boundary
+/// (out of range, or inside a multibyte sequence — which should not happen
+/// for a byte offset upstream computed honestly, but a corrupted/mismatched
+/// input must not panic) falls back to the original byte column rather than
+/// silently reporting a wrong one.
+fn byte_col_to_scalar_col(line: &str, byte_col_1based: usize) -> usize {
+    let byte_offset = byte_col_1based.saturating_sub(1);
+    line.get(..byte_offset)
+        .map_or(byte_col_1based, |prefix| prefix.chars().count() + 1)
 }
 
 /// Convert an upstream `Fix` (line/column [`Position`]s) to a byte-offset
@@ -958,6 +1001,56 @@ mod tests {
         let fix = d.fix.as_ref().expect("MD009 fix should not be dropped");
         let fixed = apply(body, fix);
         assert_eq!(fixed, "日本語のテキスト\n");
+    }
+
+    // --- iter-218 NEW-11: MD010's upstream `Violation.column` is a byte
+    // offset (`line.find('\t')` in mdbook-lint-rulesets), not the
+    // Unicode-scalar column DEC-073 requires. `byte_col_to_scalar_col` in
+    // this file corrects it before the diagnostic is emitted. ---
+
+    #[test]
+    fn md010_reports_unicode_scalar_column_not_byte_offset() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+
+        // "àéî" is 3 Unicode scalars but 6 UTF-8 bytes (2 bytes each), so the
+        // tab's byte offset (6) and scalar offset (3) diverge. Before
+        // iter-218 the reported column was 7 (byte offset + 1); the correct
+        // Unicode-scalar column is 4 (scalar offset + 1).
+        let body = "àéî\tTAB\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD010")
+            .expect("MD010 should fire on the hard tab");
+        assert_eq!(
+            d.column, 4,
+            "expected scalar column 4 (3 chars + 1), not the byte column 7"
+        );
+    }
+
+    #[test]
+    fn md010_reports_unicode_scalar_column_on_emoji_line() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+
+        // A single emoji is one Unicode scalar but 4 UTF-8 bytes, so the
+        // byte-vs-scalar gap is even wider than the 2-byte-per-char case
+        // above. Byte column would be 5 (4 bytes + 1); scalar column is 2.
+        let body = "😀\tTAB\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &[])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD010")
+            .expect("MD010 should fire on the hard tab");
+        assert_eq!(
+            d.column, 2,
+            "expected scalar column 2 (1 char + 1), not the byte column 5"
+        );
     }
 
     // --- Char-column rules (MD034, MD011) must not be corrupted by the

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -1834,3 +1834,41 @@ outside any bracket and would otherwise be ordinary, linkable prose —
 and `placeholder_style_bracket_text_is_never_corrupted` in `auto_link.rs`
 lock in the corrected behavior; the former replaced a same-named-in-spirit
 test that asserted the opposite under the superseded design.
+
+## DEC-085: `lint --fix` JSON renames `errors`/`warnings` to `remaining_errors`/`remaining_warnings` (2026-08-23)
+
+**Decision:** rename, don't unify. Plain `lint`'s `errors`/`warnings` keep
+meaning whole-run severity counts, unchanged. `lint --fix`'s JSON — which
+used to carry the same key names for a different quantity (violations left
+after fixing) — now carries `remaining_errors`/`remaining_warnings`
+instead. `dispatch.rs`'s `inject_ext_file_result` (which patches injected
+`views`-sourced violations into either shape) now bumps whichever key pair
+the payload it is patching actually carries.
+
+**Why not unify the meaning instead:** the two numbers answer genuinely
+different questions and both are needed. A CI gate wants "did anything I
+couldn't autofix stay broken" (remaining, fix-mode's meaning); an audit
+wants "how much is wrong with this vault, before any fix" (whole-run,
+plain lint's meaning). Making fix-mode also report whole-run counts would
+have made the exit code (already driven by the remaining-after-fix count,
+correctly — a fully-autofixed vault should exit 0) disagree with the
+`errors`/`warnings` in the same payload it drives. Making plain `lint`
+report a "remaining" count makes no sense — nothing was fixed. There was
+no single meaning that served both callers; only a key name pretended
+there was.
+
+**Why this is worth a breaking JSON-shape change instead of leaving it**:
+dogfood NEW-6b — a script reading `.errors` off both `lint` and
+`lint --fix` output got answers to two different questions under one key
+name, with no signal in the JSON that the meaning had shifted. That is
+exactly the class of output-truth defect iter-210/iter-218 exist to
+remove elsewhere in this same command's counters (see NEW-6 above, and
+BUG-6 in iter-210). Landing it in the same iteration as NEW-6 means one
+CHANGELOG entry and one migration note instead of two.
+
+**Blast radius checked:** the only other producer/consumer of the old
+`errors`/`warnings` keys on the fix-mode shape was `dispatch.rs`'s view-
+violation injection path; the text renderer (`format_lint_fix_output_text`)
+never read those keys at all (the footer is built entirely from
+`total_fixed`/`total_remaining`/`total_conflicts`), so no text-output
+change was needed.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -1866,9 +1866,14 @@ remove elsewhere in this same command's counters (see NEW-6 above, and
 BUG-6 in iter-210). Landing it in the same iteration as NEW-6 means one
 CHANGELOG entry and one migration note instead of two.
 
-**Blast radius checked:** the only other producer/consumer of the old
-`errors`/`warnings` keys on the fix-mode shape was `dispatch.rs`'s view-
-violation injection path; the text renderer (`format_lint_fix_output_text`)
-never read those keys at all (the footer is built entirely from
-`total_fixed`/`total_remaining`/`total_conflicts`), so no text-output
-change was needed.
+**Blast radius checked:** the other producers/consumers of the old
+`errors`/`warnings` keys on the fix-mode shape were `dispatch.rs`'s view-
+violation injection path and `run.rs`'s `empty_result_for_command` (the
+`--files-from`-resolves-to-zero-files shortcut, which hand-built the
+fix-mode JSON shape rather than reusing `ExtLintFixOutput` — review finding
+#5 on the first review round switched it to serializing
+`ExtLintFixOutput::default()` so this rename, and any future one, cannot
+drift out of sync there again). The text renderer
+(`format_lint_fix_output_text`) never read those keys at all (the footer is
+built entirely from `total_fixed`/`total_remaining`/`total_conflicts`), so
+no text-output change was needed.

--- a/hyalo-knowledgebase/iterations/iteration-218-lint-fix-counter-truth.md
+++ b/hyalo-knowledgebase/iterations/iteration-218-lint-fix-counter-truth.md
@@ -50,29 +50,29 @@ independently by two agents:
 
 ## Tasks
 
-- [ ] Accumulate `lint --fix` totals (fixed / remaining / conflicts, per
+- [x] Accumulate `lint --fix` totals (fixed / remaining / conflicts, per
       rule and whole-run) over the full run before display truncation, in
       both text footer and JSON; `--limit` affects listing only
-- [ ] Unify or rename `errors`/`warnings` so the same key never switches
+- [x] Unify or rename `errors`/`warnings` so the same key never switches
       between whole-run and remaining-only semantics across modes
-- [ ] MD010 (and any other straggler found by an audit of column-emitting
+- [x] MD010 (and any other straggler found by an audit of column-emitting
       rules) reports 1-based Unicode scalar columns per DEC-073
-- [ ] The links `[writes]` fuzzy hint counts only candidates at/above the
+- [x] The links `[writes]` fuzzy hint counts only candidates at/above the
       effective floor; when 0, the hint suggests `--min-confidence`
       review instead of promising an apply
-- [ ] e2e tests: fix totals invariant across `--limit 1/50/100000` on a
+- [x] e2e tests: fix totals invariant across `--limit 1/50/100000` on a
       fixture with >50 violating files including conflicts; MD010 column
       on multibyte line; hint text at 0-applicable-fuzzy
-- [ ] Docs sync in same PR: `lint --help` counter wording if it changes,
+- [x] Docs sync in same PR: `lint --help` counter wording if it changes,
       CHANGELOG
 
 ## Acceptance criteria
 
-- [ ] `lint --fix --dry-run` totals identical at any `--limit`, equal to
+- [x] `lint --fix --dry-run` totals identical at any `--limit`, equal to
       `--limit 0`, and equal to what a real `--fix` run then writes
-- [ ] `conflicts` is never understated by truncation
-- [ ] MD010 on `àéî\tTAB` reports column 4; emoji line reports column 2
-- [ ] The below-floor hint either names an accurate count or does not
+- [x] `conflicts` is never understated by truncation
+- [x] MD010 on `àéî\tTAB` reports column 4; emoji line reports column 2
+- [x] The below-floor hint either names an accurate count or does not
       claim it will apply anything
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-218-lint-fix-counter-truth.md
+++ b/hyalo-knowledgebase/iterations/iteration-218-lint-fix-counter-truth.md
@@ -2,7 +2,7 @@
 title: "Iteration 218 — lint --fix counter truth and column-semantics stragglers"
 type: iteration
 date: 2026-08-23
-status: in-progress
+status: completed
 branch: iter-218/lint-fix-counter-truth
 tags: [iteration, lint, cli, output-truth]
 related:


### PR DESCRIPTION
## Summary
- `lint --fix` totals (`total_fixed`/`total_remaining`/`total_conflicts`, text footer and JSON) are now accumulated over the full run before display truncation — `--limit` affects only the listing. Previously the default limit understated fixes (646 vs 1,618 on GH Docs) and hid all 12 conflicts (NEW-6)
- BREAKING (JSON): fix-mode `errors`/`warnings` renamed to `remaining_errors`/`remaining_warnings` so the same key never switches between whole-run and remaining-only semantics across modes (NEW-6b, DEC-085); also fixes the wrong-shape stub when `--files-from` resolves to 0 files under `--fix`
- Column-semantics audit of all stock rules: MD010, MD042, and MD052 reported byte columns; now converted to 1-based Unicode scalars per DEC-073 (NEW-11)
- The links `[writes]` fuzzy hint now counts only candidates at/above the confidence floor; at 0 applicable it suggests `--min-confidence` review instead of promising an apply that writes nothing (NEW-14)

## Test plan
- [x] Fail-first verified e2e/unit tests: fix-totals invariance across `--limit 1/50/100000` on a 55-file conflict-bearing fixture; MD010 multibyte/emoji columns; below-floor hint text; `remaining_*` key shape
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace -q` clean (single gate run)
- [x] All xtask gates pass
- [x] GH Docs corpus: totals identical at limit 1/50/0 (1618/6109/12, matching the dogfood report's ground truth); real `--fix` trees byte-identical at default limit vs `--limit 0`; hint's promised 2,253 fuzzy fixes equals the 2,253 actually applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEuPjCTq74bwJgoWbcvHrD