### PR TITLE
fix(publish): vendor pi-package files into hyalo-cli so cargo package can build the tarball

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -25,5 +25,7 @@ jobs:
         run: cargo run -p xtask -- check-command-reference
       - name: Check bundled skills pass the skills profile
         run: cargo run -p xtask -- check-bundled-skills
+      - name: Check pi-package vendored copies are in sync
+        run: cargo run -p xtask -- check-pi-package-sync
       - name: Check mutating commands go through MutationJournal
         run: cargo run -p xtask -- check-mutation-journal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `hyalo-cli` crates.io publish (v0.21.0) failed at the tarball verify step because the pi integration files were embedded via `include_str!` reaching outside the crate into the top-level `pi-package/` directory, which `cargo package` cannot see. The four files are now vendored inside `crates/hyalo-cli/templates/pi/`, kept in sync with `pi-package/` by a new `check-pi-package-sync` CI gate (`just sync-pi-package` to fix drift).
+
 ## [0.21.0] - 2026-08-28
 
 ### Added

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -15,16 +15,24 @@ const SKILL_CONTENT: &str = include_str!("../../templates/skill-hyalo.md");
 const TIDY_SKILL_CONTENT: &str = include_str!("../../templates/skill-hyalo-tidy.md");
 const RULE_TEMPLATE: &str = include_str!("../../templates/rule-knowledgebase.md");
 
-// Single source of truth (iter-237): the pi integration lives in the
-// top-level `pi-package/` directory — the same layout `pi install
-// git:github.com/ractive/hyalo` consumes — and is embedded here directly via
-// `include_str!`. There is no second template copy, so package/binary drift
-// is impossible by construction.
-const PI_SKILL_CONTENT: &str = include_str!("../../../../pi-package/skills/hyalo/SKILL.md");
-const PI_TIDY_SKILL_CONTENT: &str =
-    include_str!("../../../../pi-package/skills/hyalo-tidy/SKILL.md");
-const PI_EXTENSION_CONTENT: &str = include_str!("../../../../pi-package/extensions/hyalo.ts");
-const PI_PACKAGE_JSON_CONTENT: &str = include_str!("../../../../pi-package/package.json");
+// The top-level `pi-package/` directory — the same layout `pi install
+// git:github.com/ractive/hyalo` consumes — is the canonical source for the pi
+// integration (iter-237). It used to be embedded here directly via
+// `include_str!("../../../../pi-package/...")`, but `cargo package` builds
+// the crate's verify tarball with only the crate directory on disk, so a
+// `include_str!` reaching outside `crates/hyalo-cli/` fails the tarball build
+// with "No such file or directory" — this broke the `hyalo-cli` 0.21.0
+// crates.io publish on 2026-08-29 (`cargo publish` failed at the verify
+// step). The fix vendors byte-identical copies under
+// `crates/hyalo-cli/templates/pi/`, embedded from there instead. The
+// `check-pi-package-sync` xtask gate (`just sync-pi-package` to fix drift)
+// fails CI if the vendored copies ever diverge from `pi-package/`, so this
+// is a second file, not a second source of truth. See DEC-250 in the
+// knowledgebase for the discussion of alternatives considered.
+const PI_SKILL_CONTENT: &str = include_str!("../../templates/pi/skills/hyalo/SKILL.md");
+const PI_TIDY_SKILL_CONTENT: &str = include_str!("../../templates/pi/skills/hyalo-tidy/SKILL.md");
+const PI_EXTENSION_CONTENT: &str = include_str!("../../templates/pi/extensions/hyalo.ts");
+const PI_PACKAGE_JSON_CONTENT: &str = include_str!("../../templates/pi/package.json");
 
 const PI_INSTALL_HINT: &str = "tip: to get extension and skill updates automatically, install the pi package instead: pi install git:github.com/ractive/hyalo";
 

