### PR TITLE
feat(pi): opt-in session-start vault summary injection

### DIFF
--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -77,6 +77,10 @@ pub(crate) struct ConfigReport {
     /// surprisingly small `--apply-fuzzy` run is one command away from an
     /// explanation.
     pub fuzzy_min_confidence: f64,
+    /// Effective `[pi] session_summary` (opt-in): when `true`, the pi
+    /// extension injects a `hyalo summary` snapshot into the LLM context at
+    /// session start. `false` when unset.
+    pub pi_session_summary: bool,
 }
 
 /// Effective `[links.auto]` settings, as `hyalo config` reports them.
@@ -166,6 +170,7 @@ pub(crate) fn collect_config_report(
         fuzzy_min_confidence: resolved
             .fuzzy_min_confidence
             .unwrap_or(hyalo_core::link_score::DEFAULT_FUZZY_MIN_CONFIDENCE),
+        pi_session_summary: resolved.pi_session_summary,
     })
 }
 
@@ -258,6 +263,12 @@ pub(crate) fn config_envelope(report: &ConfigReport) -> serde_json::Value {
             // Effective `links fix --apply-fuzzy` confidence floor (iter-212).
             // Always a number — the built-in default when the key is unset.
             "links_fuzzy_min_confidence": report.fuzzy_min_confidence,
+            // Effective `[pi]` agent-integration settings (iter-230).
+            // Always present, `false` when unset, so consumers never have to
+            // distinguish "absent" from "off".
+            "pi": {
+                "session_summary": report.pi_session_summary,
+            },
         },
         "hints": hints,
         "dir": report.dir.display().to_string(),
