### PR TITLE
iter-245: dot-path property filters descend sequences of maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to
 
 ### Added
 
+- **Iteration 245 — deferral carry-overs.**
+  - **UX-3 follow-up: dot-path property filters descend sequences.** A
+    frontmatter list of maps (`contacts: [{name, email}, …]`) is now
+    traversable: `--property 'contacts.email=x'` auto-descends into every
+    element and matches when any of them carries that value, while a numeric
+    segment pins one element (`contacts.0.email`). The collected values are
+    returned as a list, so the established list semantics apply unchanged
+    (`=`/`~=` match when any element matches, `!=` when none does, and a bare
+    key exists when at least one element yielded a value). Applies to every
+    filter consumer, including `--where-property` on the mutating commands.
+
 - **Iteration 244 — index remaining deferrals.**
   - **UX-3: nested dot-path property filters.** `--property 'a.b=v'` now
     traverses nested YAML mappings (`contact.email=team@example.com`

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ hyalo find --property status=draft --tag research
 # Nested properties filter by dot-path: contact.email=x@y.z traverses
 # `contact: {email: ...}`; a literal dotted key in a flat map wins first
 hyalo find --property contact.email=team@example.com
+# Lists of maps are descended too: any element matching wins, and a numeric
+# segment pins one element (`contacts.0.email`)
+hyalo find --property contacts.email=team@example.com
 # Compact filename-only projection for agents / shell pipelines
 hyalo find --property status=planned --filenames-only | sort
 # Sequence-keyed documents: glob by number (recursively reaches archived files)

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -362,7 +362,7 @@ pub(crate) struct FindFilters {
     #[arg(long, short = 'e', value_name = "REGEX")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regexp: Option<String>,
-    /// Property filter: K=V (eq), K!=V (neq), K>=V, K<=V, K>V, K<V, K (exists), !K (absent), K~=pat or K~=/pat/i (regex). Repeatable (AND)
+    /// Property filter: K=V (eq), K!=V (neq), K>=V, K<=V, K>V, K<V, K (exists), !K (absent), K~=pat or K~=/pat/i (regex). Repeatable (AND). K may be a dot-path into nested maps and sequences (contact.email, contacts.0.email, contacts.email = any element)
     #[arg(short, long = "property", value_name = "FILTER")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub properties: Vec<String>,
@@ -593,6 +593,11 @@ pub(crate) enum Commands {
             but should not under-match a real substring.\n\n\
             FILTERS: All filters are AND'd together.\n\
             - --property K=V: frontmatter property filter (supports =, !=, >, >=, <, <=, bare K for existence, !K for absence, K~=pattern or K~=/pattern/i for regex)\n\
+            \u{00a0} Dot-paths traverse nested frontmatter: a literal dotted key in a flat map wins first, \
+            then `contact.email=x` descends the map `contact: {email: x}`. Sequences are descended too: \
+            a numeric segment indexes one element (`contacts.0.email`), any other segment auto-descends into \
+            EVERY element and collects the hits (`contacts.email=x` matches when any contact has that email; \
+            `!=` matches when none does).\n\
             - --tag T: tag filter (exact or prefix via '/': 'project' matches 'project/backend' but NOT 'projects' — no substring or fuzzy matching)\n\
             - --task STATUS: task presence filter ('todo', 'done', 'any', or a single status char)\n\
             - --section HEADING: section scope filter (exclude files without a matching section; within \
@@ -645,6 +650,7 @@ pub(crate) enum Commands {
             \u{00a0} hyalo find 'error handling'\n\
             \u{00a0} hyalo find --property status=draft --tag project\n\
             \u{00a0} hyalo find --property 'title~=/^Design/i'\n\
+            \u{00a0} hyalo find --property contacts.email=team@example.com   # dot-path into a list of maps\n\
             \u{00a0} hyalo find --section 'Tasks' --task todo\n\
             \u{00a0} hyalo find --fields links --jq '[.results[] | select(.links | map(select(.path == null)) | length > 0)]'\n\
             \u{00a0} hyalo find --property status=planned --filenames-only   # agent/pipeline projection\n\

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -64,6 +64,19 @@ hyalo find --property 'title~=draft'      # title contains "draft"
 hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
 ```
 
+`K` may be a **dot-path** into nested frontmatter. A literal dotted key in a flat map is
+tried first; otherwise the path is walked. Maps descend by key, and sequences descend too:
+a numeric segment pins one element, any other segment auto-descends into *every* element and
+collects the hits — so the usual list semantics apply (`=`/`~=` match when any element
+matches, `!=` when none does):
+
+```bash
+hyalo find --property contact.email=team@example.com   # contact: {email: ...}
+hyalo find --property contacts.email=ada@example.com   # contacts: [{name, email}, ...] — any element
+hyalo find --property contacts.0.email=ada@example.com # first element only
+hyalo find --property '!contacts.phone'                # no element has a phone
+```
+
 `--title` filters by the displayed title (frontmatter `title` or first H1 heading).
 Case-insensitive substring by default; use `"/regex/"` for regex. Note: `--title` checks
 the *displayed* title, while `--property title~=` only checks the frontmatter property.

--- a/crates/hyalo-cli/tests/e2e/iteration245_followups.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration245_followups.rs
@@ -141,7 +141,11 @@ fn find_property_dot_path_sequence_index_segment() {
         &tmp,
         &["find", "--property", "contacts.0.email=ada@example.com"],
     );
-    assert_eq!(total(&json), 1, "index 0 must select the first element: {json}");
+    assert_eq!(
+        total(&json),
+        1,
+        "index 0 must select the first element: {json}"
+    );
 
     let (_, json) = run(
         &tmp,
@@ -163,7 +167,11 @@ fn find_property_dot_path_sequence_index_segment() {
         &tmp,
         &["find", "--property", "contacts.9.email=ada@example.com"],
     );
-    assert_eq!(total(&json), 0, "out-of-range index must match nothing: {json}");
+    assert_eq!(
+        total(&json),
+        0,
+        "out-of-range index must match nothing: {json}"
+    );
 }
 
 /// Existence, absence, inequality and regex all follow the established list

--- a/crates/hyalo-cli/tests/e2e/iteration245_followups.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration245_followups.rs
@@ -1,0 +1,234 @@
+//! Iteration 245 — deferral carry-overs from the iteration 244 review.
+//!
+//! - **UX-3 follow-up — dot-paths through sequences of maps**: iteration 244
+//!   taught `--property 'a.b=v'` to traverse nested *mappings*; a frontmatter
+//!   list of maps (`contacts: [{name, email}, …]`) still resolved to nothing.
+//!   Traversal now also descends sequences: a numeric segment indexes one
+//!   element (`contacts.0.email`), any other segment auto-descends into every
+//!   element and collects the hits, so the established list semantics apply
+//!   (`=`/`~=` match when any element matches, `!=` when none does).
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn hyalo_no_hints() -> Command {
+    crate::common::hyalo_no_hints()
+}
+
+fn run(tmp: &TempDir, args: &[&str]) -> (std::process::Output, Value) {
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path().to_str().unwrap())
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "`hyalo {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout not JSON: {e}: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    (output, json)
+}
+
+/// Result count from the standard envelope.
+fn total(json: &Value) -> u64 {
+    json["total"]
+        .as_u64()
+        .or_else(|| json["results"].as_array().map(|a| a.len() as u64))
+        .unwrap_or_else(|| panic!("no total/results in envelope: {json}"))
+}
+
+/// A vault with one file whose frontmatter holds a sequence of maps, and one
+/// control file that must never match.
+fn write_vault(tmp: &TempDir) {
+    std::fs::write(
+        tmp.path().join("team.md"),
+        "---\n\
+         title: Team\n\
+         contacts:\n\
+         \x20 - name: Ada\n\
+         \x20   email: ada@example.com\n\
+         \x20 - name: Grace\n\
+         \x20   email: grace@example.com\n\
+         ---\n\n# Team\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("solo.md"),
+        "---\n\
+         title: Solo\n\
+         contacts:\n\
+         \x20 - name: Alan\n\
+         \x20   email: alan@example.com\n\
+         ---\n\n# Solo\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("plain.md"),
+        "---\ntitle: Plain\n---\n\n# Plain\n",
+    )
+    .unwrap();
+}
+
+/// `contacts.email=v` must auto-descend into every element of a sequence of
+/// maps — on the disk-scan path and on the persisted-index path alike.
+#[test]
+fn find_property_dot_path_descends_sequence_of_maps() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_vault(&tmp);
+
+    // Second element of the two-element list.
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.email=grace@example.com"],
+    );
+    assert_eq!(
+        total(&json),
+        1,
+        "auto-descent must match a non-first element: {json}"
+    );
+    assert_eq!(json["results"][0]["file"], "team.md", "{json}");
+
+    // First element of a different file.
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.email=alan@example.com"],
+    );
+    assert_eq!(total(&json), 1, "{json}");
+    assert_eq!(json["results"][0]["file"], "solo.md", "{json}");
+
+    // A value that is in no element genuinely returns nothing.
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.email=nobody@example.com"],
+    );
+    assert_eq!(total(&json), 0, "{json}");
+
+    // Same verdicts through the persisted index.
+    run(&tmp, &["create-index"]);
+    let (_, json) = run(
+        &tmp,
+        &[
+            "find",
+            "--property",
+            "contacts.email=grace@example.com",
+            "--index",
+        ],
+    );
+    assert_eq!(
+        total(&json),
+        1,
+        "index path must agree with the disk scan: {json}"
+    );
+}
+
+/// A numeric segment pins one element: `contacts.0.email` is the first
+/// contact only, and an out-of-range index matches nothing.
+#[test]
+fn find_property_dot_path_sequence_index_segment() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_vault(&tmp);
+
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.0.email=ada@example.com"],
+    );
+    assert_eq!(total(&json), 1, "index 0 must select the first element: {json}");
+
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.1.email=ada@example.com"],
+    );
+    assert_eq!(
+        total(&json),
+        0,
+        "index 1 must not match the first element's value: {json}"
+    );
+
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.1.email=grace@example.com"],
+    );
+    assert_eq!(total(&json), 1, "{json}");
+
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.9.email=ada@example.com"],
+    );
+    assert_eq!(total(&json), 0, "out-of-range index must match nothing: {json}");
+}
+
+/// Existence, absence, inequality and regex all follow the established list
+/// semantics once the sequence has been descended.
+#[test]
+fn find_property_dot_path_sequence_operators() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_vault(&tmp);
+
+    // Existence: both files with contacts, not `plain.md`.
+    let (_, json) = run(&tmp, &["find", "--property", "contacts.email"]);
+    assert_eq!(total(&json), 2, "{json}");
+
+    // Absence: only the file with no contacts at all.
+    let (_, json) = run(&tmp, &["find", "--property", "!contacts.email"]);
+    assert_eq!(total(&json), 1, "{json}");
+    assert_eq!(json["results"][0]["file"], "plain.md", "{json}");
+
+    // A key no element carries is absent everywhere.
+    let (_, json) = run(&tmp, &["find", "--property", "contacts.phone"]);
+    assert_eq!(total(&json), 0, "{json}");
+
+    // `!=` means "no element equals": team.md has Ada, solo.md does not.
+    let (_, json) = run(
+        &tmp,
+        &["find", "--property", "contacts.email!=ada@example.com"],
+    );
+    assert_eq!(total(&json), 1, "{json}");
+    assert_eq!(json["results"][0]["file"], "solo.md", "{json}");
+
+    // Regex matches when any element matches.
+    let (_, json) = run(&tmp, &["find", "--property", "contacts.name~=^Grac"]);
+    assert_eq!(total(&json), 1, "{json}");
+    assert_eq!(json["results"][0]["file"], "team.md", "{json}");
+}
+
+/// The same resolution feeds every filter consumer, not just `find` — a
+/// mutating command's `--where-property` sees sequence dot-paths too.
+#[test]
+fn where_property_dot_path_descends_sequence_of_maps() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_vault(&tmp);
+
+    let (_, json) = run(
+        &tmp,
+        &[
+            "set",
+            "--property",
+            "status=reviewed",
+            "--where-property",
+            "contacts.email=grace@example.com",
+            "--glob",
+            "**/*.md",
+        ],
+    );
+    assert_eq!(
+        json["results"]["modified"]
+            .as_array()
+            .map(std::vec::Vec::len),
+        Some(1),
+        "--where-property must select exactly the file with that contact: {json}"
+    );
+    assert_eq!(json["results"]["modified"][0], "team.md", "{json}");
+
+    let (_, json) = run(&tmp, &["find", "--property", "status=reviewed"]);
+    assert_eq!(total(&json), 1, "{json}");
+    assert_eq!(json["results"][0]["file"], "team.md", "{json}");
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -33,6 +33,7 @@ mod iteration238_followups;
 mod iteration241_followups;
 mod iteration243_followups;
 mod iteration244_followups;
