### PR TITLE
iter-251: short -h pages and zero-result hints for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to
 
 ### Changed
 
+- **`-h` is a short page again, and every command's page names its
+  capabilities.** Measured on 0.21.0, `hyalo -h` was 7.7 KB and `hyalo find -h`
+  12.3 KB, because no flag's documentation had a first-line/rest split (so
+  clap's short help printed whole paragraphs) and the ~1.9 KB global-options
+  block was repeated on all 27 subcommands. Every `#[arg]`/`#[command]` doc
+  comment now leads with a one-line summary and keeps its full text as
+  `--help`'s long help; on a subcommand, `-h` stands in for the global block
+  with a single `Global: --dir --format --jq … — see hyalo -h` line. `hyalo -h`
+  groups the commands by intent (read / write / config and scaffolds) with
+  one-line descriptions that name the capability families, and its examples
+  each compose two or three features instead of demonstrating one flag; the 40
+  single-flag examples moved to `--help`. `find -h` groups its flags under
+  Filters and Output and keeps the property-operator line, the dot-path note,
+  the `--fields` values and the `--sort` keys — the four things agents were
+  falling back to `grep` for. Result: `hyalo -h` 2.5 KB, `hyalo find -h` 2.9
+  KB, every other subcommand under 2.3 KB, with `--help` unchanged in content.
+  A new `check-help-drift` gate (3c/3d) and an e2e suite that walks the
+  binary's own command list hold the ceilings.
+- **A `find` that matches nothing now says what it ran and what to try.** Text
+  mode prints `No results for --property status=x --tag y` instead of a bare
+  `No results`, and both formats carry 1–3 hints: a did-you-mean over the
+  values the property really has (fired only when the edit distance is small,
+  so `status=draf` suggests `draft` while `status=nonexistent` does not), the
+  observed values named inline, and the same query with its most selective
+  filter dropped. The values come from the scan the query already paid for, so
+  the empty path costs no extra I/O.
 - **mdbook-lint bumped to 0.16.1.** `mdbook-lint-core` and
   `mdbook-lint-rulesets` move 0.16.0 → 0.16.1 (lockfile only; the manifest
   requirement `"0.16"` is unchanged). The release carries upstream

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -399,7 +399,12 @@ pub(crate) struct FindFilters {
     /// Property filter: K=V (eq), K!=V (neq), K>=V, K<=V, K>V, K<V, K (exists), !K (absent),
     /// K~=pat or K~=/pat/i (regex). Repeatable (AND). K may be a dot-path into nested maps and
     /// sequences (contact.email, contacts.0.email, contacts.email = any element).
-    #[arg(short, long = "property", value_name = "FILTER", help_heading = "Filters")]
+    #[arg(
+        short,
+        long = "property",
+        value_name = "FILTER",
+        help_heading = "Filters"
+    )]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub properties: Vec<String>,
     /// Tag, exact or prefix ('project' matches 'project/backend'); repeatable (AND)
@@ -418,7 +423,12 @@ pub(crate) struct FindFilters {
     /// Section heading filter: case-insensitive substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
     /// prefix '##' to pin heading level; use '/regex/' for regex (e.g. '/DEC-03[12]/'). Repeatable (OR).
     /// A file with more than one matching heading unions all of them (unlike `task --section`, which refuses)
-    #[arg(short, long = "section", value_name = "HEADING", help_heading = "Filters")]
+    #[arg(
+        short,
+        long = "section",
+        value_name = "HEADING",
+        help_heading = "Filters"
+    )]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sections: Vec<String>,
     #[arg(
@@ -462,7 +472,12 @@ pub(crate) struct FindFilters {
     /// scanning all files; 'title' is the frontmatter title property or first H1 heading (null if
     /// neither found). Note: in JSON output, `properties-typed` is serialized as
     /// `properties_typed` (underscore).
-    #[arg(long, value_name = "FIELDS", use_value_delimiter = true, help_heading = "Output")]
+    #[arg(
+        long,
+        value_name = "FIELDS",
+        use_value_delimiter = true,
+        help_heading = "Output"
+    )]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<String>,
     /// file (default)|modified|backlinks_count|links_count|title|date|property:K

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -25,6 +25,10 @@ pub(crate) const LIMITED_COMMANDS_PLACEHOLDER: &str = "{LIMITED_COMMANDS}";
 const FILE_FLAG_DOC: &str = "Target file(s) (repeatable; falls back to case-insensitive matching \
      per `[links] case_insensitive`, default auto). Mutually exclusive with --glob and --files-from";
 
+/// One-line `-h` form of [`FILE_FLAG_DOC`] (iter-251). The case-folding and
+/// mutual-exclusion detail stays on `--help`, where there is room for it.
+const FILE_FLAG_SHORT_DOC: &str = "Target file(s), repeatable (excludes --glob / --files-from)";
+
 #[allow(clippy::trivially_copy_pass_by_ref)] // serde skip_serializing_if requires &bool
 pub(crate) fn is_false(v: &bool) -> bool {
     !v
@@ -52,7 +56,7 @@ pub(crate) fn parse_threshold(s: &str) -> Result<f64, String> {
 /// Index flags, flattened into subcommands that can consume a snapshot index.
 #[derive(Args, Debug, Default, Clone)]
 pub(crate) struct IndexFlags {
-    /// Use the snapshot index at `.hyalo-index` in the vault directory.
+    /// Use the `.hyalo-index` snapshot in the vault dir
     ///
     /// Read-only commands (find, summary, tags summary, properties summary,
     /// backlinks) skip the disk scan entirely when the index is present.
@@ -89,7 +93,7 @@ pub(crate) struct IndexFlags {
     #[arg(long)]
     pub index: bool,
 
-    /// Use the snapshot index at PATH instead of the default `.hyalo-index`.
+    /// Use the snapshot index at PATH instead of `.hyalo-index`
     ///
     /// Implies `--index`. Relative paths are resolved against the current
     /// working directory (not the vault dir); absolute paths are used as-is.
@@ -243,6 +247,8 @@ const LONG_ABOUT_TEMPLATE: &str = "Hyalo — query, filter, and mutate YAML fron
     long_about = build_long_about()
 )]
 pub(crate) struct Cli {
+    /// Vault root for file and glob paths (default: .)
+    ///
     /// Root directory for resolving all file and --glob paths.
     /// Default: "." (Override via .hyalo.toml)
     #[arg(
@@ -266,12 +272,16 @@ pub(crate) struct Cli {
     )]
     pub dir: Option<PathBuf>,
 
+    /// Output format (default: text on a terminal, json when piped)
+    ///
     /// Output format: "json" or "text".
     /// Default: "text" when stdout is a terminal, "json" when piped.
     /// Override for a session via .hyalo.toml: format = "text"
     #[arg(long, global = true)]
     pub format: Option<Format>,
 
+    /// jq filter over the JSON envelope
+    ///
     /// Apply a jq filter expression to the JSON output of any command.
     /// Operates on the full JSON envelope: {"results": ..., "total": N, "hints": [...]}.
     /// The filtered result is printed as plain text. Incompatible with --format text
@@ -286,6 +296,8 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "FILTER")]
     pub jq: Option<String>,
 
+    /// Print just the total as a bare integer (list commands)
+    ///
     /// Print only the total count as a bare integer for list commands.
     /// Shortcut for --jq '.total'. Incompatible with --jq.
     // The full command list lives in `build_count_long_help()` so it is derived
@@ -293,6 +305,8 @@ pub(crate) struct Cli {
     #[arg(long, global = true, long_help = build_count_long_help())]
     pub count: bool,
 
+    /// Force hints on (already the default)
+    ///
     /// Force hints on (already the default).
     /// Text mode: '-> hyalo ...  # description' lines — concrete, copy-pasteable commands with descriptions.
     /// JSON mode: populates the "hints" array in the envelope (always present, empty when suppressed).
@@ -300,14 +314,17 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub hints: bool,
 
+    /// Disable drill-down hints (on by default)
+    ///
     /// Disable drill-down command hints (enabled by default).
     /// Override via .hyalo.toml: hints = false
     /// When both --hints and --no-hints are present, --hints takes precedence.
     #[arg(long, global = true)]
     pub no_hints: bool,
 
-    /// Site prefix for resolving root-absolute links like `/docs/page.md`.
+    /// Prefix stripped from /root-absolute/links
     ///
+    /// Site prefix for resolving root-absolute links like `/docs/page.md`.
     /// When a markdown file contains a link like `/docs/guides/setup.md`, hyalo strips the
     /// leading `/<prefix>/` to get the vault-relative path `guides/setup.md`. This is how
     /// documentation sites (GitHub Pages, VuePress, Docusaurus) map URL paths to file paths.
@@ -332,8 +349,9 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "PREFIX")]
     pub site_prefix: Option<String>,
 
-    /// Suppress all warnings printed to stderr.
+    /// Suppress warnings on stderr
     ///
+    /// Suppress all warnings printed to stderr.
     /// Useful in scripts or CI pipelines where warning noise is undesirable.
     /// Identical warnings are always deduplicated regardless of this flag;
     /// use `--quiet` to suppress them entirely.
@@ -344,8 +362,9 @@ pub(crate) struct Cli {
     #[arg(short = 'q', long, global = true)]
     pub quiet: bool,
 
-    /// Use the snapshot index at PATH (global alias for the per-subcommand `--index-file`).
+    /// Snapshot index path (alias for the subcommand flag)
     ///
+    /// Use the snapshot index at PATH (global alias for the per-subcommand `--index-file`).
     /// Equivalent to passing `--index-file PATH` after the subcommand.
     /// When both the global flag and the subcommand flag are provided, the
     /// subcommand value takes precedence.
@@ -368,35 +387,59 @@ pub(crate) struct FindFilters {
     #[arg(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
-    /// Regex body text search (case-insensitive by default; use (?-i) to override). Mutually exclusive with PATTERN
-    #[arg(long, short = 'e', value_name = "REGEX")]
+    /// Regex body search, case-insensitive (excludes PATTERN)
+    ///
+    /// Regex body text search (case-insensitive by default; use (?-i) to override).
+    /// Mutually exclusive with PATTERN.
+    #[arg(long, short = 'e', value_name = "REGEX", help_heading = "Filters")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regexp: Option<String>,
-    /// Property filter: K=V (eq), K!=V (neq), K>=V, K<=V, K>V, K<V, K (exists), !K (absent), K~=pat or K~=/pat/i (regex). Repeatable (AND). K may be a dot-path into nested maps and sequences (contact.email, contacts.0.email, contacts.email = any element)
-    #[arg(short, long = "property", value_name = "FILTER")]
+    /// K=V|K!=V|K>V|K>=V|K<V|K<=V|K|!K|K~=re|K~=/re/i; AND; K may be a dot-path
+    ///
+    /// Property filter: K=V (eq), K!=V (neq), K>=V, K<=V, K>V, K<V, K (exists), !K (absent),
+    /// K~=pat or K~=/pat/i (regex). Repeatable (AND). K may be a dot-path into nested maps and
+    /// sequences (contact.email, contacts.0.email, contacts.email = any element).
+    #[arg(short, long = "property", value_name = "FILTER", help_heading = "Filters")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub properties: Vec<String>,
-    /// Tag filter: exact or prefix match (e.g. 'project' matches 'project/backend' but not 'projects'). Repeatable (AND)
-    #[arg(short, long, value_name = "TAG")]
+    /// Tag, exact or prefix ('project' matches 'project/backend'); repeatable (AND)
+    ///
+    /// Tag filter: exact or prefix match (e.g. 'project' matches 'project/backend' but not
+    /// 'projects'). Repeatable (AND).
+    #[arg(short, long, value_name = "TAG", help_heading = "Filters")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tag: Vec<String>,
-    /// Task presence filter: 'todo', 'done', 'any', or a single status character
-    #[arg(long, value_name = "STATUS")]
+    /// Task presence: 'todo', 'done', 'any', or a single status character
+    #[arg(long, value_name = "STATUS", help_heading = "Filters")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
+    /// Heading substring, '##' pins the level, or /regex/; repeatable (OR)
+    ///
     /// Section heading filter: case-insensitive substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
     /// prefix '##' to pin heading level; use '/regex/' for regex (e.g. '/DEC-03[12]/'). Repeatable (OR).
     /// A file with more than one matching heading unions all of them (unlike `task --section`, which refuses)
-    #[arg(short, long = "section", value_name = "HEADING")]
+    #[arg(short, long = "section", value_name = "HEADING", help_heading = "Filters")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sections: Vec<String>,
-    #[arg(short, long, conflicts_with_all = ["glob", "files_from"], help = FILE_FLAG_DOC)]
+    #[arg(
+        short,
+        long,
+        conflicts_with_all = ["glob", "files_from"],
+        help = FILE_FLAG_SHORT_DOC,
+        long_help = FILE_FLAG_DOC,
+        help_heading = "Filters"
+    )]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub file: Vec<String>,
-    /// Glob pattern(s) to select files, relative to --dir (repeatable); prefix '!' to negate (e.g. '!**/draft-*')
-    #[arg(short, long, conflicts_with_all = ["file", "files_from"])]
+    /// Glob(s) relative to --dir, repeatable; '!' negates ('!**/draft-*')
+    ///
+    /// Glob pattern(s) to select files, relative to --dir (repeatable); prefix '!' to negate
+    /// (e.g. '!**/draft-*').
+    #[arg(short, long, conflicts_with_all = ["file", "files_from"], help_heading = "Filters")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub glob: Vec<String>,
+    /// Read paths from PATH, one per line ('-' = stdin)
+    ///
     /// Read file paths from PATH (one per line); use '-' to read from stdin.
     /// Mutually exclusive with --file and --glob.
     /// Non-.md paths and paths outside the vault are silently skipped (counters appear in JSON envelope).
@@ -406,26 +449,48 @@ pub(crate) struct FindFilters {
     /// CHANGED-FILES RECIPE: `git diff --name-only origin/main | hyalo <cmd> --files-from -`
     /// restricts a run to what a branch touched (any VCS or `find`/`fd`/`rg -l` works the same way;
     /// hyalo shells out to nothing and has no VCS-specific flag).
-    #[arg(long, value_name = "PATH", conflicts_with_all = ["file", "glob"])]
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["file", "glob"], help_heading = "Filters")]
     #[serde(skip)]
     pub files_from: Option<String>,