--- a/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
+++ b/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
@@ -1,0 +1,485 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type, type Static } from "typebox";
+import * as path from "node:path";
+
+const HYALO_TIMEOUT_MS = 60_000;
+
+interface HyaloToolArgs {
+  /** The hyalo subcommand (find, read, set, summary, lint, etc.) */
+  subcommand: string;
+  /** Arguments to pass to hyalo */
+  args?: string[];
+  /** Use --format text for compact output (default: true) */
+  formatText?: boolean;
+  /** Use --jq filter (mutually exclusive with formatText) */
+  jq?: string;
+  /** Path to a snapshot index created with `hyalo create-index` */
+  indexFile?: string;
+}
+
+/**
+ * Shared execution core for every hyalo tool (generic + typed): runs the
+ * argv through `pi.exec` and renders exit codes / stderr / stdout into a
+ * uniform tool result. One path — no behavioral divergence between tools.
+ */
+async function runHyalo(
+  pi: ExtensionAPI,
+  argv: string[],
+  signal?: AbortSignal,
+) {
+  try {
+    const { stdout, stderr, code } = await pi.exec("hyalo", argv, {
+      signal,
+      timeout: HYALO_TIMEOUT_MS,
+    });
+
+    if (code !== 0) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `hyalo ${argv[0]} failed with exit code ${code}`,
+          },
+          ...(stderr ? [{ type: "text" as const, text: `Stderr:\n${stderr}` }] : []),
+          ...(stdout ? [{ type: "text" as const, text: `Stdout:\n${stdout}` }] : []),
+        ],
+        details: undefined,
+      };
+    }
+
+    return {
+      content: [{ type: "text" as const, text: stdout || "(no output)" }],
+      details: undefined,
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error executing hyalo: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      details: undefined,
+    };
+  }
+}
+
+/** Whether the argv already carries a value-taking flag (long or short). */
+function hasFlag(argv: string[], long: string, short?: string): boolean {
+  return argv.includes(long) || (short !== undefined && argv.includes(short));
+}
+
+function buildCommand(params: HyaloToolArgs): string[] {
+  const { subcommand, args: extraArgs = [], formatText = true, jq, indexFile } = params;
+  const cmdArgs = [subcommand];
+
+  // Only inject defaults the caller did not supply themselves: the model
+  // often repeats `--format text` from the skill's guidance, and a duplicate
+  // `--format` is a hard clap error ("cannot be used multiple times").
+  const hasFormat = hasFlag(extraArgs, "--format", "-f");
+  if (formatText && !jq && !hasFormat) {
+    cmdArgs.push("--format", "text");
+  }
+  if (jq && !hasFlag(extraArgs, "--jq")) {
+    cmdArgs.push("--jq", jq);
+  }
+  if (indexFile && !hasFlag(extraArgs, "--index-file")) {
+    cmdArgs.push("--index-file", indexFile);
+  }
+  cmdArgs.push(...extraArgs);
+  return cmdArgs;
+}
+
+/**
+ * Post-write lint guardrail.
+ *
+ * After pi's write/edit tools touch a .md file inside the hyalo vault,
+ * run `hyalo lint <file>` and append any violations to the tool result.
+ * The agent sees the findings in the same turn and fixes them immediately
+ * — schema drift can no longer land silently. Clean files add nothing.
+ *
+ * The vault directory is resolved once via `hyalo config` and cached for
+ * the session; files outside the vault (or a failed config lookup) skip
+ * the check entirely, so non-hyalo projects pay zero cost.
+ */
+/** Parsed `hyalo config --format json` — the bits the extension needs. */
+interface HyaloConfigInfo {
+  /** Vault directory name, or null when no vault is configured. */
+  vaultDir: string | null;
+  /** Effective `[pi] session_summary` (opt-in LLM context injection). */
+  sessionSummary: boolean;
+}
+
+async function loadHyaloConfig(pi: ExtensionAPI): Promise<HyaloConfigInfo | null> {
+  const cached = loadHyaloConfig.cache;
+  if (cached !== undefined) return cached;
+  try {
+    const { stdout, code } = await pi.exec("hyalo", ["config", "--format", "json"], {
+      timeout: 10_000,
+    });
+    if (code !== 0) {
+      loadHyaloConfig.cache = null;
+      return null;
+    }
+    // The JSON is an envelope with a top-level `dir` compat key (older
+    // hyalo versions printed the flat object without an envelope — both
+    // shapes carry the top-level `dir`). `pi` lives under `.results.pi`.
+    const parsed = JSON.parse(stdout);
+    const dir = parsed?.dir ?? parsed?.results?.dir;
+    const sessionSummary = parsed?.results?.pi?.session_summary === true;
+    const resolved: HyaloConfigInfo = {
+      vaultDir: typeof dir === "string" && dir ? dir : null,
+      sessionSummary,
+    };
+    loadHyaloConfig.cache = resolved;
+    return resolved;
+  } catch {
+    // hyalo not installed or no config: no vault, no guardrail.
+    loadHyaloConfig.cache = null;
+    return null;
+  }
+}
+// Module-level cache slot (survives across event handler invocations).
+loadHyaloConfig.cache = undefined as HyaloConfigInfo | null | undefined;
+
+async function findVaultDir(pi: ExtensionAPI): Promise<string | null> {
+  return (await loadHyaloConfig(pi))?.vaultDir ?? null;
+}
+
+async function lintVaultFile(
+  pi: ExtensionAPI,
+  filePath: string,
+  signal: AbortSignal | undefined,
+): Promise<string | null> {
+  try {
+    const { stdout, code } = await pi.exec(
+      "hyalo",
+      ["lint", filePath, "--format", "text", "--no-hints"],
+      { signal, timeout: 30_000 },
+    );
+    // lint exits 0 = clean, 1 = violations found (stdout holds them),
+    // anything else = lint itself failed: stay silent, don't mask the write.
+    if (code !== 0 && code !== 1) return null;
+    // Clean single-file output is "N file checked, no issues".
+    if (/no issues/.test(stdout)) return null;
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+const hyaloToolParams = Type.Object({
+  subcommand: Type.String({
+    description: "Hyalo subcommand (find, read, set, summary, lint, task, backlinks, config, ...)",
+  }),
+  args: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "Additional arguments for the subcommand. Property filters use '--property K=V' (e.g. '--property', 'status=planned'); there is NO --status/--type/--priority flag — status is not a flag, it is a property. Other common flags: '--tag T', '--task todo|done|any', '--section H', '--count', '--limit N'.",
+    }),
+  ),
+  formatText: Type.Optional(
+    Type.Boolean({
+      description:
+        "Use --format text for compact LLM-friendly output (default: true; ignored when jq is set)",
+    }),
+  ),
+  jq: Type.Optional(
+    Type.String({
+      description:
+        "Apply a jq filter to the JSON envelope, e.g. '.results[].file' or '.total' (overrides formatText)",
+    }),
+  ),
+  indexFile: Type.Optional(
+    Type.String({
+      description:
+        "Path to a snapshot index (created via `hyalo create-index`) for fast queries on large vaults",
+    }),
+  ),
+});
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "hyalo",
+    label: "Hyalo",
+    description:
+      "Run hyalo commands to search, read, and mutate a markdown knowledgebase " +
+      "(YAML frontmatter, tags, tasks, wikilinks). Subcommands: find, read, set, " +
+      "append, remove, task, summary, properties, tags, lint, backlinks, config, ...",
+    promptSnippet:
+      "hyalo: structured search/mutation of markdown knowledgebases (frontmatter, tags, tasks, links). Prefer hyalo_find/hyalo_read/hyalo_set/hyalo_task for common operations; use this tool for everything else.",
+    promptGuidelines: [
+      "For .md files with YAML frontmatter in a knowledgebase/vault, prefer the typed hyalo tools first — `hyalo_find` (search/filter by query/property/tag/task status), `hyalo_read` (read a file or section), `hyalo_set` (set one frontmatter property), `hyalo_task` (toggle checkboxes) — they take structured parameters, no flags or quoting. Fall back to the generic hyalo tool for anything they don't cover (summary, lint, mv, links, views, --jq, ...).",
+      "hyalo output includes drill-down hints (lines starting with `->`) — follow them to refine queries; hints marked `=>` with `[writes]` modify the vault.",
+    ],
+    parameters: hyaloToolParams,
+    async execute(_toolCallId, params: Static<typeof hyaloToolParams>, signal) {
+      return runHyalo(pi, buildCommand(params), signal);
+    },
+  });
+
+  // --- typed tools -------------------------------------------------------
+  // Structured parameters for the ~80% operations. No argv assembly, no
+  // flag spelling, no quoting — the schema is the interface. All route
+  // through runHyalo, so behavior (timeouts, signals, error rendering) is
+  // identical to the generic tool.
+
+  const hyaloFindParams = Type.Object({
+    query: Type.Optional(
+      Type.String({
+        description:
+          "BM25 full-text search term(s). Supports 'a OR b', '" +
+          '"quoted phrase"' +
+          "', and '-term' exclusions.",
+      }),
+    ),
+    property: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Property filter(s) as 'K=V'. Also supports 'K!=V', 'K>=V', 'K<=V', 'K~=pattern', '!K'. Repeatable.",
+      }),
+    ),
+    tag: Type.Optional(
+      Type.String({ description: "Filter by tag." }),
+    ),
+    glob: Type.Optional(
+      Type.String({ description: "Restrict to files matching a glob, e.g. 'iterations/*.md'." }),
+    ),
+    taskStatus: Type.Optional(
+      Type.Union([
+        Type.Literal("todo"),
+        Type.Literal("done"),
+        Type.Literal("any"),
+      ], {
+        description: "Filter by task checkbox status in the file.",
+      }),
+    ),
+    countOnly: Type.Optional(
+      Type.Boolean({ description: "Return only the match count (--count)." }),
+    ),
+    limit: Type.Optional(
+      Type.Number({ description: "Maximum number of results to return." }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_find",
+    label: "Hyalo Find",
+    description:
+      "Search/filter a markdown knowledgebase by full-text query, frontmatter " +
+      "properties, tags, glob, or task status. Preferred over the generic hyalo tool for queries.",
+    promptSnippet: "hyalo_find: search/filter knowledgebase files (query, property, tag, task status)",
+    parameters: hyaloFindParams,
+    async execute(_toolCallId, params: Static<typeof hyaloFindParams>, signal) {
+      const argv = ["find", "--format", "text"];
+      if (params.query !== undefined) argv.push(params.query);
+      for (const prop of params.property ?? []) argv.push("--property", prop);
+      if (params.tag !== undefined) argv.push("--tag", params.tag);
+      if (params.glob !== undefined) argv.push("--glob", params.glob);
+      if (params.taskStatus !== undefined) argv.push("--task", params.taskStatus);
+      if (params.countOnly) argv.push("--count");
+      if (params.limit !== undefined) argv.push("--limit", String(Math.trunc(params.limit)));
+      return runHyalo(pi, argv, signal);
+    },
+  });
+
+  const hyaloReadParams = Type.Object({
+    file: Type.String({ description: "File to read (relative to the vault directory)." }),
+    section: Type.Optional(
+      Type.String({
+        description:
+          "Extract only this section by heading (case-insensitive substring; prefix '#' pins level; '/regex/' form also accepted). Nested subsections included.",
+      }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_read",
+    label: "Hyalo Read",
+    description:
+      "Read a markdown file's body from the knowledgebase (frontmatter stripped), optionally only one section. Returns plain text.",
+    promptSnippet: "hyalo_read: read a vault file (optionally a single section) as text",
+    parameters: hyaloReadParams,
+    async execute(_toolCallId, params: Static<typeof hyaloReadParams>, signal) {
+      const argv = ["read", "--format", "text", "--file", params.file];
+      if (params.section !== undefined) argv.push("--section", params.section);
+      return runHyalo(pi, argv, signal);
+    },
+  });
+
+  const hyaloSetParams = Type.Object({
+    file: Type.String({ description: "File to mutate (relative to the vault directory)." }),
+    property: Type.String({
+      description:
+        "Frontmatter assignment as 'K=V'. Type is auto-inferred (number/bool/text); use K=[a,b,c] for lists.",
+    }),
+    tag: Type.Optional(
+      Type.String({ description: "Additionally add this tag (idempotent; creates the tags list if absent)." }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_set",
+    label: "Hyalo Set",
+    description:
+      "Set (create or overwrite) one frontmatter property on a knowledgebase file, optionally adding a tag. The post-write lint guardrail applies to writes automatically.",
+    promptSnippet: "hyalo_set: set a file's frontmatter property (K=V), optionally add a tag",
+    parameters: hyaloSetParams,
+    async execute(_toolCallId, params: Static<typeof hyaloSetParams>, signal) {
+      const argv = [
+        "set",
+        "--format",
+        "text",
+        "--property",
+        params.property,
+      ];
+      if (params.tag !== undefined) argv.push("--tag", params.tag);
+      argv.push(params.file);
+      return runHyalo(pi, argv, signal);
+    },
+  });
+
+  const hyaloTaskParams = Type.Object({
+    file: Type.String({ description: "File containing the tasks (relative to the vault directory)." }),
+    mode: Type.Union([Type.Literal("all"), Type.Literal("section"), Type.Literal("line")], {
+      description:
+        "'all': toggle every task in the file; 'section': all tasks under one heading; 'line': specific lines.",
+    }),
+    section: Type.Optional(
+      Type.String({ description: "Heading for mode='section' (case-insensitive substring)." }),
+    ),
+    lines: Type.Optional(
+      Type.Array(Type.Number(), { description: "1-based line numbers for mode='line'." }),
+    ),
+  });
+
+  pi.registerTool({
+    name: "hyalo_task",
+    label: "Hyalo Task",
+    description:
+      "Toggle task checkboxes ([ ] <-> [x]) in a knowledgebase file: every task, all tasks under a section heading, or specific lines.",
+    promptSnippet: "hyalo_task: toggle task checkboxes (all / by section / by line)",
+    parameters: hyaloTaskParams,
+    async execute(_toolCallId, params: Static<typeof hyaloTaskParams>, signal) {
+      const argv = ["task", "toggle"];
+      if (params.mode === "section") {
+        if (params.section === undefined) {
+          return {
+            content: [{ type: "text" as const, text: "hyalo_task: mode 'section' requires the section parameter" }],
+            details: undefined,
+          };
+        }
+        argv.push("--section", params.section);
+      } else if (params.mode === "line") {
+        const lines = (params.lines ?? []).map((l) => Math.trunc(l));
+        if (lines.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "hyalo_task: mode 'line' requires at least one line number" }],
+            details: undefined,
+          };
+        }
+        argv.push("--line", lines.join(","));
+      } else {
+        argv.push("--all");
+      }
+      argv.push(params.file);
+      return runHyalo(pi, argv, signal);
+    },
+  });
+
+  // Opt-in vault summary injection: with `[pi] session_summary = true` in
+  // .hyalo.toml, inject a `hyalo summary` snapshot into the LLM context at
+  // session start (custom message, not displayed in the TUI). Injected at
+  // most once per pi process — a fork/new session in the same process keeps
+  // the summary already present in the transcript or skips a duplicate.
+  let summaryInjected = false;
+  pi.on("session_start", async () => {
+    if (summaryInjected) return;
+    const config = await loadHyaloConfig(pi);
+    if (!config?.sessionSummary || !config.vaultDir) return;
+    summaryInjected = true;
+    try {
+      const { stdout, code } = await pi.exec(
+        "hyalo",
+        ["summary", "--format", "text", "--no-hints"],
+        { timeout: 30_000 },
+      );
+      if (code !== 0 || !stdout.trim()) return;
+      pi.sendMessage({
+        customType: "hyalo-vault-summary",
+        content:
+          `Knowledgebase snapshot (${config.vaultDir}/) for this session:\n\n` +
+          stdout.trim() +
+          "\n\nUse this to orient yourself; refine with the hyalo tool.",
+        display: false,
+        details: undefined,
+      });
+    } catch {
+      // summary unavailable: skip injection silently
+    }
+  });
+
+  // Post-write lint guardrail: append hyalo lint findings to write/edit
+  // tool results for vault .md files (see findVaultDir/lintVaultFile above).
+  pi.on("tool_result", async (event, ctx) => {
+    if (event.toolName !== "write" && event.toolName !== "edit") return;
+    if (event.isError) return; // failed writes: don't pile on
+
+    const rawPath = event.input.path;
+    if (typeof rawPath !== "string" || !rawPath.endsWith(".md")) return;
+
+    const vaultDir = await findVaultDir(pi);
+    if (!vaultDir) return;
+
+    // Vault membership: normalized absolute path containment check.
+    const vaultAbs = path.resolve(process.cwd(), vaultDir);
+    const fileAbs = path.resolve(process.cwd(), rawPath);
+    if (fileAbs !== vaultAbs && !fileAbs.startsWith(vaultAbs + path.sep)) return;
+
+    const lintOutput = await lintVaultFile(pi, rawPath, ctx.signal);
+    if (!lintOutput) return; // clean or lint unavailable
+
+    return {
+      content: [
+        ...event.content,
+        {
+          type: "text" as const,
+          text:
+            `⚠ hyalo lint found issues in ${path.relative(vaultAbs, fileAbs)} ` +
+            `(write succeeded, but fix the violations now — e.g. 'hyalo set' for ` +
+            `frontmatter, 'hyalo lint --fix' for formatting):\n\n${lintOutput}`,
+        },
+      ],
+    };
+  });
+
+  // Register commands for common hyalo operations
+  pi.registerCommand("hyalo-help", {
+    description: "Show hyalo help",
+    handler: async (_args, ctx) => {
+      const { stdout } = await pi.exec("hyalo", ["--help"]);
+      ctx.ui.notify(stdout, "info");
+    },
+  });
+
+  pi.registerCommand("hyalo-summary", {
+    description: "Show knowledgebase summary",
+    handler: async (_args, ctx) => {
+      const { stdout } = await pi.exec("hyalo", ["summary", "--format", "text"]);
+      ctx.ui.notify(stdout, "info");
+    },
+  });
+
+  pi.registerCommand("hyalo-lint", {
+    description: "Run hyalo lint on knowledgebase",
+    handler: async (_args, ctx) => {
+      const { stdout } = await pi.exec("hyalo", [
+        "lint",
+        "--strict",
+        "--format",
+        "text",
+      ]);
+      ctx.ui.notify(stdout, "info");
+    },
+  });
+}

