### PR TITLE
docs: plan iterations 250–252 + DEC-251 (axi.md review)

### DIFF
--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3327,3 +3327,44 @@ sync-pi-package` copies `pi-package/` onto the vendored tree to fix drift.
 Manual sync is exactly the failure mode DEC-237 was trying to avoid by having
 one source in the first place; a gate makes drift a CI failure instead of a
 silent divergence that only surfaces (as this bug did) at publish time.
+
+## DEC-251: axi.md agent-CLI principles — what hyalo adopts and what it rejects (2026-08-29)
+
+**Context.** The owner asked what [axi.md](https://axi.md/) (AXI, "Agent
+eXperience Interface" — a design spec for agent-facing CLIs with a
+conformance catalog and LLM-judged benchmarks, not a knowledgebase tool)
+teaches. A research pass compared its ten principles against
+`target/release/hyalo` 0.21.0 on the own KB.
+
+**Already at or above the bar.** Structured `hints[]` with a `writes`
+flag (stricter than AXI's free-text `help[]`); `summary` as a pre-computed
+aggregate; idempotent no-op mutations (`0/1 modified`, exit 0); structured
+errors on stderr with exit codes.
+
+**Measured gaps → adopted.**
+- Concise per-command help: `hyalo -h` 7.7 KB, `find -h` 12.3 KB
+  (`--help` 29 / 24 KB) because flag docs have no short/long split and the
+  global-options block repeats on all 27 subcommands →
+  [[iterations/iteration-251-agent-discoverability-help]].
+- Definitive empty states: bare `No results`, `hints: []` on zero results →
+  iteration 251.
+- Minimal default list schema: `find --tag iteration --limit 20
+  --format json` = 73 KB vs 8 KB with `--fields properties` →
+  [[iterations/iteration-252-find-result-shape]] (breaking; minor bump).
+- Size hints before reading: no `size`/`lines` on results → iteration 252.
+
+**Rejected.**
+- TOON as a third output format: breaks `--jq` and the envelope contract;
+  the savings come from the default field set instead.
+- Errors on stdout: stderr + exit code is the Unix contract CI relies on.
+- Content-first bare invocation (`hyalo` alone printing live data): a KB
+  has no single "most relevant" view; surprises humans and `hyalo | less`.
+- `SessionStart` hook / ambient context: `summary` is one call away.
+- npx/`skills add` distribution: hyalo has real packaging; no polyglot
+  tooling.
+- Benchmarks as marketing: a before/after token count of `find` on ten
+  tasks is enough evidence for a solo tool.
+
+**Constraint carried into both iterations.** No new CLI flags
+([[decision-log#DEC-249]] discipline): every adoption is a default, a
+layout, a hint, or metadata on existing output.

--- a/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
+++ b/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
@@ -1,0 +1,70 @@
+---
+type: iteration
+title: Iteration 250 — mdbook-lint 0.16.1 bump, strip the MD047 CRLF override
+date: 2026-08-29
+status: planned
+tags:
+  - iteration
+  - upstream
+  - mdlint
+branch: iter-250/mdlint-0161-workaround-strip
+---
+
+# Iteration 250 — mdbook-lint 0.16.1 bump, strip the MD047 CRLF override
+
+## Goal
+
+Upstream closed [joshrotenberg/mdbook-lint#495](https://github.com/joshrotenberg/mdbook-lint/issues/495)
+(our 2026-08-23 report) with mdbook-lint#496, shipped in **0.16.1
+(2026-08-27)**: MD047 now inserts the file's own terminator and counts
+CRLF as one unit when detecting extra trailing blank lines. Maintainer's
+note: MD047 was the last LF-centric rule. That makes `md047_fix` in
+`crates/hyalo-mdlint/src/engine.rs` — documented as "the one exception
+still open" in [[docs/upstream-mdbook-lint-reports]] — the last piece of
+upstream compensation code we carry. Remove it. Context:
+[[iterations/iteration-196-mdlint-workaround-strip]].
+
+## Tasks
+
+- [ ] `cargo update -p mdbook-lint-core -p mdbook-lint-rulesets` to 0.16.1
+      (`Cargo.toml` already says `"0.16"`; no manifest change). Commit
+      `Cargo.lock`.
+- [ ] Delete `md047_fix` and its dispatch branch
+      (`engine.rs` ~line 667: `if rule_id == "MD047" && body.contains("\r\n")`)
+      so MD047 on CRLF bodies goes through the generic `convert_fix` path
+      like every other rule. Reword the `convert_fix` doc comment (~line 768)
+      that contrasts itself with "the CRLF gap `md047_fix` compensates for".
+- [ ] Keep every CRLF fixture and e2e test that exercised the override
+      (`tests/e2e/lint.rs` MD047 convergence tests, `hyalo-mdlint` unit
+      tests) — they become the regression check that upstream's fix holds
+      through our CRLF-atomic offset translation. Add one case for a
+      mixed-endings file (upstream: terminator of the line before EOF wins);
+      if our old override disagreed, upstream's behaviour is the one to keep.
+- [ ] Verify on a real CRLF vault copy: `lint --fix --rule MD047` converges
+      in one run on (a) missing final newline, (b) three trailing blank
+      lines, (c) mixed endings; no bare `\n` introduced (`grep -c $'\r$'`
+      unchanged except the intended line).
+- [ ] Docs: `docs/upstream-mdbook-lint-reports.md` — turn "One exception
+      still open" into an outcome section ("all compensation removed in
+      iter-250"); CHANGELOG `[Unreleased]` → Changed (dependency bump) and
+      Removed (override); any README/skill text that mentions the CRLF
+      exception.
+- [ ] Gates: fmt, clippy -D warnings, test --workspace -q, all xtask
+      check-* gates; `cargo package -p hyalo-mdlint` still succeeds.
+
+## Acceptance criteria
+
+- [ ] `grep -rn md047_fix crates/` is empty; `hyalo-mdlint` contains no
+      rule-specific fix overrides.
+- [ ] All pre-existing CRLF MD047 tests pass unmodified against 0.16.1.
+- [ ] Gates green.
+
+## Non-goals
+
+- Any other dependency bump.
+- A release. This is patch-level (v0.21.1) whenever the next one is cut.
+
+## Links
+
+- [[docs/upstream-mdbook-lint-reports]]
+- [[iterations/iteration-196-mdlint-workaround-strip]]

--- a/hyalo-knowledgebase/iterations/iteration-251-agent-discoverability-help.md
+++ b/hyalo-knowledgebase/iterations/iteration-251-agent-discoverability-help.md
@@ -1,0 +1,90 @@
+---
+type: iteration
+title: "Iteration 251 — agent discoverability: short -h pages and zero-result hints"
+date: 2026-08-29
+status: planned
+tags:
+  - iteration
+  - agent-cli
+  - help
+branch: iter-251/agent-discoverability-help
+---
+
+# Iteration 251 — agent discoverability: short `-h` pages and zero-result hints
+
+## Goal
+
+Owner observation (2026-08-29): agents don't know what hyalo can do — they
+use bare-minimum `find` and pipe through `grep`. Two causes measured
+against `target/release/hyalo` 0.21.0: `hyalo -h` is 7.7 KB and
+`hyalo find -h` is 12.3 KB (`--help`: 29 KB / 24 KB), because no flag doc
+has a first-line/rest split so clap's short help prints whole paragraphs,
+and the ~1.9 KB global-options block is repeated on all 27 subcommands.
+And when a query returns nothing, text mode prints a bare `No results` and
+JSON has `hints: []` — the moment an agent most needs a next step.
+Source: the axi.md principles review (2026-08-29, see decision log) —
+"concise per-command help" and "definitive empty states". Targets are the
+two draft pages (2.4 KB each) attached to that review; they are the
+acceptance shape, not a suggestion.
+
+**No new flags.** `-h` already exists; this is content and layout.
+
+## Tasks
+
+- [ ] Every `#[arg]`/`#[command]` doc comment gets a one-line first
+      paragraph (clap `help`) followed by a blank line and the existing
+      text (clap `long_help`). Target: `hyalo <cmd> -h` ≤ 3 KB for every
+      subcommand; `--help` unchanged in content.
+- [ ] Global options: one-line short help each; the `--jq` limits paragraph
+      lives only in `--help`. On subcommands, `-h` shows globals as a single
+      pointer line (`Global: --format --jq --count --no-hints -q — see
+      hyalo -h`) — via the existing help template machinery in
+      `cli/help.rs`, not a new flag.
+- [ ] Top-level `-h`: commands grouped by intent (Read / Write / Config &
+      scaffolds), two per line where they pair naturally, one-line
+      descriptions naming the capability families (e.g. `find`: "BM25 text,
+      regex, property, tag, task, section, title, glob, link-graph
+      filters; sort, limit, --fields, --view, --count"). Keep a short
+      "Start here" block of ≤ 8 examples that each **compose** 2–3
+      features — the current 40 single-flag examples move to `--help`.
+- [ ] `find -h`: flags grouped Filters / Output; the property-operator
+      line, dot-path note, `--fields` values and `--sort` keys stay (these
+      are exactly where agents fall back to grep). ≤ 8 composed examples;
+      last line points at `find --help`.
+- [ ] Zero-result hints: when `total == 0`, emit 1–3 hints — drop the most
+      selective filter (re-run with one filter removed), `hyalo properties`
+      / `hyalo tags` to list observed values, and for `--property K=V` a
+      did-you-mean over the observed values of K when edit distance is
+      small. Text mode: `No results for --property status=x --tag y`
+      (echo the effective filters). JSON: same hints in the envelope, with
+      `writes: false`.
+- [ ] `check-help-drift` / `check-command-reference` / `check-bundled-skills`
+      xtask gates updated to the new shape; SKILL.md (bundled + pi-package,
+      keep in sync via `just sync-pi-package`) trimmed to workflow +
+      pitfalls and told to use `-h` first, `--help` for syntax detail.
+- [ ] e2e tests: byte-size ceilings for `-h` on every subcommand (loop over
+      `hyalo help` list); zero-result hint presence in text and JSON;
+      did-you-mean fires for a one-character typo and not for an unrelated
+      value.
+- [ ] CHANGELOG `[Unreleased]` → Changed.
+
+## Acceptance criteria
+
+- [ ] `hyalo -h` ≤ 2.5 KB, `hyalo find -h` ≤ 3 KB, every other
+      `hyalo <cmd> -h` ≤ 3 KB; every capability named on the current pages
+      is still named.
+- [ ] `hyalo find --property status=nonexistent` prints a non-empty hint
+      block in text and a non-empty `hints` array in JSON.
+- [ ] `--help` output loses nothing; all xtask gates and CI green.
+
+## Non-goals
+
+- Any change to JSON result shape or defaults —
+  [[iterations/iteration-252-find-result-shape]].
+- TOON or any third output format; errors on stdout; content-first bare
+  invocation; SessionStart hooks (rejected in the axi review).
+
+## Links
+
+- [[iterations/iteration-246-help-coherence-review-followups]]
+- [[iterations/iteration-252-find-result-shape]]

--- a/hyalo-knowledgebase/iterations/iteration-252-find-result-shape.md
+++ b/hyalo-knowledgebase/iterations/iteration-252-find-result-shape.md
@@ -1,0 +1,79 @@
+---
+type: iteration
+title: "Iteration 252 — find result shape: compact default fields and size metadata"
+date: 2026-08-29
+status: planned
+tags:
+  - iteration
+  - agent-cli
+  - breaking
+branch: iter-252/find-result-shape
+depends-on: "[[iterations/iteration-251-agent-discoverability-help]]"
+---
+
+# Iteration 252 — `find` result shape: compact default fields and size metadata
+
+## Goal
+
+Measured 2026-08-29 on the own KB: `hyalo find --tag iteration --limit 20
+--format json` is **73 KB**; the same with `--fields properties` is 8 KB.
+The default field set (`properties, tags, sections, links`) makes every
+listing pay ~9× for structure nobody asked for, and nothing in a result
+tells an agent how big a file is before it `read`s it. Source: axi.md
+principles review ("minimal default schema", "truncation with size
+hints"). This is the **only breaking change** in the 250–252 batch, so it
+gets its own iteration and a minor bump.
+
+**No new flags.** `--fields` exists; the auto-include precedent exists
+(`--broken-links` adds `links`, `--orphan` adds `backlinks`).
+
+## Tasks
+
+- [ ] New `find` default field set: `file, modified, size, title,
+      properties, tags` (+ `score`/`matches` when a PATTERN or `-e` is
+      present, as today). `sections`, `links`, `tasks`, `backlinks`,
+      `properties-typed` only on request (`--fields …` or `all`) or via
+      the existing auto-includes (`--section` → `sections`, `--task` →
+      `tasks`, `--broken-links`/`--dead-end` → `links`, `--orphan` →
+      `backlinks`, `--sort links_count|backlinks_count` → the counted field).
+- [ ] Size metadata: `size` (bytes) and `lines` on every `find` item and
+      on `read` results; `read` emits a hint (`--lines 1:80`, `--section`)
+      when the body exceeds a threshold (~8 KB). Text mode shows size in
+      the header line.
+- [ ] Every `find` result set carries one hint: `--fields all` (or the
+      specific missing field when a filter implies it). Text summary line
+      names the fields included.
+- [ ] Snapshot index: `size`/`lines` stored per entry; `create-index`
+      populates them; mutation journal keeps them current; index/disk
+      parity tests extended (the iter-243/244 parity suite).
+- [ ] Views: a saved view may pin `fields`; views without it get the new
+      default. Document in `views --help`.
+- [ ] Sweep consumers of the old default: hints generators, bundled skills,
+      `.claude/rules`, README examples, cookbook `--jq` recipes that read
+      `.results[].sections` / `.links` — add `--fields` where needed.
+- [ ] CHANGELOG `[Unreleased]` → **Changed** with a migration line
+      (`--fields all` restores the previous shape); bump workspace version
+      to 0.22.0 in the three Cargo.toml spots (minor: breaking default).
+- [ ] e2e: default shape byte-budget test (20-file listing ≤ 12 KB on the
+      test vault), auto-include matrix, `size`/`lines` correctness on CRLF
+      and UTF-8 files, index parity for the new fields.
+
+## Acceptance criteria
+
+- [ ] `find --tag iteration --limit 20 --format json` on the own KB ≤ 12 KB;
+      `--fields all` reproduces the pre-change shape.
+- [ ] Every filter that implies a field still returns it without
+      `--fields`.
+- [ ] `size` and `lines` present on `find` and `read` items, identical
+      between disk scan and `--index`.
+- [ ] Gates and CI green; version 0.22.0.
+
+## Non-goals
+
+- Truncating `read` bodies (agents need the full text; hints suffice).
+- Changing text-mode layout beyond the size column and summary line.
+
+## Links
+
+- [[iterations/iteration-251-agent-discoverability-help]]
+- [[iterations/iteration-244-index-remaining-deferrals]]


### PR DESCRIPTION
## Summary
- iteration-250: mdbook-lint 0.16.1 bump (upstream #495 closed via #496), strip the `md047_fix` CRLF override — last compensation code in hyalo-mdlint.
- iteration-251: agent discoverability — short `-h` pages (≤ 3 KB per command, grouped, composed examples) and non-empty hints on zero results. No new flags.
- iteration-252: `find` result shape — compact default field set + `size`/`lines` metadata; the only breaking change, own iteration, 0.22.0.
- DEC-251 records what the axi.md principles review adopts and rejects.

Docs only. `hyalo lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS