### PR TITLE
iter-239: record verification results, DEC-101 tag strategy, README install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,16 @@ For the [pi](https://github.com/earendil-works/pi-coding-agent) coding agent, th
 pi install git:github.com/ractive/hyalo
 ```
 
-This registers the `hyalo` extension (generic + typed tools: `hyalo_find`, `hyalo_read`, `hyalo_set`, `hyalo_task`, and a post-write lint guardrail) plus the `hyalo` and `hyalo-tidy` skills. Updates are delivered independently of hyalo releases:
+From **hyalo ≥ 0.21** on, pin the release tag matching your binary instead
+(recommended — the extension's expected output shapes track the binary, so a
+matched tag avoids extension/binary drift; the tag form needs ≥ v0.21.0,
+earlier tags predate the root package manifest):
 
 ```sh
-pi update --extensions
+pi install git:github.com/ractive/hyalo@v0.21.0
 ```
+
+This registers the `hyalo` extension (generic + typed tools: `hyalo_find`, `hyalo_read`, `hyalo_set`, `hyalo_task`, and a post-write lint guardrail) plus the `hyalo` and `hyalo-tidy` skills. A main-HEAD install updates independently of hyalo releases via `pi update --extensions`; a pinned-tag install moves only on an explicit re-pin (`pi install git:…@vX.Y.Z`).
 
 A `hyalo` binary on `PATH` is required (any recent release; typed tools need ≥ 0.21). See `pi-package/README.md` for details.
 

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -2809,6 +2809,26 @@ Main-branch HEAD is acceptable as the ref for now; a tag strategy is a
 carry-over. Minimum-hyalo-version requirements are documented in
 `pi-package/README.md` (typed tools need ≥ 0.21).
 
+**Correction + tag strategy (resolved 2026-08-27, iter-239):** the original
+premise "a top-level `pi-package/` directory … is a valid pi package" was
+half right: pi only reads the **clone root** for a `package.json` manifest
+or convention directories, so the manifest at `pi-package/package.json` was
+invisible to `pi install git:…` — the package registered but loaded zero
+extensions/skills. Fixed with a root `package.json` manifest pointing into
+`pi-package/` (single source of truth unchanged, verified live: all five
+tools + skills load from the global git install, and a pushed change was
+delivered by `pi update --extensions`).
+
+**DEC-101 carry-over decision — tag pinning:** releases are tagged with the
+hyalo release tags (`vX.Y.Z`), and the README recommends installing with a
+tag ref (`pi install git:github.com/ractive/hyalo@v0.20.0`) over main HEAD.
+Rationale: the extension is a thin CLI wrapper whose expected output shapes
+track the binary, so pairing the package ref with the installed hyalo
+version avoids extension/binary drift; main HEAD remains the living-edge
+option. Because `pi update` reconciles but never moves pinned refs, moving
+to a new release is an explicit `pi install git:…@vX.Y.Z` — that pins to
+the release that matches the binary the user has, by design.
+
 ## DEC-102: `--filenames0` emits NUL-terminated bytes via a `RawBytes` outcome; `--iteration` extends the shared input resolver (2026-08-25)
 
 **Decision:** two iter-238 ergonomics follow-ups:

--- a/hyalo-knowledgebase/iterations/iteration-237-pi-package-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-237-pi-package-distribution.md
@@ -116,12 +116,12 @@ Open questions to resolve at implementation time (not blocking the plan):
 
 ## Acceptance criteria [3/5]
 
-- [ ] A machine with pi but no hyalo repo checkout can install the
+- [x] A machine with pi but no hyalo repo checkout can install the
       integration via `pi install git:github.com/ractive/hyalo` and gets a
       working `hyalo` tool + skills (given a `hyalo` binary on PATH)
       <!-- NOT verified: only local-path source exercised pre-merge; git-source
       install needs the merged repo → carried into iteration 238. -->
-- [ ] Pushing an extension change to the package and running `pi update`
+- [x] Pushing an extension change to the package and running `pi update`
       delivers it — verified with a trivial marker change (e.g. a version
       bump in the tool description)
       <!-- NOT verified pre-merge (needs pushed git-source install) → carried

--- a/hyalo-knowledgebase/iterations/iteration-239-pi-install-verification.md
+++ b/hyalo-knowledgebase/iterations/iteration-239-pi-install-verification.md
@@ -1,8 +1,10 @@
 ---
-title: "Iteration 239 — pi install/update verification, DEC-101 tag strategy, conditional tooling"
+title: >-
+  Iteration 239 — pi install/update verification, DEC-101 tag strategy,
+  conditional tooling
 type: iteration
 date: 2026-08-26
-status: planned
+status: completed
 branch: iter-239/pi-install-verification
 tags:
   - iteration
@@ -30,21 +32,21 @@ and two conditionals whose triggers have not fired yet.
 
 ## Tasks
 
-- [ ] Verify the git-source install end-to-end: `pi install git:github.com/ractive/hyalo`
+- [x] Verify the git-source install end-to-end: `pi install git:github.com/ractive/hyalo`
       from a scratch checkout, confirm tool + skills register, then tick AC-1 of
       [[iterations/iteration-237-pi-package-distribution]]
-- [ ] Verify `pi update --extensions` delivers a pushed change to that install
+- [x] Verify `pi update --extensions` delivers a pushed change to that install
       (trivial marker change, e.g. package.json version bump), then tick AC-2 of
       [[iterations/iteration-237-pi-package-distribution]]
-- [ ] Decide the tag-per-release pinning strategy after the first real update
+- [x] Decide the tag-per-release pinning strategy after the first real update
       cycle (DEC-101 carry-over): tag naming, whether README recommends a tag
       ref over main HEAD
 
 ## Acceptance criteria
 
-- [ ] Both post-merge verifications above are done against the real global pi
+- [x] Both post-merge verifications above are done against the real global pi
       installation and the corresponding iter-237 ACs are ticked
-- [ ] DEC-101 has a recorded decision in [[decision-log]]
+- [x] DEC-101 has a recorded decision in [[decision-log]]
 
 ## Non-goals
 
@@ -54,14 +56,35 @@ and two conditionals whose triggers have not fired yet.
 
 ## Conditionals (implement only if their trigger fires)
 
-- [ ] (Conditional) `hyalo doctor`-style check reporting extension/hyalo
-      version compatibility drift — only if dogfooding shows drift confusion
-- [ ] (Conditional, from [[iterations/iteration-236-typed-pi-tools]] via 237)
-      `--jq` passthrough on `hyalo_find` and a `hyalo_lint` typed tool — only
-      if observed model friction justifies
+Not triggered, left unimplemented (their triggers never fired — no drift
+confusion or model friction observed):
+
+- `hyalo doctor`-style check reporting extension/hyalo version compatibility
+  drift
+- `--jq` passthrough on `hyalo_find` and a `hyalo_lint` typed tool (from
+  [[iterations/iteration-236-typed-pi-tools]] via 237)
 
 ## Out of scope / carry-over candidates
 
 - `--property 'title~='` normalization for non-iteration types — revisit only
   if a concrete friction case appears on a non-`iteration` type
 - `--iteration` addressing on `links` — no consumer friction observed yet
+  (and `--iteration` was since removed entirely, see DEC-242)
+
+## Results (2026-08-27)
+
+- **Bug found and fixed:** pi only reads the **clone root** for a
+  `package.json` manifest / convention dirs; the manifest lived only at
+  `pi-package/package.json`, so git-source installs registered but loaded
+  zero extensions/skills. The local e2e guard never caught this because it
+  installs by direct path into `pi-package/`. Fixed with a root
+  `package.json` manifest pointing into `pi-package/` (PR #279).
+- **AC-1 of iter-237 verified:** `pi install git:github.com/ractive/hyalo`
+  (post-merge, live global install) loads all 5 tools + the hyalo skills.
+- **AC-2 of iter-237 verified:** after merging PR #279, `pi update
+  --extensions` reconciled the existing global install to the new main HEAD
+  and the tools/skills loaded.
+- **DEC-101 tag strategy recorded:** pin to hyalo release tags
+  (`@vX.Y.Z`, needs ≥ v0.21.0 — earlier tags predate the root manifest);
+  READMEs updated. Conditional items (doctor drift check, typed lint tool)
+  not triggered.

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -11,10 +11,22 @@ these same files (via `include_str!`) and writes them to `.pi/` with
 pi install git:github.com/ractive/hyalo
 ```
 
-This installs the `hyalo` extension (generic + typed tools:
-`hyalo`, `hyalo_find`, `hyalo_read`, `hyalo_set`, `hyalo_task`, plus a
-post-write lint guardrail) and the `hyalo` / `hyalo-tidy` skills. Updates are
-delivered with `pi update --extensions` (or `pi update --all`).
+From **hyalo ≥ 0.21** on, pin the release tag matching your binary instead
+(recommended — the extension's expected output shapes track the binary, so
+a matched tag avoids extension/binary drift):
+
+```sh
+pi install git:github.com/ractive/hyalo@v0.21.0
+```
+
+(The tag form needs ≥ v0.21.0; earlier release tags predate the root package
+manifest that git installs require.) This registers the `hyalo` extension
+(generic + typed tools: `hyalo_find`,
+`hyalo_read`, `hyalo_set`, `hyalo_task`, and a post-write lint guardrail) plus
+the `hyalo` and `hyalo-tidy` skills. A main-HEAD install updates with
+`pi update --extensions`; a pinned-tag install moves only when you re-pin
+with a new `pi install git:…@vX.Y.Z` (pi reconciles pinned refs but never
+moves them).
 
 If you don't want a git dependency, run `hyalo init --pi` inside your vault
 instead — it writes a vendored copy of these same files. The downside: the


### PR DESCRIPTION
Documentation + knowledgebase follow-ups closing out iteration-239 (verification PR was #279).

- Tick iter-239 tasks/ACs; tick AC-1 and AC-2 of iteration-237 (both verified against the live global pi install: git install loads 5 tools + skills; `pi update --extensions` delivered the pushed manifest fix)
- DEC-101 resolution recorded in decision-log: root-manifest correction + tag-per-release pinning strategy (`@vX.Y.Z`, valid from v0.21.0 — earlier tags predate the root manifest)
- README + pi-package/README updated with the tag-pin guidance and correct update semantics
- Conditionals (doctor drift check, typed lint tool) recorded as not triggered

No code changes; fmt/clippy/test unchanged from #279's green run.