### PR TITLE
feat(pi): post-write lint guardrail for vault markdown files

### DIFF
--- a/crates/hyalo-cli/templates/extension-hyalo.ts
+++ b/crates/hyalo-cli/templates/extension-hyalo.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "typebox";
+import * as path from "node:path";
 
 const HYALO_TIMEOUT_MS = 60_000;
 
@@ -31,6 +32,66 @@ function buildCommand(params: HyaloToolArgs): string[] {
   }
   cmdArgs.push(...extraArgs);
   return cmdArgs;
+}
+
+/**
+ * Post-write lint guardrail.
+ *
+ * After pi's write/edit tools touch a .md file inside the hyalo vault,
+ * run `hyalo lint <file>` and append any violations to the tool result.
+ * The agent sees the findings in the same turn and fixes them immediately
+ * — schema drift can no longer land silently. Clean files add nothing.
+ *
+ * The vault directory is resolved once via `hyalo config` and cached for
+ * the session; files outside the vault (or a failed config lookup) skip
+ * the check entirely, so non-hyalo projects pay zero cost.
+ */
+async function findVaultDir(pi: ExtensionAPI): Promise<string | null> {
+  const cached = findVaultDir.cache;
+  if (cached !== undefined) return cached;
+  try {
+    const { stdout, code } = await pi.exec("hyalo", ["config", "--format", "json"], {
+      timeout: 10_000,
+    });
+    if (code !== 0) {
+      findVaultDir.cache = null;
+      return null;
+    }
+    // config's JSON is a flat object; .dir is the vault directory name
+    // (e.g. "hyalo-knowledgebase"), absent/null when no vault is configured.
+    const dir = JSON.parse(stdout)?.dir;
+    const resolved = typeof dir === "string" && dir ? dir : null;
+    findVaultDir.cache = resolved;
+    return resolved;
+  } catch {
+    // hyalo not installed or no config: no vault, no guardrail.
+    findVaultDir.cache = null;
+    return null;
+  }
+}
+// Module-level cache slot (survives across event handler invocations).
+findVaultDir.cache = undefined as string | null | undefined;
+
+async function lintVaultFile(
+  pi: ExtensionAPI,
+  filePath: string,
+  signal: AbortSignal | undefined,
+): Promise<string | null> {
+  try {
+    const { stdout, code } = await pi.exec(
+      "hyalo",
+      ["lint", filePath, "--format", "text", "--no-hints"],
+      { signal, timeout: 30_000 },
+    );
+    // lint exits 0 = clean, 1 = violations found (stdout holds them),
+    // anything else = lint itself failed: stay silent, don't mask the write.
+    if (code !== 0 && code !== 1) return null;
+    // Clean single-file output is "N file checked, no issues".
+    if (/no issues/.test(stdout)) return null;
+    return stdout.trim();
+  } catch {
+    return null;
+  }
 }
 
 const hyaloToolParams = Type.Object({
@@ -120,6 +181,40 @@ export default function (pi: ExtensionAPI) {
         };
       }
     },
+  });
+
+  // Post-write lint guardrail: append hyalo lint findings to write/edit
+  // tool results for vault .md files (see findVaultDir/lintVaultFile above).
+  pi.on("tool_result", async (event, ctx) => {
+    if (event.toolName !== "write" && event.toolName !== "edit") return;
+    if (event.isError) return; // failed writes: don't pile on
+
+    const rawPath = event.input.path;
+    if (typeof rawPath !== "string" || !rawPath.endsWith(".md")) return;
+
+    const vaultDir = await findVaultDir(pi);
+    if (!vaultDir) return;
+
+    // Vault membership: normalized absolute path containment check.
+    const vaultAbs = path.resolve(process.cwd(), vaultDir);
+    const fileAbs = path.resolve(process.cwd(), rawPath);
+    if (fileAbs !== vaultAbs && !fileAbs.startsWith(vaultAbs + path.sep)) return;
+
+    const lintOutput = await lintVaultFile(pi, rawPath, ctx.signal);
+    if (!lintOutput) return; // clean or lint unavailable
+
+    return {
+      content: [
+        ...event.content,
+        {
+          type: "text" as const,
+          text:
+            `⚠ hyalo lint found issues in ${path.relative(vaultAbs, fileAbs)} ` +
+            `(write succeeded, but fix the violations now — e.g. 'hyalo set' for ` +
+            `frontmatter, 'hyalo lint --fix' for formatting):\n\n${lintOutput}`,
+        },
+      ],
+    };
   });
 
   // Register commands for common hyalo operations


### PR DESCRIPTION
## What

After pi's `write`/`edit` tools successfully touch a `.md` file inside the hyalo vault, the extension runs `hyalo lint <file>` and **appends any violations to the tool result**. The agent sees the findings in the same turn and self-corrects immediately — schema drift can no longer land silently.

This is the differentiator that a plain CLI wrapper can't have: hyalo becomes an *active enforcer* of vault consistency rather than a passive tool.

## How it works

```
agent writes file → pi tool_result event → extension:
  ├─ tool write/edit only, success only, .md only
  ├─ vault dir (hyalo config, cached once per session)
  ├─ path containment check (normalized absolute)
  └─ hyalo lint <file> --no-hints
       ├─ clean → append nothing (zero noise)
       └─ violations → append findings + fix hints to tool result
```

Details:
- `hyalo config` JSON is `JSON.parse`d in the extension (config ignores `--jq`)
- lint exit-code contract: 0 = clean, 1 = violations, other = lint failed → silent (never masks the write result)
- Zero cost outside hyalo projects: no vault → no exec after the one-time config lookup
- Findings suggest the fix: `hyalo set` for frontmatter, `hyalo lint --fix` for formatting

## Verification (live pi runs)

1. **Bad write** (missing required `type`): violations appended verbatim to the write tool result ✓
2. **Full self-correction loop**: write → guardrail flags → agent fixed frontmatter via `hyalo set type=note` → `hyalo lint` clean, all in one turn ✓
3. **Clean write**: tool result unchanged — no noise ✓
4. `just pi-extension` drift guard passes (type-check + forced tool call) ✓
5. fmt / clippy `-D warnings` / `cargo test --workspace` green ✓

## Notes

- Existing users pick this up by re-running `hyalo init --pi` (overwrites `.pi/extensions/hyalo.ts`)
- Always-on when a vault exists — the guardrail is the point of the extension; opt-out could be added later if anyone asks

Remaining roadmap (separate PRs): session-start vault summary injection, typed tools, `pi install` package distribution.