--- a/crates/hyalo-cli/templates/pi/package.json
+++ b/crates/hyalo-cli/templates/pi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hyalo-pi",
+  "version": "0.1.1",
+  "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
+  "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
+  "pi": {
+    "extensions": ["./extensions"],
+    "skills": ["./skills"],
+    "prompts": [],
+    "themes": []
+  }
+}

--- a/crates/hyalo-cli/templates/pi/skills/hyalo-tidy/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo-tidy/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: hyalo-tidy
+user_invocable: false
+description: >
+  Perform a reflective consolidation pass over a hyalo-managed knowledgebase directory —
+  detecting structural issues, fixing broken links, flagging stale content, normalizing
+  metadata, and reporting what changed. Use this skill when the user says /hyalo-tidy,
+  "consolidate the knowledgebase", "clean up the KB", "run KB hygiene", "tidy", or
+  "what needs attention in the knowledgebase". Also use when the user asks about
+  knowledgebase health, broken links, orphan files, stale iterations, or metadata
+  inconsistencies.
+context: fork
+disable-model-invocation: true
+---
+
+# Hyalo Tidy — Knowledgebase Consolidation for pi
+
+You are performing a tidy — a reflective pass over a knowledgebase. Your job is to
+detect issues, fix what you can, and report what needs human attention. Think of this
+as a librarian doing a periodic shelf-read: checking that everything is filed correctly,
+cross-references work, and nothing is gathering dust in the wrong place.
+
+**For pi sessions, ALWAYS use `--format text` for compact output.**
+
+This process has 5 phases. Take your time — a thorough tidy is worth more than a fast
+one. A few minutes is fine.
+
+## Before you start
+
+Locate the hyalo binary:
+```bash
+which hyalo 2>/dev/null || echo "target/release/hyalo"
+```
+
+Confirm `.hyalo.toml` exists in the project root to determine the KB directory. If it
+doesn't exist, ask the user which directory to consolidate.
+
+## Phase 1 — Orient and snapshot
+
+Get the lay of the land and create a snapshot index for fast repeated queries.
+
+```bash
+# 1. High-level overview (baseline for the final health dashboard)
+hyalo summary --format text
+
+# 2. Create snapshot index (one scan, reused by all subsequent queries)
+hyalo create-index --format text
+
+# 3. Save recurring diagnostic queries as views for reuse
+hyalo views set stale-in-progress --property status=in-progress --fields tasks --format text
+hyalo views set missing-status --property '!status' --format text
+hyalo views set missing-type --property '!type' --format text
+hyalo views set orphans --orphan --fields backlinks --format text
+hyalo views set completed-with-todos --property status=completed --task todo --fields tasks --format text
+```
+
+The snapshot index captures every file's metadata in a binary file (`.hyalo-index`).
+All read-only queries in Phase 2 and Phase 3 should use `--index` to
+avoid repeated disk scans. For complex reshaping, combine hyalo filtering with `--jq`.
+
+Also grab the tag vocabulary for inconsistency detection:
+```bash
+hyalo tags summary --index --format text
+```
+
+## Phase 2 — Gather recent signal
+
+Before looking for issues, understand what happened recently. This context is what
+makes the tidy valuable — it tells you what *should* have changed in the KB, so you
+can spot what didn't.
+
+### Git history
+
+```bash
+# What branches were merged recently? What iteration branches shipped?
+git log --oneline --merges --since="4 weeks ago"
+
+# What areas of code changed? (helps identify which features shipped)
+git log --oneline --since="4 weeks ago" -- "*.rs" | head -30
+```
+
+Extract non-completed iterations and their branches from the index:
+```bash
+hyalo find --property type=iteration --index --jq '.results | map(select(.properties.status != "completed" and .properties.status != "superseded" and .properties.status != "wont-do")) | map({file, branch: .properties.branch, status: .properties.status})'
+```
+
+For each non-completed iteration that has a branch, check if that branch was merged:
+```bash
+git log --oneline --merges --all | grep "<branch-name>"
+```
+
+### Claude's auto-memory
+
+Check what was recently worked on from Claude's perspective:
+```bash
+MEMORY_FILE=$(find ~/.claude/projects/ -path "*/memory/MEMORY.md" -print -quit 2>/dev/null)
+if [ -n "$MEMORY_FILE" ]; then
+  MEMORY_DIR=$(dirname "$MEMORY_FILE")
+fi
+```
+
+If found, query it with hyalo (memory files are outside the vault, so no --index here):
+```bash
+hyalo --dir "$MEMORY_DIR" find --property type=project --format text
+hyalo --dir "$MEMORY_DIR" find --property type=feedback --format text
+```
+
+Look for:
+- Project memories mentioning iterations/features that shipped — cross-reference with KB
+- Stale project memories that reference outdated plans (note for the report, but
+  don't modify memory files — that's Claude's own territory)
+
+### Recent KB changes
+
+```bash
+git log --oneline --since="4 weeks ago" -- "hyalo-knowledgebase/" | head -20
+git log --diff-filter=A --name-only --since="4 weeks ago" -- "hyalo-knowledgebase/"
+```
+
+## Phase 3 — Detect structural issues
+
+All queries below use `--index` — no additional disk scans needed.
+
+### Schema & lint
+Check if type schemas are defined, then run lint in strict mode. `hyalo lint` covers
+both frontmatter schema *and* the markdown body (stock mdbook-lint rules + HYALO native
+rules for things like bare `[]` checkboxes and `status: completed` with open tasks).
+`--strict` promotes the "no `type` property" and "undeclared property in frontmatter"
+warnings to errors so a tidy pass fails fast on schema drift:
+```bash
+hyalo types list --format text
+hyalo lint --strict --index --format text
+```
+
+If `hyalo types list` returns zero types but files have a `type` property, propose
+creating type schemas. Use `hyalo properties summary` to discover common property
+values, then suggest `hyalo types set <name> --required ...`
+commands for the user's most common document types. Don't create them unilaterally —
+report the suggestion in Phase 5.
+
+Note the lint summary's per-rule counts. If **one rule dominates the noise** (e.g.
+MD013 line-length on prose-heavy KBs), that's a signal the rule may not fit the KB —
+flag it for Phase 5 as a candidate to disable via `hyalo lint-rules`. Track fixable
+counts for Phase 4.
+
+Lint also validates `[views.*]` in `.hyalo.toml`. A view whose only narrowing key is
+`fields` (display columns, not a filter) is surfaced as a warning — suggest adding an
+explicit filter like `orphan = true`, `dead_end = true`, or `tag = [...]` when you see
+one in Phase 5.
+
+### Broken links
+```bash
+# Dry-run shows broken links with proposed fixes and confidence scores
+hyalo links fix --index --format text
+```
+This categorizes links as **fixable** (fuzzy match found) vs **unfixable** (no match).
+Note the counts for the health dashboard. Actual fixes happen in Phase 4.
+
+### Orphan files
+```bash
+hyalo find --view orphans --index --jq '.results | map(select(.backlinks | length == 0)) | map(.file)'
+```
+Not all orphans are problems. Expect these to be legitimately orphaned:
+- Top-level files (SEED.md, project-pitch.md, decision-log.md)
+- Research documents (standalone reports)
+- Older completed items in `done/` directories
+
+Focus on **actionable orphans**: active/planned items that should be cross-referenced.
+
+### Dead-end files
+```bash
+hyalo find --dead-end --index --jq '.results | map(.file)'
+```
+Dead-end files have inbound links but no outbound links — often stubs or leaf nodes
+that could benefit from cross-references. Not always a problem, but worth reviewing.
+
+### Stale statuses
+```bash
+# In-progress items — should any be completed?
+hyalo find --view stale-in-progress --index --jq '.results | map({file, date: .properties.date, branch: .properties.branch})'
+
+# Planned items where all tasks are done
+hyalo find --property status=planned --index --jq '.results | map(select((.tasks | length > 0) and ([.tasks[] | select(.status != "x")] | length) == 0)) | map(.file)'
+
+# In-progress items sorted by date (oldest first — possibly stale)
+hyalo find --view stale-in-progress --index --jq '.results | map(select(.properties.date != null)) | sort_by(.properties.date) | map({file, date: .properties.date})'
+```
+Cross-reference with git merges from Phase 2. If the branch was merged, update status.
+
+### Stale backlog items
+```bash
+hyalo find --property status=planned --property type=backlog --index --jq '.results | map({file, title: .properties.title})'
+```
+Compare each planned backlog item against merged iterations and recent git history.
+If the feature clearly shipped (in a different iteration or under a different name),
+flag it.
+
+### Missing metadata
+```bash
+hyalo find --view missing-status --index --jq '.results | map(.file)'
+hyalo find --view missing-type --index --jq '.results | map(.file)'
+```
+
+### Tag inconsistencies
+Review the `hyalo tags summary` output from Phase 1. Look for near-duplicates:
+singular/plural (`filter`/`filters`), hyphenation variants (`bugfix`/`bug-fix`),
+abbreviations (`perf`/`performance`). The canonical form should be the one used by
+more files.
+
+### Task completion vs status mismatch
+The `HYALO002` rule from the lint pass already flags `status: completed` files with
+open tasks (fires only when `[schema.types.*].properties.status` is declared as an enum
+containing `"completed"`). If you want a per-file breakdown with open/total counts, use the view:
+```bash
+hyalo find --view completed-with-todos --index --jq '.results | map({file, open: ([.tasks[] | select(.status != "x")] | length), total: (.tasks | length)})'
+```
+If many completed items have unchecked tasks, this is a workflow pattern — note it once
+in the report rather than listing every file.
+
+## Phase 4 — Consolidate
+
+Fix what you can. Be conservative — prefer fixing metadata over deleting files. For
+each change, note what you did and why.
+
+**Keep using `--index`** for all mutations — hyalo now patches the index
+in-place after each file write, so it stays current for subsequent queries. No need to
+drop the index before making changes. Only drop it at the very end (Phase 5).
+
+### Fix lint violations
+If lint reported fixable violations in Phase 3, auto-fix them. `--fix` covers both
+passes — frontmatter (defaults, typos, dates, types) and body (e.g. `HYALO001` bare
+brackets, trailing whitespace). Always preview with `--dry-run` first:
+```bash
+hyalo lint --fix --dry-run --index --format text
+hyalo lint --fix --index --format text
+```
+
+If you only want to fix specific rules (e.g. body fixes only, leaving frontmatter
+alone), use `--fix-rule` or `--rule-prefix HYALO` — see `hyalo lint --help`.
+
+Unfixable violations (missing required properties, open tasks under `HYALO002`) are
+reported in Phase 5 for human attention.
+
+### Fix broken links
+Use `hyalo links fix` to auto-repair broken links. It uses fuzzy matching to find the
+correct target (handles moves to `done/`, case changes, extension mismatches, etc.).
+
+```bash
+# Preview what will be fixed
+hyalo links fix --index --format text
+
+# Apply fixes
+hyalo links fix --apply --index --format text
+```
+
+Review the dry-run output first. For any links it can't resolve (reported as unfixable),
+leave them and report them in Phase 5.
+
+### Update stale statuses
+If an iteration's branch was merged:
+```bash
+hyalo set <path> --property status=completed --index --format text
+```
+
+If a backlog item's feature clearly shipped:
+```bash
+hyalo set <path> --property status=completed --index --format text
+```
+
+Only update when the evidence is clear. When uncertain, flag it in the report.
+
+### Archive completed items
+If completed items are in a top-level directory and a `done/` subfolder exists:
+```bash
+hyalo mv <old-path> --to <done-subdir/filename> --dry-run --index --format text
+```
+Review the dry-run output. If correct, execute without `--dry-run`.
+
+### Normalize tags
+```bash
+hyalo tags rename --from <variant> --to <canonical> --index --format text
+```
+
+### Add missing cross-references
+If a backlog item was implemented by an iteration but neither links to the other,
+add a `[[wikilink]]`. Only where the relationship is clear and useful.
+
+## Phase 5 — Report
+
+Summarize everything. Structure as:
+
+### Changes made
+One line per change with reasoning:
+```
+- Set status=completed on iteration-43.md (branch iter-43/data-quality merged in abc1234)
+- Moved iteration-46.md to iterations/done/ (completed, all tasks verified)
+- Renamed tag: bugfix → bug-fix (2 files, matching existing convention)
+- Fixed 5 broken links in research/dogfooding-v0.4.1-consolidated.md (same-dir targets)
+```
+
+### Issues requiring human attention
+Things you detected but couldn't (or shouldn't) fix unilaterally. Keep it concise —
+one line per issue with enough context to act on.
+
+If a single lint rule produced an outsized share of the noise (or if a rule fired only
+on legitimate exceptions), suggest tuning it via `hyalo lint-rules` rather than
+silently leaving the warnings in place.
+
+### KB health dashboard
+Re-run `hyalo summary --format text` (fresh scan after mutations — no `--index`) and compare with
+Phase 1 baseline. Report the delta: statuses changed, links fixed, tags normalized,
+files moved.
+
+## Ground rules
+
+- **Conservative by default**: when in doubt, report rather than change.
+- **Never delete files or body content**: update frontmatter, fix links, move files,
+  suggest changes — but the user decides what to throw away.
+- **Explain every change**: include the evidence (commit hash, task counts, etc.).
+- **Don't modify Claude's memory files**: report stale memories but don't edit them.
+- **Use hyalo for mutations**: `hyalo set`/`remove` for frontmatter, `hyalo tags rename`
+  for tags, `hyalo mv` for moves. Fall back to Edit only for body content (fixing
+  wikilink text in prose, adding cross-reference lines).
+- **Batch similar findings**: if 15 completed items have unchecked tasks, say that once
+  with the count. The report should be scannable in 30 seconds.
+- **Minimize disk scans**: use `--index` for all queries and mutations.
+  Mutations automatically patch the index in-place — no need to drop and recreate.
+  Only drop the index at the very end when the session is complete.