-    /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags, sections (alias: outline), tasks, links, backlinks, title (default: properties, tags, sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to include every field. 'file' and 'modified' are always included. 'properties' is a {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires scanning all files; 'title' is the frontmatter title property or first H1 heading (null if neither found). Note: in JSON output, `properties-typed` is serialized as `properties_typed` (underscore)
-    #[arg(long, value_name = "FIELDS", use_value_delimiter = true)]
+    /// all|properties|properties-typed|tags|sections|tasks|links|backlinks|title (default: properties,tags,sections,links)
+    ///
+    /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags,
+    /// sections (alias: outline), tasks, links, backlinks, title (default: properties, tags,
+    /// sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to
+    /// include every field. 'file' and 'modified' are always included. 'properties' is a
+    /// {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires
+    /// scanning all files; 'title' is the frontmatter title property or first H1 heading (null if
+    /// neither found). Note: in JSON output, `properties-typed` is serialized as
+    /// `properties_typed` (underscore).
+    #[arg(long, value_name = "FIELDS", use_value_delimiter = true, help_heading = "Output")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<String>,
-    /// Sort order: 'file' / 'path' (default), 'modified', 'backlinks_count', 'links_count', 'title', 'date', or 'property:<KEY>' for any frontmatter property. For 'property:<KEY>', values of different JSON types (e.g. some files have a string, others a number) compare by raw JSON text -- grouped by type but not sensibly ordered within a numeric group -- and a stderr warning names the property when this happens; use a consistent type in frontmatter for a meaningful sort
-    #[arg(long)]
+    /// file (default)|modified|backlinks_count|links_count|title|date|property:K
+    ///
+    /// Sort order: 'file' / 'path' (default), 'modified', 'backlinks_count', 'links_count',
+    /// 'title', 'date', or 'property:<KEY>' for any frontmatter property. For 'property:<KEY>',
+    /// values of different JSON types (e.g. some files have a string, others a number) compare by
+    /// raw JSON text -- grouped by type but not sensibly ordered within a numeric group -- and a
+    /// stderr warning names the property when this happens; use a consistent type in frontmatter
+    /// for a meaningful sort.
+    #[arg(long, help_heading = "Output")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<String>,
-    /// Reverse the sort order (ascending becomes descending and vice versa). Alias: --desc
-    #[arg(long, alias = "desc")]
+    /// Reverse the sort order [alias: --desc]
+    ///
+    /// Reverse the sort order (ascending becomes descending and vice versa). Alias: --desc.
+    #[arg(long, alias = "desc", help_heading = "Output")]
     #[serde(skip_serializing_if = "is_false")]
     pub reverse: bool,
+    /// Max results, 0 = unlimited (default cap: 50)
+    ///
     /// Maximum number of results to return (0 = unlimited).
-    /// Default cap is bypassed when --jq or --count is used
-    #[arg(short = 'n', long, value_parser = parse_limit)]
+    /// Default cap is bypassed when --jq or --count is used.
+    #[arg(short = 'n', long, value_parser = parse_limit, help_heading = "Output")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
+    /// Only files with an unresolved link or dead heading anchor
+    ///
     /// Only return files with at least one unresolved link or dead heading anchor
     /// (auto-includes links field).
     /// Targets that resolve above the vault root are out of scope, not broken: they are
@@ -437,41 +502,54 @@ pub(crate) struct FindFilters {
     /// renders to an anchor hyalo cannot compute, so anchors into such a file are never
     /// reported broken.
     /// Every listed link carries its 1-based source `line`, the same one `lint` (HYALO006)
-    /// reports, and links are listed in document order
-    #[arg(long)]
+    /// reports, and links are listed in document order.
+    #[arg(long, help_heading = "Filters")]
     #[serde(skip_serializing_if = "is_false")]
     pub broken_links: bool,
-    /// Exit 1 if the query returns any results (0 if empty) — a CI gate for any find query, most
-    /// commonly `find --broken-links --strict` to fail a build on a dead heading anchor. Before
-    /// this, `find --broken-links` always exited 0 even when it reported findings, so a vault
-    /// whose only defect was a dead anchor passed CI silently
-    #[arg(long)]
+    /// Exit 1 if any results, 0 if empty — a CI gate
+    ///
+    /// A CI gate for any find query, most commonly `find --broken-links --strict` to fail a build
+    /// on a dead heading anchor. Before this, `find --broken-links` always exited 0 even when it
+    /// reported findings, so a vault whose only defect was a dead anchor passed CI silently.
+    #[arg(long, help_heading = "Output")]
     #[serde(skip_serializing_if = "is_false")]
     pub strict: bool,
-    /// Only return orphan files: no inbound links and no outbound links (auto-includes backlinks field)
-    #[arg(long)]
+    /// Only orphan files: no inbound and no outbound links
+    ///
+    /// Only return orphan files: no inbound links and no outbound links (auto-includes backlinks
+    /// field).
+    #[arg(long, help_heading = "Filters")]
     #[serde(skip_serializing_if = "is_false")]
     pub orphan: bool,
-    /// Only return dead-end files: have inbound links but no outbound links (auto-includes links field)
-    #[arg(long)]
+    /// Only dead-end files: inbound links but no outbound links
+    ///
+    /// Only return dead-end files: have inbound links but no outbound links (auto-includes links
+    /// field).
+    #[arg(long, help_heading = "Filters")]
     #[serde(skip_serializing_if = "is_false")]
     pub dead_end: bool,
+    /// Title substring (case-insensitive) or /regex/[i]
+    ///
     /// Filter by title: case-insensitive substring match against the displayed title
     /// (frontmatter 'title' property or first H1 heading). Use /regex/ for regex
     /// (e.g. '/^The/' or '/^The/i').
-    #[arg(long)]
+    #[arg(long, help_heading = "Filters")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// BM25 Snowball stemmer language (default: english) [alias: --stemmer]
+    ///
     /// Stemmer language for BM25 body search (also --stemmer). Selects Snowball stemmer for BM25
     /// tokenization — NOT markdown code-block language.
     /// Default: english. Accepts full names (english, german, …) or ISO 639-1 codes (en, de, …).
     /// Supported: arabic (ar), danish (da), dutch (nl), english (en), finnish (fi), french (fr),
     /// german (de), greek (el), hungarian (hu), italian (it), norwegian (no, nb, nn),
     /// portuguese (pt), romanian (ro), russian (ru), spanish (es), swedish (sv), tamil (ta),
-    /// turkish (tr)
-    #[arg(long, alias = "stemmer", value_name = "LANG")]
+    /// turkish (tr).
+    #[arg(long, alias = "stemmer", value_name = "LANG", help_heading = "Filters")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+    /// Print matching paths only, one per line — no envelope, no hints
+    ///
     /// Print only the file path of each matching entry, one per line — no JSON,
     /// no envelope, no count, no hints. grep `-l` precedent: the agent/
     /// pipeline projection of a find result set, usable in `sort`, `xargs`,
@@ -486,10 +564,13 @@ pub(crate) struct FindFilters {
     /// normally does.
     #[arg(
         long,
-        conflicts_with_all = ["jq", "count", "filenames0"]
+        conflicts_with_all = ["jq", "count", "filenames0"],
+        help_heading = "Output"
     )]
     #[serde(skip_serializing_if = "is_false")]
     pub filenames_only: bool,
+    /// Like --filenames-only but NUL-separated, for `xargs -0`
+    ///
     /// NUL-delimited sibling of `--filenames-only` (iter-238): each matching
     /// file path is printed terminated by a NUL byte instead of a newline,
     /// exactly like GNU `find -print0`. Safe for filenames that contain
@@ -502,7 +583,7 @@ pub(crate) struct FindFilters {
     ///
     /// Mutually exclusive with `--filenames-only`, `--jq`, `--count`, and an
     /// explicit `--format json` (pick one projection).
-    #[arg(long, conflicts_with_all = ["jq", "count", "filenames_only"])]
+    #[arg(long, conflicts_with_all = ["jq", "count", "filenames_only"], help_heading = "Output")]
     #[serde(skip_serializing_if = "is_false")]
     pub filenames0: bool,
 }
@@ -669,16 +750,21 @@ pub(crate) enum Commands {
             \u{00a0} hyalo find --property status=planned --filenames-only   # agent/pipeline projection\n\
             \u{00a0} git diff --name-only origin/main | hyalo find --files-from -")]
     Find {
-        /// BM25 ranked body text search with stemming (e.g. "running" matches "run", "ran"); results sorted by relevance
+        /// BM25 ranked full-text body search (stemmed; sorted by relevance)
+        ///
+        /// BM25 ranked body text search with stemming (e.g. "running" matches "run", "ran");
+        /// results sorted by relevance.
         #[arg(value_name = "PATTERN", conflicts_with = "regexp")]
         pattern: Option<String>,
-        /// Target file(s) as positional args — alternative to --file (repeatable after PATTERN)
+        /// Target file(s), positional form of --file
         #[arg(value_name = "FILE", conflicts_with_all = ["glob", "file"])]
         file_positional: Vec<String>,
+        /// Start from a saved view; CLI filters merge on top
+        ///
         /// Use a saved view (named filter set from .hyalo.toml). Additional CLI filters
         /// are merged on top: list filters (--property, --tag, --section, --glob) extend
-        /// the view; scalar filters (--sort, --limit, --regexp, --title, --task) override it
-        #[arg(long, value_name = "NAME")]
+        /// the view; scalar filters (--sort, --limit, --regexp, --title, --task) override it.
+        #[arg(long, value_name = "NAME", help_heading = "Filters")]
         view: Option<String>,
         #[command(flatten)]
         filters: FindFilters,
@@ -706,6 +792,7 @@ pub(crate) enum Commands {
         #[command(flatten)]
         selection: InputSelection,
         /// Extract section(s) by substring match (e.g. 'Tasks' matches 'Tasks [4/4]');
+        ///
         /// prefix '##' to pin heading level; use '/regex/' for regex. Nested subsections included
         #[arg(short, long, value_name = "HEADING")]
         section: Option<String>,
@@ -729,11 +816,13 @@ pub(crate) enum Commands {
         \u{00a0} hyalo properties rename --from old-key --to new-key")]
     Properties {
         /// Glob pattern(s) to filter which files to scan, relative to --dir
+        ///
         /// (repeatable); prefix '!' to negate. Bare-group form of
         /// `properties summary --glob`.
         #[arg(short, long)]
         glob: Vec<String>,
         /// Maximum number of results to return (0 = unlimited). Bare-group
+        ///
         /// form of `properties summary --limit`.
         #[arg(short = 'n', long, value_parser = parse_limit)]
         limit: Option<usize>,
@@ -751,11 +840,13 @@ pub(crate) enum Commands {
         \u{00a0} hyalo tags rename --from old-tag --to new-tag")]
     Tags {
         /// Glob pattern(s) to filter which files to scan, relative to --dir
+        ///
         /// (repeatable); prefix '!' to negate. Bare-group form of
         /// `tags summary --glob`.
         #[arg(short, long)]
         glob: Vec<String>,
         /// Maximum number of results to return (0 = unlimited). Bare-group
+        ///
         /// form of `tags summary --limit`.
         #[arg(short = 'n', long, value_parser = parse_limit)]
         limit: Option<usize>,
@@ -816,6 +907,7 @@ pub(crate) enum Commands {
         #[arg(short, long)]
         glob: Vec<String>,
         /// Number of recent files to show (default: 10).
+        ///
         /// NOTE: on this command -n means --recent, not --limit as on find and backlinks —
         /// it caps only the "recently modified" list, never the summary's stats
         #[arg(short = 'n', long, default_value = "10")]
@@ -850,6 +942,7 @@ pub(crate) enum Commands {
         #[command(flatten)]
         selection: InputSelection,
         /// Maximum number of backlinks to return (0 = unlimited).
+        ///
         /// Default cap is bypassed when --jq or --count is used
         #[arg(short = 'n', long, value_parser = parse_limit)]
         limit: Option<usize>,
@@ -907,6 +1000,7 @@ pub(crate) enum Commands {
         #[arg(short, long, value_name = "FILE", conflicts_with_all = ["file_positional", "glob", "properties", "tag", "type", "files_from"])]
         file: Option<String>,
         /// Destination path — positional form (single-file mode only). Alias for --to:
+        ///
         /// `hyalo mv old.md new.md` is equivalent to `hyalo mv old.md --to new.md`.
         /// Requires the positional source FILE (not --file); mutually exclusive with --to.
         #[arg(
@@ -922,6 +1016,7 @@ pub(crate) enum Commands {
         #[arg(short, long, value_name = "GLOB", conflicts_with = "files_from")]
         glob: Vec<String>,
         /// Read file paths from PATH (one per line); use '-' to read from stdin (batch mode).
+        ///
         /// Mutually exclusive with --file, positional FILE, and --glob.
         /// Repo-relative paths with the configured vault dir prefix are resolved automatically.
         /// Input is deduplicated; results follow first-seen order.
@@ -940,6 +1035,7 @@ pub(crate) enum Commands {
         #[arg(long)]
         dry_run: bool,
         /// Commit changes in batch mode (required when using --glob/--property/--tag/--type).
+        ///
         /// Rejected in single-file mode, which applies by default — use --dry-run to preview.
         #[arg(long, conflicts_with = "dry_run")]
         apply: bool,
@@ -947,6 +1043,7 @@ pub(crate) enum Commands {
         #[arg(long = "on-conflict", value_name = "POLICY", default_value = "error")]
         on_conflict: String,
         /// Allow rewriting bare wikilinks ([[note]]) even when the stem is ambiguous
+        ///
         /// (matches multiple vault files). By default, ambiguous bare wikilinks are
         /// skipped with a warning to avoid silent retargeting (BUG-2 prevention).
         #[arg(long)]
@@ -1017,6 +1114,7 @@ Repeatable (AND).\n\
         #[arg(short, long, conflicts_with_all = ["file", "files_from"])]
         glob: Vec<String>,
         /// Read file paths from PATH (one per line); use '-' to read from stdin.
+        ///
         /// Mutually exclusive with --file, positional FILE, and --glob.
         /// Repo-relative paths with the configured vault dir prefix are resolved automatically.
         /// Input is deduplicated; results follow first-seen order.
@@ -1032,6 +1130,7 @@ Repeatable (AND).\n\
         #[arg(long)]
         dry_run: bool,
         /// Validate new values against the schema from .hyalo.toml; reject writes that would
+        ///
         /// create lint errors. Implied by `validate_on_write = true` in [schema] config.
         #[arg(long, alias = "strict")]
         validate: bool,
@@ -1091,6 +1190,7 @@ Repeatable (AND).\n\
         #[arg(short, long, conflicts_with_all = ["file", "files_from"])]
         glob: Vec<String>,
         /// Read file paths from PATH (one per line); use '-' to read from stdin.
+        ///
         /// Mutually exclusive with --file, positional FILE, and --glob.
         #[arg(long, value_name = "PATH", conflicts_with_all = ["file", "file_positional", "glob"])]
         files_from: Option<String>,
@@ -1139,6 +1239,7 @@ Repeatable (AND).\n\
         #[arg(long)]
         pi: bool,
         /// Scaffold a preset vault flavour (okf, madr, skills, changelog) by
+        ///
         /// merging an embedded config fragment into .hyalo.toml
         #[arg(long, value_name = "PROFILE")]
         profile: Option<String>,
@@ -1208,6 +1309,7 @@ Repeatable (AND).\n\
     )]
     CreateIndex {
         /// Output path for the index file (default: .hyalo-index in --dir).
+        ///
         /// Equivalent to the global --index-file flag on this subcommand.
         /// Also accepted as --path, matching `drop-index --path`.
         #[arg(short, long, visible_alias = "path")]
@@ -1228,6 +1330,7 @@ Repeatable (AND).\n\
     )]
     DropIndex {
         /// Path to the index file to delete (default: .hyalo-index in --dir).
+        ///
         /// Also accepted as --output, matching `create-index --output`.
         #[arg(short, long, visible_alias = "output")]
         path: Option<PathBuf>,
@@ -1285,6 +1388,7 @@ Repeatable (AND).\n\
         #[arg(short, long, conflicts_with_all = ["file", "files_from"])]
         glob: Vec<String>,
         /// Read file paths from PATH (one per line); use '-' to read from stdin.
+        ///
         /// Mutually exclusive with --file, positional FILE, and --glob.
         #[arg(long, value_name = "PATH", conflicts_with_all = ["file", "file_positional", "glob"])]
         files_from: Option<String>,
@@ -1298,6 +1402,7 @@ Repeatable (AND).\n\
         #[arg(long)]
         dry_run: bool,
         /// Validate new values against the schema from .hyalo.toml; reject writes that would
+        ///
         /// create lint errors. Implied by `validate_on_write = true` in [schema] config.
         #[arg(long, alias = "strict")]
         validate: bool,
@@ -1538,6 +1643,7 @@ Repeatable (AND).\n\
     )]
     Lint {
         /// Target file(s) (relative to --dir) — positional form, repeatable.
+        ///
         /// `hyalo lint a.md b.md` lints both, matching `--files-from` semantics.
         #[arg(value_name = "FILE", conflicts_with_all = ["file", "glob", "type", "files_from"])]
         file_positional: Vec<String>,
@@ -1548,10 +1654,12 @@ Repeatable (AND).\n\
         #[arg(short, long, conflicts_with_all = ["file", "type", "files_from"])]
         glob: Vec<String>,
         /// Restrict linting to files matching the named type's filename template.
+        ///
         /// Equivalent to --glob <template-as-glob>. Mutually exclusive with --file, --glob, and --files-from.
         #[arg(long = "type", conflicts_with_all = ["file", "glob", "file_positional", "files_from"])]
         r#type: Option<String>,
         /// Read file paths from PATH (one per line); use '-' to read from stdin.
+        ///
         /// Mutually exclusive with --file, positional FILE, --glob, and --type.
         /// Repo-relative paths with the configured vault dir prefix are resolved automatically.
         /// Input is deduplicated; results follow first-seen order.
@@ -1564,6 +1672,7 @@ Repeatable (AND).\n\
         #[arg(long, requires = "fix")]
         dry_run: bool,
         /// Maximum number of files to include in output.
+        ///
         /// Default cap is bypassed when --jq or --count is used
         #[arg(short = 'n', long, value_parser = parse_limit)]
         limit: Option<usize>,
@@ -1583,6 +1692,7 @@ Repeatable (AND).\n\
         #[arg(long, value_name = "RULE_ID", requires = "fix")]
         fix_rule: Vec<String>,
         /// Promote schema warnings to errors: "no 'type' property",
+        ///
         /// "undeclared property in frontmatter", and date-format violations
         /// (HYALO003), causing lint to exit non-zero when those issues are found.
         ///
@@ -1595,6 +1705,7 @@ Repeatable (AND).\n\
         #[arg(long)]
         strict: bool,
         /// Overlay a named conformance profile for this invocation only (no
+        ///
         /// `.hyalo.toml` change). `okf` enables the Open Knowledge Format §9
         /// rules plus advisory citation / augmentation checks; `madr` enables
         /// the MADR ADR schema (path-bound to `docs/decisions/**`) plus the
@@ -1668,10 +1779,12 @@ Repeatable (AND).\n\
         #[arg(long, value_name = "TYPE", required = true)]
         r#type: String,
         /// Vault-relative path for the new file (must not exist; parent dirs created if
+        ///
         /// missing; must still resolve inside the vault after symlinks)
         #[arg(long, value_name = "FILE", required = true)]
         file: String,
         /// When `--index` or `--index-file` is set, patch the snapshot index in
+        ///
         /// place after the file is created so later `--index` queries see it
         /// without a full rebuild.
         #[command(flatten)]
@@ -1879,6 +1992,7 @@ pub(crate) enum OkfAction {
         #[arg(long)]
         dry_run: bool,
         /// Overwrite a marker-less `index.md`, discarding its hand-written body.
+        ///
         /// Without this flag such a file is *adopted*: its body is preserved and
         /// the managed region is appended (non-destructive default).
         #[arg(long)]
@@ -1956,6 +2070,7 @@ pub(crate) enum MadrAction {
     )]
     Toc {
         /// ADR directory (vault-relative, must resolve inside the vault);
+        ///
         /// defaults to `docs/decisions`
         #[arg(value_name = "DIR")]
         adr_dir: Option<String>,
@@ -1966,6 +2081,7 @@ pub(crate) enum MadrAction {
         #[arg(long)]
         dry_run: bool,
         /// Overwrite a marker-less `README.md`, discarding its hand-written body.
+        ///
         /// Without this flag such a file is *adopted*: its body is preserved and
         /// the managed region is appended (non-destructive default).
         #[arg(long)]
@@ -2029,6 +2145,7 @@ pub(crate) enum ChangelogAction {
         #[arg(long, value_name = "TEXT", required = true)]
         message: String,
         /// Wrap the entry to COLS columns, breaking on word boundaries and
+        ///
         /// hanging-indenting continuation lines under the bullet text (2 spaces).
         /// Useful for 80-column changelogs. Omit for a single unwrapped bullet.
         #[arg(long, value_name = "COLS")]
@@ -2066,6 +2183,7 @@ pub(crate) enum ViewsAction {
         #[arg(value_name = "NAME")]
         name: String,
         /// Optional BM25 search pattern to save with the view (second positional arg).
+        ///
         /// Example: `hyalo views set my-view "search terms" --tag foo`
         #[arg(value_name = "PATTERN")]
         pattern: Option<String>,
@@ -2106,6 +2224,7 @@ pub(crate) enum ViewsAction {
         #[arg(value_name = "NAME")]
         name: String,
         /// BM25 ranked full-text search pattern, same semantics as `find <PATTERN>`.
+        ///
         /// Overrides a pattern saved in the view. Mutually exclusive with -e/--regexp
         #[arg(value_name = "PATTERN", conflicts_with = "regexp")]
         pattern: Option<String>,
@@ -2293,6 +2412,7 @@ pub(crate) enum LinksAction {
         #[arg(long, conflicts_with = "dry_run")]
         apply: bool,
         /// Minimum Jaro-Winkler stem similarity for a file to be considered a
+        ///
         /// fuzzy candidate at all (0.0–1.0). Candidates that clear it are then
         /// scored and ranked by confidence — see --min-confidence.
         #[arg(long, default_value = "0.8", value_parser = parse_threshold)]
@@ -2309,6 +2429,7 @@ pub(crate) enum LinksAction {
         #[arg(long)]
         apply_fuzzy: bool,
         /// Confidence floor for applying low-confidence fixes (0.0–1.0).
+        ///
         /// Implies --apply-fuzzy.
         ///
         /// Defaults to 0.8, or to `[links] fuzzy_min_confidence` in
@@ -2322,6 +2443,7 @@ pub(crate) enum LinksAction {
         #[arg(short, long)]
         glob: Vec<String>,
         /// Ignore broken links whose target contains any of these substrings (repeatable).
+        ///
         /// Useful for skipping Hugo template links, external paths, etc.
         #[arg(long)]
         ignore_target: Vec<String>,
@@ -2335,6 +2457,7 @@ pub(crate) enum LinksAction {
         #[arg(long)]
         expand_short_form: bool,
         /// Treat links that resolve only by case folding as resolved rather
+        ///
         /// than fixable (UX-6, iter-244).
         ///
         /// On case-folded vault layouts (MDN-style `en-US` vs `en-us`
@@ -2454,11 +2577,13 @@ pub(crate) enum LinksAction {
         #[arg(long)]
         exclude_title: Vec<String>,
         /// Only emit the first match of each target title per source file.
+        ///
         /// An existing [[wikilink]] to a target anywhere in the file counts
         /// as its first mention (case-insensitive; aliased links count too).
         #[arg(long)]
         first_only: bool,
         /// Link every mention for this run even when `[links.auto] first_only = true`
+        ///
         /// is set in .hyalo.toml.
         ///
         /// The counter-flag to --first-only: it forces first-only OFF for a single
@@ -2466,10 +2591,12 @@ pub(crate) enum LinksAction {
         #[arg(long, conflicts_with = "first_only")]
         no_first_only: bool,
         /// Exclude target pages whose vault-relative path matches a glob pattern
+        ///
         /// (repeatable; matched case-insensitively, mirroring --exclude-title)
         #[arg(long)]
         exclude_target_glob: Vec<String>,
         /// Do not print the advisory note naming noisy candidate titles: common
+        ///
         /// English words (e.g. "permissions", "index") and titles that dominate
         /// the run (at least 25 matches and 2.5% of the proposed links).
         ///
@@ -2612,6 +2739,7 @@ pub(crate) enum PropertiesAction {
         #[arg(short, long)]
         glob: Vec<String>,
         /// Maximum number of results to return (0 = unlimited).
+        ///
         /// Default cap is bypassed when --jq or --count is used
         #[arg(short = 'n', long, value_parser = parse_limit)]
         limit: Option<usize>,
@@ -2659,6 +2787,7 @@ pub(crate) enum TagsAction {
         #[arg(short, long)]
         glob: Vec<String>,
         /// Maximum number of results to return (0 = unlimited).
+        ///
         /// Default cap is bypassed when --jq or --count is used
         #[arg(short = 'n', long, value_parser = parse_limit)]
         limit: Option<usize>,

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -1,3 +1,80 @@
+/// The `-h` command list: every command grouped by intent, one line each
+/// (iteration 251).
+///
+/// Clap's generated `Commands:` block lists 27 subcommands alphabetically with
+/// their `about` text, which told an agent the names but not the *capability
+/// families* behind them — the measured consequence was agents reaching for
+/// bare `find` plus `grep` instead of the filters that already exist. This
+/// block is rendered instead of `{subcommands}` on the top-level `-h` (see
+/// [`run::run_inner`](crate::run)); `--help` keeps the full COMMAND REFERENCE.
+pub(crate) const HELP_COMMANDS: &str = "COMMANDS \u{2014} read (no writes):
+  find              BM25 text, regex, property, tag, task, section, title, glob,
+                    link-graph filters; --sort --fields --view --count --limit
+  read summary      File body (--section/--lines) | vault overview counts
+  properties tags   Keys / tags with counts (bare = summary; also rename)
+  backlinks lint    Inbound links | frontmatter schema + markdown rules (--fix)
+  config            Effective .hyalo.toml: dir, format, hints, site_prefix
+COMMANDS \u{2014} write (mutates files):
+  set remove append   Properties/tags on --file/--glob + --where-property/-tag
+  task mv             Checkbox read/toggle/set | move-rename, rewriting links
+  links new           fix broken / auto-link mentions | scaffold from a type
+  madr okf changelog  ADR toc | OKF index+log | Keep a Changelog add/release
+COMMANDS \u{2014} config and scaffolds (write .hyalo.toml):
+  init deinit              Create/remove .hyalo.toml (--claude --pi --profile)
+  types lint-rules views   Schemas | lint rule catalog | saved find queries
+  create-index drop-index  Snapshot index for faster repeated queries
+  completions              Shell completion script";
+
+/// The `-h` examples block: every line composes two or three features.
+///
+/// The 40 single-flag examples this replaced taught one flag per line and so
+/// never showed that filters compose — the exact gap that sent agents to
+/// `grep`. They still exist verbatim in `--help`'s COOKBOOK.
+pub(crate) const HELP_EXAMPLES_SHORT: &str = "EXAMPLES (each composes 2-3 features):
+  hyalo find --property status=planned --tag iteration --sort modified --reverse
+  hyalo find 'broken links' --property 'title~=/^Iter/i' --fields tags,tasks
+  hyalo find --section Tasks --task todo --filenames-only
+  hyalo find --broken-links --strict --glob 'docs/**/*.md'
+  hyalo set --property status=done --where-property status=draft --glob '**/*.md'
+Everything else:  hyalo --help  |  hyalo <cmd> -h";
+
+/// `find -h` tail: composed examples, the global-options pointer, and the
+/// pointer at `find --help` (iteration 251).
+///
+/// `find` is the command agents live in and the one whose `-h` was worst
+/// (12.3 KB). Examples here compose filters rather than demonstrating one flag
+/// each, because "these compose" is precisely what the old page failed to say.
+pub(crate) fn find_after_short_help(global_pointer: &str) -> String {
+    format!(
+        "EXAMPLES (filters compose \u{2014} AND across kinds):\n\
+         \u{20}\u{20}hyalo find --property status=planned --tag iteration --sort modified --reverse\n\
+         \u{20}\u{20}hyalo find 'broken links' --section Tasks --task todo --fields tasks\n\
+         \u{20}\u{20}hyalo find --broken-links --strict --glob 'docs/**/*.md' --filenames-only\n\
+         \n{global_pointer}\n\
+         Full reference (operators, sort keys, fields):  hyalo find --help"
+    )
+}
+
+/// The single line that stands in for the global-options block on a
+/// subcommand's `-h` (iteration 251).
+///
+/// The block is ~1.9 KB and was repeated identically on all 27 subcommands —
+/// the largest single contributor to subcommand `-h` size, and pure noise once
+/// you have read it once. `--dir` and `--format` are omitted when
+/// `.hyalo.toml` already supplies them, matching the existing hiding rule in
+/// [`filter_examples`].
+pub(crate) fn global_pointer(hide_dir: bool, hide_format: bool) -> String {
+    let mut flags: Vec<&str> = Vec::with_capacity(7);
+    if !hide_dir {
+        flags.push("--dir");
+    }
+    if !hide_format {
+        flags.push("--format");
+    }
+    flags.extend(["--jq", "--count", "--no-hints", "--site-prefix", "-q"]);
+    format!("Global: {} — see `hyalo -h`", flags.join(" "))
+}
+
 /// Short help (shown by `-h`): one example per feature.
 pub(crate) const HELP_EXAMPLES: &str = "EXAMPLES:
   Search for files:             hyalo find --property status=draft

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -55,6 +55,22 @@ pub(crate) fn find_after_short_help(global_pointer: &str) -> String {
     )
 }
 
+/// The whole `-h` body below the usage line: the grouped command list and the
+/// composed examples, with config-defaulted flags filtered out of the examples
+/// exactly as [`filter_examples`] does for the long-form list.
+pub(crate) fn short_help_body(hide_dir: bool, hide_format: bool) -> String {
+    let examples: Vec<&str> = HELP_EXAMPLES_SHORT
+        .lines()
+        .filter(|line| {
+            if hide_format && line.contains(" --format") {
+                return false;
+            }
+            !(hide_dir && (line.contains("-d/--dir") || line.contains(" --dir ")))
+        })
+        .collect();
+    format!("{HELP_COMMANDS}\n\n{}", examples.join("\n"))
+}
+
 /// The single line that stands in for the global-options block on a
 /// subcommand's `-h` (iteration 251).
 ///

--- a/crates/hyalo-cli/src/commands/find/run.rs
+++ b/crates/hyalo-cli/src/commands/find/run.rs
@@ -279,10 +279,7 @@ pub(crate) fn run(
             // key actually carries, reusing the index this query already
             // walked, so the hint layer can offer a did-you-mean and name the
             // real values instead of printing a bare `No results`.
-            if matches!(
-                outcome,
-                CommandOutcome::Success { total: Some(0), .. }
-            ) {
+            if matches!(outcome, CommandOutcome::Success { total: Some(0), .. }) {
                 ctx.zero_result_values =
                     observed_property_values(resolved.as_index(), &prop_filters);
             }

--- a/crates/hyalo-cli/src/commands/find/run.rs
+++ b/crates/hyalo-cli/src/commands/find/run.rs
@@ -274,6 +274,18 @@ pub(crate) fn run(
             if let Some(code) = strict_exit_code(&outcome, strict) {
                 ctx.exit_code_override = Some(code);
             }
+            // iter-251: an empty result set is where an agent most needs a
+            // next step. Collect the distinct values each filtered property
+            // key actually carries, reusing the index this query already
+            // walked, so the hint layer can offer a did-you-mean and name the
+            // real values instead of printing a bare `No results`.
+            if matches!(
+                outcome,
+                CommandOutcome::Success { total: Some(0), .. }
+            ) {
+                ctx.zero_result_values =
+                    observed_property_values(resolved.as_index(), &prop_filters);
+            }
             // iter-235: `--filenames-only` projects the find result
             // set onto raw file paths (one per line, no envelope,
             // no count, no hints). It runs *after* the `--strict`
@@ -295,6 +307,73 @@ pub(crate) fn run(
             Ok(outcome)
         }
         IndexResolution::Outcome(outcome) => Ok(outcome),
+    }
+}
+
+/// Maximum distinct values collected per property key for the zero-result
+/// did-you-mean. A key with more values than this is not a controlled
+/// vocabulary, so naming them all would be noise rather than a correction.
+const MAX_OBSERVED_VALUES: usize = 50;
+
+/// Distinct scalar values of every key named by an equality `--property`
+/// filter, in first-seen-sorted order.
+///
+/// Only equality (`K=V`) filters are probed: an existence, absence, or regex
+/// filter has no misspelled value to correct. Non-scalar values (maps,
+/// sequences) are skipped — a did-you-mean over `[a, b]` would suggest
+/// something the user cannot type back into `--property`.
+fn observed_property_values(
+    index: &dyn hyalo_core::index::VaultIndex,
+    filters: &[hyalo_core::filter::PropertyFilter],
+) -> std::collections::BTreeMap<String, Vec<String>> {
+    use hyalo_core::filter::{FilterOp, PropertyFilter};
+
+    let keys: Vec<&str> = filters
+        .iter()
+        .filter_map(|f| match f {
+            PropertyFilter::Scalar {
+                name,
+                op: FilterOp::Eq,
+                value: Some(_),
+            } => Some(name.as_str()),
+            _ => None,
+        })
+        .collect();
+    if keys.is_empty() {
+        return std::collections::BTreeMap::new();
+    }
+
+    let mut out: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> = keys
+        .iter()
+        .map(|k| ((*k).to_owned(), std::collections::BTreeSet::new()))
+        .collect();
+    for entry in index.entries() {
+        for key in &keys {
+            let Some(value) = entry.properties.get(*key) else {
+                continue;
+            };
+            let Some(rendered) = scalar_to_string(value) else {
+                continue;
+            };
+            let bucket = out.entry((*key).to_owned()).or_default();
+            if bucket.len() < MAX_OBSERVED_VALUES {
+                bucket.insert(rendered);
+            }
+        }
+    }
+    out.into_iter()
+        .map(|(k, v)| (k, v.into_iter().collect()))
+        .collect()
+}
+
+/// Render a scalar JSON value the way `--property K=V` would accept it back.
+/// Returns `None` for maps and sequences, which have no single typeable form.
+fn scalar_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
     }
 }
 

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -206,6 +206,13 @@ pub(crate) struct CommandContext<'a> {
     /// `--files-from` inside `resolve_inputs` (read/backlinks/task). Surfaced by
     /// the output pipeline as `files_from_counters` in the envelope.
     pub files_from_counters: Option<crate::commands::files_from::FilesFromCounters>,
+    /// Distinct frontmatter values observed for each property key named by a
+    /// `--property K=V` filter, collected by `find` when the query matched
+    /// nothing (iter-251). The index has already been walked at that point, so
+    /// this costs no extra I/O; `run.rs` copies it into the hint context so the
+    /// zero-result did-you-mean can be computed without a second scan. Empty
+    /// for every command other than an empty `find`.
+    pub zero_result_values: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 /// Resolve the effective limit for a list command.

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -204,6 +204,11 @@ pub struct HintContext {
     /// `[lint] profiles` in `.hyalo.toml`. When true the `okf` validate hint
     /// drops the redundant `--profile okf` flag (plain `hyalo lint` runs it).
     pub okf_profile_active: bool,
+    /// Distinct frontmatter values observed for each property key named by a
+    /// `--property K=V` filter, collected by the `find` scan when it matched
+    /// nothing (iter-251). Feeds the zero-result did-you-mean and the
+    /// "values of `K` in this vault" hint; empty on every non-empty result.
+    pub observed_property_values: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 /// Common global flags captured once per command dispatch and threaded into
@@ -259,6 +264,7 @@ impl HintContext {
             lint_rule_prefix: None,
             lint_fix_rules: vec![],
             okf_profile_active: false,
+            observed_property_values: std::collections::BTreeMap::new(),
         }
     }
 
@@ -474,6 +480,7 @@ mod lint;
 mod mutation;
 mod summary;
 mod util;
+mod zero_result;
 
 pub use command::{HintBuilder, shell_quote, shorten_index_path_for_hint};
 use command::{
@@ -495,6 +502,7 @@ use mutation::{
 };
 use summary::{hints_for_properties_summary, hints_for_summary, hints_for_tags_summary};
 use util::{first_modified_file, status_priority};
+pub(crate) use zero_result::filter_echo;
 
 #[cfg(test)]
 mod tests;

--- a/crates/hyalo-cli/src/hints/find.rs
+++ b/crates/hyalo-cli/src/hints/find.rs
@@ -137,7 +137,13 @@ pub(super) fn hints_for_find(
     };
 
     if results.is_empty() {
-        // When a multi-word BM25 search returns nothing, suggest trying OR instead.
+        // iter-251: an empty result set is the moment an agent most needs a
+        // next step, and it used to be the moment hyalo said the least
+        // (`No results`, `hints: []`). Lead with the BM25 OR rewrite when a
+        // multi-word body search is what came up empty — it is the single most
+        // likely fix — then fall through to the generic zero-result hints
+        // (did-you-mean, observed values, drop the most selective filter).
+        let mut hints: Vec<Hint> = Vec::new();
         // Skip if the query already contains quotes (phrase search) — splitting on
         // whitespace would produce malformed tokens like `"exact` and `phrase"`.
         if let Some(pat) = &ctx.body_pattern {
@@ -152,13 +158,15 @@ pub(super) fn hints_for_find(
                 .collect();
             if !has_quotes && words.len() >= 2 {
                 let or_query = words.join(" OR ");
-                return vec![Hint::new(
+                hints.push(Hint::new(
                     "Try OR instead of AND (match any word)",
                     build_find_command_with_pattern(ctx, &or_query),
-                )];
+                ));
             }
         }
-        return vec![];
+        hints.extend(super::zero_result::zero_result_hints(ctx));
+        hints.truncate(super::zero_result::MAX_ZERO_RESULT_HINTS);
+        return hints;
     }
 
     let mut hints = Vec::new();

--- a/crates/hyalo-cli/src/hints/tests.rs
+++ b/crates/hyalo-cli/src/hints/tests.rs
@@ -451,11 +451,19 @@ fn make_find_item(file: &str, status: Option<&str>, tags: &[&str]) -> serde_json
     })
 }
 
+/// iter-251 reversed this: an unfiltered `find` that matched nothing used to
+/// return no hints at all — the moment an agent most needs a next step. It now
+/// points at the property listing, and never at more than three things.
 #[test]
-fn find_empty_results_no_hints() {
+fn find_empty_results_hint_at_the_vocabulary() {
     let c = ctx(HintSource::Find);
     let hints = generate_hints(&c, &json!([]), None);
-    assert!(hints.is_empty());
+    assert!(!hints.is_empty(), "an empty result set must still hint");
+    assert!(hints.len() <= 3, "zero-result hints are capped at 3");
+    assert!(
+        hints.iter().any(|h| h.cmd.contains("properties summary")),
+        "with no filters to drop, point at the property listing: {hints:?}"
+    );
 }
 
 #[test]

--- a/crates/hyalo-cli/src/hints/zero_result.rs
+++ b/crates/hyalo-cli/src/hints/zero_result.rs
@@ -276,7 +276,10 @@ pub(super) fn zero_result_hints(ctx: &HintContext) -> Vec<Hint> {
                     String::new()
                 };
                 hints.push(Hint::new(
-                    format!("Values of `{key}` in this vault: {}{suffix}", shown.join(", ")),
+                    format!(
+                        "Values of `{key}` in this vault: {}{suffix}",
+                        shown.join(", ")
+                    ),
                     HintBuilder::cmd("find")
                         .flag_value("--property", key)
                         .flag_value("--fields", "properties")

--- a/crates/hyalo-cli/src/hints/zero_result.rs
+++ b/crates/hyalo-cli/src/hints/zero_result.rs
@@ -1,0 +1,441 @@
+//! Zero-result hints for `find` (iteration 251).
+//!
+//! A query that matches nothing used to be the one place hyalo said the least:
+//! `--format text` printed a bare `No results`, JSON carried `hints: []`. That
+//! is the moment an agent most needs a next step, so an empty result set now
+//! answers three questions instead of none:
+//!
+//! 1. *Did I misspell the value?* — a did-you-mean over the values property `K`
+//!    actually has in the vault, fired only when the edit distance is small.
+//! 2. *What values are there?* — the observed values, named inline when the
+//!    scan collected them, otherwise a `properties` / `tags` listing command.
+//! 3. *Which filter killed the query?* — the same query with its most
+//!    selective filter dropped, ready to paste.
+//!
+//! The observed values come from the `find` scan itself
+//! ([`crate::dispatch::CommandContext::zero_result_values`]): the index was
+//! already walked to evaluate the filter, so collecting the distinct values of
+//! the filtered keys on the empty path costs no extra I/O.
+
+use std::collections::BTreeMap;
+
+use super::{Hint, HintBuilder, HintContext};
+
+/// Maximum hints emitted for a zero-result query (plan: 1–3).
+pub(super) const MAX_ZERO_RESULT_HINTS: usize = 3;
+
+/// Maximum edit distance between a filter value and an observed value for the
+/// did-you-mean hint to fire.
+const DID_YOU_MEAN_MAX_DISTANCE: usize = 2;
+
+/// How many observed values to name inline before eliding the rest.
+const MAX_NAMED_VALUES: usize = 6;
+
+/// One active filter on the query that returned nothing.
+///
+/// `rank` orders filters most-selective-first; the drop hint removes the
+/// lowest-ranked (i.e. most selective) one.
+struct ActiveFilter {
+    /// Rendered for the `No results for …` echo, e.g. `--property status=x`.
+    echo: String,
+    /// Selectivity rank; lower is more selective.
+    rank: u8,
+    /// The argv tokens this filter contributes to a rebuilt `find` command.
+    argv: Vec<String>,
+}
+
+/// Collect the filters active on this `find` query, most selective first.
+///
+/// Selectivity is a fixed heuristic, not a measurement: a body search or an
+/// exact property value almost always narrows harder than a tag or a glob, and
+/// the hint only has to name a plausible culprit for the user to try dropping.
+fn active_filters(ctx: &HintContext) -> Vec<ActiveFilter> {
+    let mut out: Vec<ActiveFilter> = Vec::new();
+
+    if let Some(pattern) = &ctx.body_pattern {
+        out.push(ActiveFilter {
+            echo: format!("'{pattern}'"),
+            rank: 0,
+            argv: vec![pattern.clone()],
+        });
+    }
+    for pf in &ctx.property_filters {
+        // An equality filter pins one value; `!K` / `K` / `K~=re` are broader.
+        let rank = if pf.contains('=') && !pf.contains("~=") && !pf.contains("=~") {
+            1
+        } else {
+            4
+        };
+        out.push(ActiveFilter {
+            echo: format!("--property {pf}"),
+            rank,
+            argv: vec!["--property".to_owned(), pf.clone()],
+        });
+    }
+    for sf in &ctx.section_filters {
+        out.push(ActiveFilter {
+            echo: format!("--section {sf}"),
+            rank: 2,
+            argv: vec!["--section".to_owned(), sf.clone()],
+        });
+    }
+    if let Some(task) = &ctx.task_filter {
+        out.push(ActiveFilter {
+            echo: format!("--task {task}"),
+            rank: 3,
+            argv: vec!["--task".to_owned(), task.clone()],
+        });
+    }
+    if let Some(title) = &ctx.title_filter {
+        out.push(ActiveFilter {
+            echo: format!("--title {title}"),
+            rank: 3,
+            argv: vec!["--title".to_owned(), title.clone()],
+        });
+    }
+    for tf in &ctx.tag_filters {
+        out.push(ActiveFilter {
+            echo: format!("--tag {tf}"),
+            rank: 5,
+            argv: vec!["--tag".to_owned(), tf.clone()],
+        });
+    }
+    if ctx.broken_links_filter {
+        out.push(ActiveFilter {
+            echo: "--broken-links".to_owned(),
+            rank: 6,
+            argv: vec!["--broken-links".to_owned()],
+        });
+    }
+    if ctx.orphan_filter {
+        out.push(ActiveFilter {
+            echo: "--orphan".to_owned(),
+            rank: 6,
+            argv: vec!["--orphan".to_owned()],
+        });
+    }
+    if ctx.dead_end_filter {
+        out.push(ActiveFilter {
+            echo: "--dead-end".to_owned(),
+            rank: 6,
+            argv: vec!["--dead-end".to_owned()],
+        });
+    }
+    for g in &ctx.glob {
+        out.push(ActiveFilter {
+            echo: format!("--glob {g}"),
+            rank: 7,
+            argv: vec!["--glob".to_owned(), g.clone()],
+        });
+    }
+    out.sort_by_key(|f| f.rank);
+    out
+}
+
+/// Human-readable echo of the filters that produced an empty result set, e.g.
+/// `--property status=x --tag y`. `None` when the query carried no filters at
+/// all (an empty vault, where echoing nothing is the honest answer).
+///
+/// Rendered by `--format text` next to `No results` so the line names what was
+/// actually asked instead of leaving the reader to reconstruct it from history.
+#[must_use]
+pub(crate) fn filter_echo(ctx: &HintContext) -> Option<String> {
+    let filters = active_filters(ctx);
+    if filters.is_empty() {
+        return None;
+    }
+    Some(
+        filters
+            .iter()
+            .map(|f| f.echo.as_str())
+            .collect::<Vec<_>>()
+            .join(" "),
+    )
+}
+
+/// The `K` and `V` of every `--property K=V` equality filter on the query.
+fn equality_property_filters(ctx: &HintContext) -> Vec<(&str, &str)> {
+    ctx.property_filters
+        .iter()
+        .filter_map(|pf| {
+            if pf.contains("~=") || pf.contains("=~") || pf.starts_with('!') {
+                return None;
+            }
+            let (key, value) = pf.split_once('=')?;
+            // Exclude the ordering / inequality operators, whose trailing
+            // character lands in `key` (`status!`, `date>`, …).
+            if key.ends_with(['!', '>', '<']) || key.is_empty() || value.is_empty() {
+                return None;
+            }
+            Some((key, value))
+        })
+        .collect()
+}
+
+/// Closest observed value to `value`, when it is close enough to be a typo.
+///
+/// Two guards keep an unrelated value from being offered as a correction: an
+/// absolute ceiling of [`DID_YOU_MEAN_MAX_DISTANCE`] edits, and a relative one
+/// requiring the edits to be a small fraction of the longer string — so
+/// `draf` → `draft` fires while `done` → `todo` (3 edits over 4 characters)
+/// does not.
+fn did_you_mean<'a>(value: &str, observed: &'a [String]) -> Option<&'a str> {
+    let lowered = value.to_lowercase();
+    observed
+        .iter()
+        .filter(|candidate| !candidate.eq_ignore_ascii_case(value))
+        .map(|candidate| {
+            let dist = strsim::damerau_levenshtein(&lowered, &candidate.to_lowercase());
+            (dist, candidate)
+        })
+        .filter(|(dist, candidate)| {
+            let longer = lowered.chars().count().max(candidate.chars().count());
+            *dist <= DID_YOU_MEAN_MAX_DISTANCE && dist * 3 <= longer
+        })
+        .min_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)))
+        .map(|(_, candidate)| candidate.as_str())
+}
+
+/// Rebuild the `find` command from `ctx`, skipping the filter at `skip_index`
+/// in the [`active_filters`] ordering. `None` skips nothing.
+fn rebuild_find(ctx: &HintContext, filters: &[ActiveFilter], skip_index: Option<usize>) -> String {
+    let mut b = HintBuilder::cmd("find");
+    for (i, f) in filters.iter().enumerate() {
+        if Some(i) == skip_index {
+            continue;
+        }
+        for (n, token) in f.argv.iter().enumerate() {
+            // The flag name is a literal; only its value needs quoting.
+            if n == 0 && token.starts_with("--") {
+                b.push_raw(token);
+            } else {
+                b.push_quoted(token);
+            }
+        }
+    }
+    b.finish(ctx)
+}
+
+/// Build the 1–3 hints shown when a `find` query matched nothing.
+///
+/// `observed` maps a property key to the distinct values that key carries in
+/// the vault, as collected by the scan that returned nothing. An empty map
+/// (no equality filters, or an index that could not be walked) simply drops
+/// the value-aware hints.
+#[must_use]
+pub(super) fn zero_result_hints(ctx: &HintContext) -> Vec<Hint> {
+    let observed: &BTreeMap<String, Vec<String>> = &ctx.observed_property_values;
+    let mut hints: Vec<Hint> = Vec::new();
+    let filters = active_filters(ctx);
+
+    // 1. Did-you-mean over the observed values of each filtered key.
+    for (key, value) in equality_property_filters(ctx) {
+        if hints.len() >= MAX_ZERO_RESULT_HINTS {
+            break;
+        }
+        let Some(values) = observed.get(key) else {
+            continue;
+        };
+        if let Some(suggestion) = did_you_mean(value, values) {
+            let corrected = format!("{key}={suggestion}");
+            let mut b = HintBuilder::cmd("find");
+            for f in &filters {
+                for (n, token) in f.argv.iter().enumerate() {
+                    if n == 0 && token.starts_with("--") {
+                        b.push_raw(token);
+                    } else if token == &format!("{key}={value}") {
+                        b.push_quoted(&corrected);
+                    } else {
+                        b.push_quoted(token);
+                    }
+                }
+            }
+            hints.push(Hint::new(
+                format!("Did you mean {key}={suggestion}?"),
+                b.finish(ctx),
+            ));
+        }
+    }
+
+    // 2. Name the values the key actually has, so the next query is informed.
+    for (key, _) in equality_property_filters(ctx) {
+        if hints.len() >= MAX_ZERO_RESULT_HINTS {
+            break;
+        }
+        match observed.get(key) {
+            Some(values) if !values.is_empty() => {
+                let shown: Vec<&str> = values
+                    .iter()
+                    .take(MAX_NAMED_VALUES)
+                    .map(String::as_str)
+                    .collect();
+                let more = values.len().saturating_sub(shown.len());
+                let suffix = if more > 0 {
+                    format!(", … (+{more})")
+                } else {
+                    String::new()
+                };
+                hints.push(Hint::new(
+                    format!("Values of `{key}` in this vault: {}{suffix}", shown.join(", ")),
+                    HintBuilder::cmd("find")
+                        .flag_value("--property", key)
+                        .flag_value("--fields", "properties")
+                        .finish(ctx),
+                ));
+            }
+            _ => {
+                hints.push(Hint::new(
+                    format!("No file has a `{key}` property — list the ones that exist"),
+                    HintBuilder::cmd("properties summary").finish(ctx),
+                ));
+            }
+        }
+    }
+
+    // 3. Re-run without the most selective filter.
+    if filters.len() >= 2 && hints.len() < MAX_ZERO_RESULT_HINTS {
+        hints.push(Hint::new(
+            format!("Drop the most selective filter ({})", filters[0].echo),
+            rebuild_find(ctx, &filters, Some(0)),
+        ));
+    }
+
+    // Fallbacks when nothing above applied: point at the observed-value
+    // listings, which is what `--tag`-only and filter-less empty queries need.
+    if hints.len() < MAX_ZERO_RESULT_HINTS && !ctx.tag_filters.is_empty() {
+        hints.push(Hint::new(
+            "List the tags this vault actually uses",
+            HintBuilder::cmd("tags summary").finish(ctx),
+        ));
+    }
+    if hints.is_empty() {
+        hints.push(Hint::new(
+            "List the properties this vault actually uses",
+            HintBuilder::cmd("properties summary").finish(ctx),
+        ));
+    }
+
+    hints.truncate(MAX_ZERO_RESULT_HINTS);
+    hints
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hints::{HintSource, generate_hints};
+
+    fn ctx_with(properties: &[&str], tags: &[&str]) -> HintContext {
+        let mut ctx = HintContext::new(HintSource::Find);
+        ctx.property_filters = properties.iter().map(|s| (*s).to_owned()).collect();
+        ctx.tag_filters = tags.iter().map(|s| (*s).to_owned()).collect();
+        ctx
+    }
+
+    fn observed(ctx: &mut HintContext, key: &str, values: &[&str]) {
+        ctx.observed_property_values.insert(
+            key.to_owned(),
+            values.iter().map(|s| (*s).to_owned()).collect(),
+        );
+    }
+
+    #[test]
+    fn did_you_mean_fires_for_one_character_typo() {
+        let values = vec!["draft".to_owned(), "completed".to_owned()];
+        assert_eq!(did_you_mean("draf", &values), Some("draft"));
+        assert_eq!(did_you_mean("Draft", &values), None, "exact match, no typo");
+    }
+
+    #[test]
+    fn did_you_mean_ignores_unrelated_values() {
+        let values = vec!["todo".to_owned(), "completed".to_owned()];
+        assert_eq!(
+            did_you_mean("done", &values),
+            None,
+            "3 edits over 4 chars is a different word, not a typo"
+        );
+        assert_eq!(did_you_mean("nonexistent", &values), None);
+    }
+
+    #[test]
+    fn zero_result_hints_are_non_empty_for_a_bad_property_value() {
+        let mut ctx = ctx_with(&["status=nonexistent"], &[]);
+        observed(&mut ctx, "status", &["draft", "completed"]);
+        let hints = zero_result_hints(&ctx);
+        assert!(!hints.is_empty(), "empty result must still hint");
+        assert!(
+            hints.iter().any(|h| h.description.contains("Values of")),
+            "should name the observed values: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn typo_produces_a_runnable_corrected_query() {
+        let mut ctx = ctx_with(&["status=draf"], &["iteration"]);
+        observed(&mut ctx, "status", &["draft", "completed"]);
+        let hints = zero_result_hints(&ctx);
+        let first = &hints[0];
+        assert_eq!(first.description, "Did you mean status=draft?");
+        assert!(
+            first.cmd.contains("status=draft") && first.cmd.contains("--tag iteration"),
+            "corrected query keeps the other filters: {}",
+            first.cmd
+        );
+    }
+
+    #[test]
+    fn drop_hint_names_the_most_selective_filter() {
+        let ctx = ctx_with(&["status=draft"], &["iteration"]);
+        let hints = zero_result_hints(&ctx);
+        let drop = hints
+            .iter()
+            .find(|h| h.description.starts_with("Drop the most selective"))
+            .expect("two filters ⇒ a drop hint");
+        assert!(drop.description.contains("--property status=draft"));
+        assert!(
+            !drop.cmd.contains("status=draft") && drop.cmd.contains("--tag iteration"),
+            "the dropped filter is gone, the rest survives: {}",
+            drop.cmd
+        );
+    }
+
+    #[test]
+    fn filter_echo_lists_active_filters() {
+        let ctx = ctx_with(&["status=x"], &["y"]);
+        assert_eq!(
+            filter_echo(&ctx).as_deref(),
+            Some("--property status=x --tag y")
+        );
+        assert_eq!(filter_echo(&HintContext::new(HintSource::Find)), None);
+    }
+
+    #[test]
+    fn generate_hints_emits_them_for_an_empty_find() {
+        let mut ctx = ctx_with(&["status=nonexistent"], &[]);
+        observed(&mut ctx, "status", &["draft"]);
+        let hints = generate_hints(&ctx, &serde_json::json!([]), Some(0));
+        assert!(
+            !hints.is_empty(),
+            "the empty-array find path must route through zero_result_hints"
+        );
+        assert!(hints.len() <= MAX_ZERO_RESULT_HINTS);
+    }
+
+    #[test]
+    fn hints_are_capped_at_three() {
+        let mut ctx = ctx_with(&["status=draf", "type=iteratio"], &["iteration"]);
+        observed(&mut ctx, "status", &["draft", "completed"]);
+        observed(&mut ctx, "type", &["iteration", "decision"]);
+        assert!(zero_result_hints(&ctx).len() <= MAX_ZERO_RESULT_HINTS);
+    }
+
+    #[test]
+    fn unknown_key_points_at_the_properties_listing() {
+        let ctx = ctx_with(&["nosuchkey=1"], &[]);
+        let hints = zero_result_hints(&ctx);
+        assert!(
+            hints[0].description.contains("No file has a `nosuchkey`"),
+            "{hints:?}"
+        );
+        assert!(hints[0].cmd.contains("properties summary"));
+    }
+}

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -247,7 +247,14 @@ impl OutputPipeline<'_> {
                         && total == Some(0)
                         && value.as_array().is_some_and(Vec::is_empty)
                     {
-                        eprintln!("No results");
+                        // iter-251: echo the effective filters. `No results`
+                        // alone left the reader to reconstruct what was asked;
+                        // naming the filters makes the empty state definitive
+                        // and pairs with the zero-result hints below it.
+                        match self.hint_ctx.and_then(crate::hints::filter_echo) {
+                            Some(filters) => eprintln!("No results for {filters}"),
+                            None => eprintln!("No results"),
+                        }
                     }
                 }
                 0

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -469,6 +469,75 @@ pub fn run() {
     }
 }
 
+/// `-h` layout for the top-level command (iteration 251).
+///
+/// Clap has one template per `Command`, so the grouped command list lives in
+/// `after_help` and this template moves it *above* the global options — the
+/// order an agent needs (what can I run? then how do I shape the output?).
+/// `{subcommands}` is deliberately absent: the grouped block replaces the
+/// alphabetical one. `--help` keeps clap's default layout untouched.
+const TOP_SHORT_HELP_TEMPLATE: &str = "\
+{before-help}{about-with-newline}
+{usage-heading} {usage}{after-help}
+
+GLOBAL OPTIONS (every command):
+{options}";
+
+/// Hide every global flag from `-h` (but not `--help`) so a subcommand's short
+/// help can stand in one pointer line for the whole block.
+///
+/// `hide_short_help` is set on the root's own arg objects; clap propagates
+/// `global = true` args to subcommands at build time, so the flag travels with
+/// them. A subcommand that declares its *own* arg of the same name (`find`'s
+/// `--index-file` from [`crate::cli::args::IndexFlags`]) keeps its own copy
+/// visible, which is the intent: it is documented per command, not globally.
+fn hide_globals_from_short_help(mut cmd: clap::Command) -> clap::Command {
+    const GLOBAL_ARG_IDS: [&str; 9] = [
+        "dir",
+        "format",
+        "jq",
+        "count",
+        "hints",
+        "no_hints",
+        "site_prefix",
+        "quiet",
+        "index_file",
+    ];
+    for id in GLOBAL_ARG_IDS {
+        cmd = cmd.mut_arg(id, |a| a.hide_short_help(true));
+    }
+    cmd
+}
+
+/// Append the global-options pointer line to every subcommand's `-h`,
+/// recursively (so `hyalo properties rename -h` gets it too).
+///
+/// Only `after_help` is set, never `after_long_help`: this runs solely on an
+/// invocation that already contains `-h`, so `--help` never reaches it.
+fn attach_subcommand_pointer(cmd: clap::Command, pointer: &str) -> clap::Command {
+    let names: Vec<String> = cmd
+        .get_subcommands()
+        .map(|s| s.get_name().to_owned())
+        .collect();
+    let mut cmd = cmd;
+    for name in names {
+        cmd = cmd.mut_subcommand(name, |sub| {
+            // `help` prints other commands' help; a pointer on it is noise.
+            if sub.get_name() == "help" {
+                return sub;
+            }
+            let sub = attach_subcommand_pointer(sub, pointer);
+            match sub.get_after_help().map(ToString::to_string) {
+                Some(existing) if !existing.is_empty() => {
+                    sub.after_help(format!("{existing}\n\n{pointer}"))
+                }
+                _ => sub.after_help(pointer.to_owned()),
+            }
+        });
+    }
+    cmd
+}
+
 #[allow(clippy::too_many_lines)]
 fn run_inner() -> Result<(), AppError> {
     // Pre-scan for --quiet / -q so config-loading warnings are also suppressed.
@@ -531,6 +600,44 @@ fn run_inner() -> Result<(), AppError> {
     // they don't exist on the subcommand Command node yet.  This is a known
     // clap limitation with `global = true` derive args.
     let raw_args: Vec<String> = std::env::args().collect();
+
+    // iter-251: reshape *short* help only. `-h` is what an agent reads first
+    // and 7.7 KB of it (29 KB for `--help`) is what stopped them reading past
+    // `find`; `--help` keeps every word. The reshaping is applied here rather
+    // than as static clap attributes because clap has no per-page (`-h` vs
+    // `--help`) template or subcommand-level `hide_short_help`, and because
+    // both variants depend on what `.hyalo.toml` already supplies.
+    if raw_args.iter().any(|a| a == "-h") {
+        if crate::suggest::top_level_subcommand(&raw_args, &Cli::command()).is_some() {
+            // Subcommand `-h`: the ~1.9 KB global block was repeated
+            // identically on all 27 subcommands. Collapse it to one pointer
+            // line; `--help` still lists every global in full.
+            cmd = hide_globals_from_short_help(cmd);
+            let pointer = crate::cli::help::global_pointer(hide_dir, hide_format);
+            cmd = attach_subcommand_pointer(cmd, &pointer);
+            // `find` additionally gets composed examples and its own
+            // `--help` pointer, overriding the bare global line.
+            let find_tail = crate::cli::help::find_after_short_help(&pointer);
+            cmd = cmd.mut_subcommand("find", |sub| sub.after_help(find_tail));
+        } else {
+            // Top-level `-h`: commands grouped by intent ahead of the global
+            // options, with composed examples instead of 40 single-flag ones.
+            // `[possible values: …]` duplicates what the one-line help
+            // already says and forces a wrap; `--help` still prints it.
+            // The global `--index-file` is a pure alias for a flag each
+            // index-aware subcommand documents itself, so it earns no line on
+            // the page an agent reads first.
+            cmd = cmd
+                .mut_arg("format", |a| a.hide_possible_values(true))
+                .mut_arg("index_file", |a| a.hide_short_help(true))
+                .help_template(TOP_SHORT_HELP_TEMPLATE)
+                .after_help(format!(
+                    "{}\n\n{}",
+                    crate::cli::help::HELP_COMMANDS,
+                    crate::cli::help::HELP_EXAMPLES_SHORT
+                ));
+        }
+    }
     let matches = match cmd.try_get_matches_from(raw_args.iter().map(String::as_str)) {
         Ok(m) => m,
         Err(e) => {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -590,9 +590,15 @@ fn run_inner() -> Result<(), AppError> {
     // Apply runtime-filtered help text so that examples and cookbook entries
     // that reference config-defaulted flags are stripped from help output.
     // `after_help` is shown by `-h`; `after_long_help` is shown by `--help`.
-    cmd = cmd
-        .after_help(filter_examples(hide_dir, hide_format))
-        .after_long_help(filter_long_help(hide_dir, hide_format));
+    // iter-251: the 40 one-flag EXAMPLES moved off `-h` (where they taught one
+    // flag per line and never that filters compose) onto `--help`, which now
+    // carries both them and the COOKBOOK. `-h`'s own examples are installed
+    // below, in the short-help branch.
+    cmd = cmd.after_long_help(format!(
+        "{}\n\n{}",
+        filter_long_help(hide_dir, hide_format),
+        filter_examples(hide_dir, hide_format)
+    ));
 
     // Global args (--format, --jq, etc.) are only defined on the root Command
     // in clap derive — they aren't propagated to subcommands until parse time.
@@ -631,11 +637,7 @@ fn run_inner() -> Result<(), AppError> {
                 .mut_arg("format", |a| a.hide_possible_values(true))
                 .mut_arg("index_file", |a| a.hide_short_help(true))
                 .help_template(TOP_SHORT_HELP_TEMPLATE)
-                .after_help(format!(
-                    "{}\n\n{}",
-                    crate::cli::help::HELP_COMMANDS,
-                    crate::cli::help::HELP_EXAMPLES_SHORT
-                ));
+                .after_help(crate::cli::help::short_help_body(hide_dir, hide_format));
         }
     }
     let matches = match cmd.try_get_matches_from(raw_args.iter().map(String::as_str)) {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1961,6 +1961,7 @@ fn run_inner() -> Result<(), AppError> {
         lint_strict: lint_strict_from_config,
         lint_profiles: lint_profiles_active,
         files_from_counters: None,
+        zero_result_values: std::collections::BTreeMap::new(),
     };
 
     // When --files-from resolved to zero files (all entries filtered/missing),
@@ -1998,6 +1999,11 @@ fn run_inner() -> Result<(), AppError> {
     // Inject elapsed into hint context so slow_query_hint can read it.
     if let Some(ref mut hctx) = hint_ctx {
         hctx.elapsed_ms = Some(elapsed_ms);
+        // iter-251: a `find` that matched nothing collected the distinct
+        // values of every filtered property key during the scan it already
+        // paid for. Hand them to the hint layer so the zero-result
+        // did-you-mean names real values instead of guessing.
+        hctx.observed_property_values = std::mem::take(&mut ctx.zero_result_values);
     }
 
     let exit_code_override = ctx.exit_code_override;

--- a/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
@@ -48,9 +48,29 @@ multiple read + edit calls.
 
 **For pi sessions, ALWAYS use `--format text` for compact, LLM-friendly output.**
 
+## Read the CLI's own help before guessing a flag
+
+`hyalo -h` lists every command grouped by intent (read / write / config), one line each,
+naming the capability families behind them. `hyalo <cmd> -h` is one screen for one command;
+`hyalo <cmd> --help` is the full syntax reference — property operators, sort keys,
+`--fields` values, output shapes, and a cookbook. Both are generated from the binary you
+are running, so unlike any copy in this file they cannot go stale. Reach for `-h` first and
+`--help` for detail; do not fall back to `grep` because a filter looked unavailable.
+
+```bash
+hyalo -h                 # every command, grouped, with composed examples
+hyalo find -h            # filters and output flags on one screen
+hyalo find --help        # every operator, sort key, field name and recipe
+```
+
+An empty result set is also self-documenting: `find` that matches nothing echoes the
+filters it applied and hints at the next step (a did-you-mean over the values the property
+actually has, and the same query with its most selective filter dropped).
+
 ## Core Philosophy for pi
 
 - **Use hyalo first**: Before using read/edit/grep/write on .md files, check if hyalo can do it
+- **Read `-h` before guessing**: `hyalo <cmd> -h` for the short page, `--help` for full syntax
 - **Batch operations**: Use hyalo's bulk mutation features instead of individual edits
 - **Snapshot indexes**: For vaults >500 files, use `hyalo create-index` + `--index` for speed
 - **Follow hints**: hyalo outputs drill-down suggestions (`-> hyalo ...`) — use them
@@ -271,6 +291,7 @@ hyalo find --orphan --fields properties,links --format text \
 4. **Using system `mv` instead of `hyalo mv`**: Breaks links — always use `hyalo mv`
 5. **Ignoring hints**: hyalo suggests next commands — follow them
 6. **Not validating schemas**: Run `hyalo lint --strict` regularly
+7. **Guessing flags instead of reading `-h`**: every command's short help fits on one screen; `--help` has the full syntax
 
 ## Integration with pi Extension
 

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -3,6 +3,12 @@ paths:
   - "hyalo-knowledgebase/**"
 ---
 Prefer `hyalo` CLI for operations on files in this directory:
+- **Read the CLI's own help before guessing a flag**: `hyalo -h` lists every command grouped by
+  intent, one line each; `hyalo <cmd> -h` is one screen for one command; `hyalo <cmd> --help` is the
+  full syntax reference (operators, sort keys, `--fields` values, output shapes, cookbook).
+- **Empty result sets are self-documenting**: a `find` that matches nothing echoes the filters it
+  applied and hints at the next step (did-you-mean over the values the property really has, and the
+  same query with its most selective filter dropped).
 - **Search/filter**: `hyalo find --property status=planned --tag iteration`
 - **Body search**: `hyalo find "broken links"`
 - **Title regex**: `hyalo find --property 'title~=link'`

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -318,39 +318,47 @@ hyalo read my-note.md --frontmatter                # include YAML frontmatter
 Start with `hyalo summary` to orient yourself in a new directory (text output is the
 default in interactive terminals).
 
-## Available commands
+## Available commands — read the CLI's own help first
 
-- **find** — BM25 ranked full-text search (AND, OR, phrase, negation) or regex; filter by property, tag, task status
-- **read** — extract body content, a section, or line range
-- **summary** — compact fixed-size orientation view: file counts, tags, tasks, orphans, dead-ends, links, schema lint count (use `--depth N` to override directory depth)
-- **lint** — validate frontmatter against the `[schema]` and lint markdown body with mdbook-lint MD001..MD059 + HYALO001/002 native rules; supports `--rule`, `--rule-prefix`, `--detailed`, `--max-per-rule`, `--strict` (promotes missing-type and undeclared-property warnings to errors), `--fix`, `--fix-rule`; exit 1 when errors found
-- **lint-rules** — manage which lint rules are enabled and their severity in `.hyalo.toml` (list, show, set, remove; `lint-rules summary` aliases `list`)
-- **types** — manage `[schema.types.*]` entries in `.hyalo.toml` (list, show, set, remove; `types summary` aliases `list`)
-- **properties summary** — list property names and types (`properties list` is an alias)
-- **properties rename** — bulk rename a property key across files (`--from old --to new`)
-- **tags summary** — list tags with counts (`tags list` is an alias)
-- **tags rename** — bulk rename a tag across files (`--from old --to new`)
-- **set** — create/overwrite frontmatter properties, add tags (supports `--where-property`/`--where-tag` for conditional bulk updates, which default to all `**/*.md` when no `--file`/`--glob` is given; `--property 'K=[a,b,c]'` creates YAML sequences; `--property 'K=[[foo/bar]]'` stores a literal wikilink string; `--validate` rejects values that would fail schema lint; file arg is positional or `--file`, repeatable)
-- **remove** — delete properties or tags
-- **append** — add to list properties (supports `--validate`; note: tags are not appendable; use `set --tag` instead)
-- **task** — read, toggle, or set status on checkboxes (supports `--line 5,7`, `--section "Tasks"`, `--all`; `--dry-run` to preview toggles)
-- **mv** — move/rename a file and rewrite all inbound links across the vault. Single-file mode
-  writes immediately (`--dry-run` to preview; `--apply` is rejected there). Batch mode
-  (`--glob`/`--property`/`--tag`/`--type`) defaults to dry-run and needs `--apply` to commit
-- **links fix** — detect broken wikilinks/markdown links and auto-repair (dry-run by default; `--apply` to write). Targets that normalize above the vault root (`../../CONTRIBUTING.md`) are counted under `out_of_vault`, not `broken`, and are never offered a fix. Also detects case mismatches when `[links] case_insensitive` is enabled (default `"auto"` on macOS/Windows; detection is stat-only and writes nothing into the vault). Low-confidence matches — fuzzy hits and basename fallbacks — are reported separately and excluded from `--apply` unless you pass `--apply-fuzzy`. `--apply-fuzzy` is gated a second time by a confidence floor (0.8 by default, overridable with `--min-confidence <0.0-1.0>` or `[links] fuzzy_min_confidence`; `--min-confidence 0` accepts everything): proposals below it are counted under `fuzzy_below_floor` and never written. Confidence weights the final path segment at 70% and the directory path at 30%, so a relocation inside a section outranks a same-name substitution across sections. A basename fallback is any repair that discards a directory the author actually wrote (`/actions` or `guides/actions` matching some `actions.md` elsewhere in the vault); a target written with no directory at all (`[[actions]]`, `[x](actions.md)`) resolves by the Obsidian short-form rule and stays a plain-`--apply` fix. Every repair is written in the form the link was written in (site-absolute stays site-absolute; a relative destination is computed from the source file's own directory), and a fix whose emitted target would still not resolve is refused and reported under `unfixable` rather than written. Destinations containing `{%`, `{{` or `${` are template expressions, not paths (`{% ifversion ghes %}/admin{% endif %}/guides`): they are counted under `templated`/`templated_links` and never rewritten, because a fuzzy match on the literal text would silently drop the conditional
-- **backlinks** — reverse link lookup: lists all files that link to a given file
-- **create-index** — build a snapshot index for faster repeated read-only queries (`-o/--output PATH`, also accepted as `--path`)
-- **drop-index** — delete a snapshot index file created with create-index (`-p/--path PATH`, also accepted as `--output`)
-- **views list** — show all saved views and their filters (`views summary` is an alias)
-- **views set** — save a find query as a named view (`hyalo views set todo --task todo`)
-- **views remove** — delete a saved view
-- **views run** — run a saved view (`hyalo views run <name> [PATTERN] [extra filters]`), identical
-  to `hyalo find [PATTERN] --view <name>`
-- **config** — print the effective configuration (which `.hyalo.toml` is active, resolved dir,
-  format, hints, site prefix). Add `--raw` for the file's text. `results.malformed` /
-  `results.parse_error` report a config that exists but does not parse — every other value shown
-  is then a built-in default. Wrapped in the standard envelope, so `hyalo config --jq
-  '.results.dir'` works like any other command
+`hyalo -h` lists every command grouped by intent (read / write / config), one line each,
+with the capability families each one covers. `hyalo <cmd> -h` is the short page for one
+command; `hyalo <cmd> --help` is its full syntax reference — property operators, sort keys,
+`--fields` values, output shapes, and a cookbook. Both are generated from the binary you
+are actually running, so they cannot drift the way a copy in this file can. Read them
+before guessing a flag, and before falling back to `grep`.
+
+```bash
+hyalo -h                 # every command, grouped, with composed examples
+hyalo find -h            # one screen: filters, output flags, examples
+hyalo find --help        # every operator, sort key, field name and recipe
+```
+
+What follows is only what those pages do not say — the behaviour that surprises people.
+
+### Pitfalls
+
+- **`mv` has two modes.** Single-file mode writes immediately (`--dry-run` to preview;
+  `--apply` is rejected there). Batch mode (`--glob`/`--property`/`--tag`/`--type`)
+  defaults to dry-run and needs `--apply` to commit.
+- **`links fix` withholds low-confidence repairs.** Fuzzy hits and basename fallbacks are
+  reported separately and excluded from `--apply` unless you pass `--apply-fuzzy`, which is
+  gated again by a confidence floor (0.8 default; `--min-confidence <0.0-1.0>` or
+  `[links] fuzzy_min_confidence`). Confidence weights the final path segment at 70% and the
+  directory path at 30%. A repair is written in the form the link was written in, and one
+  whose emitted target would still not resolve is refused and reported under `unfixable`.
+  Targets normalizing above the vault root count as `out_of_vault`, not `broken`.
+  Destinations containing `{%`, `{{` or `${` are template expressions, counted under
+  `templated` and never rewritten.
+- **`append` does not accept `--tag`.** Tags are scalar list items; use `set --tag`.
+- **`--where-property` / `--where-tag` default to all `**/*.md`** when neither `--file` nor
+  `--glob` is given. Always pair a bulk mutation with `--dry-run` first.
+- **Bare `properties` / `tags` / `types` / `views` / `lint-rules` run their `summary`
+  (or `list`) action** — there is no separate command to remember.
+- **`lint` exits 1 when errors are found**, which is what makes it usable as a CI gate;
+  `--strict` promotes missing-type and undeclared-property warnings to errors.
+- **`config` reports a broken config rather than failing.** `results.malformed` /
+  `results.parse_error` mean every other value shown is a built-in default.
+- **`views run <name>` is exactly `find --view <name>`** — same merge rules, same output.
 
 ## Schema & Lint
 

--- a/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
+++ b/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
@@ -10,7 +10,7 @@
 
 use std::fs;
 
-use super::common::{hyalo, hyalo_no_hints, write_md};
+use super::common::{hyalo, hyalo_no_hints, shell_split, write_md};
 use tempfile::TempDir;
 
 /// `hyalo -h` ceiling (2.5 KiB).
@@ -340,10 +340,13 @@ fn a_zero_result_hint_is_a_runnable_command() {
         .unwrap();
     let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let cmd = parsed["hints"][0]["cmd"].as_str().unwrap().to_owned();
-    // Re-run the suggested command verbatim through a shell-free split: every
-    // hint is built by HintBuilder, so its tokens are already shell-quoted and
-    // single-quoting only appears around values with spaces (none here).
-    let argv: Vec<&str> = cmd.split_whitespace().skip(1).collect();
+    // Re-run the suggested command verbatim, undoing HintBuilder's own
+    // single-quote escaping with `shell_split` rather than a bare
+    // `split_whitespace()`: on Windows the `--dir` value is a temp path
+    // containing `\`, which `shell_quote` wraps in single quotes even though
+    // it has no space, and a naive whitespace split leaves the literal quote
+    // characters in the token, so the path hyalo receives never exists.
+    let argv: Vec<String> = shell_split(&cmd).into_iter().skip(1).collect();
     let rerun = hyalo().args(&argv).output().unwrap();
     assert!(
         rerun.status.success(),

--- a/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
+++ b/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
@@ -1,0 +1,370 @@
+//! Iteration 251 — the two things an agent reads first: `-h` and an empty
+//! result set.
+//!
+//! Measured against 0.21.0, `hyalo -h` was 7.7 KB and `hyalo find -h` 12.3 KB,
+//! and a query that matched nothing printed `No results` with `hints: []`.
+//! Both are load-bearing for whether an agent discovers that filters compose
+//! at all, so both are pinned here: byte ceilings on every `-h` page (walked
+//! from the binary's own command list, so a new subcommand cannot slip past
+//! the gate), and the presence and shape of the zero-result hints.
+
+use std::fs;
+
+use super::common::{hyalo, hyalo_no_hints, write_md};
+use tempfile::TempDir;
+
+/// `hyalo -h` ceiling (2.5 KiB).
+const TOP_SHORT_HELP_MAX: usize = 2560;
+
+/// `hyalo <cmd> -h` ceiling (3 KiB).
+const SUB_SHORT_HELP_MAX: usize = 3072;
+
+/// Every top-level subcommand name, read out of `hyalo help` rather than
+/// hard-coded, so a command added later is covered without touching this file.
+fn subcommand_names() -> Vec<String> {
+    let output = hyalo_no_hints().arg("help").output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // The block between the `Commands:` heading and the `Options:` that
+    // follows it — `hyalo help` prints the long help, whose COOKBOOK lines are
+    // also two-space indented and would otherwise be read as command names.
+    let commands = stdout
+        .split_once("Commands:")
+        .map_or(stdout.as_str(), |(_, rest)| rest);
+    let commands = commands
+        .split_once("\nOptions:")
+        .map_or(commands, |(block, _)| block);
+    let mut names = Vec::new();
+    for line in commands.lines() {
+        // Command rows are indented two spaces and start with the name; the
+        // wrapped continuation of a description is indented much further.
+        if !line.starts_with("  ") || line.starts_with("      ") {
+            continue;
+        }
+        let Some(first) = line.split_whitespace().next() else {
+            continue;
+        };
+        if first == "help" || !first.chars().all(|c| c.is_ascii_lowercase() || c == '-') {
+            continue;
+        }
+        names.push(first.to_owned());
+    }
+    assert!(
+        names.len() >= 20,
+        "expected the full subcommand list, parsed: {names:?}"
+    );
+    names
+}
+
+#[test]
+fn top_level_short_help_is_under_its_ceiling() {
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo_no_hints()
+        .arg("-h")
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.len() <= TOP_SHORT_HELP_MAX,
+        "`hyalo -h` is {} bytes, ceiling {TOP_SHORT_HELP_MAX}",
+        stdout.len()
+    );
+}
+
+#[test]
+fn every_subcommand_short_help_is_under_its_ceiling() {
+    let tmp = TempDir::new().unwrap();
+    let mut oversized: Vec<(String, usize)> = Vec::new();
+    for name in subcommand_names() {
+        let output = hyalo_no_hints()
+            .args([name.as_str(), "-h"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "`hyalo {name} -h` failed");
+        let len = output.stdout.len();
+        if len > SUB_SHORT_HELP_MAX {
+            oversized.push((name, len));
+        }
+    }
+    assert!(
+        oversized.is_empty(),
+        "subcommand -h pages over the {SUB_SHORT_HELP_MAX}-byte ceiling: {oversized:?}"
+    );
+}
+
+#[test]
+fn subcommand_short_help_replaces_the_global_block_with_one_line() {
+    let tmp = TempDir::new().unwrap();
+    for name in subcommand_names() {
+        let output = hyalo_no_hints()
+            .args([name.as_str(), "-h"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            stdout.contains("Global: "),
+            "`hyalo {name} -h` lost the global-options pointer:\n{stdout}"
+        );
+        // The pointer stands in for the block, so the block's own prose must
+        // be gone — `--jq`'s LIMITS paragraph is the bulkiest part of it.
+        assert!(
+            !stdout.contains("LIMITS: a filter is given"),
+            "`hyalo {name} -h` still prints the --jq limits paragraph"
+        );
+    }
+}
+
+#[test]
+fn long_help_still_carries_the_full_global_block() {
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo_no_hints()
+        .args(["find", "--help"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("LIMITS: a filter is given"),
+        "--help must keep every word the short page dropped"
+    );
+    assert!(
+        stdout.contains("--site-prefix"),
+        "--help must keep the global flags"
+    );
+}
+
+#[test]
+fn find_short_help_names_the_operator_sort_and_field_vocabularies() {
+    let tmp = TempDir::new().unwrap();
+    let output = hyalo_no_hints()
+        .args(["find", "-h"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    for needle in [
+        "Filters:",
+        "Output:",
+        "K~=/re/i",   // the property-operator line
+        "dot-path",   // the dot-path note
+        "backlinks",  // a --fields value
+        "property:K", // a --sort key
+        "EXAMPLES",
+        "hyalo find --help",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "`find -h` must still name {needle:?}:\n{stdout}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Zero-result hints
+// ---------------------------------------------------------------------------
+
+fn vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\nstatus: draft\ntitle: A\ntags: [research]\n---\n\nbody\n",
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        "---\nstatus: completed\ntitle: B\n---\n\nbody\n",
+    );
+    tmp
+}
+
+#[test]
+fn text_mode_echoes_the_filters_that_matched_nothing() {
+    let tmp = vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=nonexistent",
+            "--tag",
+            "research",
+            "--format",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("No results for --property status=nonexistent --tag research"),
+        "the empty state must name the query it ran:\n{stderr}"
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("-> hyalo "),
+        "text mode must still render the zero-result hints:\n{stdout}"
+    );
+}
+
+#[test]
+fn json_mode_carries_non_empty_zero_result_hints() {
+    let tmp = vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=nonexistent",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["total"], 0);
+    let hints = parsed["hints"].as_array().expect("hints array");
+    assert!(
+        !hints.is_empty() && hints.len() <= 3,
+        "expected 1-3 zero-result hints: {parsed}"
+    );
+    for hint in hints {
+        assert_eq!(
+            hint["writes"], false,
+            "zero-result hints never suggest a mutation: {hint}"
+        );
+    }
+    assert!(
+        hints.iter().any(|h| h["description"]
+            .as_str()
+            .is_some_and(|d| d.contains("draft"))),
+        "the hints must name the values `status` really has: {parsed}"
+    );
+}
+
+#[test]
+fn did_you_mean_fires_for_a_one_character_typo() {
+    let tmp = vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--property", "status=draf", "--format", "json"])
+        .output()
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = parsed["hints"].as_array().unwrap();
+    let suggestion = hints
+        .iter()
+        .find(|h| {
+            h["description"]
+                .as_str()
+                .is_some_and(|d| d.starts_with("Did you mean"))
+        })
+        .unwrap_or_else(|| panic!("no did-you-mean hint: {parsed}"));
+    assert_eq!(suggestion["description"], "Did you mean status=draft?");
+    assert!(
+        suggestion["cmd"]
+            .as_str()
+            .unwrap()
+            .contains("--property status=draft")
+    );
+}
+
+#[test]
+fn did_you_mean_stays_silent_for_an_unrelated_value() {
+    let tmp = vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=nonexistent",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = parsed["hints"].as_array().unwrap();
+    assert!(
+        !hints.iter().any(|h| h["description"]
+            .as_str()
+            .is_some_and(|d| d.starts_with("Did you mean"))),
+        "an unrelated value is not a typo: {parsed}"
+    );
+}
+
+#[test]
+fn a_second_filter_earns_a_drop_the_most_selective_hint() {
+    let tmp = vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args([
+            "find",
+            "--property",
+            "status=archived",
+            "--tag",
+            "research",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = parsed["hints"].as_array().unwrap();
+    let drop = hints
+        .iter()
+        .find(|h| {
+            h["description"]
+                .as_str()
+                .is_some_and(|d| d.starts_with("Drop the most selective"))
+        })
+        .unwrap_or_else(|| panic!("no drop-filter hint: {parsed}"));
+    let cmd = drop["cmd"].as_str().unwrap();
+    assert!(
+        !cmd.contains("status=archived") && cmd.contains("--tag research"),
+        "the drop hint removes exactly one filter: {cmd}"
+    );
+}
+
+#[test]
+fn a_zero_result_hint_is_a_runnable_command() {
+    let tmp = vault();
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .args(["find", "--property", "status=draf", "--format", "json"])
+        .output()
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let cmd = parsed["hints"][0]["cmd"].as_str().unwrap().to_owned();
+    // Re-run the suggested command verbatim through a shell-free split: every
+    // hint is built by HintBuilder, so its tokens are already shell-quoted and
+    // single-quoting only appears around values with spaces (none here).
+    let argv: Vec<&str> = cmd.split_whitespace().skip(1).collect();
+    let rerun = hyalo().args(&argv).output().unwrap();
+    assert!(
+        rerun.status.success(),
+        "hint `{cmd}` did not run: {}",
+        String::from_utf8_lossy(&rerun.stderr)
+    );
+}
+
+#[test]
+fn an_empty_vault_still_gets_a_next_step() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("empty")).unwrap();
+    let output = hyalo()
+        .args(["--dir", tmp.path().join("empty").to_str().unwrap()])
+        .args(["find", "--format", "json"])
+        .output()
+        .unwrap();
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = parsed["hints"].as_array().unwrap();
+    assert!(
+        !hints.is_empty(),
+        "even a filter-less empty query names a next step: {parsed}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/help.rs
+++ b/crates/hyalo-cli/tests/e2e/help.rs
@@ -9,11 +9,14 @@ fn short_help_is_compact() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
 
-    // -h should contain the basic sections
+    // iter-251: `-h` groups the commands by intent instead of listing them
+    // alphabetically, and its examples compose filters rather than showing one
+    // flag each.
     assert!(stdout.contains("Usage: hyalo"));
-    assert!(stdout.contains("Commands:"));
-    assert!(stdout.contains("Options:"));
-    assert!(stdout.contains("EXAMPLES:"));
+    assert!(stdout.contains("COMMANDS \u{2014} read (no writes)"));
+    assert!(stdout.contains("COMMANDS \u{2014} write (mutates files)"));
+    assert!(stdout.contains("GLOBAL OPTIONS"));
+    assert!(stdout.contains("EXAMPLES (each composes"));
 
     // -h should NOT contain the enriched sections
     assert!(
@@ -241,9 +244,11 @@ fn help_shows_dir_without_config() {
 // Config-aware help: examples and cookbook filtering
 // ---------------------------------------------------------------------------
 
-/// Extract the EXAMPLES block from `-h` output (short help).
+/// Extract the EXAMPLES block from `--help` output (long help).
 ///
 /// Returns the text from the `EXAMPLES:` heading to the end of the output.
+/// iter-251 moved this block off `-h` (whose examples now compose filters
+/// instead of demonstrating one flag each) onto `--help`.
 fn examples_block(help: &str) -> &str {
     let start = help.find("EXAMPLES:").expect("no EXAMPLES: block in help");
     &help[start..]
@@ -270,7 +275,7 @@ fn examples_omit_format_when_config_sets_it() {
     fs::write(tmp.path().join(".hyalo.toml"), "format = \"text\"\n").unwrap();
 
     let output = hyalo_no_hints()
-        .arg("-h")
+        .arg("--help")
         .current_dir(tmp.path())
         .output()
         .unwrap();
@@ -291,7 +296,7 @@ fn examples_show_format_without_config() {
     // No .hyalo.toml
 
     let output = hyalo_no_hints()
-        .arg("-h")
+        .arg("--help")
         .current_dir(tmp.path())
         .output()
         .unwrap();

--- a/crates/hyalo-cli/tests/e2e/hints.rs
+++ b/crates/hyalo-cli/tests/e2e/hints.rs
@@ -662,7 +662,7 @@ fn find_with_hints_json_envelope() {
 }
 
 #[test]
-fn find_with_hints_empty_results_no_hints() {
+fn find_with_hints_empty_results_hint_at_the_vocabulary() {
     let tmp = setup_vault();
     let output = hyalo()
         .args(["--dir", tmp.path().to_str().unwrap()])
@@ -679,15 +679,25 @@ fn find_with_hints_empty_results_no_hints() {
         .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    // Empty results -> no hints generated; output is a plain empty array or
-    // a hints envelope with an empty hints array.
+    // iter-251: an empty result set is the moment an agent most needs a next
+    // step, so it now carries 1-3 hints instead of the empty array this test
+    // used to assert. A `--tag` miss points at the tag vocabulary.
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    if let Some(hints) = parsed.get("hints") {
-        assert!(
-            hints.as_array().is_some_and(std::vec::Vec::is_empty),
-            "expected empty hints for empty results: {parsed}"
-        );
-    }
+    let hints = parsed
+        .get("hints")
+        .and_then(serde_json::Value::as_array)
+        .expect("envelope carries a hints array");
+    assert!(
+        !hints.is_empty() && hints.len() <= 3,
+        "expected 1-3 zero-result hints: {parsed}"
+    );
+    assert!(
+        hints.iter().any(|h| h
+            .get("cmd")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|c| c.contains("tags summary"))),
+        "a --tag miss should point at the tag listing: {parsed}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -1,3 +1,4 @@
+mod agent_discoverability;
 mod common;
 
 mod anchors;

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -8,7 +8,7 @@ pub use fields::Fields;
 pub use match_props::{
     extract_tags, matches_filters_with_tags, matches_frontmatter_filters, tag_matches,
 };
-pub use parse::{PropertyFilter, parse_property_filter};
+pub use parse::{FilterOp, PropertyFilter, parse_property_filter};
 pub use sort::{SortField, compare_property_values, parse_sort};
 pub use tasks::{FindTaskFilter, parse_task_filter};
 

--- a/crates/xtask/src/help_drift.rs
+++ b/crates/xtask/src/help_drift.rs
@@ -6,6 +6,16 @@
 //!
 //! 3b. No `--help` output for any listed command may contain any phrase in
 //!     `crates/xtask/stale-help-patterns.toml`.
+//!
+//! 3c. (iter-251) Short help stays short: `hyalo -h` under
+//!     [`TOP_SHORT_HELP_MAX`] bytes and every `hyalo <cmd> -h` under
+//!     [`SUB_SHORT_HELP_MAX`]. `-h` is the page an agent reads first, and it
+//!     regressed to 7.7 KB (12.3 KB for `find`) purely by accretion — one
+//!     unsplit doc comment at a time, plus the global-options block repeated
+//!     on all 27 subcommands. A ceiling is the only thing that keeps it short.
+//!
+//! 3d. (iter-251) Every subcommand's `-h` ends with the one-line global-options
+//!     pointer instead of reprinting the block.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -58,6 +68,17 @@ const STALE_ONLY_COMMANDS: &[&[&str]] = &[&[]];
 
 /// Commands allowed to skip the EXAMPLES requirement (no-op / meta commands).
 const EXAMPLES_ALLOWLIST: &[&str] = &["help", "completions"];
+
+/// Byte ceiling for `hyalo -h` (2.5 KiB — iter-251 acceptance criterion).
+const TOP_SHORT_HELP_MAX: usize = 2560;
+
+/// Byte ceiling for every `hyalo <cmd> -h` (3 KiB — iter-251 acceptance
+/// criterion). `find` is the one that lives closest to it.
+const SUB_SHORT_HELP_MAX: usize = 3072;
+
+/// The literal every subcommand's `-h` must carry in place of the global
+/// options block. Kept in sync with `cli::help::global_pointer` by this gate.
+const GLOBAL_POINTER_PREFIX: &str = "Global: ";
 
 #[derive(Debug, Deserialize)]
 pub struct StalePatternFile {
@@ -130,6 +151,75 @@ pub fn count_examples(help: &str) -> usize {
         }
     }
     count
+}
+
+/// Get the `-h` (short help) output for a given argv.
+fn short_help_text(workspace_root: &std::path::Path, argv: &[&str]) -> Option<String> {
+    let mut args = vec!["run", "-q", "-p", "hyalo-cli", "--"];
+    args.extend_from_slice(argv);
+    args.push("-h");
+
+    let out = Command::new("cargo")
+        .args(&args)
+        .current_dir(workspace_root)
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    if stdout.trim().is_empty() {
+        None
+    } else {
+        Some(stdout)
+    }
+}
+
+/// 3c + 3d: short help stays short, and stands in one line for the globals.
+fn check_short_help(root: &std::path::Path) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    match short_help_text(root, &[]) {
+        Some(help) => {
+            if help.len() > TOP_SHORT_HELP_MAX {
+                failures.push(format!(
+                    "Help drift (3c): 'hyalo -h' is {} bytes; ceiling is {TOP_SHORT_HELP_MAX}. \
+                     Move detail into the second paragraph of the doc comment (clap long_help) \
+                     rather than growing the short page.",
+                    help.len()
+                ));
+            }
+            if !help.contains("COMMANDS") {
+                failures.push(
+                    "Help drift (3c): 'hyalo -h' no longer renders the grouped COMMANDS block."
+                        .to_owned(),
+                );
+            }
+        }
+        None => failures.push("Help drift (3c): could not get 'hyalo -h' output".to_owned()),
+    }
+
+    for argv in SUBCOMMANDS {
+        let cmd_label = argv.join(" ");
+        let Some(help) = short_help_text(root, argv) else {
+            failures.push(format!(
+                "Help drift (3c): could not get help output for 'hyalo {cmd_label} -h'"
+            ));
+            continue;
+        };
+        if help.len() > SUB_SHORT_HELP_MAX {
+            failures.push(format!(
+                "Help drift (3c): 'hyalo {cmd_label} -h' is {} bytes; ceiling is \
+                 {SUB_SHORT_HELP_MAX}.",
+                help.len()
+            ));
+        }
+        if !help.contains(GLOBAL_POINTER_PREFIX) {
+            failures.push(format!(
+                "Help drift (3d): 'hyalo {cmd_label} -h' is missing the \
+                 \"{GLOBAL_POINTER_PREFIX}…\" pointer line that stands in for the global \
+                 options block."
+            ));
+        }
+    }
+    failures
 }
 
 /// 3a: Check EXAMPLES blocks.
@@ -214,8 +304,14 @@ pub fn run_with_root(root: &std::path::Path) -> Result<bool> {
     let stale_failures = check_stale_patterns(root, &stale_patterns);
     all_failures.extend(stale_failures);
 
+    let short_help_failures = check_short_help(root);
+    all_failures.extend(short_help_failures);
+
     if all_failures.is_empty() {
-        println!("check-help-drift: all subcommands have EXAMPLES blocks and no stale patterns.");
+        println!(
+            "check-help-drift: all subcommands have EXAMPLES blocks, no stale patterns, and \
+             short help within its byte ceilings."
+        );
         Ok(true)
     } else {
         eprintln!(

--- a/hyalo-knowledgebase/iterations/iteration-251-agent-discoverability-help.md
+++ b/hyalo-knowledgebase/iterations/iteration-251-agent-discoverability-help.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 251 — agent discoverability: short -h pages and zero-result hints"
 date: 2026-08-29
-status: in-progress
+status: completed
 tags:
   - iteration
   - agent-cli

--- a/hyalo-knowledgebase/iterations/iteration-251-agent-discoverability-help.md
+++ b/hyalo-knowledgebase/iterations/iteration-251-agent-discoverability-help.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 251 — agent discoverability: short -h pages and zero-result hints"
 date: 2026-08-29
-status: planned
+status: in-progress
 tags:
   - iteration
   - agent-cli
@@ -31,51 +31,51 @@ acceptance shape, not a suggestion.
 
 ## Tasks
 
-- [ ] Every `#[arg]`/`#[command]` doc comment gets a one-line first
+- [x] Every `#[arg]`/`#[command]` doc comment gets a one-line first
       paragraph (clap `help`) followed by a blank line and the existing
       text (clap `long_help`). Target: `hyalo <cmd> -h` ≤ 3 KB for every
       subcommand; `--help` unchanged in content.
-- [ ] Global options: one-line short help each; the `--jq` limits paragraph
+- [x] Global options: one-line short help each; the `--jq` limits paragraph
       lives only in `--help`. On subcommands, `-h` shows globals as a single
       pointer line (`Global: --format --jq --count --no-hints -q — see
       hyalo -h`) — via the existing help template machinery in
       `cli/help.rs`, not a new flag.
-- [ ] Top-level `-h`: commands grouped by intent (Read / Write / Config &
+- [x] Top-level `-h`: commands grouped by intent (Read / Write / Config &
       scaffolds), two per line where they pair naturally, one-line
       descriptions naming the capability families (e.g. `find`: "BM25 text,
       regex, property, tag, task, section, title, glob, link-graph
       filters; sort, limit, --fields, --view, --count"). Keep a short
       "Start here" block of ≤ 8 examples that each **compose** 2–3
       features — the current 40 single-flag examples move to `--help`.
-- [ ] `find -h`: flags grouped Filters / Output; the property-operator
+- [x] `find -h`: flags grouped Filters / Output; the property-operator
       line, dot-path note, `--fields` values and `--sort` keys stay (these
       are exactly where agents fall back to grep). ≤ 8 composed examples;
       last line points at `find --help`.
-- [ ] Zero-result hints: when `total == 0`, emit 1–3 hints — drop the most
+- [x] Zero-result hints: when `total == 0`, emit 1–3 hints — drop the most
       selective filter (re-run with one filter removed), `hyalo properties`
       / `hyalo tags` to list observed values, and for `--property K=V` a
       did-you-mean over the observed values of K when edit distance is
       small. Text mode: `No results for --property status=x --tag y`
       (echo the effective filters). JSON: same hints in the envelope, with
       `writes: false`.
-- [ ] `check-help-drift` / `check-command-reference` / `check-bundled-skills`
+- [x] `check-help-drift` / `check-command-reference` / `check-bundled-skills`
       xtask gates updated to the new shape; SKILL.md (bundled + pi-package,
       keep in sync via `just sync-pi-package`) trimmed to workflow +
       pitfalls and told to use `-h` first, `--help` for syntax detail.
-- [ ] e2e tests: byte-size ceilings for `-h` on every subcommand (loop over
+- [x] e2e tests: byte-size ceilings for `-h` on every subcommand (loop over
       `hyalo help` list); zero-result hint presence in text and JSON;
       did-you-mean fires for a one-character typo and not for an unrelated
       value.
-- [ ] CHANGELOG `[Unreleased]` → Changed.
+- [x] CHANGELOG `[Unreleased]` → Changed.
 
 ## Acceptance criteria
 
-- [ ] `hyalo -h` ≤ 2.5 KB, `hyalo find -h` ≤ 3 KB, every other
+- [x] `hyalo -h` ≤ 2.5 KB, `hyalo find -h` ≤ 3 KB, every other
       `hyalo <cmd> -h` ≤ 3 KB; every capability named on the current pages
       is still named.
-- [ ] `hyalo find --property status=nonexistent` prints a non-empty hint
+- [x] `hyalo find --property status=nonexistent` prints a non-empty hint
       block in text and a non-empty `hints` array in JSON.
-- [ ] `--help` output loses nothing; all xtask gates and CI green.
+- [x] `--help` output loses nothing; all xtask gates and CI green.
 
 ## Non-goals
 

--- a/pi-package/skills/hyalo/SKILL.md
+++ b/pi-package/skills/hyalo/SKILL.md
@@ -48,9 +48,29 @@ multiple read + edit calls.
 
 **For pi sessions, ALWAYS use `--format text` for compact, LLM-friendly output.**
 
+## Read the CLI's own help before guessing a flag
+
+`hyalo -h` lists every command grouped by intent (read / write / config), one line each,
+naming the capability families behind them. `hyalo <cmd> -h` is one screen for one command;
+`hyalo <cmd> --help` is the full syntax reference — property operators, sort keys,
+`--fields` values, output shapes, and a cookbook. Both are generated from the binary you
+are running, so unlike any copy in this file they cannot go stale. Reach for `-h` first and
+`--help` for detail; do not fall back to `grep` because a filter looked unavailable.
+
+```bash
+hyalo -h                 # every command, grouped, with composed examples
+hyalo find -h            # filters and output flags on one screen
+hyalo find --help        # every operator, sort key, field name and recipe
+```
+
+An empty result set is also self-documenting: `find` that matches nothing echoes the
+filters it applied and hints at the next step (a did-you-mean over the values the property
+actually has, and the same query with its most selective filter dropped).
+
 ## Core Philosophy for pi
 
 - **Use hyalo first**: Before using read/edit/grep/write on .md files, check if hyalo can do it
+- **Read `-h` before guessing**: `hyalo <cmd> -h` for the short page, `--help` for full syntax
 - **Batch operations**: Use hyalo's bulk mutation features instead of individual edits
 - **Snapshot indexes**: For vaults >500 files, use `hyalo create-index` + `--index` for speed
 - **Follow hints**: hyalo outputs drill-down suggestions (`-> hyalo ...`) — use them
@@ -271,6 +291,7 @@ hyalo find --orphan --fields properties,links --format text \
 4. **Using system `mv` instead of `hyalo mv`**: Breaks links — always use `hyalo mv`
 5. **Ignoring hints**: hyalo suggests next commands — follow them
 6. **Not validating schemas**: Run `hyalo lint --strict` regularly
+7. **Guessing flags instead of reading `-h`**: every command's short help fits on one screen; `--help` has the full syntax
 
 ## Integration with pi Extension
 


### PR DESCRIPTION
## Summary

Agents were using bare-minimum `find` and piping through `grep` because the two
pages they read first told them almost nothing. Both are fixed here.

- **`-h` is short again.** Every `#[arg]`/`#[command]` doc comment now leads
  with a one-line summary and keeps its full text as clap `long_help`, and the
  ~1.9 KB global-options block that was repeated on all 27 subcommands
  collapses to a single `Global: --dir --format --jq … — see hyalo -h` line.
  Measured: `hyalo -h` **7741 → 2458 bytes**, `hyalo find -h` **12263 → 2875**,
  every other subcommand ≤ 2215 (was up to 5903). `--help` loses nothing — it
  gains the 40 single-flag examples that moved off `-h`.
- **`hyalo -h` names capabilities, not just command names.** Commands are
  grouped by intent (read / write / config and scaffolds) with one-line
  descriptions of the capability families behind each, and the examples each
  compose two or three features instead of demonstrating one flag.
  `find -h` groups its flags under `Filters:` / `Output:` and keeps the
  property-operator line, the dot-path note, the `--fields` values and the
  `--sort` keys — the four things agents were falling back to `grep` for.
- **A `find` that matches nothing now says what it ran and what to try.** Text
  mode prints `No results for --property status=x --tag y`; both formats carry
  1–3 hints: a did-you-mean over the values the key really has (`status=draf`
  → `draft`; `status=nonexistent` stays silent), the observed values named
  inline, and the same query with its most selective filter dropped. The values
  come from the scan the query already paid for — the empty path costs no extra
  I/O. New module `crates/hyalo-cli/src/hints/zero_result.rs`.
- **Gates hold the ceilings.** `check-help-drift` gains 3c (byte ceilings on
  `hyalo -h` and every `hyalo <cmd> -h`) and 3d (the pointer line must be
  there instead of the block). Docs updated in lockstep: bundled + pi-package
  `SKILL.md` trimmed to workflow + pitfalls and told to read `-h` first, the
  knowledgebase rule template, and the CHANGELOG.

No new flags, and no change to the JSON result shape or defaults.

## Test plan

- [x] `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` /
      `cargo test --workspace -q` — all green (3387 tests).
- [x] All eight `xtask check-*` gates exit 0, including the new 3c/3d checks.
- [x] New e2e suite `crates/hyalo-cli/tests/e2e/agent_discoverability.rs`
      (12 tests): byte ceilings walked from `hyalo help`'s own command list so
      a future subcommand cannot slip past; the global pointer present and the
      `--jq` LIMITS paragraph absent on every subcommand `-h`; `--help` still
      carries both; `find -h` still names the operator / sort / field
      vocabularies; zero-result hints in text and JSON; did-you-mean fires for
      a one-character typo and not for an unrelated value; the drop-filter hint
      removes exactly one filter; a zero-result hint re-runs successfully.
- [x] 8 unit tests in `hints/zero_result.rs` covering the distance guards, the
      filter echo, the 3-hint cap and the unknown-key fallback.
- [x] `hyalo lint` clean over the knowledgebase and the CHANGELOG
      (`--profile changelog`).

## Review

Local-only review pass (`/review-pr local-only`): re-ran `cargo fmt --check`,
`cargo clippy --workspace --all-targets -- -D warnings`, and
`cargo test --workspace -q` (3355 tests) — all green. Manually walked the
diff for correctness (hint ranking/selectivity, did-you-mean edit-distance
guards, the clap short-help template surgery in `run.rs`, the
`check-help-drift` gate additions) and dogfooded `hyalo -h`, `hyalo find -h`,
and a live zero-result query against this repo's own knowledgebase — all
behave as documented. No findings.

## Carry-over

None. Every task and acceptance criterion in
`hyalo-knowledgebase/iterations/iteration-251-agent-discoverability-help.md`
landed in this diff and is ticked against the real changes (verified, not
speculative). The plan's "Non-goals" (JSON result shape/defaults, TOON
output, content-first bare invocation, SessionStart hooks) are explicit
rejections from the axi review, not deferrals — no follow-up needed. The one
related forward-looking item, JSON result-shape changes, already has its own
plan at `iteration-252-find-result-shape.md` (depends-on this iteration),
which was pre-existing and needs no edit from this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS