### PR TITLE
iter-246: help coherence fixes + read UTF-8 diagnostic (deep-review follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to
 
 ### Fixed
 
+- **`read` no longer misreports invalid UTF-8 lines as oversized (iter-246,
+  F-5).** A body line containing invalid UTF-8 was skipped with the
+  "exceeds 1 MiB per-line limit" placeholder because the capped line reader
+  folded both skip causes into one flag. `scanner::read_line_capped` now
+  reports a distinct `LineOutcome::InvalidUtf8`, and `hyalo read` emits
+  `<line skipped: invalid UTF-8 (lossy in search; fix encoding to read)>`;
+  the oversized-line placeholder is reserved for real over-quota lines.
 - **BUG-4 (carry-over): post-mutation BM25 parity.** After a mutation wave
   under `--index`, `find --index` scores are byte-identical to a disk scan
   without an intervening `create-index`: incremental re-scans re-tokenize

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ hyalo lint --fix     # apply autofixes
 hyalo new --type iteration --file iterations/iter-99-example.md
 ```
 
-Every write command supports `--dry-run` to preview changes before applying them, and every command documents its flags: `hyalo <cmd> --help`.
+Write commands that modify existing files support `--dry-run` to preview changes before applying them, and every command documents its flags: `hyalo <cmd> --help`.
 
 ### Agent loop: new → edit → lint
 
@@ -214,7 +214,8 @@ pi install git:github.com/ractive/hyalo
 From **hyalo ≥ 0.21** on, pin the release tag matching your binary instead
 (recommended — the extension's expected output shapes track the binary, so a
 matched tag avoids extension/binary drift; the tag form needs ≥ v0.21.0,
-earlier tags predate the root package manifest):
+earlier tags predate the root package manifest; the `@v0.21.0` examples
+below work once v0.21.0 is tagged):
 
 ```sh
 pi install git:github.com/ractive/hyalo@v0.21.0

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -47,7 +47,7 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
   Find (search and filter, read-only):
     hyalo find [PATTERN | -e/--regexp REGEX] [-p/--property K=V ...] [-t/--tag T ...] [--task STATUS]
                [-s/--section HEADING ...] [--title PAT] [--broken-links] [--orphan] [--dead-end]
-               [-f/--file F | -g/--glob G] [--filenames-only | --filenames0] [--fields ...] [--sort ...] [--reverse] [--strict] [-n/--limit N]
+               [-f/--file F | -g/--glob G] [--filenames-only | --filenames0] [--fields ...] [--sort ...] [--reverse] [--strict] [--language LANG] [-n/--limit N]
 
   Read (display file body content, read-only):
     hyalo read FILE [-s/--section HEADING] [-l/--lines RANGE] [--frontmatter]
@@ -71,19 +71,21 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo tags rename --from OLD --to NEW [-g/--glob G]           Rename a tag across files (mutates files)
 
   Summary (vault overview, read-only):
-    hyalo summary [-g/--glob G] [-n/--recent N] [--depth N] [--limit N]
+    hyalo summary [-g/--glob G] [-n/--recent N] [--depth N]
 
   Task (single-task operations):
     hyalo task read       -f/--file F -l/--line N           Read task at a line
     hyalo task toggle     -f/--file F -l/--line N           Toggle completion
     hyalo task set        -f/--file F -l/--line N -s/--status C
+    --line accepts comma-separated lists; --section H and --all select tasks without line numbers
 
   Backlinks (reverse link lookup, read-only):
     hyalo backlinks FILE [-n/--limit N]
     hyalo backlinks -f/--file F [...]                             Flag form; FILE positional is equivalent
 
   Links (link operations):
-    hyalo links fix [--apply] [--threshold T] [-g/--glob G] [--ignore-target S ...]   Detect and fix broken links (default: dry-run)
+    hyalo links fix [--apply] [--apply-fuzzy] [--min-confidence F] [--case-insensitive]
+                    [--expand-short-form] [--threshold T] [-g/--glob G] [--ignore-target S ...]   Detect and fix broken links (default: dry-run)
     hyalo links auto [--apply] [--first-only | --no-first-only] [--min-length N] [--exclude-title T ...] [--exclude-target-glob G ...] [--file F | -g/--glob G ...]   Auto-link unlinked title mentions (default: dry-run)
     Persist the exclusions in .hyalo.toml:  [links.auto] exclude_titles / exclude_target_globs / first_only (flags extend the lists; --no-first-only overrides first_only for one run)
 
@@ -124,12 +126,12 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo madr toc [--apply]                               Regenerate the ADR table of contents / status dashboard
 
   Changelog (Keep a Changelog 1.1.0 maintenance):
-    hyalo changelog add <CATEGORY> <TEXT>                  Append an entry under `## [Unreleased]`
+    hyalo changelog add --category CAT --message TEXT     Append an entry under `## [Unreleased]`
     hyalo changelog release <VERSION>                      Rotate `## [Unreleased]` into a dated release section
 
   Okf (Open Knowledge Format artifact generators):
     hyalo okf index [--apply]                              Regenerate each directory's index.md from concept frontmatter
-    hyalo okf log <TEXT> [--apply]                         Prepend a dated entry to a scope-selectable log.md
+    hyalo okf log --message TEXT [TARGET] [--apply]       Prepend a dated entry to a scope-selectable log.md
 
   Config (print the effective configuration, read-only):
     hyalo config [--raw] [-d/--dir DIR]                    # --raw also prints the .hyalo.toml text

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -194,6 +194,15 @@ fn oversized_line_placeholder() -> String {
     )
 }
 
+/// Placeholder pushed in place of a body line that contains invalid UTF-8
+/// (iter-246, F-5).  Deliberately does NOT mention the byte limit: the line
+/// was skipped because of its encoding, not its size, and the old behaviour
+/// of blaming the per-line limit misdiagnosed the problem.  The line's
+/// position is preserved, same as the oversized-line case.
+fn invalid_utf8_line_placeholder() -> String {
+    "<line skipped: invalid UTF-8 (lossy in search; fix encoding to read)>".to_owned()
+}
+
 /// Read the raw body lines from a markdown file, skipping frontmatter.
 /// Returns the lines with their trailing newlines stripped.
 ///
@@ -208,7 +217,7 @@ fn read_body_lines(path: &Path) -> Result<Vec<String>> {
 
     // Read first line (capped) to check for frontmatter.
     let mut first_line = String::new();
-    let (n, first_truncated) =
+    let (n, first_outcome) =
         scanner::read_line_capped(&mut reader, &mut first_line, scanner::MAX_BODY_LINE_BYTES)
             .with_context(|| format!("failed to read {}", path.display()))?;
     if n == 0 {
@@ -217,10 +226,13 @@ fn read_body_lines(path: &Path) -> Result<Vec<String>> {
 
     let mut lines = Vec::new();
 
-    if first_truncated {
+    if first_outcome.is_skipped() {
         // A real `---` frontmatter delimiter is 3 bytes, so a line this long
         // can only be body content.
-        lines.push(oversized_line_placeholder());
+        lines.push(match first_outcome {
+            scanner::LineOutcome::InvalidUtf8 => invalid_utf8_line_placeholder(),
+            _ => oversized_line_placeholder(),
+        });
     } else {
         let first_trimmed = first_line.trim_end_matches(['\n', '\r']);
         let fm_lines = frontmatter::skip_frontmatter(&mut reader, first_trimmed)?;
@@ -232,14 +244,17 @@ fn read_body_lines(path: &Path) -> Result<Vec<String>> {
 
     loop {
         let mut buf = String::new();
-        let (n, truncated) =
+        let (n, outcome) =
             scanner::read_line_capped(&mut reader, &mut buf, scanner::MAX_BODY_LINE_BYTES)
                 .with_context(|| format!("failed to read {}", path.display()))?;
         if n == 0 {
             break;
         }
-        if truncated {
-            lines.push(oversized_line_placeholder());
+        if outcome.is_skipped() {
+            lines.push(match outcome {
+                scanner::LineOutcome::InvalidUtf8 => invalid_utf8_line_placeholder(),
+                _ => oversized_line_placeholder(),
+            });
         } else {
             lines.push(buf.trim_end_matches(['\n', '\r']).to_owned());
         }

--- a/crates/hyalo-cli/tests/e2e/help_reference.rs
+++ b/crates/hyalo-cli/tests/e2e/help_reference.rs
@@ -1,0 +1,650 @@
+//! Mechanical guard for the hand-maintained COMMAND REFERENCE and COOKBOOK
+//! blocks in `hyalo --help` (iter-246, F-7).
+//!
+//! `help.rs` holds a hand-written string template, so it can (and did — F-1,
+//! F-2, F-4) drift from the real clap surface: a synopsis names a flag the
+//! subcommand does not have (`summary [--limit N]`) or omits the real
+//! invocation form (`changelog add <CATEGORY> <TEXT>` for a flags-only
+//! subcommand). This test extracts every `hyalo ...` synopsis from the COMMAND
+//! REFERENCE section of the *actual* `hyalo --help` output, compiles it into
+//! concrete argv (placeholders → benign values, synopsis-only notation
+//! stripped), and runs each against a throwaway vault. Every executable
+//! `hyalo ...` line in COOKBOOK is run the same way.
+//!
+//! It asserts parse-level acceptance only — a command "passes" when the CLI
+//! did not reject it as a parse error (`unexpected argument`, `required
+//! arguments`, `invalid value`). Runtime user errors (`file not found`, an
+//! unknown rule id, dry-run drift exiting non-zero) are fine: they prove the
+//! command was *understood*, which is exactly what the reference must not get
+//! wrong.
+//!
+//! Robustness notes:
+//! - clap wraps long help lines at the terminal width, so synopsis entries
+//!   span physical lines unpredictably. Entries are re-joined with the rules
+//!   in [`accumulate_entry`] (see its docs).
+//! - Lines that embed shell/jq pipes (`hyalo ... | xargs ...`, jq filters
+//!   containing `|`) are skipped in COOKBOOK: they are shell, not hyalo
+//!   grammar, and the pipe characters live inside quoted jq strings that a
+//!   line-level parser cannot reliably strip.
+
+use super::common::{hyalo_no_hints, shell_split};
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+/// Run `hyalo --help` once and return its full stdout.
+fn long_help() -> String {
+    let output = hyalo_no_hints().arg("--help").output().unwrap();
+    assert!(
+        output.status.success(),
+        "hyalo --help failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+/// Cut a section (from its `HEADING:` marker to the next section marker).
+fn section<'a>(help: &'a str, start: &str, end: &str) -> &'a str {
+    let from = help
+        .find(start)
+        .unwrap_or_else(|| panic!("--help output missing section marker {start:?}"));
+    let rest = &help[from..];
+    match rest.find(end) {
+        Some(to) => &rest[..to],
+        None => rest,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Synopsis extraction
+// ---------------------------------------------------------------------------
+
+/// Subcommand and verb words that legitimately appear in a synopsis. A token
+/// outside this vocabulary that isn't a flag/placeholder ends the synopsis
+/// (it is trailing prose like "Flag form; ...").
+const SUBCOMMAND_WORDS: &[&str] = &[
+    "find",
+    "read",
+    "set",
+    "remove",
+    "append",
+    "properties",
+    "tags",
+    "summary",
+    "task",
+    "toggle",
+    "backlinks",
+    "links",
+    "fix",
+    "auto",
+    "mv",
+    "views",
+    "list",
+    "lint",
+    "lint-rules",
+    "show",
+    "types",
+    "new",
+    "madr",
+    "toc",
+    "changelog",
+    "add",
+    "release",
+    "okf",
+    "index",
+    "log",
+    "config",
+    "init",
+    "deinit",
+    "create-index",
+    "drop-index",
+    "completions",
+    "rename",
+    // Prose lines that are part of the reference block but not commands
+    // (`--line accepts comma-separated lists; ...`) start with `--`, which
+    // is covered by the flag branch — no vocab entry needed.
+];
+
+/// Is `tok` a token that can legitimately appear in a synopsis (as opposed to
+/// trailing prose like `Flag form; ...`)?  Deliberately permissive — a token
+/// that *looks* structural keeps the line; prose ends it.
+fn is_synopsis_token(tok: &str) -> bool {
+    if tok == "|" {
+        return true;
+    }
+    // Strip synopsis brackets, then classify the inner text.
+    let bare = tok.trim_start_matches('[').trim_end_matches(']');
+    if bare.starts_with('-') || tok.starts_with('<') {
+        return true;
+    }
+    if bare == "..." || tok.ends_with("...") {
+        return true;
+    }
+    // Inline alternatives enumerations (`okf|madr|skills|changelog]`) are
+    // synopsis notation, not prose.
+    if bare.contains('|') {
+        return true;
+    }
+    // A wrapped `]` fragment (`STATUS]`, `FILTER ...]`) is synopsis material.
+    if bare.is_empty() {
+        return true;
+    }
+    if bare.ends_with("...") {
+        return true;
+    }
+    if is_placeholder(bare) {
+        return true;
+    }
+    SUBCOMMAND_WORDS.contains(&bare)
+}
+
+/// `K=V`, `K,K`, `N`, `F`, `SHELL`, `K|K=V`, `DIR/` — all-caps synopsis
+/// placeholders (alternatives and path separators allowed inside).
+fn is_placeholder(tok: &str) -> bool {
+    let bare = tok.trim_end_matches('/');
+    !bare.is_empty()
+        && bare
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c == '=' || c == ',' || c == '|' || c == '_')
+        && bare.chars().any(|c| c.is_ascii_uppercase())
+}
+
+/// Concrete benign value for a synopsis placeholder. Values are chosen so the
+/// instantiated command reaches (or fails *past*) clap parsing:
+/// numeric/enum-ish placeholders get parser-valid values; everything else is
+/// an arbitrary token.
+fn placeholder_value(tok: &str) -> String {
+    match tok {
+        "COLS" => "80".to_owned(),
+        "DATE" => "2026-01-01".to_owned(),
+        "VERSION" => "1.2.3".to_owned(),
+        "SHELL" => "bash".to_owned(),
+        "PROFILE" => "okf".to_owned(),
+        "POLICY" => "skip".to_owned(),
+        "RANGE" => "1:10".to_owned(),
+        "K=V" => "status=x".to_owned(),
+        "CAT" => "Added".to_owned(),
+        // `N` serves numeric counts/limits; `T` serves `--threshold T`
+        // (0.0..=1.0) and `-t/--tag T` (any string).
+        "N" | "T" => "1".to_owned(),
+        // `F` serves both `--file F` (any path parses) and `--min-confidence
+        // F` (threshold parser demands 0.0..=1.0).
+        "F" => "0.9".to_owned(),
+        "BOOL" => "true".to_owned(),
+        "RULE_ID" => "MD013".to_owned(),
+        _ => "x".to_owned(),
+    }
+}
+
+/// Compile one COMMAND REFERENCE synopsis line into runnable argv.
+fn synopsis_to_argv(entry: &str) -> Vec<String> {
+    // Strip trailing hand-written comments (`# bash, zsh, fish, ...`).
+    let line = entry.split_once(" # ").map_or(entry, |(l, _)| l);
+
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    // Drop trailing prose: everything from the first non-synopsis token on.
+    let end = tokens[2..]
+        .iter()
+        .position(|t| !is_synopsis_token(t))
+        .map_or(tokens.len(), |i| i + 2);
+    let tokens = &tokens[..end];
+
+    let mut argv: Vec<String> = Vec::new();
+    // Raw tokens of the bracket group currently being collected (`[a | b]`,
+    // `[--flag P ...]`, `[...]`). A group is compiled and flushed when its
+    // `]` closes it. `pipe_at` records where a `|` alternatives separator
+    // sits so the flush can keep only the first (complete) alternative;
+    // `prose` marks word-only groups (`[find filters...]`) — synopsis prose,
+    // not argv.
+    let mut group: Option<(Vec<String>, Option<usize>, bool)> = None;
+
+    let flush = |argv: &mut Vec<String>, group: &mut Option<(Vec<String>, Option<usize>, bool)>| {
+        let Some((group_toks, pipe_at, prose)) = group.take() else {
+            return;
+        };
+        // `[find filters...]`-style word-only groups name a concept, not args.
+        if prose {
+            return;
+        }
+        // Compile each raw token now that the group's shape is known.
+        let mut compiled: Vec<String> = Vec::new();
+        for tok in group_toks {
+            if tok == "..." || tok == "|" {
+                continue;
+            }
+            // `-f/--file` shorthand: emit the long form so the value that
+            // follows pairs with it.
+            let tok = match tok.strip_prefix('-') {
+                Some(rest) => match rest.strip_prefix(|c: char| c.is_ascii_alphabetic()) {
+                    Some(body) if body.starts_with("/--") => format!("--{}", &body[3..]),
+                    _ => tok.clone(),
+                },
+                None => tok.clone(),
+            };
+            // Inline alternatives (`okf|madr|skills|changelog`) resolve to
+            // their first alternative.
+            let tok = tok.split('|').next().unwrap_or(&tok).to_owned();
+            let had_slash = tok.ends_with('/');
+            let stem = tok.trim_end_matches('/').trim_matches(['<', '>']);
+            if is_placeholder(stem) {
+                compiled.push(format!(
+                    "{}{}",
+                    placeholder_value(stem),
+                    if had_slash { "/" } else { "" }
+                ));
+            } else if !tok.is_empty() {
+                compiled.push(tok);
+            }
+        }
+        match pipe_at {
+            // `[a | b]` alternatives group: keep only the first alternative,
+            // complete with its value(s) (the second is usually its negation
+            // and would conflict with it).
+            Some(pipe) => argv.extend(compiled.into_iter().take(pipe)),
+            None => argv.extend(compiled),
+        }
+    };
+
+    for tok in tokens {
+        let in_group = group.is_some();
+        let opens = tok.starts_with('[') && !tok.ends_with(']');
+        let closes = tok.ends_with(']');
+
+        let clean = tok.trim_start_matches('[').trim_end_matches(']');
+
+        if clean == "..." || clean == "|" {
+            if clean == "|"
+                && let Some((group_toks, pipe_at, _)) = group.as_mut()
+            {
+                *pipe_at = Some(group_toks.len());
+            }
+            continue;
+        }
+
+        let (compiled, prose) = {
+            // `-f/--file` shorthand outside a bracket group: pick the long
+            // form (same rule as `flush` applies inside groups) so a
+            // following value pairs with it.
+            let shorthand_resolved = match clean.strip_prefix('-') {
+                Some(rest) => match rest.strip_prefix(|c: char| c.is_ascii_alphabetic()) {
+                    Some(body) if body.starts_with("/--") => format!("--{}", &body[3..]),
+                    _ => clean.to_owned(),
+                },
+                None => clean.to_owned(),
+            };
+            let first_alt = shorthand_resolved
+                .split('|')
+                .next()
+                .unwrap_or(&shorthand_resolved);
+            let stem = first_alt.trim_end_matches('/').trim_matches(['<', '>']);
+            if is_placeholder(stem) {
+                (
+                    format!(
+                        "{}{}",
+                        placeholder_value(stem),
+                        if first_alt.ends_with('/') { "/" } else { "" }
+                    ),
+                    false,
+                )
+            } else if !first_alt.is_empty() {
+                (first_alt.to_owned(), !structural_word(first_alt))
+            } else {
+                continue;
+            }
+        };
+
+        if opens {
+            if in_group {
+                flush(&mut argv, &mut group);
+            }
+            group = Some((vec![compiled], None, prose));
+        } else if in_group {
+            let g = group.as_mut().unwrap();
+            g.0.push(compiled);
+            g.2 |= prose;
+            if closes {
+                flush(&mut argv, &mut group);
+            }
+        } else {
+            argv.push(compiled);
+        }
+    }
+    // Defensive: flush a group left open by an unbalanced synopsis.
+    flush(&mut argv, &mut group);
+
+    // The synopsis's own `[-d/--dir DIR]` would fight the runner's injected
+    // `--dir` — drop any `--dir VALUE` pair from the compiled argv.
+    let mut out = Vec::with_capacity(argv.len());
+    let mut skip = false;
+    for tok in argv {
+        if skip {
+            skip = false;
+            continue;
+        }
+        if tok == "--dir" || tok == "-d" {
+            skip = true;
+            continue;
+        }
+        out.push(tok);
+    }
+    out
+}
+
+/// A bare word that names an argument concept rather than a flag/value.
+/// Subcommand words are structural; lowercase prose words are not.
+fn structural_word(tok: &str) -> bool {
+    tok.starts_with('-') || is_placeholder(tok) || tok == "..."
+}
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+/// Parse errors that mean "the reference names a command the CLI does not
+/// accept". Runtime user errors are fine (see module docs).
+fn clap_rejection(stderr: &str) -> Option<String> {
+    for line in stderr.lines() {
+        let t = line.trim_start();
+        if t.starts_with("error:")
+            && (t.contains("unexpected argument")
+                || t.contains("required arguments")
+                || t.contains("invalid value")
+                || t.contains("cannot be used multiple times")
+                || t.contains("unrecognized subcommand"))
+        {
+            return Some(t.to_owned());
+        }
+    }
+    None
+}
+
+/// Run one compiled argv against a fresh vault; return the clap rejection if
+/// any (see [`clap_rejection`]).
+fn run_against_fresh_vault(argv: &[String]) -> Result<(), String> {
+    let tmp = TempDir::new().unwrap();
+    let mut cmd = StdCommand::new(env!("CARGO_BIN_EXE_hyalo"));
+    cmd.arg("--dir")
+        .arg(tmp.path())
+        .arg("--format")
+        .arg("json")
+        .stdin(std::process::Stdio::null())
+        .args(argv);
+    let output = cmd.output().unwrap();
+    clap_rejection(&String::from_utf8_lossy(&output.stderr)).map_or(Ok(()), Err)
+}
+
+/// Append a physical help line to the synopsis currently being accumulated.
+///
+/// clap wraps long help lines at the terminal width (breaking at spaces), so
+/// a synopsis may span several physical lines whose wrap points are not under
+/// our control. A line belongs to the current entry when:
+/// - it starts with `[` — a bracket group was pushed to the next line, or
+/// - the accumulated entry has an unbalanced `[` — the wrap split a group
+///   (e.g. `[--task` / `STATUS]`), or
+/// - the entry ends with a `-x/--long` shorthand whose value was wrapped to
+///   the next line.
+///
+/// Description prose (`Flag form; ...`, `Unique property names, ...`) never
+/// satisfies any rule: the entries' descriptions are balanced and don't start
+/// with `[`, and the shorthand rule only fires directly after a flag token.
+fn accumulate_entry(entry: &mut String, line: &str) {
+    let trimmed = line.trim();
+    let unbalanced = entry.matches('[').count() > entry.matches(']').count();
+    let dangling_flag = entry
+        .split_whitespace()
+        .last()
+        .is_some_and(|last| last.starts_with('-') && last.contains("/--"));
+    if trimmed.starts_with('[') || unbalanced || dangling_flag {
+        entry.push(' ');
+        entry.push_str(trimmed);
+    }
+}
+
+/// Every `hyalo ...` synopsis in COMMAND REFERENCE (wrapped lines joined) must
+/// compile to argv the CLI accepts.
+#[test]
+fn command_reference_synopses_parse() {
+    let help = long_help();
+    let reference = section(&help, "COMMAND REFERENCE:", "COOKBOOK:");
+
+    let mut entries: Vec<String> = Vec::new();
+    for line in reference.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("hyalo ") {
+            entries.push(trimmed.to_owned());
+        } else if let Some(cur) = entries.last_mut() {
+            accumulate_entry(cur, line);
+        }
+    }
+    assert!(
+        entries.len() >= 30,
+        "only {} `hyalo ...` entries extracted from COMMAND REFERENCE — \
+         the extraction heuristic broke",
+        entries.len()
+    );
+
+    let mut failures = Vec::new();
+    for entry in &entries {
+        let argv = synopsis_to_argv(entry);
+        // The compiled argv carries the leading `hyalo` word for display;
+        // strip it before invoking the binary.
+        if let Err(rejection) = run_against_fresh_vault(&argv[1..]) {
+            failures.push(format!(
+                "  {entry}\n    compiled: {argv:?}\n    rejected: {rejection}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} COMMAND REFERENCE synopses do not parse:\n{}",
+        failures.len(),
+        entries.len(),
+        failures.join("\n")
+    );
+}
+
+/// Every executable `hyalo ...` line in COOKBOOK must run (pipes skipped —
+/// see module docs).
+#[test]
+fn cookbook_lines_parse() {
+    let help = long_help();
+    let cookbook = section(&help, "COOKBOOK:", "OUTPUT SHAPES");
+
+    let mut checked = 0;
+    let mut failures = Vec::new();
+    for line in cookbook.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("hyalo ") || trimmed.contains('|') {
+            continue;
+        }
+        checked += 1;
+        // Cookbook lines are shell command lines: quoted args (jq filters,
+        // globs with spaces) must survive as single argv tokens.
+        let argv: Vec<String> = shell_split(trimmed)
+            .into_iter()
+            .skip(1) // drop the leading `hyalo` word
+            .collect();
+        if let Err(rejection) = run_against_fresh_vault(&argv) {
+            failures.push(format!("  {trimmed}\n    rejected: {rejection}"));
+        }
+    }
+    assert!(
+        checked >= 30,
+        "only {checked} cookbook lines checked — extraction heuristic broke"
+    );
+    assert!(
+        failures.is_empty(),
+        "{} cookbook lines do not parse:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// Pin the specific drift findings this guard exists for (F-1, F-2, F-4), so
+/// a regression in the extraction heuristics above cannot silently un-cover
+/// them.
+#[test]
+fn known_drift_findings_stay_fixed() {
+    let help = long_help();
+
+    // F-1: summary has no --limit.
+    assert!(
+        !help.contains("summary [-g/--glob G] [-n/--recent N] [--depth N] [--limit N]"),
+        "summary synopsis must not advertise a phantom --limit"
+    );
+    // F-2: changelog add is flags-only, not positional.
+    assert!(
+        !help.contains("hyalo changelog add <CATEGORY> <TEXT>"),
+        "changelog add synopsis must show --category/--message, not positionals"
+    );
+    // F-3: okf log takes --message, not a bare TEXT positional.
+    assert!(
+        !help.contains("hyalo okf log <TEXT>"),
+        "okf log synopsis must show --message"
+    );
+    // F-4: links fix names its gating flags.
+    let fix_block = section(&help, "hyalo links fix", "Persist the exclusions");
+    for flag in [
+        "--apply-fuzzy",
+        "--min-confidence",
+        "--case-insensitive",
+        "--expand-short-form",
+    ] {
+        assert!(
+            fix_block.contains(flag),
+            "links fix synopsis missing {flag}"
+        );
+    }
+    // And the real invocation works end-to-end (AC).
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .args([
+            "changelog",
+            "add",
+            "--category",
+            "Added",
+            "--message",
+            "x",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        clap_rejection(&String::from_utf8_lossy(&output.stderr)).is_none(),
+        "changelog add --category/--message rejected"
+    );
+}
+
+/// `hyalo summary --limit N` must still be rejected (F-1 regression check on
+/// the CLI surface itself, not just the prose).
+#[test]
+fn summary_still_has_no_limit_flag() {
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .args(["summary", "--limit", "5"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "summary must reject --limit");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unexpected argument"),
+        "expected an unexpected-argument error for summary --limit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for the extraction helpers themselves
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compiles_shorthand_flags_from_bracketed_groups() {
+    let argv = synopsis_to_argv("hyalo summary [-g/--glob G] [-n/--recent N] [--depth N]");
+    assert_eq!(
+        argv,
+        vec![
+            "hyalo", "summary", "--glob", "x", "--recent", "1", "--depth", "1"
+        ]
+    );
+}
+
+#[test]
+fn compiles_alternatives_group_to_first_alternative() {
+    let argv =
+        synopsis_to_argv("hyalo links auto [--first-only | --no-first-only] [--min-length N]");
+    // The first alternative survives complete; the negation is dropped
+    // (conflicts with the first and both parse identically alone).
+    assert_eq!(
+        argv,
+        vec![
+            "hyalo",
+            "links",
+            "auto",
+            "--first-only",
+            "--min-length",
+            "1"
+        ]
+    );
+}
+
+#[test]
+fn compiles_repeatable_group_with_sample_value() {
+    let argv =
+        synopsis_to_argv("hyalo set  -p/--property K=V [-p ...] [-t/--tag T ...] [--dry-run]");
+    // Repeat markers emit the flag once (a second occurrence would just
+    // repeat the same parse); a placeholder-only sample value is dropped.
+    assert_eq!(
+        argv,
+        vec![
+            "hyalo",
+            "set",
+            "--property",
+            "status=x",
+            "-p",
+            "--tag",
+            "1",
+            "--dry-run"
+        ]
+    );
+}
+
+#[test]
+fn compiles_bare_positionals_and_keeps_subcommand_words() {
+    let argv = synopsis_to_argv(
+        "hyalo task set        -f/--file F -l/--line N -s/--status C           Set a custom",
+    );
+    assert_eq!(
+        argv,
+        vec![
+            "hyalo", "task", "set", "--file", "0.9", "--line", "1", "--status", "x"
+        ]
+    );
+}
+
+#[test]
+fn joins_wrapped_group_split_across_lines() {
+    // Reproduces the real wrapping of the find synopsis (`[--task` / `STATUS]`).
+    let mut entry =
+        "hyalo find [PATTERN | -e/--regexp REGEX] [-p/--property K=V ...] [-t/--tag T ...] [--task"
+            .to_owned();
+    accumulate_entry(&mut entry, "    STATUS]");
+    assert!(
+        entry.ends_with("[--task STATUS]"),
+        "wrapped fragment must rejoin: {entry}"
+    );
+    let argv = synopsis_to_argv(&entry);
+    assert!(argv.contains(&"--task".to_owned()));
+    assert!(argv.contains(&"x".to_owned()));
+}
+
+#[test]
+fn does_not_join_description_prose() {
+    let mut entry =
+        "hyalo properties summary [-g/--glob G] [-n/--limit N]         Unique property names, types, and"
+            .to_owned();
+    accumulate_entry(&mut entry, "    file counts (read-only) [alias: list]");
+    assert!(
+        !entry.contains("alias"),
+        "description prose must not be joined: {entry}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/hint_execution.rs
+++ b/crates/hyalo-cli/tests/e2e/hint_execution.rs
@@ -101,6 +101,39 @@ tags:
 Linked from [[note-0]] and links to [[note-1]].
 "),
     );
+
+    // A Keep a Changelog file so the `changelog` seed commands have a target
+    // (iter-246). The grammar requires the `# Changelog` title and a
+    // `## [Unreleased]` section to append under.
+    std::fs::write(
+        root.join("CHANGELOG.md"),
+        "# Changelog\n\nAll notable changes to this project.\n\n## [Unreleased]\n\n### Added\n\n- Initial entry.\n",
+    )
+    .unwrap();
+
+    // A minimal MADR ADR directory so `madr toc` scans a real ADR: number
+    // from the `NNNN-slug.md` filename, title/status/date from frontmatter
+    // (same shape `madr_profile.rs` scaffolds), plus a README whose managed
+    // region the TOC regenerates into.
+    write_md(
+        root,
+        "docs/decisions/0001-use-postgres.md",
+        md!(r"
+---
+title: Use Postgres
+status: accepted
+date: 2026-01-15
+---
+# Use Postgres
+
+We chose Postgres.
+"),
+    );
+    write_md(
+        root,
+        "docs/decisions/README.md",
+        "# Architecture Decision Records\n\n<!-- madr:toc:begin -->\n<!-- madr:toc:end -->\n",
+    );
 }
 
 /// Seed commands whose hints are harvested. Each is argv *after* `hyalo`.
@@ -162,6 +195,20 @@ const SEED_COMMANDS: &[&[&str]] = &[
         "notes/note-3.md",
     ],
     &["mv", "notes/note-4.md", "notes/moved-4.md"],
+    // Profile-generator sources (iter-246): their hints validate the
+    // generated artifact via `lint --profile <p>` or apply the pending
+    // regeneration — both must execute cleanly.
+    &[
+        "changelog",
+        "add",
+        "--category",
+        "Added",
+        "--message",
+        "Test entry",
+    ],
+    &["okf", "index"],
+    &["okf", "log", "--message", "Test entry"],
+    &["madr", "toc"],
 ];
 
 /// A harvested hint: the seed command that produced it, its description, and

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -22,6 +22,7 @@ mod files_from;
 mod find;
 mod frontmatter_preservation;
 mod help;
+mod help_reference;
 mod hint_execution;
 mod hints;
 mod hyalo_config;

--- a/crates/hyalo-cli/tests/e2e/read.rs
+++ b/crates/hyalo-cli/tests/e2e/read.rs
@@ -827,6 +827,46 @@ fn read_oversized_single_line_is_placeholdered_not_buffered() {
     );
 }
 
+/// A line containing invalid UTF-8 must be reported with the invalid-UTF-8
+/// placeholder — not the oversized-line one (iter-246, F-5).  The two skip
+/// causes used to share `truncated = true`, so a 36-byte file with a `\xff`
+/// body byte was misdiagnosed as exceeding the per-line byte limit.
+#[test]
+fn read_invalid_utf8_line_gets_dedicated_placeholder() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("bad-encoding.md");
+    // Well under the per-line byte cap; the only problem is the encoding.
+    let mut bytes: Vec<u8> = Vec::new();
+    bytes.extend_from_slice(b"first line is fine\n");
+    bytes.extend_from_slice(b"bad \xff\xfe rest of line\n");
+    bytes.extend_from_slice(b"after the bad line\n");
+    fs::write(&path, &bytes).unwrap();
+
+    let output = hyalo_no_hints()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["read", "--file", "bad-encoding.md"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(
+        stdout.contains("invalid UTF-8"),
+        "expected invalid-UTF-8 placeholder, got: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("per-line limit"),
+        "must not blame the byte limit for an encoding problem: {stdout:?}"
+    );
+    // Surrounding lines still read; the bad line keeps its position.
+    assert!(stdout.contains("first line is fine"));
+    assert!(stdout.contains("after the bad line"));
+}
+
 /// Pin exact output for an ordinary small file across the fix — the capped
 /// reader must remain byte-for-byte equivalent to the previous
 /// `BufRead::lines()` based implementation for normal input.

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -476,16 +476,16 @@ pub(crate) fn scan_reader_multi<R: BufRead>(
 
     loop {
         buf.clear();
-        let (n, truncated) = read_line_capped(&mut reader, &mut buf, MAX_BODY_LINE_BYTES)
+        let (n, outcome) = read_line_capped(&mut reader, &mut buf, MAX_BODY_LINE_BYTES)
             .context("failed to read line")?;
         if n == 0 {
             break;
         }
         line_num += 1;
-        if truncated {
-            // Line either exceeded the per-line byte limit or contained
-            // invalid UTF-8 — skip it entirely to prevent OOM on files with
-            // no newlines (e.g. minified HTML/JSON accidentally placed in the
+        if outcome.is_skipped() {
+            // Line exceeded the per-line byte limit or contained invalid
+            // UTF-8 — skip it entirely to prevent OOM on files with no
+            // newlines (e.g. minified HTML/JSON accidentally placed in the
             // vault) and to avoid propagating malformed encoding. The line
             // counter still advances so that downstream line numbers remain
             // correct.
@@ -509,12 +509,33 @@ pub(crate) fn scan_reader_multi<R: BufRead>(
 /// accidentally-added minified blobs) would otherwise exhaust memory.
 pub const MAX_BODY_LINE_BYTES: usize = 1024 * 1024; // 1 MiB
 
+/// Why a line could not be reported verbatim by [`read_line_capped`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineOutcome {
+    /// The line fit entirely in the byte quota and is valid UTF-8.
+    Complete,
+    /// The line exceeded the per-line byte quota; excess bytes were drained.
+    Truncated,
+    /// The line contained invalid UTF-8 and is not representable in `buf`.
+    InvalidUtf8,
+}
+
+impl LineOutcome {
+    /// `true` when the caller must skip the line (position is preserved).
+    pub fn is_skipped(self) -> bool {
+        !matches!(self, LineOutcome::Complete)
+    }
+}
+
 /// Read one newline-terminated line into `buf`, but stop after `limit` bytes.
 ///
-/// Returns `(bytes_consumed, truncated)`.  When `truncated` is `true` the
-/// reader is positioned just after where the logical line ended (i.e. excess
-/// bytes are drained until the next `\n` or EOF), and the caller should treat
-/// the line as skipped.
+/// Returns `(bytes_consumed, outcome)`.  When the outcome is not
+/// [`LineOutcome::Complete`] the reader is positioned just after where the
+/// logical line ended (i.e. excess or invalid bytes are drained until the next
+/// `\n` or EOF), and the caller should treat the line as skipped — the
+/// outcome says *why* (over-quota truncation vs. invalid UTF-8).  Both skip
+/// paths still drain to the next newline and advance the reader; only the
+/// reported cause differs.
 ///
 /// Exposed beyond `#[cfg(test)]` so other crates (e.g. `hyalo-cli`'s `read`
 /// command) can stream a single file with the same per-line memory bound the
@@ -523,7 +544,7 @@ pub fn read_line_capped<R: BufRead>(
     reader: &mut R,
     buf: &mut String,
     limit: usize,
-) -> std::io::Result<(usize, bool)> {
+) -> std::io::Result<(usize, LineOutcome)> {
     let mut total = 0usize;
     loop {
         // Inspect the internal buffer to find a newline and measure how many
@@ -531,7 +552,7 @@ pub fn read_line_capped<R: BufRead>(
         // releasing the borrow so that we can then call `consume`.
         let (newline_pos, chunk_len) = loop {
             match reader.fill_buf() {
-                Ok([]) => return Ok((total, false)),
+                Ok([]) => return Ok((total, LineOutcome::Complete)),
                 Ok(b) => {
                     let nl = b.iter().position(|&byte| byte == b'\n');
                     let len = b.len();
@@ -557,19 +578,19 @@ pub fn read_line_capped<R: BufRead>(
             if newline_pos == Some(0) {
                 reader.consume(1);
                 total += 1;
-                // Keep parity with the other non-truncated paths, which
+                // Keep parity with the other complete paths, which
                 // include the terminating newline in `buf`.
                 buf.push('\n');
-                return Ok((total, false));
+                return Ok((total, LineOutcome::Complete));
             }
             // Otherwise there is more line content beyond the quota — drain it.
             reader.consume(consume);
             total += consume;
             if newline_pos.is_some() {
-                return Ok((total, true));
+                return Ok((total, LineOutcome::Truncated));
             }
             drain_until_newline(reader)?;
-            return Ok((total, true));
+            return Ok((total, LineOutcome::Truncated));
         }
 
         // Within quota: copy up to `to_copy` bytes into a temporary Vec so we
@@ -586,14 +607,16 @@ pub fn read_line_capped<R: BufRead>(
         reader.consume(consume);
         total += consume;
 
-        // Validate UTF-8; treat invalid bytes as a truncated/skipped line.
+        // Validate UTF-8; invalid bytes are a distinct skip cause so callers
+        // can report the real problem (F-5, iter-246) instead of blaming the
+        // byte limit.
         if let Ok(s) = std::str::from_utf8(&chunk) {
             buf.push_str(s);
         } else {
             if newline_pos.is_none() {
                 drain_until_newline(reader)?;
             }
-            return Ok((total, true));
+            return Ok((total, LineOutcome::InvalidUtf8));
         }
 
         let truncated = to_copy < consume;
@@ -601,12 +624,19 @@ pub fn read_line_capped<R: BufRead>(
             // The newline was within the consumed range — line is complete.
             // If quota was hit before the newline, we already consumed past it,
             // so no further draining is needed.
-            return Ok((total, truncated));
+            return Ok((
+                total,
+                if truncated {
+                    LineOutcome::Truncated
+                } else {
+                    LineOutcome::Complete
+                },
+            ));
         }
         if truncated {
             // Quota hit on a chunk with no newline — drain the rest of the line.
             drain_until_newline(reader)?;
-            return Ok((total, true));
+            return Ok((total, LineOutcome::Truncated));
         }
     }
 }
@@ -1758,17 +1788,20 @@ code only
         let mut reader = std::io::BufReader::with_capacity(chunk_cap, input.as_bytes());
 
         let mut buf = String::new();
-        let (n, truncated) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        let (n, outcome) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
         assert!(
-            !truncated,
+            outcome == LineOutcome::Complete,
             "line exactly at the limit must not be truncated"
         );
         assert_eq!(buf, format!("{line}\n"));
         assert_eq!(n, limit + 1);
 
         buf.clear();
-        let (_, truncated2) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
-        assert!(!truncated2, "subsequent line must be read normally");
+        let (_, outcome2) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        assert!(
+            outcome2 == LineOutcome::Complete,
+            "subsequent line must be read normally"
+        );
         assert_eq!(buf, "next\n");
     }
 
@@ -1783,12 +1816,76 @@ code only
         let mut reader = std::io::BufReader::with_capacity(chunk_cap, input.as_bytes());
 
         let mut buf = String::new();
-        let (_, truncated) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
-        assert!(truncated, "line one byte over the limit must be truncated");
+        let (_, outcome) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        assert_eq!(outcome, LineOutcome::Truncated);
 
         buf.clear();
-        let (_, truncated2) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
-        assert!(!truncated2, "subsequent line must be read normally");
+        let (_, outcome2) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+        assert!(
+            outcome2 == LineOutcome::Complete,
+            "subsequent line must be read normally"
+        );
         assert_eq!(buf, "next\n");
+    }
+
+    #[test]
+    fn read_line_capped_invalid_utf8_is_not_truncation() {
+        // F-5 (iter-246): a line containing invalid UTF-8 must be reported as
+        // `InvalidUtf8`, not `Truncated` — the two skip causes have different
+        // user-facing messages and blaming the byte limit misdiagnosed the
+        // real problem (a bad encoding).
+        let mut input: Vec<u8> = Vec::new();
+        input.extend_from_slice(b"valid\n");
+        input.extend_from_slice(b"bad ");
+        input.push(0xFF);
+        input.push(0xFE);
+        input.extend_from_slice(b" rest\n");
+        input.extend_from_slice(b"after\n");
+        let mut reader = std::io::BufReader::with_capacity(4, &input[..]);
+
+        let mut buf = String::new();
+        // Consume the leading valid line first.
+        let (_, outcome0) = read_line_capped(&mut reader, &mut buf, 1024).unwrap();
+        assert_eq!(outcome0, LineOutcome::Complete);
+        assert_eq!(buf, "valid\n");
+
+        buf.clear();
+        let (n, outcome) = read_line_capped(&mut reader, &mut buf, 1024).unwrap();
+        assert_eq!(outcome, LineOutcome::InvalidUtf8);
+        assert!(n > 0, "bytes consumed must still be reported");
+
+        // The invalid line is drained: the following line reads normally.
+        buf.clear();
+        let (_, outcome2) = read_line_capped(&mut reader, &mut buf, 1024).unwrap();
+        assert_eq!(outcome2, LineOutcome::Complete);
+        assert_eq!(buf, "after\n");
+
+        // A valid line before the invalid one is unaffected.
+        let mut reader2 = std::io::BufReader::with_capacity(4, &input[..]);
+        buf.clear();
+        let (_, outcome3) = read_line_capped(&mut reader2, &mut buf, 1024).unwrap();
+        assert_eq!(outcome3, LineOutcome::Complete);
+        assert_eq!(buf, "valid\n");
+    }
+
+    #[test]
+    fn read_line_capped_invalid_utf8_before_quota_reports_invalid_utf8() {
+        // Encoding is the reported cause even when the line also exceeds the
+        // byte quota, as long as the invalid bytes are copied before the
+        // quota is exhausted (the quota check runs per chunk).
+        let mut input: Vec<u8> = b"aaaa".to_vec();
+        input.push(0xFF);
+        input.extend_from_slice(b"aaaaaaaaaaaa\n"); // line well past the 16-byte limit
+        input.extend_from_slice(b"after\n");
+        let mut reader = std::io::BufReader::with_capacity(4, &input[..]);
+
+        let mut buf = String::new();
+        let (_, outcome) = read_line_capped(&mut reader, &mut buf, 16).unwrap();
+        assert_eq!(outcome, LineOutcome::InvalidUtf8);
+
+        buf.clear();
+        let (_, outcome2) = read_line_capped(&mut reader, &mut buf, 16).unwrap();
+        assert_eq!(outcome2, LineOutcome::Complete);
+        assert_eq!(buf, "after\n");
     }
 }

--- a/hyalo-knowledgebase/iterations/iteration-246-help-coherence-review-followups.md
+++ b/hyalo-knowledgebase/iterations/iteration-246-help-coherence-review-followups.md
@@ -1,5 +1,7 @@
 ---
-title: "Iteration 246 — help coherence fixes and read UTF-8 diagnostic (deep-review follow-ups)"
+title: >-
+  Iteration 246 — help coherence fixes and read UTF-8 diagnostic (deep-review
+  follow-ups)
 type: iteration
 date: 2026-08-28
 tags:
@@ -7,7 +9,7 @@ tags:
   - ux
   - help
   - review
-status: planned
+status: completed
 branch: iter-246/help-coherence-review-followups
 related:
   - "[[reviews/deep-review-2026-08-27]]"
@@ -46,7 +48,7 @@ trade-off; record, don't change). `reviews/` using the undeclared
 
 ### F-5: read UTF-8 misdiagnosis (code fix — do first, it's the only real bug)
 
-- [ ] Change `read_line_capped` in `crates/hyalo-core/src/scanner/mod.rs:522`
+- [x] Change `read_line_capped` in `crates/hyalo-core/src/scanner/mod.rs:522`
       to distinguish invalid UTF-8 from over-quota truncation. Replace the
       `bool` in the `(usize, bool)` return with a small public enum, e.g.
       `LineOutcome { Complete, Truncated, InvalidUtf8 }` (keep the `usize`
@@ -54,26 +56,26 @@ trade-off; record, don't change). `reviews/` using the undeclared
       returns `truncated = true`; make it return `InvalidUtf8`. Both
       `Truncated` and `InvalidUtf8` still drain to the next newline and
       advance the reader — only the reported cause differs.
-- [ ] Update the two call sites in
+- [x] Update the two call sites in
       `crates/hyalo-cli/src/commands/read.rs:212` and `:236`: on
       `InvalidUtf8` push a new placeholder
       `<line skipped: invalid UTF-8 (lossy in search; fix encoding to read)>`
       — wording bikesheddable, must not mention the MiB limit. Keep
       `oversized_line_placeholder()` for the real over-quota case.
-- [ ] Grep for other `read_line_capped` callers (only scanner internals +
+- [x] Grep for other `read_line_capped` callers (only scanner internals +
       read.rs today) and update unit tests in
       `crates/hyalo-core/src/scanner/mod.rs` (`mod tests` at :744 — the
       `read_line_capped_*` tests around :1753-1776) for the new enum; add a
       test: a chunk containing `0xFF` returns `InvalidUtf8`, not `Truncated`.
-- [ ] Add e2e test in `crates/hyalo-cli/tests/e2e/` (extend an existing
+- [x] Add e2e test in `crates/hyalo-cli/tests/e2e/` (extend an existing
       read test file or `errors.rs`): file with a `\xff` body byte →
       `hyalo read <file>` output contains the invalid-UTF-8 placeholder and
       does NOT contain "per-line limit".
-- [ ] CHANGELOG entry under `### Fixed`.
+- [x] CHANGELOG entry under `### Fixed`.
 
 ### F-1: summary `--limit` phantom flag
 
-- [ ] In `crates/hyalo-cli/src/cli/help.rs:74`, change the summary synopsis
+- [x] In `crates/hyalo-cli/src/cli/help.rs:74`, change the summary synopsis
       from `hyalo summary [-g/--glob G] [-n/--recent N] [--depth N] [--limit N]`
       to `hyalo summary [-g/--glob G] [-n/--recent N] [--depth N]`
       (drop `[--limit N]` — `summary` has no `--limit`; its own subcommand
@@ -81,30 +83,30 @@ trade-off; record, don't change). `reviews/` using the undeclared
 
 ### F-2/F-3: changelog and okf synopses
 
-- [ ] help.rs:127: `hyalo changelog add <CATEGORY> <TEXT>` →
+- [x] help.rs:127: `hyalo changelog add <CATEGORY> <TEXT>` →
       `hyalo changelog add --category <CAT> --message "..."` (verify against
       `hyalo changelog add --help` Usage line:
       `hyalo changelog add [OPTIONS] --category <CATEGORY> --message <TEXT>`).
-- [ ] help.rs:128: `hyalo changelog release <VERSION>` is CORRECT (positional
+- [x] help.rs:128: `hyalo changelog release <VERSION>` is CORRECT (positional
       VERSION is real) — leave unchanged.
-- [ ] help.rs:132: `hyalo okf log <TEXT> [--apply]` →
+- [x] help.rs:132: `hyalo okf log <TEXT> [--apply]` →
       `hyalo okf log --message <TEXT> [TARGET] [--apply]`.
 
 ### F-4: missing flags in reference synopses
 
-- [ ] help.rs:86 (links fix): extend to include `[--apply-fuzzy]`,
+- [x] help.rs:86 (links fix): extend to include `[--apply-fuzzy]`,
       `[--min-confidence F]`, `[--case-insensitive]`, `[--expand-short-form]`.
       Keep it one line if possible; wrap to a continuation line matching the
       existing style if not.
-- [ ] help.rs:77-79 (task): add a note line under the three synopses:
+- [x] help.rs:77-79 (task): add a note line under the three synopses:
       `--line accepts comma-separated lists; --section H and --all select
       tasks without line numbers` (both `--section` and `--all` are real on
       task read/toggle/set).
-- [ ] help.rs:48-50 (find): add `[--language LANG]` to the find synopsis.
+- [x] help.rs:48-50 (find): add `[--language LANG]` to the find synopsis.
 
 ### F-7: mechanical guards (the recurrence prevention)
 
-- [ ] Add e2e test `help_reference_synopses_parse` (new file
+- [x] Add e2e test `help_reference_synopses_parse` (new file
       `crates/hyalo-cli/tests/e2e/help_reference.rs` or extend `help.rs`):
       extract every `hyalo <...>` line from the COMMAND REFERENCE section of
       `hyalo --help`, strip synopsis-only notation (`[...]`, `<...>`,
@@ -117,7 +119,7 @@ trade-off; record, don't change). `reviews/` using the undeclared
       If full synopsis-to-argv compilation proves fiddly, the accepted
       fallback is a table of (subcommand, flag) assertions for the specific
       flags in F-1..F-4 plus a comment pointing here.
-- [ ] Extend `SEED_COMMANDS` in
+- [x] Extend `SEED_COMMANDS` in
       `crates/hyalo-cli/tests/e2e/hint_execution.rs:112` with seeds for
       `changelog` (needs a `CHANGELOG.md` with an `## [Unreleased]` section
       in the fixture), `okf index`, `okf log --message x`, and `madr toc`
@@ -125,40 +127,40 @@ trade-off; record, don't change). `reviews/` using the undeclared
       `tests/e2e/madr_profile.rs` / `okf_profile.rs` for minimal fixtures to
       copy). Harvested hints from these must then execute cleanly, same as
       existing seeds.
-- [ ] Cookbook examples: the review verified all 57 parse today. Add the
+- [x] Cookbook examples: the review verified all 57 parse today. Add the
       cookbook lines to the same `help_reference_synopses_parse` test (same
       extraction, from the COOKBOOK section; skip lines containing `|` pipes
       and multi-line jq strings — document why).
 
 ### F-6 + README touch-ups
 
-- [ ] README.md:177: change "Every write command supports `--dry-run`" to
+- [x] README.md:177: change "Every write command supports `--dry-run`" to
       "Write commands that modify existing files support `--dry-run`"
       (new/views set/types set write-or-refuse without one).
-- [ ] README.md pi-integration section (~:216-220): the `@v0.21.0` tag
+- [x] README.md pi-integration section (~:216-220): the `@v0.21.0` tag
       references are forward-dated for a tag that doesn't exist yet. Either
       gate the wording on release or add "(available once v0.21.0 is
       tagged)" — owner call; smallest honest fix is the parenthetical.
 
 ### Wrap-up
 
-- [ ] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings &&
+- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings &&
       cargo test --workspace -q` all green.
-- [ ] Dogfood: run `target/release/hyalo --help` and spot-check the three
+- [x] Dogfood: run `target/release/hyalo --help` and spot-check the three
       corrected synopses; run the UTF-8 repro from the review (36-byte file
       with `\xff\xfe` body) and confirm the new message.
-- [ ] Update [[reviews/deep-review-2026-08-27]] status to `resolved` and add
+- [x] Update [[reviews/deep-review-2026-08-27]] status to `resolved` and add
       a `related` link back to this iteration.
 
 ## Acceptance criteria
 
-- [ ] `hyalo summary --limit 5` still errors (unchanged), but `--help` no
+- [x] `hyalo summary --limit 5` still errors (unchanged), but `--help` no
       longer shows `[--limit N]` for summary.
-- [ ] Every `hyalo ...` line in COMMAND REFERENCE parses when instantiated
+- [x] Every `hyalo ...` line in COMMAND REFERENCE parses when instantiated
       (enforced by the new test, not just by hand).
-- [ ] `hyalo changelog add --category Added --message "x" --dry-run` works
+- [x] `hyalo changelog add --category Added --message "x" --dry-run` works
       AND the help synopsis shows this flag form.
-- [ ] The UTF-8 repro file yields the new invalid-UTF-8 placeholder.
-- [ ] Hint execution gate covers changelog/okf/madr seeds.
-- [ ] README dry-run sentence no longer overclaims.
-- [ ] All quality gates green; no clippy/fmt/test regressions.
+- [x] The UTF-8 repro file yields the new invalid-UTF-8 placeholder.
+- [x] Hint execution gate covers changelog/okf/madr seeds.
+- [x] README dry-run sentence no longer overclaims.
+- [x] All quality gates green; no clippy/fmt/test regressions.

--- a/hyalo-knowledgebase/iterations/iteration-247-carry-over-sweep.md
+++ b/hyalo-knowledgebase/iterations/iteration-247-carry-over-sweep.md
@@ -1,0 +1,54 @@
+---
+title: "Iteration 247 — carry-over sweep from iter-246 (deep-review non-goals and dogfood notes)"
+type: iteration
+date: 2026-08-28
+tags:
+  - iteration
+  - carry-over
+  - review
+status: planned
+branch: iter-247/carry-over-sweep
+related:
+  - "[[iterations/iteration-246-help-coherence-review-followups]]"
+  - "[[reviews/deep-review-2026-08-27]]"
+  - "[[iterations/iteration-245-deferral-carryovers]]"
+---
+
+# Iteration 247 — carry-over sweep from iter-246
+
+## Goal
+
+Keep every item [[iterations/iteration-246-help-coherence-review-followups]]
+declared a non-goal or flagged as out-of-scope from being silently
+forgotten. Iteration 246 itself is fully complete (all 27 tasks/ACs ticked);
+everything below was explicitly parked during it.
+
+## Tasks
+
+- [ ] Large-file refactor (review hotspot): `crates/hyalo-cli/src/commands/hints.rs`
+      (~5,059 lines), `lint.rs` (~4,005), and the output modules are large
+      single files. Split into cohesive submodules without behavior change;
+      gates must stay green. Declared a non-goal of iter-246 to keep its diff
+      reviewable.
+- [ ] S-2 stale-index design: warn-but-serve staleness is a deliberate
+      trade-off (recorded, not changed, in iter-246). The review suggests an
+      opt-in `--strict-index` that falls back to disk on staleness — decide
+      whether to implement it or record the decision to keep warn-but-serve
+      permanently (owner call, cf. DEC-098/DEC-101 discipline).
+- [ ] Vault schema drift: files under `reviews/` use `type: review`, but
+      `hyalo types show review` fails and `reviews/` sits in `[lint] ignore`
+      so nothing notices. Either register a `review` type in the schema or
+      migrate the files to a declared type and shrink the ignore list.
+- [ ] `summary` text output prints a `kb dir: hyalo-knowledgebase` banner as
+      its first line — the only command doing so; mildly breaks the
+      "text output is data" contract when scripting in text mode. Move it to
+      stderr or behind a flag (decide with care: hints/output drift).
+- [ ] Feature request (minor): `hyalo find --changed-since <ref>` as a
+      friendlier built-in for the `--files-from <(git diff …)` cookbook
+      pattern. Decide whether to implement or reject with rationale.
+
+## Acceptance criteria
+
+- [ ] Each task above is implemented, or explicitly closed with a recorded
+      owner decision (decision-log entry) instead of re-deferral.
+- [ ] All quality gates green; no clippy/fmt/test regressions.

--- a/hyalo-knowledgebase/reviews/deep-review-2026-08-27.md
+++ b/hyalo-knowledgebase/reviews/deep-review-2026-08-27.md
@@ -2,7 +2,7 @@
 title: Deep review 2026-08-27 — code quality, security, help coherence, README, dogfood
 type: research
 date: 2026-08-27
-status: active
+status: resolved
 tags:
   - review
   - security
@@ -13,6 +13,7 @@ related:
   - "[[reviews/adversarial-review-2026-08-23]]"
   - "[[reviews/codebase-review-2026-08-06]]"
   - "[[dogfood-results/dogfood-v0200-arch-refactors-and-agent-cli-followups]]"
+  - "[[iterations/iteration-246-help-coherence-review-followups]]"
 ---
 
 # Deep review — hyalo 0.20.0 (2026-08-27)


### PR DESCRIPTION
Implements [iteration-246](hyalo-knowledgebase/iterations/iteration-246-help-coherence-review-followups.md) — all actionable findings from the [2026-08-27 deep review](hyalo-knowledgebase/reviews/deep-review-2026-08-27.md).

## Changes

- **F-5 (real bug):** `scanner::read_line_capped` now returns `LineOutcome::{Complete, Truncated, InvalidUtf8}` instead of conflating invalid UTF-8 with over-quota truncation. `hyalo read` on a file with bad encoding emits `<line skipped: invalid UTF-8 ...>` instead of the misleading "exceeds 1 MiB per-line limit".
- **F-1:** dropped phantom `[--limit N]` from the `summary` synopsis in the top-level COMMAND REFERENCE.
- **F-2/F-3:** `changelog add` / `okf log` synopses now show the real `--category`/`--message` flag form (previously documented a positional form that is a parse error).
- **F-4:** COMMAND REFERENCE gains `links fix --apply-fuzzy/--min-confidence/--case-insensitive/--expand-short-form`, a `task --section/--all` note, and `find --language`.
- **F-7 (recurrence guards):** new `help_reference` e2e test compiles every COMMAND REFERENCE synopsis and cookbook line into argv and asserts clap accepts it (would have caught F-1..F-4); hint execution gate gains changelog/okf/madr seeds.
- **F-6:** README dry-run sentence no longer overclaims (`new` has no `--dry-run`); the `@v0.21.0` pi-install examples are marked as pending the tag.

## Review pass

Independent review of this PR found no defects: fmt/clippy/tests all green locally (4130 tests) and in CI; all `xtask` check-* gates pass; UTF-8 repro and the three corrected synopses dogfooded against the built binary. The iteration plan has been ticked against the merged diff (27/27 tasks and ACs, status `completed`).

## Carry-over

No scope task or AC from iteration 246 was left unticked — every item landed. The following were explicitly parked (non-goals / out-of-scope findings), and each is now dispositioned into the new plan [iteration-247-carry-over-sweep.md](hyalo-knowledgebase/iterations/iteration-247-carry-over-sweep.md) (committed on this branch):

1. **Large-file refactor of `hints.rs`/`lint.rs`/`output.rs`** (review hotspot, iter-246 non-goal) → iteration-247 task 1.
2. **S-2 stale-index design** (warn-but-serve deliberate; review suggests opt-in `--strict-index`) → iteration-247 task 2 (decide or record).
3. **`type: review` vault-schema drift** (`reviews/` uses an undeclared type; owner decision per iter-246 plan) → iteration-247 task 3.
4. **`summary` text output `kb dir:` banner** breaks "text output is data" (review dogfood note) → iteration-247 task 4.
5. **`find --changed-since <ref>` feature request** (review dogfood note, minor) → iteration-247 task 5.

No deferral from the iter-246 plan itself was silently dropped: every unticked box was verified landed against the merged diff before ticking.

## Gates

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` — all green (4130 passed). All `xtask` gates (`check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`, `check-mutation-journal`) exit 0.
