### PR TITLE
feat(cli): unknown --<property> flags suggest --property K=V

### DIFF
--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -540,6 +540,27 @@ fn run_inner() -> Result<(), AppError> {
                 return Err(AppError::Exit(2));
             }
 
+            // Unknown long flag that names a schema-declared property →
+            // `--property` hint. Models and users reach for natural-language
+            // flags (`hyalo find --status planned`) even though the skill/help
+            // teach `--property status=planned`; clap's own tip ("to pass
+            // '--status' as a value, use '-- --status'") actively misleads.
+            // Only fires when the flag names a real property in the effective
+            // schema (checked via suggest::is_schema_property), so unrelated
+            // typos keep clap's normal error.
+            if e.kind() == clap::error::ErrorKind::UnknownArgument
+                && let Some(name) = crate::suggest::unknown_long_flag_name(&e)
+                && crate::suggest::is_schema_property(&config.schema, &name)
+            {
+                eprintln!(
+                    "error: unexpected argument '--{name}' found\n\n\
+                     tip: '{name}' is a frontmatter property, not a flag — did you mean \
+                     '--property {name}=<value>'?\n\n\
+                     Example: hyalo find --property {name}=<value>\n"
+                );
+                return Err(AppError::Exit(2));
+            }
+
             // Intercept `--tag` / `-t` on the `append` subcommand. Tags are
             // scalar list items, so there is nothing to "append" in the
             // property-level sense — `hyalo set --tag T` is the right tool.

--- a/crates/hyalo-cli/src/suggest.rs
+++ b/crates/hyalo-cli/src/suggest.rs
@@ -58,6 +58,43 @@ pub fn top_level_subcommand<'a>(args: &'a [String], cmd: &clap::Command) -> Opti
     None
 }
 
+/// Extract the long-flag name from a clap `UnknownArgument` error.
+///
+/// Returns the flag without leading dashes and without any `=value`
+/// suffix (e.g. `hyalo find --status=planned` → `Some("status")`).
+/// Short flags (single-dash) and `--` return `None` — the property hint
+/// only makes sense for long flags that read like property names.
+pub fn unknown_long_flag_name(err: &clap::Error) -> Option<String> {
+    use clap::error::{ContextKind, ContextValue};
+    err.context().find_map(|(kind, value)| {
+        if kind != ContextKind::InvalidArg {
+            return None;
+        }
+        let ContextValue::String(s) = value else {
+            return None;
+        };
+        let name = s.strip_prefix("--")?;
+        if name.is_empty() || name.starts_with('-') {
+            return None;
+        }
+        Some(name.split('=').next().unwrap_or(name).to_owned())
+    })
+}
+
+/// Whether `name` is a property declared in the effective schema:
+/// any type's `properties`, `required`, or `defaults` keys — or the
+/// `[schema.default]` type's. This powers the `--status` →
+/// `--property status=…` unknown-flag hint: only flags that name a real
+/// property get the suggestion; everything else keeps clap's normal error.
+pub fn is_schema_property(schema: &hyalo_core::schema::SchemaConfig, name: &str) -> bool {
+    let check = |ts: &hyalo_core::schema::TypeSchema| {
+        ts.properties.contains_key(name)
+            || ts.required.iter().any(|r| r == name)
+            || ts.defaults.contains_key(name)
+    };
+    check(&schema.default) || schema.types.values().any(check)
+}
+
 /// Given the raw CLI args and the clap Command tree, detect when an unknown
 /// `--flag` matches a known subcommand name and return a corrected command suggestion.
 ///