+mod iteration245_followups;
 mod iteration_ergonomics;
 mod jq;
 mod json_errors;

--- a/crates/hyalo-core/src/filter/match_props.rs
+++ b/crates/hyalo-core/src/filter/match_props.rs
@@ -65,10 +65,12 @@ impl PropertyFilter {
     pub fn matches(&self, props: &IndexMap<String, Value>) -> bool {
         match self {
             PropertyFilter::Absent { key } => resolve_prop(props, key).is_none(),
-            PropertyFilter::RegexMatch { key, .. } => resolve_prop(props, key)
-                .is_some_and(|resolved| self.matches_value(&resolved)),
-            PropertyFilter::Scalar { name, .. } => resolve_prop(props, name)
-                .is_some_and(|resolved| self.matches_value(&resolved)),
+            PropertyFilter::RegexMatch { key, .. } => {
+                resolve_prop(props, key).is_some_and(|resolved| self.matches_value(&resolved))
+            }
+            PropertyFilter::Scalar { name, .. } => {
+                resolve_prop(props, name).is_some_and(|resolved| self.matches_value(&resolved))
+            }
         }
     }
 

--- a/crates/hyalo-core/src/filter/match_props.rs
+++ b/crates/hyalo-core/src/filter/match_props.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::Value;
@@ -56,46 +58,17 @@ pub fn tag_matches(tag: &str, query: &str) -> bool {
 
 impl PropertyFilter {
     /// Return true if the given property map satisfies this filter.
+    ///
+    /// Resolution goes through [`resolve_prop`], so nested dot-paths (maps and
+    /// sequences of maps) are handled here; the comparison itself is shared
+    /// with [`PropertyFilter::matches_value`].
     pub fn matches(&self, props: &IndexMap<String, Value>) -> bool {
         match self {
             PropertyFilter::Absent { key } => resolve_prop(props, key).is_none(),
-            PropertyFilter::RegexMatch { key, pattern } => {
-                let Some(yaml_val) = resolve_prop(props, key) else {
-                    return false;
-                };
-                yaml_value_regex_match(yaml_val, pattern)
-            }
-            PropertyFilter::Scalar { name, op, value } => {
-                if *op == FilterOp::Exists {
-                    return resolve_prop(props, name).is_some();
-                }
-
-                let Some(yaml_val) = resolve_prop(props, name) else {
-                    return false;
-                };
-                let filter_val = value.as_deref().unwrap_or("");
-
-                match op {
-                    FilterOp::Eq => yaml_value_eq(yaml_val, filter_val),
-                    FilterOp::NotEq => !yaml_value_eq(yaml_val, filter_val),
-                    FilterOp::Gt => {
-                        yaml_cmp(yaml_val, filter_val) == Some(std::cmp::Ordering::Greater)
-                    }
-                    FilterOp::Gte => matches!(
-                        yaml_cmp(yaml_val, filter_val),
-                        Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
-                    ),
-                    FilterOp::Lt => {
-                        yaml_cmp(yaml_val, filter_val) == Some(std::cmp::Ordering::Less)
-                    }
-                    FilterOp::Lte => matches!(
-                        yaml_cmp(yaml_val, filter_val),
-                        Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
-                    ),
-                    // SAFETY: Exists is handled by the early return above
-                    FilterOp::Exists => unreachable!("Exists handled by early return"),
-                }
-            }
+            PropertyFilter::RegexMatch { key, .. } => resolve_prop(props, key)
+                .is_some_and(|resolved| self.matches_value(&resolved)),
+            PropertyFilter::Scalar { name, .. } => resolve_prop(props, name)
+                .is_some_and(|resolved| self.matches_value(&resolved)),
         }
     }
 
@@ -153,28 +126,80 @@ impl PropertyFilter {
 // ---------------------------------------------------------------------------
 
 /// Resolve a property key against a frontmatter map, supporting nested
-/// dot-path traversal (UX-3, iter-244).
+/// dot-path traversal (UX-3, iter-244; arrays of maps added in iter-245).
 ///
 /// `a.b=v` first tries the literal key `"a.b"` (a flat map may genuinely
-/// contain dotted keys), then falls back to walking the nested map: `a.b`
-/// matches `{a: {b: …}}`. Traversal only descends through JSON objects —
-/// `a.b` against `{a: [1,2]}` does not resolve. A missing segment yields
-/// `None`, which the callers turn into the same verdict as a missing flat
-/// key (fails `Scalar`/`RegexMatch`, passes `Absent`).
-fn resolve_prop<'a>(props: &'a IndexMap<String, Value>, key: &str) -> Option<&'a Value> {
+/// contain dotted keys), then falls back to walking the nested value:
+///
+/// - **Maps** — `a.b` matches `{a: {b: …}}`; the segment is a key lookup.
+/// - **Sequences** — a numeric segment indexes (`contacts.0.email` is the
+///   first element's `email`); any other segment auto-descends into *every*
+///   element and collects the hits, so `contacts.email` against
+///   `contacts: [{email: a}, {email: b}]` resolves to `[a, b]`. Because the
+///   collected values are returned as a sequence, the existing sequence
+///   semantics apply unchanged: `=`/`~=` match when **any** element matches,
+///   `!=` when **none** does, and a bare key exists when at least one element
+///   yielded a value.
+///
+/// A missing segment yields `None`, which the callers turn into the same
+/// verdict as a missing flat key (fails `Scalar`/`RegexMatch`, passes
+/// `Absent`).
+///
+/// The return type is a [`Cow`] so the common flat/map path stays borrowed;
+/// only auto-descent through a sequence allocates.
+fn resolve_prop<'a>(props: &'a IndexMap<String, Value>, key: &str) -> Option<Cow<'a, Value>> {
     if let Some(v) = props.get(key) {
-        return Some(v);
+        return Some(Cow::Borrowed(v));
     }
-    if !key.contains('.') {
-        return None;
+    let (first, rest) = key.split_once('.')?;
+    resolve_path(props.get(first)?, Some(rest))
+}
+
+/// Walk `path` (a dot-separated remainder, `None` once exhausted) from `value`.
+///
+/// See [`resolve_prop`] for the traversal rules. Recursion depth is bounded by
+/// the number of path segments times the nesting depth of the frontmatter
+/// value, both of which are user data of bounded size in practice.
+fn resolve_path<'a>(value: &'a Value, path: Option<&str>) -> Option<Cow<'a, Value>> {
+    let Some(path) = path else {
+        return Some(Cow::Borrowed(value));
+    };
+    let (segment, rest) = match path.split_once('.') {
+        Some((segment, rest)) => (segment, Some(rest)),
+        None => (path, None),
+    };
+    match value {
+        Value::Object(map) => resolve_path(map.get(segment)?, rest),
+        Value::Array(items) => {
+            // Indexed segment form: `contacts.0.email`.
+            if let Ok(index) = segment.parse::<usize>()
+                && let Some(item) = items.get(index)
+            {
+                return resolve_path(item, rest);
+            }
+            // Auto-descent: apply the *same* segment to every element and
+            // collect the hits into a sequence ("any element matches").
+            let mut collected: Vec<Value> = Vec::new();
+            for item in items {
+                if let Some(found) = resolve_path(item, Some(path)) {
+                    match found.into_owned() {
+                        // Flatten, so `a.b.c` over nested lists stays a flat
+                        // list of leaves rather than a list of lists.
+                        Value::Array(inner) => collected.extend(inner),
+                        other => collected.push(other),
+                    }
+                }
+            }
+            match collected.len() {
+                0 => None,
+                // A single hit is returned bare so ordering ops (`>`, `<`)
+                // still work; they cannot compare a sequence.
+                1 => collected.pop().map(Cow::Owned),
+                _ => Some(Cow::Owned(Value::Array(collected))),
+            }
+        }
+        _ => None,
     }
-    let mut segments = key.split('.');
-    let first = segments.next()?;
-    let mut current = props.get(first)?;
-    for segment in segments {
-        current = current.as_object()?.get(segment)?;
-    }
-    Some(current)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -117,6 +117,213 @@ mod tests {
         assert!(!f.matches(&props));
     }
 
+    // ------------------------------------------------------------------
+    // UX-3 follow-up (iter-245): dot-paths through sequences of maps
+    // ------------------------------------------------------------------
+
+    /// `contacts: [{name, email}, …]` — a non-numeric segment auto-descends
+    /// into every element, so `contacts.email=v` matches when ANY element's
+    /// `email` equals `v`.
+    fn contacts_props() -> IndexMap<String, Value> {
+        let mut props = IndexMap::new();
+        props.insert(
+            "contacts".to_owned(),
+            json!([
+                {"name": "Ada", "email": "ada@example.com"},
+                {"name": "Grace", "email": "grace@example.com"},
+            ]),
+        );
+        props
+    }
+
+    #[test]
+    fn dot_path_array_of_maps_matches_any_element() {
+        let props = contacts_props();
+        for value in ["ada@example.com", "grace@example.com"] {
+            let f = parse_property_filter(&format!("contacts.email={value}")).unwrap();
+            assert!(f.matches(&props), "expected {value} to match any element");
+        }
+    }
+
+    #[test]
+    fn dot_path_array_of_maps_non_matching_value_fails() {
+        let f = parse_property_filter("contacts.email=nobody@example.com").unwrap();
+        assert!(!f.matches(&contacts_props()));
+    }
+
+    #[test]
+    fn dot_path_array_of_maps_missing_key_fails() {
+        let f = parse_property_filter("contacts.phone=555").unwrap();
+        assert!(!f.matches(&contacts_props()));
+    }
+
+    #[test]
+    fn dot_path_array_index_segment_selects_one_element() {
+        let props = contacts_props();
+        assert!(
+            parse_property_filter("contacts.0.email=ada@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            parse_property_filter("contacts.1.email=grace@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+        // An index pins the element: element 1 is not Ada.
+        assert!(
+            !parse_property_filter("contacts.1.email=ada@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+    }
+
+    #[test]
+    fn dot_path_array_index_out_of_range_yields_no_match() {
+        let props = contacts_props();
+        assert!(
+            !parse_property_filter("contacts.9.email=ada@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(!parse_property_filter("contacts.9.email").unwrap().matches(&props));
+    }
+
+    #[test]
+    fn dot_path_array_index_into_scalar_sequence() {
+        let mut props = IndexMap::new();
+        props.insert("tags".to_owned(), json!(["alpha", "beta"]));
+        assert!(parse_property_filter("tags.0=alpha").unwrap().matches(&props));
+        assert!(parse_property_filter("tags.1=beta").unwrap().matches(&props));
+        assert!(!parse_property_filter("tags.0=beta").unwrap().matches(&props));
+        // A non-numeric segment cannot descend into scalar elements.
+        assert!(!parse_property_filter("tags.name=alpha").unwrap().matches(&props));
+    }
+
+    #[test]
+    fn dot_path_array_not_eq_requires_no_element_to_match() {
+        let props = contacts_props();
+        // One element matches, so "not equal" is false — the same semantics a
+        // flat list property already has.
+        assert!(
+            !parse_property_filter("contacts.email!=ada@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            parse_property_filter("contacts.email!=nobody@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+    }
+
+    #[test]
+    fn dot_path_array_regex_matches_any_element() {
+        let props = contacts_props();
+        assert!(
+            parse_property_filter("contacts.email~=^grace@")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            !parse_property_filter("contacts.email~=^nobody@")
+                .unwrap()
+                .matches(&props)
+        );
+    }
+
+    #[test]
+    fn dot_path_array_exists_and_absent() {
+        let props = contacts_props();
+        assert!(parse_property_filter("contacts.email").unwrap().matches(&props));
+        assert!(!parse_property_filter("!contacts.email").unwrap().matches(&props));
+        assert!(!parse_property_filter("contacts.phone").unwrap().matches(&props));
+        assert!(parse_property_filter("!contacts.phone").unwrap().matches(&props));
+    }
+
+    #[test]
+    fn dot_path_array_single_hit_supports_ordering_ops() {
+        // Exactly one element yields a value, so it is returned bare and the
+        // ordering operators (which cannot compare a sequence) still work.
+        let mut props = IndexMap::new();
+        props.insert(
+            "scores".to_owned(),
+            json!([{"name": "unit"}, {"name": "e2e", "value": 42}]),
+        );
+        assert!(parse_property_filter("scores.value>10").unwrap().matches(&props));
+        assert!(!parse_property_filter("scores.value>100").unwrap().matches(&props));
+        assert!(parse_property_filter("scores.value<=42").unwrap().matches(&props));
+    }
+
+    #[test]
+    fn dot_path_nested_sequences_flatten_to_leaves() {
+        let mut props = IndexMap::new();
+        props.insert(
+            "groups".to_owned(),
+            json!([
+                {"members": [{"name": "Ada"}, {"name": "Grace"}]},
+                {"members": [{"name": "Alan"}]},
+            ]),
+        );
+        for name in ["Ada", "Grace", "Alan"] {
+            assert!(
+                parse_property_filter(&format!("groups.members.name={name}"))
+                    .unwrap()
+                    .matches(&props),
+                "expected {name} to be reachable through both sequence levels"
+            );
+        }
+        assert!(
+            !parse_property_filter("groups.members.name=Nobody")
+                .unwrap()
+                .matches(&props)
+        );
+        // Mixed index + auto-descent segments compose.
+        assert!(
+            parse_property_filter("groups.1.members.0.name=Alan")
+                .unwrap()
+                .matches(&props)
+        );
+    }
+
+    #[test]
+    fn dot_path_map_then_sequence_composes() {
+        let mut props = IndexMap::new();
+        props.insert(
+            "meta".to_owned(),
+            json!({"contacts": [{"email": "ada@example.com"}]}),
+        );
+        assert!(
+            parse_property_filter("meta.contacts.email=ada@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            !parse_property_filter("meta.contacts.email=nobody@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+    }
+
+    #[test]
+    fn dot_path_literal_dotted_key_still_wins_over_sequence_descent() {
+        let mut props = contacts_props();
+        props.insert(
+            "contacts.email".to_owned(),
+            Value::String("flat".to_owned()),
+        );
+        assert!(
+            parse_property_filter("contacts.email=flat")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            !parse_property_filter("contacts.email=ada@example.com")
+                .unwrap()
+                .matches(&props)
+        );
+    }
+
     #[test]
     fn parse_not_eq() {
         let f = parse_property_filter("status!=superseded").unwrap();

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -186,18 +186,38 @@ mod tests {
                 .unwrap()
                 .matches(&props)
         );
-        assert!(!parse_property_filter("contacts.9.email").unwrap().matches(&props));
+        assert!(
+            !parse_property_filter("contacts.9.email")
+                .unwrap()
+                .matches(&props)
+        );
     }
 
     #[test]
     fn dot_path_array_index_into_scalar_sequence() {
         let mut props = IndexMap::new();
         props.insert("tags".to_owned(), json!(["alpha", "beta"]));
-        assert!(parse_property_filter("tags.0=alpha").unwrap().matches(&props));
-        assert!(parse_property_filter("tags.1=beta").unwrap().matches(&props));
-        assert!(!parse_property_filter("tags.0=beta").unwrap().matches(&props));
+        assert!(
+            parse_property_filter("tags.0=alpha")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            parse_property_filter("tags.1=beta")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            !parse_property_filter("tags.0=beta")
+                .unwrap()
+                .matches(&props)
+        );
         // A non-numeric segment cannot descend into scalar elements.
-        assert!(!parse_property_filter("tags.name=alpha").unwrap().matches(&props));
+        assert!(
+            !parse_property_filter("tags.name=alpha")
+                .unwrap()
+                .matches(&props)
+        );
     }
 
     #[test]
@@ -235,10 +255,26 @@ mod tests {
     #[test]
     fn dot_path_array_exists_and_absent() {
         let props = contacts_props();
-        assert!(parse_property_filter("contacts.email").unwrap().matches(&props));
-        assert!(!parse_property_filter("!contacts.email").unwrap().matches(&props));
-        assert!(!parse_property_filter("contacts.phone").unwrap().matches(&props));
-        assert!(parse_property_filter("!contacts.phone").unwrap().matches(&props));
+        assert!(
+            parse_property_filter("contacts.email")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            !parse_property_filter("!contacts.email")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            !parse_property_filter("contacts.phone")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            parse_property_filter("!contacts.phone")
+                .unwrap()
+                .matches(&props)
+        );
     }
 
     #[test]
@@ -250,9 +286,21 @@ mod tests {
             "scores".to_owned(),
             json!([{"name": "unit"}, {"name": "e2e", "value": 42}]),
         );
-        assert!(parse_property_filter("scores.value>10").unwrap().matches(&props));
-        assert!(!parse_property_filter("scores.value>100").unwrap().matches(&props));
-        assert!(parse_property_filter("scores.value<=42").unwrap().matches(&props));
+        assert!(
+            parse_property_filter("scores.value>10")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            !parse_property_filter("scores.value>100")
+                .unwrap()
+                .matches(&props)
+        );
+        assert!(
+            parse_property_filter("scores.value<=42")
+                .unwrap()
+                .matches(&props)
+        );
     }
 
     #[test]

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3058,3 +3058,64 @@ is "the agent doesn't know the vault layout", the fix is teaching (help text,
 skills), not a new selector. Convenience flags for agents are a bad trade —
 the agent doesn't mind typing 40 characters; it minds not being able to
 predict behavior.
+
+## DEC-243: dot-path property filters descend sequences by auto-descent, with numeric segments as an index (2026-08-28)
+
+Implemented in [[iterations/iteration-245-deferral-carryovers]], closing the
+UX-3 follow-up carried out of [[iterations/iteration-244-index-remaining-deferrals]].
+
+**Decision.** `--property 'contacts.email=v'` traverses a frontmatter
+*sequence* as well as a mapping. Both forms the plan offered are supported,
+and they compose:
+
+- a **numeric** segment indexes one element — `contacts.0.email`;
+- **any other** segment auto-descends into *every* element and collects the
+  hits into a sequence — `contacts.email` over
+  `contacts: [{email: a}, {email: b}]` resolves to `[a, b]`.
+
+**Why both.** Auto-descent alone cannot express "the first contact"; an
+index alone forces the caller to know the list's shape, which is exactly
+what a vault-wide query does not know. The precedence rule keeps them
+unambiguous: a segment is only read as an index when the value at hand is a
+sequence *and* the segment parses as an in-range `usize`. A mapping keyed
+`"0"` is still a key lookup, and an out-of-range index falls through to
+auto-descent (which then finds nothing, rather than silently matching a
+neighbour).
+
+**Why collect into a sequence.** Returning the hits as a list means the
+established list semantics apply with no new operator rules to learn or
+document: `=`/`~=` match when any element matches, `!=` when none does, a
+bare key exists when at least one element yielded a value, and `!K` passes
+when none did. A single hit is returned bare so the ordering operators
+(`>`, `<`, …), which cannot compare a sequence, keep working. Nested
+sequences flatten, so `groups.members.name` reaches leaves through two
+levels.
+
+**Cost.** `resolve_prop` now returns `Cow<'_, Value>`: the flat-key and
+mapping paths stay borrowed, and only auto-descent through a sequence
+allocates — a per-file cost paid solely by queries that actually use the
+form. The literal-dotted-key-wins rule from iter-244 is unchanged.
+
+## DEC-244: v0.21.0 is deferred; the release stays parked pending an explicit owner decision (2026-08-28)
+
+Recorded in [[iterations/iteration-245-deferral-carryovers]] against that
+plan's second task ("cut v0.21.0 … or record the owner's explicit decision
+to stay on 0.20.x; owner call, do not tag without it").
+
+**Decision.** No tag is cut. Releases are on hold by standing owner
+decision, and the loop that implemented iteration 245 was explicitly barred
+from tagging, running `/release`, or invoking `gh release create`. The
+release question is therefore closed *as recorded*, not as executed: the
+`Unreleased` section of the changelog keeps accumulating, and the workspace
+stays on 0.20.0.
+
+**What is queued for whenever the release is unparked.** The `Unreleased`
+section already justifies a minor bump under DEC-101 version discipline —
+BUG-4 post-mutation BM25 parity, UX-3 nested dot-path filters and this
+iteration's sequence follow-up, UX-6 case-insensitive link resolution, and
+the `new` link-graph upsert. None of it is a breaking change, so 0.21.0
+remains the right number when the owner says go.
+
+**How to unpark.** The owner runs `/release` (the `release` skill) and
+picks the version; nothing in this decision constrains that choice beyond
+recording that the accumulated work is minor-bump-shaped.

--- a/hyalo-knowledgebase/iterations/iteration-245-deferral-carryovers.md
+++ b/hyalo-knowledgebase/iterations/iteration-245-deferral-carryovers.md
@@ -5,7 +5,7 @@ date: 2026-09-14
 tags:
   - iteration
   - carry-over
-status: planned
+status: completed
 branch: iter-245/deferral-carryovers
 ---
 
@@ -27,22 +27,22 @@ left as explicit non-goal owner decisions) from being silently forgotten.
 
 ## Tasks
 
-- [ ] UX-3 follow-up — extend dot-path property-filter traversal to nested
+- [x] UX-3 follow-up — extend dot-path property-filter traversal to nested
       arrays of maps (e.g. `contacts` as a list of `{name, email}` maps):
       either auto-descent ("any element matches") or an indexed segment
       form; decide, implement, and add unit + e2e tests alongside the
       existing object traversal in `resolve_prop`
-- [ ] DEC-101 / release — cut v0.21.0 (BUG-4 parity + UX-3/UX-6 warrant a
+- [x] DEC-101 / release — cut v0.21.0 (BUG-4 parity + UX-3/UX-6 warrant a
       minor bump) or record the owner's explicit decision to stay on
       0.20.x; owner call, do not tag without it
 
 ## Acceptance criteria
 
-- [ ] `find --property '<path>.<key>=v'` handles frontmatter where the
+- [x] `find --property '<path>.<key>=v'` handles frontmatter where the
       intermediate segment is an array of maps (documented behaviour +
       tests), or the limitation is documented as a known constraint with a
       workaround hint
-- [ ] The release question is either executed or explicitly closed with an
+- [x] The release question is either executed or explicitly closed with an
       owner-recorded decision
 
 ## Non-goals
@@ -50,6 +50,36 @@ left as explicit non-goal owner decisions) from being silently forgotten.
 - Concurrency guarantees — permanent non-goal per owner verdict
   2026-08-27 (single-writer atomicity only); listed here so it is visible,
   not to be worked on
+
+## Outcome
+
+- **UX-3 follow-up — implemented, not documented away.** `resolve_prop` in
+  `crates/hyalo-core/src/filter/match_props.rs` now walks sequences as well
+  as mappings: a numeric segment indexes one element
+  (`contacts.0.email`), any other segment auto-descends into every element
+  and collects the hits into a sequence (`contacts.email` matches when any
+  contact carries the value). Both forms the plan offered are supported and
+  compose; see [[decision-log#DEC-243: dot-path property filters descend sequences by auto-descent, with numeric segments as an index (2026-08-28)]] for the precedence rule and why the
+  hits are collected as a list. `resolve_prop` returns `Cow<'_, Value>` so
+  only the sequence path allocates. `PropertyFilter::matches` now delegates
+  its comparison to `matches_value`, removing the duplicated operator match.
+- **Tests.** 12 new unit tests in `crates/hyalo-core/src/filter/mod.rs`
+  (auto-descent, index segments, out-of-range index, scalar sequences,
+  `!=`/regex/exists/absent, single-hit ordering ops, nested-sequence
+  flattening, map-then-sequence composition, literal-dotted-key precedence)
+  and 4 new e2e tests in
+  `crates/hyalo-cli/tests/e2e/iteration245_followups.rs` covering the disk
+  scan, the persisted index, and `set --where-property`.
+- **Docs.** `find --help` FILTERS block, the `--property` short help, an
+  example line, `README.md`, `CHANGELOG.md`, and both bundled skill
+  documents (`crates/hyalo-cli/templates/skill-hyalo.md`,
+  `pi-package/skills/hyalo/SKILL.md`) now describe dot-path traversal
+  through sequences.
+- **Release — recorded, not executed.** No tag was cut: releases are on
+  hold by standing owner decision and the implementing loop was barred from
+  tagging. The question is closed as a recorded decision,
+  [[decision-log#DEC-244: v0.21.0 is deferred; the release stays parked pending an explicit owner decision (2026-08-28)]], which also lists what the `Unreleased` section
+  has queued for whenever the release is unparked.
 
 ## Links
 

--- a/pi-package/skills/hyalo/SKILL.md
+++ b/pi-package/skills/hyalo/SKILL.md
@@ -110,6 +110,19 @@ hyalo find --property 'title~=draft'      # title contains "draft"
 hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
 ```
 
+`K` may be a **dot-path** into nested frontmatter. A literal dotted key in a flat map is
+tried first; otherwise the path is walked. Maps descend by key, and sequences descend too:
+a numeric segment pins one element, any other segment auto-descends into *every* element and
+collects the hits — so the usual list semantics apply (`=`/`~=` match when any element
+matches, `!=` when none does):
+
+```bash
+hyalo find --property contact.email=team@example.com   # contact: {email: ...}
+hyalo find --property contacts.email=ada@example.com   # contacts: [{name, email}, ...] — any element
+hyalo find --property contacts.0.email=ada@example.com # first element only
+hyalo find --property '!contacts.phone'                # no element has a phone
+```
+
 ## Schema & Lint Integration
 
 Hyalo supports frontmatter schema validation. Define schemas in `.hyalo.toml` then run:


### PR DESCRIPTION
## Summary

Implements [iteration 245](hyalo-knowledgebase/iterations/iteration-245-deferral-carryovers.md) — the two deferral carry-overs from the iteration 244 review.

- **UX-3 follow-up — dot-path property filters now descend sequences.** Iteration 244 taught `--property 'a.b=v'` to traverse nested *mappings*; a frontmatter list of maps (`contacts: [{name, email}, …]`) still resolved to nothing. `resolve_prop` (`crates/hyalo-core/src/filter/match_props.rs`) now walks sequences too: a **numeric** segment indexes one element (`contacts.0.email`), any **other** segment auto-descends into *every* element and collects the hits into a sequence (`contacts.email=x` matches when any contact carries that email). Both forms the plan offered are supported and compose (`groups.1.members.0.name`). Because the hits are returned as a list, the established list semantics apply with no new operator rules: `=`/`~=` match when any element matches, `!=` when none does, a bare key exists when at least one element yielded a value. A single hit is returned bare so the ordering operators (`>`, `<`) keep working. Nested sequences flatten to leaves.
- **Cost is paid only by queries that use it.** `resolve_prop` returns `Cow<'_, Value>`: the flat-key and mapping paths stay borrowed, and only sequence auto-descent allocates. The iter-244 rule that a literal dotted key in a flat map wins over traversal is unchanged. Applies to every filter consumer, including `--where-property` on the mutating commands.
- **Drive-by simplification.** `PropertyFilter::matches` now delegates its comparison to `matches_value`, removing a duplicated ~35-line operator `match` that had to be kept in sync by hand.
- **Release task — closed as *recorded*, not executed.** No tag was cut and no release was run: releases are on hold by standing owner decision, and this loop was explicitly barred from tagging / `gh release create` / `/release`. The plan's second task is closed by a decision-log entry, **DEC-244**, which defers v0.21.0 pending an explicit owner decision and lists what `Unreleased` has queued for whenever it is unparked (BUG-4 parity, UX-3 + this follow-up, UX-6, `new` link-graph upsert — all minor-bump-shaped). **DEC-243** records the traversal design and why both segment forms exist.

## Test plan

- [x] `cargo fmt` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace -q` — all green, no failures.
- [x] xtask gates all exit 0: `check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`, `check-mutation-journal`.
- [x] **12 new unit tests** (`crates/hyalo-core/src/filter/mod.rs`): auto-descent over a sequence of maps, non-matching value, missing key, index segment selection, out-of-range index, index into a scalar sequence, `!=` requiring no element to match, regex on any element, exists/absent, single-hit ordering ops, nested-sequence flattening + mixed index/auto-descent, map-then-sequence composition, literal-dotted-key precedence.
- [x] **4 new e2e tests** (`crates/hyalo-cli/tests/e2e/iteration245_followups.rs`): auto-descent on the disk-scan path *and* through the persisted index (verdicts must agree), index-segment selection incl. out-of-range, the operator matrix, and `set --where-property` proving it reaches the mutating commands.
- [x] Dogfooded against the real knowledgebase with the release binary: `hyalo find --property 'tags.0=iteration' --count` → 196.
- [x] `hyalo lint` clean on the touched knowledgebase files; `hyalo links fix --dry-run` shows 0 broken links and no new broken anchors (5 pre-existing, unchanged).
- [x] Docs updated in the same PR: `find --help` FILTERS block + `--property` short help + a new example line, `README.md`, `CHANGELOG.md`, and both bundled skill documents (`crates/hyalo-cli/templates/skill-hyalo.md`, `pi-package/skills/hyalo/SKILL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS

## Carry-over

Carry-over sweep for iteration 245: no items to place.

- Both plan tasks (UX-3 sequence-of-maps traversal, DEC-101 release call) landed in this PR and both ACs are ticked and verified against the diff.
- The local `/review-pr` pass (local-only) found 0 issues — no fixes, no new deferrals.
- No `[deferred …]` annotations were introduced by this iteration's plan or outcome section.
- The only forward-looking item is DEC-244 (release stays parked pending an explicit owner decision) — that is itself the closure of a task, not an open carry-over; nothing further to schedule.
- The `Concurrency guarantees` line under Non-goals is a **permanent** non-goal per owner verdict 2026-08-27, not a deferral — explicitly not to be worked on, so it is not carried anywhere.

iteration-246-help-coherence-review-followups.md was checked and needs no edits: it predates this run's iteration (already `status: completed`, merged as PR #283) and there is nothing from iteration 245 to fold into it.
