### PR TITLE
iter-236: typed pi tools (hyalo_find/read/set/task) alongside the generic hyalo tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Typed pi tools: `hyalo_find`, `hyalo_read`, `hyalo_set`, `hyalo_task`**
+  (iter-236). The pi extension previously registered one generic `hyalo`
+  tool where the model assembled CLI argv itself (`subcommand` + free-form
+  `args[]`), and every dogfooding bug so far came from that surface:
+  duplicate `--format text`, hallucinated flags, quoting of search terms.
+  The four new typed tools take structured parameters instead — e.g.
+  `hyalo_find` with `property: ["status=planned"]`, `tag`, `taskStatus`,
+  `countOnly`, `limit`; `hyalo_set` with `file` + a single `K=V` property;
+  `hyalo_task` with `mode: all|section|line`. All route through the same
+  shared execution core as the generic tool (timeouts, signals, error
+  rendering unchanged); the generic tool stays as the escape hatch for
+  everything else. `pi-extension-e2e.sh` gains a layer forcing one call per
+  typed tool, and `skill-hyalo-pi.md` teaches the typed tools first.
+
 ### Fixed
 
 - **A heading containing a template expression is never reported as a dead

--- a/crates/hyalo-cli/templates/extension-hyalo.ts
+++ b/crates/hyalo-cli/templates/extension-hyalo.ts
@@ -154,7 +154,7 @@ async function lintVaultFile(
   try {
     const { stdout, code } = await pi.exec(
       "hyalo",
-      ["lint", filePath, "--format", "text"],
+      ["lint", filePath, "--format", "text", "--no-hints"],
       { signal, timeout: 30_000 },
     );
     // lint exits 0 = clean, 1 = violations found (stdout holds them),
@@ -401,7 +401,7 @@ export default function (pi: ExtensionAPI) {
     try {
       const { stdout, code } = await pi.exec(
         "hyalo",
-        ["summary", "--format", "text"],
+        ["summary", "--format", "text", "--no-hints"],
         { timeout: 30_000 },
       );
       if (code !== 0 || !stdout.trim()) return;

--- a/crates/hyalo-cli/templates/extension-hyalo.ts
+++ b/crates/hyalo-cli/templates/extension-hyalo.ts
@@ -17,6 +17,53 @@ interface HyaloToolArgs {
   indexFile?: string;
 }
 
+/**
+ * Shared execution core for every hyalo tool (generic + typed): runs the
+ * argv through `pi.exec` and renders exit codes / stderr / stdout into a
+ * uniform tool result. One path — no behavioral divergence between tools.
+ */
+async function runHyalo(
+  pi: ExtensionAPI,
+  argv: string[],
+  signal?: AbortSignal,
+) {
+  try {
+    const { stdout, stderr, code } = await pi.exec("hyalo", argv, {
+      signal,
+      timeout: HYALO_TIMEOUT_MS,
+    });
+
+    if (code !== 0) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `hyalo ${argv[0]} failed with exit code ${code}`,
+          },
+          ...(stderr ? [{ type: "text" as const, text: `Stderr:\n${stderr}` }] : []),
+          ...(stdout ? [{ type: "text" as const, text: `Stdout:\n${stdout}` }] : []),
+        ],
+        details: undefined,
+      };
+    }
+
+    return {
+      content: [{ type: "text" as const, text: stdout || "(no output)" }],
+      details: undefined,
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error executing hyalo: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      details: undefined,
+    };
+  }
+}
+
 /** Whether the argv already carries a value-taking flag (long or short). */
 function hasFlag(argv: string[], long: string, short?: string): boolean {
   return argv.includes(long) || (short !== undefined && argv.includes(short));
@@ -107,7 +154,7 @@ async function lintVaultFile(
   try {
     const { stdout, code } = await pi.exec(
       "hyalo",
-      ["lint", filePath, "--format", "text", "--no-hints"],
+      ["lint", filePath, "--format", "text"],
       { signal, timeout: 30_000 },
     );
     // lint exits 0 = clean, 1 = violations found (stdout holds them),
@@ -160,54 +207,183 @@ export default function (pi: ExtensionAPI) {
       "(YAML frontmatter, tags, tasks, wikilinks). Subcommands: find, read, set, " +
       "append, remove, task, summary, properties, tags, lint, backlinks, config, ...",
     promptSnippet:
-      "hyalo: structured search/mutation of markdown knowledgebases (frontmatter, tags, tasks, links)",
+      "hyalo: structured search/mutation of markdown knowledgebases (frontmatter, tags, tasks, links). Prefer hyalo_find/hyalo_read/hyalo_set/hyalo_task for common operations; use this tool for everything else.",
     promptGuidelines: [
-      "For .md files with YAML frontmatter in a knowledgebase/vault, prefer the hyalo tool over read/edit/grep: use `hyalo find` to search or filter by content/tags/properties, `hyalo read` to read, and `hyalo set`/`hyalo task` to bulk-mutate instead of many edit calls.",
+      "For .md files with YAML frontmatter in a knowledgebase/vault, prefer the typed hyalo tools first — `hyalo_find` (search/filter by query/property/tag/task status), `hyalo_read` (read a file or section), `hyalo_set` (set one frontmatter property), `hyalo_task` (toggle checkboxes) — they take structured parameters, no flags or quoting. Fall back to the generic hyalo tool for anything they don't cover (summary, lint, mv, links, views, --jq, ...).",
       "hyalo output includes drill-down hints (lines starting with `->`) — follow them to refine queries; hints marked `=>` with `[writes]` modify the vault.",
-      "hyalo flags map to the tool's args array: e.g. `hyalo find --property status=planned --tag iteration` → subcommand 'find', args ['--property', 'status=planned', '--tag', 'iteration']. Filter by a property with '--property K=V' — there are no per-property flags like --status.",
     ],
     parameters: hyaloToolParams,
     async execute(_toolCallId, params: Static<typeof hyaloToolParams>, signal) {
-      const cmdArgs = buildCommand(params);
-      try {
-        const { stdout, stderr, code } = await pi.exec("hyalo", cmdArgs, {
-          signal,
-          timeout: HYALO_TIMEOUT_MS,
-        });
+      return runHyalo(pi, buildCommand(params), signal);
+    },
+  });
 
-        if (code !== 0) {
+  // --- typed tools -------------------------------------------------------
+  // Structured parameters for the ~80% operations. No argv assembly, no
+  // flag spelling, no quoting — the schema is the interface. All route
+  // through runHyalo, so behavior (timeouts, signals, error rendering) is
+  // identical to the generic tool.
+
+  const hyaloFindParams = Type.Object({
+    query: Type.Optional(
+      Type.String({
+        description:
+          "BM25 full-text search term(s). Supports 'a OR b', '" +
+          '"quoted phrase"' +
+          "', and '-term' exclusions.",
+      }),
+    ),
+    property: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Property filter(s) as 'K=V'. Also supports 'K!=V', 'K>=V', 'K<=V', 'K~=pattern', '!K'. Repeatable.",
+      }),
+    ),
+    tag: Type.Optional(
+      Type.String({ description: "Filter by tag." }),
+    ),
+    glob: Type.Optional(
+      Type.String({ description: "Restrict to files matching a glob, e.g. 'iterations/*.md'." }),
+    ),
+    taskStatus: Type.Optional(
+      Type.Union([
+        Type.Literal("todo"),
+        Type.Literal("done"),
+        Type.Literal("any"),
+      ], {
+        description: "Filter by task checkbox status in the file.",
+      }),
+    ),
+    countOnly: Type.Optional(
+      Type.Boolean({ description: "Return only the match count (--count)." }),
+    ),
+    limit: Type.Optional(
+      Type.Number({ description: "Maximum number of results to return." }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_find",
+    label: "Hyalo Find",
+    description:
+      "Search/filter a markdown knowledgebase by full-text query, frontmatter " +
+      "properties, tags, glob, or task status. Preferred over the generic hyalo tool for queries.",
+    promptSnippet: "hyalo_find: search/filter knowledgebase files (query, property, tag, task status)",
+    parameters: hyaloFindParams,
+    async execute(_toolCallId, params: Static<typeof hyaloFindParams>, signal) {
+      const argv = ["find", "--format", "text"];
+      if (params.query !== undefined) argv.push(params.query);
+      for (const prop of params.property ?? []) argv.push("--property", prop);
+      if (params.tag !== undefined) argv.push("--tag", params.tag);
+      if (params.glob !== undefined) argv.push("--glob", params.glob);
+      if (params.taskStatus !== undefined) argv.push("--task", params.taskStatus);
+      if (params.countOnly) argv.push("--count");
+      if (params.limit !== undefined) argv.push("--limit", String(Math.trunc(params.limit)));
+      return runHyalo(pi, argv, signal);
+    },
+  });
+
+  const hyaloReadParams = Type.Object({
+    file: Type.String({ description: "File to read (relative to the vault directory)." }),
+    section: Type.Optional(
+      Type.String({
+        description:
+          "Extract only this section by heading (case-insensitive substring; prefix '#' pins level; '/regex/' form also accepted). Nested subsections included.",
+      }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_read",
+    label: "Hyalo Read",
+    description:
+      "Read a markdown file's body from the knowledgebase (frontmatter stripped), optionally only one section. Returns plain text.",
+    promptSnippet: "hyalo_read: read a vault file (optionally a single section) as text",
+    parameters: hyaloReadParams,
+    async execute(_toolCallId, params: Static<typeof hyaloReadParams>, signal) {
+      const argv = ["read", "--format", "text", "--file", params.file];
+      if (params.section !== undefined) argv.push("--section", params.section);
+      return runHyalo(pi, argv, signal);
+    },
+  });
+
+  const hyaloSetParams = Type.Object({
+    file: Type.String({ description: "File to mutate (relative to the vault directory)." }),
+    property: Type.String({
+      description:
+        "Frontmatter assignment as 'K=V'. Type is auto-inferred (number/bool/text); use K=[a,b,c] for lists.",
+    }),
+    tag: Type.Optional(
+      Type.String({ description: "Additionally add this tag (idempotent; creates the tags list if absent)." }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_set",
+    label: "Hyalo Set",
+    description:
+      "Set (create or overwrite) one frontmatter property on a knowledgebase file, optionally adding a tag. The post-write lint guardrail applies to writes automatically.",
+    promptSnippet: "hyalo_set: set a file's frontmatter property (K=V), optionally add a tag",
+    parameters: hyaloSetParams,
+    async execute(_toolCallId, params: Static<typeof hyaloSetParams>, signal) {
+      const argv = [
+        "set",
+        "--format",
+        "text",
+        "--property",
+        params.property,
+      ];
+      if (params.tag !== undefined) argv.push("--tag", params.tag);
+      argv.push(params.file);
+      return runHyalo(pi, argv, signal);
+    },
+  });
+
+  const hyaloTaskParams = Type.Object({
+    file: Type.String({ description: "File containing the tasks (relative to the vault directory)." }),
+    mode: Type.Union([Type.Literal("all"), Type.Literal("section"), Type.Literal("line")], {
+      description:
+        "'all': toggle every task in the file; 'section': all tasks under one heading; 'line': specific lines.",
+    }),
+    section: Type.Optional(
+      Type.String({ description: "Heading for mode='section' (case-insensitive substring)." }),
+    ),
+    lines: Type.Optional(
+      Type.Array(Type.Number(), { description: "1-based line numbers for mode='line'." }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_task",
+    label: "Hyalo Task",
+    description:
+      "Toggle task checkboxes ([ ] <-> [x]) in a knowledgebase file: every task, all tasks under a section heading, or specific lines.",
+    promptSnippet: "hyalo_task: toggle task checkboxes (all / by section / by line)",
+    parameters: hyaloTaskParams,
+    async execute(_toolCallId, params: Static<typeof hyaloTaskParams>, signal) {
+      const argv = ["task", "toggle"];
+      if (params.mode === "section") {
+        if (params.section === undefined) {
           return {
-            content: [
-              {
-                type: "text" as const,
-                text: `hyalo ${params.subcommand} failed with exit code ${code}`,
-              },
-              ...(stderr
-                ? [{ type: "text" as const, text: `Stderr:\n${stderr}` }]
-                : []),
-              ...(stdout
-                ? [{ type: "text" as const, text: `Stdout:\n${stdout}` }]
-                : []),
-            ],
+            content: [{ type: "text" as const, text: "hyalo_task: mode 'section' requires the section parameter" }],
             details: undefined,
           };
         }
-
-        return {
-          content: [{ type: "text" as const, text: stdout || "(no output)" }],
-          details: undefined,
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Error executing hyalo: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-          details: undefined,
-        };
+        argv.push("--section", params.section);
+      } else if (params.mode === "line") {
+        const lines = (params.lines ?? []).map((l) => Math.trunc(l));
+        if (lines.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "hyalo_task: mode 'line' requires at least one line number" }],
+            details: undefined,
+          };
+        }
+        argv.push("--line", lines.join(","));
+      } else {
+        argv.push("--all");
       }
+      argv.push(params.file);
+      return runHyalo(pi, argv, signal);
     },
   });
 
@@ -225,7 +401,7 @@ export default function (pi: ExtensionAPI) {
     try {
       const { stdout, code } = await pi.exec(
         "hyalo",
-        ["summary", "--format", "text", "--no-hints"],
+        ["summary", "--format", "text"],
         { timeout: 30_000 },
       );
       if (code !== 0 || !stdout.trim()) return;

--- a/crates/hyalo-cli/templates/skill-hyalo-pi.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-pi.md
@@ -20,8 +20,22 @@ description: >
 # Hyalo CLI — Prime Tool for Markdown Knowledgebases in pi
 
 Hyalo is a fast CLI for querying and mutating YAML frontmatter, tags, tasks, and structure
-in directories of markdown files. Use hyalo via the `bash` tool for all markdown knowledgebase
-operations in pi. Its killer features are combined filtering (e.g.
+in directories of markdown files. If the hyalo pi extension is installed
+(`.pi/extensions/hyalo.ts`), prefer its **typed tools** for the common operations —
+they take structured parameters, so there is no flag spelling or quoting to get wrong:
+
+| Operation | Typed tool | Example parameters |
+|-----------|------------|--------------------|
+| Search/filter | **hyalo_find** | `property: ["status=planned", "type=iteration"]`, `query: "rust"`, `tag: "feature"`, `taskStatus: "todo"`, `countOnly: true`, `limit: 10` |
+| Read a file/section | **hyalo_read** | `file: "iterations/iter-1-x.md"`, `section: "Scope"` |
+| Set one property | **hyalo_set** | `file: "note.md"`, `property: "status=done"`, `tag: "shipped"` |
+| Toggle tasks | **hyalo_task** | `file: "plan.md"`, `mode: "all"` / `mode: "section"`, `section: "Tasks"` / `mode: "line"`, `lines: [5, 7]` |
+
+Use the generic **hyalo** tool (subcommand + args) only for operations the typed tools
+don't cover: summary, lint, mv, links, views, types, backlinks, --jq filters, bulk
+mutations (`--glob`, `--where-property`), etc.
+
+Its killer features are combined filtering (e.g.
 `hyalo find -e "regex" --property status!=done --tag feature`) which you can't easily
 replicate with read/edit/grep/write, and bulk mutations (`hyalo set --where-property`) that replace
 multiple read + edit calls.
@@ -232,15 +246,20 @@ hyalo find --orphan --fields properties,links --format text \
 
 ## Common Pitfalls & Solutions
 
-1. **Missing `--format text`**: Output is verbose JSON — always use `--format text` in pi
-2. **Not using `--index` for large vaults**: Queries are slow — create index for >500 files
-3. **Using system `mv` instead of `hyalo mv`**: Breaks links — always use `hyalo mv`
-4. **Ignoring hints**: hyalo suggests next commands — follow them
-5. **Not validating schemas**: Run `hyalo lint --strict` regularly
+1. **Using the generic tool for common operations**: prefer hyalo_find/hyalo_read/hyalo_set/hyalo_task — no flag spelling or quoting to get wrong
+2. **Missing `--format text`**: Output is verbose JSON — always use `--format text` in pi (the extension injects it automatically; only needed via bash)
+3. **Not using `--index` for large vaults**: Queries are slow — create index for >500 files
+4. **Using system `mv` instead of `hyalo mv`**: Breaks links — always use `hyalo mv`
+5. **Ignoring hints**: hyalo suggests next commands — follow them
+6. **Not validating schemas**: Run `hyalo lint --strict` regularly
 
 ## Integration with pi Extension
 
-If the hyalo extension is installed (`.pi/extensions/hyalo.ts`), use the dedicated `hyalo` tool:
+If the hyalo extension is installed (`.pi/extensions/hyalo.ts`), use the typed tools first:
+```json
+{"tool": "hyalo_find", "property": ["status=planned"], "tag": "iteration"}
+```
+For anything they don't cover, use the generic `hyalo` tool:
 ```json
 {
   "subcommand": "find",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,7 +276,12 @@ truth:
 ## Agent integration (`[pi]`)
 
 Hyalo ships a pi coding-agent extension (`hyalo init --pi`) that registers a
-`hyalo` tool, slash commands, and a post-write lint guardrail: when pi's
+generic `hyalo` tool plus four typed tools — `hyalo_find`, `hyalo_read`,
+`hyalo_set`, and `hyalo_task` — which take structured parameters instead of
+CLI argv for the most common operations (search/filter, read, frontmatter
+mutation, task toggling); the generic tool remains the escape hatch for
+everything else. It also registers slash commands and a post-write lint
+guardrail: when pi's
 `write`/`edit` tools touch a `.md` file inside the vault, the extension runs
 `hyalo lint <file>` on it and appends any violations to the tool result, so
 schema drift cannot land silently.

--- a/hyalo-knowledgebase/iterations/iteration-236-typed-pi-tools.md
+++ b/hyalo-knowledgebase/iterations/iteration-236-typed-pi-tools.md
@@ -130,3 +130,17 @@ Design decisions (from the session discussion, 2026-08-24):
 - `--jq` passthrough param on `hyalo_find` (if agents ask for it)
 - A `hyalo_lint` typed tool (once a dogfood session shows the model linting
   via the generic tool often enough to justify it)
+
+Both folded into [[iterations/iteration-237-pi-package-distribution]] (see
+its Out of scope / carry-over candidates section).
+
+## Review pass (2026-08-25, pre-merge)
+
+- Restored `--no-hints` on the lint-guardrail and session-summary calls in
+  `extension-hyalo.ts`. The iteration commit had silently dropped it,
+  contradicting the "behavior byte-identical" claim of the `runHyalo`
+  refactor and the deliberate design of #259/#261 (zero noise on every
+  write; hints are for interactive queries, not injected context).
+- All `pi-extension-e2e.sh` layers re-verified green locally (pi 0.84.3)
+  after the fix; fmt/clippy/test green.
+- Verified every ticked task/AC above against the merged diff — all landed.

--- a/hyalo-knowledgebase/iterations/iteration-236-typed-pi-tools.md
+++ b/hyalo-knowledgebase/iterations/iteration-236-typed-pi-tools.md
@@ -2,7 +2,7 @@
 title: "Iteration 236 — typed pi tools: structured find/read/set/task alongside the generic hyalo tool"
 type: iteration
 date: 2026-08-25
-status: planned
+status: completed
 branch: iter-236/typed-pi-tools
 tags:
   - iteration
@@ -65,52 +65,52 @@ Design decisions (from the session discussion, 2026-08-24):
 
 ## Tasks
 
-- [ ] Extract a shared `runHyalo(pi, argv, signal)` helper in the template
+- [x] Extract a shared `runHyalo(pi, argv, signal)` helper in the template
       (`pi.exec` + exit-code/error rendering + `details: undefined`), and
       refactor the generic tool's `execute` onto it. Pure refactor; behavior
       byte-identical.
-- [ ] Implement `hyalo_find` tool: params `query?`, `property?`
+- [x] Implement `hyalo_find` tool: params `query?`, `property?`
       (array of `K=V` filter strings), `tag?`, `glob?`, `taskStatus?`
       (`todo|done|any`), `countOnly?` (→ `--count`), `limit?`; always
       `--format text`; composes nothing else.
-- [ ] Implement `hyalo_read` tool: params `file`, `section?`; text output.
-- [ ] Implement `hyalo_set` tool: params `file`, `property` (single `K=V`),
+- [x] Implement `hyalo_read` tool: params `file`, `section?`; text output.
+- [x] Implement `hyalo_set` tool: params `file`, `property` (single `K=V`),
       `tag?` (optional add-tag); text output; honors the existing lint
       guardrail automatically (it fires on tool_result regardless of which
       tool wrote).
-- [ ] Implement `hyalo_task` tool: params `file`, `mode` (`all|section|line`),
+- [x] Implement `hyalo_task` tool: params `file`, `mode` (`all|section|line`),
       `section?`, `lines?` (array of ints); dispatches to `task toggle`.
-- [ ] Rework `promptSnippet`/`promptGuidelines`/tool descriptions: typed
+- [x] Rework `promptSnippet`/`promptGuidelines`/tool descriptions: typed
       tools listed as primary, generic `hyalo` as fallback; drop the
       "no --status flag" bullet if `hyalo_find.property` makes it redundant
       (verify with a live hallucination probe before deleting).
-- [ ] Extend `pi-extension-e2e.sh` (layer 4): one forced call per typed tool
+- [x] Extend `pi-extension-e2e.sh` (layer 4): one forced call per typed tool
       (`--no-builtin-tools`, asserting non-empty structured output), keeping
       the whole guard under ~2 minutes.
-- [ ] Update `skill-hyalo-pi.md` template: teach the typed tools first,
+- [x] Update `skill-hyalo-pi.md` template: teach the typed tools first,
       generic tool as escape hatch; keep `--format text` guidance only for
       the generic tool.
-- [ ] Live dogfood verification (hyalo-demo worktree): the three historical
+- [x] Live dogfood verification (hyalo-demo worktree): the three historical
       failure scenarios (status filter, search with quotes, set property)
       must each succeed through a typed tool with no clap error and no
       bash fallback.
-- [ ] Docs: `docs/configuration.md` `[pi]` section gains a sentence naming
+- [x] Docs: `docs/configuration.md` `[pi]` section gains a sentence naming
       the typed tools; CHANGELOG unreleased entry.
 
 ## Acceptance criteria
 
-- [ ] A fresh pi session with the extension loaded answers "find all
+- [x] A fresh pi session with the extension loaded answers "find all
       planned iterations", "read the decision log", "set iteration-236's
       status to in-progress", and "toggle all tasks in file X" using the
       typed tools — no generic-tool calls, no bash, no clap errors
-- [ ] `hyalo find --property status=planned`-equivalent query via
+- [x] `hyalo find --property status=planned`-equivalent query via
       `hyalo_find` returns the same files as the CLI invocation (spot-check
       3 queries)
-- [ ] `just pi-extension` covers every registered tool (generic + 4 typed +
+- [x] `just pi-extension` covers every registered tool (generic + 4 typed +
       guardrail); all layers green; fmt/clippy/test green
-- [ ] No change to the Rust crate — this iteration is template + guard
+- [x] No change to the Rust crate — this iteration is template + guard
       script + docs only (`hyalo init --pi` picks it up on re-run)
-- [ ] Template still type-checks against installed pi (guard layer 1) with
+- [x] Template still type-checks against installed pi (guard layer 1) with
       the 4 new registrations
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-237-pi-package-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-237-pi-package-distribution.md
@@ -133,3 +133,8 @@ Open questions to resolve at implementation time (not blocking the plan):
   first real update cycle)
 - A `hyalo doctor`-style check that reports extension/hyalo version
   compatibility drift (e.g. `[pi]` unknown → old hyalo binary)
+- Carry-overs from [[iterations/iteration-236-typed-pi-tools]] (both
+  conditional on observed model friction — do not build preemptively):
+  a `--jq` passthrough param on the `hyalo_find` typed tool, and a
+  `hyalo_lint` typed tool (if dogfooding shows the model linting via the
+  generic tool often enough to justify one).

--- a/pi-extension-e2e.sh
+++ b/pi-extension-e2e.sh
@@ -79,7 +79,7 @@ echo "type-check OK"
 
 # --- layer 2: live e2e with builtin tools disabled ----------------------
 echo
-echo "== [2/3] live e2e: forcing the hyalo tool (no bash fallback possible) =="
+echo "== [2/4] live e2e: forcing the hyalo tool (no bash fallback possible) =="
 # Query must return a plain count. Vault contents change, but the term
 # "iteration" always matches in hyalo's own knowledgebase and test vaults
 # that run this script; --count output is a bare number.
@@ -101,7 +101,7 @@ echo "e2e OK: hyalo tool returned count=$COUNT"
 # Catches drift in BOTH the pi event API and hyalo's config/lint output
 # shapes (e.g. the JSON envelope changing would break vault resolution).
 echo
-echo "== [3/3] guardrail e2e: lint findings appended to write result =="
+echo "== [3/4] guardrail e2e: lint findings appended to write result =="
 GUARD_FILE="hyalo-knowledgebase/.pi-e2e-guard.md"
 rm -f "$GUARD_FILE"
 OUT="$(pi -ne -t write -e "$TEMPLATE" -p "Use the write tool to create $GUARD_FILE with exactly this content:
@@ -118,5 +118,63 @@ if ! grep -q "hyalo lint" <<<"$OUT"; then
     fail "guardrail did not fire: expected hyalo lint findings in the write result, got: $OUT"
 fi
 echo "guardrail e2e OK: lint findings were appended to the write result"
+
+# --- layer 4: typed-tool e2e ---------------------------------------------
+#
+# One forced call per typed tool (hyalo_find / hyalo_read / hyalo_set /
+# hyalo_task) with --no-builtin-tools, asserting non-empty structured
+# output. The model MUST use the named tool; a broken registration or a
+# schema/exec drift shows up as an error string instead of real output.
+# Uses a scratch file so the vault is left untouched.
 echo
-echo "PASS: template is compatible with installed pi; tool path and lint guardrail work"
+echo "== [4/4] typed-tool e2e: one forced call each (find/read/set/task) =="
+SCRATCH="hyalo-knowledgebase/pi-e2e-scratch/pi-e2e-typed.md"
+# The scratch file must live at a visible path inside the vault: hyalo skips
+# hidden files AND hidden directories during find queries. Cleaned up below.
+mkdir -p "$(dirname "$SCRATCH")"
+rm -f "$SCRATCH"
+cat > "$SCRATCH" <<'EOF'
+---
+title: Typed tool e2e
+type: note
+status: draft
+tags:
+  - e2e
+---
+# Typed tool e2e
+
+## Tasks
+
+- [ ] sample task
+EOF
+
+run_typed() {
+    local label="$1" prompt="$2" needle="$3"
+    local out
+    out="$(pi -ne --no-builtin-tools -e "$TEMPLATE" -p "$prompt")" \
+        || fail "typed tool '$label': pi run failed (tool may not be registered)"
+    if ! grep -q "$needle" <<<"$out"; then
+        fail "typed tool '$label': expected output containing '$needle', got: $out"
+    fi
+    echo "typed tool OK: $label"
+}
+
+run_typed hyalo_find \
+    'Call the hyalo_find tool with property ["title~=Typed tool"] and countOnly true. Reply with ONLY the number returned.' \
+    '^[[:space:]]*1[[:space:]]*$'
+run_typed hyalo_read \
+    'Call the hyalo_read tool with file "pi-e2e-scratch/pi-e2e-typed.md". Then reply with ONLY the exact heading text of its second heading, nothing else.' \
+    'Tasks'
+run_typed hyalo_set \
+    'Call the hyalo_set tool with file "pi-e2e-scratch/pi-e2e-typed.md", property "status=review". Reply with ONLY the word DONE when it succeeded.' \
+    'DONE'
+grep -q 'status: review' "$SCRATCH" || fail "hyalo_set ran but did not persist status=review"
+run_typed hyalo_task \
+    'Call the hyalo_task tool with file "pi-e2e-scratch/pi-e2e-typed.md" and mode "all". Reply with ONLY the word DONE when it succeeded.' \
+    'DONE'
+grep -q '\[x\]' "$SCRATCH" || fail "hyalo_task ran but no checkbox toggled to [x]"
+rm -rf "$(dirname "$SCRATCH")"
+echo "typed-tool e2e OK: all four typed tools answered structured calls"
+
+echo
+echo "PASS: template is compatible with installed pi; generic + typed tools and lint guardrail work"


### PR DESCRIPTION
## Summary

Replaces the argv-assembly footgun with **typed pi tools** for the highest-frequency hyalo operations. The extension previously registered one generic `hyalo` tool (`subcommand` + free-form `args[]`), and every dogfooding bug so far came from that surface (duplicate `--format text` #262, hallucinated `--status` flag #264/#265, quoting of search terms). The schema is now the interface.

- **`hyalo_find`**: `query?`, `property?` (K=V filters), `tag?`, `glob?`, `taskStatus? (todo|done|any)`, `countOnly?`, `limit?` — always `--format text`
- **`hyalo_read`**: `file`, `section?` → plain text
- **`hyalo_set`**: `file`, one `property` K=V, optional `tag?`; lint guardrail applies automatically
- **`hyalo_task`**: `file`, `mode` (all|section|line), `section?`, `lines?[]`
- Shared `runHyalo(pi, argv, signal)` execution core extracted; the generic tool refactored onto it — behavior byte-identical, no divergence in timeouts/signals/error rendering
- Generic `hyalo` tool stays as escape hatch for summary/lint/mv/links/views/--jq etc.; prompt guidelines now prefer typed tools (≤3 bullets)

## Guard & docs

- `pi-extension-e2e.sh`: new layer 4 forces one call per typed tool with `--no-builtin-tools` and asserts persisted effects on a scratch vault file (find count, read heading, set status, task toggle)
- `skill-hyalo-pi.md`: typed tools taught first with a parameter table; generic tool as fallback
- `docs/configuration.md` [pi] section names the typed tools; CHANGELOG Unreleased entry

## Verification

- `just pi-extension` all 4 layers green against installed pi 0.84.3 (type-check + generic e2e + guardrail + typed-tool e2e)
- No Rust changes (template + guard script + docs only); fmt/clippy/test green; all xtask check-* gates exit 0
- Iteration file marked completed via hyalo itself

Closes the iteration plan in `iterations/iteration-236-typed-pi-tools.md`.

## Review pass (2026-08-25)

- **Fixed**: restored `--no-hints` on the post-write lint guardrail and session-summary calls in `extension-hyalo.ts`. The iteration commit had silently dropped it, contradicting the "behavior byte-identical" `runHyalo` refactor claim and the deliberate zero-noise design of #259/#261 (hints belong to interactive queries, not injected context / write results).
- Re-verified locally after the fix: all 4 `pi-extension-e2e.sh` layers green (pi 0.84.3), fmt/clippy/test green, all xtask check-* gates exit 0.
- Verified every ticked task/AC in the iteration plan against the diff — all landed; no unticked boxes.

## Carry-over

Every deferral / out-of-scope item flagged this iteration and its disposition:

1. **`--jq` passthrough param on `hyalo_find`** (conditional: only if agents ask) → folded into iteration-237 plan's carry-over candidates (no work this iteration; revisit after dogfooding).
2. **`hyalo_lint` typed tool** (conditional: only when dogfooding shows frequent generic-tool linting) → folded into iteration-237 plan's carry-over candidates.
3. **Typed tools for remaining subcommands** (summary, lint, backlinks, links, types, views) → remains a non-goal by policy ("add one only after a dogfood session shows repeated model friction"); no plan filed.
4. **Custom `renderCall`/`renderResult` TUI rendering** (roadmap item 6b) → stays deferred as a separate future iteration; typed tools landing first was a prerequisite and is now satisfied.
5. **MCP server / non-pi transports** → remains a non-goal; no plan filed.
6. **Changes to hyalo CLI flags** → non-goal; flag design belongs to iteration-235.

Unticked ACs: none — all 9 tasks and 5 ACs in the plan are ticked and verified against the diff.
