### PR TITLE
iter-239: root package.json manifest for git-source pi installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hyalo-pi",
+  "version": "0.1.0",
+  "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
+  "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
+  "private": true,
+  "pi": {
+    "extensions": ["./pi-package/extensions"],
+    "skills": ["./pi-package/skills"],
+    "prompts": [],
+    "themes": []
+  }
+}


### PR DESCRIPTION
## What

Adds a root `package.json` with a `pi` manifest pointing at `pi-package/extensions` and `pi-package/skills`.

## Why (verified live)

pi only looks at the **clone root** for a `package.json` manifest or convention directories. The manifest lived only at `pi-package/package.json`, so `pi install git:github.com/ractive/hyalo` registered the package but loaded **zero** extensions and skills — confirmed against the live global installation (task 1 of iteration-239). The local e2e guard (`pi-extension-e2e.sh`) installs by direct path into `pi-package/`, so it never exercised the git-source path and never caught this.

Verified the root manifest loads all 5 tools (`hyalo`, `hyalo_find`, `hyalo_read`, `hyalo_set`, `hyalo_task`) via `pi -e <repo-root>`.

The single source of truth stays `pi-package/`; the vendored `hyalo init --pi` path is unaffected.

## Notes

- After merge, `pi update --extensions` on the existing global install serves as the task-2 update-cycle verification.
- No Rust changes; fmt/clippy/test all green.