--- a/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: hyalo
+user_invocable: false
+description: >
+  Use the hyalo CLI instead of read/edit/grep/write when working with markdown (.md) files
+  that have YAML frontmatter. This skill MUST be consulted whenever pi is working with
+  markdown documentation directories, knowledgebases, wikis, notes, Obsidian-compatible
+  collections, Zettelkasten systems, iteration plans, or any collection of .md files with
+  frontmatter. Trigger this skill when: searching or filtering markdown files by content,
+  tags, or properties; reading or modifying YAML frontmatter; managing tags or metadata
+  across documents; toggling task checkboxes in markdown; getting an overview of a
+  documentation directory; querying document properties or status fields; bulk-updating
+  metadata across many markdown files; or when you find yourself repeatedly using
+  read/edit/grep/write on .md files. Even if the user does not mention "hyalo" by name, use this
+  skill whenever the task involves structured markdown documents with frontmatter.
+
+  For pi sessions, ALWAYS use `--format text` for compact, LLM-friendly output.
+---
+
+# Hyalo CLI — Prime Tool for Markdown Knowledgebases in pi
+
+Hyalo is a fast CLI for querying and mutating YAML frontmatter, tags, tasks, and structure
+in directories of markdown files. If the hyalo pi extension is installed
+(`.pi/extensions/hyalo.ts`), prefer its **typed tools** for the common operations —
+they take structured parameters, so there is no flag spelling or quoting to get wrong:
+
+| Operation | Typed tool | Example parameters |
+|-----------|------------|--------------------|
+| Search/filter | **hyalo_find** | `property: ["status=planned", "type=iteration"]`, `query: "rust"`, `tag: "feature"`, `taskStatus: "todo"`, `countOnly: true`, `limit: 10` |
+| Read a file/section | **hyalo_read** | `file: "iterations/iter-1-x.md"`, `section: "Scope"` |
+| Set one property | **hyalo_set** | `file: "note.md"`, `property: "status=done"`, `tag: "shipped"` |
+| Toggle tasks | **hyalo_task** | `file: "plan.md"`, `mode: "all"` / `mode: "section"`, `section: "Tasks"` / `mode: "line"`, `lines: [5, 7]` |
+
+Use the generic **hyalo** tool (subcommand + args) only for operations the typed tools
+don't cover: summary, lint, mv, links, views, types, backlinks, --jq filters, bulk
+mutations (`--glob`, `--where-property`), etc.
+
+`--glob` is how you address sequence-keyed documents (iterations, decisions, ...): the
+number may be zero-padded and the file archived in a subdirectory, so prefer the
+recursive form — `find --glob '**/iteration-02-*.md'` reaches both
+`iterations/iteration-2-*.md` and `iterations/done/iteration-02-links.md`.
+(`--file` is exact; `--glob` is the only globbing flag.)
+
+Its killer features are combined filtering (e.g.
+`hyalo find -e "regex" --property status!=done --tag feature`) which you can't easily
+replicate with read/edit/grep/write, and bulk mutations (`hyalo set --where-property`) that replace
+multiple read + edit calls.
+
+**For pi sessions, ALWAYS use `--format text` for compact, LLM-friendly output.**
+
+## Core Philosophy for pi
+
+- **Use hyalo first**: Before using read/edit/grep/write on .md files, check if hyalo can do it
+- **Batch operations**: Use hyalo's bulk mutation features instead of individual edits
+- **Snapshot indexes**: For vaults >500 files, use `hyalo create-index` + `--index` for speed
+- **Follow hints**: hyalo outputs drill-down suggestions (`-> hyalo ...`) — use them
+- **Schema validation**: Use `hyalo lint --strict` to catch frontmatter issues early
+
+## Quick Start in pi
+
+```bash
+# 1. Check hyalo is installed and configured
+bash: which hyalo
+bash: hyalo --version
+
+# 2. Get overview of knowledgebase
+bash: hyalo summary --format text
+
+# 3. Search for files with BM25 full-text search
+bash: hyalo find "iteration" --property status=planned --tag iteration --format text
+
+# 4. Read a specific file's content or section
+bash: hyalo read iterations/iteration-66-spec-refresh-drift-fixes.md --section "Scope" --format text
+
+# 5. Update frontmatter properties
+bash: hyalo set iterations/iteration-66-spec-refresh-drift-fixes.md --property status=in-progress --format text
+```
+
+## BM25 Full-Text Search
+
+The positional argument to `find` triggers BM25 ranked full-text search with automatic
+stemming ("running" matches "run", "runner", etc.). Results sorted by relevance score.
+
+```bash
+hyalo find "rust"                        # single term, stemmed
+hyalo find "rust programming"            # AND: both terms required (implicit)
+hyalo find "rust OR golang"              # OR: either term matches
+hyalo find "rust -java"                  # NOT: exclude documents with "java"
+hyalo find '\"error handling\"'          # Phrase: exact consecutive match (after stemming)
+hyalo find "rust OR golang -obsolete"    # Mixed: either rust or golang, not obsolete
+```
+
+For literal pattern matching (not stemmed), use regex: `hyalo find -e "exact_string"`.
+
+## Property & Tag Filtering
+
+Filters combine freely — content search + property conditions + tag + section + task status
+in a single call:
+
+```bash
+hyalo find "error handling" --property status!=completed --tag iteration --section "Tasks" --task todo --format text
+```
+
+Property filters support: `K=V` (eq), `K!=V` (neq), `K>=V`/`K<=V`/`K>V`/`K<V` (comparison),
+`K` (existence), `!K` (absence), `K~=pattern` or `K~=/pattern/flags` (regex match):
+
+```bash
+hyalo find --property '!status'           # files missing the status property
+hyalo find --property 'title~=draft'      # title contains "draft"
+hyalo find --property 'title~=/^Draft/i'  # case-insensitive regex on title
+```
+
+`K` may be a **dot-path** into nested frontmatter. A literal dotted key in a flat map is
+tried first; otherwise the path is walked. Maps descend by key, and sequences descend too:
+a numeric segment pins one element, any other segment auto-descends into *every* element and
+collects the hits — so the usual list semantics apply (`=`/`~=` match when any element
+matches, `!=` when none does):
+
+```bash
+hyalo find --property contact.email=team@example.com   # contact: {email: ...}
+hyalo find --property contacts.email=ada@example.com   # contacts: [{name, email}, ...] — any element
+hyalo find --property contacts.0.email=ada@example.com # first element only
+hyalo find --property '!contacts.phone'                # no element has a phone
+```
+
+## Schema & Lint Integration
+
+Hyalo supports frontmatter schema validation. Define schemas in `.hyalo.toml` then run:
+
+```bash
+# Strict linting (errors on schema violations)
+hyalo lint --strict --format text
+
+# Auto-fix lint violations
+hyalo lint --fix --dry-run --format text  # preview
+hyalo lint --fix --format text           # apply
+
+# Manage lint rules
+hyalo lint-rules list --format text
+hyalo lint-rules set MD013 --enabled false --format text  # disable line-length rule
+```
+
+## Snapshot Index for Performance
+
+For vaults >500 files, create a snapshot index to avoid repeated disk scans:
+
+```bash
+# Create index (one scan, reused by all queries)
+hyalo create-index
+
+# Use --index on all subsequent commands
+hyalo find --property status=in-progress --index --format text
+hyalo summary --index --format text
+
+# Mutations also work with --index (patches index after each write)
+hyalo set note.md --property status=completed --index --format text
+
+# Drop when done
+hyalo drop-index
+```
+
+## File Movement with Link Rewriting
+
+**Always use `hyalo mv`** — never system `mv` or `git mv`. It rewrites all `[[wikilinks]]` and
+`[markdown](links)` across the vault that pointed to the old path.
+
+```bash
+hyalo mv backlog/my-item.md --to backlog/done/my-item.md --dry-run --format text  # preview
+hyalo mv backlog/my-item.md --to backlog/done/my-item.md --format text           # execute
+```
+
+## Broken Link Detection & Repair
+
+```bash
+# Detect broken links with proposed fixes
+hyalo links fix --format text
+
+# Apply fixes
+hyalo links fix --apply --format text
+```
+
+## Saved Views for Common Queries
+
+Save frequently-used filter combinations as named views:
+
+```bash
+# Create views for common queries
+hyalo views set stale-in-progress --property status=in-progress --fields tasks
+hyalo views set orphans --orphan --fields backlinks
+hyalo views set missing-status --property '!status'
+
+# Use views
+hyalo find --view stale-in-progress --format text
+hyalo find --view orphans --limit 5 --format text
+```
+
+## Task Management
+
+```bash
+# Toggle task checkboxes
+hyalo task toggle note.md --line 5,7 --format text
+hyalo task toggle note.md --section "Tasks" --all --format text
+
+# Read tasks with status
+hyalo read note.md --section "Tasks" --format text
+```
+
+## Type Schema Management
+
+```bash
+# List defined types
+hyalo types list --format text
+
+# Create/update iteration type schema
+hyalo types set iteration --required title,date,status,branch,tags --format text
+hyalo types set iteration --property-values "status=planned,in-progress,completed" --format text
+hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.md" --format text
+```
+
+## When to Use hyalo vs Built-in pi Tools
+
+| Task | Tool | Example |
+|------|------|---------|
+| Search/filter markdown files | **hyalo** | `hyalo find "rust" --property type=iteration --format text` |
+| Read frontmatter properties | **hyalo** | `hyalo find --property status=planned --format text` |
+| Update frontmatter | **hyalo** | `hyalo set note.md --property status=completed --format text` |
+| Toggle task checkboxes | **hyalo** | `hyalo task toggle note.md --line 5 --format text` |
+| Move/rename markdown files | **hyalo** | `hyalo mv old.md --to new.md --format text` |
+| Fix broken links | **hyalo** | `hyalo links fix --apply --format text` |
+| Rewrite body prose | **edit** | `edit` tool for paragraph changes |
+| Create new markdown files | **write** | `write` tool for new files |
+| Complex text transformations | **edit** | `edit` tool for regex replacements |
+
+## Setup Checklist for New Projects
+
+1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`)
+2. **Configure vault**: Create `.hyalo.toml` with `dir = "knowledgebase"`
+3. **Add to AGENTS.md**: Include: "Use `hyalo` CLI for all markdown knowledgebase operations. Always use `--format text` for compact output."
+4. **Create views**: Set up common views (`stale-in-progress`, `orphans`, etc.)
+5. **Define schemas**: Create type schemas for consistent frontmatter
+
+## Advanced Patterns for pi
+
+### Bulk Status Updates
+```bash
+# Update all planned iterations older than 30 days to deferred
+hyalo find --property status=planned --property type=iteration --jq '.results | map(select(.properties.date < "2026-06-01")) | map(.file)' \
+  | xargs -I {} hyalo set {} --property status=deferred --format text
+```
+
+### Health Dashboard
+```bash
+# Generate KB health report
+hyalo summary --format text
+hyalo lint --strict --format text
+hyalo links fix --format text
+```
+
+### Orphan Analysis
+```bash
+# Find orphans with context
+hyalo find --orphan --fields properties,links --format text \
+  | grep -v "SEED.md\|decision-log.md\|development-roadmap.md"  # exclude expected orphans
+```
+
+## Common Pitfalls & Solutions
+
+1. **Using the generic tool for common operations**: prefer hyalo_find/hyalo_read/hyalo_set/hyalo_task — no flag spelling or quoting to get wrong
+2. **Missing `--format text`**: Output is verbose JSON — always use `--format text` in pi (the extension injects it automatically; only needed via bash)
+3. **Not using `--index` for large vaults**: Queries are slow — create index for >500 files
+4. **Using system `mv` instead of `hyalo mv`**: Breaks links — always use `hyalo mv`
+5. **Ignoring hints**: hyalo suggests next commands — follow them
+6. **Not validating schemas**: Run `hyalo lint --strict` regularly
+
+## Integration with pi Extension
+
+If the hyalo extension is installed (`.pi/extensions/hyalo.ts`), use the typed tools first:
+```json
+{"tool": "hyalo_find", "property": ["status=planned"], "tag": "iteration"}
+```
+For anything they don't cover, use the generic `hyalo` tool:
+```json
+{
+  "subcommand": "find",
+  "args": ["iteration", "--property", "status=planned", "--format", "text"],
+  "formatText": true
+}
+```
+
+Otherwise, use via `bash` tool:
+```bash
+hyalo find "iteration" --property status=planned --format text
+```

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,6 +6,7 @@ mod command_reference;
 mod feature_fanout;
 mod help_drift;
 mod mutation_journal;
+mod pi_package_sync;
 mod stubs;
 mod workspace;
 
@@ -30,6 +31,9 @@ enum Commands {
     CheckCommandReference,
     /// Gate: verify every bundled skill template passes the skills profile.
     CheckBundledSkills,
+    /// Gate: verify the vendored `crates/hyalo-cli/templates/pi/` copies
+    /// match the canonical `pi-package/` files byte-for-byte.
+    CheckPiPackageSync,
     /// Stub — not yet implemented (iter-142b).
     CheckDeadPrimitives(stubs::StubArgs),
     /// Stub — not yet implemented (iter-142b).
@@ -50,6 +54,7 @@ fn main() {
         Commands::CheckHelpDrift => help_drift::run(),
         Commands::CheckCommandReference => command_reference::run(),
         Commands::CheckBundledSkills => bundled_skills::run(),
+        Commands::CheckPiPackageSync => pi_package_sync::run(),
         Commands::CheckDeadPrimitives(_) => stubs::check_dead_primitives(),
         Commands::CheckTodoAnnotations(_) => stubs::check_todo_annotations(),
         Commands::CheckMutationJournal => mutation_journal::run(),

--- a/crates/xtask/src/pi_package_sync.rs
+++ b/crates/xtask/src/pi_package_sync.rs
@@ -1,0 +1,163 @@
+//! Gate — pi-package / vendored-copy sync check.
+//!
+//! `crates/hyalo-cli/src/commands/init.rs` embeds the pi integration files
+//! (`hyalo` and `hyalo-tidy` skills, the `hyalo.ts` extension, `package.json`)
+//! via `include_str!`. Those files must live *inside* `crates/hyalo-cli/`
+//! because `cargo package`/`cargo publish` build the verify tarball with only
+//! the crate directory on disk — an `include_str!` reaching outside the crate
+//! (as it used to, pointing at the top-level `pi-package/`) fails that build.
+//! This broke the `hyalo-cli` 0.21.0 crates.io publish on 2026-08-29.
+//!
+//! The fix vendors byte-identical copies under
+//! `crates/hyalo-cli/templates/pi/`. The top-level `pi-package/` directory
+//! stays canonical — it is the exact layout `pi install
+//! git:github.com/ractive/hyalo` consumes, and cannot move or gain a
+//! symlink (Windows checkouts don't support them). This gate keeps the two
+//! copies from drifting apart: it fails CI if any vendored file differs from
+//! its `pi-package/` counterpart, or if `pi-package/{skills,extensions}` or
+//! `pi-package/package.json` gains a file with no vendored counterpart.
+//! Run `just sync-pi-package` to fix drift.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::workspace::workspace_root;
+
+/// Run the gate: `Ok(true)` when the vendored copies match `pi-package/`
+/// exactly, `Ok(false)` on any mismatch (details printed to stderr).
+pub fn run() -> Result<bool> {
+    let root = workspace_root()?;
+    let pi_package = root.join("pi-package");
+    let vendored = root
+        .join("crates")
+        .join("hyalo-cli")
+        .join("templates")
+        .join("pi");
+
+    let mut pairs: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+    // skills/*/SKILL.md
+    let skills_dir = pi_package.join("skills");
+    match std::fs::read_dir(&skills_dir) {
+        Ok(entries) => {
+            for entry in entries.filter_map(|e| e.ok()) {
+                let skill_dir = entry.path();
+                let skill_md = skill_dir.join("SKILL.md");
+                if skill_md.is_file() {
+                    let name = skill_dir
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    pairs.push((
+                        skill_md,
+                        vendored.join("skills").join(&name).join("SKILL.md"),
+                    ));
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("check-pi-package-sync: {skills_dir:?} not found, skipping");
+        }
+        Err(e) => return Err(e).with_context(|| format!("reading {skills_dir:?}")),
+    }
+
+    // extensions/*.ts
+    let extensions_dir = pi_package.join("extensions");
+    match std::fs::read_dir(&extensions_dir) {
+        Ok(entries) => {
+            for entry in entries.filter_map(|e| e.ok()) {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("ts") {
+                    let name = path.file_name().unwrap_or_default();
+                    pairs.push((path.clone(), vendored.join("extensions").join(name)));
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("check-pi-package-sync: {extensions_dir:?} not found, skipping");
+        }
+        Err(e) => return Err(e).with_context(|| format!("reading {extensions_dir:?}")),
+    }
+
+    // package.json
+    let package_json = pi_package.join("package.json");
+    if package_json.is_file() {
+        pairs.push((package_json, vendored.join("package.json")));
+    }
+
+    if pairs.is_empty() {
+        eprintln!("check-pi-package-sync: no pi-package files found to check");
+        return Ok(false);
+    }
+
+    let mut all_ok = true;
+    let mut checked = 0usize;
+    for (source, vendored_copy) in &pairs {
+        checked += 1;
+        if !vendored_copy.is_file() {
+            all_ok = false;
+            eprintln!(
+                "check-pi-package-sync: {} has no vendored counterpart at {} — run `just sync-pi-package`",
+                display_rel(&root, source),
+                display_rel(&root, vendored_copy),
+            );
+            continue;
+        }
+        let source_bytes = std::fs::read(source).with_context(|| format!("reading {source:?}"))?;
+        let vendored_bytes =
+            std::fs::read(vendored_copy).with_context(|| format!("reading {vendored_copy:?}"))?;
+        if source_bytes != vendored_bytes {
+            all_ok = false;
+            eprintln!(
+                "check-pi-package-sync: {} differs from vendored copy {} — run `just sync-pi-package`",
+                display_rel(&root, source),
+                display_rel(&root, vendored_copy),
+            );
+        }
+    }
+
+    if all_ok {
+        println!("check-pi-package-sync: {checked} pi-package file(s) match their vendored copies");
+    }
+    Ok(all_ok)
+}
+
+fn display_rel(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn display_rel_strips_root() {
+        let root = Path::new("/repo");
+        let path = Path::new("/repo/pi-package/package.json");
+        assert_eq!(display_rel(root, path), "pi-package/package.json");
+    }
+
+    #[test]
+    fn display_rel_falls_back_to_absolute_outside_root() {
+        let root = Path::new("/repo");
+        let path = Path::new("/elsewhere/file.txt");
+        assert_eq!(display_rel(root, path), "/elsewhere/file.txt");
+    }
+
+    #[test]
+    fn detects_identical_and_diverging_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, b"same").expect("write a");
+        fs::write(&b, b"same").expect("write b");
+        assert_eq!(fs::read(&a).unwrap(), fs::read(&b).unwrap());
+
+        fs::write(&b, b"different").expect("write b");
+        assert_ne!(fs::read(&a).unwrap(), fs::read(&b).unwrap());
+    }
+}

--- a/crates/xtask/src/pi_package_sync.rs
+++ b/crates/xtask/src/pi_package_sync.rs
@@ -116,10 +116,59 @@ pub fn run() -> Result<bool> {
         }
     }
 
+    // Reverse direction: a vendored file whose canonical source was deleted
+    // or renamed would otherwise go stale forever (review finding on
+    // PR #289). Walk the vendored tree with the same file selection the
+    // forward pass uses and demand a source for each.
+    let expected: std::collections::HashSet<&PathBuf> = pairs
+        .iter()
+        .map(|(_, vendored_copy)| vendored_copy)
+        .collect();
+    for orphan in vendored_files(&vendored)? {
+        if !expected.contains(&orphan) {
+            all_ok = false;
+            eprintln!(
+                "check-pi-package-sync: vendored {} has no source under pi-package/ — delete it (and any include_str! of it)",
+                display_rel(&root, &orphan),
+            );
+        }
+    }
+
     if all_ok {
         println!("check-pi-package-sync: {checked} pi-package file(s) match their vendored copies");
     }
     Ok(all_ok)
+}
+
+/// The vendored files the gate is responsible for: `skills/*/SKILL.md`,
+/// `extensions/*.ts`, and `package.json` under `templates/pi/` — the same
+/// selection as the forward pass, so the two directions cannot disagree on
+/// scope. A missing directory yields an empty list.
+fn vendored_files(vendored: &Path) -> Result<Vec<PathBuf>> {
+    let mut found = Vec::new();
+    let read = |dir: &Path| -> Result<Vec<PathBuf>> {
+        match std::fs::read_dir(dir) {
+            Ok(entries) => Ok(entries.filter_map(|e| e.ok().map(|e| e.path())).collect()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(e) => Err(e).with_context(|| format!("reading {dir:?}")),
+        }
+    };
+    for skill_dir in read(&vendored.join("skills"))? {
+        let skill_md = skill_dir.join("SKILL.md");
+        if skill_md.is_file() {
+            found.push(skill_md);
+        }
+    }
+    for path in read(&vendored.join("extensions"))? {
+        if path.extension().and_then(|e| e.to_str()) == Some("ts") {
+            found.push(path);
+        }
+    }
+    let package_json = vendored.join("package.json");
+    if package_json.is_file() {
+        found.push(package_json);
+    }
+    Ok(found)
 }
 
 fn display_rel(root: &Path, path: &Path) -> String {
@@ -146,6 +195,30 @@ mod tests {
         let root = Path::new("/repo");
         let path = Path::new("/elsewhere/file.txt");
         assert_eq!(display_rel(root, path), "/elsewhere/file.txt");
+    }
+
+    #[test]
+    fn vendored_files_selects_same_scope_as_forward_pass() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let v = dir.path();
+        fs::create_dir_all(v.join("skills/hyalo")).expect("mkdir");
+        fs::create_dir_all(v.join("extensions")).expect("mkdir");
+        fs::write(v.join("skills/hyalo/SKILL.md"), "s").expect("write");
+        fs::write(v.join("skills/hyalo/notes.txt"), "ignored").expect("write");
+        fs::write(v.join("extensions/hyalo.ts"), "t").expect("write");
+        fs::write(v.join("extensions/README.md"), "ignored").expect("write");
+        fs::write(v.join("package.json"), "{}").expect("write");
+        let mut found = vendored_files(v).expect("walk");
+        found.sort();
+        let mut expected = vec![
+            v.join("extensions/hyalo.ts"),
+            v.join("package.json"),
+            v.join("skills/hyalo/SKILL.md"),
+        ];
+        expected.sort();
+        assert_eq!(found, expected);
+        // A missing tree is empty, not an error.
+        assert!(vendored_files(&v.join("nope")).expect("walk").is_empty());
     }
 
     #[test]

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3279,3 +3279,51 @@ reported bug.
 unchanged and still governed by DEC-241/DEC-245: the run warns and exits 0.
 A caller who wants disk truth over snapshot speed still has that lever —
 omit `--index`/`--index-file` — it was just never a new one.
+
+## DEC-250: pi-package stays canonical at the repo root; the crate embeds a vendored, gate-enforced copy (2026-08-29)
+
+**Problem.** `crates/hyalo-cli/src/commands/init.rs` embedded the four pi
+integration files (`hyalo`/`hyalo-tidy` `SKILL.md`, `hyalo.ts`, `package.json`)
+via `include_str!("../../../../pi-package/...")` — reaching four directories
+up, outside `crates/hyalo-cli/`. DEC-237 called this a "single source of
+truth" with "drift impossible by construction." That held for a normal build,
+but `cargo package`/`cargo publish` builds the verify tarball with only the
+crate directory on disk, so the `include_str!` paths resolved to nothing and
+the `hyalo-cli` 0.21.0 crates.io publish failed at the tarball verify step
+(`hyalo-core` and `hyalo-mdlint` 0.21.0 had already published). `cargo
+package -p hyalo-cli` reproduces the same failure locally.
+
+**Decision.** Vendor byte-identical copies of the four files under
+`crates/hyalo-cli/templates/pi/` (mirroring `pi-package/`'s own
+`skills/<name>/SKILL.md` and `extensions/<name>.ts` layout) and point the
+`include_str!`s there instead. The top-level `pi-package/` directory remains
+canonical and unchanged — it is the exact layout `pi install
+git:github.com/ractive/hyalo` consumes, and moving or symlinking it was ruled
+out (symlinks don't survive a Windows checkout). A new `check-pi-package-sync`
+xtask gate, wired into the `quality-gates` CI job alongside
+`check-bundled-skills`, fails the build if any vendored file differs
+byte-for-byte from its `pi-package/` counterpart, or if `pi-package/` gains a
+skill/extension/`package.json` with no vendored counterpart. `just
+sync-pi-package` copies `pi-package/` onto the vendored tree to fix drift.
+
+**Alternatives considered.**
+- *Publish `pi-package/` as its own crate/package and depend on it.* Rejected:
+  `pi-package/` isn't Rust — it's a `pi` extension (TypeScript) plus
+  Markdown skills consumed by `pi install`, not something Cargo can depend on
+  without inventing a packaging format nobody else needs.
+- *Move `pi-package/` inside `crates/hyalo-cli/` and symlink (or generate) the
+  root-level path `pi install` expects.* Rejected on the same grounds
+  DEC-237 already reflects in the README/justfile/e2e-script constraints
+  this task inherited: `pi install git:...` needs `pi-package/` at the repo
+  root, and symlinks are unusable in Windows checkouts.
+- *Keep the single-source `include_str!` and special-case `cargo publish`
+  (e.g. a build script that copies files in before packaging).* Rejected:
+  `cargo package`'s verify step runs from the extracted tarball in a temp
+  directory with no access to the original working tree, so a build script
+  can't reach back out to `pi-package/` either — the constraint that broke
+  `include_str!` breaks this too.
+
+**Why a gate instead of trusting reviewers to keep both copies in sync.**
+Manual sync is exactly the failure mode DEC-237 was trying to avoid by having
+one source in the first place; a gate makes drift a CI failure instead of a
+silent divergence that only surfaces (as this bug did) at publish time.

--- a/justfile
+++ b/justfile
@@ -43,3 +43,12 @@ miri-all:
 # the model must use the hyalo tool (no silent bash fallback).
 pi-extension:
     ./pi-extension-e2e.sh
+
+# Sync the vendored pi-package copies (crates/hyalo-cli/templates/pi/) from
+# the canonical top-level pi-package/. Run after editing any pi-package
+# skill, extension, or package.json — `cargo run -p xtask -- check-pi-package-sync`
+# fails CI until the copies match again.
+sync-pi-package:
+    cp -R pi-package/skills/. crates/hyalo-cli/templates/pi/skills/
+    cp -R pi-package/extensions/. crates/hyalo-cli/templates/pi/extensions/
+    cp pi-package/package.json crates/hyalo-cli/templates/pi/package.json

--- a/justfile
+++ b/justfile
@@ -48,7 +48,13 @@ pi-extension:
 # the canonical top-level pi-package/. Run after editing any pi-package
 # skill, extension, or package.json — `cargo run -p xtask -- check-pi-package-sync`
 # fails CI until the copies match again.
+# Copies exactly the set the gate checks (skills/*/SKILL.md, extensions/*.ts,
+# package.json). POSIX shell: on Windows run from Git Bash or WSL.
 sync-pi-package:
-    cp -R pi-package/skills/. crates/hyalo-cli/templates/pi/skills/
-    cp -R pi-package/extensions/. crates/hyalo-cli/templates/pi/extensions/
+    for d in pi-package/skills/*/; do \
+      n=$(basename "$d"); mkdir -p "crates/hyalo-cli/templates/pi/skills/$n"; \
+      cp "$d/SKILL.md" "crates/hyalo-cli/templates/pi/skills/$n/SKILL.md"; \
+    done
+    mkdir -p crates/hyalo-cli/templates/pi/extensions
+    cp pi-package/extensions/*.ts crates/hyalo-cli/templates/pi/extensions/
     cp pi-package/package.json crates/hyalo-cli/templates/pi/package.json


### PR DESCRIPTION
## Summary
`cargo publish hyalo-cli` 0.21.0 failed in the tarball verify build: `init.rs` used `include_str!("../../../../pi-package/…")` — four files outside the crate, so absent from the crates.io tarball (`hyalo-core`/`hyalo-mdlint` 0.21.0 published fine; `hyalo-cli` is still 0.20.0 on crates.io).

- Vendored byte-identical copies under `crates/hyalo-cli/templates/pi/`; `init.rs` includes those. Root `pi-package/` stays canonical (`pi install git:…` consumes it).
- New xtask gate `check-pi-package-sync` fails on any byte difference or missing counterpart; wired into `quality-gates.yml`. `just sync-pi-package` recipe to refresh the copy.
- CHANGELOG entry; DEC-250 records the decision and rejected alternatives (own crate, symlink, build-script copy — the latter fails the same way because verify runs from the extracted tarball).

No CLI/behaviour change; `hyalo init` output byte-identical.

## Test plan
- [x] `cargo package -p hyalo-cli` fails on main, succeeds here (177 files, 4.2 MiB, verify build clean)
- [x] fmt / clippy -D warnings / cargo test --workspace -q green
- [x] all 6 xtask check-* gates green; new gate verified to fail on a tampered copy
- [ ] after merge: `gh workflow run publish-crates.yml -f ref=main` to publish hyalo-cli 0.21.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS