### PR TITLE
docs(kb): iteration plans 236 (typed pi tools) and 237 (pi package distribution)

### DIFF
--- a/hyalo-knowledgebase/iterations/iteration-236-typed-pi-tools.md
+++ b/hyalo-knowledgebase/iterations/iteration-236-typed-pi-tools.md
@@ -1,0 +1,132 @@
+---
+title: "Iteration 236 — typed pi tools: structured find/read/set/task alongside the generic hyalo tool"
+type: iteration
+date: 2026-08-25
+status: planned
+branch: iter-236/typed-pi-tools
+tags:
+  - iteration
+  - pi
+  - agent-ergonomics
+  - extension
+related:
+  - "[[iterations/iteration-227-agent-ergonomics]]"
+  - "[[research/agent-ergonomics-ralph-loop-port-2026-08-24]]"
+---
+
+# Iteration 236 — typed pi tools: structured find/read/set/task alongside the generic hyalo tool
+
+## Goal
+
+Replace the argv-assembly footgun with typed tools for the highest-frequency
+hyalo operations. The pi extension today registers one generic `hyalo` tool
+(`subcommand` + free-form `args[]`); the model assembles CLI argv itself,
+and every dogfooding bug so far came from exactly that surface:
+
+- duplicate `--format text` (extension default + model-supplied — PR #262)
+- hallucinated `--status` flag (status is a property — PRs #264, #265)
+- quoting/escaping of search terms inside `args[]`
+
+Typed tools (`hyalo_find`, `hyalo_read`, `hyalo_set`, `hyalo_task`) give the
+model structured parameters instead: no flag spelling, no quoting, no
+default-injection collisions — the schema *is* the interface. The generic
+`hyalo` tool stays as the escape hatch for everything else.
+
+## Context
+
+Shipped so far (this roadmap): extension repair + prompt presence (#257),
+local drift guard `just pi-extension` (#258), post-write lint guardrail
+(#259), opt-in session summary (#261), argv-collision and hallucination
+patches (#262, #264, #265). Each patch taught the model *not* to make one
+specific mistake; typed tools remove the mistake class.
+
+Design decisions (from the session discussion, 2026-08-24):
+
+1. **Typed tools for the ~80% cases only.** `find` (queries), `read`
+   (one file, optional section), `set` (frontmatter mutation), `task`
+   (toggle). Everything else — `summary`, `lint`, `backlinks`, `config`,
+   `links`, `types`, … — keeps the generic tool. Each typed tool is a
+   maintenance surface that can drift from CLI flags; the generic tool
+   cannot break.
+2. **A small typed surface beats a complete one.** Only parameters with
+   stable, high-frequency value: `query`, `property` (single `K=V` or list),
+   `tag`, `taskStatus`, `count`, `limit` for find; `file`, `section` for
+   read; `file`, `property`, `value` for set; `file`, `line` / `--all` for
+   task. Exotic flags (`--view`, `--files-from`, `--index-file`, `--jq`)
+   stay generic-tool territory.
+3. **Shared execution core.** All typed tools build argv and route through
+   the *same* `pi.exec` + error-rendering path as the generic tool (one
+   `runHyalo(pi, argv)` helper). No behavioral divergence in timeouts,
+   signals, or error formatting.
+4. **Guidelines shift, not grow.** `promptGuidelines` stays ≤ 3 bullets:
+   prefer the typed tools, fall back to the generic tool for anything not
+   covered, follow `->` hints. The per-property-flag teaching from #264 can
+   be dropped from the tool schema once `hyalo_find.property` makes it moot.
+
+## Tasks
+
+- [ ] Extract a shared `runHyalo(pi, argv, signal)` helper in the template
+      (`pi.exec` + exit-code/error rendering + `details: undefined`), and
+      refactor the generic tool's `execute` onto it. Pure refactor; behavior
+      byte-identical.
+- [ ] Implement `hyalo_find` tool: params `query?`, `property?`
+      (array of `K=V` filter strings), `tag?`, `glob?`, `taskStatus?`
+      (`todo|done|any`), `countOnly?` (→ `--count`), `limit?`; always
+      `--format text`; composes nothing else.
+- [ ] Implement `hyalo_read` tool: params `file`, `section?`; text output.
+- [ ] Implement `hyalo_set` tool: params `file`, `property` (single `K=V`),
+      `tag?` (optional add-tag); text output; honors the existing lint
+      guardrail automatically (it fires on tool_result regardless of which
+      tool wrote).
+- [ ] Implement `hyalo_task` tool: params `file`, `mode` (`all|section|line`),
+      `section?`, `lines?` (array of ints); dispatches to `task toggle`.
+- [ ] Rework `promptSnippet`/`promptGuidelines`/tool descriptions: typed
+      tools listed as primary, generic `hyalo` as fallback; drop the
+      "no --status flag" bullet if `hyalo_find.property` makes it redundant
+      (verify with a live hallucination probe before deleting).
+- [ ] Extend `pi-extension-e2e.sh` (layer 4): one forced call per typed tool
+      (`--no-builtin-tools`, asserting non-empty structured output), keeping
+      the whole guard under ~2 minutes.
+- [ ] Update `skill-hyalo-pi.md` template: teach the typed tools first,
+      generic tool as escape hatch; keep `--format text` guidance only for
+      the generic tool.
+- [ ] Live dogfood verification (hyalo-demo worktree): the three historical
+      failure scenarios (status filter, search with quotes, set property)
+      must each succeed through a typed tool with no clap error and no
+      bash fallback.
+- [ ] Docs: `docs/configuration.md` `[pi]` section gains a sentence naming
+      the typed tools; CHANGELOG unreleased entry.
+
+## Acceptance criteria
+
+- [ ] A fresh pi session with the extension loaded answers "find all
+      planned iterations", "read the decision log", "set iteration-236's
+      status to in-progress", and "toggle all tasks in file X" using the
+      typed tools — no generic-tool calls, no bash, no clap errors
+- [ ] `hyalo find --property status=planned`-equivalent query via
+      `hyalo_find` returns the same files as the CLI invocation (spot-check
+      3 queries)
+- [ ] `just pi-extension` covers every registered tool (generic + 4 typed +
+      guardrail); all layers green; fmt/clippy/test green
+- [ ] No change to the Rust crate — this iteration is template + guard
+      script + docs only (`hyalo init --pi` picks it up on re-run)
+- [ ] Template still type-checks against installed pi (guard layer 1) with
+      the 4 new registrations
+
+## Non-goals
+
+- Typed tools for every subcommand (`summary`, `lint`, `backlinks`, `links`,
+  `types`, `views`, …) — generic tool covers them; add one only after a
+  dogfood session shows repeated model friction
+- Custom `renderCall`/`renderResult` TUI rendering (roadmap item 6b —
+  separate iteration; typed tools must land first so renderers have stable
+  tool identities to key on)
+- MCP server or any non-pi transport
+- Changes to hyalo CLI flags themselves (the typed layer maps onto the
+  existing CLI; flag design is [[iterations/iteration-235-agent-cli-ergonomics]])
+
+## Out of scope / carry-over candidates
+
+- `--jq` passthrough param on `hyalo_find` (if agents ask for it)
+- A `hyalo_lint` typed tool (once a dogfood session shows the model linting
+  via the generic tool often enough to justify it)

--- a/hyalo-knowledgebase/iterations/iteration-237-pi-package-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-237-pi-package-distribution.md
@@ -1,0 +1,135 @@
+---
+title: "Iteration 237 — pi install package distribution: decouple extension updates from hyalo releases"
+type: iteration
+date: 2026-08-25
+status: planned
+branch: iter-237/pi-package-distribution
+tags:
+  - iteration
+  - pi
+  - distribution
+  - extension
+related:
+  - "[[iterations/iteration-236-typed-pi-tools]]"
+  - "[[decision-log]]"
+---
+
+# Iteration 237 — pi install package distribution: decouple extension updates from hyalo releases
+
+## Goal
+
+Publish the pi extension + skills as an installable pi package so `pi update`
+delivers extension fixes independently of hyalo releases. Today the only
+distribution channel is `hyalo init --pi`, which copies a template embedded
+in the hyalo binary — every user of the old broken extension is stuck until
+they both upgrade hyalo *and* re-run `hyalo init --pi`. The 2026-08-24
+dogfood demonstrated the failure mode live: the demo pane ran a broken
+extension for months because no mechanism existed to push the fix.
+
+## Context
+
+pi supports package installation from git sources (`pi install
+git:github.com/ractive/hyalo`, then `pi update` / `pi update-packages`
+refreshes). The repo already ships the required shape in
+`crates/hyalo-cli/templates/package.json` (written to `.pi/package.json` by
+`hyalo init --pi`): `pi.extensions`, `pi.skills` entries. What is missing is
+a **top-level package layout** — pi installs point at a repo (or subpath),
+and today the templates live under `crates/hyalo-cli/templates/` with the
+extension as a single `.ts` file that is `include_str!`-ed into the binary.
+
+Design decisions (from the session discussion, 2026-08-24):
+
+1. **Single source of truth stays in-repo.** A new top-level `pi-package/`
+   directory (extension `extensions/hyalo.ts`, skills `skills/hyalo/`,
+   `skills/hyalo-tidy/`, `package.json`) is the canonical package; the
+   `include_str!` template switches to `include_str!("../../../pi-package/...")`
+   or a build step verifies the two copies are identical. No dual
+   maintenance.
+2. **The extension shells out to the installed `hyalo` binary** — it must
+   stay compatible with *released* hyalo versions, not just main. The
+   drift guard's layer-1 type-check runs against installed pi; add an
+   equivalent compatibility note: extension release notes must state the
+   minimum hyalo version (e.g. `[pi] session_summary` needs ≥ the 0.21
+   release).
+3. **`hyalo init --pi` keeps working and becomes an installer of last
+   resort** — vendored copy for users who don't want a git dependency. It
+   should print a hint suggesting `pi install git:github.com/ractive/hyalo`
+   for auto-updates.
+4. **Versioning**: the package carries its own `version` in `package.json`,
+   bumped on every extension/skill change, with a CHANGELOG entry. pi's
+   update mechanism handles fetching; we handle semver honesty.
+
+Open questions to resolve at implementation time (not blocking the plan):
+
+- Git source pinning: does the repo want a `pi` branch/tag strategy for
+  package releases, or is main acceptable? (Check what `pi install
+  git:...` actually pins to — commit, tag, or branch.)
+- Whether `pi-package/` or a subpath install (`pi install
+  git:github.com/ractive/hyalo#path=crates/hyalo-cli/templates`) is the
+  better shape; the top-level directory is the assumption until proven
+  otherwise.
+
+## Tasks
+
+- [ ] Verify pi's package-install mechanics against the installed version
+      (`pi install --help`, docs `/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/docs/`):
+      what a git source resolves to (commit/tag/branch), where packages are
+      stored, how `pi update` refreshes them, and whether subpath installs
+      exist. Record findings in this file (amend the Open questions).
+- [ ] Create top-level `pi-package/` layout:
+      `pi-package/package.json` (version 0.1.0, pi manifest),
+      `pi-package/extensions/hyalo.ts`, `pi-package/skills/hyalo/SKILL.md`,
+      `pi-package/skills/hyalo-tidy/SKILL.md` — seeded as copies of the
+      current templates.
+- [ ] De-duplicate: switch `PI_EXTENSION_CONTENT`/skill `include_str!`
+      sources in `crates/hyalo-cli/src/commands/init.rs` to the
+      `pi-package/` files, or (if path-escaping `include_str!` is cleaner
+      avoided) add a CI/test check that template files and package files
+      are byte-identical. Choose one mechanism; document why in code.
+- [ ] `hyalo init --pi` update path: after installing the vendored copy,
+      print the `pi install git:github.com/ractive/hyalo` hint (one line,
+      only when `.pi/` is being created, not on every re-run).
+- [ ] End-to-end verify in a scratch checkout: `pi install
+      git:github.com/ractive/hyalo` (or local path equivalent), confirm the
+      `hyalo` tool registers, the lint guardrail fires, and `pi list` shows
+      the package; then `pi update` picks up a pushed change.
+- [ ] Extend `pi-extension-e2e.sh`: when `pi-package/` exists, type-check
+      the package copy too (cheap: same layer-1 invocation on a second path).
+- [ ] Docs: README section "Install the pi integration" (package install as
+      primary, `hyalo init --pi` as vendored fallback); CHANGELOG entry;
+      minimum-hyalo-version note in the package README.
+- [ ] Decision log entry: distribution model decision (package-first,
+  vendored fallback, versioning policy).
+
+## Acceptance criteria
+
+- [ ] A machine with pi but no hyalo repo checkout can install the
+      integration via `pi install git:github.com/ractive/hyalo` and gets a
+      working `hyalo` tool + skills (given a `hyalo` binary on PATH)
+- [ ] Pushing an extension change to the package and running `pi update`
+      delivers it — verified with a trivial marker change (e.g. a version
+      bump in the tool description)
+- [ ] `hyalo init --pi` output is unchanged except the one-line package
+      install hint, and the vendored copy it writes is byte-identical to
+      the package copy
+- [ ] No template/package drift is possible in CI: either single-source
+      `include_str!` or a byte-identity test gates it
+- [ ] fmt / clippy / test green; `just pi-extension` green against both
+      the package copy and the template copy
+
+## Non-goals
+
+- npm registry publishing (git source is sufficient until someone asks for
+  a registry)
+- Auto-updating the *hyalo binary* via pi (pi updates the extension/skills;
+  hyalo stays Homebrew/cargo-install as-is)
+- Making the extension work without a `hyalo` binary on PATH (it is a CLI
+  wrapper by design)
+- Divergent package/template contents (the whole point is one source)
+
+## Out of scope / carry-over candidates
+
+- Publishing the package version to a release tag strategy (decide after
+  first real update cycle)
+- A `hyalo doctor`-style check that reports extension/hyalo version
+  compatibility drift (e.g. `[pi]` unknown → old hyalo binary)


### PR DESCRIPTION
Plan-only PR — two iteration files, no implementation, per the batch workflow (plan first, execute in batches later).

## iteration-236-typed-pi-tools.md
Typed `hyalo_find`/`hyalo_read`/`hyalo_set`/`hyalo_task` tools alongside the generic `hyalo` tool. Removes the argv-assembly mistake class that caused every dogfooded extension bug (duplicate `--format`, `--status` hallucination, quoting): structured params instead of free-form `args[]`. Template + guard script + docs only — no Rust changes.

## iteration-237-pi-package-distribution.md
Publish the extension + skills as an installable pi package (`pi install git:github.com/ractive/hyalo`) so `pi update` delivers extension fixes independently of hyalo releases — the 2026-08-24 dogfood showed users stuck on the broken extension with no update path. Includes open questions (git-source pinning, subpath vs top-level layout) to resolve at implementation time.

Both follow the house style of iteration-234/235, lint clean via `hyalo lint`, numbered after the burned 227–233 and planned 234/235.