--- a/crates/hyalo-cli/tests/e2e/suggest.rs
+++ b/crates/hyalo-cli/tests/e2e/suggest.rs
@@ -313,3 +313,108 @@ fn alias_output_matches_canonical_verb() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// unknown --<property> flag → suggest --property K=V
+// ---------------------------------------------------------------------------
+//
+// Models and users reach for natural-language flags (`hyalo find --status
+// planned`) even though the help teaches `--property status=planned`. When
+// the unknown long flag names a property declared in the effective schema,
+// the CLI says so; when it doesn't, clap's normal error stays untouched.
+
+/// Helper: run `hyalo <args>` with CWD set to a temp vault holding `config`.
+/// CWD-based (not `--dir`) because config discovery is CWD-anchored — this
+/// mirrors the real scenario (`cd vault && hyalo find --status …`).
+fn run_with_config(config: &str, args: &[&str]) -> (Option<i32>, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".hyalo.toml"), config).unwrap();
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(args)
+        .output()
+        .unwrap();
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+const SCHEMA_WITH_STATUS: &str = "\
+[schema.default]
+required = [\"title\", \"type\"]
+
+[schema.types.note.properties.status]
+type = \"string\"
+";
+
+#[test]
+fn unknown_flag_naming_a_schema_property_suggests_property_flag() {
+    let (code, stderr) = run_with_config(SCHEMA_WITH_STATUS, &["find", "--status", "planned"]);
+    assert_eq!(code, Some(2));
+    assert!(
+        stderr.contains("'status' is a frontmatter property"),
+        "expected the property hint; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--property status="),
+        "expected the corrected flag form; got: {stderr}"
+    );
+    // The misleading clap tip must be gone.
+    assert!(
+        !stderr.contains("as a value"),
+        "clap's '--status as a value' tip must be replaced; got: {stderr}"
+    );
+}
+
+#[test]
+fn unknown_flag_with_equals_form_also_gets_the_hint() {
+    let (code, stderr) = run_with_config(SCHEMA_WITH_STATUS, &["find", "--status=planned"]);
+    assert_eq!(code, Some(2));
+    assert!(
+        stderr.contains("--property status="),
+        "the --flag=value form should hit the same hint; got: {stderr}"
+    );
+}
+
+#[test]
+fn unknown_flag_for_undeclared_property_keeps_clap_error() {
+    // No [schema.types.note.properties.banana] — no hint, clap's normal error.
+    let (code, stderr) = run_with_config(SCHEMA_WITH_STATUS, &["find", "--banana"]);
+    assert_eq!(code, Some(2));
+    assert!(
+        !stderr.contains("frontmatter property"),
+        "no property hint for an undeclared name; got: {stderr}"
+    );
+}
+
+#[test]
+fn unknown_flag_without_any_schema_types_keeps_clap_error() {
+    // Config with no [schema] section at all: `--status` is just unknown.
+    let (code, stderr) = run_with_config("dir = \".\"\n", &["find", "--status", "planned"]);
+    assert_eq!(code, Some(2));
+    assert!(
+        !stderr.contains("frontmatter property"),
+        "no schema → no property hint; got: {stderr}"
+    );
+}
+
+#[test]
+fn required_and_default_properties_also_trigger_the_hint() {
+    // `milestone` is only in [schema.default].required — still a known
+    // property. (Not `title`/`type`: `--title` is a real find flag, so it
+    // never reaches the unknown-arg path.)
+    let config = "\
+[schema.default]
+required = [\"title\", \"milestone\"]
+
+[schema.types.note.properties.status]
+type = \"string\"
+";
+    let (code, stderr) = run_with_config(config, &["find", "--milestone"]);
+    assert_eq!(code, Some(2));
+    assert!(
+        stderr.contains("'milestone' is a frontmatter property"),
+        "required properties should trigger the hint too; got: {stderr}"
+    );
+}


### PR DESCRIPTION
## What

When clap rejects an unknown long flag whose name matches a **property declared in the effective schema**, hyalo replaces the generic error with a corrective hint:

```
$ hyalo find --status planned
error: unexpected argument '--status' found

tip: 'status' is a frontmatter property, not a flag — did you mean '--property status=<value>'?

Example: hyalo find --property status=<value>
```

Fires only for schema-declared property names (any type's `properties`/`required`/`defaults` keys, or `[schema.default]`'s) — unrelated typos (`--statuz`, `--banana`) keep clap's normal error, so no false positives.

## Why

clap's built-in tip — `to pass '--status' as a value, use '-- --status'` — actively misleads. Both humans and LLM agents reach for natural-language flags even when help/skill teach `--property`; this was observed live in the pi dogfooding sessions (twice). With this hint, the model **self-corrects through the tool path**: verified live — `find --status planned` → tip in the tool's error output → model retried with `--property status=planned` → correct count.

## Implementation

- `suggest.rs`: `unknown_long_flag_name()` (long flags only, strips `=value` suffix) + `is_schema_property()` against the CWD-loaded schema
- `run.rs`: interception alongside the existing `--filter` and `--tag` special cases, before generic subcommand suggestions
- 5 e2e tests, using a CWD-based `run_with_config` helper (`Command::current_dir(tmp)`) — mirroring the real `cd vault && hyalo …` scenario. `--dir` is *not* sufficient: config discovery is CWD-anchored (ancestor adoption only inside the vault) and the interceptor reads the pre-parse CWD config

## Verification

- `hyalo find --status planned` / `--status=planned` → hint (exit 2) ✓
- `--statuz` / `--banana` / no-schema config → clap's normal error ✓
- Live through the pi tool: model self-corrected and returned the right count ✓
- fmt / clippy `-D warnings` / `cargo test --workspace` green ✓

This closes the loop suggested in the #264 review discussion: the CLI itself now teaches the correct form, benefiting bash users and agents alike, independent of the extension.