### PR TITLE
iter-252: compact find result shape + size/lines metadata (0.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to
 
 ### Changed
 
+- **BREAKING: `find` returns a compact result shape.** The default field set
+  was `properties, tags, sections, links` on every item, so a 20-file listing
+  of this project's own knowledgebase was 73 KB of JSON — nine times the 8 KB
+  the same query costs with `--fields properties`, nearly all of it document
+  structure nobody had asked for. The default is now `file`, `modified`,
+  `size`, `lines`, `title`, `properties` and `tags` (11.9 KB for that same
+  listing). `sections`, `tasks`, `links`, `backlinks` and `properties-typed`
+  are opt-in — `--fields all` restores the previous shape and then some — but
+  a filter that implies a field still returns it with no flag: `--section`
+  adds `sections`, `--task` adds `tasks`, `--broken-links`/`--dead-end` add
+  `links`, `--orphan` adds both, and `--sort links_count`/`backlinks_count`
+  now return the field they rank on instead of computing it invisibly.
+  `title` is promoted: it joined the default set and is no longer repeated
+  inside `properties`, so read it as `.results[].title`
+  (`--fields properties` on its own still carries the raw property). Sorting
+  and filtering are unaffected — `--sort property:title` and
+  `--property title=…` compare exactly what they compared before.
+- **`size` and `lines` on every `find` and `read` result.** Nothing in a
+  result used to say how big a file was before you read it. Both numbers are
+  now always present, count the whole file (a `read --section` reports the
+  file's totals, not the slice's), are identical between a disk scan and an
+  `--index` snapshot, and count CRLF and LF documents the same. `read` over
+  8 KB offers a line-range read and a section listing instead of another
+  whole-file pull, and `--format text` prints the size and line count in each
+  result's header line plus a `fields:` summary naming what the payload
+  carries and what `--fields all` would add. Snapshot indexes written by
+  0.21.0 and earlier report `0` for both until the next `create-index`.
+
 - **`-h` is a short page again, and every command's page names its
   capabilities.** Measured on 0.21.0, `hyalo -h` was 7.7 KB and `hyalo find -h`
   12.3 KB, because no flag's documentation had a first-line/rest split (so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hyalo-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-mdlint"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -2103,7 +2103,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xtask"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ members = ["crates/*"]
 default-members = ["crates/hyalo-cli"]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ractive/hyalo"
 
 [workspace.dependencies]
 # Internal crates
-hyalo-core = { path = "crates/hyalo-core", version = "0.21.0" }
-hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.21.0" }
+hyalo-core = { path = "crates/hyalo-core", version = "0.22.0" }
+hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.22.0" }
 
 # External dependencies
 anyhow = "1"

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -462,15 +462,19 @@ pub(crate) struct FindFilters {
     #[arg(long, value_name = "PATH", conflicts_with_all = ["file", "glob"], help_heading = "Filters")]
     #[serde(skip)]
     pub files_from: Option<String>,
-    /// all|properties|properties-typed|tags|sections|tasks|links|backlinks|title (default: properties,tags,sections,links)
+    /// all|properties|properties-typed|tags|sections|tasks|links|backlinks|title (default: title,properties,tags)
     ///
     /// Comma-separated list of optional fields to include: all, properties, properties-typed, tags,
-    /// sections (alias: outline), tasks, links, backlinks, title (default: properties, tags,
-    /// sections, links — excludes tasks, properties-typed, backlinks, and title). Use 'all' to
-    /// include every field. 'file' and 'modified' are always included. 'properties' is a
-    /// {key: value} map; 'properties-typed' is a [{name, type, value}] array; 'backlinks' requires
-    /// scanning all files; 'title' is the frontmatter title property or first H1 heading (null if
-    /// neither found). Note: in JSON output, `properties-typed` is serialized as
+    /// sections (alias: outline), tasks, links, backlinks, title (default: title, properties, tags
+    /// — excludes sections, tasks, links, backlinks, and properties-typed). Use 'all' to
+    /// include every field. 'file', 'modified', 'size' (bytes) and 'lines' are always included.
+    /// A filter that implies a field returns it without --fields: --section adds sections,
+    /// --task adds tasks, --broken-links/--dead-end add links, --orphan adds links and backlinks,
+    /// and --sort links_count/backlinks_count add the field they rank on. 'properties' is a
+    /// {key: value} map WITHOUT the promoted 'title' property (which has its own field whenever
+    /// 'title' is included); 'properties-typed' is a [{name, type, value}] array; 'backlinks'
+    /// requires scanning all files; 'title' is the frontmatter title property or first H1 heading
+    /// (null if neither found). Note: in JSON output, `properties-typed` is serialized as
     /// `properties_typed` (underscore).
     #[arg(
         long,
@@ -720,8 +724,15 @@ pub(crate) enum Commands {
             different heading sets, so there is no single 'the' match to disambiguate against, unlike a \
             single-file mutation. A stderr warning names how many result files hit this (not per-file, \
             to avoid spamming a large result set).\n\n\
-            FIELDS: Use --fields to limit which fields appear (default: all). \
-            Properties are a {key: value} map; use --fields properties-typed for [{name, type, value}] array.\n\
+            FIELDS: Every item carries file, modified, size (bytes) and lines. The default optional \
+            fields are title, properties and tags; sections, tasks, links, backlinks and \
+            properties-typed are opt-in via --fields (or --fields all), or come automatically from \
+            the filter that implies them (--section, --task, --broken-links, --orphan, --dead-end, \
+            --sort links_count|backlinks_count). Properties are a {key: value} map and do NOT repeat \
+            the promoted title; use --fields properties-typed for a [{name, type, value}] array. \
+            --format text prints the included field names under the results.\n\
+            SIZE: size/lines let a caller budget before reading -- pair them with \
+            `read --lines A:B` or `read --section H` instead of pulling a large body whole.\n\
             JQ: --jq operates on the full envelope. Examples: --jq '.results[].file', --jq '.total'.\n\
             VIEWS: --view <name> loads a saved filter set from .hyalo.toml. Additional CLI flags \
             merge on top: list filters (--property, --tag, --section, --glob) extend the view's \
@@ -1435,10 +1446,16 @@ Repeatable (AND).\n\
             - list: Show all saved views and their filters (default).\n\
             - set: Create or update a view.\n\
             - remove: Delete a view.\n\n\
+            FIELDS: a view may pin --fields, and running it then uses that shape instead of the \
+            compact default (file, modified, size, lines, title, properties, tags). Pin the fields \
+            a query is actually about -- `views set orphans --orphan --fields backlinks` -- so the \
+            saved query stays cheap; a view with no --fields gets the default shape, plus whatever \
+            its own filters imply.\n\n\
             SIDE EFFECTS: 'set' and 'remove' modify .hyalo.toml. 'list' is read-only.\n\n\
             EXAMPLES:\n\
             \u{00a0} hyalo views list\n\
             \u{00a0} hyalo views set drafts --property status=draft --tag project\n\
+            \u{00a0} hyalo views set audit --broken-links --fields links\n\
             \u{00a0} hyalo find --view drafts --limit 5\n\
             \u{00a0} hyalo views remove drafts"
     )]

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -335,6 +335,15 @@ COOKBOOK:
   # Sort by modification time, newest first
   hyalo find --sort modified --reverse --limit 5
 
+  # Full result shape for one file (sections, tasks, links, backlinks)
+  hyalo find --file note.md --fields all
+
+  # Biggest matches first — size (bytes) and lines are on every result item
+  hyalo find --tag research --jq '[.results[] | {file, size, lines}] | sort_by(-.size)'
+
+  # Budget a read: the first 80 lines of a large file
+  hyalo read notes/todo.md --lines 1:80
+
   # Exclude draft files with glob negation
   hyalo find --glob '!**/draft-*'
 

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -267,19 +267,31 @@ pub fn find(
     // When sorting by a frontmatter property or title, or when --broken-links /
     // --orphan / --dead-end is active, force the relevant fields on even if not
     // requested via --fields.
+    // iter-252: with `sections`/`tasks`/`links`/`backlinks` out of the default
+    // field set, a filter that selects on one of them must still return it —
+    // `--section` without an outline, or `--task todo` without the tasks, is a
+    // result the caller cannot act on. The auto-include list therefore covers
+    // every filter and sort that implies a field, not just the graph filters.
     let original_fields = fields;
     let effective_fields;
+    let auto_sections = has_section_filter;
+    let auto_tasks = has_task_filter;
+    let auto_links = broken_links || orphan || dead_end || sort_needs_links;
+    let auto_backlinks = orphan || dead_end || sort_needs_backlinks;
     let needs_field_override = (sort_needs_properties && !fields.properties)
         || (sort_needs_title && !fields.title)
-        || (broken_links && !fields.links)
-        || (orphan && (!fields.links || !fields.backlinks))
-        || (dead_end && (!fields.links || !fields.backlinks));
+        || (auto_sections && !fields.sections)
+        || (auto_tasks && !fields.tasks)
+        || (auto_links && !fields.links)
+        || (auto_backlinks && !fields.backlinks);
     let fields = if needs_field_override {
         effective_fields = Fields {
             properties: fields.properties || sort_needs_properties,
             title: fields.title || sort_needs_title,
-            links: fields.links || broken_links || orphan || dead_end,
-            backlinks: fields.backlinks || orphan || dead_end,
+            sections: fields.sections || auto_sections,
+            tasks: fields.tasks || auto_tasks,
+            links: fields.links || auto_links,
+            backlinks: fields.backlinks || auto_backlinks,
             ..fields.clone()
         };
         &effective_fields
@@ -1022,6 +1034,8 @@ pub fn find(
         let obj = FileObject {
             file: entry.rel_path.clone(),
             modified: entry.modified.clone(),
+            size: entry.size,
+            lines: entry.lines,
             title,
             properties,
             properties_typed,
@@ -1172,11 +1186,13 @@ pub fn find(
     }
 
     // Strip internally-computed fields that the user didn't request in --fields.
-    if sort_needs_links && !original_fields.links {
-        for obj in &mut results {
-            obj.links = None;
-        }
-    }
+    //
+    // iter-252: `links`/`backlinks` are NOT stripped after a
+    // `--sort links_count`/`backlinks_count` run any more — the counted field
+    // is exactly what the caller is ranking by, so it is an auto-include
+    // (like `--broken-links` → `links`) rather than a hidden intermediate.
+    // `properties`/`title` stay internal: sorting by them says nothing about
+    // wanting them printed, and both are cheap to ask for explicitly.
     if sort_needs_properties && !original_fields.properties {
         for obj in &mut results {
             obj.properties = None;

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -959,6 +959,10 @@ pub fn find(
         }
 
         // --- Build properties fields ---
+        // iter-252: `title` joins `tags` as a *promoted* property — it has its
+        // own top-level field, so repeating it inside `properties` shipped the
+        // same string twice in every result item. One rule, one place: a
+        // promoted property is never echoed in the map.
         let properties = if fields.properties {
             let mut map = serde_json::Map::new();
             for (name, value) in entry
@@ -1226,6 +1230,29 @@ pub fn find(
     if total == 0 {
         fuzzy_suggest_tags(index, tag_filters);
         fuzzy_suggest_property_keys(index, property_filters);
+    }
+
+    // iter-252: `title` is a promoted field — when it is included, the same
+    // string in `properties.title` is pure duplicate payload (`tags` has been
+    // promoted the same way since the first `find`, and is filtered out where
+    // the map is built). Removed *here*, after sorting and filtering, so
+    // `--sort property:title` and every `--property title=…` filter keep
+    // comparing exactly what they always compared; only the bytes on the wire
+    // change. `--fields properties` without `title` keeps the property, so no
+    // request can lose the value entirely.
+    if fields.title && fields.properties {
+        for obj in &mut results {
+            if let Some(props) = obj.properties.as_mut() {
+                props.remove("title");
+            }
+        }
+    }
+    if fields.title && fields.properties_typed {
+        for obj in &mut results {
+            if let Some(props) = obj.properties_typed.as_mut() {
+                props.retain(|p| p.name != "title");
+            }
+        }
     }
 
     // --- Serialize ---

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -404,7 +404,17 @@ pub fn run(
     let content_str = content_lines.join("\n");
 
     // Build the JSON representation (used for both JSON output and the internal pipeline).
-    let mut obj = serde_json::json!({ "file": rel_path });
+    //
+    // iter-252: `size`/`lines` describe the whole file, not the slice being
+    // returned — they are the same two numbers `find` reports, so an agent can
+    // compare a `read --section` result against the file it came from and
+    // decide whether the rest is worth another call.
+    let total_lines = scanner::count_file_lines(&full_path)?;
+    let mut obj = serde_json::json!({
+        "file": rel_path,
+        "size": file_size,
+        "lines": total_lines,
+    });
     if let Some(ref props) = fm_value {
         let json_val =
             serde_json::to_value(props).context("failed to serialize frontmatter as JSON")?;

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -183,6 +183,10 @@ pub struct HintContext {
     /// Task selector used: "all", "section:<name>", or "lines" (for multi-line).
     /// `None` means single-line or no task context.
     pub task_selector: Option<String>,
+    /// `read` already narrowed its output with `--section` or `--lines`
+    /// (iter-252). Suppresses the large-file "read less" hint, which would
+    /// otherwise tell a caller to do what they just did.
+    pub read_narrowed: bool,
     // Mutation context
     pub dry_run: bool,
     // Index context
@@ -254,6 +258,7 @@ impl HintContext {
             find_index: FindIndexHint::None,
             view_name: None,
             task_selector: None,
+            read_narrowed: false,
             dry_run: false,
             index_path: None,
             auto_link_file: None,

--- a/crates/hyalo-cli/src/hints/find.rs
+++ b/crates/hyalo-cli/src/hints/find.rs
@@ -10,6 +10,11 @@ use super::{
     build_find_command_with_pattern, status_priority,
 };
 
+/// Largest untruncated result set for which `find` still offers
+/// `--fields all` (iter-252). Above a handful of files, the full shape is the
+/// payload the compact default exists to avoid, so the hint stays quiet.
+const MAX_EXPANDABLE_RESULTS: usize = 5;
+
 /// Slugify a string to the charset valid for view names: `[a-z0-9_-]`.
 /// Replaces invalid chars with `-`, collapses runs of `-`, and trims leading/trailing `-`.
 pub(super) fn slugify(s: &str) -> String {
@@ -192,12 +197,22 @@ pub(super) fn hints_for_find(
     }
 
     // iter-252: the default result shape carries file, modified, size, lines,
-    // title, properties and tags — everything else (sections, links, tasks,
-    // backlinks, properties-typed) is opt-in, so every listing says how to
-    // get it back. Skipped when the caller already chose `--fields`, and for
-    // a single result, where the richer "See all metadata for this file"
-    // hint above already spells out `--fields all` for that one file.
-    if ctx.fields.is_empty() && !is_single {
+    // title, properties and tags; sections, links, tasks, backlinks and
+    // properties-typed are opt-in, so a listing has to say how to get them.
+    //
+    // Deliberately *not* on every result set. `--fields all` is roughly a 10x
+    // payload — the very cost this iteration removed — so suggesting it under
+    // a 50-file listing would hand an agent the bill it was just spared. It
+    // fires only where expanding is affordable: a handful of results, none of
+    // them truncated away. Skipped when the caller already chose `--fields`,
+    // and for a single result, where the richer "See all metadata for this
+    // file" hint above already spells out `--fields all` for that one file.
+    let untruncated = total.is_none_or(|t| result_count as u64 >= t);
+    if ctx.fields.is_empty()
+        && !is_single
+        && untruncated
+        && result_count <= MAX_EXPANDABLE_RESULTS
+    {
         hints.push(Hint::new(
             "Include the omitted fields (sections, links, tasks, backlinks)",
             build_find_command_preserving_filters(ctx, &["--fields", "all"]),

--- a/crates/hyalo-cli/src/hints/find.rs
+++ b/crates/hyalo-cli/src/hints/find.rs
@@ -208,10 +208,7 @@ pub(super) fn hints_for_find(
     // and for a single result, where the richer "See all metadata for this
     // file" hint above already spells out `--fields all` for that one file.
     let untruncated = total.is_none_or(|t| result_count as u64 >= t);
-    if ctx.fields.is_empty()
-        && !is_single
-        && untruncated
-        && result_count <= MAX_EXPANDABLE_RESULTS
+    if ctx.fields.is_empty() && !is_single && untruncated && result_count <= MAX_EXPANDABLE_RESULTS
     {
         hints.push(Hint::new(
             "Include the omitted fields (sections, links, tasks, backlinks)",

--- a/crates/hyalo-cli/src/hints/find.rs
+++ b/crates/hyalo-cli/src/hints/find.rs
@@ -191,6 +191,19 @@ pub(super) fn hints_for_find(
         ));
     }
 
+    // iter-252: the default result shape carries file, modified, size, lines,
+    // title, properties and tags — everything else (sections, links, tasks,
+    // backlinks, properties-typed) is opt-in, so every listing says how to
+    // get it back. Skipped when the caller already chose `--fields`, and for
+    // a single result, where the richer "See all metadata for this file"
+    // hint above already spells out `--fields all` for that one file.
+    if ctx.fields.is_empty() && !is_single {
+        hints.push(Hint::new(
+            "Include the omitted fields (sections, links, tasks, backlinks)",
+            build_find_command_preserving_filters(ctx, &["--fields", "all"]),
+        ));
+    }
+
     // --- Task bulk operation hints ---
     // When find results target a single file and include task data, suggest bulk task ops.
     if ctx.file_targets.len() == 1 {

--- a/crates/hyalo-cli/src/hints/mutation.rs
+++ b/crates/hyalo-cli/src/hints/mutation.rs
@@ -32,7 +32,9 @@ pub(super) fn hints_for_mutation(ctx: &HintContext, data: &serde_json::Value) ->
 }
 
 pub(super) fn hints_for_read(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
-    let mut hints = Vec::new();
+    // iter-252: a large body is the one case where the *next* command should
+    // not be another whole-file read, so those hints lead.
+    let mut hints = read_size_hints(ctx, data);
 
     let file = data
         .get("file")
@@ -63,6 +65,48 @@ pub(super) fn hints_for_read(ctx: &HintContext, data: &serde_json::Value) -> Vec
         }
     }
 
+    hints
+}
+
+/// Body size (bytes) above which `read` offers a narrower way to read the
+/// file (iter-252). 8 KiB is roughly where a whole-file read stops being a
+/// cheap lookup for an agent and starts being a budget decision.
+pub(super) const READ_LARGE_BODY_BYTES: u64 = 8 * 1024;
+
+/// Suggest reading less of a large file: a leading line range, or one
+/// section. Only fires when the caller asked for the whole body (no
+/// `--lines`, no `--section`) and the file is over
+/// [`READ_LARGE_BODY_BYTES`] — a caller who already narrowed the read needs
+/// no reminder, and a small file has nothing to save.
+pub(super) fn read_size_hints(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
+    let mut hints = Vec::new();
+    if ctx.read_narrowed {
+        return hints;
+    }
+    let size = data.get("size").and_then(serde_json::Value::as_u64);
+    if size.is_none_or(|s| s <= READ_LARGE_BODY_BYTES) {
+        return hints;
+    }
+    let Some(file) = data
+        .get("file")
+        .and_then(|f| f.as_str())
+        .or_else(|| ctx.file_targets.first().map(String::as_str))
+    else {
+        return hints;
+    };
+    let lines = data
+        .get("lines")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let kib = size.unwrap_or(0) / 1024;
+    hints.push(Hint::new(
+        format!("Read only the first 80 of {lines} lines ({kib} KB file)"),
+        build_command_with_file(ctx, &["read"], file, &["--lines", "1:80"]),
+    ));
+    hints.push(Hint::new(
+        "List this file's sections, to read just one",
+        build_command_no_glob(ctx, &["find", "--file", file, "--fields", "sections"]),
+    ));
     hints
 }
 

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -339,7 +339,10 @@ fn format_results_as_text(
         }
     }
 
-    let text = format_value_as_text(results, cache);
+    let mut text = format_value_as_text(results, cache);
+    if let Some(fields_line) = find_fields_summary(results) {
+        let _ = write!(text, "\n{fields_line}");
+    }
     if let Some(total) = total {
         let shown = match results {
             serde_json::Value::Array(arr) => arr.len() as u64,
@@ -350,6 +353,62 @@ fn format_results_as_text(
         }
     }
     text
+}
+
+/// Every field a `find` result item can carry, in the order the JSON struct
+/// declares them. `serde_json::Map` is a `BTreeMap` here (no `preserve_order`
+/// feature), so the keys come back alphabetised — this list restores the
+/// order a reader expects.
+const FIND_FIELD_ORDER: &[&str] = &[
+    "file",
+    "modified",
+    "size",
+    "lines",
+    "title",
+    "properties",
+    "properties_typed",
+    "tags",
+    "sections",
+    "tasks",
+    "links",
+    "backlinks",
+    "matches",
+    "score",
+];
+
+/// The `fields:` footer under a `--format text` find listing (iter-252).
+///
+/// The default result shape omits `sections`, `links`, `tasks`, `backlinks`
+/// and `properties-typed`, and a reader cannot tell an omitted field from an
+/// empty one. Naming what is present — and what `--fields all` would add —
+/// makes the shape self-describing without a round trip.
+///
+/// `None` for anything that is not a non-empty array of find result items
+/// (detected the same way the text renderer detects a `FileObject`: a
+/// `file` + `modified` pair).
+fn find_fields_summary(results: &serde_json::Value) -> Option<String> {
+    let arr = results.as_array()?;
+    let first = arr.first()?.as_object()?;
+    if !(first.contains_key("file") && first.contains_key("modified")) {
+        return None;
+    }
+    let present: Vec<&str> = FIND_FIELD_ORDER
+        .iter()
+        .copied()
+        .filter(|k| first.contains_key(*k))
+        .collect();
+    let missing: Vec<&str> = FIND_FIELD_ORDER
+        .iter()
+        .copied()
+        .filter(|k| {
+            !first.contains_key(*k) && !matches!(*k, "matches" | "score" | "properties_typed")
+        })
+        .collect();
+    let mut line = format!("fields: {}", present.join(", "));
+    if !missing.is_empty() {
+        let _ = write!(line, " (--fields all adds {})", missing.join(", "));
+    }
+    Some(line)
 }
 
 /// Format an error for output to stderr.

--- a/crates/hyalo-cli/src/output/file_object.rs
+++ b/crates/hyalo-cli/src/output/file_object.rs
@@ -21,8 +21,14 @@
 /// multi-line text block. This coupling is intentional: changing the separator
 /// in `run_jq_filter` would affect `FileObject` rendering.
 pub(super) fn build_file_object_filter(map: &serde_json::Map<String, serde_json::Value>) -> String {
-    // Header: file path and modified timestamp — always present.
-    let mut parts = vec![r#""\"\(.file)\"  (\(.modified))""#.to_owned()];
+    // Header: file path, modified timestamp — always present — plus the
+    // iter-252 size/lines pair when the payload carries it (a find result
+    // always does; other FileObject-shaped payloads and pre-252 JSON may not).
+    let mut parts = if map.contains_key("size") && map.contains_key("lines") {
+        vec![r#""\"\(.file)\"  (\(.modified), \(.size) B, \(.lines) lines)""#.to_owned()]
+    } else {
+        vec![r#""\"\(.file)\"  (\(.modified))""#.to_owned()]
+    };
 
     // Title: "  title: <value>" or "  title: (none)"
     if map.contains_key("title") {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1508,7 +1508,12 @@ fn run_inner() -> Result<(), AppError> {
                 ctx.dry_run = *dry_run;
                 Some(ctx)
             }
-            Commands::Read { selection, .. } => {
+            Commands::Read {
+                selection,
+                section,
+                lines,
+                ..
+            } => {
                 let mut ctx = HintContext::from_common(HintSource::Read, &common);
                 if let Some(f) = selection
                     .file_positional
@@ -1517,6 +1522,7 @@ fn run_inner() -> Result<(), AppError> {
                 {
                     ctx.file_targets = vec![f.clone()];
                 }
+                ctx.read_narrowed = section.is_some() || lines.is_some();
                 Some(ctx)
             }
             Commands::Backlinks {

--- a/crates/hyalo-cli/templates/pi/skills/hyalo-tidy/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo-tidy/SKILL.md
@@ -189,7 +189,7 @@ Cross-reference with git merges from Phase 2. If the branch was merged, update s
 
 ### Stale backlog items
 ```bash
-hyalo find --property status=planned --property type=backlog --index --jq '.results | map({file, title: .properties.title})'
+hyalo find --property status=planned --property type=backlog --index --jq '.results | map({file, title})'
 ```
 Compare each planned backlog item against merged iterations and recent git history.
 If the feature clearly shipped (in a different iteration or under a different name),

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -38,6 +38,15 @@ Prefer `hyalo` CLI for operations on files in this directory:
 - **Hints marked `[writes]`** (`=>` prefix in text, `"writes": true` in JSON) modify the vault or
   `.hyalo.toml`; `->` hints are read-only and safe to run unattended.
 - **Read frontmatter/metadata**: `hyalo find --file <path>`, `hyalo properties`, `hyalo tags`
+- **`find` results are compact by default**: every item carries `file`, `modified`, `size`
+  (bytes), `lines`, `title`, `properties` and `tags`. `sections`, `tasks`, `links`, `backlinks`
+  and `properties-typed` come only from `--fields` (or `--fields all`) — or automatically from the
+  filter that implies them (`--section`, `--task`, `--broken-links`, `--orphan`, `--dead-end`,
+  `--sort links_count|backlinks_count`). `title` is promoted out of `properties`, so read it as
+  `.results[].title`, not `.results[].properties.title`.
+- **Check `size`/`lines` before reading**: both appear on `find` items and on `read` results, so a
+  large file can be taken in slices — `hyalo read <path> --lines 1:80` or `--section "Heading"` —
+  instead of whole.
 - **Read content/sections**: `hyalo read <path>` or `hyalo read <path> --section "Heading"`
 - **Mutate frontmatter**: `hyalo set`, `hyalo remove`, `hyalo append`
 - **Auto-link**: `hyalo links auto --first-only --exclude-target-glob 'templates/*' --apply`.

--- a/crates/hyalo-cli/templates/skill-hyalo-tidy.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-tidy.md
@@ -186,7 +186,7 @@ Cross-reference with git merges from Phase 2. If the branch was merged, update s
 
 ### Stale backlog items
 ```bash
-hyalo find --property status=planned --property type=backlog --index --jq '.results | map({file, title: .properties.title})'
+hyalo find --property status=planned --property type=backlog --index --jq '.results | map({file, title})'
 ```
 Compare each planned backlog item against merged iterations and recent git history.
 If the feature clearly shipped (in a different iteration or under a different name),

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -108,13 +108,21 @@ hyalo find --sort property:priority                # sort by custom property
 hyalo find --sort backlinks_count --reverse        # most-linked files first
 ```
 
-The `--fields` flag controls which data is returned. Available fields: `properties`,
-`properties-typed`, `tags`, `sections` (alias: `outline`), `tasks`, `links`, `backlinks`, `title`. Default fields are
-`properties`, `tags`, `sections`, `links`. Opt-in fields: `tasks`, `properties-typed`,
-`backlinks`, `title`. Use `--fields all` or `--fields tasks` to include them. `properties-typed`
-returns a `[{name, type, value}]` array instead of a `{key: value}` map; `backlinks` requires
-scanning all files to build the link graph. Each backlink entry contains `source` (file path),
-`line` (line number), and an optional `label`.
+Every result item carries `file`, `modified`, `size` (bytes) and `lines` — read `size`/`lines`
+before a `read` to know what a file will cost.
+
+The `--fields` flag controls which *optional* data is returned. Available fields: `properties`,
+`properties-typed`, `tags`, `sections` (alias: `outline`), `tasks`, `links`, `backlinks`, `title`.
+Default fields are `title`, `properties`, `tags` — everything whose size scales with the document
+body (`sections`, `tasks`, `links`) and the whole-vault `backlinks` lookup are opt-in, via
+`--fields` or the filter that implies them: `--section` adds `sections`, `--task` adds `tasks`,
+`--broken-links`/`--dead-end` add `links`, `--orphan` adds both, and `--sort links_count` /
+`--sort backlinks_count` add the field they rank on. Use `--fields all` for every field (the
+pre-0.22 default shape and then some). `title` is promoted: it has its own field and is *not*
+repeated inside `properties` — ask for `--fields properties` alone to get the raw property map
+including `title`. `properties-typed` returns a `[{name, type, value}]` array instead of a
+`{key: value}` map; `backlinks` requires scanning all files to build the link graph. Each backlink
+entry contains `source` (file path), `line` (line number), and an optional `label`.
 
 ```bash
 hyalo find --fields backlinks --file my-note.md       # see who links to this note (--file required: positional is PATTERN)

--- a/crates/hyalo-cli/tests/e2e/errors.rs
+++ b/crates/hyalo-cli/tests/e2e/errors.rs
@@ -543,9 +543,10 @@ title: Nested
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let results = json["results"].as_array().unwrap();
     assert_eq!(results.len(), 1);
-    // Prefix stripped unconditionally: resolves to note.md (title: Top)
+    // Prefix stripped unconditionally: resolves to note.md (title: Top).
+    // iter-252: `title` is a promoted field, no longer echoed in `properties`.
     assert_eq!(results[0]["file"], "note.md");
-    assert_eq!(results[0]["properties"]["title"], "Top");
+    assert_eq!(results[0]["title"], "Top");
 }
 
 /// Mutation commands (set) also accept CWD-relative paths.

--- a/crates/hyalo-cli/tests/e2e/find.rs
+++ b/crates/hyalo-cli/tests/e2e/find.rs
@@ -2625,24 +2625,27 @@ fn find_sort_links_count() {
 }
 
 #[test]
-fn find_sort_backlinks_count_without_fields_backlinks() {
-    // Sort by backlinks_count should work even without --fields backlinks
+fn find_sort_backlinks_count_auto_includes_backlinks() {
+    // Sort by backlinks_count works without --fields backlinks, and (iter-252)
+    // returns the counted field: ranking by a number the caller cannot see was
+    // a dead end, so the sort auto-includes it the way --orphan does.
     let tmp = setup_link_vault();
     let (status, json, stderr) = find_typed(&tmp, &["--sort", "backlinks_count"]);
     assert!(status.success(), "stderr: {stderr}");
     let arr = &json.results;
     let files: Vec<&str> = arr.iter().map(|v| v.file.as_str()).collect();
     assert_eq!(files[0], "c.md", "c.md should be first (most backlinks)");
-    // Verify backlinks field is NOT in output (user didn't request it)
     assert!(
-        arr[0].backlinks.is_none(),
-        "backlinks should not appear in output when not in --fields"
+        arr[0].backlinks.is_some(),
+        "the counted field must be included by the sort that ranks on it"
     );
 }
 
 #[test]
-fn find_sort_links_count_without_fields_links() {
-    // Sort by links_count should work even when --fields excludes links
+fn find_sort_links_count_auto_includes_links() {
+    // Sort by links_count works with a narrower --fields, and (iter-252) the
+    // counted field comes back regardless — an auto-include, like
+    // --broken-links → links, which has always overridden --fields.
     let tmp = setup_link_vault();
     let (status, json, stderr) =
         find_typed(&tmp, &["--sort", "links_count", "--fields", "properties"]);
@@ -2650,10 +2653,9 @@ fn find_sort_links_count_without_fields_links() {
     let arr = &json.results;
     let files: Vec<&str> = arr.iter().map(|v| v.file.as_str()).collect();
     assert_eq!(files[0], "a.md", "a.md should be first (most links)");
-    // Verify links field is NOT in output (user excluded it via --fields)
     assert!(
-        arr[0].links.is_none(),
-        "links should not appear in output when not in --fields"
+        arr[0].links.is_some(),
+        "the counted field must be included by the sort that ranks on it"
     );
 }
 
@@ -2955,16 +2957,25 @@ fn find_title_null_when_neither_found() {
 }
 
 #[test]
-fn find_title_not_present_by_default() {
+fn find_title_present_by_default_and_not_duplicated_in_properties() {
+    // iter-252: `title` joined the default field set, and stopped being
+    // echoed inside `properties` — one string, one place.
     let tmp = setup_title_vault();
     let (status, json, stderr) = find_typed(&tmp, &["--file", "with_fm_title.md"]);
     assert!(status.success(), "stderr: {stderr}");
     let arr = &json.results;
     assert_eq!(arr.len(), 1);
     let obj = &arr[0];
+    assert_eq!(
+        obj.title.as_ref().and_then(|v| v.as_str()),
+        Some("Frontmatter Title"),
+        "title should be a default field: {obj:?}"
+    );
     assert!(
-        obj.title.is_none(),
-        "title should not appear in default output: {obj:?}"
+        obj.properties
+            .as_ref()
+            .is_some_and(|p| !p.contains_key("title")),
+        "the promoted title must not be repeated in properties: {obj:?}"
     );
 }
 

--- a/crates/hyalo-cli/tests/e2e/find_result_shape.rs
+++ b/crates/hyalo-cli/tests/e2e/find_result_shape.rs
@@ -1,0 +1,466 @@
+//! `find`/`read` result shape (iteration 252).
+//!
+//! The default `find` payload was `properties, tags, sections, links` for
+//! every item, which made a 20-file listing roughly nine times larger than
+//! the metadata most callers asked for, and nothing in a result said how big
+//! a file was before you read it. This suite pins the replacement contract:
+//!
+//! - the default field set is `file, modified, size, lines, title,
+//!   properties, tags`, and nothing else;
+//! - every filter or sort that *implies* a field still returns it, with no
+//!   `--fields` needed;
+//! - `size`/`lines` are present on `find` and `read`, agree with the bytes on
+//!   disk (CRLF and multi-byte UTF-8 included), and are identical between a
+//!   disk scan and a `--index` snapshot;
+//! - `--fields all` reproduces the pre-252 shape.
+
+use super::common::{hyalo_no_hints, write_md};
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Run `hyalo find …` (JSON, no hints) and return the `results` array.
+fn find_results(dir: &Path, args: &[&str]) -> Vec<serde_json::Value> {
+    let output = hyalo_no_hints()
+        .current_dir(dir)
+        .arg("find")
+        .args(args)
+        .args(["--format", "json"])
+        .output()
+        .expect("hyalo should run");
+    assert!(
+        output.status.success(),
+        "find {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("find should print an envelope");
+    envelope["results"]
+        .as_array()
+        .expect("results should be an array")
+        .clone()
+}
+
+/// The keys of the first result item, sorted (serde_json orders them itself).
+fn keys(item: &serde_json::Value) -> Vec<String> {
+    item.as_object()
+        .expect("result item should be an object")
+        .keys()
+        .cloned()
+        .collect()
+}
+
+/// A vault of `n` iteration-shaped notes: frontmatter, headings, tasks and a
+/// wikilink each — every field the old default shape used to carry.
+fn vault(n: usize) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    for i in 0..n {
+        write_md(
+            tmp.path(),
+            &format!("note-{i:02}.md"),
+            &format!(
+                "---\ntitle: Note {i}\ntype: note\nstatus: planned\ntags:\n  - note\n  - batch\n---\n\n\
+                 # Note {i}\n\nSee [[note-00]] for context.\n\n## Tasks\n\n- [ ] first task {i}\n- [x] second task {i}\n\n\
+                 ## Notes\n\nSome prose about note {i} that makes the body worth measuring.\n"
+            ),
+        );
+    }
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// Default field set
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_shape_is_the_compact_field_set() {
+    let tmp = vault(3);
+    let results = find_results(tmp.path(), &["--tag", "note"]);
+    assert_eq!(results.len(), 3);
+    let mut expected = vec![
+        "file",
+        "lines",
+        "modified",
+        "properties",
+        "size",
+        "tags",
+        "title",
+    ];
+    expected.sort_unstable();
+    assert_eq!(
+        keys(&results[0]),
+        expected,
+        "default find item must carry exactly the compact field set"
+    );
+}
+
+#[test]
+fn default_shape_stays_under_the_byte_budget() {
+    // The regression this iteration exists to prevent: a 20-file listing must
+    // stay small enough for an agent to read without a projection. The old
+    // default was ~9x this on the same kind of vault.
+    let tmp = vault(20);
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--tag", "note", "--limit", "20", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let bytes = output.stdout.len();
+    assert!(
+        bytes <= 12 * 1024,
+        "20-file default listing must stay within 12 KB, was {bytes} bytes"
+    );
+
+    let all = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "find", "--tag", "note", "--limit", "20", "--fields", "all", "--format", "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        all.stdout.len() > bytes * 2,
+        "--fields all should be markedly larger ({} vs {bytes} bytes)",
+        all.stdout.len()
+    );
+}
+
+#[test]
+fn fields_all_restores_the_full_shape() {
+    let tmp = vault(2);
+    let results = find_results(tmp.path(), &["--tag", "note", "--fields", "all"]);
+    for key in [
+        "file",
+        "modified",
+        "size",
+        "lines",
+        "title",
+        "properties",
+        "properties_typed",
+        "tags",
+        "sections",
+        "tasks",
+        "links",
+        "backlinks",
+    ] {
+        assert!(
+            results[0].get(key).is_some(),
+            "--fields all must include {key}: {:?}",
+            keys(&results[0])
+        );
+    }
+}
+
+#[test]
+fn promoted_title_is_not_repeated_inside_properties() {
+    let tmp = vault(1);
+    let results = find_results(tmp.path(), &["--tag", "note"]);
+    assert_eq!(results[0]["title"], "Note 0");
+    assert!(
+        results[0]["properties"].get("title").is_none(),
+        "title is promoted to its own field: {:?}",
+        results[0]["properties"]
+    );
+    // Asking for properties *without* the title field keeps the property, so
+    // no request can lose the value entirely.
+    let narrowed = find_results(tmp.path(), &["--tag", "note", "--fields", "properties"]);
+    assert_eq!(narrowed[0]["properties"]["title"], "Note 0");
+}
+
+#[test]
+fn sort_by_title_property_still_orders_by_the_frontmatter_value() {
+    // The de-duplication happens after sorting, so `--sort property:title`
+    // compares exactly what it compared before.
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: Zulu\ntype: note\n---\n\n# A\n");
+    write_md(tmp.path(), "b.md", "---\ntitle: Alpha\ntype: note\n---\n\n# B\n");
+    let results = find_results(tmp.path(), &["--sort", "property:title"]);
+    let files: Vec<&str> = results
+        .iter()
+        .map(|r| r["file"].as_str().unwrap())
+        .collect();
+    assert_eq!(files, vec!["b.md", "a.md"], "Alpha sorts before Zulu");
+}
+
+// ---------------------------------------------------------------------------
+// Auto-includes: every filter that implies a field still returns it
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_include_matrix() {
+    let tmp = vault(2);
+    // (extra args, field the query implies)
+    let cases: [(&[&str], &str); 5] = [
+        (&["--section", "Tasks"], "sections"),
+        (&["--task", "todo"], "tasks"),
+        (&["--sort", "links_count"], "links"),
+        (&["--sort", "backlinks_count"], "backlinks"),
+        (&["--broken-links"], "links"),
+    ];
+    for (extra, field) in cases {
+        let mut args: Vec<&str> = vec!["--glob", "*.md"];
+        args.extend_from_slice(extra);
+        let results = find_results(tmp.path(), &args);
+        if field == "links" && extra == ["--broken-links"] {
+            // This vault has no broken links, so the filter matches nothing —
+            // the auto-include is asserted by the two sort cases instead.
+            continue;
+        }
+        assert!(
+            !results.is_empty(),
+            "{extra:?} should match something in the fixture vault"
+        );
+        assert!(
+            results[0].get(field).is_some(),
+            "{extra:?} implies {field}, which must be present without --fields: {:?}",
+            keys(&results[0])
+        );
+    }
+}
+
+#[test]
+fn broken_links_filter_auto_includes_links() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\n---\n\n# A\n\nSee [[nowhere]].\n",
+    );
+    let results = find_results(tmp.path(), &["--broken-links"]);
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0]["links"].as_array().is_some_and(|l| !l.is_empty()),
+        "--broken-links must return the links it filtered on"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// size / lines
+// ---------------------------------------------------------------------------
+
+/// Byte length and line count of a file, computed independently of hyalo.
+fn on_disk(dir: &Path, name: &str) -> (u64, usize) {
+    let bytes = std::fs::read(dir.join(name)).unwrap();
+    let newlines = bytes.iter().filter(|b| **b == b'\n').count();
+    let lines = match bytes.last() {
+        None => 0,
+        Some(b'\n') => newlines,
+        Some(_) => newlines + 1,
+    };
+    (bytes.len() as u64, lines)
+}
+
+#[test]
+fn size_and_lines_match_disk_for_crlf_and_utf8() {
+    let tmp = TempDir::new().unwrap();
+    // Written through std::fs directly: `write_md` is LF-only, and CRLF is
+    // exactly what this test is about.
+    std::fs::write(
+        tmp.path().join("crlf.md"),
+        "---\r\ntitle: CRLF\r\n---\r\n\r\n# CRLF\r\n\r\nTwo lines here.\r\n",
+    )
+    .unwrap();
+    // Multi-byte UTF-8: `size` counts bytes, `lines` counts lines — a naive
+    // char count would disagree with both.
+    std::fs::write(
+        tmp.path().join("utf8.md"),
+        "---\ntitle: Üñïçôdé\n---\n\n# Üñïçôdé\n\n日本語のテキスト。\n",
+    )
+    .unwrap();
+    // No trailing newline: the last unterminated line still counts.
+    std::fs::write(tmp.path().join("noeol.md"), "---\ntitle: No EOL\n---\n\n# End").unwrap();
+
+    let results = find_results(tmp.path(), &[]);
+    for item in &results {
+        let file = item["file"].as_str().unwrap();
+        let (size, lines) = on_disk(tmp.path(), file);
+        assert_eq!(item["size"].as_u64(), Some(size), "size mismatch for {file}");
+        assert_eq!(
+            item["lines"].as_u64(),
+            Some(lines as u64),
+            "lines mismatch for {file}"
+        );
+    }
+    assert_eq!(results.len(), 3);
+}
+
+#[test]
+fn size_and_lines_are_identical_with_and_without_index() {
+    let tmp = vault(4);
+    std::fs::write(
+        tmp.path().join("crlf.md"),
+        "---\r\ntitle: CRLF\r\n---\r\n\r\n# CRLF\r\n",
+    )
+    .unwrap();
+    let disk = find_results(tmp.path(), &[]);
+
+    let created = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(created.status.success());
+    let indexed = find_results(tmp.path(), &["--index"]);
+
+    assert_eq!(disk.len(), indexed.len());
+    for (d, i) in disk.iter().zip(indexed.iter()) {
+        assert_eq!(d["file"], i["file"]);
+        assert_eq!(d["size"], i["size"], "size parity for {}", d["file"]);
+        assert_eq!(d["lines"], i["lines"], "lines parity for {}", d["file"]);
+    }
+}
+
+#[test]
+fn index_size_and_lines_survive_a_mutation() {
+    // The journal refreshes body-derived fields on every write path; `size`
+    // and `lines` are body-derived, so a `set` under --index must not leave
+    // them describing the pre-mutation file.
+    let tmp = vault(2);
+    assert!(
+        hyalo_no_hints()
+            .current_dir(tmp.path())
+            .arg("create-index")
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    let before = find_results(tmp.path(), &["--index", "--file", "note-00.md"]);
+    let set = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "set",
+            "note-00.md",
+            "--property",
+            "status=in-progress-with-a-much-longer-value",
+            "--index",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        set.status.success(),
+        "set failed: {}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+    let after = find_results(tmp.path(), &["--index", "--file", "note-00.md"]);
+    let (size, lines) = on_disk(tmp.path(), "note-00.md");
+    assert_ne!(before[0]["size"], after[0]["size"], "the file grew");
+    assert_eq!(after[0]["size"].as_u64(), Some(size));
+    assert_eq!(after[0]["lines"].as_u64(), Some(lines as u64));
+}
+
+#[test]
+fn read_reports_whole_file_size_and_lines() {
+    let tmp = vault(1);
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["read", "note-00.md", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let (size, lines) = on_disk(tmp.path(), "note-00.md");
+    assert_eq!(envelope["results"]["size"].as_u64(), Some(size));
+    assert_eq!(envelope["results"]["lines"].as_u64(), Some(lines as u64));
+
+    // A narrowed read still describes the whole file, so the numbers can be
+    // compared against the `find` result that led here.
+    let section = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["read", "note-00.md", "--section", "Tasks", "--format", "json"])
+        .output()
+        .unwrap();
+    let envelope: serde_json::Value = serde_json::from_slice(&section.stdout).unwrap();
+    assert_eq!(envelope["results"]["size"].as_u64(), Some(size));
+    assert_eq!(envelope["results"]["lines"].as_u64(), Some(lines as u64));
+}
+
+// ---------------------------------------------------------------------------
+// Hints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_of_a_large_file_hints_at_reading_less() {
+    let tmp = TempDir::new().unwrap();
+    let body: String = (0..600)
+        .map(|i| format!("Line {i} of a document that is comfortably over the hint threshold.\n"))
+        .collect();
+    write_md(tmp.path(), "big.md", &format!("---\ntitle: Big\n---\n\n# Big\n\n{body}"));
+
+    let output = super::common::hyalo()
+        .current_dir(tmp.path())
+        .args(["read", "big.md", "--format", "json", "--hints"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = envelope["hints"].as_array().expect("hints array");
+    assert!(
+        hints
+            .iter()
+            .any(|h| h["cmd"].as_str().is_some_and(|c| c.contains("--lines 1:80"))),
+        "a large read should offer a line-range read: {hints:?}"
+    );
+
+    // A read that already narrowed does not get told to narrow.
+    let narrowed = super::common::hyalo()
+        .current_dir(tmp.path())
+        .args(["read", "big.md", "--lines", "1:20", "--format", "json", "--hints"])
+        .output()
+        .unwrap();
+    let envelope: serde_json::Value = serde_json::from_slice(&narrowed.stdout).unwrap();
+    let hints = envelope["hints"].as_array().expect("hints array");
+    assert!(
+        !hints
+            .iter()
+            .any(|h| h["cmd"].as_str().is_some_and(|c| c.contains("--lines 1:80"))),
+        "an already-narrowed read must not repeat the suggestion: {hints:?}"
+    );
+}
+
+#[test]
+fn small_result_set_offers_fields_all() {
+    let tmp = vault(2);
+    let output = super::common::hyalo()
+        .current_dir(tmp.path())
+        .args(["find", "--tag", "note", "--format", "json", "--hints"])
+        .output()
+        .unwrap();
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let hints = envelope["hints"].as_array().expect("hints array");
+    assert!(
+        hints
+            .iter()
+            .any(|h| h["cmd"].as_str().is_some_and(|c| c.contains("--fields all"))),
+        "a small listing should say how to get the omitted fields: {hints:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Text mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn text_mode_names_the_fields_and_shows_the_size() {
+    let tmp = vault(1);
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--tag", "note", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let (size, lines) = on_disk(tmp.path(), "note-00.md");
+    assert!(
+        stdout.contains(&format!("{size} B, {lines} lines")),
+        "the header line should carry size and lines: {stdout}"
+    );
+    assert!(
+        stdout.contains("fields: file, modified, size, lines, title, properties, tags"),
+        "the summary line should name the included fields: {stdout}"
+    );
+    assert!(
+        stdout.contains("--fields all adds sections, tasks, links, backlinks"),
+        "the summary line should name what is missing: {stdout}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/find_result_shape.rs
+++ b/crates/hyalo-cli/tests/e2e/find_result_shape.rs
@@ -172,8 +172,16 @@ fn sort_by_title_property_still_orders_by_the_frontmatter_value() {
     // The de-duplication happens after sorting, so `--sort property:title`
     // compares exactly what it compared before.
     let tmp = TempDir::new().unwrap();
-    write_md(tmp.path(), "a.md", "---\ntitle: Zulu\ntype: note\n---\n\n# A\n");
-    write_md(tmp.path(), "b.md", "---\ntitle: Alpha\ntype: note\n---\n\n# B\n");
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: Zulu\ntype: note\n---\n\n# A\n",
+    );
+    write_md(
+        tmp.path(),
+        "b.md",
+        "---\ntitle: Alpha\ntype: note\n---\n\n# B\n",
+    );
     let results = find_results(tmp.path(), &["--sort", "property:title"]);
     let files: Vec<&str> = results
         .iter()
@@ -229,8 +237,55 @@ fn broken_links_filter_auto_includes_links() {
     let results = find_results(tmp.path(), &["--broken-links"]);
     assert_eq!(results.len(), 1);
     assert!(
-        results[0]["links"].as_array().is_some_and(|l| !l.is_empty()),
+        results[0]["links"]
+            .as_array()
+            .is_some_and(|l| !l.is_empty()),
         "--broken-links must return the links it filtered on"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Views
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_view_can_pin_fields_and_one_without_gets_the_default() {
+    let tmp = vault(2);
+    for args in [
+        &[
+            "views", "set", "outlines", "--tag", "note", "--fields", "sections",
+        ][..],
+        &["views", "set", "plain", "--tag", "note"][..],
+    ] {
+        let out = hyalo_no_hints()
+            .current_dir(tmp.path())
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "{args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let pinned = find_results(tmp.path(), &["--view", "outlines"]);
+    assert!(
+        pinned[0].get("sections").is_some(),
+        "a view that pins --fields sections must return them: {:?}",
+        keys(&pinned[0])
+    );
+    assert!(
+        pinned[0].get("tags").is_none(),
+        "a pinned field set replaces the default, it does not extend it: {:?}",
+        keys(&pinned[0])
+    );
+
+    let plain = find_results(tmp.path(), &["--view", "plain"]);
+    assert!(
+        plain[0].get("sections").is_none() && plain[0].get("tags").is_some(),
+        "a view without --fields gets the compact default: {:?}",
+        keys(&plain[0])
     );
 }
 
@@ -239,6 +294,11 @@ fn broken_links_filter_auto_includes_links() {
 // ---------------------------------------------------------------------------
 
 /// Byte length and line count of a file, computed independently of hyalo.
+///
+/// Deliberately naive: the point is to check hyalo's `memchr` counter against
+/// the most obvious possible implementation, so it must not share code (or a
+/// crate) with it.
+#[allow(clippy::naive_bytecount)]
 fn on_disk(dir: &Path, name: &str) -> (u64, usize) {
     let bytes = std::fs::read(dir.join(name)).unwrap();
     let newlines = bytes.iter().filter(|b| **b == b'\n').count();
@@ -268,13 +328,21 @@ fn size_and_lines_match_disk_for_crlf_and_utf8() {
     )
     .unwrap();
     // No trailing newline: the last unterminated line still counts.
-    std::fs::write(tmp.path().join("noeol.md"), "---\ntitle: No EOL\n---\n\n# End").unwrap();
+    std::fs::write(
+        tmp.path().join("noeol.md"),
+        "---\ntitle: No EOL\n---\n\n# End",
+    )
+    .unwrap();
 
     let results = find_results(tmp.path(), &[]);
     for item in &results {
         let file = item["file"].as_str().unwrap();
         let (size, lines) = on_disk(tmp.path(), file);
-        assert_eq!(item["size"].as_u64(), Some(size), "size mismatch for {file}");
+        assert_eq!(
+            item["size"].as_u64(),
+            Some(size),
+            "size mismatch for {file}"
+        );
         assert_eq!(
             item["lines"].as_u64(),
             Some(lines as u64),
@@ -367,7 +435,14 @@ fn read_reports_whole_file_size_and_lines() {
     // compared against the `find` result that led here.
     let section = hyalo_no_hints()
         .current_dir(tmp.path())
-        .args(["read", "note-00.md", "--section", "Tasks", "--format", "json"])
+        .args([
+            "read",
+            "note-00.md",
+            "--section",
+            "Tasks",
+            "--format",
+            "json",
+        ])
         .output()
         .unwrap();
     let envelope: serde_json::Value = serde_json::from_slice(&section.stdout).unwrap();
@@ -382,10 +457,19 @@ fn read_reports_whole_file_size_and_lines() {
 #[test]
 fn read_of_a_large_file_hints_at_reading_less() {
     let tmp = TempDir::new().unwrap();
-    let body: String = (0..600)
-        .map(|i| format!("Line {i} of a document that is comfortably over the hint threshold.\n"))
-        .collect();
-    write_md(tmp.path(), "big.md", &format!("---\ntitle: Big\n---\n\n# Big\n\n{body}"));
+    let mut body = String::new();
+    for i in 0..600 {
+        use std::fmt::Write as _;
+        let _ = writeln!(
+            body,
+            "Line {i} of a document that is comfortably over the hint threshold."
+        );
+    }
+    write_md(
+        tmp.path(),
+        "big.md",
+        &format!("---\ntitle: Big\n---\n\n# Big\n\n{body}"),
+    );
 
     let output = super::common::hyalo()
         .current_dir(tmp.path())
@@ -396,24 +480,26 @@ fn read_of_a_large_file_hints_at_reading_less() {
     let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let hints = envelope["hints"].as_array().expect("hints array");
     assert!(
-        hints
-            .iter()
-            .any(|h| h["cmd"].as_str().is_some_and(|c| c.contains("--lines 1:80"))),
+        hints.iter().any(|h| h["cmd"]
+            .as_str()
+            .is_some_and(|c| c.contains("--lines 1:80"))),
         "a large read should offer a line-range read: {hints:?}"
     );
 
     // A read that already narrowed does not get told to narrow.
     let narrowed = super::common::hyalo()
         .current_dir(tmp.path())
-        .args(["read", "big.md", "--lines", "1:20", "--format", "json", "--hints"])
+        .args([
+            "read", "big.md", "--lines", "1:20", "--format", "json", "--hints",
+        ])
         .output()
         .unwrap();
     let envelope: serde_json::Value = serde_json::from_slice(&narrowed.stdout).unwrap();
     let hints = envelope["hints"].as_array().expect("hints array");
     assert!(
-        !hints
-            .iter()
-            .any(|h| h["cmd"].as_str().is_some_and(|c| c.contains("--lines 1:80"))),
+        !hints.iter().any(|h| h["cmd"]
+            .as_str()
+            .is_some_and(|c| c.contains("--lines 1:80"))),
         "an already-narrowed read must not repeat the suggestion: {hints:?}"
     );
 }
@@ -429,9 +515,9 @@ fn small_result_set_offers_fields_all() {
     let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let hints = envelope["hints"].as_array().expect("hints array");
     assert!(
-        hints
-            .iter()
-            .any(|h| h["cmd"].as_str().is_some_and(|c| c.contains("--fields all"))),
+        hints.iter().any(|h| h["cmd"]
+            .as_str()
+            .is_some_and(|c| c.contains("--fields all"))),
         "a small listing should say how to get the omitted fields: {hints:?}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -21,6 +21,7 @@ mod examples_contract;
 mod feature_matrix;
 mod files_from;
 mod find;
+mod find_result_shape;
 mod frontmatter_preservation;
 mod help;
 mod help_reference;

--- a/crates/hyalo-cli/tests/e2e/new.rs
+++ b/crates/hyalo-cli/tests/e2e/new.rs
@@ -654,7 +654,10 @@ fn new_with_index_refreshes_stale_entry() {
     // The scaffolded skeleton uses title "TBD", not the pre-existing "Old".
     // iter-252: read it from the promoted `title` field, which replaced the
     // duplicate copy inside `properties`.
-    let title = body.pointer("/title").and_then(|v| v.as_str()).unwrap_or("");
+    let title = body
+        .pointer("/title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     assert_eq!(
         title, "TBD",
         "stale entry must be replaced by fresh scaffold"

--- a/crates/hyalo-cli/tests/e2e/new.rs
+++ b/crates/hyalo-cli/tests/e2e/new.rs
@@ -652,10 +652,9 @@ fn new_with_index_refreshes_stale_entry() {
         .cloned()
         .unwrap_or_default();
     // The scaffolded skeleton uses title "TBD", not the pre-existing "Old".
-    let title = body
-        .pointer("/properties/title")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    // iter-252: read it from the promoted `title` field, which replaced the
+    // duplicate copy inside `properties`.
+    let title = body.pointer("/title").and_then(|v| v.as_str()).unwrap_or("");
     assert_eq!(
         title, "TBD",
         "stale entry must be replaced by fresh scaffold"

--- a/crates/hyalo-core/src/auto_link.rs
+++ b/crates/hyalo-core/src/auto_link.rs
@@ -1201,6 +1201,8 @@ mod tests {
         IndexEntry {
             rel_path: rel_path.to_owned(),
             modified: String::new(),
+            size: 0,
+            lines: 0,
             properties,
             tags: Vec::new(),
             sections: Vec::new(),

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -1917,6 +1917,8 @@ mod tests {
             IndexEntry {
                 rel_path: "a.md".to_owned(),
                 modified: String::new(),
+                size: 0,
+                lines: 0,
                 properties: IndexMap::new(),
                 tags: Vec::new(),
                 sections: Vec::new(),
@@ -1930,6 +1932,8 @@ mod tests {
             IndexEntry {
                 rel_path: "b.md".to_owned(),
                 modified: String::new(),
+                size: 0,
+                lines: 0,
                 properties: IndexMap::new(),
                 tags: Vec::new(),
                 sections: Vec::new(),
@@ -1959,6 +1963,8 @@ mod tests {
         let entries = vec![IndexEntry {
             rel_path: "a.md".to_owned(),
             modified: String::new(),
+            size: 0,
+            lines: 0,
             properties: IndexMap::new(),
             tags: Vec::new(),
             sections: Vec::new(),

--- a/crates/hyalo-core/src/filter/fields.rs
+++ b/crates/hyalo-core/src/filter/fields.rs
@@ -21,21 +21,38 @@ impl Default for Fields {
             properties: true,
             properties_typed: false,
             tags: true,
-            sections: true,
+            sections: false,
             tasks: false,
-            links: true,
+            links: false,
             backlinks: false,
-            title: false,
+            title: true,
         }
     }
 }
+
+/// The default field set, in the order `find` emits it, for help texts and
+/// the `--format text` summary line. `file`, `modified`, `size`, and `lines`
+/// are structural — always present, never selectable — so they lead the list.
+pub const DEFAULT_FIELD_NAMES: &[&str] = &[
+    "file",
+    "modified",
+    "size",
+    "lines",
+    "title",
+    "properties",
+    "tags",
+];
 
 impl Fields {
     /// Parse a fields selection from a list of `--fields` argument values.
     ///
     /// Each element may be a comma-separated list of field names. An empty
-    /// slice returns the default (properties, tags, sections, links;
-    /// `tasks`, `properties-typed`, `backlinks`, and `title` are opt-in).
+    /// slice returns the default (iteration 252: `properties`, `tags`,
+    /// `title` — alongside the always-present `file`, `modified`, `size`,
+    /// `lines`). `sections`, `links`, `tasks`, `properties-typed`, and
+    /// `backlinks` are opt-in, either via `--fields` or via the filter that
+    /// implies them (`--section`, `--task`, `--broken-links`, `--orphan`,
+    /// `--dead-end`, `--sort links_count|backlinks_count`).
     pub fn parse(input: &[String]) -> Result<Fields> {
         if input.is_empty() {
             return Ok(Fields::default());

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -4,7 +4,7 @@ mod parse;
 mod sort;
 mod tasks;
 
-pub use fields::Fields;
+pub use fields::{DEFAULT_FIELD_NAMES, Fields};
 pub use match_props::{
     extract_tags, matches_filters_with_tags, matches_frontmatter_filters, tag_matches,
 };

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -864,7 +864,15 @@ mod tests {
         let f = Fields::default();
         assert_eq!(
             DEFAULT_FIELD_NAMES,
-            &["file", "modified", "size", "lines", "title", "properties", "tags"]
+            &[
+                "file",
+                "modified",
+                "size",
+                "lines",
+                "title",
+                "properties",
+                "tags"
+            ]
         );
         assert_eq!(f.properties, DEFAULT_FIELD_NAMES.contains(&"properties"));
         assert_eq!(f.tags, DEFAULT_FIELD_NAMES.contains(&"tags"));

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -841,11 +841,38 @@ mod tests {
     #[test]
     fn fields_empty_returns_default() {
         let f = Fields::parse(&[]).unwrap();
-        // Default: properties, tags, sections, links enabled; tasks is opt-in (off by default)
-        assert!(f.properties && f.tags && f.sections && f.links);
+        // iter-252 default: properties, tags and title. Everything whose size
+        // scales with the document body (sections, tasks, links) and the
+        // whole-vault backlinks lookup are opt-in, via `--fields` or the
+        // filter that implies them.
+        assert!(f.properties && f.tags && f.title);
+        assert!(!f.sections, "sections should be off by default");
+        assert!(!f.links, "links should be off by default");
         assert!(!f.tasks, "tasks should be off by default");
         assert!(!f.backlinks, "backlinks should be off by default");
-        assert!(!f.title, "title should be off by default");
+        assert!(
+            !f.properties_typed,
+            "properties-typed should be off by default"
+        );
+    }
+
+    #[test]
+    fn default_field_names_match_the_default_fields() {
+        // The help/summary-line constant and `Fields::default()` are two
+        // spellings of one decision; drift between them shows up as a text
+        // summary that names fields the payload does not carry.
+        let f = Fields::default();
+        assert_eq!(
+            DEFAULT_FIELD_NAMES,
+            &["file", "modified", "size", "lines", "title", "properties", "tags"]
+        );
+        assert_eq!(f.properties, DEFAULT_FIELD_NAMES.contains(&"properties"));
+        assert_eq!(f.tags, DEFAULT_FIELD_NAMES.contains(&"tags"));
+        assert_eq!(f.title, DEFAULT_FIELD_NAMES.contains(&"title"));
+        assert_eq!(f.sections, DEFAULT_FIELD_NAMES.contains(&"sections"));
+        assert_eq!(f.links, DEFAULT_FIELD_NAMES.contains(&"links"));
+        assert_eq!(f.tasks, DEFAULT_FIELD_NAMES.contains(&"tasks"));
+        assert_eq!(f.backlinks, DEFAULT_FIELD_NAMES.contains(&"backlinks"));
     }
 
     #[test]

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -36,6 +36,16 @@ pub struct IndexEntry {
     pub rel_path: String,
     /// ISO 8601 mtime string.
     pub modified: String,
+    /// File size in bytes (iteration 252). Defaulted so a snapshot written by
+    /// an older hyalo still loads — it reports `0` until the next
+    /// `create-index`.
+    #[serde(default)]
+    pub size: u64,
+    /// Line count (see [`crate::scanner::ScanStats`] for the exact
+    /// definition). Defaulted for the same backwards-compatibility reason as
+    /// [`size`](Self::size).
+    #[serde(default)]
+    pub lines: usize,
     /// Raw frontmatter properties.
     pub properties: IndexMap<String, serde_json::Value>,
     /// Extracted tags (from properties).
@@ -497,6 +507,9 @@ impl SnapshotIndex {
     /// `sections`, `tasks`, and `links` fields, plus the graph's outbound
     /// edges for this file.
     ///
+    /// `size` and `lines` are refreshed too (both are derived from the bytes
+    /// on disk, which a body rewrite changes).
+    ///
     /// `properties`, `tags`, and `modified` are left untouched — callers that
     /// already know the new values in memory (e.g. `set`/`append`/`remove`)
     /// should patch those directly, since they don't require a disk read.
@@ -531,6 +544,11 @@ impl SnapshotIndex {
         entry.sections = scanned.sections;
         entry.tasks = scanned.tasks;
         entry.links = scanned.links;
+        // iter-252: `size`/`lines` are body-derived, so every write path that
+        // routes through `refresh_links` (set/append/remove, task toggles)
+        // keeps them in step with the bytes now on disk.
+        entry.size = scanned.size;
+        entry.lines = scanned.lines;
         // BUG-4 (iter-244): keep BM25 tokens current alongside the body so a
         // post-mutation rebuild of the inverted index scores this file as a
         // fresh disk scan would. Only touched when the snapshot is a BM25
@@ -1582,6 +1600,7 @@ pub(crate) fn scan_one_file(
     let mut fm = FrontmatterCollector::new(scan_body);
     let mut body_collector = BodyCollector::new(bm25_tokenize);
 
+    let stats;
     let (sections, tasks, links, file_links) = if scan_body {
         let mut section_scanner = SectionScanner::new();
         let mut task_extractor = TaskExtractor::new();
@@ -1590,7 +1609,7 @@ pub(crate) fn scan_one_file(
             frontmatter_link_props.to_vec(),
         );
 
-        scanner::scan_file_multi(
+        stats = scanner::scan_file_multi_stats(
             full_path,
             &mut [
                 &mut fm,
@@ -1599,6 +1618,7 @@ pub(crate) fn scan_one_file(
                 &mut link_visitor,
                 &mut body_collector,
             ],
+            true,
         )?;
 
         let sections = section_scanner.into_sections();
@@ -1612,7 +1632,8 @@ pub(crate) fn scan_one_file(
         let self_anchors = fl.self_anchors.clone();
         (sections, tasks, (links_clone, self_anchors), Some(fl))
     } else {
-        scanner::scan_file_multi(full_path, &mut [&mut fm, &mut body_collector])?;
+        stats =
+            scanner::scan_file_multi_stats(full_path, &mut [&mut fm, &mut body_collector], true)?;
         (Vec::new(), Vec::new(), (Vec::new(), Vec::new()), None)
     };
     let (links, self_anchors) = links;
@@ -1659,6 +1680,8 @@ pub(crate) fn scan_one_file(
     let entry = IndexEntry {
         rel_path: rel_path.to_owned(),
         modified,
+        size: stats.size,
+        lines: stats.lines,
         properties: props,
         tags,
         sections,
@@ -2461,6 +2484,8 @@ Content.
             entries: vec![IndexEntry {
                 rel_path: rel_path.to_owned(),
                 modified: "2024-01-01T00:00:00Z".to_owned(),
+                size: 0,
+                lines: 0,
                 properties: IndexMap::default(),
                 tags: vec![],
                 sections: vec![],
@@ -2580,6 +2605,8 @@ Content.
             entries: vec![IndexEntry {
                 rel_path: "doc.md".to_owned(),
                 modified: "2024-01-01T00:00:00Z".to_owned(),
+                size: 0,
+                lines: 0,
                 properties: IndexMap::default(),
                 tags: vec![],
                 sections: vec![],
@@ -2633,6 +2660,8 @@ Content.
             entries: vec![IndexEntry {
                 rel_path: "doc.md".to_owned(),
                 modified: "2024-01-01T00:00:00Z".to_owned(),
+                size: 0,
+                lines: 0,
                 properties: IndexMap::default(),
                 tags: vec![],
                 sections: vec![],

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -1557,6 +1557,8 @@ mod tests {
                 .map(|(rel, links)| crate::index::IndexEntry {
                     rel_path: (*rel).to_string(),
                     modified: String::new(),
+                    size: 0,
+                    lines: 0,
                     properties: indexmap::IndexMap::default(),
                     tags: Vec::new(),
                     sections: Vec::new(),
@@ -2930,6 +2932,8 @@ See [broken](old-name.md) here.
         let make_entry = |rel_path: &str, links: Vec<(usize, Link)>| crate::index::IndexEntry {
             rel_path: rel_path.to_string(),
             modified: String::new(),
+            size: 0,
+            lines: 0,
             properties: indexmap::IndexMap::default(),
             tags: Vec::new(),
             sections: Vec::new(),
@@ -2978,6 +2982,8 @@ See [broken](old-name.md) here.
         let entry = crate::index::IndexEntry {
             rel_path: "source.md".to_string(),
             modified: String::new(),
+            size: 0,
+            lines: 0,
             properties: indexmap::IndexMap::default(),
             tags: Vec::new(),
             sections: Vec::new(),

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -39,6 +39,36 @@ pub enum ScanAction {
 /// Files larger than this are skipped with a warning written to stderr.
 pub const MAX_FILE_SIZE: u64 = 100 * 1024 * 1024;
 
+/// Byte size and line count of a file, measured by [`scan_file_multi_stats`].
+///
+/// Both numbers are what `find`/`read` report as `size`/`lines` (iteration
+/// 252): `size` is the file's length in bytes as the filesystem reports it,
+/// `lines` counts `\n`-separated lines with a final unterminated line still
+/// counted (an empty file is 0 lines). Counting `\n` and not `\r\n` keeps a
+/// CRLF file's count identical to the same file with LF endings.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScanStats {
+    /// File length in bytes.
+    pub size: u64,
+    /// Number of lines (see the type docs for the exact definition).
+    pub lines: usize,
+}
+
+/// Count lines in a byte slice: one per `\n`, plus a final unterminated line.
+/// Empty input is zero lines.
+#[must_use]
+pub fn count_lines(data: &[u8]) -> usize {
+    if data.is_empty() {
+        return 0;
+    }
+    let newlines = memchr::memchr_iter(b'\n', data).count();
+    if data.last() == Some(&b'\n') {
+        newlines
+    } else {
+        newlines + 1
+    }
+}
+
 /// Scan a file with multiple visitors in a single pass.
 ///
 /// Reads the file into memory then delegates to `scan_slice_multi` for
@@ -50,6 +80,26 @@ pub const MAX_FILE_SIZE: u64 = 100 * 1024 * 1024;
 ///
 /// Files exceeding [`MAX_FILE_SIZE`] are skipped with a warning to stderr.
 pub fn scan_file_multi(path: &Path, visitors: &mut [&mut dyn FileVisitor]) -> Result<()> {
+    scan_file_multi_stats(path, visitors, false).map(|_| ())
+}
+
+/// [`scan_file_multi`] that also reports the file's [`ScanStats`].
+///
+/// `count_lines` selects how much the frontmatter-only fast path pays: with
+/// `false` the returned `lines` covers only the bytes that were actually read
+/// (the 16 KiB frontmatter prefix), which is all a caller that ignores the
+/// field needs; with `true` the remainder of the file is streamed through
+/// `memchr` — no UTF-8 conversion, no allocation per line — so the count is
+/// exact. The body path always reads the whole file anyway and is exact
+/// either way.
+///
+/// A file skipped for exceeding [`MAX_FILE_SIZE`] reports its size with
+/// `lines: 0`, matching the "not scanned" outcome the visitors see.
+pub fn scan_file_multi_stats(
+    path: &Path,
+    visitors: &mut [&mut dyn FileVisitor],
+    count_lines_exact: bool,
+) -> Result<ScanStats> {
     let file_size = std::fs::metadata(path)
         .with_context(|| format!("failed to stat {}", path.display()))?
         .len();
@@ -60,14 +110,22 @@ pub fn scan_file_multi(path: &Path, visitors: &mut [&mut dyn FileVisitor]) -> Re
             file_size / (1024 * 1024),
             MAX_FILE_SIZE / (1024 * 1024)
         );
-        return Ok(());
+        return Ok(ScanStats {
+            size: file_size,
+            lines: 0,
+        });
     }
 
     let any_needs_body = visitors.iter().any(|v| v.needs_body());
     if any_needs_body {
         let data =
             std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
-        scan_slice_multi(&data, visitors)
+        let lines = count_lines(&data);
+        scan_slice_multi(&data, visitors)?;
+        Ok(ScanStats {
+            size: file_size,
+            lines,
+        })
     } else {
         // Frontmatter-only: read a limited prefix to avoid loading the full file.
         use std::io::Read;
@@ -79,7 +137,34 @@ pub fn scan_file_multi(path: &Path, visitors: &mut [&mut dyn FileVisitor]) -> Re
             .read(&mut buf)
             .with_context(|| format!("failed to read {}", path.display()))?;
         buf.truncate(n);
-        scan_slice_multi(&buf, visitors)
+        // Count over the prefix first; the tail (if any) is streamed below so
+        // the frontmatter fast path still never holds the whole file at once.
+        let mut newlines = memchr::memchr_iter(b'\n', &buf).count();
+        let mut last_byte = buf.last().copied();
+        if count_lines_exact && (n as u64) < file_size {
+            const TAIL_CHUNK: usize = 64 * 1024;
+            let mut chunk = vec![0u8; TAIL_CHUNK];
+            loop {
+                let m = file
+                    .read(&mut chunk)
+                    .with_context(|| format!("failed to read {}", path.display()))?;
+                if m == 0 {
+                    break;
+                }
+                newlines += memchr::memchr_iter(b'\n', &chunk[..m]).count();
+                last_byte = chunk[..m].last().copied();
+            }
+        }
+        scan_slice_multi(&buf, visitors)?;
+        let lines = match last_byte {
+            None => 0,
+            Some(b'\n') => newlines,
+            Some(_) => newlines + 1,
+        };
+        Ok(ScanStats {
+            size: file_size,
+            lines,
+        })
     }
 }
 

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -2004,4 +2004,76 @@ code only
         assert_eq!(outcome2, LineOutcome::Complete);
         assert_eq!(buf, "after\n");
     }
+    // -- line counting (iter-252) ------------------------------------------
+
+    #[test]
+    fn count_lines_counts_a_final_unterminated_line() {
+        assert_eq!(count_lines(b""), 0, "an empty file has no lines");
+        assert_eq!(count_lines(b"\n"), 1);
+        assert_eq!(count_lines(b"a"), 1, "no trailing newline still counts");
+        assert_eq!(count_lines(b"a\n"), 1);
+        assert_eq!(count_lines(b"a\nb"), 2);
+        assert_eq!(count_lines(b"a\nb\n"), 2);
+    }
+
+    #[test]
+    fn count_lines_is_identical_for_crlf_and_lf() {
+        // `\r` is part of the line, not a separator: a CRLF document must not
+        // report twice the lines of the same document with LF endings.
+        assert_eq!(count_lines(b"a\r\nb\r\n"), count_lines(b"a\nb\n"));
+        assert_eq!(count_lines("üñï\r\n日本\r\n".as_bytes()), 2);
+    }
+
+    #[test]
+    fn count_file_lines_matches_count_lines_across_chunk_boundaries() {
+        // The streaming counter reads in 64 KiB chunks; a file several chunks
+        // long is where an off-by-one at the boundary would show up.
+        let dir = tempfile::tempdir().unwrap();
+        for (name, body) in [
+            ("empty.md", String::new()),
+            ("one.md", "single line, no newline".to_owned()),
+            ("small.md", "a\nb\nc\n".to_owned()),
+            ("big.md", (0..20_000).map(|i| format!("line {i}\n")).collect()),
+            (
+                "big_noeol.md",
+                (0..20_000)
+                    .map(|i| format!("line {i}\n"))
+                    .collect::<String>()
+                    + "tail",
+            ),
+        ] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, &body).unwrap();
+            assert_eq!(
+                count_file_lines(&path).unwrap(),
+                count_lines(body.as_bytes()),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn scan_file_multi_stats_counts_the_whole_file_on_the_frontmatter_path() {
+        // The frontmatter-only fast path reads a 16 KiB prefix; with exact
+        // counting requested it must still report the file's real line count,
+        // not the prefix's.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.md");
+        let body: String = (0..5_000).map(|i| format!("body line {i}\n")).collect();
+        let text = format!("---\ntitle: Big\n---\n\n{body}");
+        std::fs::write(&path, &text).unwrap();
+
+        let mut fm = FrontmatterCollector::new(false);
+        let stats = scan_file_multi_stats(&path, &mut [&mut fm], true).unwrap();
+        assert_eq!(stats.size, text.len() as u64);
+        assert_eq!(stats.lines, count_lines(text.as_bytes()));
+        assert!(stats.lines > 5_000, "sanity: the tail was counted");
+
+        // Without exact counting the prefix is all that is measured — cheaper,
+        // and correct for callers that ignore `lines`.
+        let mut fm = FrontmatterCollector::new(false);
+        let prefix_only = scan_file_multi_stats(&path, &mut [&mut fm], false).unwrap();
+        assert_eq!(prefix_only.size, text.len() as u64);
+        assert!(prefix_only.lines < stats.lines);
+    }
 }

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -69,6 +69,37 @@ pub fn count_lines(data: &[u8]) -> usize {
     }
 }
 
+/// Count the lines of a file without holding it in memory.
+///
+/// Streams the file through `memchr` in 64 KiB chunks — no UTF-8 conversion,
+/// no per-line allocation — and applies the same counting rule as
+/// [`count_lines`]. Used by `read`, which reports the whole file's `lines`
+/// even when it returns one section or line range of it.
+pub fn count_file_lines(path: &Path) -> Result<usize> {
+    use std::io::Read;
+    const CHUNK: usize = 64 * 1024;
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    let mut chunk = vec![0u8; CHUNK];
+    let mut newlines = 0usize;
+    let mut last_byte: Option<u8> = None;
+    loop {
+        let n = file
+            .read(&mut chunk)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        newlines += memchr::memchr_iter(b'\n', &chunk[..n]).count();
+        last_byte = chunk[..n].last().copied();
+    }
+    Ok(match last_byte {
+        None => 0,
+        Some(b'\n') => newlines,
+        Some(_) => newlines + 1,
+    })
+}
+
 /// Scan a file with multiple visitors in a single pass.
 ///
 /// Reads the file into memory then delegates to `scan_slice_multi` for

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -78,8 +78,8 @@ pub fn count_lines(data: &[u8]) -> usize {
 pub fn count_file_lines(path: &Path) -> Result<usize> {
     use std::io::Read;
     const CHUNK: usize = 64 * 1024;
-    let mut file = std::fs::File::open(path)
-        .with_context(|| format!("failed to open {}", path.display()))?;
+    let mut file =
+        std::fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
     let mut chunk = vec![0u8; CHUNK];
     let mut newlines = 0usize;
     let mut last_byte: Option<u8> = None;
@@ -2024,6 +2024,17 @@ code only
         assert_eq!(count_lines("üñï\r\n日本\r\n".as_bytes()), 2);
     }
 
+    /// `n` newline-terminated lines, built with `writeln!` so clippy's
+    /// `format_collect` lint stays happy about the per-line allocation.
+    fn repeated_lines(n: usize) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        for i in 0..n {
+            let _ = writeln!(out, "line {i}");
+        }
+        out
+    }
+
     #[test]
     fn count_file_lines_matches_count_lines_across_chunk_boundaries() {
         // The streaming counter reads in 64 KiB chunks; a file several chunks
@@ -2033,14 +2044,8 @@ code only
             ("empty.md", String::new()),
             ("one.md", "single line, no newline".to_owned()),
             ("small.md", "a\nb\nc\n".to_owned()),
-            ("big.md", (0..20_000).map(|i| format!("line {i}\n")).collect()),
-            (
-                "big_noeol.md",
-                (0..20_000)
-                    .map(|i| format!("line {i}\n"))
-                    .collect::<String>()
-                    + "tail",
-            ),
+            ("big.md", repeated_lines(20_000)),
+            ("big_noeol.md", repeated_lines(20_000) + "tail"),
         ] {
             let path = dir.path().join(name);
             std::fs::write(&path, &body).unwrap();
@@ -2059,7 +2064,7 @@ code only
         // not the prefix's.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("big.md");
-        let body: String = (0..5_000).map(|i| format!("body line {i}\n")).collect();
+        let body: String = repeated_lines(5_000);
         let text = format!("---\ntitle: Big\n---\n\n{body}");
         std::fs::write(&path, &text).unwrap();
 

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -335,6 +335,12 @@ pub struct ContentMatch {
 pub struct FileObject {
     pub file: String,
     pub modified: String,
+    /// File size in bytes (iteration 252) — always present, so an agent can
+    /// budget a `read` before issuing it.
+    pub size: u64,
+    /// Line count (see [`crate::scanner::ScanStats`]) — always present, and
+    /// the unit `read --lines A:B` takes.
+    pub lines: usize,
     /// Title extracted from frontmatter `title` property or first H1 heading.
     /// - `None`: field not requested (omitted from JSON output)
     /// - `Some(Value::String(...))`: title found

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3368,3 +3368,36 @@ errors on stderr with exit codes.
 **Constraint carried into both iterations.** No new CLI flags
 ([[decision-log#DEC-249]] discipline): every adoption is a default, a
 layout, a hint, or metadata on existing output.
+
+## DEC-252: `title` is promoted out of `properties`, and `--fields all` is hinted only where it is affordable (2026-08-30)
+
+**Decision (a):** `find` promotes `title` to a top-level field in the default
+result shape and stops repeating it inside the `properties` map. The removal
+happens *after* sorting and filtering, so `--sort property:title` and
+`--property title=…` compare exactly what they compared before; only the
+serialized payload changes. `--fields properties` without `title` still
+carries the raw `title` property, so no request can lose the value.
+
+**Why:** `tags` has been promoted this way since the first `find`, so the rule
+already existed — `title` joining the default field set (iteration 252) simply
+made the duplicate visible: the same string, twice, in every result item. It
+is also what closed the last kilobyte of the iteration's byte budget: the
+20-file own-KB listing lands at 11.9 KB against a 12 KB acceptance criterion,
+where keeping the duplicate put it at 13.3 KB. Callers reading
+`.results[].properties.title` must read `.results[].title` — recorded as a
+breaking change in the 0.22.0 changelog, and swept out of the bundled skills,
+the knowledgebase rule file and the tests in the same PR.
+
+**Decision (b):** the `--fields all` hint fires only for an untruncated result
+set of five or fewer items, not on every `find` as
+[[iterations/iteration-252-find-result-shape]] proposed.
+
+**Why:** `--fields all` is roughly a 10x payload — precisely the cost this
+iteration removed. Suggesting it under a 50-file listing would hand an agent
+the bill it was just spared, and with `MAX_HINTS = 5` it would displace the
+narrowing hints (`--limit`, narrow-by-tag) that actually help at that size.
+Where the whole result set is a handful of files, expanding it is cheap and
+the hint is the fastest way to the full shape. The general statement lives
+where it costs nothing instead: the `--format text` `fields:` summary line
+names what the payload carries and what `--fields all` would add, and
+`find --help` says the same.

--- a/hyalo-knowledgebase/iterations/iteration-252-find-result-shape.md
+++ b/hyalo-knowledgebase/iterations/iteration-252-find-result-shape.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 252 — find result shape: compact default fields and size metadata"
 date: 2026-08-29
-status: in-progress
+status: completed
 tags:
   - iteration
   - agent-cli
@@ -27,7 +27,7 @@ gets its own iteration and a minor bump.
 **No new flags.** `--fields` exists; the auto-include precedent exists
 (`--broken-links` adds `links`, `--orphan` adds `backlinks`).
 
-## Tasks
+## Tasks [7/7]
 
 - [x] New `find` default field set: `file, modified, size, title,
       properties, tags` (+ `score`/`matches` when a PATTERN or `-e` is
@@ -58,7 +58,7 @@ gets its own iteration and a minor bump.
       test vault), auto-include matrix, `size`/`lines` correctness on CRLF
       and UTF-8 files, index parity for the new fields.
 
-## Acceptance criteria
+## Acceptance criteria [4/4]
 
 - [x] `find --tag iteration --limit 20 --format json` on the own KB ≤ 12 KB;
       `--fields all` reproduces the pre-change shape.

--- a/hyalo-knowledgebase/iterations/iteration-252-find-result-shape.md
+++ b/hyalo-knowledgebase/iterations/iteration-252-find-result-shape.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 252 — find result shape: compact default fields and size metadata"
 date: 2026-08-29
-status: planned
+status: in-progress
 tags:
   - iteration
   - agent-cli
@@ -29,44 +29,73 @@ gets its own iteration and a minor bump.
 
 ## Tasks
 
-- [ ] New `find` default field set: `file, modified, size, title,
+- [x] New `find` default field set: `file, modified, size, title,
       properties, tags` (+ `score`/`matches` when a PATTERN or `-e` is
       present, as today). `sections`, `links`, `tasks`, `backlinks`,
       `properties-typed` only on request (`--fields …` or `all`) or via
       the existing auto-includes (`--section` → `sections`, `--task` →
       `tasks`, `--broken-links`/`--dead-end` → `links`, `--orphan` →
       `backlinks`, `--sort links_count|backlinks_count` → the counted field).
-- [ ] Size metadata: `size` (bytes) and `lines` on every `find` item and
+- [x] Size metadata: `size` (bytes) and `lines` on every `find` item and
       on `read` results; `read` emits a hint (`--lines 1:80`, `--section`)
       when the body exceeds a threshold (~8 KB). Text mode shows size in
       the header line.
-- [ ] Every `find` result set carries one hint: `--fields all` (or the
+- [x] Every `find` result set carries one hint: `--fields all` (or the
       specific missing field when a filter implies it). Text summary line
       names the fields included.
-- [ ] Snapshot index: `size`/`lines` stored per entry; `create-index`
+- [x] Snapshot index: `size`/`lines` stored per entry; `create-index`
       populates them; mutation journal keeps them current; index/disk
       parity tests extended (the iter-243/244 parity suite).
-- [ ] Views: a saved view may pin `fields`; views without it get the new
+- [x] Views: a saved view may pin `fields`; views without it get the new
       default. Document in `views --help`.
-- [ ] Sweep consumers of the old default: hints generators, bundled skills,
+- [x] Sweep consumers of the old default: hints generators, bundled skills,
       `.claude/rules`, README examples, cookbook `--jq` recipes that read
       `.results[].sections` / `.links` — add `--fields` where needed.
-- [ ] CHANGELOG `[Unreleased]` → **Changed** with a migration line
+- [x] CHANGELOG `[Unreleased]` → **Changed** with a migration line
       (`--fields all` restores the previous shape); bump workspace version
       to 0.22.0 in the three Cargo.toml spots (minor: breaking default).
-- [ ] e2e: default shape byte-budget test (20-file listing ≤ 12 KB on the
+- [x] e2e: default shape byte-budget test (20-file listing ≤ 12 KB on the
       test vault), auto-include matrix, `size`/`lines` correctness on CRLF
       and UTF-8 files, index parity for the new fields.
 
 ## Acceptance criteria
 
-- [ ] `find --tag iteration --limit 20 --format json` on the own KB ≤ 12 KB;
+- [x] `find --tag iteration --limit 20 --format json` on the own KB ≤ 12 KB;
       `--fields all` reproduces the pre-change shape.
-- [ ] Every filter that implies a field still returns it without
+- [x] Every filter that implies a field still returns it without
       `--fields`.
-- [ ] `size` and `lines` present on `find` and `read` items, identical
+- [x] `size` and `lines` present on `find` and `read` items, identical
       between disk scan and `--index`.
-- [ ] Gates and CI green; version 0.22.0.
+- [x] Gates and CI green; version 0.22.0.
+
+## Outcome (2026-08-30)
+
+Measured on the own KB after the change: `find --tag iteration --limit 20
+--format json` is **11.9 KB** (was 73 KB); `--fields all` is 231 KB, i.e. the
+old shape and then some. Default items carry `file, modified, size, lines,
+title, properties, tags`.
+
+Two deliberate departures from the plan, both recorded in
+[[decision-log#DEC-252]]:
+
+- **`title` is promoted out of `properties`.** Adding `title` to the default
+  set made the duplicate copy inside `properties` visible — the same string
+  twice per item, and the 1.4 KB that separated 13.3 KB from the 12 KB
+  acceptance criterion. Removed after sorting/filtering, so `--sort
+  property:title` and `--property title=…` are unaffected; `--fields
+  properties` alone still carries the property. Breaking for
+  `.results[].properties.title` readers; swept and changelogged.
+- **The `--fields all` hint is not on every result set.** It fires for an
+  untruncated set of ≤5 items. `--fields all` is the ~10x payload this
+  iteration removed, and at `MAX_HINTS = 5` an unconditional hint displaced
+  the narrowing hints that matter on a large listing. The always-on statement
+  moved to the `--format text` `fields:` summary line and `find --help`.
+
+Also landed beyond the plan's letter: `--sort links_count` /
+`--sort backlinks_count` now *return* the field they rank on (the plan listed
+this as an existing auto-include; it was in fact stripped after sorting), and
+`scanner::scan_file_multi_stats` counts lines without giving up the
+frontmatter-only fast path's 16 KiB prefix read for the scan itself.
 
 ## Non-goals
 

--- a/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
+++ b/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
@@ -1,0 +1,88 @@
+---
+type: iteration
+title: "Iteration 253 — read: compute lines without a second full-file scan"
+date: 2026-08-30
+status: planned
+tags:
+  - iteration
+  - agent-cli
+  - performance
+depends-on: "[[iterations/iteration-252-find-result-shape]]"
+branch: iter-253/read-lines-single-pass
+---
+
+# Iteration 253 — `read`: compute `lines` without a second full-file scan
+
+## Goal
+
+Carry-over from [[iterations/iteration-252-find-result-shape]] review (PR
+#293, not a blocker — merged as-is). `hyalo read` now always reports `lines`
+(iter-252), computed via `scanner::count_file_lines(&full_path)` —
+an unconditional second full read of the file from disk.
+
+Whenever the read needs the body anyway (`need_body == true`: no
+`--frontmatter`-only request, or `--section`/`--lines` given), the file's
+body is *already* fully read into memory via `read_body_lines` before that
+second scan runs. Since `read_body_lines` reads every body line and
+`frontmatter::skip_frontmatter` already returns the frontmatter's line
+count, the total line count matching `scanner::count_lines`'s definition can
+be derived from data already in hand — no second disk pass.
+
+The `--frontmatter`-only path (`need_body == false`) does need a dedicated
+scan to get `lines`, since the body was deliberately not read there — that
+call to `count_file_lines` stays.
+
+This is a performance-only finding (no incorrect output), so it is not a
+blocker on #293; low absolute cost per single-file CLI invocation, but worth
+fixing since it doubles disk I/O for exactly the large-file case this
+feature exists to help with, and contradicts the "frontmatter-only queries
+pay zero cost for body scanning" principle ([[decision-log]], scanner
+section) for the one case still forced to eat a full second read anyway.
+
+## Tasks
+
+- [ ] `read_body_lines` returns the frontmatter line count alongside the body
+      lines (e.g. `(Vec<String>, usize)`), without adding I/O — it already
+      has this number from `skip_frontmatter`, it just isn't propagated.
+- [ ] In `commands/read.rs::run`, capture the raw body line count right after
+      `read_body_lines` returns (before `--section`/`--lines` narrow
+      `content_lines`), and compute `total_lines = fm_lines + raw_body_lines`
+      when `need_body` was true. Keep `scanner::count_file_lines` only for
+      the `need_body == false` (`--frontmatter`-only) path.
+- [ ] Unit/e2e test: `total_lines` computed this way matches
+      `scanner::count_lines` applied to the whole file, across the same
+      CRLF / no-trailing-newline / invalid-UTF-8 / oversized-line cases the
+      iter-252 suite already covers for `find` — reuse or extend
+      `find_result_shape.rs`'s baseline-comparison helper rather than
+      duplicating it.
+- [ ] Confirm no behavior change for `--frontmatter`-only reads (still one
+      full-file scan, not zero — `lines` requires reading the file; this
+      iteration only removes the *second* read on the already-body-reading
+      paths).
+
+## Acceptance criteria
+
+- [ ] `read` without `--frontmatter`-only reads the file's bytes once, not
+      twice (verified by the new test comparing against the pre-253 double-
+      read behavior, or by inspecting call sites — no new I/O-counting
+      instrumentation needs to ship).
+- [ ] `read`'s reported `lines` is byte-identical to today's for every
+      existing `find_result_shape.rs` / `read` e2e case (CRLF, UTF-8,
+      no-EOL, frontmatter-only, `--section`, `--lines`).
+- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D
+      warnings`, `cargo test --workspace -q`.
+
+## Non-goals
+
+- Changing what `lines` means, or which `read` invocations report it —
+  iter-252 already settled that (every `read` result carries `size`/`lines`
+  matching the whole file). This iteration only changes how the number is
+  computed.
+- The `--frontmatter`-only path's forced full scan is out of scope: reporting
+  `lines` there requires reading the file no matter what, by the iter-252
+  contract itself.
+
+## Links
+
+- [[iterations/iteration-252-find-result-shape]]
+- [[decision-log#DEC-252]]

--- a/pi-package/skills/hyalo-tidy/SKILL.md
+++ b/pi-package/skills/hyalo-tidy/SKILL.md
@@ -189,7 +189,7 @@ Cross-reference with git merges from Phase 2. If the branch was merged, update s
 
 ### Stale backlog items
 ```bash
-hyalo find --property status=planned --property type=backlog --index --jq '.results | map({file, title: .properties.title})'
+hyalo find --property status=planned --property type=backlog --index --jq '.results | map({file, title})'
 ```
 Compare each planned backlog item against merged iterations and recent git history.
 If the feature clearly shipped (in a different iteration or under a different name),


### PR DESCRIPTION
## Summary

- **BREAKING — `find` returns a compact default shape.** The default field set was `properties, tags, sections, links` on every item: a 20-file listing of this repo's own knowledgebase was **73 KB** of JSON, nine times what the same query costs with `--fields properties`, nearly all of it document structure nobody asked for. The default is now `file, modified, size, lines, title, properties, tags` — **11.9 KB** for that same listing, against the plan's 12 KB budget. `--fields all` restores the previous shape (231 KB) and then some.
- **Nothing is silently lost.** Every filter that implies a field returns it with no flag: `--section` → `sections`, `--task` → `tasks`, `--broken-links`/`--dead-end` → `links`, `--orphan` → both, and `--sort links_count`/`backlinks_count` now *return* the field they rank on instead of computing it invisibly and stripping it.
- **`size` (bytes) and `lines` on every `find` and `read` result**, so an agent can budget a read before issuing it. Both count the whole file (a `read --section` reports the file's totals, not the slice's), are identical between a disk scan and an `--index` snapshot, and treat CRLF and LF documents the same. A `read` over 8 KB offers a line-range read and a section listing instead of another whole-file pull.
- **`title` is promoted out of `properties`** (it joined the default set; carrying the same string twice per item was the last 1.4 KB between 13.3 KB and the budget). Removed *after* sorting/filtering, so `--sort property:title` and `--property title=…` compare exactly what they compared before; `--fields properties` alone still carries the raw property. See DEC-252.
- `--format text` shows `size`/`lines` in each result's header line and a `fields:` footer naming what the payload carries and what `--fields all` would add. Version bumped to **0.22.0** (breaking default → minor).

## Implementation notes

- `scanner::scan_file_multi_stats` reports `ScanStats { size, lines }` from the pass the scanner already makes; the frontmatter-only fast path keeps its 16 KiB prefix read and streams only the newline count of the tail through `memchr` — no UTF-8 conversion, no per-line allocation.
- `IndexEntry` gained serde-defaulted `size`/`lines`, so snapshots written by 0.21.0 still load (reporting `0` until the next `create-index`). `SnapshotIndex::refresh_links` refreshes both, which puts every mutation write path (`set`/`append`/`remove`, task toggles, `links fix`, `lint --fix`) on the same journal path that already kept `sections`/`tasks`/BM25 tokens current.
- Deviation from the plan, recorded in DEC-252 and the iteration file: the `--fields all` hint fires only for an untruncated result set of ≤5 items. `--fields all` is the ~10× payload this iteration removed, and with `MAX_HINTS = 5` an unconditional hint displaced the narrowing hints that matter on a large listing; the always-on statement lives in the text `fields:` line and `find --help` instead.

## Test plan

- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` — all green (3207 tests).
- [x] Every xtask gate: `check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`, `check-pi-package-sync`, `check-mutation-journal` (plus the two stubs) exit 0.
- [x] New e2e suite `crates/hyalo-cli/tests/e2e/find_result_shape.rs` (15 tests): default shape, 12 KB byte budget, `--fields all` round-trip, promoted-title contract, auto-include matrix, CRLF/UTF-8/no-EOL `size`+`lines` against an independently computed baseline, disk↔`--index` parity, parity after a mutation, `read` whole-file totals, large-read and small-listing hints, text-mode header and summary line, views with and without pinned `--fields`.
- [x] 4 new scanner unit tests: line counting (empty / unterminated / CRLF), streaming count across 64 KiB chunk boundaries, exact count on the frontmatter-only fast path.
- [x] 5 pre-existing tests updated to the new contract (two sort auto-includes, title default, two `.properties.title` readers) — each failure was the intended breaking change, not a regression.
- [x] Dogfooded: `hyalo find`, `read`, `lint`, `task toggle`, `set` against this repo's knowledgebase with the release build; `hyalo lint` clean over 105 files.
- [x] Docs swept in the same PR: bundled skills (`skill-hyalo`, `skill-hyalo-tidy`, and the `pi-package/` originals with their vendored copies), `.claude/rules/knowledgebase.md`, `--fields`/`find`/`views` help text, the cookbook, CHANGELOG, decision log, iteration file.

## Carry-over

Review pass (local-only /review-pr, no correctness issues found; all gates green) surfaced one out-of-scope finding. This is the last iteration of the 250-252 run, so it is filed as its own plan rather than folded forward:

- **`read` computes `lines` via a redundant second full-file scan.** On every path where the body is already read into memory (`need_body == true`), `commands/read.rs::run` still calls `scanner::count_file_lines` separately to get the total line count, re-reading the file from disk a second time instead of deriving the count from data already in hand. Performance-only (no incorrect output), low absolute cost per single-file CLI call, but doubles I/O for exactly the large-file case this feature exists to help with. Filed as [[iterations/iteration-253-read-lines-single-pass]].

No unticked ACs and no `[deferred …]` annotations were found in the iteration-252 plan or PR body — all scope items landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS
