### PR TITLE
fix(pi): preempt hallucinated per-property flags in tool schema

### DIFF
--- a/crates/hyalo-cli/templates/extension-hyalo.ts
+++ b/crates/hyalo-cli/templates/extension-hyalo.ts
@@ -128,7 +128,7 @@ const hyaloToolParams = Type.Object({
   args: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        "Additional arguments for the subcommand, e.g. ['\"search terms\"', '--tag', 'iteration', '--property', 'status=planned']",
+        "Additional arguments for the subcommand. Property filters use '--property K=V' (e.g. '--property', 'status=planned'); there is NO --status/--type/--priority flag — status is not a flag, it is a property. Other common flags: '--tag T', '--task todo|done|any', '--section H', '--count', '--limit N'.",
     }),
   ),
   formatText: Type.Optional(
@@ -164,6 +164,7 @@ export default function (pi: ExtensionAPI) {
     promptGuidelines: [
       "For .md files with YAML frontmatter in a knowledgebase/vault, prefer the hyalo tool over read/edit/grep: use `hyalo find` to search or filter by content/tags/properties, `hyalo read` to read, and `hyalo set`/`hyalo task` to bulk-mutate instead of many edit calls.",
       "hyalo output includes drill-down hints (lines starting with `->`) — follow them to refine queries; hints marked `=>` with `[writes]` modify the vault.",
+      "hyalo flags map to the tool's args array: e.g. `hyalo find --property status=planned --tag iteration` → subcommand 'find', args ['--property', 'status=planned', '--tag', 'iteration']. Filter by a property with '--property K=V' — there are no per-property flags like --status.",
     ],
     parameters: hyaloToolParams,
     async execute(_toolCallId, params: Static<typeof hyaloToolParams>, signal) {


### PR DESCRIPTION
## What

Dogfooding round 2 from the hyalo-demo setup: the model called `hyalo find --status planned`. Status is a *property*, not a flag — clap rejects it with a tip (`to pass '--status' as a value, use '-- --status'`) that actively misleads the model instead of pointing at `--property status=planned`.

The skill teaches the correct form, but models reach for the natural-language flag anyway (likely conflating `--status` with the real `--task STATUS` filter). The tool schema is the more reliable teaching surface — it's in front of the model on every call, even in sessions where the skill didn't load.

## Changes (2 lines, template only)

- `args` description now states explicitly: **no `--status`/`--type`/`--priority` flag — status is not a flag, it is a property** — plus a reference of common flags (`--tag`, `--task todo|done|any`, `--section`, `--count`, `--limit`)
- New `promptGuidelines` bullet: a worked example translating `hyalo find --property status=planned --tag iteration` into `subcommand` + `args` array form

## Verification

- Live: `find all notes with status planned` → correct `--property status=planned` call, same 4 results as manual verification, no clap error
- `just pi-extension`: all 3 layers pass
- fmt / clippy `-D warnings` / `cargo test --workspace` green

Follow-up idea (not here): hyalo could give clap a custom `--status`-style error hint (`did you mean --property status=…?`) so bash users get the same guidance — happy to take that as a separate iteration.