### PR TITLE
iter-219: list splice, mixed-EOL honesty, frontmatter budget truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ and this project adheres to
 
 ### Fixed
 
+- **`append`/`remove <key>=<value>` touch only the appended or removed list
+  item, not the whole list** (iter-219, dogfood NEW-5). Extends iter-214's
+  minimal-diff guarantee inside a key's own span: appending one item to a
+  block-style list now inserts one dash line; removing one item drops one
+  dash line; flow-style lists (`tags: [a, b]`) stay flow. On a GitHub Docs
+  corpus, one appended `redirect_from` entry used to change more than one
+  line in 361 of 406 files (worst case 118 lines); it is now 0. Detected
+  structurally (old/new list values differ by exactly one scalar item), so
+  it applies uniformly to `append`, `remove --property k=v`, and
+  `remove --tag t` with no CLI-layer changes. A replacement, reorder, or
+  non-scalar item still falls back to the existing whole-key re-serialize.
+  See DEC-086.
+- **Mixed line endings in a frontmatter block no longer silently drop or
+  add `\r`s** (iter-219, dogfood NEW-7). A block that mixed `\r\n` and `\n`
+  per line used to be re-expanded to a single style based only on the
+  *opening* delimiter's ending, with no warning — untouched lines could
+  lose their `\r` (or gain one they never had) on any unrelated `set`. This
+  now routes through the same "full rewrite, explicit warning" fallback as
+  every other unsupported shape (DEC-081); the file still ends up on one
+  consistent line ending, but the warning names why. See DEC-087.
+- **Frontmatter parser errors no longer leak Rust struct internals**
+  (iter-219, dogfood NEW-8). A budget breach read `budget breached:
+  ScalarBytes { total_scalar_bytes: 8205 }`; a duplicate key read `...,
+  set DuplicateKeyPolicy in Options if acceptable` — both are now plain,
+  actionable text naming what happened, with no leaked type names. See
+  DEC-088.
+- **A file whose last bytes are literally `---` (no trailing newline, no
+  body) no longer gains one on write** (iter-219, dogfood NEW-16a).
+- **`set`/`append --property a.b=x` now rejects the write, instead of
+  silently creating a literal `"a.b"` key, when a top-level `a` already
+  exists as a mapping** (iter-219, dogfood NEW-16b). hyalo does not support
+  dotted path syntax for nested properties; only this specific collision is
+  guarded — a dotted key with no colliding map is unchanged (still a
+  literal flat key). See DEC-089.
+- **`set` now notes when type inference silently retypes a previously
+  string-valued property** (iter-219, dogfood NEW-16c), e.g. `code: '42'`
+  (string) becoming `code: 42` (number) via `set --property code=42`. The
+  write still proceeds — this is an advisory, like the existing date and
+  enum/pattern advisories, not a new gate. See DEC-089.
 - **`lint --fix` totals now describe the whole run, not the display-capped
   listing** (iter-218, dogfood NEW-6). `total_fixed`, `total_remaining`,
   and `total_conflicts` — in both the text footer and JSON — were
@@ -79,6 +118,11 @@ and this project adheres to
 
 ### Changed
 
+- **Frontmatter's internal scalar-content budget raised to match the
+  documented 64 KiB limit** (iter-219, dogfood NEW-8), from an undocumented
+  8192-byte parser default. A real GitHub Docs `admin/index.md` (7,961
+  bytes of frontmatter) was about 40 redirect entries from becoming
+  unreadable, well inside its own documented ceiling. See DEC-088.
 - **`lint --fix` JSON reports `remaining_errors`/`remaining_warnings`
   instead of `errors`/`warnings`** (iter-218, dogfood NEW-6b — **BREAKING
   JSON shape change**). Both plain `lint` and `lint --fix` used the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to
   it applies uniformly to `append`, `remove --property k=v`, and
   `remove --tag t` with no CLI-layer changes. A replacement, reorder, or
   non-scalar item still falls back to the existing whole-key re-serialize.
+  A list that itself doesn't fit the splicer's simple model — a `#`-comment
+  interleaved between items, or a flow list with a trailing comment the
+  tokenizer can't represent — now falls back with an explicit warning
+  rather than a silent whole-key re-serialize that could drop the comment.
   See DEC-086.
 - **Mixed line endings in a frontmatter block no longer silently drop or
   add `\r`s** (iter-219, dogfood NEW-7). A block that mixed `\r\n` and `\n`
@@ -39,12 +43,6 @@ and this project adheres to
   DEC-088.
 - **A file whose last bytes are literally `---` (no trailing newline, no
   body) no longer gains one on write** (iter-219, dogfood NEW-16a).
-- **`set`/`append --property a.b=x` now rejects the write, instead of
-  silently creating a literal `"a.b"` key, when a top-level `a` already
-  exists as a mapping** (iter-219, dogfood NEW-16b). hyalo does not support
-  dotted path syntax for nested properties; only this specific collision is
-  guarded — a dotted key with no colliding map is unchanged (still a
-  literal flat key). See DEC-089.
 - **`set` now notes when type inference silently retypes a previously
   string-valued property** (iter-219, dogfood NEW-16c), e.g. `code: '42'`
   (string) becoming `code: 42` (number) via `set --property code=42`. The
@@ -118,6 +116,18 @@ and this project adheres to
 
 ### Changed
 
