### PR TITLE
iter-250: mdbook-lint 0.16.1, delete the last upstream compensation (MD047 CRLF)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **mdbook-lint bumped to 0.16.1.** `mdbook-lint-core` and
+  `mdbook-lint-rulesets` move 0.16.0 → 0.16.1 (lockfile only; the manifest
+  requirement `"0.16"` is unchanged). The release carries upstream
+  [#496](https://github.com/joshrotenberg/mdbook-lint/pull/496), which fixes
+  MD047 on CRLF files: trailing terminators are counted with CRLF as one unit
+  (so a CRLF file with several trailing blank lines is now detected at all),
+  and the missing-final-newline fix inserts the file's own terminator instead
+  of a hard-coded LF. Where a file's endings are mixed, the terminator of the
+  line immediately before EOF wins.
+
+### Removed
+
+- **The last downstream compensation for an upstream mdbook-lint bug.**
+  `md047_fix` in `hyalo-mdlint` — which computed MD047 fixes locally for CRLF
+  bodies, the one documented exception left after iteration 196 — is deleted
+  along with its dispatch branch. MD047 now goes through the same generic
+  `convert_fix` translation as every other rule, so `hyalo-mdlint` carries no
+  rule-specific fix overrides. No user-visible behaviour change: the CRLF and
+  mixed-endings MD047 tests written against the override pass unmodified
+  against 0.16.1 and stay as the regression check.
+
 ### Fixed
 
 - `hyalo-cli` crates.io publish (v0.21.0) failed at the tarball verify step because the pi integration files were embedded via `include_str!` reaching outside the crate into the top-level `pi-package/` directory, which `cargo package` cannot see. The four files are now vendored inside `crates/hyalo-cli/templates/pi/`, kept in sync with `pi-package/` by a new `check-pi-package-sync` CI gate (`just sync-pi-package` to fix drift).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ and this project adheres to
   along with its dispatch branch. MD047 now goes through the same generic
   `convert_fix` translation as every other rule, so `hyalo-mdlint` carries no
   rule-specific fix overrides. No user-visible behaviour change: the CRLF and
-  mixed-endings MD047 tests written against the override pass unmodified
-  against 0.16.1 and stay as the regression check.
+  mixed-endings MD047 tests written against the override keep their expected
+  outputs against 0.16.1 (re-pointed at the engine, one extra convergence
+  assertion) and stay as the regression check.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,9 +976,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccfa4ed4e7259047e418cf251c8d94f5f336630178f3868b78a071957b305d8"
+checksum = "1291ba5652609c79c5265a9c1b71ff5bc8f99fc44be0a857def923c695e566aa"
 dependencies = [
  "anyhow",
  "comrak",
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f6d2d117581f3a968ebe185ab5b68ddaf251abcae28035febf54ffc681c86e"
+checksum = "737e691fe5f6c7a15e6933ba098dba529b45d2fa667d77fe956bcf496462d084"
 dependencies = [
  "anyhow",
  "comrak",

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -1529,7 +1529,11 @@ fn lint_fix_md047_crlf_and_mixed_endings_converge_in_one_run() {
     // single-line body carries no terminator for MD047 to sample, so it
     // falls back to LF — the same answer the deleted override gave, since it
     // sniffed the same body text.
-    write_md(tmp.path(), "a.md", "---\r\ntitle: A\r\n---\r\nline one\r\nbody");
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\r\ntitle: A\r\n---\r\nline one\r\nbody",
+    );
     // (b) CRLF, three trailing terminators.
     write_md(
         tmp.path(),

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -1514,6 +1514,76 @@ fn lint_fix_md047_converges_in_one_run() {
     assert_eq!(results2.files.len(), 0);
 }
 
+/// MD047 on CRLF and mixed-ending files, end to end through the vault
+/// writer. Until mdbook-lint 0.16.1 (upstream #496) MD047 hard-coded `"\n"`
+/// for the missing-EOF insertion and counted trailing terminators by bare
+/// `'\n'`, so hyalo carried a local `md047_fix` override; iteration 250
+/// deleted it. These cases are the regression check that upstream's fix
+/// survives frontmatter splitting and hyalo's CRLF-atomic offset
+/// translation.
+#[test]
+fn lint_fix_md047_crlf_and_mixed_endings_converge_in_one_run() {
+    let tmp = TempDir::new().unwrap();
+    write_schema_toml(tmp.path(), "dir = \".\"\n");
+    // (a) CRLF, no final newline. The body needs a second line: a
+    // single-line body carries no terminator for MD047 to sample, so it
+    // falls back to LF — the same answer the deleted override gave, since it
+    // sniffed the same body text.
+    write_md(tmp.path(), "a.md", "---\r\ntitle: A\r\n---\r\nline one\r\nbody");
+    // (b) CRLF, three trailing terminators.
+    write_md(
+        tmp.path(),
+        "b.md",
+        "---\r\ntitle: B\r\n---\r\nbody\r\n\r\n\r\n",
+    );
+    // (c) Mixed endings, no final newline: the terminator of the line before
+    // EOF wins, so this gets a bare LF appended, not CRLF.
+    write_md(
+        tmp.path(),
+        "c.md",
+        "---\r\ntitle: C\r\n---\r\ncrlf line\r\nlf line\nlast line",
+    );
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD047", "--format", "json"])
+        .output()
+        .unwrap();
+    let results: ExtLintFixOutput = typed_results(&output.stdout);
+    assert_eq!(results.total_fixed, 3, "all three files must be fixed");
+    assert_eq!(results.total_remaining, 0);
+
+    let a = std::fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        a.ends_with("line one\r\nbody\r\n"),
+        "CRLF file must get a CRLF terminator, not a bare LF, got: {a:?}"
+    );
+    let b = std::fs::read_to_string(tmp.path().join("b.md")).unwrap();
+    assert!(
+        b.ends_with("body\r\n") && !b.ends_with("body\r\n\r\n"),
+        "CRLF file must converge to one trailing terminator, got: {b:?}"
+    );
+    let c = std::fs::read_to_string(tmp.path().join("c.md")).unwrap();
+    assert!(
+        c.ends_with("lf line\nlast line\n") && !c.ends_with("last line\r\n"),
+        "mixed endings: the terminator before EOF (LF) wins, got: {c:?}"
+    );
+    // No file gained or lost a CR anywhere but the intended terminator.
+    assert_eq!(a.matches("\r\n").count(), 5, "a.md CR count, got: {a:?}");
+    assert_eq!(b.matches("\r\n").count(), 4, "b.md CR count, got: {b:?}");
+    assert_eq!(c.matches("\r\n").count(), 4, "c.md CR count, got: {c:?}");
+
+    // A second run must report zero fixes for all three.
+    let output2 = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD047", "--format", "json"])
+        .output()
+        .unwrap();
+    let results2: ExtLintFixOutput = typed_results(&output2.stdout);
+    assert_eq!(results2.total_fixed, 0);
+    assert_eq!(results2.files.len(), 0);
+}
+
 #[test]
 fn lint_fix_frontmatter_and_body_fixes_both_persist() {
     let tmp = TempDir::new().unwrap();

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -1517,7 +1517,7 @@ fn lint_fix_md047_converges_in_one_run() {
 /// MD047 on CRLF and mixed-ending files, end to end through the vault
 /// writer. Until mdbook-lint 0.16.1 (upstream #496) MD047 hard-coded `"\n"`
 /// for the missing-EOF insertion and counted trailing terminators by bare
-/// `'\n'`, so hyalo carried a local `md047_fix` override; iteration 250
+/// `'\n'`, so hyalo carried a local CRLF-only override; iteration 250
 /// deleted it. These cases are the regression check that upstream's fix
 /// survives frontmatter splitting and hyalo's CRLF-atomic offset
 /// translation.

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -1290,8 +1290,8 @@ mod tests {
     // These went through hyalo's own CRLF-only MD047 override until
     // mdbook-lint 0.16.1 (upstream #496) taught MD047 to count CRLF as one
     // terminator and to insert the file's own line ending. The override is
-    // gone (iter-250);
-    // the assertions are unchanged, so they now pin *upstream's* behaviour
+    // gone (iter-250); the tests were re-pointed at `lint_body` with the same
+    // inputs and expected outputs, so they now pin *upstream's* behaviour
     // travelling through `convert_fix` and our CRLF-atomic offset
     // translation.
 

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -1345,6 +1345,19 @@ mod tests {
         assert_eq!(fixed, "lf line\ncrlf line\r\nlast line\r\n");
     }
 
+    /// A single-line body carries no terminator for MD047 to sample, so
+    /// upstream falls back to LF even when the surrounding file uses CRLF.
+    /// The deleted override sniffed the same body text and answered the same
+    /// way, so this is unchanged behaviour rather than a regression — pinned
+    /// here so a future upstream change is visible instead of silent.
+    #[test]
+    fn md047_single_line_body_without_terminator_falls_back_to_lf() {
+        assert_eq!(
+            md047_fixed("body").expect("missing newline should fire"),
+            "body\n"
+        );
+    }
+
     /// Mixed *trailing* terminators each count as one, so the extras are
     /// removed down to the first terminator after the content — whatever kind
     /// that one is.

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -659,16 +659,7 @@ impl HyaloLintEngine {
                     if *rule_id == "MD011" && is_regex_false_positive(&v.message) {
                         continue;
                     }
-                    // Upstream MD047 hard-codes "\n" for the missing-EOF-newline
-                    // insertion and never fires on CRLF files with extra
-                    // trailing blank lines (see `md047_fix`), so CRLF bodies
-                    // still need the local computation. LF bodies take the
-                    // upstream fix, which is exact since 0.16.0.
-                    let fix = if *rule_id == "MD047" && body_content.contains("\r\n") {
-                        md047_fix(body_content)
-                    } else {
-                        convert_fix(&v, body_content)
-                    };
+                    let fix = convert_fix(&v, body_content);
                     // A handful of upstream rules report `column` as a byte
                     // offset, not a Unicode scalar one — see
                     // `BYTE_COLUMN_RULE_IDS` (DEC-073, iter-218 NEW-11).
@@ -765,9 +756,11 @@ impl HyaloLintEngine {
 /// an already-scalar column through [`byte_col_to_scalar_col`] would corrupt
 /// it on any line with multibyte content before the flagged position.
 ///
-/// Not filed upstream (unlike the CRLF gap `md047_fix` compensates for) — the
-/// three rules here each compute the byte offset a different way, so there is
-/// no single upstream fix to track. Re-check this table on every
+/// Not filed upstream — the three rules here each compute the byte offset a
+/// different way, so there is no single upstream fix to track. (The other
+/// gap hyalo used to compensate for, MD047's LF-centric CRLF handling, *was*
+/// filed as joshrotenberg/mdbook-lint#495 and fixed in 0.16.1; that
+/// compensation is gone as of iteration 250.) Re-check this table on every
 /// `mdbook-lint-rulesets` version bump: if a rule listed here switches to a
 /// `Vec<char>`/scalar computation upstream (as MD011/MD034 already do) and
 /// stays in this list, its column gets converted twice and silently comes
@@ -855,6 +848,14 @@ fn byte_col_to_scalar_col(line: &str, byte_col_1based: usize) -> usize {
 /// replace-vs-insert heuristic all became unnecessary and were deleted in
 /// iteration 196.
 ///
+/// Every rule now goes through here, MD047 included. Until 0.16.1 (upstream
+/// #496, our report #495) MD047 was the last LF-centric rule — it hard-coded
+/// `"\n"` for the missing-EOF insertion and counted trailing terminators by
+/// bare `'\n'`, so a `md047_fix` override computed CRLF fixes locally. 0.16.1
+/// inserts the file's own terminator and counts CRLF as one unit, so that
+/// override was deleted in iteration 250; the CRLF MD047 tests below are what
+/// keeps the upstream behaviour honest.
+///
 /// A position that cannot be resolved (out-of-range line/column, or an
 /// offset inside a CRLF pair) yields `None`; the violation is still reported,
 /// just without a fix.
@@ -872,78 +873,6 @@ fn convert_fix(v: &mdbook_lint_core::Violation, content: &str) -> Option<DiagFix
         start,
         end,
         replacement: fix.replacement.clone().unwrap_or_default(),
-    })
-}
-
-/// Compute a corrected single-pass fix for MD047 (single-trailing-newline)
-/// on **CRLF** bodies, bypassing upstream's own `Fix` positions.
-///
-/// mdbook-lint 0.16.0 fixed the LF range arithmetic (upstream #486/#493), so
-/// LF bodies now go through [`convert_fix`] unchanged. Two CRLF gaps remain
-/// in the shipped 0.16.0 crate, both in `mdbook-lint-rulesets`
-/// `src/standard/md047.rs`:
-///
-/// 1. The missing-trailing-newline branch builds
-///    `Fix::insertion("Add newline at end of file", "\n", …)` with a
-///    hard-coded LF, which would flip the last line of a CRLF file to a bare
-///    LF.
-/// 2. `check_file_ending` counts trailing terminators with
-///    `content.chars().rev().take_while(|&c| c == '\n')`, which stops at the
-///    `\r` of the second-to-last CRLF — so a CRLF file with several trailing
-///    blank lines counts one terminator and the rule never fires.
-///
-/// (2) is a detection gap upstream owns; (1) is a fix-output gap this
-/// function compensates for. Both are filed upstream as
-/// joshrotenberg/mdbook-lint#495; drop this function once a release carrying
-/// that fix is picked up. Kept as the documented exception required by
-/// iteration 196's acceptance criteria; re-check on the next mdbook-lint
-/// bump.
-fn md047_fix(body: &str) -> Option<DiagFix> {
-    // Match the body's own line-ending style so the fix never flips a CRLF
-    // file to LF (or vice versa).
-    let nl = if body.contains("\r\n") { "\r\n" } else { "\n" };
-    if body.is_empty() {
-        return Some(DiagFix {
-            description: "Add newline at end of file".to_owned(),
-            start: 0,
-            end: 0,
-            replacement: "\n".to_owned(),
-        });
-    }
-    if !body.ends_with('\n') {
-        return Some(DiagFix {
-            description: "Add newline at end of file".to_owned(),
-            start: body.len(),
-            end: body.len(),
-            replacement: nl.to_owned(),
-        });
-    }
-    // Count trailing line terminators, treating each CRLF pair as one.
-    let bytes = body.as_bytes();
-    let mut content_end = bytes.len();
-    let mut terminators = 0usize;
-    while content_end > 0 && bytes[content_end - 1] == b'\n' {
-        content_end -= if content_end >= 2 && bytes[content_end - 2] == b'\r' {
-            2
-        } else {
-            1
-        };
-        terminators += 1;
-    }
-    if terminators <= 1 {
-        return None; // MD047 would not have fired.
-    }
-    // Keep the first terminator after the content, drop the rest.
-    let first_terminator_len = if bytes.get(content_end) == Some(&b'\r') {
-        2
-    } else {
-        1
-    };
-    Some(DiagFix {
-        description: "Remove extra trailing newlines".to_owned(),
-        start: content_end + first_terminator_len,
-        end: body.len(),
-        replacement: String::new(),
     })
 }
 
@@ -1356,27 +1285,74 @@ mod tests {
         );
     }
 
-    // --- md047_fix must handle CRLF terminators ---
+    // --- MD047 must handle CRLF terminators ---
+    //
+    // These went through hyalo's own `md047_fix` override until mdbook-lint
+    // 0.16.1 (upstream #496) taught MD047 to count CRLF as one terminator and
+    // to insert the file's own line ending. The override is gone (iter-250);
+    // the assertions are unchanged, so they now pin *upstream's* behaviour
+    // travelling through `convert_fix` and our CRLF-atomic offset
+    // translation.
 
-    #[test]
-    fn md047_fix_crlf_removes_extra_trailing_newlines_in_one_pass() {
-        let body = "body\r\n\r\n\r\n";
-        let fix = md047_fix(body).expect("multiple trailing CRLF should produce a fix");
-        let fixed = apply(body, &fix);
-        assert_eq!(fixed, "body\r\n");
+    /// Run MD047 over `body` and apply the fix it reports, if any.
+    fn md047_fixed(body: &str) -> Option<String> {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD047".to_owned()])
+            .unwrap();
+        let d = diagnostics.iter().find(|d| d.rule_id == "MD047")?;
+        let fix = d.fix.as_ref().expect("MD047 fix should not be dropped");
+        Some(apply(body, fix))
     }
 
     #[test]
-    fn md047_fix_crlf_adds_matching_terminator() {
-        let body = "line one\r\nlast line";
-        let fix = md047_fix(body).expect("missing trailing newline should produce a fix");
-        let fixed = apply(body, &fix);
+    fn md047_crlf_removes_extra_trailing_newlines_in_one_pass() {
+        let fixed = md047_fixed("body\r\n\r\n\r\n").expect("multiple trailing CRLF should fire");
+        assert_eq!(fixed, "body\r\n");
+        assert!(
+            md047_fixed(&fixed).is_none(),
+            "the fixed body must be clean on a second pass"
+        );
+    }
+
+    #[test]
+    fn md047_crlf_adds_matching_terminator() {
+        let fixed = md047_fixed("line one\r\nlast line").expect("missing newline should fire");
         assert_eq!(fixed, "line one\r\nlast line\r\n");
     }
 
     #[test]
-    fn md047_fix_crlf_single_trailing_newline_is_clean() {
-        assert!(md047_fix("body\r\n").is_none());
+    fn md047_crlf_single_trailing_newline_is_clean() {
+        assert!(md047_fixed("body\r\n").is_none());
+    }
+
+    /// Mixed endings: upstream 0.16.1 inserts the terminator of the line
+    /// immediately before EOF, "since that is what the file was doing at the
+    /// point of insertion". The deleted `md047_fix` used a whole-body
+    /// `contains("\r\n")` test instead, which would have appended CRLF here;
+    /// upstream's rule is the one to keep.
+    #[test]
+    fn md047_mixed_endings_uses_the_terminator_before_eof() {
+        let fixed = md047_fixed("crlf line\r\nlf line\nlast line")
+            .expect("missing newline should fire on a mixed-endings body");
+        assert_eq!(fixed, "crlf line\r\nlf line\nlast line\n");
+
+        // ...and the other way round: an LF body whose last terminator is
+        // CRLF gets a CRLF appended.
+        let fixed = md047_fixed("lf line\ncrlf line\r\nlast line")
+            .expect("missing newline should fire on a mixed-endings body");
+        assert_eq!(fixed, "lf line\ncrlf line\r\nlast line\r\n");
+    }
+
+    /// Mixed *trailing* terminators each count as one, so the extras are
+    /// removed down to the first terminator after the content — whatever kind
+    /// that one is.
+    #[test]
+    fn md047_mixed_trailing_terminators_converge_in_one_pass() {
+        let fixed = md047_fixed("body\r\n\n\r\n").expect("three trailing terminators should fire");
+        assert_eq!(fixed, "body\r\n");
+        assert!(md047_fixed(&fixed).is_none());
     }
 
     // --- H-1b: MD009 must not duplicate the line terminator ---
@@ -1588,11 +1564,11 @@ mod tests {
         assert_eq!(fixed, "Some prose.\n\n# Heading\n\nMore prose.\n");
     }
 
-    /// Upstream #493 promises CRLF preservation, but the shipped 0.16.0
-    /// MD047 still hard-codes `"\n"` for the missing-EOF-newline insertion
-    /// (see [`md047_fix`]). This asserts hyalo's remaining CRLF
-    /// compensation, which is the one documented exception to the
-    /// "no downstream workarounds" rule.
+    /// Upstream #493 promised CRLF preservation but the shipped 0.16.0 MD047
+    /// still hard-coded `"\n"` for the missing-EOF-newline insertion, which
+    /// hyalo compensated for locally. 0.16.1 (#496) closed that gap and the
+    /// compensation was deleted in iteration 250, so this now asserts the
+    /// upstream fix reaches the file intact through [`convert_fix`].
     #[test]
     fn md047_crlf_body_keeps_crlf_when_adding_the_final_terminator() {
         let config = LintConfig::default();

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -851,7 +851,7 @@ fn byte_col_to_scalar_col(line: &str, byte_col_1based: usize) -> usize {
 /// Every rule now goes through here, MD047 included. Until 0.16.1 (upstream
 /// #496, our report #495) MD047 was the last LF-centric rule — it hard-coded
 /// `"\n"` for the missing-EOF insertion and counted trailing terminators by
-/// bare `'\n'`, so a `md047_fix` override computed CRLF fixes locally. 0.16.1
+/// bare `'\n'`, so a CRLF-only override computed those fixes locally. 0.16.1
 /// inserts the file's own terminator and counts CRLF as one unit, so that
 /// override was deleted in iteration 250; the CRLF MD047 tests below are what
 /// keeps the upstream behaviour honest.
@@ -1287,15 +1287,16 @@ mod tests {
 
     // --- MD047 must handle CRLF terminators ---
     //
-    // These went through hyalo's own `md047_fix` override until mdbook-lint
-    // 0.16.1 (upstream #496) taught MD047 to count CRLF as one terminator and
-    // to insert the file's own line ending. The override is gone (iter-250);
+    // These went through hyalo's own CRLF-only MD047 override until
+    // mdbook-lint 0.16.1 (upstream #496) taught MD047 to count CRLF as one
+    // terminator and to insert the file's own line ending. The override is
+    // gone (iter-250);
     // the assertions are unchanged, so they now pin *upstream's* behaviour
     // travelling through `convert_fix` and our CRLF-atomic offset
     // translation.
 
     /// Run MD047 over `body` and apply the fix it reports, if any.
-    fn md047_fixed(body: &str) -> Option<String> {
+    fn apply_md047(body: &str) -> Option<String> {
         let config = LintConfig::default();
         let engine = HyaloLintEngine::create().unwrap();
         let diagnostics = engine
@@ -1308,39 +1309,39 @@ mod tests {
 
     #[test]
     fn md047_crlf_removes_extra_trailing_newlines_in_one_pass() {
-        let fixed = md047_fixed("body\r\n\r\n\r\n").expect("multiple trailing CRLF should fire");
+        let fixed = apply_md047("body\r\n\r\n\r\n").expect("multiple trailing CRLF should fire");
         assert_eq!(fixed, "body\r\n");
         assert!(
-            md047_fixed(&fixed).is_none(),
+            apply_md047(&fixed).is_none(),
             "the fixed body must be clean on a second pass"
         );
     }
 
     #[test]
     fn md047_crlf_adds_matching_terminator() {
-        let fixed = md047_fixed("line one\r\nlast line").expect("missing newline should fire");
+        let fixed = apply_md047("line one\r\nlast line").expect("missing newline should fire");
         assert_eq!(fixed, "line one\r\nlast line\r\n");
     }
 
     #[test]
     fn md047_crlf_single_trailing_newline_is_clean() {
-        assert!(md047_fixed("body\r\n").is_none());
+        assert!(apply_md047("body\r\n").is_none());
     }
 
     /// Mixed endings: upstream 0.16.1 inserts the terminator of the line
     /// immediately before EOF, "since that is what the file was doing at the
-    /// point of insertion". The deleted `md047_fix` used a whole-body
+    /// point of insertion". The deleted override used a whole-body
     /// `contains("\r\n")` test instead, which would have appended CRLF here;
     /// upstream's rule is the one to keep.
     #[test]
     fn md047_mixed_endings_uses_the_terminator_before_eof() {
-        let fixed = md047_fixed("crlf line\r\nlf line\nlast line")
+        let fixed = apply_md047("crlf line\r\nlf line\nlast line")
             .expect("missing newline should fire on a mixed-endings body");
         assert_eq!(fixed, "crlf line\r\nlf line\nlast line\n");
 
         // ...and the other way round: an LF body whose last terminator is
         // CRLF gets a CRLF appended.
-        let fixed = md047_fixed("lf line\ncrlf line\r\nlast line")
+        let fixed = apply_md047("lf line\ncrlf line\r\nlast line")
             .expect("missing newline should fire on a mixed-endings body");
         assert_eq!(fixed, "lf line\ncrlf line\r\nlast line\r\n");
     }
@@ -1353,7 +1354,7 @@ mod tests {
     #[test]
     fn md047_single_line_body_without_terminator_falls_back_to_lf() {
         assert_eq!(
-            md047_fixed("body").expect("missing newline should fire"),
+            apply_md047("body").expect("missing newline should fire"),
             "body\n"
         );
     }
@@ -1363,9 +1364,9 @@ mod tests {
     /// that one is.
     #[test]
     fn md047_mixed_trailing_terminators_converge_in_one_pass() {
-        let fixed = md047_fixed("body\r\n\n\r\n").expect("three trailing terminators should fire");
+        let fixed = apply_md047("body\r\n\n\r\n").expect("three trailing terminators should fire");
         assert_eq!(fixed, "body\r\n");
-        assert!(md047_fixed(&fixed).is_none());
+        assert!(apply_md047(&fixed).is_none());
     }
 
     // --- H-1b: MD009 must not duplicate the line terminator ---
@@ -1410,7 +1411,7 @@ mod tests {
     // --- H-1c: MD047 must converge in a single application ---
 
     #[test]
-    fn md047_fix_converges_two_trailing_newlines_in_one_pass() {
+    fn md047_converges_two_trailing_newlines_in_one_pass() {
         let config = LintConfig::default();
         let engine = HyaloLintEngine::create().unwrap();
         let body = "body\n\n";
@@ -1436,7 +1437,7 @@ mod tests {
     }
 
     #[test]
-    fn md047_fix_converges_many_trailing_newlines_in_one_pass() {
+    fn md047_converges_many_trailing_newlines_in_one_pass() {
         let config = LintConfig::default();
         let engine = HyaloLintEngine::create().unwrap();
         let body = "body\n\n\n\n\n";
@@ -1453,7 +1454,7 @@ mod tests {
     }
 
     #[test]
-    fn md047_fix_adds_missing_trailing_newline() {
+    fn md047_adds_missing_trailing_newline() {
         let config = LintConfig::default();
         let engine = HyaloLintEngine::create().unwrap();
         let body = "body without newline";

--- a/hyalo-knowledgebase/docs/upstream-mdbook-lint-reports.md
+++ b/hyalo-knowledgebase/docs/upstream-mdbook-lint-reports.md
@@ -7,6 +7,7 @@ tags:
   - upstream
   - mdbook-lint
   - iteration-193
+  - iteration-250
 ---
 
 # Upstream mdbook-lint reports

--- a/hyalo-knowledgebase/docs/upstream-mdbook-lint-reports.md
+++ b/hyalo-knowledgebase/docs/upstream-mdbook-lint-reports.md
@@ -214,23 +214,54 @@ Upstream shipped every report in this document. Release
 
 Removal work is [[iterations/iteration-196-mdlint-workaround-strip]].
 
-### One exception still open (filed upstream as #495)
+### The last exception — MD047 on CRLF (closed in 0.16.1)
 
-Shipped 0.16.0 `mdbook-lint-rulesets/src/standard/md047.rs` is still
+Shipped 0.16.0 `mdbook-lint-rulesets/src/standard/md047.rs` was still
 LF-centric, despite the release note claim that "standard-rule fixes now
 preserve CRLF":
 
-1. The missing-trailing-newline branch builds
+1. The missing-trailing-newline branch built
    `Fix::insertion("Add newline at end of file", "\n", …)` with a hard-coded
-   LF, so applying it to a CRLF file appends a bare LF.
-2. `check_file_ending` counts trailing terminators with
+   LF, so applying it to a CRLF file appended a bare LF.
+2. `check_file_ending` counted trailing terminators with
    `content.chars().rev().take_while(|&c| c == '\n')`, which stops at the
    `\r` of the preceding CRLF — so a CRLF file with several trailing blank
-   lines counts one terminator and MD047 never fires at all.
+   lines counted one terminator and MD047 never fired at all.
 
-hyalo keeps `md047_fix` for CRLF bodies only (LF bodies go through
-`convert_fix` unchanged) as the documented compensation for (1); (2) is a
-detection gap upstream owns. **Filed 2026-08-23** (user-authorized) as
+**Filed 2026-08-23** (user-authorized) as
 [joshrotenberg/mdbook-lint#495](https://github.com/joshrotenberg/mdbook-lint/issues/495).
 The follow-up comment on #456 reporting the embedder result was dropped by
 user choice.
+
+## Outcome — mdbook-lint 0.16.1 (2026-08-27): all compensation removed
+
+Upstream closed #495 with
+[#496](https://github.com/joshrotenberg/mdbook-lint/pull/496), released in
+[v0.16.1](https://github.com/joshrotenberg/mdbook-lint/releases/tag/v0.16.1)
+(2026-08-27). MD047 now counts trailing terminators via a
+`strip_suffix("\r\n").or_else(strip_suffix('\n'))` loop (CRLF is one unit, so
+both gaps above close at once) and inserts the file's own terminator — where
+endings are mixed, the terminator of the line immediately before EOF wins.
+The maintainer's note: MD047 was the last LF-centric rule.
+
+That was hyalo's last piece of upstream compensation code.
+[[iterations/iteration-250-mdlint-0161-workaround-strip]] deleted `md047_fix`
+and its dispatch branch, so **every** rule — MD047 included — now goes through
+the generic `convert_fix` translation with no per-rule special cases.
+`grep -rn md047_fix crates/` is empty and `hyalo-mdlint` carries no
+rule-specific fix overrides.
+
+What remains in `engine.rs` is not upstream compensation and must not be
+confused with it:
+
+- `BYTE_COLUMN_RULE_IDS` (MD010/MD042/MD052) converts *reported diagnostic
+  columns* — not `Fix` ranges — from byte to scalar offsets. Deliberately not
+  filed upstream: each rule computes the offset a different way, so there is
+  no single fix to track. Re-check it on every ruleset bump.
+- `is_regex_false_positive` suppresses an MD011 false positive on regex prose
+  (dogfood UX-4).
+
+The CRLF and mixed-endings MD047 tests kept from the override era
+(`hyalo-mdlint` unit tests plus `lint_fix_md047_crlf_and_mixed_endings_converge_in_one_run`
+in the CLI e2e suite) are now the regression check that upstream's fix keeps
+surviving hyalo's frontmatter splitting and CRLF-atomic offset translation.

--- a/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
+++ b/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
@@ -56,7 +56,9 @@ upstream compensation code we carry. Remove it. Context:
 
 - [x] `grep -rn md047_fix crates/` is empty; `hyalo-mdlint` contains no
       rule-specific fix overrides.
-- [x] All pre-existing CRLF MD047 tests pass unmodified against 0.16.1.
+- [x] All pre-existing CRLF MD047 tests pass against 0.16.1 with their
+      expected outputs preserved (re-pointed from `md047_fix` to `lint_body`;
+      one gained a second-pass convergence assertion).
 - [x] Gates green.
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
+++ b/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 250 — mdbook-lint 0.16.1 bump, strip the MD047 CRLF override
 date: 2026-08-29
-status: planned
+status: in-progress
 tags:
   - iteration
   - upstream

--- a/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
+++ b/hyalo-knowledgebase/iterations/iteration-250-mdlint-0161-workaround-strip.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 250 — mdbook-lint 0.16.1 bump, strip the MD047 CRLF override
 date: 2026-08-29
-status: in-progress
+status: completed
 tags:
   - iteration
   - upstream
@@ -26,38 +26,38 @@ upstream compensation code we carry. Remove it. Context:
 
 ## Tasks
 
-- [ ] `cargo update -p mdbook-lint-core -p mdbook-lint-rulesets` to 0.16.1
+- [x] `cargo update -p mdbook-lint-core -p mdbook-lint-rulesets` to 0.16.1
       (`Cargo.toml` already says `"0.16"`; no manifest change). Commit
       `Cargo.lock`.
-- [ ] Delete `md047_fix` and its dispatch branch
+- [x] Delete `md047_fix` and its dispatch branch
       (`engine.rs` ~line 667: `if rule_id == "MD047" && body.contains("\r\n")`)
       so MD047 on CRLF bodies goes through the generic `convert_fix` path
       like every other rule. Reword the `convert_fix` doc comment (~line 768)
       that contrasts itself with "the CRLF gap `md047_fix` compensates for".
-- [ ] Keep every CRLF fixture and e2e test that exercised the override
+- [x] Keep every CRLF fixture and e2e test that exercised the override
       (`tests/e2e/lint.rs` MD047 convergence tests, `hyalo-mdlint` unit
       tests) — they become the regression check that upstream's fix holds
       through our CRLF-atomic offset translation. Add one case for a
       mixed-endings file (upstream: terminator of the line before EOF wins);
       if our old override disagreed, upstream's behaviour is the one to keep.
-- [ ] Verify on a real CRLF vault copy: `lint --fix --rule MD047` converges
+- [x] Verify on a real CRLF vault copy: `lint --fix --rule MD047` converges
       in one run on (a) missing final newline, (b) three trailing blank
       lines, (c) mixed endings; no bare `\n` introduced (`grep -c $'\r$'`
       unchanged except the intended line).
-- [ ] Docs: `docs/upstream-mdbook-lint-reports.md` — turn "One exception
+- [x] Docs: `docs/upstream-mdbook-lint-reports.md` — turn "One exception
       still open" into an outcome section ("all compensation removed in
       iter-250"); CHANGELOG `[Unreleased]` → Changed (dependency bump) and
       Removed (override); any README/skill text that mentions the CRLF
       exception.
-- [ ] Gates: fmt, clippy -D warnings, test --workspace -q, all xtask
+- [x] Gates: fmt, clippy -D warnings, test --workspace -q, all xtask
       check-* gates; `cargo package -p hyalo-mdlint` still succeeds.
 
 ## Acceptance criteria
 
-- [ ] `grep -rn md047_fix crates/` is empty; `hyalo-mdlint` contains no
+- [x] `grep -rn md047_fix crates/` is empty; `hyalo-mdlint` contains no
       rule-specific fix overrides.
-- [ ] All pre-existing CRLF MD047 tests pass unmodified against 0.16.1.
-- [ ] Gates green.
+- [x] All pre-existing CRLF MD047 tests pass unmodified against 0.16.1.
+- [x] Gates green.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

- **Bumps `mdbook-lint-core` / `mdbook-lint-rulesets` 0.16.0 → 0.16.1** (lockfile only — the manifest requirement is already `"0.16"`). 0.16.1 carries upstream [#496](https://github.com/joshrotenberg/mdbook-lint/pull/496), which closes [#495](https://github.com/joshrotenberg/mdbook-lint/issues/495) — our 2026-08-23 report. MD047 now counts trailing terminators with CRLF as one unit and inserts the file's *own* terminator instead of a hard-coded `\n`; where endings are mixed, the terminator of the line immediately before EOF wins.
- **Deletes `md047_fix` and its dispatch branch in `crates/hyalo-mdlint/src/engine.rs`.** MD047 now goes through the same generic `convert_fix` translation as every other rule. This was the last piece of upstream compensation code hyalo carried — the "one exception still open" left standing by iteration 196. `grep -rn md047_fix crates/` is now empty, including the residual identifiers (test names, a helper) that referenced the deleted symbol.
- **What stays, and is not upstream compensation:** `BYTE_COLUMN_RULE_IDS` (MD010/MD042/MD052) converts *reported diagnostic columns*, not `Fix` ranges, and is deliberately unfiled upstream; `is_regex_false_positive` suppresses an MD011 false positive on regex prose. Both doc comments were reworded so the distinction is explicit.
- **Docs:** `hyalo-knowledgebase/docs/upstream-mdbook-lint-reports.md` turns "One exception still open" into an outcome section for 0.16.1; CHANGELOG `[Unreleased]` gains a **Changed** entry (dep bump) and a **Removed** entry (the override). No user-visible behaviour change, so no README/help/skill text is affected.

## Test plan

- [x] Every CRLF MD047 test written against the override passes with its **assertions unmodified** against 0.16.1. The three unit tests that called `md047_fix` directly had to be re-pointed at `lint_body` (the function no longer exists) — same inputs, same expected outputs, now exercising upstream's fix through hyalo's CRLF-atomic offset translation.
- [x] New unit tests: mixed-endings insertion in both directions (`crlf\r\nlf\nlast` → LF appended; `lf\ncrlf\r\nlast` → CRLF appended), mixed *trailing* terminators (`body\r\n\n\r\n` → `body\r\n`, clean on a second pass), and the single-line-body fallback (no terminator to sample → LF, unchanged from the override's own answer — pinned so a future upstream change is visible).
- [x] New e2e test `lint_fix_md047_crlf_and_mixed_endings_converge_in_one_run`: three files in one vault (CRLF missing final newline / CRLF with three trailing terminators / mixed endings), asserting one-run convergence, exact CRLF counts, and zero fixes on a second run.
- [x] Manual verification on a real CRLF vault copy — all three cases converge in one `hyalo lint --fix --rule MD047`, second run reports 0 fixes, and CRLF counts move only by the intended terminator (a: 6→7, b: 9→6, c: unchanged, one bare LF added).
- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace -q` all green.
- [x] All eight xtask gates exit 0: `check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`, `check-pi-package-sync`, `check-dead-primitives`, `check-todo-annotations`, `check-mutation-journal`.
- [x] `cargo package -p hyalo-mdlint` succeeds.
- [x] `hyalo lint --strict` on the knowledgebase: 105 files, no issues; the edited doc has no broken links or anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS