### PR TITLE
docs(kb): external reviews + iterations 221-226 (review follow-ups)

### DIFF
--- a/hyalo-knowledgebase/iterations/iteration-221-config-dir-boundary.md
+++ b/hyalo-knowledgebase/iterations/iteration-221-config-dir-boundary.md
@@ -1,0 +1,91 @@
+---
+title: "Iteration 221 — config dir boundary (untrusted .hyalo.toml write-scope escape)"
+type: iteration
+date: 2026-08-23
+status: planned
+branch: iter-221/config-dir-boundary
+tags: [iteration, security, config, write-path]
+related:
+  - "[[reviews/adversarial-review-2026-08-23]]"
+  - "[[reviews/deep-analysis-2-2026-08-23]]"
+  - "[[iterations/iteration-201-config-trust]]"
+---
+
+# Iteration 221 — config dir boundary
+
+## Goal
+
+Close the one HIGH finding from [[reviews/adversarial-review-2026-08-23]]
+(H-1, re-confirmed as F-6 in [[reviews/deep-analysis-2-2026-08-23]]): a
+project-local `.hyalo.toml`'s `dir` value is honored verbatim, so an
+untrusted cloned repo can point the vault root at its own parent or an
+absolute path like `$HOME` and every downstream boundary gate then defends
+containment against that attacker-chosen root. This is the release gate for
+the security story and is a deliberate revisit of iter-201's decision.
+
+## Context
+
+**H-1 (HIGH, VERIFIED)** — `crates/hyalo-cli/src/config.rs:706`:
+
+```rust
+dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
+```
+
+The configured `dir` is taken with no check that it is at-or-below the
+config directory; `..` and absolute paths both pass. Verified repro: a
+malicious repo at `/tmp/evilrepo` with `docs/.hyalo.toml` containing
+`dir = ".."` lets `hyalo mv docs/a.md stolen.md` move a file OUT of the
+repo into the parent; `dir = "/Users/james"` is accepted silently
+(`hyalo config` shows it, no warning).
+
+Asymmetry the fix must resolve: the **ancestor-adoption** path already has
+containment (`config.rs:426-429`, `canonical_cwd.starts_with(&vault)`), and
+`[changelog] path` is validated against the config dir — but the
+**local-config `dir`** path has neither gate. iter-201 (DEC-069/070/071)
+deliberately moved toward "no silent config discard"; the decision to
+revisit is narrow: honoring the config is fine, honoring its *scope
+expansion* silently is not.
+
+Threat model note: CLAUDE.md instructs agents to run hyalo commands
+verbatim from hints, so a hostile repo + a normal agent loop is a plausible
+write-scope-escape primitive — this is exactly the surface the boundary
+layer (iter-202) is supposed to protect.
+
+## Tasks
+
+- [ ] For a **project-local** config (discovered in cwd or an ancestor, not
+      `--dir`, not the global/XDG config), reject or contain a `dir` that
+      resolves above the config directory or is absolute. Decide the exact
+      policy (hard refuse vs. clamp-to-config-dir-with-loud-warning) and
+      record it in the decision log, explicitly noting how it interacts with
+      iter-201's DEC-069/070/071 "no silent discard" stance
+- [ ] Preserve the legitimate cases: an explicit `--dir` (the user's own
+      choice), the global config, and a `dir` that stays at-or-below the
+      config directory must all continue to work unchanged
+- [ ] Whatever the policy, emit a loud stderr `note:`/`warning:` when a
+      config's requested vault root is not at-or-below the config dir,
+      mirroring `announce_ancestor_config`'s treatment — never silent
+- [ ] Audit the other config-supplied paths that feed the filesystem
+      (`site_prefix` is display-only, but re-check `[okf]`, `[scan]`, index
+      locations) for the same "config redefines its own boundary" shape
+- [ ] Tests: e2e reproducing the H-1 `dir = ".."` and absolute-path escapes
+      and asserting they are refused/contained + warned; regression tests
+      that `--dir`, global config, and in-bounds relative `dir` still work;
+      a test that the ancestor-adoption containment is unchanged
+
+## Acceptance criteria
+
+- [ ] The H-1 repro (`dir = ".."` in a cloned repo, then `hyalo mv`) no
+      longer moves a file outside the config directory
+- [ ] An absolute `dir` in a project-local config is refused or clamped, and
+      always warned — never silently honored
+- [ ] `--dir <anywhere>` (explicit user intent) and an in-bounds relative
+      `dir` both behave exactly as before
+- [ ] A decision-log entry records the policy and its relationship to
+      iter-201
+
+## Non-goals
+
+- Windows drive-relative / ADS path gaps (M-2 → [[iterations/iteration-222-security-robustness-batch]])
+- Sandboxing hyalo against a fully hostile repo beyond the write-scope root
+  (out of scope for a local single-user CLI; document the residual model)

--- a/hyalo-knowledgebase/iterations/iteration-222-security-robustness-batch.md
+++ b/hyalo-knowledgebase/iterations/iteration-222-security-robustness-batch.md
@@ -1,0 +1,98 @@
+---
+title: "Iteration 222 — security & robustness batch (UTF-8 lint, symlink policy, Windows paths, error leaks)"
+type: iteration
+date: 2026-08-23
+status: planned
+branch: iter-222/security-robustness-batch
+tags: [iteration, security, lint, write-path, cross-platform]
+related:
+  - "[[reviews/adversarial-review-2026-08-23]]"
+  - "[[reviews/deep-analysis-2-2026-08-23]]"
+  - "[[iterations/iteration-202-boundary-completion]]"
+---
+
+# Iteration 222 — security & robustness batch
+
+## Goal
+
+Clear the MEDIUM/LOW security findings and the ADVISORY items from
+[[reviews/adversarial-review-2026-08-23]] that don't belong to the H-1
+config-dir iteration: the invalid-UTF-8 lint abort, the `create-index -o`
+symlink-policy divergence, the Windows drive-relative/ADS gap, and the
+parser-internal error leaks.
+
+## Context
+
+- **M-1 (MEDIUM, VERIFIED)** — `crates/hyalo-cli/src/commands/lint.rs:2226`:
+  `std::fs::read_to_string(full_path).with_context(...)?` propagates out of
+  the per-file loop, so one invalid-UTF-8 file aborts the whole `lint` /
+  `lint --fix` run (exit 2). Other commands already skip+warn per file
+  (`scanner/mod.rs:99-104`). One corrupt file disables all autofix.
+- **L-1 (LOW, VERIFIED)** — `crates/hyalo-core/src/index.rs:925-929`:
+  `write_snapshot` uses raw `NamedTempFile::new_in` + `persist`, bypassing
+  `fs_util`'s `resolve_write_target` and so replacing a symlinked
+  `.hyalo-index` instead of following it (DEC-062 says the target is
+  replaced, the symlink stays). Safety-neutral but a silent policy
+  divergence: the `-o` path and the frontmatter write path give different
+  answers for the same input.
+- **M-2 (MEDIUM, SUSPECTED — needs Windows)** — `index.rs:659-676`
+  (SEC-1) and the lexical `resolve_file` gate accept `C:foo`
+  (drive-relative: `is_absolute()` is false, no `ParentDir` component) and
+  `a.md:stream` (NTFS ADS is lexically in-vault). The `Component::Prefix`
+  match only fires for absolute prefixed paths.
+- **ADVISORY** — (a) `anyhow` RUSTSEC-2026-0190 (`downcast_mut` unsoundness)
+  is not in `deny.toml`'s ignore list; if `cargo deny check` gates CI it may
+  fail, and if not the advisory is untriaged. (b) YAML alias-bomb rejection
+  leaks `budget breached: Anchors { anchors: 1 }` (saphyr-internal); same
+  family as the NEW-8 `ScalarBytes {…}` leak that
+  [[iterations/iteration-219-list-splice-and-write-polish]] is already
+  wrapping — coordinate so the mapping lives in one place. (c) case-probe
+  files (`case_index.rs:420-437`) are created/deleted inside the vault,
+  pinging file watchers and racing `git status`.
+
+## Tasks
+
+- [ ] M-1: catch the UTF-8 (and read) error per file in the lint loop, emit
+      one diagnostic per offending file, continue; still exit non-zero at
+      the end when strictness requires it. Mirror `scanner/mod.rs`'s
+      skip+warn. Test: a vault with one invalid-UTF-8 file lints the rest
+      and `--fix` still fixes the rest
+- [ ] L-1: route `write_snapshot` through `fs_util::atomic_write`/
+      `atomic_write_within` (or `resolve_write_target` + the boundary check)
+      so index writes share the one symlink policy — OR amend DEC-062 to say
+      index writes replace links and document why. Test: `create-index -o`
+      onto a symlink follows it (or the documented decision)
+- [ ] M-2: on Windows, reject any rel path with a `Prefix` component or a
+      colon in the final component, in BOTH the SEC-1 snapshot check and the
+      lexical `resolve_file` gate. Gate the tests behind `#[cfg(windows)]`
+      (and, if feasible, a lexical unit test that runs everywhere by
+      constructing the components directly)
+- [ ] ADVISORY-a: triage `anyhow` RUSTSEC-2026-0190 — bump anyhow if a fixed
+      version exists, else add it to `deny.toml` with a written rationale.
+      Confirm whether `cargo deny check` is actually a CI gate and record it
+- [ ] ADVISORY-b: map the saphyr `Anchors {…}` (and any sibling budget
+      structs) to a human message; reuse the wrapper
+      [[iterations/iteration-219-list-splice-and-write-polish]] adds for
+      `ScalarBytes` rather than duplicating it
+- [ ] ADVISORY-c: move the case-insensitivity probe to a temp dir on the
+      same filesystem (or a hidden `.hyalo`-prefixed transient) so it does
+      not create/delete files in the user's vault; verify no residual file
+      on either branch, and that the detection result is unchanged
+
+## Acceptance criteria
+
+- [ ] One invalid-UTF-8 file no longer aborts `lint` or `lint --fix`; the
+      rest of the vault is linted/fixed and the bad file is reported once
+- [ ] `create-index -o` onto a symlink follows one consistent, tested policy
+      shared with the frontmatter write path (or DEC-062 is amended)
+- [ ] Windows drive-relative and ADS rel paths are rejected by both gates
+      (tested under `#[cfg(windows)]`)
+- [ ] No user-facing error contains a saphyr/parser-internal debug struct
+- [ ] `cargo deny check` is green with a documented disposition for
+      RUSTSEC-2026-0190
+
+## Non-goals
+
+- The H-1 config-dir escape ([[iterations/iteration-221-config-dir-boundary]])
+- Concurrency/crash-recovery tests for the write path
+  ([[iterations/iteration-224-test-quality-hardening]])

