### PR TITLE
iter-235: agent-facing CLI ergonomics — find --filenames-only, --iteration, self-healing boundary error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,38 @@ already complied (`total = modified + skipped`) and are unchanged.
 
 ### Added
 
+- **`find --filenames-only`, `find`/`set --iteration <ID>`, and a self-healing
+  vault-boundary error** (iter-235, agent-ergonomics review findings 1/2/3/5).
+  These close the three highest-friction traps the ralph-loop port dogfood
+  documented workarounds for instead of the tool providing the feature:
+  - `find --filenames-only` prints one raw file path per line — no JSON,
+    no envelope, no count, no hints — the `grep -l` projection of a find
+    result set, usable in `sort`, `xargs`, and `while read` loops. Zero
+    results → empty output, exit 0. Conflicts with `--jq`, `--count`, and an
+    explicit `--format json` (mutually exclusive projections); `--strict`
+    still flips the exit code, so `find --property status=planned
+    --filenames-only --strict` is a CI gate that lists the offenders and
+    fails.
+  - `--iteration <ID>` resolves a sequence-keyed document by its natural
+    key (`--iteration 206` → `iterations/iteration-206-*.md`) using the
+    type schema's `filename_template` `{n}` slot, so iteration lookups no
+    longer need a hand-built glob (`--property 'title~=206'` silently fails
+    because the frontmatter title is `"Iteration 206 — …"`). Accepts a bare
+    integer (`206`), zero-padded integer (`01`), or integer + letter suffix
+    (`16b`); the ID is substituted verbatim, so `01` matches
+    `iteration-01-*` (not `iteration-1-*`) and `16b` matches only
+    `iteration-16b-*` (bare `16` does not match the suffixed file). On
+    `find` this is a filter (returns every match); on `set` it selects the
+    file to mutate and errors unless exactly one match is found, listing
+    the candidates so the caller can disambiguate by suffix. `--where-*`
+    still composes on `set --iteration` (filters within the selection).
+  - The vault-boundary error now names the effective vault directory and
+    offers a self-healing hint (`pass a path relative to <dir>, or cd to a
+    parent of it`), so an agent that passed `/tmp/foo.md` learns the vault
+    root and the fix in the same message instead of guessing another
+    absolute path. The long-standing `resolves outside vault boundary`
+    substring is preserved for existing assertions.
+
 - **Every link in `find --broken-links` / `--fields links` now carries its
   source `line`** (iter-215, dogfood UX-6). The report listed every link of a
   matching file with no location, so finding the one that was actually broken

--- a/README.md
+++ b/README.md
@@ -146,9 +146,15 @@ hyalo summary
 # Full-text search (BM25 ranked, boolean operators) and frontmatter filters
 hyalo find "retry OR timeout -deprecated"
 hyalo find --property status=draft --tag research
+# Compact filename-only projection for agents / shell pipelines
+hyalo find --property status=planned --filenames-only | sort
+# Natural-key lookup of a sequence-numbered document (respects filename_template)
+hyalo find --iteration 206 --filenames-only
 
 # Bulk-update metadata
 hyalo set --property status=reviewed --where-tag research
+# Address a sequence-numbered document by its natural key (no glob math)
+hyalo set --iteration 206 --property status=completed
 
 # Move or rename — every [[wikilink]] and [markdown](link) across the vault is rewritten
 hyalo mv old/path.md archive/path.md

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -452,6 +452,40 @@ pub(crate) struct FindFilters {
     #[arg(long, alias = "stemmer", value_name = "LANG")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+    /// Print only the file path of each matching entry, one per line — no JSON,
+    /// no envelope, no count, no hints. grep `-l` precedent: the agent/
+    /// pipeline projection of a find result set, usable in `sort`, `xargs`,
+    /// and `while read` loops. Zero results → empty output, exit 0.
+    ///
+    /// Conflicts with `--jq`, `--count`, and an explicit `--format json`
+    /// (mutually exclusive projections — pick one). `--strict` still flips
+    /// the exit code (1 when results exist), so `find --property status=planned
+    /// --filenames-only --strict` is a CI gate that lists the offenders and
+    /// fails. Combines with every other filter (`--property`, `--tag`,
+    /// `--iteration`, `--glob`, `--broken-links`, …) exactly as `find`
+    /// normally does.
+    #[arg(long, conflicts_with_all = ["jq", "count"])]
+    #[serde(skip_serializing_if = "is_false")]
+    pub filenames_only: bool,
+    /// Resolve a sequence-keyed document by its natural ID instead of a glob:
+    /// `--iteration 206` expands to `iterations/iteration-206-*.md` using the
+    /// type schema's `filename_template` `{n}` slot. Accepts a bare integer
+    /// (`206`), a zero-padded integer (`01`), or an integer + letter suffix
+    /// (`16b`). The ID is substituted verbatim, so `01` matches
+    /// `iteration-01-*` (not `iteration-1-*`) and `16b` matches only
+    /// `iteration-16b-*`. A bare `16` matches `iteration-16-*` and *not*
+    /// `iteration-16b-*` (the letter suffix is a separate identifier).
+    ///
+    /// Every configured type whose template carries an `{n}` placeholder is
+    /// consulted; the union of their globs is the filter (OR among types, then
+    /// AND with the other filters). `--iteration` without any matching
+    /// template is a clear error naming the configured templates.
+    ///
+    /// In `find` this is a filter (returns every match); in `set` it selects
+    /// the file to mutate and errors unless exactly one match is found.
+    #[arg(long, value_name = "ID")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iteration: Option<String>,
 }
 
 impl FindFilters {
@@ -502,6 +536,13 @@ impl FindFilters {
         }
         if overlay.language.is_some() {
             self.language.clone_from(&overlay.language);
+        }
+        // --filenames-only is an output-shaping bool (like --strict): the
+        // overlay can turn it on, never off. A view may carry it, and a CLI
+        // --filenames-only turns on top of any view.
+        self.filenames_only = self.filenames_only || overlay.filenames_only;
+        if overlay.iteration.is_some() {
+            self.iteration.clone_from(&overlay.iteration);
         }
     }
 }
@@ -567,10 +608,23 @@ pub(crate) enum Commands {
             merge on top: list filters (--property, --tag, --section, --glob) extend the view's \
             lists; scalar filters (--regexp, --sort, --limit, --title, --task, --language) override; bool \
             flags (--broken-links, --orphan, --dead-end, --reverse) OR. Example: hyalo find --view drafts --limit 5\n\
+            PROJECTIONS: --filenames-only prints one raw file path per line (no JSON, no\n\
+            envelope, no count, no hints) — the agent/pipeline counterpart to --format text's\n\
+            human layout, usable in `sort`, `xargs`, and `while read` loops. Zero results →\n\
+            empty output, exit 0. Conflicts with --jq, --count, and an explicit --format json.\n\
+            --strict still flips the exit code (1 when results exist), so `find --filenames-only\n\
+            --strict` is a CI gate that lists the offenders and fails.\n\
+            ITERATION ADDRESSING: --iteration <ID> resolves a sequence-keyed document by its\n\
+            natural key (`--iteration 206` → `iterations/iteration-206-*.md`) using the\n\
+            type schema's filename_template {n} slot. Accepts a bare integer (206), zero-\n\
+            padded integer (01), or integer + letter suffix (16b). Bare `16` matches\n\
+            `iteration-16-*` and NOT `iteration-16b-*` (the suffix is a separate id).\n\
             COMMON MISTAKES:\n\
             - Property regex uses ~= (tilde-equals), NOT =~ (Perl-style). Wrong: 'title=~/pat/', right: 'title~=/pat/'.\n\
             - --title searches the displayed title (frontmatter or H1); --property title~= only searches frontmatter.\n\
             - --tag uses prefix matching: 'project' matches 'project/backend' but NOT 'projects'.\n\
+            - For iteration lookups, prefer --iteration <N> over `--property 'title~=N'` — the\n\
+              frontmatter title is typically `Iteration N: …`, which does not contain `iteration-N`.\n\
             POSITIONAL ARGUMENTS: The first positional argument is always PATTERN (body text search), not a file path. \
             Subsequent positional arguments are treated as FILE targets. \
             To filter by file without a body search, use --file instead of a positional argument.\n\
@@ -585,6 +639,9 @@ pub(crate) enum Commands {
             \u{00a0} hyalo find --property 'title~=/^Design/i'\n\
             \u{00a0} hyalo find --section 'Tasks' --task todo\n\
             \u{00a0} hyalo find --fields links --jq '[.results[] | select(.links | map(select(.path == null)) | length > 0)]'\n\
+            \u{00a0} hyalo find --property status=planned --filenames-only   # agent/pipeline projection\n\
+            \u{00a0} hyalo find --iteration 206                          # natural-key lookup, no glob\n\
+            \u{00a0} hyalo find --iteration 206 --filenames-only          # the common agent idiom\n\
             \u{00a0} git diff --name-only origin/main | hyalo find --files-from -")]
     Find {
         /// BM25 ranked body text search with stemming (e.g. "running" matches "run", "ran"); results sorted by relevance
@@ -914,11 +971,12 @@ Repeatable (AND).\n\
             \u{00a0} hyalo set --property tags=[a,b,c] --file notes/todo.md\n\
             \u{00a0} hyalo set --tag reviewed --glob 'research/**/*.md'\n\
             \u{00a0} hyalo set --property status=in-progress --where-property status=draft --glob '**/*.md'\n\
-            \u{00a0} hyalo set --property due=2026-12-31 --validate --file notes/todo.md"
+            \u{00a0} hyalo set --property due=2026-12-31 --validate --file notes/todo.md\n\
+            \u{00a0} hyalo set --iteration 206 --property status=completed"
     )]
     Set {
         /// Target file(s) as positional argument(s) — alternative to --file
-        #[arg(value_name = "FILE", conflicts_with_all = ["glob", "file", "files_from"])]
+        #[arg(value_name = "FILE", conflicts_with_all = ["glob", "file", "files_from", "iteration"])]
         file_positional: Vec<String>,
         /// Property to set: K=V (type inferred from V). Repeatable
         #[arg(short, long = "property", value_name = "K=V")]
@@ -926,14 +984,34 @@ Repeatable (AND).\n\
         /// Tag to add (idempotent). Repeatable
         #[arg(short, long, value_name = "TAG")]
         tag: Vec<String>,
-        #[arg(short, long, conflicts_with_all = ["glob", "files_from"], help = FILE_FLAG_DOC)]
+        /// Resolve the file to mutate by its iteration natural key — e.g.
+        /// `--iteration 206` expands to `iterations/iteration-206-*.md`
+        /// using the type schema's `filename_template` `{n}` slot. Accepts a
+        /// bare integer (`206`), zero-padded integer (`01`), or integer +
+        /// letter suffix (`16b`). The ID is substituted verbatim.
+        ///
+        /// A *competing* file selector: conflicts with `--file`, the
+        /// positional FILE, `--glob`, and `--files-from` (pass exactly one
+        /// of them). `--where-property` / `--where-tag` still compose with
+        /// `--iteration` — they filter *within* the selected file, not
+        /// across files, so `set --iteration 206 --where-property status=planned`
+        /// mutates iteration 206 only if its status is `planned`.
+        ///
+        /// Unlike `find --iteration` (which returns every match), `set` errors
+        /// unless the ID resolves to exactly one file; an ambiguous match
+        /// lists the candidates so the caller can disambiguate by suffix.
+        #[arg(long, value_name = "ID", conflicts_with_all = ["file_positional", "file", "glob", "files_from"])]
+        iteration: Option<String>,
+        #[arg(short, long, conflicts_with_all = ["glob", "files_from", "iteration"], help = FILE_FLAG_DOC)]
         file: Vec<String>,
         /// Glob pattern(s) for multiple files, relative to --dir (repeatable); prefix '!' to negate
-        #[arg(short, long, conflicts_with_all = ["file", "files_from"])]
+        #[arg(short, long, conflicts_with_all = ["file", "files_from", "iteration"])]
         glob: Vec<String>,
         /// Read file paths from PATH (one per line); use '-' to read from stdin.
-        /// Mutually exclusive with --file, positional FILE, and --glob.
-        #[arg(long, value_name = "PATH", conflicts_with_all = ["file", "file_positional", "glob"])]
+        /// Mutually exclusive with --file, positional FILE, --glob, and --iteration.
+        /// Repo-relative paths with the configured vault dir prefix are resolved automatically.
+        /// Input is deduplicated; results follow first-seen order.
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["file", "file_positional", "glob", "iteration"])]
         files_from: Option<String>,
         /// Filter: only mutate files whose frontmatter property matches (repeatable, AND). Same syntax as find --property
         #[arg(long = "where-property", value_name = "FILTER")]

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -47,14 +47,14 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
   Find (search and filter, read-only):
     hyalo find [PATTERN | -e/--regexp REGEX] [-p/--property K=V ...] [-t/--tag T ...] [--task STATUS]
                [-s/--section HEADING ...] [--title PAT] [--broken-links] [--orphan] [--dead-end]
-               [-f/--file F | -g/--glob G] [--fields ...] [--sort ...] [--reverse] [--strict] [-n/--limit N]
+               [-f/--file F | -g/--glob G | --iteration ID] [--filenames-only] [--fields ...] [--sort ...] [--reverse] [--strict] [-n/--limit N]
 
   Read (display file body content, read-only):
     hyalo read FILE [-s/--section HEADING] [-l/--lines RANGE] [--frontmatter]
     hyalo read -f/--file F [...]                                  Flag form; FILE positional is equivalent
 
   Set (create or overwrite, mutates files):
-    hyalo set  -p/--property K=V [-p ...] [-t/--tag T ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...] [--dry-run] [--validate]
+    hyalo set  -p/--property K=V [-p ...] [-t/--tag T ...] [-f/--file F | -g/--glob G | --iteration ID] [--where-property FILTER ...] [--where-tag T ...] [--dry-run] [--validate]
 
   Remove (delete properties/tags, mutates files):
     hyalo remove -p/--property K|K=V [...] [-t/--tag T ...] [-f/--file F | -g/--glob G] [--where-property FILTER ...] [--where-tag T ...] [--dry-run]

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -64,7 +64,7 @@ pub fn backlinks(
         match crate::commands::resolve_file_user_ci(dir, file_arg, case_insensitive) {
             Ok(r) => r,
             Err(e) => {
-                return Ok(crate::commands::resolve_error_to_outcome(e, format));
+                return Ok(crate::commands::resolve_error_to_outcome(e, format, dir));
             }
         };
 

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -208,9 +208,13 @@ pub fn find(
             } else {
                 return Ok(CommandOutcome::UserError(crate::output::format_error(
                     format,
-                    "file resolves outside vault boundary",
+                    &hyalo_core::fs_util::outside_vault_message_with_dir(
+                        "file",
+                        None,
+                        &canonical_dir,
+                    ),
                     Some(f),
-                    Some("pass a path relative to the vault dir"),
+                    Some(&hyalo_core::fs_util::outside_vault_hint(&canonical_dir)),
                     None,
                 )));
             }
@@ -241,7 +245,11 @@ pub fn find(
                 continue;
             }
             if let Err(err) = discovery::resolve_file(dir, f) {
-                return Ok(crate::commands::resolve_error_to_outcome(err, format));
+                return Ok(crate::commands::resolve_error_to_outcome(
+                    err,
+                    format,
+                    &canonical_dir,
+                ));
             }
         }
     }
@@ -1218,6 +1226,54 @@ pub fn find(
         crate::output::format_success(format, &json_output),
         total as u64,
     ))
+}
+
+/// Project a `find` outcome onto bare file paths, one per line (iter-235).
+///
+/// `--filenames-only` is the agent/pipeline counterpart to `--format text`'s
+/// human layout: a compact, copy-pasteable list of the matching `file` paths
+/// with no JSON envelope, no count, no hints. It bypasses the entire output
+/// pipeline by producing a [`CommandOutcome::RawOutput`], so `--jq`, `--count`,
+/// and `--format` all become irrelevant (and are rejected upstream).
+///
+/// A `Success` outcome carries the find result array as a JSON string (the
+/// internal format is always JSON). Each element's `file` field is the
+/// vault-relative path we want. Zero results → empty output (no trailing
+/// newline), so `find --filenames-only` in a pipe yields nothing rather than
+/// a blank line. A non-empty result set ends with a newline so the last path
+/// is complete in `while read` / `xargs` loops.
+///
+/// Errors pass through unchanged — a `UserError` (bad filter, missing
+/// file, boundary refusal) is never remangled into a filename list.
+pub(crate) fn project_filenames_only(outcome: CommandOutcome) -> CommandOutcome {
+    let CommandOutcome::Success { output, .. } = &outcome else {
+        return outcome;
+    };
+    // The internal `output` is a JSON array of find result objects. Parse it
+    // once, then walk each element's `file` field. serde_json::Value keeps the
+    // cost to one allocation per path, which is the lower bound for emitting
+    // them as text anyway.
+    let value: serde_json::Value = match serde_json::from_str(output) {
+        Ok(v) => v,
+        // Should not happen — find always emits valid JSON. Leave the
+        // original Success outcome intact rather than inventing an error.
+        Err(_) => return outcome,
+    };
+    let paths: Vec<&str> = value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("file").and_then(|f| f.as_str()))
+        .collect();
+    if paths.is_empty() {
+        // Empty output, exit 0 — indistinguishable from a successful query
+        // that matched nothing, which is the intent (no spurious blank line
+        // for a `while read` loop to trip on).
+        return CommandOutcome::RawOutput(String::new());
+    }
+    let mut out = paths.join("\n");
+    out.push('\n');
+    CommandOutcome::RawOutput(out)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/src/commands/inputs.rs
+++ b/crates/hyalo-cli/src/commands/inputs.rs
@@ -142,7 +142,7 @@ pub(crate) fn resolve_inputs(
                     counters: None,
                 })),
                 Err(e) => Ok(ResolvedInputsOrOutcome::Outcome(
-                    crate::commands::resolve_error_to_outcome(e, format),
+                    crate::commands::resolve_error_to_outcome(e, format, dir),
                 )),
             }
         }

