### PR TITLE
fix(pi): tool default flags no longer collide with model-supplied args

### DIFF
--- a/crates/hyalo-cli/templates/extension-hyalo.ts
+++ b/crates/hyalo-cli/templates/extension-hyalo.ts
@@ -17,17 +17,26 @@ interface HyaloToolArgs {
   indexFile?: string;
 }
 
+/** Whether the argv already carries a value-taking flag (long or short). */
+function hasFlag(argv: string[], long: string, short?: string): boolean {
+  return argv.includes(long) || (short !== undefined && argv.includes(short));
+}
+
 function buildCommand(params: HyaloToolArgs): string[] {
   const { subcommand, args: extraArgs = [], formatText = true, jq, indexFile } = params;
   const cmdArgs = [subcommand];
 
-  if (formatText && !jq) {
+  // Only inject defaults the caller did not supply themselves: the model
+  // often repeats `--format text` from the skill's guidance, and a duplicate
+  // `--format` is a hard clap error ("cannot be used multiple times").
+  const hasFormat = hasFlag(extraArgs, "--format", "-f");
+  if (formatText && !jq && !hasFormat) {
     cmdArgs.push("--format", "text");
   }
-  if (jq) {
+  if (jq && !hasFlag(extraArgs, "--jq")) {
     cmdArgs.push("--jq", jq);
   }
-  if (indexFile) {
+  if (indexFile && !hasFlag(extraArgs, "--index-file")) {
     cmdArgs.push("--index-file", indexFile);
   }
   cmdArgs.push(...extraArgs);

--- a/pi-extension-e2e.sh
+++ b/pi-extension-e2e.sh
@@ -24,6 +24,15 @@ TEMPLATE="${1:-crates/hyalo-cli/templates/extension-hyalo.ts}"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
+# Prefer this checkout's release binary: the guard validates the template
+# against THIS tree's hyalo (config envelope shape, [pi] section, lint
+# output). A PATH hyalo may be an older release that parses differently.
+# The extension resolves `hyalo` from PATH at runtime; this only pins the
+# binary under test.
+if [[ -x "target/release/hyalo" ]]; then
+    export PATH="$PWD/target/release:$PATH"
+fi
+
 # --- locate pi and its package directory -------------------------------
 PI_BIN="$(command -v pi)" || fail "pi not found on PATH"
 # Resolve through Homebrew/npm symlink chains to the real package dir.
@@ -74,7 +83,7 @@ echo "== [2/3] live e2e: forcing the hyalo tool (no bash fallback possible) =="
 # Query must return a plain count. Vault contents change, but the term
 # "iteration" always matches in hyalo's own knowledgebase and test vaults
 # that run this script; --count output is a bare number.
-OUT="$(pi --no-builtin-tools -e "$TEMPLATE" -p \
+OUT="$(pi -ne --no-builtin-tools -e "$TEMPLATE" -p \
     'Call the hyalo tool with subcommand "find" and args ["\"iteration\"", "--count"]. Reply with ONLY the number the tool returned, nothing else.')" \
     || fail "pi run failed (extension may not have loaded — check registerTool/registerCommand API)"
 
@@ -95,7 +104,7 @@ echo
 echo "== [3/3] guardrail e2e: lint findings appended to write result =="
 GUARD_FILE="hyalo-knowledgebase/.pi-e2e-guard.md"
 rm -f "$GUARD_FILE"
-OUT="$(pi -t write -e "$TEMPLATE" -p "Use the write tool to create $GUARD_FILE with exactly this content:
+OUT="$(pi -ne -t write -e "$TEMPLATE" -p "Use the write tool to create $GUARD_FILE with exactly this content:
 ---
 title: Guardrail test
 ---


### PR DESCRIPTION
## What

Dogfooding catch from the hyalo-demo setup: the model passed `--format text` inside `args` (as the skill teaches on every command), and the extension *also* injects `--format text` by default — clap rejects the duplicate:

```
error: the argument '--format <FORMAT>' cannot be used multiple times
```

## Fix

`buildCommand` now injects a default only when the caller did not supply that flag themselves (long or short form): `--format`/`-f`, `--jq`, `--index-file`.

## Guard-script hardening (same reproduction session)

- pi invocations use `-ne`: load the explicit `-e` template only, no project extensions — otherwise a `hyalo init --pi` checkout makes the tool name conflict (`Tool 'hyalo' conflicts`)
- Prefer `./target/release/hyalo` on PATH: an older PATH hyalo (e.g. one that doesn't know `[pi]`) silently degrades the guardrail — config parse fails, falls back to defaults, wrong vault scope (observed: count=326 whole-repo vs 311 vault-only)

## Verification

- Live: model-supplied `--format text` + default injection → single flag, correct output (no clap error), against both old and new hyalo binaries
- `just pi-extension`: all 3 layers pass
- fmt / clippy `-D warnings` / `cargo test --workspace` green