--- a/hyalo-knowledgebase/iterations/iteration-223-query-output-correctness.md
+++ b/hyalo-knowledgebase/iterations/iteration-223-query-output-correctness.md
@@ -1,0 +1,95 @@
+---
+title: "Iteration 223 — query & output correctness (CJK search, section ambiguity, jq/sort output)"
+type: iteration
+date: 2026-08-23
+status: planned
+branch: iter-223/query-output-correctness
+tags: [iteration, search, output, ux]
+related:
+  - "[[reviews/deep-analysis-2-2026-08-23]]"
+---
+
+# Iteration 223 — query & output correctness
+
+## Goal
+
+Fix the four non-security code flaws from
+[[reviews/deep-analysis-2-2026-08-23]] (F-1..F-4): silent multi-section
+toggle, CJK-unsearchable BM25, jq errors that dump the whole result set, and
+mixed-type sort that looks like nonsense.
+
+## Context
+
+- **F-1 (VERIFIED)** — `crates/hyalo-cli/src/commands/tasks.rs:33-55`:
+  `task toggle --section "Sec"` toggles tasks under EVERY heading matching
+  the name, silently, with no ambiguity signal — while `links` reports
+  `ambiguous: N` for the analogous multi-match case. `task toggle` writes
+  immediately with no dry-run, so nothing catches over-toggling in a vault
+  with repeated headings (`## Tasks` per ADR, `## Notes` per month).
+- **F-2 (VERIFIED)** — `crates/hyalo-core/src/bm25.rs:148-149`:
+  `text.split(|c| !c.is_alphanumeric())` turns a whitespace-free CJK run
+  into one giant token, so `hyalo find 日本語` returns 0 results on a file
+  containing the query verbatim. The module claims "Unicode-aware" — it is
+  Unicode-*safe*, not CJK-*aware*. Silent correctness hole for any
+  JA/ZH/KO vault.
+- **F-3 (VERIFIED)** — `crates/hyalo-cli/src/output.rs:710`
+  (`apply_jq_filter_result`): a jaq runtime error is stringified with its
+  entire input, so one mistyped `--jq` filter dumps megabytes of vault
+  content into the error envelope — a content-disclosure vector for
+  consumers that log errors.
+- **F-4 (VERIFIED)** — `crates/hyalo-core/src/filter/sort.rs:92-95`: the
+  mixed-type fallback compares JSON string representations, so
+  `priority: "10"` (string) sorts before `priority: 9` (number) because
+  `"` < any digit. The total order is deliberate but the result is
+  user-visible nonsense with no signal that types were mixed.
+
+## Tasks
+
+- [ ] F-1: when `--section` matches more than one distinct heading instance,
+      refuse with an ambiguity error naming the matched heading line numbers
+      and suggesting `--line`, OR require an explicit opt-in flag
+      (`--all-sections`/`--nth`). Decide which (prefer refuse-by-default,
+      matching the `links` ambiguity precedent) and record it. At minimum
+      the output must surface the matched section lines
+- [ ] F-2: make BM25 tokenization CJK-aware. Cheapest sufficient approach:
+      detect CJK (and other scriptio-continua) runs and additionally index
+      them as character bigrams, tokenizing CJK queries the same way so they
+      match. Fall back / document per the review's ladder if full bigram
+      indexing is too invasive for one iteration — but "documented
+      limitation only" is the floor, not the target. Add a decision-log
+      entry for the tokenization approach and note the index-format
+      implication (snapshot rebuild)
+- [ ] F-3: truncate the embedded value in a jq runtime error to ~200 chars
+      with an `…` suffix and name the failing filter/position; keep full
+      detail behind an explicit `--debug`/verbose path if wanted. Audit for
+      the same whole-input-in-error shape elsewhere in output.rs
+- [ ] F-4: keep the total order, but emit a one-line warning when a sort key
+      has mixed types across the result set ("property:priority has mixed
+      types; numbers sort after strings"), and make missing/type-mismatched
+      values group consistently (as `Null` already does)
+- [ ] Docs sync: `find --help` (CJK limitation/behavior + `--sort`
+      mixed-type note), `task toggle --help` (section ambiguity behavior),
+      README search section if it claims CJK, CHANGELOG, decision-log
+- [ ] Tests: F-1 multi-section repro (refused/flagged); F-2 `find 日本語`
+      returns the file, plus a mixed CJK+latin doc; F-3 mistyped `--jq`
+      error is bounded in length and names the filter; F-4 mixed-type sort
+      emits the warning and orders deterministically
+
+## Acceptance criteria
+
+- [ ] `task toggle --section` on a vault with two same-named headings does
+      not silently toggle both — it refuses or requires explicit opt-in, and
+      names the matched sections
+- [ ] `hyalo find 日本語` returns a file containing 日本語 (and CJK queries
+      match in general), or the limitation is documented AND a substring
+      fallback returns it — no silent empty result
+- [ ] A mistyped `--jq` filter produces a bounded error (≤ ~200 chars of
+      embedded value) that names the filter, on a large vault
+- [ ] Mixed-type `--sort property:x` warns and is deterministic
+
+## Non-goals
+
+- Full CJK morphological segmentation / a tokenizer dependency (bigrams are
+  sufficient; note the tradeoff)
+- BM25 ranking-math correctness beyond tokenization (IDF/length norm — not
+  in scope)

--- a/hyalo-knowledgebase/iterations/iteration-224-test-quality-hardening.md
+++ b/hyalo-knowledgebase/iterations/iteration-224-test-quality-hardening.md
@@ -1,0 +1,98 @@
+---
+title: "Iteration 224 — test-quality hardening (concurrency, fuzz, typed e2e, Windows, scale gate)"
+type: iteration
+date: 2026-08-23
+status: planned
+branch: iter-224/test-quality-hardening
+tags: [iteration, testing, ci, robustness]
+related:
+  - "[[reviews/deep-analysis-2-2026-08-23]]"
+  - "[[reviews/adversarial-review-2026-08-23]]"
+---
+
+# Iteration 224 — test-quality hardening
+
+## Goal
+
+Close the six test-quality gaps from
+[[reviews/deep-analysis-2-2026-08-23]] (T-1..T-6). The suite is large
+(~3,650 tests) and behavioral, and `hint_execution.rs` is a genuinely strong
+meta-test; these are the holes it doesn't cover — the safety-critical write
+path and the parser surfaces most of all.
+
+## Context
+
+- **T-1** — the atomic-write machinery (`fs_util.rs:204-278`: temp + fsync +
+  rename + dir-fsync) is the most safety-critical code and has zero tests
+  under contention or interruption: no two-process mutation race, no
+  kill-mid-write, no kill between `persist` and parent-dir sync.
+- **T-2** — the SEC-1/2/3 hardening, line caps, and anchor budgets were
+  driven by one-off PoCs; there are no `cargo-fuzz` targets for the four
+  parser surfaces (frontmatter splice, scanner, link parser, MessagePack
+  loader). Per project preference: set up targets, not CI.
+- **T-3** — e2e assertions index `serde_json::Value` by string
+  (`json["results"]["links"]["total"]`), so output-shape regressions surface
+  as `expect` panics, and nothing ties the tests to the typed output structs
+  (DEC-025). Deserializing into the real structs would make a schema change a
+  compile error across the e2e suite instead of a runtime discovery.
+- **T-4** — Windows-only behaviors (report #1 M-2: drive-relative paths,
+  ADS; case-index probe on NTFS) are untested anywhere; the CI builds
+  Windows but the case-insensitivity logic runs only under `#[cfg]`-gated
+  tests on whichever platforms execute them.
+- **T-5** — substring assertions still dominate some suites (`links.rs`: 104
+  `.contains(` vs 5 typed parses); `hint_execution.rs`'s own header explains
+  why substring assertions on CLI *output* lie (they pass while the command
+  fails to run). Where they assert on file *content* they're fine.
+- **T-6** — no scale regression gate: `bench-e2e.sh` is manual; the known
+  perf debt (iter-206 fuzzy candidates) has nothing preventing
+  reintroduction.
+
+## Tasks
+
+- [ ] T-1: add a concurrency/crash test for the write path — N processes
+      running `set`/`append` on the same file asserting the file is always
+      one of the valid old/new contents (never truncated/half-written); and,
+      where the platform allows, a kill-mid-write test asserting no partial
+      file survives (temp-file discipline). ~50-line harness per the review
+- [ ] T-2: add `cargo-fuzz` targets for the four parser surfaces
+      (frontmatter splice, scanner, link parser, MessagePack/snapshot
+      loader), with a seed corpus from existing fixtures. Wire them into the
+      manual security-review workflow (Miri + cargo-fuzz), NOT CI. Document
+      how to run them
+- [ ] T-3: introduce typed deserialization for e2e output assertions —
+      deserialize CLI JSON into the existing typed output structs (the
+      `Ext*Output` family) in a shared test helper, so shape regressions are
+      compile errors. Convert the highest-value suites first (links, lint,
+      find); leave file-content assertions as-is
+- [ ] T-4: add Windows-gated tests for M-2 (drive-relative + ADS rejection,
+      shared with [[iterations/iteration-222-security-robustness-batch]]) and
+      a real-NTFS case-probe behavior test; add lexical unit tests that run
+      everywhere by constructing path components directly
+- [ ] T-5: convert CLI-*output* substring assertions in the worst suites to
+      typed-JSON parses (rides on T-3); leave content assertions. Quantify
+      before/after `.contains(` counts in the iteration outcome
+- [ ] T-6: add a criterion (or scripted) scale gate on a generated
+      ~14k-file synthetic vault asserting a budget on `find`/`links`; decide
+      cadence (nightly CI vs. on-demand xtask gate) and record it. Must name
+      what it does NOT cover so it isn't read as full perf coverage
+
+## Acceptance criteria
+
+- [ ] A concurrent-writer test exists and asserts the target file is never
+      observed in a partial state
+- [ ] `cargo-fuzz` targets exist for all four parser surfaces and run from a
+      documented command (not gated in CI)
+- [ ] At least the links/lint/find e2e suites assert via typed
+      deserialization; a deliberate field rename breaks them at compile time
+- [ ] Windows drive-relative/ADS rejection is covered by `#[cfg(windows)]`
+      tests
+- [ ] A scale regression gate runs against a large synthetic vault with a
+      documented budget and cadence
+
+## Non-goals
+
+- Rewriting the entire e2e suite to typed assertions in one pass (convert the
+  high-value suites; the rest is follow-on)
+- Turning fuzzing into a CI gate (project preference: manual)
+- Fixing the perf debt itself ([[iterations/iteration-206-links-perf-profiling]]);
+  this only pins a regression budget

--- a/hyalo-knowledgebase/iterations/iteration-225-arch-thin-dispatch-typed-hints-core-facade.md
+++ b/hyalo-knowledgebase/iterations/iteration-225-arch-thin-dispatch-typed-hints-core-facade.md
@@ -1,0 +1,96 @@
+---
+title: "Iteration 225 — architecture: thin dispatch, typed hints, hyalo-core façade"
+type: iteration
+date: 2026-08-23
+status: planned
+branch: iter-225/arch-thin-dispatch-typed-hints
+tags: [iteration, architecture, refactor, tech-debt]
+related:
+  - "[[reviews/deep-analysis-2-2026-08-23]]"
+---
+
+# Iteration 225 — architecture: thin dispatch, typed hints, core façade
+
+## Goal
+
+Address the architecture findings from
+[[reviews/deep-analysis-2-2026-08-23]] that share one theme — a typed
+surface replacing hand-maintained parallel copies: ARCH-1 (god dispatcher),
+ARCH-4 (string-built hints that drift), ARCH-5 (hyalo-core exposes
+everything). ARCH-6 (presentation-layer mass) is largely subsumed and used
+as the success measure.
+
+**Not release-gating.** This is maintainability debt, larger and riskier
+than the correctness iterations. Sequence it AFTER the security/correctness
+iterations (221–224) and after the in-flight 219/220 land, to avoid enormous
+merge conflicts in `dispatch.rs`/`hints.rs`. Consider splitting each ARCH
+item into its own PR under this branch's plan if the diff gets unreviewable.
+
+## Context
+
+- **ARCH-1** — `crates/hyalo-cli/src/dispatch.rs:494` is one 2,100-line
+  `match` with 26 `Commands::` arms carrying real business logic (the `Find`
+  arm ~240 lines, `Lint` arm ~390): filter merging, warning policy, view
+  adaptation (`adapt_view_result_to_ext:256`), snapshot patching
+  (`patch_index_for_modified_files:427`). Command behavior can't be
+  unit-tested without the whole dispatch path — hence process-spawning e2e.
+- **ARCH-4** — `crates/hyalo-cli/src/hints.rs` (4,522 lines, 168 fns, 29
+  hand-assembled `"hyalo ..."` strings) is a parallel copy of the CLI
+  surface that must mirror clap by hand. `tests/e2e/hint_execution.rs`
+  exists precisely because the design guarantees drift (the `tags --limit 0`
+  hint that satisfied a substring test while failing to run).
+- **ARCH-5** — `crates/hyalo-core/src/lib.rs:1-26` marks all 26 modules
+  `pub` including plumbing (`fs_util`, `util`, `warn`) and internals; every
+  internal refactor is semver-breaking and invariants are doc-comment-only.
+  (The `math.rs` example the review cited was uncommitted test scaffolding,
+  since removed — the façade point stands on its own.)
+
+## Tasks
+
+- [ ] ARCH-1: extract one handler per command
+      (`commands::<cmd>::run(<Args>) -> CommandOutcome`), moving the inline
+      filter-merge / warning-policy / view-adaptation / snapshot-patch logic
+      out of the dispatch arms. `dispatch` shrinks to parsing `Commands` into
+      args structs and calling handlers. The extracted warnings become
+      in-process unit-testable. Do this incrementally, one command per
+      commit, starting with the largest arms (Find, Lint)
+- [ ] ARCH-4: stop building hints as hand-written strings. Introduce a
+      `HintBuilder::cmd(argv)` API that serializes through the existing
+      `shell_quote`, and require all NEW/edited hints to go through it;
+      ideally back it with a typed command registry shared with
+      `cli/args.rs` so the hinted command cannot reference a flag the command
+      doesn't accept. Migrate the existing 29 hand-assembled strings
+      opportunistically, prioritizing the ones `hint_execution.rs` can't
+      reach
+- [ ] ARCH-5: curate a root `pub use` façade in `hyalo-core/lib.rs`
+      (parse / find / mutate / link-graph / index types), demote internal
+      modules (`fs_util`, `util`, `warn`, `case_index`, `common_words`, …)
+      to `pub(crate)`, and mark the supported surface. Where a module must
+      stay `pub` for the CLI, re-export the specific items instead of the
+      whole module. This is semver-cheap NOW, expensive after external
+      consumers appear
+- [ ] Prove the ARCH-1 win: at least one command's warning/policy behavior
+      gains an in-process unit test that previously required an e2e spawn
+- [ ] Docs: decision-log entries for the handler pattern, the hint API, and
+      the core façade boundary; update any contributor notes on "where does a
+      new command go"
+
+## Acceptance criteria
+
+- [ ] `dispatch.rs` arms no longer contain command business logic — each arm
+      parses args and calls a `commands::<cmd>::run`; the god-function line
+      count drops materially (record before/after)
+- [ ] New hints cannot be written as raw strings without going through the
+      argv-based `HintBuilder`; the migrated hints still pass
+      `hint_execution.rs`
+- [ ] `hyalo-core`'s public surface is a curated façade; plumbing modules are
+      `pub(crate)`; the workspace still builds and all tests pass
+- [ ] At least one previously-e2e-only behavior is now covered by an
+      in-process unit test
+
+## Non-goals
+
+- Moving the lint subsystem into hyalo-mdlint (ARCH-2) and unifying index
+  maintenance (ARCH-3) — [[iterations/iteration-226-arch-lint-crate-index-journal]]
+- Any behavior change — this is a pure structural refactor; output and exit
+  codes stay byte-identical (the e2e suite is the guard)

--- a/hyalo-knowledgebase/iterations/iteration-226-arch-lint-crate-index-journal.md
+++ b/hyalo-knowledgebase/iterations/iteration-226-arch-lint-crate-index-journal.md
@@ -1,0 +1,89 @@
+---
+title: "Iteration 226 — architecture: lint crate boundary and unified index journal"
+type: iteration
+date: 2026-08-23
+status: planned
+branch: iter-226/arch-lint-crate-index-journal
+tags: [iteration, architecture, refactor, lint, index, tech-debt]
+related:
+  - "[[reviews/deep-analysis-2-2026-08-23]]"
+---
+
+# Iteration 226 — architecture: lint crate boundary and unified index journal
+
+## Goal
+
+The two larger structural findings from
+[[reviews/deep-analysis-2-2026-08-23]] that don't fit the typed-surface
+theme of [[iterations/iteration-225-arch-thin-dispatch-typed-hints-core-facade]]:
+ARCH-2 (the lint subsystem lives in hyalo-cli, not hyalo-mdlint) and ARCH-3
+(snapshot-index maintenance scattered across three mechanisms that every
+mutating command must opt into correctly).
+
+**Not release-gating.** Largest and riskiest of the review follow-ups.
+Sequence LAST, after 225, and only once the correctness work has settled —
+ARCH-3 in particular touches every mutating command's write path.
+
+## Context
+
+- **ARCH-2** — `crates/hyalo-cli/src/commands/lint.rs` is 4,375 lines;
+  `crates/hyalo-mdlint` holds only the engine wrapper + native rules
+  HYALO001–004. Schema validation, the profile system (okf/madr/changelog/
+  skills/github), and profile-lint orchestration
+  (`changelog_lint.rs`/`madr_lint.rs`/`okf_lint.rs`/`skills_lint.rs`/
+  `lint_github.rs` — five CLI modules) form a hidden subsystem in the CLI.
+  Lint logic can't be reused by the planned library consumers of hyalo-core,
+  and the e2e suite must spawn processes to drive it.
+- **ARCH-3** — three index-refresh mechanisms coexist (VERIFIED by grep):
+  `mutation.rs::save_index_if_dirty` (8 call sites across mv/set/remove/new/
+  lint/append/dispatch), a *local* `patch_index` in `commands/tasks.rs:238,344`,
+  and `index.rs:481-558` `refresh_entry`/`rename_entry` for graph-aware
+  updates. Each mutating command picks its own; nothing enforces that a new
+  mutating command refreshes the persisted index or its link graph. The
+  mtime fallback (`patch_index_for_modified_files:427`) catches stale
+  *entries* but not stale *link graph* — `index.rs:439`'s own doc comment
+  records that this class of bug already occurred.
+
+## Tasks
+
+- [ ] ARCH-2: move schema validation + profile linting into hyalo-mdlint
+      (it already depends on hyalo-core for `util::is_iso8601_*`). The CLI
+      keeps flag parsing and output formatting only. Expose an in-process
+      lint API the e2e suite can drive without spawning. Do this
+      profile-by-profile (changelog/madr/okf/skills/github) so each move is
+      independently reviewable
+- [ ] ARCH-3: make index refresh a property of the write path, not the
+      caller — a single `MutationJournal` (or equivalent) that every
+      frontmatter/link write records dirty rel_paths + whether links changed
+      into, flushed once at end of dispatch. Collapse `tasks.rs`'s local
+      `patch_index` and the scattered `save_index_if_dirty` call sites into
+      it; the graph-aware path is chosen by the journal based on whether
+      links changed, so no command can forget it
+- [ ] Add a guard that a new mutating command cannot silently skip index
+      refresh — e.g. the write goes through a type that owns the journal, so
+      "forgot to refresh" is not expressible, or an xtask/test that fails if
+      a `Commands::` arm mutates without journaling
+- [ ] Regression: the `index.rs:439` stale-link-graph scenario is covered by
+      a test that mutates via each path and asserts the persisted graph is
+      current
+- [ ] Docs: decision-log entries for the lint crate boundary and the
+      journal; update the crate-layout notes
+
+## Acceptance criteria
+
+- [ ] Schema + profile linting live in hyalo-mdlint with an in-process API;
+      at least one lint behavior is unit-tested without spawning a process
+- [ ] All mutating commands refresh the persisted index (entries AND link
+      graph) through one journal; the three old mechanisms are gone or
+      funnel through it
+- [ ] A test/guard makes "a mutating command that forgets index refresh"
+      fail to compile or fail CI
+- [ ] The stale-link-graph regression from `index.rs:439` is covered
+
+## Non-goals
+
+- ARCH-1/4/5 ([[iterations/iteration-225-arch-thin-dispatch-typed-hints-core-facade]])
+- Changing lint rule semantics or the schema model — pure relocation +
+  API extraction, output stays byte-identical
+- Changing the on-disk snapshot format (the journal is an in-memory
+  write-path concern; format changes are separate)

--- a/hyalo-knowledgebase/reviews/adversarial-review-2026-08-23.md
+++ b/hyalo-knowledgebase/reviews/adversarial-review-2026-08-23.md
@@ -1,0 +1,224 @@
+---
+title: Adversarial review 2026-08-23 — security deep-dive against untrusted vault threat model
+type: review
+date: 2026-08-23
+tags:
+  - review
+  - security
+  - audit
+status: active
+related:
+  - "[[reviews/codebase-review-2026-08-06]]"
+  - "[[reviews/deep-analysis-2-2026-08-23]]"
+---
+
+# Adversarial code review — hyalo 0.20.0 (2026-08-23)
+
+Reviewer executed code: `cargo build --release` binary against scratch vaults under `/tmp`.
+Labels: **VERIFIED** = reproduced with a command; **SUSPECTED** = static reasoning only.
+
+No CRITICAL findings. The path-boundary layer (`fs_util.rs`, iter-202) held up under
+every escape attempt I threw at it: `..` traversal, absolute link targets, symlinks to
+files and directories outside the vault, `links fix --apply`, `mv`, `create-index -o`,
+`set` — all refused or contained. The scanner's size caps (100 MB file / 1 MiB line /
+64 KiB frontmatter / YAML anchor budget) also survived pathological inputs (billion-laughs
+alias bomb, 3 MB frontmatter value, 80-deep nested brackets, CRLF, invalid UTF-8). Where
+hyalo is weakest is exactly where the threat model says it should be strongest: **the
+untrusted repo's own `.hyalo.toml` redefines the boundary the rest of the code defends.**
+
+---
+
+## HIGH
+
+### H-1. `dir` in a project-local `.hyalo.toml` is unrestricted — an untrusted repo grants itself an arbitrary vault root (write scope escape)
+
+**Location:** `crates/hyalo-cli/src/config.rs:706`
+
+```rust
+dir: cfg.dir.map(PathBuf::from).unwrap_or(defaults.dir),
+```
+
+The configured `dir` is taken verbatim. There is no check that it is at-or-below the
+config directory; absolute paths and `..` are both accepted. Every downstream boundary
+gate ("must be relative and within the vault", `resolve_file`, `atomic_write_within`)
+then enforces containment against **this attacker-chosen root**.
+
+**VERIFIED.** Repro (malicious repo cloned at `/tmp/evilrepo`, user `cd`s into it):
+
+```console
+$ mkdir -p /tmp/evilrepo/docs && cd /tmp/evilrepo/docs
+$ printf 'dir = ".."\n' > .hyalo.toml
+$ printf '%s\n' '---' 'title: x' '---' 'body' > a.md
+$ hyalo mv docs/a.md stolen.md        # cwd is docs/, vault root is now /tmp/evilrepo
+→ {"from":"docs/a.md","to":"stolen.md","total_files_updated":0,...}
+$ ls /tmp/evilrepo
+docs  secret.txt  stolen.md            # file moved OUT of the repo, into the parent dir
+```
+
+An absolute target is also accepted silently:
+
+```console
+$ printf 'dir = "/Users/james"\n' > .hyalo.toml
+$ hyalo config | grep '"dir"'
+  "dir": "/Users/james",
+```
+
+No warning is printed. The ancestor-adoption path *does* have a containment check
+(`config.rs:426-429`, `canonical_cwd.starts_with(&vault)`), and `[changelog] path` is
+validated against the config dir (verified: `../../../tmp/evil-out/CHANGELOG.md` refused
+with *"resolves outside vault boundary"*), but the local-config `dir` path has neither.
+
+**Impact:** run any mutating hyalo command inside a cloned malicious repo and its config
+widens the write scope to any directory it names — the parent of the clone, or `$HOME`
+via an absolute path. Because hyalo is designed to be driven by agents (CLAUDE.md
+instructs agents to run hyalo commands verbatim from hints), a hostile repo plus a
+normal agent loop is a plausible write-anywhere-within-scope primitive.
+
+**Fix:** for a project-local (non-`--dir`, non-global) config, refuse `dir` values that
+resolve above the config directory or that are absolute; at minimum, print a loud
+warning when the resolved vault root is not at-or-below the config dir, mirroring the
+`announce_ancestor_config` treatment. Note iter-201 deliberately moved in the opposite
+direction ("no silent config discard") — the decision itself is what needs revisiting:
+*honoring* the config is fine; *honoring its scope expansion* silently is not.
+
+---
+
+## MEDIUM
+
+### M-1. A single invalid-UTF-8 file makes `hyalo lint` / `lint --fix` abort the entire run
+
+**Location:** `crates/hyalo-cli/src/commands/lint.rs:2226`
+
+```rust
+std::fs::read_to_string(full_path).with_context(|| format!("reading {rel_path}"))?;
+```
+
+The `?` propagates out of the per-file loop and kills the whole command.
+
+**VERIFIED:**
+
+```console
+$ printf '---\ntitle: bad\n---\n\xff\xfe invalid \xff\n' > invalid.md
+$ hyalo lint >/dev/null 2>&1    → exit 2, whole run aborted
+$ hyalo lint --fix >/dev/null   → exit 2
+$ hyalo find / summary / links  → exit 0 (find even includes the file in results;
+                                   links skips bomb.md with a warning)
+```
+
+One non-UTF-8 file anywhere in a 14k-file vault disables lint entirely — and `lint
+--fix`, so a single corrupt file blocks all autofix workflows. Other commands already
+have the right behavior (skip + warn, per `scanner/mod.rs:99-104` lossy handling).
+
+**Impact:** availability — one untrusted/corrupt file turns a vault-wide gate into a
+hard failure with no per-file skip.
+
+**Fix:** catch the UTF-8 error per file, emit one diagnostic per offending file, and
+continue; exit non-zero at the end if strictness requires it.
+
+### M-2. Windows drive-relative paths and NTFS ADS are outside every boundary gate
+
+**Location:** `crates/hyalo-core/src/index.rs:659-676` (SEC-1 path validation) and
+`crates/hyalo-cli/src/config.rs`/`discovery.rs` `resolve_file` (per DEC entry,
+decision-log.md:66: "rejects absolute paths, backslash-prefixed paths, and any path
+containing `..` segments").
+
+On Windows, `C:foo` is drive-relative: `Path::is_absolute()` returns `false` and it has
+no `ParentDir` component, so the SEC-1 snapshot check and the lexical `resolve_file`
+gate both pass it. At use time it resolves against the process CWD on drive `C:` —
+potentially outside the vault. Similarly `a.md:stream` (NTFS alternate data stream)
+is lexically inside the vault, so `set`/`append` would write an ADS instead of the
+file (silent wrong-target write, no escape).
+
+**SUSPECTED** — not executable on this macOS host. To confirm: on Windows, craft a
+snapshot index with `rel_path = "C:\\Windows\\..."`-style drive-relative entries and a
+vault file referenced as `note.md:ads`, then run `hyalo set`.
+
+**Fix:** on Windows, reject any rel path containing a `Prefix` component *or* a
+colon in the final component; the existing `Component::Prefix(_)` match in SEC-1 only
+fires for absolute prefixed paths, not drive-relative ones.
+
+---
+
+## LOW
+
+### L-1. `create-index -o` replaces a symlink instead of following it — inconsistent with the documented DEC-062 write policy
+
+**Location:** `crates/hyalo-core/src/index.rs:925-929`
+
+```rust
+let mut tmp = NamedTempFile::new_in(parent)
+    .with_context(|| format!("failed to create temp file for index"))?;
+...
+tmp.persist(path)
+```
+
+`write_snapshot` uses raw `NamedTempFile::new_in` + `persist` — it does not go through
+`fs_util::write_impl`'s `resolve_write_target`, which is the documented policy
+("when the destination is a symlink … the *target* is replaced; the symlink stays a
+symlink (DEC-062)", `fs_util.rs:198-205`).
+
+**VERIFIED:**
+
+```console
+$ ln -s /tmp/outside-target.md idx-link
+$ hyalo create-index -o idx-link   → success JSON
+$ ls -la idx-link                  → regular file (104 bytes), symlink gone
+$ cat /tmp/outside-target.md       → untouched
+```
+
+Safety-neutral here (replacing the link cannot escape, and it dodges what would
+otherwise be a symlink escape), but it silently diverges from the stated policy: a
+user who symlinks `.hyalo-index` to a shared location gets the link clobbered with no
+error. It also means the `-o` path gate and the frontmatter write path give different
+answers for the same input.
+
+**Fix:** route `write_snapshot` through `fs_util::atomic_write`/`atomic_write_within`
+(or `resolve_write_target` + the existing boundary check) so all writes share one
+symlink policy; or amend DEC-062 to say index writes replace links and document why.
+
+---
+
+## ADVISORY
+
+- **Dependency advisories (VERIFIED via `cargo audit`):** `bincode` 1.3.3
+  (RUSTSEC-2025-0141) and `yaml-rust` 0.4.5 (RUSTSEC-2024-0320), both via
+  `comrak 0.21 → syntect 5.3`, are allowed in `deny.toml` with a re-verified rationale —
+  reasonable. However `anyhow` RUSTSEC-2026-0190 (`Error::downcast_mut()` unsoundness)
+  is *not* in the ignore list; if `cargo deny check` is a CI gate it may now fail, and
+  if it doesn't, the advisory is silently untriaged. Add it to the ignore list with a
+  rationale or bump anyhow.
+- **YAML-bomb rejection leaks parser internals (VERIFIED):** the alias-bomb file
+  produces `warning: skipping bomb.md: failed to parse YAML frontmatter: error: line 1
+  column 7: budget breached: Anchors { anchors: 1 }` — the `Anchors { anchors: 1 }`
+  debug struct is saphyr-internal jargon. Map it to a human message.
+- **Case-insensitivity probing writes files into the user's vault**
+  (`case_index.rs:420-437`, `CASE_PROBE_PREFIX` create/delete): transient probe files
+  in the vault directory will ping file watchers and can race `git status`. Prefer a
+  probe in a temp dir on the same filesystem.
+- **Residual TOCTOU in `atomic_write_within` is documented** (`fs_util.rs:226-233`) —
+  accepted-risk reasoning is sound for a single-user local CLI; no action.
+- **Code-quality discipline is genuinely good** (one sentence, as instructed): every
+  `unwrap()`/`expect()` I found outside `#[cfg(test)]` modules is test code; the two
+  `unsafe` blocks (`broken_pipe.rs:47`, `index.rs:980`) are narrowly scoped, justified
+  with SAFETY comments, and PID-range-checked; hints shell-quote their arguments and
+  output is ANSI-sanitized (`output.rs:126`, verified with an OSC-escape file);
+  e2e tests are behavior-asserting (checked `mv.rs`), not snapshot-diffing.
+
+---
+
+## Not reviewed
+
+- `auto_link.rs` internals (3497 lines) — only exercised indirectly via `links`/`links
+  fix` on adversarial files; no unit-level audit of its scoring/rewriting logic.
+- `bm25.rs` ranking math and persisted-inverted-index consistency beyond `validate_doc_ids`.
+- `hyalo-mdlint` rule semantics and the `mdbook-lint` dependency's parser (`comrak`)
+  as an untrusted-input surface.
+- `views`, `filename_template`, `okf`/`madr`/`changelog` generators beyond the
+  changelog path-traversal probe.
+- Real Windows behavior (see M-2), real case-insensitive-filesystem behavior beyond
+  `case_index` unit tests.
+- Concurrency stress (two simultaneous mutating hyalo processes on the same vault);
+  only the single-writer atomicity machinery was reviewed statically.
+- Performance at true 14k-file scale (only `bench-e2e.sh` existence noted); link
+  fuzzy-candidate perf is a known open item (iter-206).
+- The ~4,800-test suite's coverage quality beyond spot checks; `xtask` CI gates.

--- a/hyalo-knowledgebase/reviews/deep-analysis-2-2026-08-23.md
+++ b/hyalo-knowledgebase/reviews/deep-analysis-2-2026-08-23.md
@@ -1,0 +1,334 @@
+---
+title: Deep analysis #2 2026-08-23 — architecture, code flaws, and test quality
+type: review
+date: 2026-08-23
+tags:
+  - review
+  - architecture
+  - testing
+status: active
+related:
+  - "[[reviews/adversarial-review-2026-08-23]]"
+  - "[[reviews/codebase-review-2026-08-06]]"
+---
+
+# Deep analysis #2 — architecture, code flaws, and test quality (2026-08-23)
+
+Second-pass review, complementary to `adversarial-review-2026-08-23.md` (whose H-1, M-1,
+M-2, L-1 remain open and are cross-referenced, not repeated). Labels: **VERIFIED** =
+reproduced; **SUSPECTED** = static reasoning. All file:line cites from current tree.
+
+---
+
+## Architecture
+
+### ARCH-1. `dispatch::dispatch` is a 2,100-line god function — orchestration and business logic live in the router
+
+**Location:** `crates/hyalo-cli/src/dispatch.rs:494` — one `match` with 26 `Commands::`
+arms spanning lines 494–2660. The `Find` arm alone is ~240 lines and contains real
+business logic, not routing:
+
+```rust
+// dispatch.rs:516-543 (inside the Find arm)
+if !file_positional.is_empty() {
+    if !filters_raw.glob.is_empty() {
+        crate::warn::warn(
+            "positional file arguments override the view's --glob; \
+             glob filter has been ignored",
+        );
+    }
+    filters_raw.file = file_positional;
+    filters_raw.glob.clear(); // file overrides view's glob
+}
+...
+if orphan && dead_end {
+    crate::warn::warn(
+        "--orphan and --dead-end are mutually exclusive ...",
+    );
+}
+```
+
+The `commands/` module tree exists and holds per-command logic (`commands/set.rs`,
+`commands/mv.rs`, …), but the dispatcher re-implements per-command pre/post logic inline:
+filter merging, warning policy, view adaptation (`adapt_view_result_to_ext`,
+`dispatch.rs:256`), snapshot patching (`patch_index_for_modified_files`,
+`dispatch.rs:427`). The Lint arm runs from line 1740 to 2128 (~390 lines).
+
+**Why it matters:** this is the file every new command touches; merge conflicts and
+missed cross-cutting steps (see ARCH-3) concentrate here; and command behavior can't be
+unit-tested without going through the whole dispatch path (hence 1,594 e2e tests driving
+a full process each).
+
+**Fix:** extract one handler per command (e.g. `commands::find::run(FindArgs) ->
+CommandOutcome`), with `dispatch` reduced to parsing `Commands` into args structs and
+calling it. The warnings above move into the handler where they're testable in-process.
+
+### ARCH-2. Lint lives in hyalo-cli (4,375 lines) while hyalo-mdlint is only the rule engine — the crate split doesn't match the domain
+
+**Location:** `crates/hyalo-cli/src/commands/lint.rs` (4,375 lines) vs
+`crates/hyalo-mdlint/src/` (engine + 5 rules, ~small).
+
+Schema validation, the profile system (`okf`, `madr`, `changelog`, `skills`, `github`),
+and all the HYALO native rules' orchestration live in the CLI crate. hyalo-mdlint
+contains only the mdbook-lint engine wrapper and native rules HYALO001–004. Consequences:
+lint logic cannot be reused by the planned library consumers of hyalo-core; profile
+lints (`changelog_lint.rs`, `madr_lint.rs`, `okf_lint.rs`, `skills_lint.rs`,
+`lint_github.rs` — five more CLI modules) form a hidden subsystem spread across the CLI.
+
+**Fix:** move schema validation + profile linting into hyalo-mdlint (it already depends
+on hyalo-core for `util::is_iso8601_*`). CLI keeps flag parsing and output formatting
+only. This also gives the lint subsystem an in-process API that the e2e suite can drive
+directly instead of spawning processes.
+
+### ARCH-3. Snapshot-index maintenance is scattered across three mechanisms — every mutating command must opt in correctly
+
+**VERIFIED (by grep):** three different index-refresh mechanisms coexist:
+
+- `mutation.rs` — `save_index_if_dirty` (called from `mv.rs`, `set.rs`, `remove.rs`,
+  `new.rs`, `lint.rs`, `append.rs`, `dispatch.rs`: 8 call sites)
+- `commands/tasks.rs:238,344` — a *local* `patch_index` helper (task toggle/set status)
+- `index.rs:481-558` — `refresh_entry` / `rename_entry` for graph-aware updates
+
+Each mutating command picks its own mechanism; nothing enforces that a new mutating
+command refreshes the persisted index at all. The mtime-fallback in
+`patch_index_for_modified_files` (dispatch.rs:427) catches stale *entries* on the next
+read, but the *link graph* staleness is only patched by whoever remembered to call the
+graph-aware variant — `index.rs:439`'s own doc comment admits this class of bug existed
+("`--index` left the persisted link graph stale").
+
+**Fix:** make index refresh a property of the write path, not the caller: one
+`MutationJournal` (or equivalent) that every frontmatter/link write goes through, which
+records dirty rel_paths + whether links changed, and is flushed once at the end of
+dispatch. `tasks.rs`'s local `patch_index` then disappears.
+
+### ARCH-4. The hints layer is a hand-maintained parallel copy of the CLI surface — and the codebase knows it drifts
+
+**Location:** `crates/hyalo-cli/src/hints.rs` (4,522 lines, 168 functions, 29
+hand-assembled `"hyalo ..."` command strings).
+
+Hints are built by string concatenation that must mirror clap's argument definitions by
+hand. The project's own test docs state the consequence
+(`tests/e2e/hint_execution.rs:1-9`):
+
+> Every other hint test asserts on *substrings* of a hint's command … That is exactly
+> the assertion the broken `hyalo tags --limit 0` hint satisfied while failing to run:
+> `tags` takes no `--limit`, only `tags summary` does.
+
+`hint_execution.rs` (execution-based sweep over a fixture vault) is an excellent
+bandage, but it's an admission: the design guarantees drift, and the meta-test catches
+it only after the fact, only for commands the fixture happens to exercise.
+
+**Fix:** derive hint commands from a typed command registry shared with `cli/args.rs`
+(e.g. a `CommandSpec` table that both clap definition and hint building consume), or
+build hints as argv vectors serialized through the existing `shell_quote` — never as
+hand-written strings. Incrementally: new hints must go through a `HintBuilder::cmd()`
+API that takes argv, which is already trivially available.
+
+### ARCH-5. hyalo-core exposes everything — the "library" boundary is 26 flat `pub` modules, including dead code
+
+**Location:** `crates/hyalo-core/src/lib.rs:1-26` — every module `pub`, including
+plumbing (`fs_util`, `util`, `warn`) and internals (`case_index`, `math`,
+`common_words` — a 962-line embedded word list).
+
+**VERIFIED dead code:** `crates/hyalo-core/src/math.rs` exports exactly one function,
+`pub fn add(a: i64, b: i64) -> anyhow::Result<i64>`, with zero callers anywhere in the
+workspace (`grep -rn "hyalo_core::math" crates` → only math.rs itself). It is public
+API that exists only to be public.
+
+**Why it matters:** every internal refactor is a semver-breaking change; invariants
+(e.g. "callers must re-check the boundary after symlink resolution" in fs_util) are
+enforced only by doc comments; `keywords = ["yaml", "frontmatter", ...]` on the crate
+suggests it's meant for external consumption, but nothing marks the supported surface.
+
+**Fix:** curate a root `pub use` façade (parse/find/mutate/link-graph/index types), make
+internal modules `pub(crate)`, delete `math.rs`. Cheap now, expensive after external
+consumers appear.
+
+### ARCH-6. Presentation-layer mass rivals the core: hints (4.5k) + output (3.2k) + run (1.9k) + output_pipeline + suggest ≈ 11k lines
+
+Not a bug, but the shape says the CLI's hardest problem is *deciding what to say*, not
+doing the work. Combined with ARCH-1/ARCH-4 this means behavior changes require edits in
+up to four layers (args.rs → dispatch arm → command module → hints.rs), with no
+compile-time coupling between them. The fixes above (typed hints, thin dispatch) also
+address this; noting it so the layer count itself is treated as a cost.
+
+---
+
+## Code flaws (new; not in report #1)
+
+### F-1. `task toggle --section` silently applies to every section with a matching name
+
+**Location:** `crates/hyalo-cli/src/commands/tasks.rs:33-55` — the section filter
+matches *all* tasks whose heading matches:
+
+```rust
+let matched: Vec<usize> = tasks
+    .iter()
+    .filter(|t| { ... filter.matches(level, text) ... })
+    .map(|t| t.line)
+    .collect();
+```
+
+**VERIFIED:**
+
+```console
+$ printf '%s\n' '---' 'title: t' '---' '# Sec' '- [ ] one' '' '# Sec' '- [ ] two' > t.md
+$ hyalo task toggle t.md --section "Sec"
+→ toggles BOTH "one" and "two" (output lists both), no ambiguity warning
+```
+
+Contrast: `links` reports `ambiguous: N` when a wikilink target matches multiple files.
+The mutation analog of that ambiguity — duplicate headings — is applied silently.
+
+**Impact:** a user with repeated headings ("## Tasks" per ADR, "## Notes" per month)
+toggles far more than intended, and because `task toggle` writes immediately, there's no
+dry-run default to catch it (the write is atomic, but not previewed).
+
+**Fix:** when a `--section` selector matches multiple *distinct heading instances*,
+either refuse with an ambiguity error suggesting `--line`, or require an explicit
+`--all-sections`/`--nth` flag. At minimum include the matched section line numbers in
+the output the way links reports ambiguity.
+
+### F-2. BM25 tokenization makes CJK content silently unsearchable
+
+**Location:** `crates/hyalo-core/src/bm25.rs:148-149`:
+
+```rust
+pub fn tokenize(text: &str, stemmer: &Stemmer) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+```
+
+For CJK text (no whitespace), every alphanumeric run becomes one giant token, so query
+terms never match. **VERIFIED:**
+
+```console
+$ printf '%s\n' '---' 'title: CJK' '---' '日本語のテキストです' > cjk.md
+$ hyalo find 日本語
+→ {"results": [], "total": 0}    # the file contains the query verbatim
+```
+
+The module header claims "Unicode-aware tokenization" — it is Unicode-*safe*, not
+CJK-*aware*. For a knowledgebase tool this is a silent correctness hole for any
+Japanese/Chinese/Korean vault.
+
+**Fix (cheapest first):** (a) detect CJK runs and additionally index them as bigrams;
+(b) or fall back to substring matching when the query contains CJK and BM25 returns
+nothing; (c) at minimum, document the limitation in `find --help` and the README.
+
+### F-3. jq runtime errors embed the entire document serialization in the error message
+
+**Location:** `crates/hyalo-cli/src/output.rs:710` (`apply_jq_filter_result`) — the
+jaq runtime error is stringified with its input. **VERIFIED:**
+
+```console
+$ hyalo find --jq '.results | .file'
+→ "cause": "jq runtime error: cannot index [{\"file\":\"a.md\",...ENTIRE RESULT SET...] with \"file\""
+```
+
+On a 14k-file vault a single mistyped filter dumps megabytes of vault content into the
+error envelope (stderr/JSON). It's also a content-disclosure vector for scripted
+consumers that log error output.
+
+**Fix:** truncate the embedded value to ~200 chars (`…` suffix) and name the failing
+filter position instead; keep full detail behind `--debug` if needed.
+
+### F-4. Mixed-type property sort produces type-grouped ordering that looks wrong to users
+
+**Location:** `crates/hyalo-core/src/filter/sort.rs:92-95` — documented fallback:
+
+```rust
+// Fallback: compare JSON representations.
+let sa = va.to_string();
+let sb = vb.to_string();
+sa.cmp(&sb)
+```
+
+**VERIFIED:** with `priority: 9` (number), `priority: 10` (number), `priority: "10"`
+(string), `find --sort property:priority` returns `c.md ("10"), a.md (9), b.md (10)` —
+the string `"10"` sorts before the number `9` because `"` (0x22) < any digit. The total
+ordering is deliberate (comment says so) but the result is user-visible nonsense with no
+signal that types were mixed.
+
+**Fix:** keep the total order, but emit a one-line warning when a sort key has mixed
+types in the result set ("property:priority has mixed types; numbers sort after
+strings"), or group missing/type-mismatched last consistently (as `Null` already does).
+
+### F-5. Dead public API: `hyalo_core::math::add`
+
+**VERIFIED** (see ARCH-5): zero callers workspace-wide. Delete it. If it predates a
+checked-arithmetic policy, that policy is not enforced by having the function around —
+clippy's `arithmetic_side_effects` would be the actual mechanism.
+
+### F-6. Carry-overs from report #1 that this analysis re-confirms as the top fixes
+
+- **H-1** unrestricted `dir` in `.hyalo.toml` (`config.rs:706`) — the write-scope escape;
+- **M-1** whole-run `lint` abort on one invalid-UTF-8 file (`commands/lint.rs:2226`);
+- **L-1** `create-index -o` bypasses the DEC-062 symlink-following write policy
+  (`index.rs:925-929`).
+
+---
+
+## Test quality assessment
+
+**What's there (and good):** 3,652 tests total — 1,594 e2e (process-level, TempDir
+fixtures), 1,136 core unit, 922 CLI unit. Assertions are overwhelmingly behavioral with
+specific expected values, e.g. `tests/e2e/links.rs`:
+
+```rust
+assert_eq!(
+    broken, 2,
+    "expected 2 broken links: [[nonexistent]] from b.md and [[Authnticoton]] ..."
+);
+```
+
+The standout is `tests/e2e/hint_execution.rs`: it harvests every hint the CLI emits
+across a broad command sweep and *executes* each against a fresh vault copy — a genuinely
+unusual and valuable meta-test. Matrix tests (`dispatch.rs:2660`
+`find_needs_stem_map_matrix`), boundary/TOCTOU tests in `fs_util.rs`, and
+permission-preservation tests show the suite tests *consequences*, not snapshots.
+
+**Gaps, ordered by payoff:**
+
+1. **T-1 — No concurrency or crash-recovery tests.** The atomic-write machinery
+   (temp + fsync + rename + dir-fsync, `fs_util.rs:204-278`) is the tool's most
+   safety-critical code and has zero tests under contention or interruption: no
+   two-process mutation race, no SIGKILL-mid-write, no kill between `persist` and
+   parent-dir sync. A `#[test]` that spawns N processes running `set` on the same file
+   and asserts the file is always one of the valid old/new contents is ~50 lines.
+2. **T-2 — Fuzz-shaped inputs are hand-rolled, not systematic.** The adversarial
+   hardening (SEC-1/2/3, line caps, anchor budgets) was driven by one-off PoCs;
+   there are no `cargo-fuzz` targets for the four parser surfaces (frontmatter splice,
+   scanner, link parser, MessagePack loader). Report #1 survived my afternoon of manual
+   probing, but a corpus-based fuzzer would cover the input space continuously. (Set up
+   targets, not CI, per project preference.)
+3. **T-3 — e2e assertions parse into `serde_json::Value` and index by string** —
+   `json["results"]["links"]["total"].as_u64()`. Output-shape regressions surface as
+   `expect` panics with generic messages rather than typed assertion failures, and
+   nothing ties the tests to the typed output structs that already exist
+   (DEC-025). Deserializing into the real structs in tests would make schema changes a
+   compile error across 1,594 tests instead of a runtime discovery.
+4. **T-4 — Windows-only behaviors are untested anywhere** (see report #1 M-2): no
+   drive-relative-path test, no ADS test, and the CI matrix — per `Cross.toml` —
+   builds for Windows but the case-insensitivity logic (`case_index.rs`) is exercised
+   only by `#[cfg]`-gated tests on the platforms that happen to run them. Probe-file
+   behavior on real NTFS is unverified.
+5. **T-5 — Substring assertions still dominate some suites** (`links.rs`: 104
+   `.contains(` vs 5 typed-JSON parses). `hint_execution.rs`'s header explains exactly
+   why substring assertions lie. Where they assert on *file content* they're fine; where
+   they assert on *CLI output* they should become JSON parses.
+6. **T-6 — No scale regression gate.** `bench-e2e.sh` exists but is manual; my probe
+   (2,000 files: find 119 ms, links 367 ms cold) shows no problem today, but the known
+   perf debt (iter-206 fuzzy candidates) has nothing preventing reintroduction. A
+   criterion bench asserting a budget on the 14k-file synthetic vault, run in CI
+   nightly, would pin it.
+
+---
+
+## Not reviewed (this pass)
+
+- `auto_link.rs` scoring internals beyond the e2e surface (unchanged from report #1).
+- `bm25.rs` ranking math beyond tokenization (IDF/length normalization correctness).
+- `schema.rs` validation semantics vs. its Obsidian/OKF analogues.
+- `init.rs`/`deinit.rs` CLAUDE.md managed-section editing (managed_region.rs).
+- jaq evaluation semantics (trusted dependency).
+- Error-message quality across all 40+ commands (spot-checked only).


### PR DESCRIPTION
## Summary
Commits the two external reviews and the six iterations that carve up their findings into actionable work. KB-only; no code changes.

Reviews:
- `reviews/adversarial-review-2026-08-23.md` — security deep-dive (untrusted-vault threat model)
- `reviews/deep-analysis-2-2026-08-23.md` — architecture / code flaws / test quality

Iterations (all `status: planned`):
- **221** config-dir boundary — H-1 write-scope escape via untrusted `.hyalo.toml` `dir` (security gate)
- **222** security/robustness batch — M-1 UTF-8 lint abort, L-1 `create-index` symlink policy, M-2 Windows drive-relative/ADS, error-leak + `cargo deny` advisories
- **223** query/output correctness — F-1 silent multi-section toggle, F-2 CJK-unsearchable BM25, F-3 jq error dumps whole result set, F-4 mixed-type sort
- **224** test-quality hardening — T-1 concurrency/crash, T-2 fuzz targets, T-3 typed e2e, T-4 Windows, T-5 substring→typed, T-6 scale gate
- **225** architecture (thin dispatch + typed hints + core façade) — ARCH-1/4/5, not release-gating
- **226** architecture (lint crate boundary + index journal) — ARCH-2/3, not release-gating

Sequencing intent: 221 → 222 → 223 → 224 gate/should-fix before v0.21.0; 225/226 are post-release maintainability debt. The `math.rs` example the review cited was uncommitted test scaffolding (since removed), so the ARCH-5 façade point is kept but the "delete math.rs" framing is dropped.

## Test plan
- [x] `hyalo lint` clean on the six iteration files (reviews are in the lint-ignored `reviews/**` path)
- [x] All `[[wikilinks]]` between the iterations and reviews resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEuPjCTq74bwJgoWbcvHrD