--- a/crates/hyalo-cli/src/commands/iteration.rs
+++ b/crates/hyalo-cli/src/commands/iteration.rs
@@ -1,0 +1,197 @@
+//! `--iteration <ID>` natural-key resolution (iter-235).
+//!
+//! Agents address sequence-keyed documents (iteration plans, etc.) by their
+//! natural key — the bare number encoded in the type schema's
+//! `filename_template` `{n}` slot — instead of inventing a glob every time.
+//! This module turns an [`IterationId`] into the globs that resolve it,
+//! shared by `find --iteration` (returns every match; it's a filter) and
+//! `set --iteration` (errors unless exactly one match; it's a mutation).
+
+use std::fmt::Write as _;
+
+use hyalo_core::filename_template::FilenameTemplate;
+use hyalo_core::iteration_id::IterationId;
+use hyalo_core::schema::SchemaConfig;
+
+use crate::output::{CommandOutcome, Format};
+
+/// Outcome of resolving an `--iteration` ID against the configured type
+/// schemas. On success, `globs` holds one glob per type whose template has an
+/// `{n}` slot; the caller filters/collects files with them. On failure, an
+/// `Outcome` carries a formatted error for the agent.
+#[derive(Debug)]
+pub(crate) enum IterationGlobs {
+    /// One or more globs; union them to find the iteration's files.
+    Globs(Vec<String>),
+    /// No configured type carries an `{n}` filename template, so `--iteration`
+    /// is meaningless until one is added.
+    Outcome(CommandOutcome),
+}
+
+/// Resolve `--iteration <ID>` to glob patterns from the schema's type
+/// `filename_template`s.
+///
+/// Iterates every type with a `filename_template` containing an `{n}`
+/// placeholder and substitutes the ID (verbatim) into that slot, with `*`
+/// for the other placeholders. A vault with a single `iteration` type whose
+/// template is `iterations/iteration-{n}-{slug}.md` resolves `--iteration
+/// 206` to `["iterations/iteration-206-*.md"]`.
+///
+/// When no type has a template with an `{n}` slot, returns an error outcome
+/// naming the types that *do* have a template (so the user can see what to
+/// adjust) — the `--iteration` flag is meaningless without a natural key to
+/// substitute into.
+pub(crate) fn resolve_iteration_globs(
+    schema: &SchemaConfig,
+    id: &IterationId,
+    format: Format,
+) -> IterationGlobs {
+    let mut globs: Vec<String> = Vec::new();
+    // Types whose template carries an {n} slot — these are the ones --iteration
+    // can address. Kept only for the no-match diagnostic.
+    let mut n_types: Vec<&str> = Vec::new();
+    // Types with *some* filename_template but no {n} — surfaced in the error
+    // so a user who set a template without the numeric slot sees why their
+    // --iteration call didn't resolve.
+    let mut templated_types: Vec<&str> = Vec::new();
+
+    for (name, ts) in &schema.types {
+        let Some(template_str) = &ts.filename_template else {
+            continue;
+        };
+        let Ok(tpl) = FilenameTemplate::parse(template_str) else {
+            // A malformed template is reported elsewhere (lint --type, new);
+            // skip it here rather than turning an iteration lookup into a
+            // template-parse error.
+            templated_types.push(name);
+            continue;
+        };
+        if tpl.has_n_placeholder() {
+            n_types.push(name);
+            globs.push(tpl.to_glob_for_id(id.raw()));
+        } else {
+            templated_types.push(name);
+        }
+    }
+
+    if globs.is_empty() {
+        let mut msg = String::from(
+            "no type schema has a filename_template with an {n} placeholder, so --iteration cannot resolve any file",
+        );
+        if !n_types.is_empty() {
+            // Unreachable (globs empty ⇒ n_types empty), but kept defensive.
+            let _ = write!(msg, "; types with an {{n}} slot: {}", join(&n_types));
+        }
+        // Offer the next step: either configure a template with {n}, or fall
+        // back to an explicit --file/--glob path the ID cannot disambiguate.
+        // Built as an owned String so a dynamic templated-type list can flow
+        // into the error without leaking (`format_error` borrows for the call).
+        let hint: String = if templated_types.is_empty() {
+            "set a filename_template containing {n} on a type (e.g. `hyalo types set iteration --filename-template 'iterations/iteration-{n}-{slug}.md`)".to_owned()
+        } else {
+            let names = join(&templated_types);
+            format!(
+                "these types have a filename_template but no {{n}} slot: {names}; add {{n}} to one of them, or address the file with --file/--glob"
+            )
+        };
+        return IterationGlobs::Outcome(CommandOutcome::UserError(crate::output::format_error(
+            format,
+            &msg,
+            Some(id.raw()),
+            Some(&hint),
+            None,
+        )));
+    }
+
+    IterationGlobs::Globs(globs)
+}
+
+fn join(names: &[&str]) -> String {
+    let mut sorted: Vec<&str> = names.to_vec();
+    sorted.sort_unstable();
+    sorted
+        .iter()
+        .map(|n| format!("'{n}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn schema_with_iteration(template: Option<&str>) -> SchemaConfig {
+        let mut types = HashMap::new();
+        let mut ts = hyalo_core::schema::TypeSchema::default();
+        if let Some(t) = template {
+            ts.filename_template = Some(t.to_owned());
+        }
+        types.insert("iteration".to_owned(), ts);
+        SchemaConfig {
+            types,
+            ..SchemaConfig::default()
+        }
+    }
+
+    #[test]
+    fn resolves_bare_integer_to_iteration_glob() {
+        let schema = schema_with_iteration(Some("iterations/iteration-{n}-{slug}.md"));
+        let id = hyalo_core::iteration_id::parse_iteration_id("206").unwrap();
+        match resolve_iteration_globs(&schema, &id, Format::Text) {
+            IterationGlobs::Globs(g) => assert_eq!(g, vec!["iterations/iteration-206-*.md"]),
+            other @ IterationGlobs::Outcome(_) => panic!("expected globs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_letter_suffix() {
+        let schema = schema_with_iteration(Some("iterations/iteration-{n}-{slug}.md"));
+        let id = hyalo_core::iteration_id::parse_iteration_id("16b").unwrap();
+        match resolve_iteration_globs(&schema, &id, Format::Text) {
+            IterationGlobs::Globs(g) => assert_eq!(g, vec!["iterations/iteration-16b-*.md"]),
+            other @ IterationGlobs::Outcome(_) => panic!("expected globs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_template_with_n_slot_is_error_outcome() {
+        let schema = schema_with_iteration(Some("journal/{date}.md"));
+        let id = hyalo_core::iteration_id::parse_iteration_id("206").unwrap();
+        match resolve_iteration_globs(&schema, &id, Format::Json) {
+            IterationGlobs::Outcome(CommandOutcome::UserError(s)) => {
+                let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+                let error = v["error"].as_str().unwrap();
+                assert!(
+                    error.contains("no type schema has a filename_template with an {n}"),
+                    "got: {error}"
+                );
+                // Hint names the templated-but-slotless type and the fix.
+                let hint = v["hint"].as_str().unwrap();
+                assert!(
+                    hint.contains("'iteration'") && hint.contains("add {n}"),
+                    "hint should name the type and the fix: {hint}"
+                );
+            }
+            other => panic!("expected error outcome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_types_with_any_template_still_errors_with_setup_hint() {
+        let schema = SchemaConfig::default();
+        let id = hyalo_core::iteration_id::parse_iteration_id("206").unwrap();
+        match resolve_iteration_globs(&schema, &id, Format::Json) {
+            IterationGlobs::Outcome(CommandOutcome::UserError(s)) => {
+                let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+                assert!(
+                    v["hint"]
+                        .as_str()
+                        .unwrap()
+                        .contains("set a filename_template containing {n}")
+                );
+            }
+            other => panic!("expected error outcome, got {other:?}"),
+        }
+    }
+}

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod find;
 pub mod heading_grammar;
 pub mod init;
 pub(crate) mod inputs;
+pub(crate) mod iteration;
 pub mod link_lint;
 pub mod links;
 pub mod lint;
@@ -64,12 +65,21 @@ pub(crate) fn refuse_escaping_write(
     let Some(target) = hyalo_core::fs_util::escaping_write_target(dir, full)? else {
         return Ok(None);
     };
+    // iter-235: name the vault dir in the message and offer the relative-path
+    // / `cd` hint when the caller hasn't provided its own. Every writer that
+    // refuses an escape here already passes `dir` (the canonical vault root),
+    // so the message is self-healing without each call site repeating the
+    // hint text.
+    let effective_hint: Option<String> = match hint {
+        Some(h) => Some(h.to_owned()),
+        None => Some(hyalo_core::fs_util::outside_vault_hint(dir)),
+    };
     Ok(Some(CommandOutcome::UserError(
         crate::output::format_error(
             format,
-            &hyalo_core::fs_util::outside_vault_message(subject, Some(&target)),
+            &hyalo_core::fs_util::outside_vault_message_with_dir(subject, Some(&target), dir),
             Some(display),
-            hint,
+            effective_hint.as_deref(),
             None,
         ),
     )))
@@ -271,7 +281,7 @@ pub fn collect_files(
                 // All files failed — return error for the first one (no warning needed)
                 let (_, first_err) = errors.into_iter().next().expect("at least one error");
                 return Ok(FilesOrOutcome::Outcome(resolve_error_to_outcome(
-                    first_err, format,
+                    first_err, format, dir,
                 )));
             }
             // Some succeeded — warn about the ones that didn't
@@ -450,7 +460,7 @@ pub fn build_scanned_index(
                 && let Some(e) = first_err
             {
                 return Ok(ScannedIndexOutcome::Outcome(resolve_error_to_outcome(
-                    e, format,
+                    e, format, dir,
                 )));
             }
         }
@@ -611,8 +621,19 @@ const PARENT_TRAVERSAL_HINT: &str =
     "drop the '..' and use a vault-relative path, e.g. \"sub/note.md\" not \"../sub/note.md\"";
 
 /// Convert a `FileResolveError` into a user-facing `CommandOutcome`.
+///
+/// `dir` is the effective vault directory, used only to make an
+/// [`FileResolveError::OutsideVault`] refusal self-healing (iter-235):
+/// the message names the vault root and the hint offers the two fixes
+/// (relative path, or `cd` to a parent). Callers that have already lost
+/// the dir can pass `discovery::canonicalize_vault_dir(dir)`; passing a
+/// non-canonical dir just yields a less tidy `vault:` field.
 #[must_use]
-pub fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> CommandOutcome {
+pub fn resolve_error_to_outcome(
+    err: FileResolveError,
+    format: Format,
+    dir: &std::path::Path,
+) -> CommandOutcome {
     match err {
         FileResolveError::MissingExtension { path, hint } => {
             CommandOutcome::UserError(crate::output::format_error(
@@ -654,12 +675,13 @@ pub fn resolve_error_to_outcome(err: FileResolveError, format: Format) -> Comman
         FileResolveError::OutsideVault { path, resolved } => {
             CommandOutcome::UserError(crate::output::format_error(
                 format,
-                &hyalo_core::fs_util::outside_vault_message(
+                &hyalo_core::fs_util::outside_vault_message_with_dir(
                     "file",
                     resolved.as_deref().map(std::path::Path::new),
+                    dir,
                 ),
                 Some(&path),
-                None,
+                Some(&hyalo_core::fs_util::outside_vault_hint(dir)),
                 None,
             ))
         }

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -82,7 +82,7 @@ pub fn mv(
     // 1. Validate source exists
     let (_src_full, old_rel) = match super::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
-        Err(e) => return Ok(crate::commands::resolve_error_to_outcome(e, format)),
+        Err(e) => return Ok(crate::commands::resolve_error_to_outcome(e, format, dir)),
     };
 
     // 2. Validate target path
@@ -399,8 +399,9 @@ fn build_rename_map(
             CommandOutcome::UserError(out)
         })?;
         for (_, new_rel) in &proposed {
-            if let Err(msg) = ensure_dest_within_vault(&canonical_vault, dir, new_rel) {
-                let out = crate::output::format_error(format, &msg, Some(new_rel), None, None);
+            if let Err((msg, hint)) = ensure_dest_within_vault(&canonical_vault, dir, new_rel) {
+                let hint_opt = (!hint.is_empty()).then_some(hint.as_str());
+                let out = crate::output::format_error(format, &msg, Some(new_rel), hint_opt, None);
                 return Err(CommandOutcome::UserError(out));
             }
         }
@@ -532,7 +533,8 @@ fn execute_batch_mv(dir: &Path, renames: &[(String, String)], plans: &[RewritePl
     let canonical_vault = canonicalize_vault_dir(dir)
         .context("failed to canonicalize vault directory for write safety check")?;
     for (_, new_rel) in renames {
-        ensure_dest_within_vault(&canonical_vault, dir, new_rel).map_err(anyhow::Error::msg)?;
+        ensure_dest_within_vault(&canonical_vault, dir, new_rel)
+            .map_err(|(msg, _)| anyhow::Error::msg(msg))?;
     }
 
     // Capture source mtimes upfront to detect concurrent modifications.
@@ -757,16 +759,21 @@ fn ensure_dest_within_vault(
     canonical_vault: &Path,
     dir: &Path,
     new_rel: &str,
-) -> std::result::Result<(), String> {
+) -> std::result::Result<(), (String, String)> {
     let dst = dir.join(new_rel);
     match hyalo_core::fs_util::escaping_write_target(canonical_vault, &dst) {
         Ok(None) => Ok(()),
-        Ok(Some(target)) => Err(hyalo_core::fs_util::outside_vault_message(
-            "target path",
-            Some(&target),
+        Ok(Some(target)) => Err((
+            hyalo_core::fs_util::outside_vault_message_with_dir(
+                "target path",
+                Some(&target),
+                canonical_vault,
+            ),
+            hyalo_core::fs_util::outside_vault_hint(canonical_vault),
         )),
-        Err(e) => Err(format!(
-            "failed to verify destination {new_rel} stays within the vault: {e}"
+        Err(e) => Err((
+            format!("failed to verify destination {new_rel} stays within the vault: {e}"),
+            String::new(),
         )),
     }
 }
@@ -895,8 +902,9 @@ fn validate_target_single(
             return Err(CommandOutcome::UserError(out));
         }
     };
-    if let Err(msg) = ensure_dest_within_vault(&canonical_vault, dir, &normalized) {
-        let out = crate::output::format_error(format, &msg, Some(&normalized), None, None);
+    if let Err((msg, hint)) = ensure_dest_within_vault(&canonical_vault, dir, &normalized) {
+        let hint_opt = (!hint.is_empty()).then_some(hint.as_str());
+        let out = crate::output::format_error(format, &msg, Some(&normalized), hint_opt, None);
         return Err(CommandOutcome::UserError(out));
     }
 
@@ -983,7 +991,8 @@ fn execute_mv(
     // check in `link_rewrite::execute_plans`).
     let canonical_vault = canonicalize_vault_dir(dir)
         .context("failed to canonicalize vault directory for write safety check")?;
-    ensure_dest_within_vault(&canonical_vault, dir, new_rel).map_err(anyhow::Error::msg)?;
+    ensure_dest_within_vault(&canonical_vault, dir, new_rel)
+        .map_err(|(msg, _)| anyhow::Error::msg(msg))?;
 
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -264,7 +264,7 @@ pub fn run(
     // Resolve file
     let (full_path, rel_path) = match super::resolve_file_user(dir, file) {
         Ok(r) => r,
-        Err(e) => return Ok(super::resolve_error_to_outcome(e, format)),
+        Err(e) => return Ok(super::resolve_error_to_outcome(e, format, dir)),
     };
 
     // `read` targets one explicit file, so — unlike the read-only scanner,

--- a/crates/hyalo-cli/src/commands/tasks.rs
+++ b/crates/hyalo-cli/src/commands/tasks.rs
@@ -120,7 +120,7 @@ pub fn task_read(
 ) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match crate::commands::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
-        Err(e) => return Ok(resolve_error_to_outcome(e, format)),
+        Err(e) => return Ok(resolve_error_to_outcome(e, format, dir)),
     };
 
     let resolved = match resolve_task_lines(&full_path, lines, section, all) {
@@ -192,7 +192,7 @@ pub fn task_toggle(
 ) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match crate::commands::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
-        Err(e) => return Ok(resolve_error_to_outcome(e, format)),
+        Err(e) => return Ok(resolve_error_to_outcome(e, format, dir)),
     };
 
     let resolved = match resolve_task_lines(&full_path, lines, section, all) {
@@ -311,7 +311,7 @@ pub fn task_set_status(
 ) -> Result<CommandOutcome> {
     let (full_path, rel_path) = match crate::commands::resolve_file_user(dir, file_arg) {
         Ok(r) => r,
-        Err(e) => return Ok(resolve_error_to_outcome(e, format)),
+        Err(e) => return Ok(resolve_error_to_outcome(e, format, dir)),
     };
 
     let resolved = match resolve_task_lines(&full_path, lines, section, all) {

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -544,12 +544,48 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 dead_end,
                 title,
                 language,
+                filenames_only,
+                iteration,
                 files_from: _, // resolved in run.rs before dispatch
             } = filters_raw;
             if orphan && dead_end {
                 crate::warn::warn(
                     "--orphan and --dead-end are mutually exclusive (no file can be both); results will always be empty",
                 );
+            }
+            // Resolve --iteration <ID> into glob patterns from the schema's
+            // type filename_templates (iter-235). The globs join the --glob
+            // set with OR semantics (positive globs are unioned), so
+            // `--iteration 206` is just another way to scope the same find.
+            let mut glob = glob;
+            if let Some(id_str) = iteration {
+                match hyalo_core::iteration_id::parse_iteration_id(&id_str) {
+                    Ok(id) => {
+                        match crate::commands::iteration::resolve_iteration_globs(
+                            ctx.schema,
+                            &id,
+                            effective_format,
+                        ) {
+                            crate::commands::iteration::IterationGlobs::Globs(g) => {
+                                glob.extend(g);
+                            }
+                            crate::commands::iteration::IterationGlobs::Outcome(o) => {
+                                return Ok(o);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        return Ok(CommandOutcome::UserError(crate::output::format_error(
+                            effective_format,
+                            &e.to_string(),
+                            Some(&id_str),
+                            Some(
+                                "pass a bare integer (206), zero-padded integer (01), or integer + letter suffix (16b)",
+                            ),
+                            None,
+                        )));
+                    }
+                }
             }
             // Parse property filters
             let prop_filters: Vec<filter::PropertyFilter> = match properties
@@ -717,7 +753,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                         needs_stem_map,
                         resolved.as_snapshot(),
                     );
-                    let outcome = find_commands::find(
+                    let mut outcome = find_commands::find(
                         resolved.as_index(),
                         dir,
                         site_prefix,
@@ -755,6 +791,18 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                         && *total > 0
                     {
                         ctx.exit_code_override = Some(1);
+                    }
+                    // iter-235: `--filenames-only` projects the find result
+                    // set onto raw file paths (one per line, no envelope,
+                    // no count, no hints). It runs *after* the `--strict`
+                    // check above, so `find --filenames-only --strict`
+                    // still flips the exit code (1 when results exist) —
+                    // the CI-gate + filename-list use case. RawOutput bypasses
+                    // the JSON pipeline entirely (no jq, no count, no hints,
+                    // no envelope), which is exactly the point: an agent or
+                    // shell pipeline wants bare paths, nothing else.
+                    if filenames_only {
+                        outcome = crate::commands::find::project_filenames_only(outcome);
                     }
                     Ok(outcome)
                 }
@@ -1264,6 +1312,7 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
             mut file,
             glob,
             files_from: _, // resolved in run.rs before dispatch
+            iteration,
             where_properties,
             where_tags,
             dry_run,
@@ -1286,12 +1335,109 @@ pub(crate) fn dispatch(command: Commands, ctx: &mut CommandContext<'_>) -> Resul
                 }
             };
             let do_validate = validate || ctx.validate_on_write;
+            // iter-235: `--iteration <ID>` resolves the file to mutate from the
+            // type schema's filename_template, then must select exactly one
+            // file (set is a single-target mutation — ambiguous matches are an
+            // error, unlike find which returns all). Resolved here, before the
+            // generic `set` call, so set sees a normal file list and `--where-*`
+            // still filters within it.
+            let mut resolved_files: Option<Vec<String>> = None;
+            if let Some(id_str) = iteration {
+                match hyalo_core::iteration_id::parse_iteration_id(&id_str) {
+                    Ok(id) => {
+                        match crate::commands::iteration::resolve_iteration_globs(
+                            ctx.schema,
+                            &id,
+                            effective_format,
+                        ) {
+                            crate::commands::iteration::IterationGlobs::Globs(g) => {
+                                match crate::commands::collect_files(
+                                    dir,
+                                    &[],
+                                    &g,
+                                    effective_format,
+                                )? {
+                                    crate::commands::FilesOrOutcome::Files(pairs) => {
+                                        let paths: Vec<String> =
+                                            pairs.into_iter().map(|(_, rel)| rel).collect();
+                                        match paths.len() {
+                                            0 => {
+                                                return Ok(CommandOutcome::UserError(
+                                                    crate::output::format_error(
+                                                        effective_format,
+                                                        &format!(
+                                                            "no file found for iteration {id} \
+                                                             (resolved globs: {})",
+                                                            g.join(", ")
+                                                        ),
+                                                        Some(&id_str),
+                                                        Some(
+                                                            "check the iteration number, or list candidates with `hyalo find --iteration <ID>`",
+                                                        ),
+                                                        None,
+                                                    ),
+                                                ));
+                                            }
+                                            1 => {
+                                                resolved_files = Some(paths);
+                                            }
+                                            _ => {
+                                                let mut listed = paths.clone();
+                                                listed.sort();
+                                                return Ok(CommandOutcome::UserError(
+                                                    crate::output::format_error(
+                                                        effective_format,
+                                                        &format!(
+                                                            "iteration {id} matches multiple files — \
+                                                             pass a letter suffix to disambiguate, \
+                                                             or use --file/--glob to target one directly"
+                                                        ),
+                                                        Some(&id_str),
+                                                        Some(&format!(
+                                                            "candidates:\n{}",
+                                                            listed
+                                                                .iter()
+                                                                .map(|p| format!("  - {p}"))
+                                                                .collect::<Vec<_>>()
+                                                                .join("\n")
+                                                        )),
+                                                        None,
+                                                    ),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    crate::commands::FilesOrOutcome::Outcome(o) => return Ok(o),
+                                }
+                            }
+                            crate::commands::iteration::IterationGlobs::Outcome(o) => {
+                                return Ok(o);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        return Ok(CommandOutcome::UserError(crate::output::format_error(
+                            effective_format,
+                            &e.to_string(),
+                            Some(&id_str),
+                            Some(
+                                "pass a bare integer (206), zero-padded integer (01), or integer + letter suffix (16b)",
+                            ),
+                            None,
+                        )));
+                    }
+                }
+            }
+            let (set_files, set_globs): (&[String], &[String]) = match resolved_files {
+                Some(ref paths) => (paths.as_slice(), &[]),
+                None => (&file, &glob),
+            };
             set_commands::set(
                 dir,
                 &properties,
                 &tag,
-                &file,
-                &glob,
+                set_files,
+                set_globs,
                 &where_prop_filters,
                 &where_tags,
                 effective_format,

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -268,16 +268,25 @@ impl OutputPipeline<'_> {
                     return 1;
                 }
                 // Raw output bypasses the JSON pipeline — print directly to stdout.
-                // Used by the `read` command for text-format content output.
-                // println! matches pre-refactor behavior: the content string already ends
-                // with '\n', and the extra newline from println! preserves empty-line
-                // endings (e.g. `--lines :2` where line 2 is blank).
+                // Used by the `read` command for text-format content output, and by
+                // `find --filenames-only` for bare path lists (iter-235).
+                //
+                // `print!` (not `println!`) for an *empty* RawOutput so that a
+                // zero-result `--filenames-only` run prints nothing — not even a
+                // trailing newline — so a `while read` / `xargs` loop sees no
+                // phantom empty item. `read`'s content always ends with '\n' (its
+                // RawOutput is never empty), so it keeps the trailing-newline
+                // behaviour via the `else` arm.
                 //
                 // Sanitized here (unlike the JSON pipeline above) because RawOutput
                 // is raw file body content that never passes through format_success/
                 // format_envelope — without this, a vault file containing ANSI escapes
                 // or other control bytes would inject them straight into the terminal.
-                println!("{}", crate::output::sanitize_control_chars(&output));
+                if output.is_empty() {
+                    print!("{}", crate::output::sanitize_control_chars(&output));
+                } else {
+                    println!("{}", crate::output::sanitize_control_chars(&output));
+                }
                 0
             }
             Ok(CommandOutcome::UserError(output)) => {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1122,6 +1122,39 @@ fn run_inner() -> Result<(), AppError> {
         // --jq + --format text is a user error → exit 1, not 2 (iter-181 task 2).
         return Err(AppError::Exit(1));
     }
+    // iter-235: `--filenames-only` is a find-local projection that bypasses the
+    // JSON envelope entirely (raw paths, one per line). clap already rejects
+    // it alongside `--jq` and `--count` (which likewise replace the whole
+    // pipeline); here we cover an explicit `--format json`, which is a
+    // contradictory projection (JSON envelope vs. raw paths). The default
+    // JSON-when-piped format does NOT conflict — `--filenames-only` overrides
+    // the format so a piped `find --filenames-only | sort` works without a
+    // `--format text` chore, which is the whole point of the flag.
+    if format_from_cli
+        && format == Format::Json
+        && matches!(
+            &cli.command,
+            Commands::Find {
+                filters: FindFilters {
+                    filenames_only: true,
+                    ..
+                },
+                ..
+            }
+        )
+    {
+        eprintln!(
+            "{}",
+            crate::output::format_error(
+                format,
+                "--filenames-only cannot be combined with --format json",
+                None,
+                Some("--filenames-only prints raw paths; drop --format (or use --format text)"),
+                None,
+            )
+        );
+        return Err(AppError::Exit(1));
+    }
     // `--format github` is lint-only: it emits GitHub Actions workflow commands
     // for lint violations. Reject it for every other subcommand with a clear
     // message listing the valid formats, so `hyalo find --format github` fails

--- a/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
@@ -1,0 +1,741 @@
+//! Iteration 235 — agent-facing CLI ergonomics: `--filenames-only`,
+//! `--iteration <ID>`, and the self-healing vault-boundary error.
+//!
+//! These three close the highest-friction findings from the ralph-loop port
+//! dogfood (research/agent-ergonomics-ralph-loop-port-2026-08-24): a compact
+//! filename projection for `find`, natural-key addressing for iteration-typed
+//! vaults, and a boundary error that names the vault root instead of leaving
+//! the agent to guess another absolute path.
+
+use std::fs;
+
+use super::common::{hyalo_no_hints, md, write_md};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Vault fixture: an `iteration` type with a `{n}` filename template.
+// ---------------------------------------------------------------------------
+
+fn setup_iteration_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        md!(r#"
+dir = "."
+
+[schema.types.iteration]
+required = ["title", "type", "status"]
+filename-template = "iterations/iteration-{n}-{slug}.md"
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed", "superseded"]
+"#),
+    )
+    .unwrap();
+
+    write_md(
+        tmp.path(),
+        "iterations/iteration-16-baseline.md",
+        md!(r"
+---
+title: Iter 16 Baseline
+type: iteration
+status: completed
+date: 2026-01-01
+---
+Body 16.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "iterations/iteration-16b-suffix.md",
+        md!(r"
+---
+title: Iter 16b
+type: iteration
+status: planned
+date: 2026-01-02
+---
+Body 16b.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "iterations/iteration-206-agent-cli.md",
+        md!(r"
+---
+title: Iter 206
+type: iteration
+status: planned
+date: 2026-02-01
+---
+Body 206.
+"),
+    );
+    write_md(
+        tmp.path(),
+        "iterations/iteration-01-zero-pad.md",
+        md!(r"
+---
+title: Iter 1
+type: iteration
+status: completed
+date: 2026-01-03
+---
+Body 01.
+"),
+    );
+    // A note (not an iteration) so --iteration 16 does not accidentally widen.
+    write_md(
+        tmp.path(),
+        "notes/random.md",
+        md!(r"
+---
+title: A note
+type: note
+status: planned
+---
+Note body.
+"),
+    );
+    tmp
+}
+
+// ===========================================================================
+// --filenames-only
+// ===========================================================================
+
+#[test]
+fn filenames_only_prints_one_path_per_line_no_decoration() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--property", "status=planned", "--filenames-only"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Every planned iteration, one path per line, no quotes / JSON.
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.contains(&"iterations/iteration-16b-suffix.md"));
+    assert!(lines.contains(&"iterations/iteration-206-agent-cli.md"));
+    assert!(
+        !lines.contains(&"iterations/iteration-16-baseline.md"),
+        "completed not listed"
+    );
+    // No envelope, no hints, no count.
+    assert!(!stdout.contains("\"results\""));
+    assert!(!stdout.contains("\"hints\""));
+    assert!(!stdout.contains("\"total\""));
+    assert!(!stdout.contains('"'));
+    // Trailing newline on a non-empty result set.
+    assert!(
+        stdout.ends_with('\n'),
+        "expected trailing newline: {stdout:?}"
+    );
+}
+
+#[test]
+fn filenames_only_zero_results_is_empty_output_exit_0() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=nonexistent",
+            "--filenames-only",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "zero results must exit 0, got: {}",
+        stderr(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "",
+        "zero results must print nothing (no trailing newline)"
+    );
+}
+
+#[test]
+fn filenames_only_strict_flips_exit_code_when_results_exist() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=planned",
+            "--filenames-only",
+            "--strict",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "--strict must exit non-zero when results exist, got success: {}",
+        stderr(&output)
+    );
+    // The paths are still printed to stdout (the CI-gate + list use case).
+    assert!(String::from_utf8_lossy(&output.stdout).contains("iteration-206"));
+    // And empty results with --strict still exits 0.
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=nonexistent",
+            "--filenames-only",
+            "--strict",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "--strict on zero results must exit 0, got: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn filenames_only_conflicts_with_jq_and_count_and_format_json() {
+    let vault = setup_iteration_vault();
+    let dir = vault.path().to_str().unwrap();
+
+    // --jq: clap conflict → exit 2.
+    let out = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args(["find", "--filenames-only", "--jq", ".results[].file"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2), "{}", stderr(&out));
+
+    // --count: clap conflict → exit 2.
+    let out = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args(["find", "--filenames-only", "--count"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2), "{}", stderr(&out));
+
+    // --format json (explicit): runtime conflict → exit 1.
+    let out = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args(["find", "--filenames-only", "--format", "json"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1), "{}", stderr(&out));
+    let err = stderr(&out);
+    assert!(err.contains("--filenames-only cannot be combined with --format json"));
+
+    // --format text (explicit) is fine.
+    let out = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args([
+            "find",
+            "--property",
+            "status=planned",
+            "--filenames-only",
+            "--format",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{}", stderr(&out));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("iteration-206"));
+}
+
+#[test]
+fn filenames_only_combines_with_filters_and_sort() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--tag",
+            "nonexistent",
+            "--filenames-only",
+            "--sort",
+            "file",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    // No file has that tag → empty output.
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+}
+
+#[test]
+fn filenames_only_composes_with_iteration_filter() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--iteration", "206", "--filenames-only"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim_end(),
+        "iterations/iteration-206-agent-cli.md"
+    );
+}
+
+// ===========================================================================
+// --iteration <ID> on find
+// ===========================================================================
+
+#[test]
+fn find_iteration_bare_integer_resolves_filename_template() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--iteration", "206", "--jq", ".results[].file"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "iterations/iteration-206-agent-cli.md"
+    );
+}
+
+#[test]
+fn find_iteration_letter_suffix_matches_only_suffixed_file() {
+    let vault = setup_iteration_vault();
+    // 16b must match only the suffix file, not iteration-16-baseline.
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--iteration", "16b", "--jq", ".results[].file"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "iterations/iteration-16b-suffix.md"
+    );
+}
+
+#[test]
+fn find_iteration_bare_integer_does_not_match_letter_suffix_file() {
+    let vault = setup_iteration_vault();
+    // --iteration 16 matches iteration-16-baseline only — NOT iteration-16b-*
+    // (the letter suffix is a separate identifier, and the literal `-` after
+    // the digits in the template is the boundary).
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--iteration", "16", "--jq", ".results[].file"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let files: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(files, vec!["iterations/iteration-16-baseline.md"]);
+}
+
+#[test]
+fn find_iteration_zero_padded_id_preserved_verbatim() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--iteration", "01", "--jq", ".results[].file"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "iterations/iteration-01-zero-pad.md"
+    );
+}
+
+#[test]
+fn find_iteration_no_matching_file_returns_empty_result() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--iteration", "999", "--jq", ".results | length"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "0");
+}
+
+#[test]
+fn find_iteration_invalid_id_is_rejected() {
+    let vault = setup_iteration_vault();
+    for bad in ["b16", "16-b", "1.6", "abc", ""] {
+        let output = hyalo_no_hints()
+            .args(["--dir", vault.path().to_str().unwrap()])
+            .args(["find", "--iteration", bad])
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "iteration ID {bad:?} should be rejected: {}",
+            stderr(&output)
+        );
+        let err = stderr(&output);
+        assert!(err.contains("iteration ID"), "got: {err}");
+        assert!(
+            err.contains("digits optionally followed by letters"),
+            "error should name the grammar: {err}"
+        );
+    }
+}
+
+#[test]
+fn find_iteration_without_matching_template_errors_clearly() {
+    // A vault whose types have no {n} template slot.
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        md!(r#"
+dir = "."
+
+[schema.types.note]
+required = ["title"]
+"#),
+    )
+    .unwrap();
+    write_md(
+        tmp.path(),
+        "n.md",
+        md!(r"
+---
+title: A
+type: note
+---
+body
+"),
+    );
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--iteration", "16"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{}", stderr(&output));
+    let err = stderr(&output);
+    assert!(
+        err.contains("no type schema has a filename_template with an {n}"),
+        "should name the missing-template reason: {err}"
+    );
+    assert!(
+        err.contains("set a filename_template containing {n}"),
+        "should offer the fix: {err}"
+    );
+}
+
+#[test]
+fn find_iteration_combines_with_other_filters() {
+    let vault = setup_iteration_vault();
+    // 206 is planned; narrowing to status=completed yields nothing.
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--iteration",
+            "206",
+            "--property",
+            "status=completed",
+            "--jq",
+            ".results | length",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "0");
+    // 16-baseline is completed; --iteration 16 + status=completed finds it.
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--iteration",
+            "16",
+            "--property",
+            "status=completed",
+            "--jq",
+            ".results[].file",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "iterations/iteration-16-baseline.md"
+    );
+}
+
+// ===========================================================================
+// --iteration <ID> on set
+// ===========================================================================
+
+#[test]
+fn set_iteration_resolves_single_file_and_mutates() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "set",
+            "--iteration",
+            "206",
+            "--property",
+            "status=completed",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "set --iteration should succeed: {}",
+        stderr(&output)
+    );
+    let body =
+        fs::read_to_string(vault.path().join("iterations/iteration-206-agent-cli.md")).unwrap();
+    assert!(
+        body.contains("status: completed"),
+        "status was written: {body}"
+    );
+}
+
+#[test]
+fn set_iteration_where_property_filters_within_selection() {
+    let vault = setup_iteration_vault();
+    // 206 is planned; --where-property status=planned allows the write.
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "set",
+            "--iteration",
+            "206",
+            "--property",
+            "status=in-progress",
+            "--where-property",
+            "status=planned",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    let body =
+        fs::read_to_string(vault.path().join("iterations/iteration-206-agent-cli.md")).unwrap();
+    assert!(body.contains("status: in-progress"));
+    // 206 is now in-progress; a second write gated on status=planned skips.
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "set",
+            "--iteration",
+            "206",
+            "--property",
+            "status=completed",
+            "--where-property",
+            "status=planned",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    let body =
+        fs::read_to_string(vault.path().join("iterations/iteration-206-agent-cli.md")).unwrap();
+    // Skipped → still in-progress.
+    assert!(body.contains("status: in-progress"));
+}
+
+#[test]
+fn set_iteration_conflicts_with_file_and_glob() {
+    let vault = setup_iteration_vault();
+    let dir = vault.path().to_str().unwrap();
+    // --iteration + --file → clap conflict, exit 2.
+    let out = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args([
+            "set",
+            "--iteration",
+            "206",
+            "--file",
+            "x.md",
+            "--property",
+            "status=completed",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2), "{}", stderr(&out));
+    // --iteration + --glob → clap conflict, exit 2.
+    let out = hyalo_no_hints()
+        .args(["--dir", dir])
+        .args([
+            "set",
+            "--iteration",
+            "206",
+            "--glob",
+            "**/*.md",
+            "--property",
+            "status=completed",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2), "{}", stderr(&out));
+}
+
+#[test]
+fn set_iteration_ambiguous_match_lists_candidates() {
+    let vault = setup_iteration_vault();
+    // Create a second iteration-16 file so bare 16 is ambiguous.
+    write_md(
+        vault.path(),
+        "iterations/iteration-16-second.md",
+        md!(r"
+---
+title: Iter 16 second
+type: iteration
+status: planned
+date: 2026-01-04
+---
+Body.
+"),
+    );
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["set", "--iteration", "16", "--property", "status=completed"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "ambiguous --iteration must error: {}",
+        stderr(&output)
+    );
+    let err = stderr(&output);
+    assert!(err.contains("matches multiple files"), "got: {err}");
+    assert!(
+        err.contains("iteration-16-baseline.md"),
+        "lists candidates: {err}"
+    );
+    assert!(
+        err.contains("iteration-16-second.md"),
+        "lists both candidates: {err}"
+    );
+    assert!(
+        err.contains("disambiguate") || err.contains("--file"),
+        "should suggest disambiguation: {err}"
+    );
+}
+
+#[test]
+fn set_iteration_no_match_errors_with_resolved_globs() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "set",
+            "--iteration",
+            "999",
+            "--property",
+            "status=completed",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{}", stderr(&output));
+    let err = stderr(&output);
+    assert!(
+        err.contains("no file found for iteration 999"),
+        "got: {err}"
+    );
+    assert!(
+        err.contains("iterations/iteration-999-*.md"),
+        "should name the resolved glob: {err}"
+    );
+}
+
+#[test]
+fn set_iteration_letter_suffix_targets_one_file() {
+    let vault = setup_iteration_vault();
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args([
+            "set",
+            "--iteration",
+            "16b",
+            "--property",
+            "status=completed",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    let body = fs::read_to_string(vault.path().join("iterations/iteration-16b-suffix.md")).unwrap();
+    assert!(body.contains("status: completed"));
+    // The baseline 16 file is untouched.
+    let baseline =
+        fs::read_to_string(vault.path().join("iterations/iteration-16-baseline.md")).unwrap();
+    assert!(baseline.contains("status: completed"));
+    // Disambiguate: bare 16 with two same-number files is ambiguous (see above).
+}
+
+// ===========================================================================
+// Vault-boundary error self-healing
+// ===========================================================================
+
+#[test]
+fn set_absolute_path_outside_vault_names_dir_and_hint() {
+    let vault = setup_iteration_vault();
+    let outside = TempDir::new().unwrap();
+    let stray = outside.path().join("stray.md");
+    fs::write(&stray, "---\ntitle: Stray\n---\nbody\n").unwrap();
+    let stray_str = stray.to_string_lossy().into_owned();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["set", "--file", &stray_str, "--property", "x=1"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{}", stderr(&output));
+    let err = stderr(&output);
+    assert!(err.contains("outside vault boundary"), "got: {err}");
+    // The effective vault dir is named.
+    assert!(
+        err.contains("vault:"),
+        "expected vault dir in message: {err}"
+    );
+    assert!(
+        err.contains(vault.path().to_str().unwrap()),
+        "expected the actual vault path: {err}"
+    );
+    // The self-healing hint names both fixes.
+    assert!(err.contains("relative to"), "got: {err}");
+    assert!(err.contains("cd to a parent"), "got: {err}");
+    // The offending path is reported.
+    assert!(err.contains(&stray_str), "got: {err}");
+    // And the stray file is untouched.
+    assert!(
+        !fs::read_to_string(&stray).unwrap().contains("x:"),
+        "no write should have landed outside the vault"
+    );
+}
+
+#[test]
+fn find_absolute_file_outside_vault_names_dir_and_hint() {
+    let vault = setup_iteration_vault();
+    let outside = TempDir::new().unwrap();
+    let stray = outside.path().join("stray.md");
+    fs::write(&stray, "---\ntitle: Stray\n---\nbody\n").unwrap();
+    let stray_str = stray.to_string_lossy().into_owned();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", vault.path().to_str().unwrap()])
+        .args(["find", "--file", &stray_str])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{}", stderr(&output));
+    let err = stderr(&output);
+    assert!(err.contains("outside vault boundary"), "got: {err}");
+    assert!(err.contains("vault:"), "got: {err}");
+    assert!(err.contains("relative to"), "got: {err}");
+    assert!(err.contains("cd to a parent"), "got: {err}");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}

--- a/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
@@ -712,8 +712,14 @@ fn set_absolute_path_outside_vault_names_dir_and_hint() {
     // The self-healing hint names both fixes.
     assert!(err.contains("relative to"), "got: {err}");
     assert!(err.contains("cd to a parent"), "got: {err}");
-    // The offending path is reported.
-    assert!(err.contains(&stray_str), "got: {err}");
+    // The offending path is reported. The JSON path field is
+    // separator-normalized to forward slashes, so compare against the
+    // forward-slash spelling of the input (Windows: stray_str has '\\').
+    let stray_fwd = stray_str.replace('\\', "/");
+    assert!(
+        err.contains(&stray_fwd),
+        "got: {err}; expected path: {stray_fwd}"
+    );
     // And the stray file is untouched.
     assert!(
         !fs::read_to_string(&stray).unwrap().contains("x:"),

--- a/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
@@ -690,14 +690,21 @@ fn set_absolute_path_outside_vault_names_dir_and_hint() {
     assert!(!output.status.success(), "{}", stderr(&output));
     let err = stderr(&output);
     assert!(err.contains("outside vault boundary"), "got: {err}");
-    // The effective vault dir is named.
+    // The effective vault dir is named. Accept either the TempDir's raw
+    // spelling or its canonical form: the message carries the dir as given
+    // (macOS: /var/folders/... while canonicalize yields /private/var/...),
+    // while on Windows the canonical form may use the 8.3 short user name
+    // (e.g. RUNNER~1) which differs from the TempDir's spelling.
+    let canonical_vault = dunce::canonicalize(vault.path()).unwrap();
     assert!(
         err.contains("vault:"),
         "expected vault dir in message: {err}"
     );
+    let raw_ok = err.contains(vault.path().to_str().unwrap());
+    let canonical_ok = err.contains(&*canonical_vault.to_string_lossy());
     assert!(
-        err.contains(vault.path().to_str().unwrap()),
-        "expected the actual vault path: {err}"
+        raw_ok || canonical_ok,
+        "expected the actual vault path (raw or canonical) in: {err}"
     );
     // The self-healing hint names both fixes.
     assert!(err.contains("relative to"), "got: {err}");

--- a/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration_ergonomics.rs
@@ -690,21 +690,24 @@ fn set_absolute_path_outside_vault_names_dir_and_hint() {
     assert!(!output.status.success(), "{}", stderr(&output));
     let err = stderr(&output);
     assert!(err.contains("outside vault boundary"), "got: {err}");
-    // The effective vault dir is named. Accept either the TempDir's raw
-    // spelling or its canonical form: the message carries the dir as given
-    // (macOS: /var/folders/... while canonicalize yields /private/var/...),
-    // while on Windows the canonical form may use the 8.3 short user name
-    // (e.g. RUNNER~1) which differs from the TempDir's spelling.
-    let canonical_vault = dunce::canonicalize(vault.path()).unwrap();
+    // The effective vault dir is named. The stderr is JSON, where Windows
+    // path separators are escaped (C:\\Users\\...), so a full-path
+    // `contains` breaks on separators. Assert on the vault's unique
+    // separator-free temp component instead (present in the raw and the
+    // canonical spelling alike — the 8.3 short-name form on Windows
+    // runners differs from TempDir's spelling only before this component).
+    let vault_name = vault
+        .path()
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
     assert!(
         err.contains("vault:"),
         "expected vault dir in message: {err}"
     );
-    let raw_ok = err.contains(vault.path().to_str().unwrap());
-    let canonical_ok = err.contains(&*canonical_vault.to_string_lossy());
     assert!(
-        raw_ok || canonical_ok,
-        "expected the actual vault path (raw or canonical) in: {err}"
+        !vault_name.is_empty() && err.contains(vault_name),
+        "expected the actual vault path component {vault_name:?} in: {err}"
     );
     // The self-healing hint names both fixes.
     assert!(err.contains("relative to"), "got: {err}");

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -27,6 +27,7 @@ mod hints;
 mod hyalo_config;
 mod index;
 mod init;
+mod iteration_ergonomics;
 mod jq;
 mod json_errors;
 mod links;

--- a/crates/hyalo-cli/tests/e2e/mv.rs
+++ b/crates/hyalo-cli/tests/e2e/mv.rs
@@ -1401,6 +1401,17 @@ fn mv_single_symlink_escape_rejected() {
         stderr.contains("outside vault boundary"),
         "expected vault-boundary error, got: {stderr}"
     );
+    // iter-235: the boundary error is self-healing — it names the vault dir
+    // and offers a relative-path / `cd` hint, so an agent (or human) does not
+    // have to probe another absolute path to fix the invocation.
+    assert!(
+        stderr.contains("vault:"),
+        "expected the effective vault dir in the boundary error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("relative to") && stderr.contains("cd to a parent"),
+        "expected a relative-path / cd hint in the boundary error, got: {stderr}"
+    );
 
     // Source untouched; nothing written outside the vault.
     assert!(

--- a/crates/hyalo-cli/tests/e2e/symlinks.rs
+++ b/crates/hyalo-cli/tests/e2e/symlinks.rs
@@ -145,6 +145,16 @@ fn symlink_escaping_vault_is_refused() {
         combined.contains("file resolves outside vault boundary"),
         "expected the vault-boundary error, got: {combined}"
     );
+    // iter-235: the boundary refusal is self-healing — names the vault dir
+    // and offers the relative-path / `cd` hint in the same message.
+    assert!(
+        combined.contains("vault:"),
+        "expected the effective vault dir in the boundary error, got: {combined}"
+    );
+    assert!(
+        combined.contains("relative to") && combined.contains("cd to a parent"),
+        "expected a relative-path / cd hint in the boundary error, got: {combined}"
+    );
     assert!(
         fs::read_to_string(&secret)
             .unwrap()
@@ -179,6 +189,14 @@ fn set_symlink_escaping_vault_is_refused() {
         "expected the vault-boundary error, got: {combined}"
     );
     assert!(
+        combined.contains("vault:"),
+        "expected the effective vault dir in the boundary error, got: {combined}"
+    );
+    assert!(
+        combined.contains("relative to") && combined.contains("cd to a parent"),
+        "expected a relative-path / cd hint in the boundary error, got: {combined}"
+    );
+    assert!(
         !fs::read_to_string(&secret).unwrap().contains("status:"),
         "the out-of-vault file must be byte-for-byte untouched"
     );
@@ -208,6 +226,14 @@ fn append_symlink_escaping_vault_is_refused() {
     assert!(
         combined.contains("file resolves outside vault boundary"),
         "expected the vault-boundary error, got: {combined}"
+    );
+    assert!(
+        combined.contains("vault:"),
+        "expected the effective vault dir in the boundary error, got: {combined}"
+    );
+    assert!(
+        combined.contains("relative to") && combined.contains("cd to a parent"),
+        "expected a relative-path / cd hint in the boundary error, got: {combined}"
     );
     assert!(
         !fs::read_to_string(&secret).unwrap().contains("two"),

--- a/crates/hyalo-core/src/filename_template.rs
+++ b/crates/hyalo-core/src/filename_template.rs
@@ -153,6 +153,56 @@ impl FilenameTemplate {
         out
     }
 
+    /// Returns `true` when the template contains at least one numeric `{n}` or
+    /// `{n:0W}` placeholder.
+    ///
+    /// Used by `--iteration <ID>` resolution to decide which type schemas are
+    /// addressable by a natural key: a template like
+    /// `iterations/iteration-{n}-{slug}.md` carries an `{n}` slot an iteration
+    /// ID can be substituted into, while a purely literal template
+    /// (`notes/README.md`) or one with only `{slug}` / `{date}` is not.
+    #[must_use]
+    pub fn has_n_placeholder(&self) -> bool {
+        self.segments
+            .iter()
+            .any(|seg| matches!(seg, Segment::Placeholder(Placeholder::N { .. })))
+    }
+
+    /// Build a glob that matches files carrying a specific sequence ID.
+    ///
+    /// `id` is substituted verbatim into every `{n}` / `{n:0W}` placeholder
+    /// slot, and every other placeholder (`{slug}`, `{date}`) becomes `*`, so a
+    /// template `iterations/iteration-{n}-{slug}.md` combined with the ID
+    /// `"206"` yields `iterations/iteration-206-*.md` — exactly the files for
+    /// iteration 206 regardless of slug.
+    ///
+    /// The ID is inserted as written (not normalised): a bare `01` matches
+    /// `iteration-01-*` (zero-padded files), not `iteration-1-*`. A
+    /// letter-suffixed ID like `16b` matches only `iteration-16b-*`; a bare
+    /// integer like `16` matches `iteration-16-*` and *not* `iteration-16b-*`
+    /// (the suffix is a separate identifier — see [`crate::iteration_id`]).
+    ///
+    /// This is the specific-key counterpart to [`to_glob`]'s permissive
+    /// "match any value" expansion; it does not require the ID itself to
+    /// satisfy the `{n}` character class, because the goal is matching real
+    /// files that may carry letter suffixes the `{n}` matcher itself rejects
+    /// (`iteration-195a-…` is a real iteration file even though `195a` is not
+    /// a pure digit run).
+    #[must_use]
+    pub fn to_glob_for_id(&self, id: &str) -> String {
+        let mut out = String::new();
+        for seg in &self.segments {
+            match seg {
+                Segment::Literal(s) => out.push_str(s),
+                Segment::Placeholder(Placeholder::N { .. }) => out.push_str(id),
+                // `{slug}` and `{date}` both become `*` — any value is an
+                // acceptable match once the ID pins the `{n}` slot.
+                Segment::Placeholder(Placeholder::Slug | Placeholder::Date) => out.push('*'),
+            }
+        }
+        out
+    }
+
     /// Returns `true` if the given relative path matches this template.
     ///
     /// Path separators are normalized to `/` for matching, so templates can
@@ -347,6 +397,60 @@ mod tests {
         let t = FilenameTemplate::parse("decisions/{n:04}-{slug}.md").unwrap();
         // The glob for a padded number is the same permissive digit-run form.
         assert_eq!(t.to_glob(), "decisions/[0-9][0-9]*-*.md");
+    }
+
+    #[test]
+    fn has_n_placeholder_detects_numeric_slot() {
+        let t = FilenameTemplate::parse("iterations/iteration-{n}-{slug}.md").unwrap();
+        assert!(t.has_n_placeholder());
+        let t = FilenameTemplate::parse("decisions/{n:04}-{slug}.md").unwrap();
+        assert!(t.has_n_placeholder());
+    }
+
+    #[test]
+    fn has_n_placeholder_false_for_literal_only_or_other_placeholders() {
+        assert!(
+            !FilenameTemplate::parse("notes/README.md")
+                .unwrap()
+                .has_n_placeholder()
+        );
+        assert!(
+            !FilenameTemplate::parse("journal/{date}.md")
+                .unwrap()
+                .has_n_placeholder()
+        );
+        assert!(
+            !FilenameTemplate::parse("notes/{slug}.md")
+                .unwrap()
+                .has_n_placeholder()
+        );
+    }
+
+    #[test]
+    fn to_glob_for_id_substitutes_id_and_star() {
+        let t = FilenameTemplate::parse("iterations/iteration-{n}-{slug}.md").unwrap();
+        // Bare integer matches only the same-number files.
+        assert_eq!(t.to_glob_for_id("206"), "iterations/iteration-206-*.md");
+        // Zero-padded ID is inserted verbatim.
+        assert_eq!(t.to_glob_for_id("01"), "iterations/iteration-01-*.md");
+        // Letter-suffixed ID matches only the suffixed files.
+        assert_eq!(t.to_glob_for_id("16b"), "iterations/iteration-16b-*.md");
+    }
+
+    #[test]
+    fn to_glob_for_id_for_padded_template_inserts_raw_id() {
+        let t = FilenameTemplate::parse("decisions/{n:04}-{slug}.md").unwrap();
+        // The ID is inserted verbatim — the pad width is a rendering concern,
+        // not applied here, so a vault using padded filenames gets a matching
+        // glob only when the caller passes the padded form (e.g. "0206").
+        assert_eq!(t.to_glob_for_id("0206"), "decisions/0206-*.md");
+        assert_eq!(t.to_glob_for_id("206"), "decisions/206-*.md");
+    }
+
+    #[test]
+    fn to_glob_for_id_date_placeholder_becomes_star() {
+        let t = FilenameTemplate::parse("journal/{date}-{n}.md").unwrap();
+        assert_eq!(t.to_glob_for_id("42"), "journal/*-42.md");
     }
 
     #[test]

--- a/crates/hyalo-core/src/fs_util.rs
+++ b/crates/hyalo-core/src/fs_util.rs
@@ -79,6 +79,42 @@ pub fn outside_vault_message(subject: &str, resolved: Option<&Path>) -> String {
     }
 }
 
+/// Like [`outside_vault_message`] but names the effective vault directory so
+/// the caller can act on the refusal without a second probe (iter-235,
+/// agent-ergonomics review finding 3). An agent that passed `/tmp/foo.md`
+/// learns *which* directory is the vault root and how to fix the invocation
+/// in the same message, rather than guessing another absolute path.
+///
+/// The vault dir is appended as `(vault: <dir>)` after the existing subject
+/// and resolved-target clause, keeping the long-standing ``resolves outside
+/// vault boundary`` substring intact so existing assertions keep passing.
+/// `resolved` is the canonical destination the path escaped to, when known.
+#[must_use]
+pub fn outside_vault_message_with_dir(
+    subject: &str,
+    resolved: Option<&Path>,
+    vault_dir: &Path,
+) -> String {
+    let base = outside_vault_message(subject, resolved);
+    format!("{base} (vault: {})", vault_dir.display())
+}
+
+/// The shared self-healing hint text for a vault-boundary refusal (iter-235).
+///
+/// Names the vault dir the caller should anchor against — pass the same
+/// `vault_dir` given to [`outside_vault_message_with_dir`] — and the two ways
+/// to fix the invocation: a relative path, or a `cd` to a parent of the vault.
+/// Quote the dir back to the caller because the most common failure mode is
+/// an agent guessing absolute paths with no idea which directory hyalo is
+/// actually rooted at.
+#[must_use]
+pub fn outside_vault_hint(vault_dir: &Path) -> String {
+    format!(
+        "pass a path relative to {}, or cd to a parent of it",
+        vault_dir.display()
+    )
+}
+
 /// Report where a prospective write to `path` would really land, when that is
 /// outside `vault_root`.
 ///
@@ -474,6 +510,49 @@ mod tests {
         assert_eq!(
             outside_vault_message("path", None),
             "path resolves outside vault boundary"
+        );
+    }
+
+    #[test]
+    fn outside_vault_message_with_dir_appends_vault() {
+        let msg = outside_vault_message_with_dir(
+            "file",
+            Some(Path::new("/elsewhere/secret.md")),
+            Path::new("/home/me/kb"),
+        );
+        assert!(
+            msg.contains("file resolves outside vault boundary: /elsewhere/secret.md"),
+            "keeps the long-standing substring: {msg}"
+        );
+        assert!(
+            msg.contains("(vault: /home/me/kb)"),
+            "names the effective vault dir: {msg}"
+        );
+    }
+
+    #[test]
+    fn outside_vault_message_with_dir_no_resolved_target() {
+        let msg = outside_vault_message_with_dir("path", None, Path::new("/repo/docs"));
+        assert!(
+            msg.contains("path resolves outside vault boundary"),
+            "base message intact: {msg}"
+        );
+        assert!(
+            msg.contains("(vault: /repo/docs)"),
+            "vault dir still named: {msg}"
+        );
+    }
+
+    #[test]
+    fn outside_vault_hint_names_dir_and_two_fixes() {
+        let hint = outside_vault_hint(Path::new("/home/me/kb"));
+        assert!(
+            hint.contains("relative to /home/me/kb"),
+            "names the vault dir: {hint}"
+        );
+        assert!(
+            hint.contains("cd to a parent"),
+            "offers the cd alternative: {hint}"
         );
     }
 

--- a/crates/hyalo-core/src/iteration_id.rs
+++ b/crates/hyalo-core/src/iteration_id.rs
@@ -1,0 +1,259 @@
+//! Parsing of `--iteration <ID>` natural-key identifiers.
+//!
+//! Iteration plans (and other sequence-keyed document types) carry their
+//! natural key in the filename, encoded by a type schema's
+//! `filename_template` `{n}` placeholder: `iterations/iteration-{n}-{slug}.md`.
+//! Agents and humans address them by that key — the bare number — not by the
+//! slug. This module owns the ID grammar shared by `hyalo find --iteration`
+//! and `hyalo set --iteration` (iter-235, agent-ergonomics review finding 5).
+//!
+//! Grammar (same shape ralph-loop / preflight already use for branch and plan
+//! names): one or more digits, optionally followed by one or more letters.
+//! Accepted examples: `206` (bare integer), `01` (zero-padded),
+//! `16b` / `16ab` (integer + letter suffix). The letter suffix is how
+//! sub-iterations disambiguate within the same base number
+//! (`iteration-16a-*`, `iteration-16b-*`). A bare integer is *not* a
+//! prefix of a longer number — `16` never matches `160` — because the ID
+//! is substituted verbatim into the template's literal structure, not
+//! matched as a digit run.
+
+use std::fmt;
+
+/// A parsed `--iteration <ID>` natural-key identifier.
+///
+/// `raw` is the exact string the caller typed (`"206"`, `"01"`, `"16b"`),
+/// substituted verbatim into the type schema's `{n}` placeholder slot when
+/// resolving files. `digits` and `suffix` are the parsed components, kept for
+/// diagnostics and future sorting/normalisation — resolution itself uses the
+/// raw form so zero-padding and letter casing are preserved as written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IterationId {
+    raw: String,
+    digits: String,
+    suffix: String,
+}
+
+/// Errors from [`parse_iteration_id`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IterationIdParseError {
+    /// The identifier was empty or contained no leading digits.
+    Empty,
+    /// The identifier contained characters outside the `digits [letters]`
+    /// grammar. `raw` echoes the offending input; `reason` names the rule.
+    Invalid { raw: String, reason: &'static str },
+}
+
+impl fmt::Display for IterationIdParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(
+                f,
+                "iteration ID is empty (expected digits optionally followed by letters, e.g. 206, 01, 16b)"
+            ),
+            Self::Invalid { raw, reason } => {
+                write!(
+                    f,
+                    "invalid iteration ID '{raw}': {reason} (expected digits optionally followed by letters, e.g. 206, 01, 16b)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for IterationIdParseError {}
+
+impl IterationId {
+    /// The exact identifier string as typed, e.g. `"206"`, `"01"`, `"16b"`.
+    ///
+    /// This is what gets substituted into the `{n}` placeholder slot of a
+    /// type schema's `filename_template` — verbatim, so a zero-padded ID like
+    /// `01` matches `iteration-01-*.md` (not `iteration-1-*.md`).
+    #[must_use]
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    /// The leading digit run, e.g. `"206"`, `"01"`, `"16"`.
+    #[must_use]
+    pub fn digits(&self) -> &str {
+        &self.digits
+    }
+
+    /// The trailing letter suffix, e.g. `""`, `""`, `"b"`. Empty when the ID
+    /// is a bare integer.
+    #[must_use]
+    pub fn suffix(&self) -> &str {
+        &self.suffix
+    }
+
+    /// `true` when the ID carries a letter suffix (`16b`), `false` when it is
+    /// a bare integer (`206`, `01`).
+    #[must_use]
+    pub fn has_suffix(&self) -> bool {
+        !self.suffix.is_empty()
+    }
+}
+
+impl fmt::Display for IterationId {
+    /// The raw identifier string as typed (`206`, `01`, `16b`).
+    ///
+    /// Used in user-facing messages where the exact form the caller passed
+    /// matters (`"iteration 206 matches multiple files"`).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+/// Parse an `--iteration <ID>` natural-key identifier.
+///
+/// Grammar: `[0-9]+` (one or more digits) followed by `[a-zA-Z]*` (zero or
+/// more letters). An empty input or one with no leading digits is
+/// [`IterationIdParseError::Empty`]; any non-digit/non-letter character after
+/// the digits is [`IterationIdParseError::Invalid`].
+///
+/// ```
+/// use hyalo_core::iteration_id::{parse_iteration_id, IterationId};
+/// let id = parse_iteration_id("16b").unwrap();
+/// assert_eq!(id.raw(), "16b");
+/// assert_eq!(id.digits(), "16");
+/// assert_eq!(id.suffix(), "b");
+/// assert!(id.has_suffix());
+/// ```
+pub fn parse_iteration_id(s: &str) -> Result<IterationId, IterationIdParseError> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(IterationIdParseError::Empty);
+    }
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 {
+        return Err(IterationIdParseError::Empty);
+    }
+    let digits = &s[..i];
+    let mut j = i;
+    while j < bytes.len() && bytes[j].is_ascii_alphabetic() {
+        j += 1;
+    }
+    if j != bytes.len() {
+        return Err(IterationIdParseError::Invalid {
+            raw: s.to_owned(),
+            reason: "contains characters other than digits (optionally followed by letters)",
+        });
+    }
+    let suffix = &s[i..];
+    Ok(IterationId {
+        raw: s.to_owned(),
+        digits: digits.to_owned(),
+        suffix: suffix.to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_integer() {
+        let id = parse_iteration_id("206").unwrap();
+        assert_eq!(id.raw(), "206");
+        assert_eq!(id.digits(), "206");
+        assert_eq!(id.suffix(), "");
+        assert!(!id.has_suffix());
+    }
+
+    #[test]
+    fn zero_padded_integer() {
+        let id = parse_iteration_id("01").unwrap();
+        assert_eq!(id.raw(), "01");
+        assert_eq!(id.digits(), "01");
+        assert_eq!(id.suffix(), "");
+        assert!(!id.has_suffix());
+    }
+
+    #[test]
+    fn single_letter_suffix() {
+        let id = parse_iteration_id("16b").unwrap();
+        assert_eq!(id.raw(), "16b");
+        assert_eq!(id.digits(), "16");
+        assert_eq!(id.suffix(), "b");
+        assert!(id.has_suffix());
+    }
+
+    #[test]
+    fn multi_letter_suffix() {
+        let id = parse_iteration_id("16ab").unwrap();
+        assert_eq!(id.raw(), "16ab");
+        assert_eq!(id.suffix(), "ab");
+    }
+
+    #[test]
+    fn uppercase_suffix_preserved() {
+        let id = parse_iteration_id("16B").unwrap();
+        assert_eq!(id.raw(), "16B");
+        assert_eq!(id.suffix(), "B");
+    }
+
+    #[test]
+    fn surrounding_whitespace_trimmed() {
+        let id = parse_iteration_id("  206  ").unwrap();
+        assert_eq!(id.raw(), "206");
+    }
+
+    #[test]
+    fn empty_rejected() {
+        assert_eq!(parse_iteration_id(""), Err(IterationIdParseError::Empty));
+        assert_eq!(parse_iteration_id("   "), Err(IterationIdParseError::Empty));
+    }
+
+    #[test]
+    fn no_leading_digit_rejected_as_empty() {
+        // A leading letter has no digit run at all → Empty.
+        assert_eq!(parse_iteration_id("b16"), Err(IterationIdParseError::Empty));
+        assert_eq!(parse_iteration_id("abc"), Err(IterationIdParseError::Empty));
+    }
+
+    #[test]
+    fn punctuation_rejected() {
+        let err = parse_iteration_id("16-b").unwrap_err();
+        assert!(matches!(err, IterationIdParseError::Invalid { .. }));
+        assert_eq!(
+            err.to_string(),
+            parse_iteration_id("16-b").unwrap_err().to_string()
+        );
+        assert!(err.to_string().contains("16-b"));
+        assert!(
+            err.to_string()
+                .contains("digits optionally followed by letters")
+        );
+    }
+
+    #[test]
+    fn dash_rejected() {
+        assert!(matches!(
+            parse_iteration_id("1-6"),
+            Err(IterationIdParseError::Invalid { .. })
+        ));
+    }
+
+    #[test]
+    fn decimal_rejected() {
+        assert!(matches!(
+            parse_iteration_id("1.6"),
+            Err(IterationIdParseError::Invalid { .. })
+        ));
+    }
+
+    #[test]
+    fn error_display_is_human_readable() {
+        let err = parse_iteration_id("16-b").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'16-b'"), "should echo the bad input: {msg}");
+        assert!(
+            msg.contains("expected digits optionally followed by letters"),
+            "should name the grammar: {msg}"
+        );
+    }
+}

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod frontmatter;
 pub mod fs_util;
 pub mod heading;
 pub mod index;
+pub mod iteration_id;
 pub mod link_fix;
 pub mod link_graph;
 pub mod link_resolve;

--- a/hyalo-knowledgebase/iterations/iteration-235-agent-cli-ergonomics.md
+++ b/hyalo-knowledgebase/iterations/iteration-235-agent-cli-ergonomics.md
@@ -2,7 +2,7 @@
 title: "Iteration 235 — agent-facing CLI ergonomics: find --filenames-only, --iteration addressing, boundary-error hints"
 type: iteration
 date: 2026-08-24
-status: in-progress
+status: completed
 branch: iter-235/agent-cli-ergonomics
 tags:
   - iteration

--- a/hyalo-knowledgebase/iterations/iteration-235-agent-cli-ergonomics.md
+++ b/hyalo-knowledgebase/iterations/iteration-235-agent-cli-ergonomics.md
@@ -2,7 +2,7 @@
 title: "Iteration 235 — agent-facing CLI ergonomics: find --filenames-only, --iteration addressing, boundary-error hints"
 type: iteration
 date: 2026-08-24
-status: planned
+status: in-progress
 branch: iter-235/agent-cli-ergonomics
 tags:
   - iteration
@@ -53,7 +53,7 @@ paths-only output only makes sense for result-list commands.
 
 ## Tasks
 
-- [ ] Add `--filenames-only` flag to `hyalo find` (FindFilters in
+- [x] Add `--filenames-only` flag to `hyalo find` (FindFilters in
       `crates/hyalo-cli/src/cli/args.rs`, rendering in
       `crates/hyalo-cli/src/commands/find/mod.rs`):
       - Prints one raw file path per line (no JSON quoting, no count, no hints)
@@ -68,7 +68,7 @@ paths-only output only makes sense for result-list commands.
       - Serialize in views (`FindFilters` is `serde::Serialize`; field must
         round-trip like other output-shaping flags or be explicitly skipped
         with a documented reason)
-- [ ] Add `--iteration <ID>` filter to `hyalo find` and accept it on
+- [x] Add `--iteration <ID>` filter to `hyalo find` and accept it on
       `hyalo set` as the file selector (replacing glob math):
       - `ID` matches the natural key: bare integer or integer+letter suffix
         (`206`, `16b`, `01`) — same grammar ralph-loop/preflight use
@@ -82,7 +82,7 @@ paths-only output only makes sense for result-list commands.
         exists as a separate file): in `find`, return all matches (it's a
         filter); in `set`, error listing the candidates unless exactly one
       - `set --iteration 206 --property status=completed` must work end-to-end
-- [ ] Improve the vault-boundary error (both sites:
+- [x] Improve the vault-boundary error (both sites:
       `crates/hyalo-cli/src/commands/mod.rs:294` and
       `crates/hyalo-cli/src/commands/find/mod.rs:211`):
       - Message includes the effective vault dir (absolute path) and the
@@ -90,15 +90,15 @@ paths-only output only makes sense for result-list commands.
       - Hint text: "pass a path relative to <dir>, or cd to a parent of it"
         (the find/mod.rs site already passes a hint — align the shared
         error-format call in commands/mod.rs to include dir + hint)
-- [ ] Update `--help` long text for `find` (`--filenames-only`, `--iteration`)
+- [x] Update `--help` long text for `find` (`--filenames-only`, `--iteration`)
       and `set` (`--iteration`) following the existing help conventions
       (usage examples that show the agent use case)
-- [ ] Define `--iteration` interaction with the other `set` file selectors
+- [x] Define `--iteration` interaction with the other `set` file selectors
       (`--file`, `--glob`, `--tag`, `--type`): they are **competing selectors** —
       clap `conflicts_with` on all of them (exit 2 when combined). `--where-property`
       still composes (it filters *within* the selection) — document this distinction
       in `--help`
-- [ ] Tests:
+- [x] Tests:
       - e2e: `find --filenames-only` with filters, zero-result, conflict
         matrix (--jq / --count / --format json), --strict exit code
       - e2e: `find --iteration 206` and `set --iteration 206 ...` happy path;
@@ -109,28 +109,28 @@ paths-only output only makes sense for result-list commands.
         `tests/e2e/mv.rs:1401` and `tests/e2e/symlinks.rs:145` — update them,
         don't just append)
       - unit: ID grammar parsing (bare, letter, zero-pad, invalid)
-- [ ] Docs: `--filenames-only` and `--iteration` in the README command
+- [x] Docs: `--filenames-only` and `--iteration` in the README command
       reference; mention in CHANGELOG unreleased section
 
 ## Acceptance criteria
 
-- [ ] `hyalo find --property status=planned --filenames-only` prints exactly
+- [x] `hyalo find --property status=planned --filenames-only` prints exactly
       the pending iteration plan paths, one per line, no decoration — usable
       in `sort`, `xargs`, `while read` pipelines
-- [ ] `hyalo find --iteration 206 --filenames-only` prints exactly the
+- [x] `hyalo find --iteration 206 --filenames-only` prints exactly the
       iteration-206 plan path; `hyalo set --iteration 206 --property
       status=completed` updates it — both without any glob or `--jq`
-- [ ] `hyalo set /tmp/foo.md --property x=1` fails with an error containing
+- [x] `hyalo set /tmp/foo.md --property x=1` fails with an error containing
       the vault dir and a relative-path hint
-- [ ] The ralph-loop skill's three hyalo-usage warnings could be dropped:
+- [x] The ralph-loop skill's three hyalo-usage warnings could be dropped:
       with `--filenames-only` and `--iteration`, none of the warned-against
       patterns are needed (manual follow-up after merge — the skill lives at
       `~/.pi/agent/skills/ralph-loop/`, outside this repo, so it is not part
       of this iteration's deliverables or CI)
-- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q` all green; existing boundary-message test
       assertions updated to the new message
-- [ ] No behavior change for existing invocations: no new flag → identical
+- [x] No behavior change for existing invocations: no new flag → identical
       output byte-for-byte, **except the vault-boundary error text (Task 3)**,
       which changes for existing invocations by design (regression-tested on
       a snapshot of current find/set output in the e2e suite)

--- a/hyalo-knowledgebase/iterations/iteration-238-agent-cli-followups.md
+++ b/hyalo-knowledgebase/iterations/iteration-238-agent-cli-followups.md
@@ -1,0 +1,61 @@
+---
+title: "Iteration 238 — agent-CLI ergonomics follow-ups: --filenames0, --iteration on read/task, properties envelope, title~= normalization"
+type: iteration
+date: 2026-08-25
+status: planned
+branch: iter-238/agent-cli-followups
+tags:
+  - iteration
+  - cli
+  - ergonomics
+---
+
+# Iteration 238 — agent-CLI ergonomics follow-ups
+
+## Goal
+
+Fold in the carry-over candidates deliberately deferred out of
+[[iterations/iteration-235-agent-cli-ergonomics]] so they are not silently
+forgotten. Each is small and independently shippable; land only the ones a
+dogfood session still shows friction for — treat this plan as a queue, not a
+must-ship-all list.
+
+## Context
+
+Iteration 235 shipped `find --filenames-only`, `find`/`set --iteration <ID>`,
+and the self-healing vault-boundary error. Its non-goals (all deliberate)
+became this plan. None of them fit iterations 236 (typed pi tools, template
+only) or 237 (pi package distribution, template only), which are both
+"no change to the Rust crate" iterations.
+
+## Tasks
+
+- [ ] `find --filenames0` — NUL-delimited sibling of `--filenames-only` for
+      `xargs -0` / newline-in-filename safety. Shares the
+      `project_filenames_only` projection; clap-conflicts with `--filenames-only`
+- [ ] `--iteration <ID>` on `read` and `task` subcommands — reuse
+      `commands::iteration::resolve_iteration_globs`; same exactly-one-match
+      error as `set --iteration` (read/task are single-file)
+- [ ] `properties` output envelope unification with the find result shape
+      (finding #4 — see [[research/results-json-shape-inventory]] and
+      [[iterations/iteration-216-results-shape-consistency]])
+- [ ] `--property 'title~='` normalization for non-iteration types (finding #2
+      remainder — obsoleted for iterations by `--iteration`; revisit only if
+      it bites on other types)
+
+## Acceptance criteria
+
+- [ ] For every task above that ships: e2e tests mirroring the
+      `iteration_ergonomics.rs` patterns, help/command-reference updates
+      (`check-help-drift`, `check-command-reference` green), CHANGELOG entry
+- [ ] Tasks intentionally skipped after dogfood triage are moved to
+      Out of scope with a note naming the triage evidence
+
+## Non-goals
+
+- Touching the pi extension or templates (236/237 territory)
+- Any change to `--format text`'s human layout
+
+## Out of scope / carry-over candidates
+
+- `--iteration` on `links` (no consumer friction observed yet)


### PR DESCRIPTION
## Iteration 235 — agent-facing CLI ergonomics: `find --filenames-only`, `--iteration`, self-healing boundary error

Closes the three highest-friction findings from the ralph-loop port dogfood ([research/agent-ergonomics-ralph-loop-port-2026-08-24](../blob/main/hyalo-knowledgebase/research/agent-ergonomics-ralph-loop-port-2026-08-24.md)). Plan: [iteration-235-agent-cli-ergonomics.md](../blob/main/hyalo-knowledgebase/iterations/iteration-235-agent-cli-ergonomics.md).

### What changed

**1. `find --filenames-only`** — the `grep -l` projection of a find result set. One raw file path per line, no JSON, no envelope, no count, no hints — usable in `sort`, `xargs`, and `while read` loops. Zero results → empty output (no trailing newline), exit 0. Conflicts with `--jq`, `--count`, and an explicit `--format json` (mutually exclusive projections; the default JSON-when-piped does **not** conflict, since `--filenames-only` overrides the format). `--strict` still flips the exit code, so `find --property status=planned --filenames-only --strict` is a CI gate that lists the offenders and fails.

**2. `find`/`set --iteration <ID>`** — natural-key addressing for sequence-numbered documents. `--iteration 206` expands to `iterations/iteration-206-*.md` using the type schema's `filename_template` `{n}` slot, so iteration lookups no longer need a hand-built glob (`--property 'title~=206'` silently fails because the frontmatter title is `"Iteration 206 — …"`).

- Accepts a bare integer (`206`), zero-padded integer (`01`), or integer + letter suffix (`16b`); the ID is substituted **verbatim** (so `01` matches `iteration-01-*`, not `iteration-1-*`; `16b` matches only `iteration-16b-*`; bare `16` matches `iteration-16-*` and **not** `iteration-16b-*`).
- On `find` this is a filter (returns every match); on `set` it selects the file to mutate and **errors unless exactly one match is found**, listing the candidates so the caller can disambiguate by suffix.
- `--where-property` / `--where-tag` still compose on `set --iteration` (filter *within* the selection, not across files).
- `--iteration` is a competing selector on `set`: clap-conflicts with `--file`, the positional FILE, `--glob`, and `--files-from`.

**3. Self-healing vault-boundary error** — the refusal now names the effective vault directory (`(vault: <dir>)`) and offers a self-healing hint (`pass a path relative to <dir>, or cd to a parent of it`), so an agent that passed `/tmp/foo.md` learns the vault root and the fix in the same message instead of guessing another absolute path. Applied at both sites the plan named (`find` absolute-file path, `resolve_error_to_outcome` OutsideVault arm) plus the `mv` write-destination and shared `refuse_escaping_write` paths. The long-standing `resolves outside vault boundary` substring is preserved so existing assertions keep passing.

### New code

- `hyalo-core::iteration_id` — the ID grammar (digits + optional letter suffix), `IterationId` with `Display`, and `parse_iteration_id`. Unit tests cover bare/zero-padded/letter-suffix/uppercase/multi-letter/invalid/empty.
- `FilenameTemplate::to_glob_for_id` / `has_n_placeholder` — substitute the ID verbatim into the `{n}` slot, `*` for the others.
- `fs_util::outside_vault_message_with_dir` / `outside_vault_hint` — the richer boundary message and shared hint text.
- `find::project_filenames_only` — converts a `Success` find outcome to a `RawOutput` (bypasses the JSON pipeline entirely), with an empty-output special case in the output pipeline so zero-result `--filenames-only` prints nothing rather than a blank line.
- `commands::iteration::resolve_iteration_globs` — resolves an ID to globs from every type whose template has an `{n}` slot, with a clear "no `{n}` template configured" error naming the configured templates.

### Tests

- 22 new e2e tests in `iteration_ergonomics.rs` covering: `--filenames-only` with filters/zero-result/strict/conflict matrix (`--jq`/`--count`/`--format json`)/sort/iteration-compose; `find --iteration` bare/letter-suffix/zero-padded/non-match/invalid-ID/no-template/combination-with-filters; `set --iteration` happy path/where-property/conflicts/ambiguous/no-match/letter-suffix; and the two boundary-error sites naming the vault dir + hint.
- Existing boundary assertions in `mv.rs:1401` and the three `symlinks.rs` symlink-escape tests updated (per the plan: "update them, don't just append") to verify the new vault dir + relative-path/cd hint.
- Unit tests for the ID grammar, the template helpers, the fs_util helpers, and the iteration-globs resolver.

### Docs

- Command reference (`cli/help.rs`) updated: `find` and `set` entries now list `--iteration ID` and `--filenames-only`; `check-command-reference` passes.
- `find --help` long text gains PROJECTIONS and ITERATION ADDRESSING sections + a COMMON MISTAKE pointing at `--iteration` over `title~=`; new examples for both `find` and `set`.
- README quick start gains the two new idioms; CHANGELOG `[Unreleased] → Added` documents all three features.

### Quality gates (all green)

- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -q` — 1022 lib + 1721 e2e + 1221 core + 79+28 md-lint
- xtask: `check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills` all exit 0 (`check-dead-primitives` / `check-todo-annotations` are stubs)

### Acceptance criteria

- [x] `hyalo find --property status=planned --filenames-only` prints exactly the pending iteration plan paths, one per line, no decoration — usable in `sort`/`xargs`/`while read` pipelines
- [x] `hyalo find --iteration 206 --filenames-only` prints exactly the iteration-206 plan path; `hyalo set --iteration 206 --property status=completed` updates it — both without any glob or `--jq`
- [x] `hyalo set /tmp/foo.md --property x=1` fails with an error containing the vault dir and a relative-path hint
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all green; existing boundary-message test assertions updated to the new message
- [x] No behavior change for existing invocations except the vault-boundary error text (Task 3, by design)

### Non-goals (explicitly out of scope)

- Porting the ralph-loop skill (`~/.pi/agent/skills/ralph-loop/`) to consume the new flags — it lives outside this repo. Manual follow-up after merge; the three warnings it carries could then be dropped.
- `--filenames0` (NUL-delimited variant), `--iteration` on `read`/`task`/`links`, `properties` envelope unification (finding #4), `title~=` normalization for non-iteration types.

---
This is one iteration = one branch = one PR. Self-reviewed the diff before pushing (fmt, clippy, dead code all clean).


## Carry-over

Every deferred item from this iteration and its disposition:

1. **Port the ralph-loop skill to consume the new flags** (drop its three hyalo-usage warnings) — manual follow-up outside this repo (`~/.pi/agent/skills/ralph-loop/`); not schedulable in-repo. AC ticked as a capability statement ("could be dropped") with the manual note in the plan itself.
2. **`--filenames0` (NUL-delimited variant)** — folded into the new plan `hyalo-knowledgebase/iterations/iteration-238-agent-cli-followups.md`.
3. **`--iteration` on `read`/`task`/`links`** — `read` + `task` folded into iteration-238; `links` moved to 238's Out of scope (no observed consumer friction).
4. **`properties` envelope unification (finding #4)** — folded into iteration-238 (already referenced [[research/results-json-shape-inventory]] and [[iterations/iteration-216-results-shape-consistency]]).
5. **`title~=` normalization for non-iteration types (finding #2 remainder)** — folded into iteration-238 as dogfood-triage-first (only if it bites on non-iteration types).

Iteration 238 is a queue, not a must-ship-all list: each item lands only if a dogfood session still shows friction. Nothing was silently forgotten — all items are either scheduled in 238 or explicitly triaged out with evidence.