+- **`set`/`append --property a.b=x` now rejects the whole batch, instead of
+  silently creating a literal `"a.b"` key, when a top-level `a` already
+  exists as a mapping in a matched file's frontmatter** (iter-219, dogfood
+  NEW-16b — behavior change: a write that previously succeeded now fails
+  with an error). Scoped to `set` and `append` only — `remove` is
+  unaffected, since removing a nonexistent literal dotted key was already a
+  harmless no-op. hyalo does not support dotted path syntax for nested
+  properties; only this specific collision is guarded — a dotted key with
+  no colliding map is still unchanged (still a literal flat key). The
+  guard runs as a pre-pass over every matched file before any file in the
+  batch is written, so a collision found on file 7 of 50 does not leave
+  files 1-6 already mutated. See DEC-089.
 - **Frontmatter's internal scalar-content budget raised to match the
   documented 64 KiB limit** (iter-219, dogfood NEW-8), from an undocumented
   8192-byte parser default. A real GitHub Docs `admin/index.md` (7,961

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -200,6 +200,28 @@ pub fn append(
     let mut prop_results: Vec<(Vec<String>, Vec<String>)> =
         vec![(Vec::new(), Vec::new()); parsed_args.len()];
 
+    // --- Dotted-key collision pre-pass (iter-219 M5): reject the whole batch
+    //     before any file is modified, not mid-loop (a mid-loop `return` left
+    //     earlier files in the batch already written, and skipped the
+    //     end-of-loop `save_index_if_dirty` entirely).
+    for (full_path, rel_path) in &files {
+        let props = match frontmatter::read_frontmatter(full_path) {
+            Ok(p) => p,
+            Err(e) if frontmatter::is_parse_error(&e) => continue,
+            Err(e) => return Err(e),
+        };
+        if !filter::matches_frontmatter_filters(&props, where_property_filters, where_tag_filters) {
+            continue;
+        }
+        for (name, _, _) in &parsed_args {
+            if let Some(outcome) =
+                super::reject_dotted_property_collision(name, &props, rel_path, format)
+            {
+                return Ok(outcome);
+            }
+        }
+    }
+
     // --- Pre-validation pass (BUG-D): validate all proposed writes before any file
     //     is modified. Unlike `set`, `append` validates the *merged post-append*
     //     value so that list constraints (e.g. `type = "list"`) see the resulting
@@ -285,12 +307,10 @@ pub fn append(
 
         let mut file_changed = false;
 
+        // The dotted-key collision guard already ran as a whole-batch
+        // pre-pass above, so no per-file check (and no mid-loop `return`)
+        // is needed here.
         for (i, (name, raw_value, new_val)) in parsed_args.iter().enumerate() {
-            if let Some(outcome) =
-                super::reject_dotted_property_collision(name, &props, rel_path, format)
-            {
-                return Ok(outcome);
-            }
             match append_value_in_memory(&mut props, name, raw_value, new_val) {
                 Ok(true) => {
                     prop_results[i].0.push(rel_path.clone()); // modified

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -286,6 +286,11 @@ pub fn append(
         let mut file_changed = false;
 
         for (i, (name, raw_value, new_val)) in parsed_args.iter().enumerate() {
+            if let Some(outcome) =
+                super::reject_dotted_property_collision(name, &props, rel_path, format)
+            {
+                return Ok(outcome);
+            }
             match append_value_in_memory(&mut props, name, raw_value, new_val) {
                 Ok(true) => {
                     prop_results[i].0.push(rel_path.clone()); // modified
@@ -1075,5 +1080,48 @@ author: alice
             matches!(outcome, CommandOutcome::UserError(_)),
             "append that violates merged-value constraint should fail under --validate"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Dotted-key collision guard (iter-219 NEW-16b)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn append_rejects_dotted_property_colliding_with_existing_map() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r"
+---
+versions:
+  fpt: '*'
+---
+"),
+        )
+        .unwrap();
+
+        let outcome = append(
+            tmp.path(),
+            &["versions.fpt=X".to_owned()],
+            &["note.md".to_owned()],
+            &[],
+            &[],
+            &[],
+            Format::Json,
+            &mut None,
+            None,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
+        match outcome {
+            CommandOutcome::UserError(msg) => {
+                assert!(msg.contains("versions"), "msg: {msg}");
+            }
+            other => panic!("expected UserError, got: {other:?}"),
+        }
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("versions.fpt"), "content:\n{content}");
     }
 }

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -116,15 +116,6 @@ pub fn resolve_file_user_ci(
     discovery::resolve_file_ci(dir, path_arg, case_insensitive)
 }
 
-/// Known noisy suffixes that upstream YAML parser errors (`serde-saphyr`)
-/// append to otherwise-useful messages — internal-API advice ("set
-/// `DuplicateKeyPolicy` in `Options`...") that means nothing to a user
-/// looking at a `HYALO005` lint violation or an OKF generator skip
-/// warning. Stripped by [`terse_root_cause`] before the message reaches the
-/// user; the line/column info and the actual cause (e.g. "duplicate mapping
-/// key: type") are left intact.
-const NOISY_ERROR_SUFFIXES: &[&str] = &[", set DuplicateKeyPolicy in Options if acceptable"];
-
 /// Redundant leading prefixes on the deepest error message. Every caller of
 /// [`terse_root_cause`] already frames the message as a frontmatter parse
 /// failure (`HYALO005` prepends "could not parse frontmatter: ", the OKF
@@ -133,9 +124,16 @@ const NOISY_ERROR_SUFFIXES: &[&str] = &[", set DuplicateKeyPolicy in Options if 
 /// HYALO005 double-prefix). Stripped so the user sees a single prefix.
 const REDUNDANT_ERROR_PREFIXES: &[&str] = &["failed to parse YAML frontmatter: "];
 
-/// Deepest error message in an `anyhow` chain, condensed to its first line and
-/// stripped of known-noisy upstream advisory suffixes (see
-/// [`NOISY_ERROR_SUFFIXES`]).
+/// Deepest error message in an `anyhow` chain, condensed to its first line
+/// and stripped of the redundant leading prefix every caller here already
+/// supplies its own version of (see [`REDUNDANT_ERROR_PREFIXES`]).
+///
+/// Upstream `serde-saphyr` messages that used to carry noisy internal-API
+/// advice (`", set DuplicateKeyPolicy in Options if acceptable"`) are
+/// already rewritten to plain text before they ever reach this function —
+/// `hyalo_core::frontmatter::friendly_parse_error` intercepts those at the
+/// point the `FrontmatterError` is constructed — so there is nothing left
+/// for this function itself to strip beyond the redundant prefix.
 ///
 /// The YAML parser attaches a multi-line source snippet to its error; for a
 /// one-line lint message or generator skip warning we keep only the leading
@@ -149,19 +147,9 @@ const REDUNDANT_ERROR_PREFIXES: &[&str] = &["failed to parse YAML frontmatter: "
 pub(crate) fn terse_root_cause(err: &anyhow::Error) -> String {
     let root = err.root_cause().to_string();
     let first_line = root.lines().next().unwrap_or(&root).trim();
-    // Strip to a fixed point so one suffix's removal can expose another
-    // (matters once NOISY_ERROR_SUFFIXES grows past a single entry).
     let mut msg = first_line;
     loop {
         let mut stripped_any = false;
-        for suffix in NOISY_ERROR_SUFFIXES {
-            if let Some(stripped) = msg.strip_suffix(suffix) {
-                msg = stripped;
-                stripped_any = true;
-            }
-        }
-        // Drop a redundant leading "failed to parse YAML frontmatter: " so the
-        // caller's own prefix is not doubled (HYALO005 double-prefix).
         for prefix in REDUNDANT_ERROR_PREFIXES {
             if let Some(stripped) = msg.strip_prefix(prefix) {
                 msg = stripped;
@@ -573,10 +561,12 @@ pub fn reject_dotted_property_collision(
              mapping in this file's frontmatter"
         ),
         None,
-        Some(
-            "hyalo does not support dotted path syntax for nested properties — \
-             --property sets a literal top-level key only",
-        ),
+        Some(&format!(
+            "hyalo does not support dotted path syntax for nested properties — --property \
+             sets a literal top-level key only, which would sit beside '{prefix}' rather than \
+             nesting into it; edit the file directly to change a value inside '{prefix}', or \
+             choose a key name that does not collide with it"
+        )),
         None,
     );
     Some(CommandOutcome::UserError(out))
@@ -713,8 +703,11 @@ mod tests {
     /// A real duplicate-mapping-key YAML error, produced through the same
     /// frontmatter-parsing entry point `HYALO005` and the OKF/MADR skip
     /// warnings use, must not leak the upstream `serde-saphyr` internal-API
-    /// advice ("set DuplicateKeyPolicy in Options if acceptable") — but must
-    /// keep the actual cause and its line/column location.
+    /// advice ("set DuplicateKeyPolicy in Options if acceptable") through
+    /// `terse_root_cause`'s output — regardless of whether the stripping
+    /// happens here or (as of iter-219) upstream in
+    /// `hyalo_core::frontmatter::friendly_parse_error` — and must keep the
+    /// actual cause and its line/column location.
     #[test]
     fn terse_root_cause_strips_duplicate_key_policy_advice() {
         let tmp = tempfile::tempdir().unwrap();
@@ -737,7 +730,7 @@ mod tests {
             "must keep the actual cause: {msg:?}"
         );
         assert!(
-            msg.contains("line 2 column 1"),
+            msg.contains("line 2, column 1"),
             "must keep line/column info: {msg:?}"
         );
     }

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -543,6 +543,45 @@ pub fn reject_filter_in_mutation_property(key: &str, format: Format) -> Option<C
     Some(CommandOutcome::UserError(out))
 }
 
+/// Reject a dotted `--property a.b=x` when a top-level key `a` already
+/// exists as a mapping in `props` (iter-219 NEW-16b).
+///
+/// hyalo does not support dotted path syntax for nested properties — `set
+/// --property a.b=x` always creates (or overwrites) a literal top-level key
+/// named `"a.b"`, never a nested field under `a`. That is silently
+/// confusing exactly when `a` already exists as a mapping (e.g. GitHub
+/// Docs-shaped `versions: { fpt: '*', ghec: '*' }` plus `--property
+/// versions.fpt=X`), since the new literal key sits right next to the map
+/// it looks like it should have nested into. Only that specific collision is
+/// rejected; a dotted key with no colliding map is unchanged (still a
+/// literal flat key) — nested-path support itself is out of scope.
+#[must_use]
+pub fn reject_dotted_property_collision(
+    name: &str,
+    props: &indexmap::IndexMap<String, serde_json::Value>,
+    rel_path: &str,
+    format: Format,
+) -> Option<CommandOutcome> {
+    let (prefix, _) = name.split_once('.')?;
+    if !matches!(props.get(prefix), Some(serde_json::Value::Object(_))) {
+        return None;
+    }
+    let out = crate::output::format_error(
+        format,
+        &format!(
+            "{rel_path}: invalid property name '{name}': '{prefix}' already exists as a \
+             mapping in this file's frontmatter"
+        ),
+        None,
+        Some(
+            "hyalo does not support dotted path syntax for nested properties — \
+             --property sets a literal top-level key only",
+        ),
+        None,
+    );
+    Some(CommandOutcome::UserError(out))
+}
+
 /// If exactly one file was specified and there is exactly one result, unwrap to a bare
 /// JSON object. Otherwise return the full array.
 #[must_use]
@@ -694,7 +733,7 @@ mod tests {
             "must not leak the internal-API advice suffix: {msg:?}"
         );
         assert!(
-            msg.contains("duplicate mapping key"),
+            msg.contains("duplicate key") && msg.contains("'title'"),
             "must keep the actual cause: {msg:?}"
         );
         assert!(

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -107,12 +107,19 @@ fn has_date_shape(value: &str) -> bool {
 /// batch (a `--property type=X` assignment) or the default schema when no type
 /// is set. Per-file `type:` overrides are not probed here — advisories are
 /// best-effort hints, not a substitute for `lint`.
+///
+/// A third, independent advisory (iter-219 NEW-16c) fires when `previous_value`
+/// (the property's value in the first mutated file that already had it set,
+/// before this write) was a string and the newly inferred value is a number
+/// or boolean — the CLI arg is always a bare string, so type inference has no
+/// way to know the property was deliberately quoted to stay text.
 fn advisory_note(
     name: &str,
     raw_value: &str,
     parsed_value: &Value,
     schema: Option<&SchemaConfig>,
     batch_type: Option<&str>,
+    previous_value: Option<&Value>,
 ) -> Option<String> {
     // (1) Date-typed lexicographic-sort advisory.
     if is_date_typed_property(name) && !raw_value.is_empty() && !looks_like_date(raw_value) {
@@ -142,6 +149,21 @@ fn advisory_note(
         {
             return Some(format!(
                 "{violation}; write proceeds — run `hyalo lint` to enforce, or `set --validate` to reject"
+            ));
+        }
+    }
+
+    // (3) Type-inference retype advisory.
+    if let Some(Value::String(_)) = previous_value {
+        let new_kind = match parsed_value {
+            Value::Number(_) => Some("a number"),
+            Value::Bool(_) => Some("a boolean"),
+            _ => None,
+        };
+        if let Some(new_kind) = new_kind {
+            return Some(format!(
+                "value {raw_value:?} was previously stored as a string and is now inferred as \
+                 {new_kind}; pass a schema type to keep it a string"
             ));
         }
     }
@@ -457,6 +479,12 @@ pub fn set(
     });
     let mut batch_type_from_file: Option<String> = None;
 
+    // First observed pre-mutation value for each property (iter-219 NEW-16c),
+    // used by the retype advisory below. Captured from the first file where
+    // the property already existed, mirroring how `batch_type_from_file`
+    // samples a single representative file rather than every file in the batch.
+    let mut first_old_value: Vec<Option<Value>> = vec![None; parsed_props.len()];
+
     // L-2: relative paths skipped because their frontmatter would not parse.
     let mut skipped_unparseable: Vec<String> = Vec::new();
 
@@ -489,6 +517,14 @@ pub fn set(
 
         // Apply all --property mutations
         for (i, (name, _, value)) in parsed_props.iter().enumerate() {
+            if let Some(outcome) =
+                super::reject_dotted_property_collision(name, &props, rel_path, format)
+            {
+                return Ok(outcome);
+            }
+            if first_old_value[i].is_none() {
+                first_old_value[i] = props.get(*name).cloned();
+            }
             let already_same = props.get(*name) == Some(value);
             if already_same {
                 prop_results[i].1.push(rel_path.clone()); // skipped
@@ -552,14 +588,22 @@ pub fn set(
         .as_deref()
         .or(batch_type_from_file.as_deref());
 
-    for ((name, raw_value, parsed_value), (modified, skipped)) in
-        parsed_props.iter().zip(prop_results)
+    for (i, ((name, raw_value, parsed_value), (modified, skipped))) in
+        parsed_props.iter().zip(prop_results).enumerate()
     {
         let total = modified.len() + skipped.len();
         // Advisory note (write still proceeds; lint remains the enforcement gate):
         //   1. BUG-B: a date-typed property receiving a non-date value.
         //   2. iter-181 task 1: an enum/pattern value the schema would reject.
-        let note = advisory_note(name, raw_value, parsed_value, schema, batch_type);
+        //   3. iter-219 NEW-16c: type inference silently retyping a string.
+        let note = advisory_note(
+            name,
+            raw_value,
+            parsed_value,
+            schema,
+            batch_type,
+            first_old_value[i].as_ref(),
+        );
         let result = SetPropertyResult {
             property: (*name).to_owned(),
             value: parsed_value.clone(),
@@ -1419,5 +1463,153 @@ type: post
             matches!(outcome, CommandOutcome::Success { .. }),
             "expected success for valid enum value"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Dotted-key collision guard (iter-219 NEW-16b)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn set_rejects_dotted_property_colliding_with_existing_map() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("note.md"),
+            md!(r"
+---
+versions:
+  fpt: '*'
+  ghec: '*'
+---
+"),
+        )
+        .unwrap();
+
+        let outcome = set(
+            tmp.path(),
+            &["versions.fpt=X".to_owned()],
+            &[],
+            &["note.md".to_owned()],
+            &[],
+            &[],
+            &[],
+            Format::Json,
+            &mut None,
+            None,
+            false,
+            false,
+            None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
+        )
+        .unwrap();
+        match outcome {
+            CommandOutcome::UserError(msg) => {
+                assert!(msg.contains("versions"), "msg: {msg}");
+                assert!(msg.contains("mapping"), "msg: {msg}");
+            }
+            other => panic!("expected UserError, got: {other:?}"),
+        }
+
+        // The file must be untouched — the command aborted before writing.
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(!content.contains("versions.fpt"), "content:\n{content}");
+    }
+
+    #[test]
+    fn set_allows_dotted_property_with_no_colliding_map() {
+        // No `versions` map exists, so the dotted key is just an unusual but
+        // literal top-level key name — allowed (nested-path support itself
+        // is out of scope, only the collision is guarded against).
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+
+        let outcome = set(
+            tmp.path(),
+            &["versions.fpt=X".to_owned()],
+            &[],
+            &["note.md".to_owned()],
+            &[],
+            &[],
+            &[],
+            Format::Json,
+            &mut None,
+            None,
+            false,
+            false,
+            None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
+        )
+        .unwrap();
+        assert!(matches!(outcome, CommandOutcome::Success { .. }));
+        let content = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+        assert!(content.contains("versions.fpt"), "content:\n{content}");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Type-inference retype advisory (iter-219 NEW-16c)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn set_notes_when_a_previously_string_value_is_retyped_as_a_number() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ncode: '42'\n---\n").unwrap();
+
+        let outcome = set(
+            tmp.path(),
+            &["code=42".to_owned()],
+            &[],
+            &["note.md".to_owned()],
+            &[],
+            &[],
+            &[],
+            Format::Json,
+            &mut None,
+            None,
+            false,
+            false,
+            None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
+        )
+        .unwrap();
+        let CommandOutcome::Success { output: out, .. } = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let note = parsed["note"].as_str().unwrap_or_default();
+        assert!(
+            note.contains("previously stored as a string"),
+            "note: {note:?}"
+        );
+        assert!(note.contains("number"), "note: {note:?}");
+    }
+
+    #[test]
+    fn set_no_retype_advisory_when_property_is_new() {
+        // The property didn't exist before, so there is nothing to "retype" —
+        // this is ordinary type inference, not a surprise.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("note.md"), "---\ntitle: Note\n---\n").unwrap();
+
+        let outcome = set(
+            tmp.path(),
+            &["priority=3".to_owned()],
+            &[],
+            &["note.md".to_owned()],
+            &[],
+            &[],
+            &[],
+            Format::Json,
+            &mut None,
+            None,
+            false,
+            false,
+            None,
+            hyalo_core::case_index::CaseInsensitiveMode::Off,
+        )
+        .unwrap();
+        let CommandOutcome::Success { output: out, .. } = outcome else {
+            panic!("expected success")
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed.get("note").is_none() || parsed["note"].is_null());
     }
 }

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -162,8 +162,9 @@ fn advisory_note(
         };
         if let Some(new_kind) = new_kind {
             return Some(format!(
-                "value {raw_value:?} was previously stored as a string and is now inferred as \
-                 {new_kind}; pass a schema type to keep it a string"
+                "value {raw_value:?} is now inferred as {new_kind}, but at least one matched \
+                 file previously stored this property as a string; pass a schema type to keep \
+                 it a string (other matched files may differ)"
             ));
         }
     }
@@ -396,6 +397,31 @@ pub fn set(
     let mut tag_results: Vec<(Vec<String>, Vec<String>)> =
         vec![(Vec::new(), Vec::new()); tag_args.len()];
 
+    // --- Dotted-key collision pre-pass (iter-219 M5): reject the whole batch
+    //     before any file is modified, not mid-loop. A mid-loop `return` (the
+    //     original iter-219 shape) left files already written in an earlier
+    //     iteration on disk, and skipped the end-of-loop
+    //     `save_index_if_dirty` entirely — a partial write plus a stale
+    //     on-disk index for whichever file happened to trip the guard.
+    for (full_path, rel_path) in &files {
+        let props = match frontmatter::read_frontmatter(full_path) {
+            Ok(p) => p,
+            // Parse errors are reported as warnings during the write loop; skip here.
+            Err(e) if frontmatter::is_parse_error(&e) => continue,
+            Err(e) => return Err(e),
+        };
+        if !filter::matches_frontmatter_filters(&props, where_property_filters, where_tag_filters) {
+            continue;
+        }
+        for (name, _, _) in &parsed_props {
+            if let Some(outcome) =
+                super::reject_dotted_property_collision(name, &props, rel_path, format)
+            {
+                return Ok(outcome);
+            }
+        }
+    }
+
     // --- Pre-validation pass (BUG-D): validate all proposed writes before any file
     //     is modified. This keeps batch mutations atomic — if any file would fail
     //     validation, no files are written. The schema is chosen from the merged
@@ -515,13 +541,10 @@ pub fn set(
 
         let mut file_changed = false;
 
-        // Apply all --property mutations
+        // Apply all --property mutations. The dotted-key collision guard
+        // already ran as a whole-batch pre-pass above, so no per-file check
+        // (and no mid-loop `return`) is needed here.
         for (i, (name, _, value)) in parsed_props.iter().enumerate() {
-            if let Some(outcome) =
-                super::reject_dotted_property_collision(name, &props, rel_path, format)
-            {
-                return Ok(outcome);
-            }
             if first_old_value[i].is_none() {
                 first_old_value[i] = props.get(*name).cloned();
             }
@@ -1576,7 +1599,7 @@ versions:
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         let note = parsed["note"].as_str().unwrap_or_default();
         assert!(
-            note.contains("previously stored as a string"),
+            note.contains("previously stored this property as a string"),
             "note: {note:?}"
         );
         assert!(note.contains("number"), "note: {note:?}");

--- a/crates/hyalo-cli/tests/e2e/errors.rs
+++ b/crates/hyalo-cli/tests/e2e/errors.rs
@@ -743,7 +743,16 @@ Body
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let json: serde_json::Value = serde_json::from_str(&stderr)
+    // stderr may also carry a `warning: ... rewriting the entire frontmatter
+    // block ...` line ahead of the JSON error — appending a value this huge
+    // to `aliases: []` can legitimately hit the flow-list-not-modellable
+    // fallback (iter-219 M1) before the budget check even runs. Parse from
+    // the first `{` so an unrelated leading warning line doesn't break this
+    // test's ability to find the JSON error it actually cares about.
+    let json_start = stderr
+        .find('{')
+        .unwrap_or_else(|| panic!("expected JSON error on stderr, got: {stderr}"));
+    let json: serde_json::Value = serde_json::from_str(&stderr[json_start..])
         .unwrap_or_else(|e| panic!("expected JSON error on stderr, got: {stderr}\nerr: {e}"));
     assert_eq!(json["error"], "frontmatter would exceed size budget");
 }

--- a/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
+++ b/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
@@ -575,7 +575,7 @@ fn set_retype_advisory_fires_as_json_note() {
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     let note = parsed["results"]["note"].as_str().unwrap_or_default();
     assert!(
-        note.contains("previously stored as a string"),
+        note.contains("previously stored this property as a string"),
         "stdout: {stdout}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
+++ b/crates/hyalo-cli/tests/e2e/frontmatter_preservation.rs
@@ -155,7 +155,11 @@ fn remove_drops_only_the_removed_key() {
 }
 
 #[test]
-fn append_to_a_list_rewrites_only_that_list() {
+fn append_to_a_block_list_touches_only_the_appended_line() {
+    // iter-219 NEW-5: `append` used to re-serialize the whole touched list —
+    // even the untouched sibling items would be re-emitted, potentially with
+    // a different quote/fold style. This asserts the exact expected text,
+    // not just a coarse line-count heuristic.
     let tmp = TempDir::new().unwrap();
     gh_docs_file(&tmp);
     let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
@@ -167,11 +171,58 @@ fn append_to_a_list_rewrites_only_that_list() {
     assert!(ok, "append failed: {stderr}");
 
     let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
-    assert!(after.contains("  - Actions\n"));
-    // Only the appended item is new; the `intro`, `featuredLinks` and
-    // `children` blocks must be untouched.
+    let expected = before.replacen(
+        "topics:\n  - CI\n  - CD\n  - Developer\n",
+        "topics:\n  - CI\n  - CD\n  - Developer\n  - Actions\n",
+        1,
+    );
+    assert_eq!(
+        after, expected,
+        "expected exactly one new line, byte-for-byte"
+    );
     assert_eq!(diff_line_count(&before, &after), 1, "{after}");
-    assert!(after.contains("changelog:\n  label: actions\n  prefix: 'GitHub Actions: '\n"));
+}
+
+#[test]
+fn remove_from_a_block_list_drops_only_that_line() {
+    let tmp = TempDir::new().unwrap();
+    gh_docs_file(&tmp);
+    let before = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+
+    let (ok, stderr) = run(&tmp, &["remove", "index.md", "--property", "topics=CD"]);
+    assert!(ok, "remove failed: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
+    let expected = before.replacen(
+        "topics:\n  - CI\n  - CD\n  - Developer\n",
+        "topics:\n  - CI\n  - Developer\n",
+        1,
+    );
+    assert_eq!(
+        after, expected,
+        "expected exactly one dropped line, byte-for-byte"
+    );
+}
+
+#[test]
+fn append_to_a_flow_list_stays_flow() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Note\ntags: [a, b]\nstatus: draft\n---\n\nBody\n",
+    );
+    let before = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+
+    let (ok, stderr) = run(&tmp, &["append", "note.md", "--property", "tags=c"]);
+    assert!(ok, "append failed: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert_eq!(
+        after,
+        before.replace("tags: [a, b]\n", "tags: [a, b, c]\n"),
+        "flow list must stay flow, byte-for-byte: {after}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -297,6 +348,75 @@ fn crlf_files_stay_crlf_and_keep_untouched_lines() {
     assert!(!after.contains("\n\n"), "no bare LF expected: {after:?}");
 }
 
+#[test]
+fn mixed_line_endings_warn_instead_of_silently_dropping_cr() {
+    // iter-219 NEW-7: a file whose lines mix `\r\n` and `\n` must not lose
+    // (or gain) `\r`s with no explanation. The block is normalized to one
+    // style — but only via the announced full-rewrite fallback.
+    let tmp = TempDir::new().unwrap();
+    let content = "---\ntitle: 'Mixed'\r\nstatus: planned\n---\n\nBody\n";
+    write_md(tmp.path(), "mixed.md", content);
+
+    let (ok, stderr) = run(&tmp, &["set", "mixed.md", "--property", "status=done"]);
+    assert!(ok, "set failed: {stderr}");
+    assert!(
+        stderr.contains("mixes line endings")
+            || stderr.contains("rewriting the entire frontmatter block"),
+        "mixed endings must be announced, not silent: {stderr}"
+    );
+}
+
+#[test]
+fn no_trailing_newline_body_less_file_stays_byte_identical_outside_change() {
+    // iter-219 NEW-16a: a file whose last three bytes are literally `---`
+    // must not gain a trailing newline it never had.
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "no_trailing.md", "---\ntitle: Note\n---");
+
+    let (ok, stderr) = run(
+        &tmp,
+        &["set", "no_trailing.md", "--property", "status=draft"],
+    );
+    assert!(ok, "set failed: {stderr}");
+    let after = fs::read_to_string(tmp.path().join("no_trailing.md")).unwrap();
+    assert_eq!(after, "---\ntitle: Note\nstatus: draft\n---");
+    assert!(
+        !after.ends_with('\n'),
+        "gained a trailing newline: {after:?}"
+    );
+}
+
+#[test]
+fn frontmatter_close_to_64kib_parses_and_splices() {
+    // iter-219 NEW-8: the parser's internal scalar budget used to be an
+    // undocumented 8 KiB, well under the documented 64 KiB frontmatter
+    // limit. A large-but-compliant redirect_from list must actually work.
+    use std::fmt::Write as _;
+
+    let tmp = TempDir::new().unwrap();
+    let mut fm = String::from("title: Big\nredirect_from:\n");
+    for i in 0..40 {
+        writeln!(fm, "  - /path/to/redirect/entry-{i}").unwrap();
+    }
+    writeln!(fm, "notes: {}", "a".repeat(50 * 1024)).unwrap();
+    write_md(tmp.path(), "big.md", &format!("---\n{fm}---\n\nBody\n"));
+
+    let (ok, stderr) = run(
+        &tmp,
+        &["append", "big.md", "--property", "redirect_from=/new-path"],
+    );
+    assert!(ok, "append failed on ~50 KiB frontmatter: {stderr}");
+    assert!(
+        !stderr.contains("ScalarBytes") && !stderr.contains("budget breached"),
+        "leaked parser internals: {stderr}"
+    );
+    let after = fs::read_to_string(tmp.path().join("big.md")).unwrap();
+    assert!(
+        after.contains("/new-path"),
+        "content missing appended entry"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Fallback behaviour: explicit, warned, never silent
 // ---------------------------------------------------------------------------
@@ -410,4 +530,52 @@ fn properties_rename_preserves_surrounding_formatting() {
     let after = fs::read_to_string(tmp.path().join("index.md")).unwrap();
     assert!(after.contains("pageLayout: product-landing\n"), "{after}");
     assert_eq!(diff_line_count(&before, &after), 2, "{after}");
+}
+
+// ---------------------------------------------------------------------------
+// Write-path honesty: dotted-key collision, retype advisory (iter-219 NEW-16)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dotted_property_colliding_with_existing_map_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\nversions:\n  fpt: '*'\n---\n\nBody\n",
+    );
+    let before = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["set", "note.md", "--property", "versions.fpt=X"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "dotted-key collision must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("versions"), "stderr: {stderr}");
+    assert!(stderr.contains("mapping"), "stderr: {stderr}");
+
+    let after = fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert_eq!(after, before, "file must be untouched after rejection");
+}
+
+#[test]
+fn set_retype_advisory_fires_as_json_note() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "note.md", "---\ncode: '42'\n---\n\nBody\n");
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["set", "note.md", "--property", "code=42"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let note = parsed["results"]["note"].as_str().unwrap_or_default();
+    assert!(
+        note.contains("previously stored as a string"),
+        "stdout: {stdout}"
+    );
 }

--- a/crates/hyalo-core/src/frontmatter/mod.rs
+++ b/crates/hyalo-core/src/frontmatter/mod.rs
@@ -10,7 +10,7 @@ pub use parse::{
     FrontmatterBudgetError, body_only, check_frontmatter_size_budget, hyalo_options,
     read_frontmatter, skip_frontmatter, write_frontmatter, write_frontmatter_within,
 };
-pub(crate) use parse::{is_closing_delimiter, is_opening_delimiter};
+pub(crate) use parse::{friendly_parse_error, is_closing_delimiter, is_opening_delimiter};
 pub use types::{infer_type, parse_value};
 
 /// Maximum number of content lines in a YAML frontmatter block.
@@ -100,7 +100,7 @@ pub fn as_budget_error(err: &anyhow::Error) -> Option<&FrontmatterBudgetError> {
 mod tests {
     use super::*;
     use parse::{
-        Document, LineEnding, detect_list_indent_style, opening_delimiter,
+        Document, LineEnding, detect_list_indent_style, friendly_parse_error, opening_delimiter,
         read_frontmatter_from_reader,
     };
     use serde_json::Value;
@@ -1265,5 +1265,173 @@ Body.
             .read_exact(&mut prefix)
             .unwrap();
         assert_eq!(prefix, original);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Mixed line endings (iter-219 NEW-7)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn write_frontmatter_mixed_line_endings_uses_announced_full_rewrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mixed.md");
+        // Opening delimiter (and most lines) use LF; `title`'s line uses CRLF.
+        // A byte-preserving splice would keep `title`'s deliberate quoting
+        // verbatim; the full-rewrite fallback this must now take does not.
+        std::fs::write(
+            &path,
+            "---\ntitle: 'Keep me'\r\nstatus: draft\n---\nBody.\n",
+        )
+        .unwrap();
+
+        let mut props = read_frontmatter(&path).unwrap();
+        props.insert("extra".to_owned(), Value::String("new".into()));
+        write_frontmatter(&path, &props).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !content.contains("'Keep me'"),
+            "expected the full-rewrite fallback (quote style not preserved), got:\n{content}"
+        );
+        assert!(content.contains("extra: new"), "content:\n{content}");
+        assert!(content.contains("Keep me"), "content:\n{content}");
+    }
+
+    #[test]
+    fn write_frontmatter_pure_crlf_still_splices_minimally() {
+        // A file that is *consistently* CRLF throughout must still take the
+        // fast, minimal-diff splice path — only genuinely mixed endings
+        // should force the full-rewrite fallback.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("pure_crlf.md");
+        std::fs::write(
+            &path,
+            "---\r\ntitle: 'Keep me'\r\nstatus: draft\r\n---\r\nBody.\r\n",
+        )
+        .unwrap();
+
+        let mut props = read_frontmatter(&path).unwrap();
+        props.insert("extra".to_owned(), Value::String("new".into()));
+        write_frontmatter(&path, &props).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("'Keep me'"),
+            "consistent CRLF must still splice (quote style preserved), got:\n{content}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // No trailing newline on a body-less closing delimiter (iter-219 NEW-16a)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn write_frontmatter_no_trailing_newline_stays_byte_identical_outside_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("no_trailing.md");
+        // The file's last three bytes are literally `---` — no body, no
+        // trailing newline anywhere after the closing delimiter.
+        std::fs::write(&path, "---\ntitle: Note\n---").unwrap();
+
+        let mut props = read_frontmatter(&path).unwrap();
+        props.insert("status".to_owned(), Value::String("draft".into()));
+        write_frontmatter(&path, &props).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "---\ntitle: Note\nstatus: draft\n---");
+        assert!(
+            !content.ends_with('\n'),
+            "must not gain a trailing newline it never had: {content:?}"
+        );
+    }
+
+    #[test]
+    fn write_frontmatter_no_trailing_newline_with_body_keeps_separator() {
+        // Sanity check on the guard's other branch: when there *is* a body,
+        // the separator newline after the closing `---` is still required
+        // regardless of what the (nonexistent, in this case) prior close
+        // looked like.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("with_body.md");
+        std::fs::write(&path, "---\ntitle: Note\n---\nBody.\n").unwrap();
+
+        let mut props = read_frontmatter(&path).unwrap();
+        props.insert("status".to_owned(), Value::String("draft".into()));
+        write_frontmatter(&path, &props).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "---\ntitle: Note\nstatus: draft\n---\nBody.\n");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Friendly parser errors (iter-219 NEW-8)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn friendly_parse_error_hides_budget_breach_internals() {
+        use indexmap::IndexMap;
+
+        // A scalar value beyond the (raised) budget still needs to produce
+        // a clean message — no `ScalarBytes { total_scalar_bytes: .. }`.
+        let huge = "a".repeat(hyalo_options().budget.unwrap().max_total_scalar_bytes + 1);
+        let yaml = format!("x: {huge}\n");
+        let err =
+            serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(&yaml, hyalo_options())
+                .unwrap_err();
+        let msg = friendly_parse_error(&err);
+        assert!(!msg.contains("ScalarBytes"), "leaked internals: {msg}");
+        assert!(!msg.contains('{'), "leaked Debug-struct syntax: {msg}");
+        assert!(msg.contains("too large"), "message: {msg}");
+    }
+
+    #[test]
+    fn friendly_parse_error_hides_duplicate_key_policy_internals() {
+        use indexmap::IndexMap;
+
+        let yaml = "x: 1\nx: 2\n";
+        let err =
+            serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(yaml, hyalo_options())
+                .unwrap_err();
+        let msg = friendly_parse_error(&err);
+        assert!(
+            !msg.contains("DuplicateKeyPolicy"),
+            "leaked internal type name: {msg}"
+        );
+        assert!(msg.contains("duplicate key"), "message: {msg}");
+    }
+
+    #[test]
+    fn scalar_budget_matches_documented_frontmatter_limit() {
+        // NEW-8: the parser's scalar-content budget must not be tighter than
+        // the documented 64 KiB frontmatter limit.
+        assert_eq!(
+            hyalo_options().budget.unwrap().max_total_scalar_bytes,
+            MAX_FRONTMATTER_BYTES
+        );
+    }
+
+    #[test]
+    fn frontmatter_close_to_64kib_parses_without_leaked_errors() {
+        use indexmap::IndexMap;
+
+        // GitHub Docs-shaped repro: a large redirect_from list well under the
+        // documented 64 KiB ceiling must actually parse (it used to trip the
+        // undocumented 8 KiB scalar budget at a fraction of that size).
+        let mut yaml = String::from("redirect_from:\n");
+        // ~60 entries * ~100 bytes ≈ 6 KiB well within budget; pad one long
+        // entry to push total scalar bytes close to, but under, 64 KiB.
+        for i in 0..40 {
+            writeln!(yaml, "  - /path/to/redirect/entry-{i}").unwrap();
+        }
+        let padding = "a".repeat(60 * 1024);
+        writeln!(yaml, "notes: {padding}").unwrap();
+
+        let result =
+            serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(&yaml, hyalo_options());
+        assert!(
+            result.is_ok(),
+            "~60 KiB frontmatter must parse under the documented 64 KiB budget: {:?}",
+            result.err().map(|e| friendly_parse_error(&e))
+        );
     }
 }

--- a/crates/hyalo-core/src/frontmatter/mod.rs
+++ b/crates/hyalo-core/src/frontmatter/mod.rs
@@ -1378,7 +1378,7 @@ Body.
         let err =
             serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(&yaml, hyalo_options())
                 .unwrap_err();
-        let msg = friendly_parse_error(&err);
+        let msg = friendly_parse_error(&err, MAX_FRONTMATTER_BYTES);
         assert!(!msg.contains("ScalarBytes"), "leaked internals: {msg}");
         assert!(!msg.contains('{'), "leaked Debug-struct syntax: {msg}");
         assert!(msg.contains("too large"), "message: {msg}");
@@ -1392,7 +1392,7 @@ Body.
         let err =
             serde_saphyr::from_str_with_options::<IndexMap<String, Value>>(yaml, hyalo_options())
                 .unwrap_err();
-        let msg = friendly_parse_error(&err);
+        let msg = friendly_parse_error(&err, MAX_FRONTMATTER_BYTES);
         assert!(
             !msg.contains("DuplicateKeyPolicy"),
             "leaked internal type name: {msg}"
@@ -1431,7 +1431,9 @@ Body.
         assert!(
             result.is_ok(),
             "~60 KiB frontmatter must parse under the documented 64 KiB budget: {:?}",
-            result.err().map(|e| friendly_parse_error(&e))
+            result
+                .err()
+                .map(|e| friendly_parse_error(&e, MAX_FRONTMATTER_BYTES))
         );
     }
 }

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -34,13 +34,97 @@ pub fn hyalo_options() -> Options {
             max_aliases: 0,
             max_anchors: 0,
             max_nodes: 5_000,
-            max_total_scalar_bytes: 8192,
+            // Matches MAX_FRONTMATTER_BYTES (the documented 64 KiB frontmatter
+            // limit): scalar content is a subset of the whole block, which is
+            // already capped there by the pre-read line/byte guards in every
+            // caller, so this can never be the tighter limit in practice
+            // (iter-219 NEW-8 — it used to be 8192, well below the documented
+            // ceiling, and the resulting parser error leaked raw budget-breach
+            // internals; see `friendly_parse_error`).
+            max_total_scalar_bytes: MAX_FRONTMATTER_BYTES,
             max_documents: 1,
             ..Budget::default()
         }),
         duplicate_keys: DuplicateKeyPolicy::Error,
         strict_booleans: true,
         ..Options::default()
+    }
+}
+
+/// Turn a `serde_saphyr` parse error into a hyalo-voice message with no
+/// leaked parser-internal type names (iter-219 NEW-8).
+///
+/// `serde_saphyr`'s own `Display` is mostly clean, but two variants render
+/// their payload with `{:?}` and leak Rust struct syntax straight to the
+/// user: a budget breach (`budget breached: ScalarBytes { total_scalar_bytes:
+/// 8205 }`) and a duplicate key (`duplicate mapping key: x, set
+/// DuplicateKeyPolicy in Options if acceptable` — a hint about *our* internal
+/// `Options` type, not something the user can act on). Both are intercepted
+/// here; everything else falls through to the crate's own message, which
+/// does not have this problem.
+pub(crate) fn friendly_parse_error(err: &serde_saphyr::Error) -> String {
+    match unwrap_snippet(err) {
+        serde_saphyr::Error::Budget { breach, location } => {
+            format!(
+                "{} (line {} column {})",
+                describe_budget_breach(breach),
+                location.line(),
+                location.column()
+            )
+        }
+        serde_saphyr::Error::DuplicateMappingKey { key, location } => {
+            let what = match key {
+                Some(k) => format!("duplicate key '{k}' in frontmatter"),
+                None => "duplicate key in frontmatter".to_owned(),
+            };
+            format!(
+                "{what} — YAML mappings must have unique keys (line {} column {})",
+                location.line(),
+                location.column()
+            )
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Walk past `Error::WithSnippet` wrappers to the underlying error.
+fn unwrap_snippet(err: &serde_saphyr::Error) -> &serde_saphyr::Error {
+    let mut current = err;
+    while let serde_saphyr::Error::WithSnippet { error, .. } = current {
+        current = error;
+    }
+    current
+}
+
+/// Describe a budget breach without leaking the `BudgetBreach` Debug format.
+fn describe_budget_breach(breach: &serde_saphyr::budget::BudgetBreach) -> String {
+    use serde_saphyr::budget::BudgetBreach;
+    match breach {
+        BudgetBreach::ScalarBytes { total_scalar_bytes } => format!(
+            "frontmatter content is too large ({total_scalar_bytes} bytes of scalar text exceeds \
+             the {MAX_FRONTMATTER_BYTES}-byte limit); trim large values or split them into separate files"
+        ),
+        BudgetBreach::Anchors { .. } | BudgetBreach::Aliases { .. } => {
+            "frontmatter uses YAML anchors/aliases, which hyalo does not support — expand the \
+             anchor into a literal value"
+                .to_owned()
+        }
+        BudgetBreach::Depth { .. } => {
+            "frontmatter nests too deeply for hyalo's parser limits — flatten the structure"
+                .to_owned()
+        }
+        BudgetBreach::Documents { .. } => {
+            "frontmatter contains more than one YAML document (a `---` document separator inside \
+             the block) — hyalo expects exactly one"
+                .to_owned()
+        }
+        BudgetBreach::Nodes { .. } | BudgetBreach::Events { .. } => {
+            "frontmatter is too large or complex for hyalo's parser limits".to_owned()
+        }
+        BudgetBreach::MergeKeys { .. } => {
+            "frontmatter uses too many YAML merge keys (`<<`) for hyalo's parser limits".to_owned()
+        }
+        _ => "frontmatter exceeds hyalo's parser limits".to_owned(),
     }
 }
 
@@ -237,7 +321,8 @@ impl Document {
                 let props: IndexMap<String, Value> =
                     serde_saphyr::from_str_with_options(yaml, hyalo_options()).map_err(|e| {
                         anyhow::Error::new(FrontmatterError(format!(
-                            "failed to parse YAML frontmatter: {e}"
+                            "failed to parse YAML frontmatter: {}",
+                            friendly_parse_error(&e)
                         )))
                     })?;
                 (props, compact)
@@ -409,6 +494,16 @@ fn write_frontmatter_impl(
             // Invalid UTF-8 in the frontmatter: `fm_str` is lossy, so splicing
             // it would write replacement characters. Re-serialize instead.
             _ if !is_utf8 => splice_blocked = Some(FallbackReason::NotUtf8),
+            // iter-219 NEW-7: the block mixes line-ending styles per line.
+            // Splicing (and the CRLF re-expansion below) both assume one
+            // consistent style for the whole block, so silently proceeding
+            // would coerce every line to `span.line_ending`'s style without
+            // telling the user their `\r`s just moved or vanished. Take the
+            // full-serialization path with an explicit warning instead —
+            // still a normalization, but an announced one (DEC-081/DEC-086).
+            _ if span.mixed_line_endings => {
+                splice_blocked = Some(FallbackReason::MixedLineEndings);
+            }
             // An empty block (`---\n---`) has nothing to preserve — take the
             // full-serialization path silently.
             Some(yaml) if yaml.trim().is_empty() => {}
@@ -484,7 +579,14 @@ fn write_frontmatter_impl(
         out.extend_from_slice(eol.as_bytes());
         out.extend_from_slice(yaml.as_bytes());
         out.extend_from_slice(b"---");
-        out.extend_from_slice(eol.as_bytes());
+        // iter-219 NEW-16a: a file whose last bytes are literally `---` with
+        // no trailing newline (no body, closing delimiter unterminated)
+        // must round-trip that way — not gain a newline it never had. Any
+        // other shape (there's a body, or the original had a newline here)
+        // keeps the separator as before.
+        if !body_bytes.is_empty() || span.closing_has_trailing_newline {
+            out.extend_from_slice(eol.as_bytes());
+        }
     }
     out.extend_from_slice(&body_bytes);
 
@@ -600,9 +702,36 @@ struct FrontmatterSpan {
     /// Whether the file began with a UTF-8 BOM (only meaningful when
     /// `body_offset > 0`; preserved verbatim on rewrite).
     has_bom: bool,
-    /// Line ending used by the existing frontmatter block (only meaningful
-    /// when `body_offset > 0`).
+    /// Line ending used by the opening `---` line (only meaningful when
+    /// `body_offset > 0`).
     line_ending: LineEnding,
+    /// `true` when at least one line within the block used a different
+    /// terminator than `line_ending` (iter-219 NEW-7). A rewrite always
+    /// normalizes the whole block to one style; when this is set, that
+    /// normalization is a real, user-visible change and must be announced
+    /// via [`FallbackReason::MixedLineEndings`] rather than applied
+    /// silently.
+    mixed_line_endings: bool,
+    /// `true` when the closing `---` line itself ends with a newline.
+    /// `false` only for a file whose last three bytes are literally `---`
+    /// with nothing after them (iter-219 NEW-16a) — rewriting such a file
+    /// must not invent a trailing newline that was never there.
+    closing_has_trailing_newline: bool,
+}
+
+/// `true` when `raw_line` (a line as returned by `BufRead::read_line`,
+/// terminator included) ends with the same line-ending style as `expected`.
+/// A line with no terminator at all (only possible at EOF) is never a
+/// mismatch here — that is a distinct, separately handled concern
+/// ([`FrontmatterSpan::closing_has_trailing_newline`]), not a mixed-ending one.
+fn line_ending_matches(raw_line: &str, expected: LineEnding) -> bool {
+    if !raw_line.ends_with('\n') {
+        return true;
+    }
+    match expected {
+        LineEnding::CrLf => raw_line.ends_with("\r\n"),
+        LineEnding::Lf => !raw_line.ends_with("\r\n"),
+    }
 }
 
 /// Find the byte offset in `file` where the body starts (i.e. the byte immediately
@@ -622,6 +751,8 @@ fn find_body_offset(file: &mut File) -> Result<FrontmatterSpan> {
         body_offset: 0,
         has_bom: false,
         line_ending: LineEnding::Lf,
+        mixed_line_endings: false,
+        closing_has_trailing_newline: true,
     };
 
     // Peek at the first line.
@@ -636,6 +767,8 @@ fn find_body_offset(file: &mut File) -> Result<FrontmatterSpan> {
 
     let mut content_bytes: usize = 0;
     let mut line_count: usize = 0;
+    let mut mixed_line_endings = false;
+    let closing_has_trailing_newline;
 
     loop {
         line.clear();
@@ -656,9 +789,13 @@ fn find_body_offset(file: &mut File) -> Result<FrontmatterSpan> {
                 "unclosed frontmatter: file starts with `---` but no closing `---` was found"
             );
         }
+        if !line_ending_matches(&line, opening.line_ending) {
+            mixed_line_endings = true;
+        }
         let trimmed = line.trim_end_matches(['\n', '\r']);
         if is_closing_delimiter(trimmed) {
             // Consumed up to and including the closing `---\n`
+            closing_has_trailing_newline = line.ends_with('\n');
             break;
         }
         line_count += 1;
@@ -678,6 +815,8 @@ fn find_body_offset(file: &mut File) -> Result<FrontmatterSpan> {
         body_offset: pos,
         has_bom: opening.has_bom,
         line_ending: opening.line_ending,
+        mixed_line_endings,
+        closing_has_trailing_newline,
     })
 }
 
@@ -774,7 +913,8 @@ pub(crate) fn read_frontmatter_from_reader<R: BufRead>(
 
     serde_saphyr::from_str_with_options(&yaml, hyalo_options()).map_err(|e| {
         anyhow::Error::new(FrontmatterError(format!(
-            "failed to parse YAML frontmatter: {e}"
+            "failed to parse YAML frontmatter: {}",
+            friendly_parse_error(&e)
         )))
     })
 }

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -62,28 +62,52 @@ pub fn hyalo_options() -> Options {
 /// `Options` type, not something the user can act on). Both are intercepted
 /// here; everything else falls through to the crate's own message, which
 /// does not have this problem.
-pub(crate) fn friendly_parse_error(err: &serde_saphyr::Error) -> String {
+///
+/// `scalar_byte_limit` is the `max_total_scalar_bytes` the caller's
+/// `Options` was actually built with — passed explicitly, rather than
+/// hardcoding [`MAX_FRONTMATTER_BYTES`], because `splice_frontmatter`'s own
+/// verification pass parses with a *different* (2x) budget; a caller
+/// wiring that error path through here in the future must not get a
+/// message naming the wrong limit.
+pub(crate) fn friendly_parse_error(err: &serde_saphyr::Error, scalar_byte_limit: usize) -> String {
     match unwrap_snippet(err) {
-        serde_saphyr::Error::Budget { breach, location } => {
-            format!(
-                "{} (line {} column {})",
-                describe_budget_breach(breach),
-                location.line(),
-                location.column()
-            )
-        }
+        serde_saphyr::Error::Budget { breach, location } => with_location(
+            &describe_budget_breach(breach, scalar_byte_limit),
+            *location,
+        ),
         serde_saphyr::Error::DuplicateMappingKey { key, location } => {
             let what = match key {
                 Some(k) => format!("duplicate key '{k}' in frontmatter"),
                 None => "duplicate key in frontmatter".to_owned(),
             };
-            format!(
-                "{what} — YAML mappings must have unique keys (line {} column {})",
-                location.line(),
-                location.column()
+            with_location(
+                &format!("{what} — YAML mappings must have unique keys"),
+                *location,
             )
         }
-        other => other.to_string(),
+        // Every other variant's own `Display` is already clean — return the
+        // *original* (still-`WithSnippet`-wrapped, when present) error, not
+        // the unwrapped inner one, so its source-snippet caret/window
+        // survives. Only the two rewritten variants above need unwrapping,
+        // to reach their `location`/`breach`/`key` fields for matching.
+        _ => err.to_string(),
+    }
+}
+
+/// Append `" at line X, column Y"` — the same phrasing `serde_saphyr`'s own
+/// localizer uses for every other error — unless `location` is
+/// [`serde_saphyr::Location::UNKNOWN`] (no precise position was available),
+/// in which case the suffix is omitted entirely rather than printing
+/// "line 0, column 0".
+fn with_location(message: &str, location: serde_saphyr::Location) -> String {
+    if location == serde_saphyr::Location::UNKNOWN {
+        message.to_owned()
+    } else {
+        format!(
+            "{message} at line {}, column {}",
+            location.line(),
+            location.column()
+        )
     }
 }
 
@@ -97,12 +121,19 @@ fn unwrap_snippet(err: &serde_saphyr::Error) -> &serde_saphyr::Error {
 }
 
 /// Describe a budget breach without leaking the `BudgetBreach` Debug format.
-fn describe_budget_breach(breach: &serde_saphyr::budget::BudgetBreach) -> String {
+///
+/// `scalar_byte_limit` names the actual configured `max_total_scalar_bytes`
+/// for the `ScalarBytes` case — see [`friendly_parse_error`] for why this
+/// isn't just [`MAX_FRONTMATTER_BYTES`].
+fn describe_budget_breach(
+    breach: &serde_saphyr::budget::BudgetBreach,
+    scalar_byte_limit: usize,
+) -> String {
     use serde_saphyr::budget::BudgetBreach;
     match breach {
         BudgetBreach::ScalarBytes { total_scalar_bytes } => format!(
             "frontmatter content is too large ({total_scalar_bytes} bytes of scalar text exceeds \
-             the {MAX_FRONTMATTER_BYTES}-byte limit); trim large values or split them into separate files"
+             the {scalar_byte_limit}-byte limit); trim large values or split them into separate files"
         ),
         BudgetBreach::Anchors { .. } | BudgetBreach::Aliases { .. } => {
             "frontmatter uses YAML anchors/aliases, which hyalo does not support — expand the \
@@ -322,7 +353,7 @@ impl Document {
                     serde_saphyr::from_str_with_options(yaml, hyalo_options()).map_err(|e| {
                         anyhow::Error::new(FrontmatterError(format!(
                             "failed to parse YAML frontmatter: {}",
-                            friendly_parse_error(&e)
+                            friendly_parse_error(&e, MAX_FRONTMATTER_BYTES)
                         )))
                     })?;
                 (props, compact)
@@ -914,7 +945,7 @@ pub(crate) fn read_frontmatter_from_reader<R: BufRead>(
     serde_saphyr::from_str_with_options(&yaml, hyalo_options()).map_err(|e| {
         anyhow::Error::new(FrontmatterError(format!(
             "failed to parse YAML frontmatter: {}",
-            friendly_parse_error(&e)
+            friendly_parse_error(&e, MAX_FRONTMATTER_BYTES)
         )))
     })
 }

--- a/crates/hyalo-core/src/frontmatter/splice.rs
+++ b/crates/hyalo-core/src/frontmatter/splice.rs
@@ -56,12 +56,25 @@ pub(super) enum FallbackReason {
     VerificationFailed,
     /// Serializing an individual changed key on its own failed.
     SerializeFailed,
-    /// A single item was appended to a flow-style list (`key: [a, b]`), but
-    /// the new item cannot be represented as an inline flow token (e.g. it
-    /// would require a multi-line block scalar). Iter-219 DEC-081 update:
-    /// this falls back rather than silently converting the list to block
-    /// style with no explanation.
-    FlowListNotInlineable,
+    /// A single item was appended to or removed from a flow-style list
+    /// (`key: [a, b]`), but the existing list or the new item doesn't fit
+    /// this splicer's simple one-token-per-item model — the new item can't
+    /// be written as a single inline flow token (e.g. it would require a
+    /// multi-line block scalar), or the existing list itself has a shape
+    /// the tokenizer can't round-trip (a trailing comment, a nested flow
+    /// collection as an item). Iter-219 DEC-081/DEC-087 update: this falls
+    /// back rather than silently converting the list to block style (or
+    /// dropping a trailing comment) with no explanation.
+    FlowListNotModellable,
+    /// A single item was appended to or removed from a block-style list
+    /// (`key:\n  - a\n  - b\n`), but the existing list has a shape this
+    /// splicer's simple one-line-per-item model can't handle — most
+    /// commonly a `#`-comment interleaved between items. Splicing through
+    /// interleaved comments would need real CST support, which is out of
+    /// scope; the honest alternative is to fall back and say so rather
+    /// than silently re-serialize the whole list (losing the comment) with
+    /// no explanation.
+    BlockListNotModellable,
 }
 
 impl FallbackReason {
@@ -78,8 +91,12 @@ impl FallbackReason {
                 "the minimal-diff result did not round-trip to the requested properties"
             }
             FallbackReason::SerializeFailed => "a changed key could not be serialized on its own",
-            FallbackReason::FlowListNotInlineable => {
-                "an appended list item cannot be represented inline in the existing flow-style list"
+            FallbackReason::FlowListNotModellable => {
+                "the existing flow-style list cannot be edited in place (an unrepresentable item, \
+                 or a trailing comment/comma this splicer does not model)"
+            }
+            FallbackReason::BlockListNotModellable => {
+                "the existing list has a comment between its items, which this splicer cannot edit in place"
             }
         }
     }
@@ -311,8 +328,11 @@ fn render_changed_segment(
     {
         match try_list_splice(seg.body, old_items, new_items, &delta) {
             ListSpliceResult::Spliced(text) => return Ok(text),
-            ListSpliceResult::FlowNotInlineable => {
-                return Err(FallbackReason::FlowListNotInlineable);
+            ListSpliceResult::FlowNotModellable => {
+                return Err(FallbackReason::FlowListNotModellable);
+            }
+            ListSpliceResult::BlockNotModellable => {
+                return Err(FallbackReason::BlockListNotModellable);
             }
             ListSpliceResult::NotApplicable => {}
         }
@@ -372,11 +392,19 @@ fn classify_list_delta(old: &[Value], new: &[Value]) -> Option<ListDelta> {
 enum ListSpliceResult {
     /// The key's new span text, ready to write.
     Spliced(String),
-    /// This was an append to a flow-style list, but the new item cannot be
-    /// written as an inline flow token — DEC-081 fallback, not silent.
-    FlowNotInlineable,
-    /// The body's shape doesn't match the simple model these functions
-    /// assume; the caller should fall back to a whole-key re-serialize.
+    /// The body *is* a single-line flow list, but either the existing list
+    /// or the new item doesn't fit the tokenizer's simple model — must warn
+    /// (DEC-081/DEC-087 fallback), never silently reformat to block style.
+    FlowNotModellable,
+    /// The body *is* a block-sequence-shaped key (bare `key:` followed by
+    /// item lines), but those lines don't cleanly split one-per-item — most
+    /// commonly a `#`-comment between items — must warn, never silently
+    /// re-serialize (which would drop the comment with no explanation).
+    BlockNotModellable,
+    /// The body's shape doesn't match either model at all (e.g. it isn't a
+    /// list-shaped value in the first place); the caller falls back to a
+    /// whole-key re-serialize exactly as it always has for other changed
+    /// values — not new churn, so no warning is needed here.
     NotApplicable,
 }
 
@@ -394,33 +422,71 @@ fn try_list_splice(
             if let Some(text) = remove_block_item(body, old_items.len(), idx) {
                 return ListSpliceResult::Spliced(text);
             }
-            match splice_flow_list(body, old_items.len(), FlowOp::Remove(idx)) {
-                Some(text) => ListSpliceResult::Spliced(text),
-                None => ListSpliceResult::NotApplicable,
+            if is_single_line_flow(body) {
+                return match splice_flow_list(body, old_items.len(), FlowOp::Remove(idx)) {
+                    Some(text) => ListSpliceResult::Spliced(text),
+                    None => ListSpliceResult::FlowNotModellable,
+                };
             }
+            if is_unmodellable_block_list(body, old_items.len()) {
+                return ListSpliceResult::BlockNotModellable;
+            }
+            ListSpliceResult::NotApplicable
         }
         ListDelta::Append => {
             let Some(new_item) = new_items.last() else {
                 return ListSpliceResult::NotApplicable;
             };
-            let Some(item_text) = render_scalar_item(new_item) else {
-                // Can't be written as a single inline token at all (e.g. a
-                // multi-line block scalar) — no splice format can represent
-                // it inline, block or flow.
-                return ListSpliceResult::NotApplicable;
-            };
-            if let Some(text) = append_block_item(body, old_items.len(), &item_text) {
+            // Rendered eagerly (not just on the block-list path) because a
+            // flow list that can't accept this item inline must still warn
+            // even when the item itself is the whole problem — checking
+            // `is_single_line_flow` first, below, is what makes that
+            // reachable rather than bailing out here.
+            let item_text = render_scalar_item(new_item);
+            if is_single_line_flow(body) {
+                return match item_text
+                    .as_deref()
+                    .and_then(|text| splice_flow_list(body, old_items.len(), FlowOp::Append(text)))
+                {
+                    Some(text) => ListSpliceResult::Spliced(text),
+                    None => ListSpliceResult::FlowNotModellable,
+                };
+            }
+            if let Some(item_text) = &item_text
+                && let Some(text) = append_block_item(body, old_items.len(), item_text)
+            {
                 return ListSpliceResult::Spliced(text);
             }
-            if is_single_line_flow(body) {
-                return match splice_flow_list(body, old_items.len(), FlowOp::Append(&item_text)) {
-                    Some(text) => ListSpliceResult::Spliced(text),
-                    None => ListSpliceResult::FlowNotInlineable,
-                };
+            if is_unmodellable_block_list(body, old_items.len()) {
+                return ListSpliceResult::BlockNotModellable;
             }
             ListSpliceResult::NotApplicable
         }
     }
+}
+
+/// `true` when `body`'s key line is a bare `key:` (block-sequence shaped,
+/// i.e. not flow, not a scalar) with at least one line after it, but
+/// [`append_block_item`]/[`remove_block_item`] already failed to model it —
+/// almost always a `#`-comment interleaved between item lines. Distinguishes
+/// "this genuinely isn't (or isn't yet) a block list" (silent, existing
+/// `NotApplicable`) from "this IS one, just not one this splicer can edit
+/// in place" (must warn, iter-219 M6/DEC-081).
+fn is_unmodellable_block_list(body: &str, item_count: usize) -> bool {
+    if item_count == 0 {
+        // `key:` with nothing after parses as null, not `[]` — a real
+        // array value with zero items is never block-sequence-shaped, so
+        // failing to model it here isn't this case.
+        return false;
+    }
+    let mut lines = body.split_inclusive('\n');
+    let Some(key_line) = lines.next() else {
+        return false;
+    };
+    if !key_line.trim_end().ends_with(':') {
+        return false;
+    }
+    lines.next().is_some()
 }
 
 /// Render `value` as the token text for one YAML sequence item — no leading
@@ -665,6 +731,9 @@ fn detect_flow_separator(inner: &str, items: &[(usize, usize)]) -> &'static str 
 }
 
 /// One-item mutation to apply to a flow list's token set.
+// `Copy` isn't just nice-to-have here: clippy's `needless_pass_by_value`
+// requires it (or an `&FlowOp` signature) for `splice_flow_list`'s
+// by-value `op` parameter — checked directly, not left to guesswork.
 #[derive(Clone, Copy)]
 enum FlowOp<'a> {
     Append(&'a str),
@@ -707,9 +776,8 @@ fn splice_flow_list(body: &str, old_len: usize, op: FlowOp<'_>) -> Option<String
     new_content.push_str(&content[..=open_pos]);
     new_content.push_str(&tokens.join(sep));
     new_content.push_str(&content[close_pos..]);
-    let mut out = new_content;
-    out.push_str(eol);
-    Some(out)
+    new_content.push_str(eol);
+    Some(new_content)
 }
 
 /// Is this column-0 line blank or a comment (i.e. trivia between keys)?
@@ -1337,5 +1405,146 @@ mod tests {
         p.shift_remove("aliases");
         let out = spliced(yaml, &p);
         assert_eq!(out, "title: 'T'\nstatus: draft\n");
+    }
+
+    // -------------------------------------------------------------------
+    // Review round: fallback-routing coverage (iter-219 PR #250 findings)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn append_non_inlineable_item_to_flow_list_falls_back_with_warning() {
+        // M1: a new item that forces a multi-line block scalar (embedded
+        // newline) cannot be written as a flow token. Before the fix this
+        // silently fell through to a whole-key re-serialize that converts
+        // `tags: [a, b]` to block style with no warning — exactly the
+        // DEC-081/DEC-087 violation FlowListNotModellable exists to catch.
+        let yaml = "tags: [a, b]\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("tags".into(), json!(["a", "b", "line one\nline two"]));
+        assert_eq!(
+            fallback(yaml, &p),
+            FallbackReason::FlowListNotModellable,
+            "must warn, not silently convert flow to block"
+        );
+    }
+
+    #[test]
+    fn append_to_flow_list_with_trailing_comment_falls_back_with_warning() {
+        // M2/M3: `is_single_line_flow` recognizes this as flow-shaped (looser
+        // check, by design), but `parse_flow_list` correctly refuses it (the
+        // line doesn't end with `]`) — the gap between those two checks is
+        // exactly what routes this to an explicit warning instead of a
+        // silent flow-to-block reformat that would also drop the comment.
+        let yaml = "tags: [a, b] # keep these\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("tags".into(), json!(["a", "b", "c"]));
+        assert_eq!(fallback(yaml, &p), FallbackReason::FlowListNotModellable);
+    }
+
+    #[test]
+    fn remove_from_flow_list_with_trailing_comment_falls_back_with_warning() {
+        // M3: append and remove must be symmetric — both warn, neither
+        // silently reformats+drops the comment.
+        let yaml = "tags: [a, b, c] # keep these\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("tags") else {
+            panic!("expected array")
+        };
+        seq.remove(1);
+        assert_eq!(fallback(yaml, &p), FallbackReason::FlowListNotModellable);
+    }
+
+    #[test]
+    fn append_to_block_list_with_interleaved_comment_falls_back_with_warning() {
+        // M6: comments between block-list items are out of scope for this
+        // splicer (no full-CST support) — but the honest response is an
+        // explicit fallback+warning, not a silent whole-key re-serialize
+        // that discards the comment with no explanation.
+        let yaml = "aliases:\n  - old-name\n  # keep this note\n  - other\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("aliases") else {
+            panic!("expected array")
+        };
+        seq.push(json!("new-name"));
+        assert_eq!(fallback(yaml, &p), FallbackReason::BlockListNotModellable);
+    }
+
+    #[test]
+    fn remove_from_block_list_with_interleaved_comment_falls_back_with_warning() {
+        let yaml = "aliases:\n  - old-name\n  # keep this note\n  - other\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("aliases") else {
+            panic!("expected array")
+        };
+        seq.remove(0); // "old-name"
+        assert_eq!(fallback(yaml, &p), FallbackReason::BlockListNotModellable);
+    }
+
+    #[test]
+    fn list_splice_works_under_pure_crlf() {
+        // Nothing previously exercised the list-splice path specifically
+        // under a consistently-CRLF file (as opposed to scalar-value
+        // changes, already covered elsewhere).
+        let yaml = "aliases:\r\n  - old-name\r\nstatus: draft\r\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("aliases") else {
+            panic!("expected array")
+        };
+        seq.push(json!("new-name"));
+        let out = spliced(yaml, &p);
+        // splice_frontmatter always returns LF-normalized text; CRLF
+        // re-expansion is the caller's job (write_frontmatter_impl).
+        assert_eq!(out, "aliases:\n  - old-name\n  - new-name\nstatus: draft\n");
+    }
+
+    #[test]
+    fn list_splice_remove_works_under_pure_crlf() {
+        let yaml = "aliases:\r\n  - old-name\r\n  - other\r\nstatus: draft\r\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("aliases") else {
+            panic!("expected array")
+        };
+        seq.remove(0); // "old-name"
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "aliases:\n  - other\nstatus: draft\n");
+    }
+
+    #[test]
+    fn removing_the_only_item_from_a_flow_list_splices_to_empty_brackets() {
+        let yaml = "tags: [a]\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("tags".into(), json!([]));
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "tags: []\nstatus: draft\n");
+    }
+
+    #[test]
+    fn removing_the_only_item_from_a_block_list_via_explicit_empty_array_is_safe() {
+        // Not the CLI's real shape (remove.rs drops the key entirely when a
+        // list empties — see `removing_last_item_from_list_removes_the_key_entirely`
+        // above) but a defensive check on the splicer itself: a block
+        // sequence's only item removed via an explicit `key: []` request has
+        // no line-level representation (`key:` alone parses as null, not an
+        // empty list), so the verification gate must catch the mismatch and
+        // fall back safely rather than writing something that doesn't
+        // round-trip to what was asked for.
+        let yaml = "aliases:\n  - only-one\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("aliases".into(), json!([]));
+        let out = match splice_frontmatter(yaml, &p, false) {
+            SpliceOutcome::Spliced(s) => s,
+            // Whichever fallback fired, the caller re-serializes the whole
+            // block from `p` directly — simulate that here.
+            SpliceOutcome::Fallback(_) => {
+                serde_saphyr::to_string_with_options(&p, SerializerOptions::default())
+                    .expect("full re-serialize must succeed")
+            }
+        };
+        let reparsed = parse_map(&out).expect("output must still be valid YAML");
+        assert_eq!(
+            reparsed.get("aliases"),
+            Some(&json!([])),
+            "must round-trip to the requested empty list, however it got there:\n{out}"
+        );
     }
 }

--- a/crates/hyalo-core/src/frontmatter/splice.rs
+++ b/crates/hyalo-core/src/frontmatter/splice.rs
@@ -56,6 +56,12 @@ pub(super) enum FallbackReason {
     VerificationFailed,
     /// Serializing an individual changed key on its own failed.
     SerializeFailed,
+    /// A single item was appended to a flow-style list (`key: [a, b]`), but
+    /// the new item cannot be represented as an inline flow token (e.g. it
+    /// would require a multi-line block scalar). Iter-219 DEC-081 update:
+    /// this falls back rather than silently converting the list to block
+    /// style with no explanation.
+    FlowListNotInlineable,
 }
 
 impl FallbackReason {
@@ -72,6 +78,9 @@ impl FallbackReason {
                 "the minimal-diff result did not round-trip to the requested properties"
             }
             FallbackReason::SerializeFailed => "a changed key could not be serialized on its own",
+            FallbackReason::FlowListNotInlineable => {
+                "an appended list item cannot be represented inline in the existing flow-style list"
+            }
         }
     }
 }
@@ -179,10 +188,10 @@ pub(super) fn splice_frontmatter(
             // Changed: keep the key's comment block, re-serialize its value.
             Some(seg) => {
                 out.push_str(seg.pre_trivia);
-                let Some(rendered) = serialize_one(key, new_value, compact_list_indent) else {
-                    return SpliceOutcome::Fallback(FallbackReason::SerializeFailed);
-                };
-                out.push_str(&rendered);
+                match render_changed_segment(key, seg, new_value, compact_list_indent) {
+                    Ok(text) => out.push_str(&text),
+                    Err(reason) => return SpliceOutcome::Fallback(reason),
+                }
             }
             // New key: emit it at the position `props` asks for.
             None => {
@@ -265,6 +274,442 @@ fn serialize_one(key: &str, value: &Value, compact_list_indent: bool) -> Option<
         yaml.push('\n');
     }
     Some(yaml)
+}
+
+// ---------------------------------------------------------------------------
+// List splicing (iter-219 NEW-5)
+// ---------------------------------------------------------------------------
+//
+// `set` replacing a whole list value already had to re-serialize that key's
+// span (the general "Changed" case above). But `append`/`remove <key>=<value>`
+// only ever change a list by exactly one item — appending one, or deleting
+// one — and DEC-080's own bar ("touch only what changed") applies just as
+// much *within* a key's span as it does across keys. This section detects
+// that specific shape (old/new values are both arrays differing by exactly
+// one item, all items are plain scalars) and, when the body text matches the
+// simple one-item-per-line model these functions assume, edits just that
+// item's line(s) instead of re-serializing the whole list. Any shape this
+// doesn't recognize — nested items, multi-line flow, unusual indentation —
+// falls through to the existing whole-key re-serialize; nothing here can
+// produce an outcome that isn't first caught by `splice_frontmatter`'s
+// re-parse-and-compare verification gate.
+
+/// Render the replacement text for a single changed key: `key`'s new span,
+/// ready to append to the output (no `pre_trivia`; the caller already wrote
+/// that). Prefers a minimal single-item list splice when the value's shape
+/// allows it; otherwise falls back to serializing the whole key.
+fn render_changed_segment(
+    key: &str,
+    seg: &Segment<'_>,
+    new_value: &Value,
+    compact_list_indent: bool,
+) -> Result<String, FallbackReason> {
+    if let (Value::Array(old_items), Value::Array(new_items)) = (&seg.value, new_value)
+        && old_items.iter().all(is_inline_scalar)
+        && new_items.iter().all(is_inline_scalar)
+        && let Some(delta) = classify_list_delta(old_items, new_items)
+    {
+        match try_list_splice(seg.body, old_items, new_items, &delta) {
+            ListSpliceResult::Spliced(text) => return Ok(text),
+            ListSpliceResult::FlowNotInlineable => {
+                return Err(FallbackReason::FlowListNotInlineable);
+            }
+            ListSpliceResult::NotApplicable => {}
+        }
+    }
+    serialize_one(key, new_value, compact_list_indent).ok_or(FallbackReason::SerializeFailed)
+}
+
+/// `true` for scalar YAML values (string/number/bool/null) — the only shapes
+/// the one-line-per-item splice model below can reason about. A `false`
+/// anywhere in a list (a nested mapping or sequence item) routes the whole
+/// key through the existing whole-value re-serialize.
+fn is_inline_scalar(v: &Value) -> bool {
+    !matches!(v, Value::Array(_) | Value::Object(_))
+}
+
+/// What changed between an old and new list value, when the change is
+/// exactly one item.
+enum ListDelta {
+    /// `new_items` is `old_items` with one item appended at the end.
+    Append,
+    /// `old_items[.0]` was removed; every other item kept its order.
+    Remove(usize),
+}
+
+/// Classify a list value change as an append-one or remove-one delta.
+/// Returns `None` for anything else (replacement, reorder, multi-item
+/// change) — the caller falls back to re-serializing the whole value, which
+/// is what `set` needs anyway.
+fn classify_list_delta(old: &[Value], new: &[Value]) -> Option<ListDelta> {
+    if new.len() == old.len() + 1 && new[..old.len()] == *old {
+        return Some(ListDelta::Append);
+    }
+    if old.len() == new.len() + 1 {
+        let idx = old
+            .iter()
+            .zip(new.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or(new.len());
+        let mut ni = 0usize;
+        for (i, item) in old.iter().enumerate() {
+            if i == idx {
+                continue;
+            }
+            if new.get(ni) != Some(item) {
+                return None;
+            }
+            ni += 1;
+        }
+        if ni == new.len() {
+            return Some(ListDelta::Remove(idx));
+        }
+    }
+    None
+}
+
+/// Result of attempting a single-item list splice.
+enum ListSpliceResult {
+    /// The key's new span text, ready to write.
+    Spliced(String),
+    /// This was an append to a flow-style list, but the new item cannot be
+    /// written as an inline flow token — DEC-081 fallback, not silent.
+    FlowNotInlineable,
+    /// The body's shape doesn't match the simple model these functions
+    /// assume; the caller should fall back to a whole-key re-serialize.
+    NotApplicable,
+}
+
+/// Try to splice `delta` into `body` (the key's raw source text, including
+/// its own key line). `old_items.len()` is used to cross-check that the raw
+/// text's line count agrees with the parsed value before trusting it.
+fn try_list_splice(
+    body: &str,
+    old_items: &[Value],
+    new_items: &[Value],
+    delta: &ListDelta,
+) -> ListSpliceResult {
+    match *delta {
+        ListDelta::Remove(idx) => {
+            if let Some(text) = remove_block_item(body, old_items.len(), idx) {
+                return ListSpliceResult::Spliced(text);
+            }
+            match splice_flow_list(body, old_items.len(), FlowOp::Remove(idx)) {
+                Some(text) => ListSpliceResult::Spliced(text),
+                None => ListSpliceResult::NotApplicable,
+            }
+        }
+        ListDelta::Append => {
+            let Some(new_item) = new_items.last() else {
+                return ListSpliceResult::NotApplicable;
+            };
+            let Some(item_text) = render_scalar_item(new_item) else {
+                // Can't be written as a single inline token at all (e.g. a
+                // multi-line block scalar) — no splice format can represent
+                // it inline, block or flow.
+                return ListSpliceResult::NotApplicable;
+            };
+            if let Some(text) = append_block_item(body, old_items.len(), &item_text) {
+                return ListSpliceResult::Spliced(text);
+            }
+            if is_single_line_flow(body) {
+                return match splice_flow_list(body, old_items.len(), FlowOp::Append(&item_text)) {
+                    Some(text) => ListSpliceResult::Spliced(text),
+                    None => ListSpliceResult::FlowNotInlineable,
+                };
+            }
+            ListSpliceResult::NotApplicable
+        }
+    }
+}
+
+/// Render `value` as the token text for one YAML sequence item — no leading
+/// `- `, no trailing newline. Returns `None` when the value can't be
+/// rendered as a single-line token (e.g. it forces a multi-line block
+/// scalar), which rules out both block and flow inlining.
+fn render_scalar_item(value: &Value) -> Option<String> {
+    let seq = [value];
+    let opts = SerializerOptions {
+        compact_list_indent: true,
+        ..SerializerOptions::default()
+    };
+    let mut yaml = serde_saphyr::to_string_with_options(&seq, opts).ok()?;
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    let line = yaml.strip_prefix("- ")?.trim_end_matches('\n');
+    if line.is_empty() || line.contains('\n') {
+        return None;
+    }
+    Some(line.to_owned())
+}
+
+/// Split a block-sequence item line into `(indent, "- " + rest)`'s indent
+/// prefix and the text following `"- "`. `None` if `line` isn't a
+/// space-indented dash item.
+fn split_dash_indent(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim_start_matches(' ');
+    let indent_len = line.len() - trimmed.len();
+    let rest = trimmed.strip_prefix("- ")?;
+    Some((&line[..indent_len], rest))
+}
+
+/// Split off a single trailing `\n` (splice operates on LF-normalized text).
+fn split_trailing_eol(line: &str) -> (&str, &str) {
+    line.strip_suffix('\n').map_or((line, ""), |s| (s, "\n"))
+}
+
+/// Append one item to a block-style sequence (`key:\n  - a\n  - b\n`).
+///
+/// `item_count` is the number of items the authoritative parse found;
+/// `body` must have exactly that many dash-item lines, all sharing the same
+/// indentation, or this returns `None` (the shape doesn't match the simple
+/// model and the caller falls back to a whole-key re-serialize).
+fn append_block_item(body: &str, item_count: usize, new_item_text: &str) -> Option<String> {
+    if item_count == 0 {
+        // An empty block sequence isn't representable (`key:` alone parses
+        // as null, not `[]`) — this must be a flow `key: []` instead.
+        return None;
+    }
+    let mut lines = body.split_inclusive('\n');
+    let key_line = lines.next()?;
+    // Trailing whitespace before the newline (`key: \n`) is common in the
+    // wild ahead of a block sequence and insignificant to YAML — trim all
+    // trailing whitespace, not just the line terminator, before checking.
+    if !key_line.trim_end().ends_with(':') {
+        return None;
+    }
+
+    let item_lines: Vec<&str> = lines.collect();
+    if item_lines.len() != item_count {
+        return None;
+    }
+
+    let mut indent: Option<&str> = None;
+    for line in &item_lines {
+        let stripped = line.trim_end_matches(['\n', '\r']);
+        let (ind, _) = split_dash_indent(stripped)?;
+        match indent {
+            Some(prev) if prev != ind => return None,
+            Some(_) => {}
+            None => indent = Some(ind),
+        }
+    }
+    let indent = indent?;
+
+    let mut out = body.to_owned();
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(indent);
+    out.push_str("- ");
+    out.push_str(new_item_text);
+    out.push('\n');
+    Some(out)
+}
+
+/// Remove one item from a block-style sequence by dropping its line
+/// wholesale. Every other line — including its exact indentation and dash
+/// style — is untouched.
+fn remove_block_item(body: &str, item_count: usize, removed_index: usize) -> Option<String> {
+    let mut lines = body.split_inclusive('\n');
+    let key_line = lines.next()?;
+    // Trailing whitespace before the newline (`key: \n`) is common in the
+    // wild ahead of a block sequence and insignificant to YAML — trim all
+    // trailing whitespace, not just the line terminator, before checking.
+    if !key_line.trim_end().ends_with(':') {
+        return None;
+    }
+
+    let item_lines: Vec<&str> = lines.collect();
+    if item_lines.len() != item_count || removed_index >= item_lines.len() {
+        return None;
+    }
+    for line in &item_lines {
+        let stripped = line.trim_end_matches(['\n', '\r']);
+        split_dash_indent(stripped)?;
+    }
+
+    let mut out = String::with_capacity(body.len());
+    out.push_str(key_line);
+    for (i, line) in item_lines.iter().enumerate() {
+        if i != removed_index {
+            out.push_str(line);
+        }
+    }
+    Some(out)
+}
+
+/// `true` when `body` is a single-line `key: [...]` flow list — used to
+/// decide whether an append that couldn't be inlined deserves the
+/// `FlowNotInlineable` warning (this *is* a flow list) versus silent
+/// fallback (it isn't one at all).
+fn is_single_line_flow(body: &str) -> bool {
+    let mut lines = body.split_inclusive('\n');
+    let Some(line) = lines.next() else {
+        return false;
+    };
+    if lines.next().is_some() {
+        return false;
+    }
+    let (content, _) = split_trailing_eol(line);
+    let Some(colon) = content.find(':') else {
+        return false;
+    };
+    content[colon + 1..].trim_start().starts_with('[')
+}
+
+/// Bracket byte positions and item spans of a single-line `key: [...]` flow
+/// list. Each span in `items` is a byte range into the parsed `content`
+/// string, relative to the start of the bracket interior (i.e. relative to
+/// `open_pos + 1`).
+struct FlowListLayout {
+    open_pos: usize,
+    close_pos: usize,
+    items: Vec<(usize, usize)>,
+}
+
+/// Parse a single-line `key: [...]` body into its bracket layout. An empty
+/// list normalizes to zero item spans. `None` when the line isn't this exact
+/// shape, or an item contains a nested `[`/`{` (outside this splicer's
+/// simple model).
+fn parse_flow_list(content: &str) -> Option<FlowListLayout> {
+    let colon = content.find(':')?;
+    let value_part = content[colon + 1..].trim_start();
+    if !value_part.starts_with('[') || !value_part.ends_with(']') {
+        return None;
+    }
+    let open_pos = content.find('[')?;
+    let close_pos = content.rfind(']')?;
+    if open_pos >= close_pos {
+        return None;
+    }
+    let inner = &content[open_pos + 1..close_pos];
+    let items = split_flow_items(inner)?;
+    let items = if items.len() == 1 && inner[items[0].0..items[0].1].trim().is_empty() {
+        Vec::new()
+    } else {
+        items
+    };
+    Some(FlowListLayout {
+        open_pos,
+        close_pos,
+        items,
+    })
+}
+
+/// Split flow-sequence interior text into comma-separated item spans,
+/// respecting single/double-quoted strings. `None` if an item contains a
+/// nested `[` or `{` — flow collections nested inside a flow list item are
+/// outside this splicer's simple model.
+fn split_flow_items(inner: &str) -> Option<Vec<(usize, usize)>> {
+    let bytes = inner.as_bytes();
+    let mut items = Vec::new();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        if bytes.get(i + 1) == Some(&b'\'') {
+                            i += 2;
+                            continue;
+                        }
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b'"' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b'"' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b'[' | b'{' => return None,
+            b',' => {
+                items.push((start, i));
+                i += 1;
+                start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    items.push((start, bytes.len()));
+    Some(items)
+}
+
+/// Detect the separator style (`", "` vs `","`) already used between the
+/// first two items of a flow list, defaulting to `", "` for zero/one items.
+fn detect_flow_separator(inner: &str, items: &[(usize, usize)]) -> &'static str {
+    if items.len() < 2 {
+        return ", ";
+    }
+    let first_end = items[0].1;
+    if inner.as_bytes().get(first_end + 1) == Some(&b' ') {
+        ", "
+    } else {
+        ","
+    }
+}
+
+/// One-item mutation to apply to a flow list's token set.
+#[derive(Clone, Copy)]
+enum FlowOp<'a> {
+    Append(&'a str),
+    Remove(usize),
+}
+
+/// Splice one item into or out of a single-line `key: [a, b, c]` flow list.
+/// Rebuilds the bracket interior from trimmed tokens rather than preserving
+/// exact inter-item whitespace — the whole line was already the "intended
+/// span" for a flow-style value, so this is still a one-line diff.
+fn splice_flow_list(body: &str, old_len: usize, op: FlowOp<'_>) -> Option<String> {
+    let mut lines = body.split_inclusive('\n');
+    let line = lines.next()?;
+    if lines.next().is_some() {
+        return None;
+    }
+    let (content, eol) = split_trailing_eol(line);
+    let FlowListLayout {
+        open_pos,
+        close_pos,
+        items,
+    } = parse_flow_list(content)?;
+    if items.len() != old_len {
+        return None;
+    }
+    let inner = &content[open_pos + 1..close_pos];
+    let sep = detect_flow_separator(inner, &items);
+    let mut tokens: Vec<&str> = items.iter().map(|&(s, e)| inner[s..e].trim()).collect();
+    match op {
+        FlowOp::Remove(idx) => {
+            if idx >= tokens.len() {
+                return None;
+            }
+            tokens.remove(idx);
+        }
+        FlowOp::Append(text) => tokens.push(text),
+    }
+
+    let mut new_content = String::with_capacity(content.len() + 8);
+    new_content.push_str(&content[..=open_pos]);
+    new_content.push_str(&tokens.join(sep));
+    new_content.push_str(&content[close_pos..]);
+    let mut out = new_content;
+    out.push_str(eol);
+    Some(out)
 }
 
 /// Is this column-0 line blank or a comment (i.e. trivia between keys)?
@@ -706,5 +1151,191 @@ mod tests {
             1,
             "adding one property must change exactly one line"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // List splicing (iter-219 NEW-5)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn append_to_indented_block_list_touches_only_one_line() {
+        let yaml = "title: 'Keep me'\naliases:\n  - old-name\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("aliases") else {
+            panic!("expected array")
+        };
+        seq.push(json!("new-name"));
+        let out = spliced(yaml, &p);
+        assert_eq!(
+            out,
+            "title: 'Keep me'\naliases:\n  - old-name\n  - new-name\nstatus: draft\n"
+        );
+        assert_eq!(changed_lines(yaml, &out), 1);
+    }
+
+    #[test]
+    fn append_to_block_list_with_trailing_space_after_colon_touches_only_one_line() {
+        // Real GH Docs shape: `redirect_from: \n` — a trailing space before
+        // the block sequence starts, insignificant to YAML but originally
+        // broke the `ends_with(':')` detection and fell back to a whole-key
+        // reserialize (corpus verification finding, iter-219).
+        let yaml = "redirect_from: \n  - /old-path\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("redirect_from") else {
+            panic!("expected array")
+        };
+        seq.push(json!("/new-path"));
+        let out = spliced(yaml, &p);
+        assert_eq!(
+            out,
+            "redirect_from: \n  - /old-path\n  - /new-path\nstatus: draft\n"
+        );
+        assert_eq!(changed_lines(yaml, &out), 1);
+    }
+
+    #[test]
+    fn append_to_compact_block_list_touches_only_one_line() {
+        let yaml = "tags:\n- one\n- two\nstatus: planned\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("tags") else {
+            panic!("expected array")
+        };
+        seq.push(json!("three"));
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "tags:\n- one\n- two\n- three\nstatus: planned\n");
+        assert_eq!(changed_lines(yaml, &out), 1);
+    }
+
+    #[test]
+    fn remove_from_block_list_drops_only_that_line() {
+        let yaml = "aliases:\n  - old-name\n  - other\n  - third\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("aliases") else {
+            panic!("expected array")
+        };
+        seq.remove(1); // "other"
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "aliases:\n  - old-name\n  - third\nstatus: draft\n");
+    }
+
+    #[test]
+    fn append_to_flow_list_stays_flow() {
+        let yaml = "tags: [a, b]\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("tags") else {
+            panic!("expected array")
+        };
+        seq.push(json!("c"));
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "tags: [a, b, c]\nstatus: draft\n");
+    }
+
+    #[test]
+    fn remove_from_flow_list_stays_flow() {
+        let yaml = "tags: [a, b, c]\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("tags") else {
+            panic!("expected array")
+        };
+        seq.remove(1); // "b"
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "tags: [a, c]\nstatus: draft\n");
+    }
+
+    #[test]
+    fn append_to_empty_flow_list_produces_single_item() {
+        let yaml = "tags: []\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("tags".into(), json!(["a"]));
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "tags: [a]\nstatus: draft\n");
+    }
+
+    #[test]
+    fn appending_a_new_key_still_creates_a_fresh_list() {
+        // Not a list-splice case: the key doesn't exist yet, so this must
+        // still go through ordinary key serialization.
+        let yaml = "title: 'T'\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("aliases".into(), json!(["first"]));
+        let out = spliced(yaml, &p);
+        assert!(out.starts_with(yaml));
+        assert!(out.contains("aliases"));
+    }
+
+    #[test]
+    fn full_list_replacement_falls_back_to_whole_key_reserialize() {
+        // `set --property tags=[a,b,c]` replaces the whole value — not an
+        // append or removal of exactly one item — so the list-splice path
+        // must not fire; the existing whole-key re-serialize still handles
+        // it correctly.
+        let yaml = "tags:\n  - a\n  - b\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("tags".into(), json!(["x", "y", "z"]));
+        let out = spliced(yaml, &p);
+        let parsed = parse_map(&out).expect("output re-parses");
+        assert_eq!(parsed.get("tags"), Some(&json!(["x", "y", "z"])));
+        assert!(!out.contains("- a"));
+        assert!(out.contains("status: draft"));
+    }
+
+    #[test]
+    fn reordering_list_items_falls_back_to_whole_key_reserialize() {
+        let yaml = "tags:\n  - a\n  - b\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.insert("tags".into(), json!(["b", "a"]));
+        let out = spliced(yaml, &p);
+        // Not a supported single-item delta — must still round-trip correctly
+        // via the whole-key fallback (verification gate would catch a bug).
+        let parsed = parse_map(&out).expect("output re-parses");
+        assert_eq!(parsed.get("tags"), Some(&json!(["b", "a"])));
+    }
+
+    #[test]
+    fn append_to_list_alongside_other_unchanged_keys_touches_one_line() {
+        // GitHub-Docs shaped repro (NEW-5): a single appended redirect_from
+        // entry must not touch any other key's lines, nor any other
+        // sibling list item.
+        let yaml = concat!(
+            "title: GitHub Actions documentation\n",
+            "redirect_from:\n",
+            "  - /articles/automating-your-workflow-with-github-actions\n",
+            "  - /articles/customizing-your-project-with-github-actions\n",
+            "versions:\n",
+            "  fpt: '*'\n",
+            "  ghec: '*'\n",
+        );
+        let mut p = parse_map(yaml).expect("fixture parses");
+        let Some(Value::Array(seq)) = p.get_mut("redirect_from") else {
+            panic!("expected array")
+        };
+        seq.push(json!("/dogfood-probe"));
+        let out = spliced(yaml, &p);
+        assert_eq!(
+            out,
+            concat!(
+                "title: GitHub Actions documentation\n",
+                "redirect_from:\n",
+                "  - /articles/automating-your-workflow-with-github-actions\n",
+                "  - /articles/customizing-your-project-with-github-actions\n",
+                "  - /dogfood-probe\n",
+                "versions:\n",
+                "  fpt: '*'\n",
+                "  ghec: '*'\n",
+            )
+        );
+        assert_eq!(changed_lines(yaml, &out), 1);
+    }
+
+    #[test]
+    fn removing_last_item_from_list_removes_the_key_entirely() {
+        // The CLI layer already drops the key from `props` when a removal
+        // empties the list; the splicer just needs to honor a key's
+        // *absence*, which the existing removal path already does.
+        let yaml = "title: 'T'\naliases:\n  - only-one\nstatus: draft\n";
+        let mut p = parse_map(yaml).expect("fixture parses");
+        p.shift_remove("aliases");
+        let out = spliced(yaml, &p);
+        assert_eq!(out, "title: 'T'\nstatus: draft\n");
     }
 }

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -223,7 +223,8 @@ pub fn scan_slice_multi(data: &[u8], visitors: &mut [&mut dyn FileVisitor]) -> R
             Some(ref y) if !y.trim().is_empty() => {
                 serde_saphyr::from_str_with_options(y, hyalo_options()).map_err(|e| {
                     anyhow::Error::new(crate::frontmatter::FrontmatterError(format!(
-                        "failed to parse YAML frontmatter: {e}"
+                        "failed to parse YAML frontmatter: {}",
+                        crate::frontmatter::friendly_parse_error(&e)
                     )))
                 })?
             }
@@ -411,7 +412,8 @@ pub(crate) fn scan_reader_multi<R: BufRead>(
             Some(ref y) if !y.trim().is_empty() => {
                 serde_saphyr::from_str_with_options(y, hyalo_options()).map_err(|e| {
                     anyhow::Error::new(crate::frontmatter::FrontmatterError(format!(
-                        "failed to parse YAML frontmatter: {e}"
+                        "failed to parse YAML frontmatter: {}",
+                        crate::frontmatter::friendly_parse_error(&e)
                     )))
                 })?
             }

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -224,7 +224,10 @@ pub fn scan_slice_multi(data: &[u8], visitors: &mut [&mut dyn FileVisitor]) -> R
                 serde_saphyr::from_str_with_options(y, hyalo_options()).map_err(|e| {
                     anyhow::Error::new(crate::frontmatter::FrontmatterError(format!(
                         "failed to parse YAML frontmatter: {}",
-                        crate::frontmatter::friendly_parse_error(&e)
+                        crate::frontmatter::friendly_parse_error(
+                            &e,
+                            crate::frontmatter::MAX_FRONTMATTER_BYTES
+                        )
                     )))
                 })?
             }
@@ -413,7 +416,10 @@ pub(crate) fn scan_reader_multi<R: BufRead>(
                 serde_saphyr::from_str_with_options(y, hyalo_options()).map_err(|e| {
                     anyhow::Error::new(crate::frontmatter::FrontmatterError(format!(
                         "failed to parse YAML frontmatter: {}",
-                        crate::frontmatter::friendly_parse_error(&e)
+                        crate::frontmatter::friendly_parse_error(
+                            &e,
+                            crate::frontmatter::MAX_FRONTMATTER_BYTES
+                        )
                     )))
                 })?
             }

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -1667,11 +1667,22 @@ performs the write — by re-serializing the whole block — and emits a
 `warning:` on stderr naming the file and the reason. It does **not** refuse.
 
 **Why not refuse:** the fallback triggers on YAML hyalo can read but this
-splicer deliberately does not model — explicit `? key` syntax, top-level flow
-collections, directives, invalid UTF-8, mixed line endings. Refusing would turn
-a *cosmetic* limitation into a hard failure on files that `set` has always
-handled correctly, and would leave the user with no in-tool way to change a
+splicer deliberately does not model. Refusing would turn a *cosmetic*
+limitation into a hard failure on files that `set` has always handled
+correctly, and would leave the user with no in-tool way to change a
 property. The prior behavior (full rewrite) is still correct; it is only noisy.
+
+**Corrected fallback-trigger list (iter-219):** the real set that reaches
+this fallback is explicit `? key` syntax, top-level flow mappings/sequences,
+invalid UTF-8, and mixed line endings (DEC-087). The original list above
+also named "directives" and, implicitly, anchors/aliases — both are wrong:
+a `%directive` or `&anchor`/`*alias` inside the frontmatter block either
+fails the *baseline* parse outright (`Unparseable`, same family as any other
+malformed YAML) or — for anchors/aliases specifically — is rejected before
+splicing is ever reached, by the parser's own `max_anchors: 0` /
+`max_aliases: 0` budget (see DEC-088). Neither reaches this graceful,
+whole-block-reserialize fallback; both hard-error, and `set`/`remove`/
+`append` skip the file as unparseable rather than silently reformatting it.
 
 **Why not silent:** the entire point of DEC-080 is that unexplained diff churn
 destroys trust in the tool. A user who sees 116 changed lines must be able to
@@ -1877,3 +1888,178 @@ drift out of sync there again). The text renderer
 (`format_lint_fix_output_text`) never read those keys at all (the footer is
 built entirely from `total_fixed`/`total_remaining`/`total_conflicts`), so
 no text-output change was needed.
+
+## DEC-086: the splice engine extends inside a key's own span — one appended or removed list item is a line-level edit, not a whole-value re-serialize (2026-08-23)
+
+**Decision:** when a top-level key's *value* changes, and both the old and
+new values are arrays of plain scalars differing by exactly one item
+(append at the end, or removal of one item anywhere), `splice_frontmatter`
+edits only that item's line(s) instead of re-serializing the whole list.
+Block-style lists (`key:\n  - a\n  - b\n`, indented or compact-flush) get
+one inserted or deleted dash line; flow-style lists (`key: [a, b]`) stay
+flow, rebuilding just the bracket interior. Anything else about the change
+— replacement, reorder, multiple items, a non-scalar item anywhere in the
+list — falls through to the existing whole-key re-serialize from DEC-080;
+this is strictly additive to that path, not a replacement for it.
+
+**Why:** DEC-080 fixed cross-key diff churn (`set` on one key no longer
+rewrites every other key), but `append`/`remove <key>=<value>` — which only
+ever change a list by exactly one item — still fell into the *within-key*
+"Changed" branch and re-serialized the whole list's value. On a real
+GitHub Docs corpus, one appended `redirect_from` entry churned more than
+one line in 361 of 406 files (worst case 118 lines, `admin/index.md`) —
+DEC-080's own bar ("touch only what changed") applies just as much inside a
+key's span as across keys, and this was the same defect relocated rather
+than fixed.
+
+**Detected structurally, not by caller intent:** `splice_frontmatter` has no
+way to know whether a value change came from `append`, `remove`, or a
+`set --property tags=[...]` full replacement — all three funnel through the
+same parse → mutate → write cycle and hand the splicer only the before/after
+property maps. So the append-one/remove-one shape is classified purely from
+comparing the two array values (`classify_list_delta`): this is what makes
+the fix apply uniformly to `append`, `remove --property k=v`, and
+`remove --tag t` without any CLI-layer changes — all three already produce
+exactly this "array shrinks/grows by one scalar" shape in memory.
+
+**Verification gate covers this too:** like every other heuristic in this
+module, a list splice that doesn't match reality (wrong line count, tabs,
+an item that turns out to be multi-line) is caught by re-parsing the
+spliced output and comparing it against the requested property map before
+returning `Spliced`; anything that doesn't verify was never at risk of
+reaching disk wrong, only of missing the minimal-diff optimization.
+
+**Flow-list append that can't be inlined still falls back, and still
+warns:** if the new item can't be rendered as a single-line token (e.g. it
+would force a multi-line block scalar), the *whole document* is
+re-serialized via the DEC-081 fallback path, with the same explicit
+warning as any other fallback. This is a wider hammer than strictly
+necessary for a one-key problem, but reuses DEC-081's existing "full
+rewrite, always announced" machinery rather than inventing a second,
+narrower warning channel for a shape expected to be rare in practice (short
+redirect/alias/tag strings, not multi-paragraph values).
+
+## DEC-087: mixed line endings get an honest full-rewrite fallback, not a silent per-line-preserving splice (2026-08-23)
+
+**Decision:** when a frontmatter block's lines don't all share the same
+line-ending style as its opening `---` line, the write path treats this the
+same as any other DEC-081 fallback trigger: skip the minimal-diff splice
+entirely, re-serialize the whole block, and warn on stderr that the
+frontmatter mixed line endings. The block (and thus the file) still ends up
+on one consistent style afterward — that part doesn't change — but it is no
+longer silent.
+
+**The bug this replaces:** `find_body_offset` recorded only the *opening*
+delimiter's line-ending style; the write path re-expanded every line to
+that one style unconditionally. A file with `\r\n` on some lines and `\n`
+on others round-tripped through `set` with those `\r`s dropped (if the
+opening line was `\n`-terminated) or spuriously added to originally-`\n`
+lines (if the opening line was `\r\n`-terminated) — with an empty stderr.
+`splice_frontmatter`'s own mixed-endings guard didn't catch this either: it
+only rejects a *lone* `\r` not paired with `\n` (embedded literal `\r`
+inside a value), which is a different, narrower concern from *which* lines
+use which paired terminator.
+
+**Why the honest-warning option, not per-line preservation:** the
+alternative — tracking each line's original terminator through the splice
+and re-emitting it verbatim — would mean every span boundary, every
+`serialize_one` call, and the whole-document fallback's own re-serialize
+step would all need to carry and restore individual line endings, not just
+one block-wide style. That is real engineering weight for a shape hyalo has
+never claimed to preserve losslessly (mixed EOL within one file is already
+unusual enough that Git itself normally flags it). DEC-081 already has a
+"fall back and say so" contract for exactly this kind of edge case;
+reusing it is far cheaper than building a second preservation mechanism,
+and satisfies the actual complaint (no *silent* churn) without it.
+
+**Detection is free:** `find_body_offset` already reads every line of the
+block to find the closing delimiter; checking each line's terminator
+against the opening line's while it does so costs nothing extra. Only a
+newline-terminated line can mismatch — the file's very last line, if it
+lacks a terminator entirely (see DEC-089), is not treated as a mismatch;
+that is NEW-16a's concern, not this one's.
+
+## DEC-088: the frontmatter parser's scalar-content budget matches the documented 64 KiB limit, and its errors don't leak internals (2026-08-23)
+
+**Decision:** `hyalo_options()`'s `Budget.max_total_scalar_bytes` is set to
+`MAX_FRONTMATTER_BYTES` (64 KiB) instead of the prior 8192. Every
+`serde_saphyr` parse error that reaches a user (four call sites: the two
+production frontmatter-parse paths plus the two scanner fast-paths) is now
+passed through `friendly_parse_error`, which intercepts the two variants
+whose `Display` renders Rust struct/Debug syntax — a budget breach
+(`budget breached: ScalarBytes { total_scalar_bytes: 8205 }`) and a
+duplicate key (`..., set DuplicateKeyPolicy in Options if acceptable`, a
+hint about hyalo's own internal `Options` type) — and replaces them with
+plain, actionable text naming what happened. Every other `serde_saphyr`
+error variant's own `Display` is already clean and passes through
+unmodified.
+
+**Why the budget was wrong:** `MAX_FRONTMATTER_BYTES` (the documented "64
+KiB / 2000 lines" limit in `set`/`remove`/`append --help`, and the
+pre-flight check every write already enforces) is a limit on the *whole
+frontmatter block*. The parser's own internal `max_total_scalar_bytes`
+budget — meant as defense-in-depth against pathological inputs, not a
+user-facing limit at all — was independently set to 8192 bytes, a fraction
+of the documented ceiling. A real GitHub Docs `admin/index.md` at 7,961
+bytes of frontmatter was about 40 redirect entries from becoming unreadable
+by hyalo, well inside its own documented budget. Scalar content is a
+subset of total block bytes, which every caller already caps at
+`MAX_FRONTMATTER_BYTES` before the parser budget is even consulted, so
+raising this to match can never make the *effective* ceiling looser than
+what was already documented and enforced elsewhere.
+
+**Why interception, not a new error type:** `serde_saphyr::Error` is
+`#[non_exhaustive]` and its message formatting is a library concern hyalo
+doesn't control. Rather than growing a parallel error hierarchy,
+`friendly_parse_error` unwraps `Error::WithSnippet` to the underlying
+variant and pattern-matches the two offending shapes (`Error::Budget`,
+`Error::DuplicateMappingKey`) directly — not by string-matching the
+rendered message, which would be fragile against upstream wording changes
+— falling through to the crate's own `Display` for every other variant
+that doesn't have this problem.
+
+## DEC-089: NEW-16 write-path residue — no invented trailing newline, a narrow dotted-key guard, and a retype advisory (2026-08-23)
+
+**No invented trailing newline (NEW-16a):** a file whose last three bytes
+are literally `---` — no body, no trailing newline anywhere after the
+closing delimiter — must round-trip that way. `find_body_offset` now
+records whether the closing `---` line itself was newline-terminated; the
+write path only appends the delimiter's line-ending after the closing
+`---` when there is a body to separate from, or the original already had
+one there. Creating brand-new frontmatter (no prior close to inspect)
+always gets the separator, matching existing behavior for that case.
+
+**Dotted-key collision guard, not path syntax (NEW-16b):** `hyalo` has
+never supported dotted paths in `--property`; `set --property a.b=x`
+always writes (or overwrites) a literal top-level key named `"a.b"`. That
+is silently wrong specifically when `a` already exists as a mapping — the
+GitHub Docs repro is `--property versions.fpt=X` against a file with an
+existing `versions:` map, which used to create a `versions.fpt` key
+sitting right next to the map it looked like it should have nested into.
+`set`/`append` now reject that one collision with an error naming the
+file and the colliding key, before writing anything. A dotted key with no
+colliding map is unchanged — still a literal flat key — because adding
+real nested-path support is explicitly out of scope for this iteration;
+only the confusing collision is guarded against, not the general case.
+`remove` is not guarded: removing a nonexistent literal dotted key is
+already a harmless no-op (reported as skipped), not a data-corruption risk.
+
+**Retype advisory reuses the existing advisory mechanism, scoped to avoid
+noise (NEW-16c):** `set`'s CLI argument is always a bare string, so type
+inference has no way to know a property was deliberately quoted to stay
+text — `code: '42'` (string) silently becoming `code: 42` (number) via
+`set --property code=42` is inherent to how the CLI parses values, not a
+bug to fix. What was missing was visibility: `advisory_note` (already used
+for the date and enum/pattern advisories, DEC nnn/iter-181) gained a third
+branch that fires when the *first mutated file's* pre-existing value for
+that property was a string and the newly inferred value is a number or
+boolean (`advisory_note` already carries the BUG-B date advisory and the
+iter-181 enum/pattern advisory; this is a third branch in the same
+function, not a new mechanism). Scoped to "was previously a string, now
+isn't" rather than "is a number/boolean at all" specifically to avoid
+noise on properties that are numeric by design (`priority=3` on a file
+where `priority` never existed, or was already numeric, does not fire this
+advisory) — the surprising case is specifically the type *changing* under
+an existing value, mirroring how the date advisory only fires when a
+date-typed property's *new* value fails to look like a date, not on every
+write to that property.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -1929,15 +1929,29 @@ spliced output and comparing it against the requested property map before
 returning `Spliced`; anything that doesn't verify was never at risk of
 reaching disk wrong, only of missing the minimal-diff optimization.
 
-**Flow-list append that can't be inlined still falls back, and still
-warns:** if the new item can't be rendered as a single-line token (e.g. it
-would force a multi-line block scalar), the *whole document* is
-re-serialized via the DEC-081 fallback path, with the same explicit
-warning as any other fallback. This is a wider hammer than strictly
-necessary for a one-key problem, but reuses DEC-081's existing "full
-rewrite, always announced" machinery rather than inventing a second,
-narrower warning channel for a shape expected to be rare in practice (short
-redirect/alias/tag strings, not multi-paragraph values).
+**A list that "looks like" flow or block but doesn't fit the model still
+falls back, and still warns — for both append and remove:** the first
+implementation checked whether the *new item* could be inlined before
+checking whether the body even *was* a flow list, so a non-inlineable item
+appended to a flow list took the `NotApplicable` path and silently
+re-serialized flow to block with no warning — precisely the DEC-081
+violation this decision exists to prevent (caught in PR #250 review, M1).
+The fix reorders the checks: `is_single_line_flow(body)` is evaluated
+first, so once a body is recognized as flow-shaped, *any* reason splicing
+fails inside it — an unrenderable new item, or (M2/M3) the existing list
+itself having a trailing `#`-comment the tokenizer can't represent —
+routes to the explicit `FlowListNotModellable` fallback, symmetrically for
+`ListDelta::Append` and `ListDelta::Remove`. The same logic applies to
+block lists: a `#`-comment interleaved between item lines used to silently
+fall through to a whole-key re-serialize that discarded the comment with
+no explanation (M6); `is_unmodellable_block_list` now detects "this is
+block-sequence-shaped but doesn't split cleanly" and routes it to a
+dedicated `BlockListNotModellable` fallback instead. Both are a wider
+hammer than strictly necessary for a one-key problem, but reuse DEC-081's
+existing "full rewrite, always announced" machinery rather than inventing
+a narrower warning channel for shapes expected to be rare in practice
+(short redirect/alias/tag strings without comments, not multi-paragraph
+values or heavily annotated lists).
 
 ## DEC-087: mixed line endings get an honest full-rewrite fallback, not a silent per-line-preserving splice (2026-08-23)
 
@@ -2011,12 +2025,44 @@ what was already documented and enforced elsewhere.
 **Why interception, not a new error type:** `serde_saphyr::Error` is
 `#[non_exhaustive]` and its message formatting is a library concern hyalo
 doesn't control. Rather than growing a parallel error hierarchy,
-`friendly_parse_error` unwraps `Error::WithSnippet` to the underlying
-variant and pattern-matches the two offending shapes (`Error::Budget`,
-`Error::DuplicateMappingKey`) directly — not by string-matching the
-rendered message, which would be fragile against upstream wording changes
-— falling through to the crate's own `Display` for every other variant
-that doesn't have this problem.
+`friendly_parse_error` *matches on* `unwrap_snippet(err)` — walking past
+`Error::WithSnippet` wrappers only to reach the two offending shapes
+(`Error::Budget`, `Error::DuplicateMappingKey`) for pattern-matching, not
+by string-matching the rendered message, which would be fragile against
+upstream wording changes.
+
+**Every other variant returns the original, still-wrapped error (PR #250
+review, M4):** the first implementation's catch-all arm called
+`.to_string()` on the *unwrapped* inner error returned by
+`unwrap_snippet`, which discards `Error::WithSnippet`'s source-context
+caret/window — for the common cases this function was never meant to
+rewrite (bad indentation, an unexpected token), this made error quality
+strictly worse than before the fix, the opposite of the goal. The catch-all
+now returns `err.to_string()` — the original, outer error — so `unwrap_snippet`
+is used only to decide *which* branch to take, never to build the returned
+message for anything but the two variants actually being rewritten.
+
+**Location is preserved, not dropped, on the rewritten variants:** both
+`Error::Budget` and `Error::DuplicateMappingKey` carry a `location` field;
+the first cut of the rewrite discarded it, which broke an existing CLI-side
+test (`terse_root_cause_strips_duplicate_key_policy_advice`) that depended
+on line/column surviving into the terse message. `friendly_parse_error`
+now appends `" at line X, column Y"` — the exact phrasing
+`serde_saphyr`'s own localizer uses elsewhere, matched deliberately rather
+than invented — and omits it entirely when the location is
+`serde_saphyr::Location::UNKNOWN`, rather than printing "at line 0, column 0".
+
+**The scalar-byte limit named in the `ScalarBytes` message is passed in,
+not hardcoded (L13):** `splice_frontmatter`'s own verification pass parses
+with a 2x budget (`MAX_FRONTMATTER_BYTES * 2` — see DEC-086's
+verification-gate note), specifically so a caller-supplied value larger
+than the read-path budget isn't mistaken for a splicing failure. That path
+doesn't currently route its errors through `friendly_parse_error` (they're
+discarded and turned into a generic `VerificationFailed` fallback instead),
+but `describe_budget_breach` takes `scalar_byte_limit` as an explicit
+parameter rather than reading the `MAX_FRONTMATTER_BYTES` constant
+directly, so a future caller wiring that path through here cannot silently
+get a message naming the wrong limit.
 
 ## DEC-089: NEW-16 write-path residue — no invented trailing newline, a narrow dotted-key guard, and a retype advisory (2026-08-23)
 
@@ -2037,29 +2083,54 @@ GitHub Docs repro is `--property versions.fpt=X` against a file with an
 existing `versions:` map, which used to create a `versions.fpt` key
 sitting right next to the map it looked like it should have nested into.
 `set`/`append` now reject that one collision with an error naming the
-file and the colliding key, before writing anything. A dotted key with no
-colliding map is unchanged — still a literal flat key — because adding
-real nested-path support is explicitly out of scope for this iteration;
-only the confusing collision is guarded against, not the general case.
-`remove` is not guarded: removing a nonexistent literal dotted key is
-already a harmless no-op (reported as skipped), not a data-corruption risk.
+file and the colliding key — and the error's hint spells out what to do
+instead (edit the file directly to change a value inside the map, or
+choose a non-colliding key name) rather than only explaining what's
+unsupported. A dotted key with no colliding map is unchanged — still a
+literal flat key — because adding real nested-path support is explicitly
+out of scope for this iteration; only the confusing collision is guarded
+against, not the general case. `remove` is not guarded: removing a
+nonexistent literal dotted key is already a harmless no-op (reported as
+skipped), not a data-corruption risk.
+
+**Runs as a whole-batch pre-pass, not a mid-loop check (PR #250 review,
+M5):** the first implementation checked for the collision *inside* the
+per-file read-modify-write loop and `return`ed immediately on a hit. On a
+50-file batch, hitting the collision on file 7 left files 1-6 already
+written to disk, and skipped the end-of-loop `save_index_if_dirty` call
+entirely — a partial write plus a stale on-disk snapshot index, exactly
+the kind of half-applied batch mutation the rest of this codebase goes out
+of its way to avoid (see the existing BUG-D pre-validation pass in both
+`set` and `append`, which this guard now sits next to). The fix moves the
+check into its own read-only pass over every filtered file, run before any
+mutation and before the (also pre-existing) `--validate` pass — reject the
+whole batch, or don't touch anything.
 
 **Retype advisory reuses the existing advisory mechanism, scoped to avoid
 noise (NEW-16c):** `set`'s CLI argument is always a bare string, so type
 inference has no way to know a property was deliberately quoted to stay
 text — `code: '42'` (string) silently becoming `code: 42` (number) via
 `set --property code=42` is inherent to how the CLI parses values, not a
-bug to fix. What was missing was visibility: `advisory_note` (already used
-for the date and enum/pattern advisories, DEC nnn/iter-181) gained a third
-branch that fires when the *first mutated file's* pre-existing value for
-that property was a string and the newly inferred value is a number or
-boolean (`advisory_note` already carries the BUG-B date advisory and the
-iter-181 enum/pattern advisory; this is a third branch in the same
-function, not a new mechanism). Scoped to "was previously a string, now
-isn't" rather than "is a number/boolean at all" specifically to avoid
-noise on properties that are numeric by design (`priority=3` on a file
-where `priority` never existed, or was already numeric, does not fire this
-advisory) — the surprising case is specifically the type *changing* under
-an existing value, mirroring how the date advisory only fires when a
-date-typed property's *new* value fails to look like a date, not on every
-write to that property.
+bug to fix. What was missing was visibility: `advisory_note` (which already
+carries the BUG-B date advisory and the iter-181 enum/pattern advisory)
+gained a third branch that fires when the *first mutated file's*
+pre-existing value for that property was a string and the newly inferred
+value is a number or boolean — a third branch in the same function, not a
+new mechanism. Scoped to "was previously a string, now isn't" rather than
+"is a number/boolean at all" specifically to avoid noise on properties
+that are numeric by design (`priority=3` on a file where `priority` never
+existed, or was already numeric, does not fire this advisory) — the
+surprising case is specifically the type *changing* under an existing
+value, mirroring how the date advisory only fires when a date-typed
+property's *new* value fails to look like a date, not on every write to
+that property.
+
+**Wording hedges the batch-vs-sample gap (PR #250 review, L11):** the
+sampled value comes from exactly one representative file — the same
+"first mutated file" sampling `batch_type_from_file` already uses for
+schema resolution — not from every file the batch touches. The first cut
+of the message ("was previously stored as a string") stated this as fact
+about the whole batch; it now reads "at least one matched file previously
+stored this property as a string ... (other matched files may differ)" so
+the advisory doesn't imply a guarantee about files it never actually
+inspected.

--- a/hyalo-knowledgebase/iterations/iteration-219-list-splice-and-write-polish.md
+++ b/hyalo-knowledgebase/iterations/iteration-219-list-splice-and-write-polish.md
@@ -2,7 +2,7 @@
 title: "Iteration 219 — list splice, mixed-EOL honesty, and frontmatter budget truth"
 type: iteration
 date: 2026-08-23
-status: planned
+status: in-progress
 branch: iter-219/list-splice-and-write-polish
 tags: [iteration, frontmatter, write-path]
 related:

--- a/hyalo-knowledgebase/iterations/iteration-219-list-splice-and-write-polish.md
+++ b/hyalo-knowledgebase/iterations/iteration-219-list-splice-and-write-polish.md
@@ -2,7 +2,7 @@
 title: "Iteration 219 — list splice, mixed-EOL honesty, and frontmatter budget truth"
 type: iteration
 date: 2026-08-23
-status: in-progress
+status: completed
 branch: iter-219/list-splice-and-write-polish
 tags: [iteration, frontmatter, write-path]
 related:
@@ -54,43 +54,43 @@ From [[dogfood-results/dogfood-v0210-pre3-fix-waves-207-214]]:
 
 ## Tasks
 
-- [ ] Splice within lists: `append` inserts one item's line span into a
+- [x] Splice within lists: `append` inserts one item's line span into a
       block list without re-emitting siblings; `remove <key>=<value>`
       deletes only the matching item's span. Preserve flow style on flow
       lists (append inside the brackets) unless the new item cannot be
       represented inline, in which case fall back with the DEC-081
       warning
-- [ ] Mixed line endings: either preserve per-line endings through the
+- [x] Mixed line endings: either preserve per-line endings through the
       splice, or actually fire the documented fallback warning — no
       silent churn. Decide and record which in the decision log
-- [ ] Raise the scalar-content budget to match the documented 64 KiB (or
+- [x] Raise the scalar-content budget to match the documented 64 KiB (or
       an explicitly chosen limit), and wrap all budget/duplicate-key/
       anchor parser errors in actionable hyalo-voice messages that name
       the file and the limit — no leaked `ScalarBytes {…}` /
       `DuplicateKeyPolicy` internals
-- [ ] Files ending exactly at `---` with no trailing newline stay
+- [x] Files ending exactly at `---` with no trailing newline stay
       byte-identical outside the intended change
-- [ ] Reject a dotted `--property a.b=x` with an error when a top-level
+- [x] Reject a dotted `--property a.b=x` with an error when a top-level
       map `a` exists (pointing at the collision); document that path
       syntax is unsupported
-- [ ] Advisory note when type inference changes a value's YAML type
+- [x] Advisory note when type inference changes a value's YAML type
       (string → number/bool), reusing the existing enum/date advisory
       mechanism
-- [ ] Correct DEC-081's fallback-trigger list to the real set (`? key`
+- [x] Correct DEC-081's fallback-trigger list to the real set (`? key`
       syntax, top-level flow mappings, invalid UTF-8, and whatever
       mixed-EOL decision is made); sync `set`/`remove`/`append` help
-- [ ] e2e: GH Docs-style corpus asserting one-line diffs for
+- [x] e2e: GH Docs-style corpus asserting one-line diffs for
       append/remove on block and flow lists; mixed-EOL file; 60 KiB
       frontmatter parse; no-trailing-newline file; dotted-key rejection
 
 ## Acceptance criteria
 
-- [ ] `append`/`remove <key>=<value>` on the 406-file GH Docs corpus:
+- [x] `append`/`remove <key>=<value>` on the 406-file GH Docs corpus:
       0 files change more than the intended line span (was 361)
-- [ ] Mixed-EOL file: untouched lines keep their endings, or a fallback
+- [x] Mixed-EOL file: untouched lines keep their endings, or a fallback
       warning names mixed line endings — never silent churn
-- [ ] `admin/index.md` + 40 appended redirect entries parses and splices
-- [ ] No parser-internal type names appear in any user-facing error
+- [x] `admin/index.md` + 40 appended redirect entries parses and splices
+- [x] No parser-internal type names appear in any user-facing error
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary
- Splice within lists: `append`/`remove key=value` now insert/delete a single item's line span instead of re-serializing the whole list (NEW-5, DEC-086). Block lists get one dash line; flow lists stay flow; anything ambiguous (replace/reorder/multi-item/non-scalar, or `#`-comments interleaved between items) falls back to the existing whole-key reserialize. `set` was already at 406/406 one-line diffs — append/remove now match
- Mixed line endings no longer churn silently: the write path detects a mixed-EOL block and takes the announced DEC-081 full-rewrite path instead of a silent splice (NEW-7, DEC-087). Chose honest-fallback over per-line preservation (rationale in DEC-087)
- Frontmatter scalar budget raised from an undocumented 8 KiB to the documented 64 KiB (NEW-8); saphyr `Budget`/`DuplicateMappingKey` internals are wrapped in plain-language errors that keep line/column (DEC-088)
- Residue: body-less files without a trailing newline stay byte-identical (NEW-16a); dotted `--property a.b=x` is rejected when a top-level map `a` exists (NEW-16b); `set` warns when type inference retypes a string value to number/bool (NEW-16c); DEC-081's fallback-trigger list corrected to the real four triggers

## Test plan
- [x] 21 splice unit + 8 frontmatter unit + 5 CLI unit + 8 e2e tests, fail-first where structurally meaningful (renamed the old `append_to_a_list_rewrites_only_that_list` bug-documenting test to strict byte-exact assertions)
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace -q` clean (single run)
- [x] All xtask gates pass
- [x] GH Docs corpus (3,707 frontmatter files): `append` then `remove redirect_from` round-trips 3706/3710 byte-identical to pristine; the 4 exceptions are correctly-declined fallbacks (`#`-comment-interleaved lists + 1 known DEC-081 case, warned). `admin/index.md` + 40 sequential appends: +40/-0 lines, zero leaked internals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEuPjCTq74bwJgoWbcvHrD