@@ -381,7 +392,7 @@ fn run_config_text(report: &ConfigReport, show_hints: bool) -> CommandOutcome {
 
     let mut out = format!(
         "{dir_out_of_bounds_str}{malformed_str}config: {config_path_str}\ncwd: {cwd}\ndir: {dir}{dir_suffix}\nformat: {format_str}\nhints: {hints}\nsite_prefix: {site_prefix_str}\nexempt: {exempt_str}\n\
-         links.auto.exclude_titles: {auto_titles}\nlinks.auto.exclude_target_globs: {auto_globs}\nlinks.auto.first_only: {auto_first_only}\nlinks.auto.warn_common_titles: {auto_warn_common}\nlinks.fuzzy_min_confidence: {fuzzy_floor}\n",
+         links.auto.exclude_titles: {auto_titles}\nlinks.auto.exclude_target_globs: {auto_globs}\nlinks.auto.first_only: {auto_first_only}\nlinks.auto.warn_common_titles: {auto_warn_common}\nlinks.fuzzy_min_confidence: {fuzzy_floor}\npi.session_summary: {pi_session_summary}\n",
         cwd = report.cwd.display(),
         dir = report.dir.display(),
         hints = report.hints,
@@ -390,6 +401,7 @@ fn run_config_text(report: &ConfigReport, show_hints: bool) -> CommandOutcome {
         auto_first_only = report.links_auto.first_only,
         auto_warn_common = report.links_auto.warn_common_titles,
         fuzzy_floor = report.fuzzy_min_confidence,
+        pi_session_summary = report.pi_session_summary,
     );
 
     if let Some(ref contents) = report.raw_contents {

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -85,6 +85,16 @@ struct ChangelogConfig {
     path: Option<String>,
 }
 
+/// Agent-integration configuration from `[pi]` in `.hyalo.toml`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PiConfig {
+    /// When `true`, the pi extension injects a `hyalo summary` snapshot into
+    /// the LLM context at session start (opt-in; the extension reads this
+    /// via `hyalo config --format json`).
+    session_summary: Option<bool>,
+}
+
 /// Vault-walker configuration from `[scan]` in `.hyalo.toml`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -210,6 +220,8 @@ struct ConfigFile {
     schema: Option<toml::Value>,
     /// Default output limit for list commands (0 = unlimited).
     default_limit: Option<usize>,
+    /// Agent-integration configuration (`[pi]` section).
+    pi: Option<PiConfig>,
 }
 
 /// Resolved configuration with all defaults applied.
@@ -255,6 +267,9 @@ pub(crate) struct ResolvedDefaults {
     /// `Some(0)` = unlimited.
     /// `Some(n)` = limit to n.
     pub(crate) default_limit: Option<usize>,
+    /// When `true` (via `[pi] session_summary`), the pi extension injects a
+    /// `hyalo summary` snapshot into the LLM context at session start.
+    pub(crate) pi_session_summary: bool,
     /// Case-insensitive link resolution mode from `[links] case_insensitive`.
     pub(crate) case_insensitive_mode: CaseInsensitiveMode,
     /// Titles `hyalo links auto` never links, from `[links.auto] exclude_titles`.
@@ -341,6 +356,7 @@ impl PartialEq for ResolvedDefaults {
             && self.validate_on_write == other.validate_on_write
             && self.lint_ignore == other.lint_ignore
             && self.default_limit == other.default_limit
+            && self.pi_session_summary == other.pi_session_summary
             && self.case_insensitive_mode == other.case_insensitive_mode
             && self.fuzzy_min_confidence == other.fuzzy_min_confidence
     }
@@ -364,6 +380,7 @@ impl ResolvedDefaults {
             md_lint: hyalo_mdlint::LintConfig::default(),
             schema: SchemaConfig::default(),
             default_limit: None,
+            pi_session_summary: false,
             case_insensitive_mode: CaseInsensitiveMode::Auto,
             auto_link_exclude_titles: Vec::new(),
             auto_link_exclude_target_globs: Vec::new(),
@@ -977,6 +994,11 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
         okf_ignore: cfg.okf.map(|o| o.ignore).unwrap_or_default(),
         scan_include: cfg.scan.map(|s| s.include).unwrap_or_default(),
         changelog_path: cfg.changelog.and_then(|c| c.path),
+        pi_session_summary: cfg
+            .pi
+            .as_ref()
+            .and_then(|p| p.session_summary)
+            .unwrap_or(false),
         md_lint: parse_md_lint_config(cfg.lint.as_ref()),
         schema,
         default_limit: cfg.default_limit,

--- a/crates/hyalo-cli/templates/extension-hyalo.ts
+++ b/crates/hyalo-cli/templates/extension-hyalo.ts
@@ -46,31 +46,49 @@ function buildCommand(params: HyaloToolArgs): string[] {
  * the session; files outside the vault (or a failed config lookup) skip
  * the check entirely, so non-hyalo projects pay zero cost.
  */
-async function findVaultDir(pi: ExtensionAPI): Promise<string | null> {
-  const cached = findVaultDir.cache;
+/** Parsed `hyalo config --format json` — the bits the extension needs. */
+interface HyaloConfigInfo {
+  /** Vault directory name, or null when no vault is configured. */
+  vaultDir: string | null;
+  /** Effective `[pi] session_summary` (opt-in LLM context injection). */
+  sessionSummary: boolean;
+}
+
+async function loadHyaloConfig(pi: ExtensionAPI): Promise<HyaloConfigInfo | null> {
+  const cached = loadHyaloConfig.cache;
   if (cached !== undefined) return cached;
   try {
     const { stdout, code } = await pi.exec("hyalo", ["config", "--format", "json"], {
       timeout: 10_000,
     });
     if (code !== 0) {
-      findVaultDir.cache = null;
+      loadHyaloConfig.cache = null;
       return null;
     }
-    // config's JSON is a flat object; .dir is the vault directory name
-    // (e.g. "hyalo-knowledgebase"), absent/null when no vault is configured.
-    const dir = JSON.parse(stdout)?.dir;
-    const resolved = typeof dir === "string" && dir ? dir : null;
-    findVaultDir.cache = resolved;
+    // The JSON is an envelope with a top-level `dir` compat key (older
+    // hyalo versions printed the flat object without an envelope — both
+    // shapes carry the top-level `dir`). `pi` lives under `.results.pi`.
+    const parsed = JSON.parse(stdout);
+    const dir = parsed?.dir ?? parsed?.results?.dir;
+    const sessionSummary = parsed?.results?.pi?.session_summary === true;
+    const resolved: HyaloConfigInfo = {
+      vaultDir: typeof dir === "string" && dir ? dir : null,
+      sessionSummary,
+    };
+    loadHyaloConfig.cache = resolved;
     return resolved;
   } catch {
     // hyalo not installed or no config: no vault, no guardrail.
-    findVaultDir.cache = null;
+    loadHyaloConfig.cache = null;
     return null;
   }
 }
 // Module-level cache slot (survives across event handler invocations).
-findVaultDir.cache = undefined as string | null | undefined;
+loadHyaloConfig.cache = undefined as HyaloConfigInfo | null | undefined;
+
+async function findVaultDir(pi: ExtensionAPI): Promise<string | null> {
+  return (await loadHyaloConfig(pi))?.vaultDir ?? null;
+}
 
 async function lintVaultFile(
   pi: ExtensionAPI,
@@ -181,6 +199,38 @@ export default function (pi: ExtensionAPI) {
         };
       }
     },
+  });
+
+  // Opt-in vault summary injection: with `[pi] session_summary = true` in
+  // .hyalo.toml, inject a `hyalo summary` snapshot into the LLM context at
+  // session start (custom message, not displayed in the TUI). Injected at
+  // most once per pi process — a fork/new session in the same process keeps
+  // the summary already present in the transcript or skips a duplicate.
+  let summaryInjected = false;
+  pi.on("session_start", async () => {
+    if (summaryInjected) return;
+    const config = await loadHyaloConfig(pi);
+    if (!config?.sessionSummary || !config.vaultDir) return;
+    summaryInjected = true;
+    try {
+      const { stdout, code } = await pi.exec(
+        "hyalo",
+        ["summary", "--format", "text", "--no-hints"],
+        { timeout: 30_000 },
+      );
+      if (code !== 0 || !stdout.trim()) return;
+      pi.sendMessage({
+        customType: "hyalo-vault-summary",
+        content:
+          `Knowledgebase snapshot (${config.vaultDir}/) for this session:\n\n` +
+          stdout.trim() +
+          "\n\nUse this to orient yourself; refine with the hyalo tool.",
+        display: false,
+        details: undefined,
+      });
+    } catch {
+      // summary unavailable: skip injection silently
+    }
   });
 
   // Post-write lint guardrail: append hyalo lint findings to write/edit

--- a/crates/hyalo-cli/tests/e2e/hyalo_config.rs
+++ b/crates/hyalo-cli/tests/e2e/hyalo_config.rs
@@ -646,3 +646,74 @@ fn config_rejects_an_out_of_range_fuzzy_confidence_floor() {
         "and the built-in default must take over: {stdout}"
     );
 }
+
+/// iter-230: `[pi] session_summary` opts the pi extension into injecting a
+/// `hyalo summary` snapshot into the LLM context at session start. The
+/// extension reads the effective value from `hyalo config --format json`,
+/// so the report must expose it — false by default, true when configured —
+/// in both text and JSON renderings.
+#[test]
+fn config_reports_pi_session_summary() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+
+    // Default: off, but still reported (never "absent" vs "off").
+    let stdout = fuzzy_config_stdout(tmp.path(), "text");
+    assert!(
+        stdout.contains("pi.session_summary: false"),
+        "the built-in default must be reported, not omitted: {stdout}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&fuzzy_config_stdout(tmp.path(), "json"))
+        .expect("config --format json should emit JSON");
+    assert_eq!(
+        json["results"]["pi"]["session_summary"].as_bool(),
+        Some(false),
+        "{json}"
+    );
+
+    // Opt-in via [pi] session_summary = true.
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "[pi]\nsession_summary = true\n",
+    )
+    .expect("config write should succeed");
+
+    let stdout = fuzzy_config_stdout(tmp.path(), "text");
+    assert!(
+        stdout.contains("pi.session_summary: true"),
+        "the configured value must win: {stdout}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&fuzzy_config_stdout(tmp.path(), "json"))
+        .expect("config --format json should emit JSON");
+    assert_eq!(
+        json["results"]["pi"]["session_summary"].as_bool(),
+        Some(true),
+        "{json}"
+    );
+}
+
+/// `[pi]` rejects unknown keys (`deny_unknown_fields`), same as every other
+/// config section — a typo like `session_summaries` must not pass silently.
+/// The rejection surfaces as `malformed: true` + `parse_error` in the
+/// `hyalo config` JSON report (not stderr — stderr is only for hard errors).
+#[test]
+fn config_rejects_unknown_pi_keys() {
+    let tmp = TempDir::new().expect("tempdir creation should succeed");
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "[pi]\nsession_summaries = true\n",
+    )
+    .expect("config write should succeed");
+
+    let json: serde_json::Value = serde_json::from_str(&fuzzy_config_stdout(tmp.path(), "json"))
+        .expect("config --format json should emit JSON");
+    assert_eq!(
+        json["results"]["malformed"].as_bool(),
+        Some(true),
+        "an unknown [pi] key must mark the config malformed: {json}"
+    );
+    let parse_error = json["results"]["parse_error"].as_str().unwrap_or("");
+    assert!(
+        parse_error.contains("session_summaries"),
+        "the parse error must name the unknown key: {json}"
+    );
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,6 +273,31 @@ truth:
 | **0.8 (default)** | **2,253** | **15** | **99.3%** |
 | 0.9 | 312 | 0 | 100% |
 
+## Agent integration (`[pi]`)
+
+Hyalo ships a pi coding-agent extension (`hyalo init --pi`) that registers a
+`hyalo` tool, slash commands, and a post-write lint guardrail: when pi's
+`write`/`edit` tools touch a `.md` file inside the vault, the extension runs
+`hyalo lint <file>` on it and appends any violations to the tool result, so
+schema drift cannot land silently.
+
+The `[pi]` section configures the extension:
+
+```toml
+[pi]
+session_summary = true   # inject a vault summary into the LLM context at session start
+```
+
+- **`session_summary`** (default `false`) — on session start, run
+  `hyalo summary` once and inject the snapshot (file counts by directory,
+  link health, task and status totals) into the agent's context as a hidden
+  message. The agent starts every session already knowing the vault's shape
+  instead of spending tool calls rediscovering it. Costs a few hundred
+  tokens of context per session, which is why it is opt-in.
+
+`hyalo config` reports the effective values as `pi.session_summary` (text)
+and under `results.pi` (JSON).
+
 ## Schemas
 
 Schemas support typed properties (`string`, `date`, `datetime`, `datetime-tz`, `number`, `boolean`, `list`, `enum`, `string-list` — with regex patterns, enum values, and length bounds), per-type filename templates, path-bound types (`[[schema.bind]]`) that apply a schema to a subtree without explicit `type:` frontmatter, and reserved-file exemptions (`[schema] exempt`). Manage schemas from the CLI with `hyalo types list|show|set`, validate with `hyalo lint`, and inspect the resolved configuration with `hyalo config`.

--- a/pi-extension-e2e.sh
+++ b/pi-extension-e2e.sh
@@ -40,7 +40,7 @@ echo "pi package: $PI_PKG ($(node -p "require('$PI_PKG/package.json').version"))
 
 # --- layer 1: static type-check -----------------------------------------
 echo
-echo "== [1/2] type-checking template against installed pi types =="
+echo "== [1/3] type-checking template against installed pi types =="
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/hyalo-pi-check.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -70,7 +70,7 @@ echo "type-check OK"
 
 # --- layer 2: live e2e with builtin tools disabled ----------------------
 echo
-echo "== [2/2] live e2e: forcing the hyalo tool (no bash fallback possible) =="
+echo "== [2/3] live e2e: forcing the hyalo tool (no bash fallback possible) =="
 # Query must return a plain count. Vault contents change, but the term
 # "iteration" always matches in hyalo's own knowledgebase and test vaults
 # that run this script; --count output is a bare number.
@@ -83,5 +83,31 @@ COUNT="$(tr -d '[:space:]' <<<"$OUT")"
 [[ "$COUNT" -gt 0 ]] || fail "tool ran but returned count 0 — suspicious for term 'iteration'"
 
 echo "e2e OK: hyalo tool returned count=$COUNT"
+
+# --- layer 3: post-write lint guardrail ---------------------------------
+#
+# Verify the tool_result guardrail still fires: with only the `write` tool
+# enabled, the model writes a deliberately non-conforming vault file; the
+# extension must append hyalo lint findings to the write tool's result.
+# Catches drift in BOTH the pi event API and hyalo's config/lint output
+# shapes (e.g. the JSON envelope changing would break vault resolution).
 echo
-echo "PASS: template is compatible with installed pi and the tool path works"
+echo "== [3/3] guardrail e2e: lint findings appended to write result =="
+GUARD_FILE="hyalo-knowledgebase/.pi-e2e-guard.md"
+rm -f "$GUARD_FILE"
+OUT="$(pi -t write -e "$TEMPLATE" -p "Use the write tool to create $GUARD_FILE with exactly this content:
+---
+title: Guardrail test
+---
+body
+
+Then report verbatim any lint warnings or extra notes that appeared in the write tool's result. Do not fix anything.")" \
+    || fail "pi guardrail run failed"
+rm -f "$GUARD_FILE"
+
+if ! grep -q "hyalo lint" <<<"$OUT"; then
+    fail "guardrail did not fire: expected hyalo lint findings in the write result, got: $OUT"
+fi
+echo "guardrail e2e OK: lint findings were appended to the write result"
+echo
+echo "PASS: template is compatible with installed pi; tool path and lint guardrail work"


### PR DESCRIPTION
## What

New `[pi]` config section; first key: `session_summary` (default `false`).

```toml
[pi]
session_summary = true
```

When enabled, the pi extension injects a `hyalo summary` snapshot — file counts by directory, link health, task and status totals — into the LLM context at session start as a **hidden custom message** (`display: false`). The agent starts every session already knowing the vault's shape instead of spending tool calls rediscovering it. Opt-in because it costs a few hundred tokens of context per session.

This is roadmap item 4 of making hyalo a prime pi tool (#257 fixed the extension + prompt guidelines, #258 added the local drift guard, #259 added the post-write lint guardrail).

## Changes

**Rust**
- `[pi]` config section (`deny_unknown_fields`, like every other section) → `ResolvedDefaults.pi_session_summary`
- `hyalo config` reports it: `pi.session_summary` (text) / `results.pi` (JSON), always present — never "absent" vs "off"
- 2 e2e tests: effective-value reporting (default off + configured on), unknown-key rejection (`session_summaries` → `malformed: true`, parse error names the key)
- `docs/configuration.md`: new "Agent integration (`[pi]`)" section

**Extension template**
- `session_start` handler: inject once per pi process, only when opted in and a vault is configured; `hyalo summary --no-hints` output wrapped in orientation text
- Single cached `hyalo config --format json` call now serves both the lint guardrail (vault dir) and the opt-in flag — previously would have been a second exec per session
- `dir` parsed from both flat and envelope JSON shapes (config gained a results envelope since 0.20.0; uses the top-level compat `dir` key with `results.dir` fallback)

**Guard script (`just pi-extension`)**
- New layer 3: `pi -t write` run asserting lint findings are appended to the write result — catches drift in the pi event API *and* hyalo's own config/lint output shapes

## Verification

- Live: `session_summary = true` → model recited vault stats (400 files, 936 links, task counts) with **zero tool calls**; default → nothing injected
- `just pi-extension`: all 3 layers pass (type-check, forced tool call, guardrail)
- fmt / clippy `-D warnings` / `cargo test --workspace` green (all 9 suites)

## Notes

Existing users opt in by adding the two TOML lines + re-running `hyalo init --pi`. Remaining roadmap (separate PRs): typed tools, `pi install` package distribution.