### PR TITLE
iter-253: read computes lines from the body pass instead of a second full-file scan

### DIFF
--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -587,6 +587,94 @@ mod tests {
         assert_eq!(lines[1], "next");
     }
 
+    /// iteration 253: the whole-file line count derived from the single body
+    /// pass (`fm_lines + body.len()`) must equal what a dedicated scan of the
+    /// file's bytes returns — `scanner::count_lines` is the same counter
+    /// `scanner::count_file_lines` streams, i.e. exactly the number `read`
+    /// reported before the second read was removed.
+    ///
+    /// The cases mirror the pathological inputs the iter-252 `find` suite
+    /// pins for `lines`: CRLF, no trailing newline, invalid UTF-8, and a line
+    /// over the per-line cap — the three inputs where "one call to
+    /// `read_line_capped` is one line" could plausibly break down.
+    #[test]
+    fn derived_line_count_matches_a_whole_file_scan() {
+        let huge = "x".repeat(scanner::MAX_BODY_LINE_BYTES + 1);
+        let cases: Vec<(&str, Vec<u8>)> = vec![
+            ("empty", Vec::new()),
+            ("lone newline", b"\n".to_vec()),
+            (
+                "no frontmatter, trailing newline",
+                b"# H\n\nbody\n".to_vec(),
+            ),
+            (
+                "no frontmatter, no trailing newline",
+                b"# H\n\nbody".to_vec(),
+            ),
+            ("frontmatter only", b"---\ntitle: T\n---\n".to_vec()),
+            ("frontmatter only, no eol", b"---\ntitle: T\n---".to_vec()),
+            (
+                "frontmatter and body",
+                b"---\ntitle: T\n---\n\n# H\n\nbody\n".to_vec(),
+            ),
+            (
+                "frontmatter and body, no eol",
+                b"---\ntitle: T\n---\n\n# End".to_vec(),
+            ),
+            (
+                "crlf throughout",
+                b"---\r\ntitle: T\r\n---\r\n\r\n# H\r\nbody\r\n".to_vec(),
+            ),
+            (
+                "multi-byte utf-8",
+                "---\ntitle: Üñïçôdé\n---\n\n日本語のテキスト。\n"
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            ("trailing blank line", b"a\n\n".to_vec()),
+            (
+                "invalid utf-8 body line",
+                b"---\ntitle: T\n---\n\n\xff\xfe bad\nafter\n".to_vec(),
+            ),
+            ("invalid utf-8 first line", b"\xff bad\nafter\n".to_vec()),
+            (
+                "invalid utf-8 final line, no eol",
+                b"before\n\xff bad".to_vec(),
+            ),
+            (
+                "oversized middle line",
+                format!("before\n{huge}\nafter\n").into_bytes(),
+            ),
+            (
+                "oversized final line, no eol",
+                format!("before\n{huge}").into_bytes(),
+            ),
+            (
+                "oversized first line",
+                format!("{huge}\nafter\n").into_bytes(),
+            ),
+        ];
+
+        let tmp = tempfile::tempdir().unwrap();
+        for (name, content) in cases {
+            let path = tmp.path().join("case.md");
+            std::fs::write(&path, &content).unwrap();
+            let (body, fm_lines) = read_body_lines(&path).unwrap();
+            assert_eq!(
+                fm_lines + body.len(),
+                scanner::count_lines(&content),
+                "derived line count disagrees with a whole-file scan for {name:?}"
+            );
+            // The two counters must also agree with the streaming one `read`
+            // still uses on the `--frontmatter`-only path.
+            assert_eq!(
+                scanner::count_file_lines(&path).unwrap(),
+                scanner::count_lines(&content),
+                "the streaming scan disagrees with the slice scan for {name:?}"
+            );
+        }
+    }
+
     // -- parse_line_range --
 
     #[test]

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -204,13 +204,25 @@ fn invalid_utf8_line_placeholder() -> String {
 }
 
 /// Read the raw body lines from a markdown file, skipping frontmatter.
-/// Returns the lines with their trailing newlines stripped.
+/// Returns `(body_lines, frontmatter_line_count)`: the body lines with their
+/// trailing newlines stripped, plus how many leading lines the frontmatter
+/// block occupied (0 when the file has none).
+///
+/// The frontmatter line count is a by-product of [`frontmatter::skip_frontmatter`]
+/// — returning it costs no extra I/O and lets the caller derive the whole
+/// file's line count (`fm_lines + body_lines.len()`, identical to
+/// [`scanner::count_lines`] over the same bytes) without a second full read
+/// of the file (iteration 253).  This holds because
+/// [`scanner::read_line_capped`] consumes exactly one logical line per call —
+/// skipped lines are drained to the next `\n` and still occupy one slot — and
+/// `skip_frontmatter` counts the opening and closing `---` delimiters plus
+/// everything between them.
 ///
 /// Uses [`scanner::read_line_capped`] rather than `BufRead::lines()` so a
 /// single pathological line (e.g. a minified blob with no newlines) cannot
 /// balloon memory — such a line is replaced with [`oversized_line_placeholder`]
 /// instead of being buffered in full.
-fn read_body_lines(path: &Path) -> Result<Vec<String>> {
+fn read_body_lines(path: &Path) -> Result<(Vec<String>, usize)> {
     let file =
         std::fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
     let mut reader = std::io::BufReader::new(file);
@@ -221,10 +233,11 @@ fn read_body_lines(path: &Path) -> Result<Vec<String>> {
         scanner::read_line_capped(&mut reader, &mut first_line, scanner::MAX_BODY_LINE_BYTES)
             .with_context(|| format!("failed to read {}", path.display()))?;
     if n == 0 {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), 0));
     }
 
     let mut lines = Vec::new();
+    let mut frontmatter_lines = 0usize;
 
     if first_outcome.is_skipped() {
         // A real `---` frontmatter delimiter is 3 bytes, so a line this long
@@ -239,6 +252,8 @@ fn read_body_lines(path: &Path) -> Result<Vec<String>> {
         if fm_lines == 0 {
             // No frontmatter — first line is body content
             lines.push(first_trimmed.to_owned());
+        } else {
+            frontmatter_lines = fm_lines;
         }
     }
 
@@ -260,7 +275,7 @@ fn read_body_lines(path: &Path) -> Result<Vec<String>> {
         }
     }
 
-    Ok(lines)
+    Ok((lines, frontmatter_lines))
 }
 
 // ---------------------------------------------------------------------------
@@ -344,8 +359,18 @@ pub fn run(
     // Determine what content to return
     let need_body = section.is_some() || !frontmatter_flag || line_range.is_some();
 
+    // When the body is read, the whole file's line count falls out of that
+    // single pass (iteration 253): `read_body_lines` streams every line after
+    // the frontmatter and reports how many lines the frontmatter occupied, so
+    // `fm_lines + raw_body_lines` is exactly what `scanner::count_lines` would
+    // return for the same bytes — captured here, before `--section`/`--lines`
+    // narrow `content_lines` below.  `None` means the body was not read
+    // (`--frontmatter` only), and the count is scanned separately further down.
+    let mut whole_file_lines: Option<usize> = None;
     let mut content_lines: Vec<String> = if need_body {
-        read_body_lines(&full_path)?
+        let (body_lines, fm_lines) = read_body_lines(&full_path)?;
+        whole_file_lines = Some(fm_lines + body_lines.len());
+        body_lines
     } else {
         Vec::new()
     };
@@ -409,7 +434,14 @@ pub fn run(
     // returned — they are the same two numbers `find` reports, so an agent can
     // compare a `read --section` result against the file it came from and
     // decide whether the rest is worth another call.
-    let total_lines = scanner::count_file_lines(&full_path)?;
+    //
+    // The count comes free from the body pass above whenever the body was
+    // read; only a `--frontmatter`-only read still has to scan the file for
+    // it, since that path deliberately never touches the body (iteration 253).
+    let total_lines = match whole_file_lines {
+        Some(n) => n,
+        None => scanner::count_file_lines(&full_path)?,
+    };
     let mut obj = serde_json::json!({
         "file": rel_path,
         "size": file_size,
@@ -480,8 +512,9 @@ mod tests {
         )
         .unwrap();
 
-        let lines = read_body_lines(&path).unwrap();
+        let (lines, fm_lines) = read_body_lines(&path).unwrap();
         assert_eq!(lines, vec!["Line one", "Line two", "Line three"]);
+        assert_eq!(fm_lines, 3, "opening `---`, one key, closing `---`");
     }
 
     #[test]
@@ -490,8 +523,9 @@ mod tests {
         let path = tmp.path().join("normal.md");
         std::fs::write(&path, "# Heading\n\nBody text\n").unwrap();
 
-        let lines = read_body_lines(&path).unwrap();
+        let (lines, fm_lines) = read_body_lines(&path).unwrap();
         assert_eq!(lines, vec!["# Heading", "", "Body text"]);
+        assert_eq!(fm_lines, 0, "no frontmatter block");
     }
 
     #[test]
@@ -505,7 +539,8 @@ mod tests {
         let content = format!("before\n{huge}\nafter\n");
         std::fs::write(&path, &content).unwrap();
 
-        let lines = read_body_lines(&path).unwrap();
+        let (lines, fm_lines) = read_body_lines(&path).unwrap();
+        assert_eq!(fm_lines, 0);
         assert_eq!(lines.len(), 3, "line count must be preserved: {lines:?}");
         assert_eq!(lines[0], "before");
         assert_ne!(lines[1], huge, "oversized line must not be buffered whole");
@@ -529,7 +564,8 @@ mod tests {
         let huge: String = "y".repeat(scanner::MAX_BODY_LINE_BYTES + 1);
         std::fs::write(&path, format!("{huge}\nafter\n")).unwrap();
 
-        let lines = read_body_lines(&path).unwrap();
+        let (lines, fm_lines) = read_body_lines(&path).unwrap();
+        assert_eq!(fm_lines, 0);
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("skipped"));
         assert_eq!(lines[1], "after");
@@ -542,7 +578,8 @@ mod tests {
         let exact: String = "z".repeat(scanner::MAX_BODY_LINE_BYTES);
         std::fs::write(&path, format!("{exact}\nnext\n")).unwrap();
 
-        let lines = read_body_lines(&path).unwrap();
+        let (lines, fm_lines) = read_body_lines(&path).unwrap();
+        assert_eq!(fm_lines, 0);
         assert_eq!(
             lines[0], exact,
             "line at the limit must pass through intact"

--- a/crates/hyalo-cli/tests/e2e/find_result_shape.rs
+++ b/crates/hyalo-cli/tests/e2e/find_result_shape.rs
@@ -451,6 +451,128 @@ fn read_reports_whole_file_size_and_lines() {
 }
 
 // ---------------------------------------------------------------------------
+// read: `lines` derived from the body pass (iteration 253)
+// ---------------------------------------------------------------------------
+
+/// `hyalo read <file> <extra args>` (JSON, no hints) → the `results` object.
+fn read_result(dir: &Path, file: &str, extra: &[&str]) -> serde_json::Value {
+    let output = hyalo_no_hints()
+        .current_dir(dir)
+        .args(["read", file])
+        .args(extra)
+        .args(["--format", "json"])
+        .output()
+        .expect("hyalo should run");
+    assert!(
+        output.status.success(),
+        "read {file} {extra:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("read should print an envelope");
+    envelope["results"].clone()
+}
+
+/// iteration 253 removed `read`'s second full-file scan: on every path that
+/// reads the body, `lines` is now derived from that single pass instead of
+/// from `scanner::count_file_lines`. The number must stay byte-identical to
+/// the independent baseline `on_disk` computes — including on the inputs
+/// where "one streamed line is one counted line" is least obvious: CRLF, a
+/// missing final newline, invalid UTF-8, and a line over the 1 MiB per-line
+/// cap (all of which the body pass turns into placeholders or splits itself).
+#[test]
+fn read_lines_match_disk_for_every_read_mode() {
+    let tmp = TempDir::new().unwrap();
+    let huge = "x".repeat(1024 * 1024 + 1);
+
+    // (name, bytes, has a `## Section` heading to narrow to)
+    let files: Vec<(&str, Vec<u8>)> = vec![
+        (
+            "plain.md",
+            b"---\ntitle: Plain\n---\n\n# Plain\n\n## Section\n\nbody\n".to_vec(),
+        ),
+        (
+            "crlf.md",
+            b"---\r\ntitle: CRLF\r\n---\r\n\r\n# CRLF\r\n\r\n## Section\r\n\r\nbody\r\n".to_vec(),
+        ),
+        (
+            "noeol.md",
+            b"---\ntitle: No EOL\n---\n\n## Section\n\n# End".to_vec(),
+        ),
+        (
+            "utf8.md",
+            "---\ntitle: Üñïçôdé\n---\n\n## Section\n\n日本語のテキスト。\n"
+                .as_bytes()
+                .to_vec(),
+        ),
+        (
+            "badutf8.md",
+            b"---\ntitle: Bad\n---\n\n## Section\n\n\xff\xfe not utf-8\nafter\n".to_vec(),
+        ),
+        (
+            "oversized.md",
+            format!("---\ntitle: Huge\n---\n\n## Section\n\nbefore\n{huge}\nafter\n").into_bytes(),
+        ),
+        ("fmonly.md", b"---\ntitle: Frontmatter only\n---\n".to_vec()),
+        ("nofm.md", b"## Section\n\nno frontmatter here\n".to_vec()),
+    ];
+
+    for (name, bytes) in &files {
+        std::fs::write(tmp.path().join(name), bytes).unwrap();
+    }
+
+    for (name, _) in &files {
+        let (size, lines) = on_disk(tmp.path(), name);
+        // Every mode: whole body, frontmatter-only (the one path that still
+        // scans separately), a narrowed section, and a line range.
+        for extra in [
+            vec![],
+            vec!["--frontmatter"],
+            vec!["--section", "Section"],
+            vec!["--lines", "1:2"],
+            vec!["--frontmatter", "--lines", "1:2"],
+        ] {
+            // `fmonly.md` has no body, so there is no section to narrow to.
+            if extra.contains(&"--section") && *name == "fmonly.md" {
+                continue;
+            }
+            let result = read_result(tmp.path(), name, &extra);
+            assert_eq!(
+                result["lines"].as_u64(),
+                Some(lines as u64),
+                "lines mismatch for {name} read with {extra:?}"
+            );
+            assert_eq!(
+                result["size"].as_u64(),
+                Some(size),
+                "size mismatch for {name} read with {extra:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn read_lines_are_identical_across_narrowing_modes() {
+    // The derived count describes the whole file, so narrowing must not move
+    // it — and the `--frontmatter`-only path (which still scans the file for
+    // its count) must agree with the paths that derive it from the body pass.
+    let tmp = vault(1);
+    let whole = read_result(tmp.path(), "note-00.md", &[]);
+    for extra in [
+        vec!["--frontmatter"],
+        vec!["--section", "Tasks"],
+        vec!["--lines", "1:3"],
+        vec!["--section", "Tasks", "--lines", "1:1"],
+    ] {
+        let narrowed = read_result(tmp.path(), "note-00.md", &extra);
+        assert_eq!(
+            narrowed["lines"], whole["lines"],
+            "narrowing with {extra:?} must not change the reported line count"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Hints
 // ---------------------------------------------------------------------------
 

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -73,8 +73,14 @@ pub fn count_lines(data: &[u8]) -> usize {
 ///
 /// Streams the file through `memchr` in 64 KiB chunks — no UTF-8 conversion,
 /// no per-line allocation — and applies the same counting rule as
-/// [`count_lines`]. Used by `read`, which reports the whole file's `lines`
-/// even when it returns one section or line range of it.
+/// [`count_lines`].
+///
+/// Used by `read --frontmatter` only. `read` reports the whole file's `lines`
+/// even when it returns one section or line range of it, but on every path
+/// that reads the body it derives that number from the body pass it already
+/// made (iteration 253) rather than scanning the file a second time; the
+/// `--frontmatter`-only path deliberately never touches the body, so it is
+/// the one case still left with a dedicated scan.
 pub fn count_file_lines(path: &Path) -> Result<usize> {
     use std::io::Read;
     const CHUNK: usize = 64 * 1024;

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3401,3 +3401,49 @@ the hint is the fastest way to the full shape. The general statement lives
 where it costs nothing instead: the `--format text` `fields:` summary line
 names what the payload carries and what `--fields all` would add, and
 `find --help` says the same.
+
+## DEC-253: `read` derives `lines` from the body pass it already makes; only `--frontmatter` still scans (2026-08-30)
+
+**Decision:** `read` computes the whole-file `lines` it reports (DEC-252)
+from the single body pass it already performs, not from a second
+`scanner::count_file_lines` scan. `read_body_lines` now returns
+`(Vec<String>, usize)` — the body lines plus the frontmatter's line count,
+which `frontmatter::skip_frontmatter` already computed and simply was not
+propagating — and `commands/read.rs::run` captures `fm_lines +
+body_lines.len()` *before* `--section`/`--lines` narrow the vector.
+`count_file_lines` survives for exactly one caller: the
+`--frontmatter`-only path (`need_body == false`), which deliberately never
+touches the body and so has nothing to derive from.
+
+**Why:** DEC-252 made `lines` unconditional, which made the scan
+unconditional too — every `read` that returned body content read the file's
+bytes twice, once streamed through `read_line_capped` and once through
+`memchr`. That doubles disk I/O for precisely the large-file case the
+feature exists to help with, and it contradicts the scanner's standing
+"frontmatter-only queries pay zero cost for body scanning" principle by
+being the one path forced to eat a second full read *after* the body was
+already in hand. Output is byte-identical; this is a pure how-computed
+change, which is why it was not a blocker on PR #293 and landed as its own
+iteration.
+
+**The invariant it rests on:** `scanner::read_line_capped` consumes exactly
+one logical line per call — an over-quota or invalid-UTF-8 line is drained
+to the next `\n` and still occupies exactly one slot in the returned vector
+(as a placeholder), and EOF after an unterminated final line yields that
+line and then `n == 0`. That is the same rule `count_lines` applies (one
+line per `\n`, plus a final unterminated one, zero for an empty file), so
+`fm_lines + body.len()` is not an approximation of the scan — it is the same
+count by construction. `skip_frontmatter` counts the opening and closing
+`---` and everything between them, and bails with an error on unclosed or
+oversized frontmatter, so there is no path where it under-reports a block it
+actually consumed. Both halves are pinned by
+`derived_line_count_matches_a_whole_file_scan` (unit, `read.rs`) and
+`read_lines_match_disk_for_every_read_mode` (e2e, `find_result_shape.rs`),
+which compare against an independent naive counter across CRLF, no-EOL,
+multi-byte UTF-8, invalid-UTF-8 and over-cap-line inputs in every read mode.
+
+**Not done:** removing the `--frontmatter`-only scan. Reporting `lines` there
+requires reading the file's bytes no matter what — the DEC-252 contract says
+every `read` result carries the whole file's `lines` — so that path reads
+the file once, which is already the floor. Making `lines` conditional again
+to avoid it would undo DEC-252, not improve it.

--- a/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
+++ b/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
@@ -41,35 +41,35 @@ section) for the one case still forced to eat a full second read anyway.
 
 ## Tasks
 
-- [ ] `read_body_lines` returns the frontmatter line count alongside the body
+- [x] `read_body_lines` returns the frontmatter line count alongside the body
       lines (e.g. `(Vec<String>, usize)`), without adding I/O — it already
       has this number from `skip_frontmatter`, it just isn't propagated.
-- [ ] In `commands/read.rs::run`, capture the raw body line count right after
+- [x] In `commands/read.rs::run`, capture the raw body line count right after
       `read_body_lines` returns (before `--section`/`--lines` narrow
       `content_lines`), and compute `total_lines = fm_lines + raw_body_lines`
       when `need_body` was true. Keep `scanner::count_file_lines` only for
       the `need_body == false` (`--frontmatter`-only) path.
-- [ ] Unit/e2e test: `total_lines` computed this way matches
+- [x] Unit/e2e test: `total_lines` computed this way matches
       `scanner::count_lines` applied to the whole file, across the same
       CRLF / no-trailing-newline / invalid-UTF-8 / oversized-line cases the
       iter-252 suite already covers for `find` — reuse or extend
       `find_result_shape.rs`'s baseline-comparison helper rather than
       duplicating it.
-- [ ] Confirm no behavior change for `--frontmatter`-only reads (still one
+- [x] Confirm no behavior change for `--frontmatter`-only reads (still one
       full-file scan, not zero — `lines` requires reading the file; this
       iteration only removes the *second* read on the already-body-reading
       paths).
 
 ## Acceptance criteria
 
-- [ ] `read` without `--frontmatter`-only reads the file's bytes once, not
+- [x] `read` without `--frontmatter`-only reads the file's bytes once, not
       twice (verified by the new test comparing against the pre-253 double-
       read behavior, or by inspecting call sites — no new I/O-counting
       instrumentation needs to ship).
-- [ ] `read`'s reported `lines` is byte-identical to today's for every
+- [x] `read`'s reported `lines` is byte-identical to today's for every
       existing `find_result_shape.rs` / `read` e2e case (CRLF, UTF-8,
       no-EOL, frontmatter-only, `--section`, `--lines`).
-- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D
+- [x] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D
       warnings`, `cargo test --workspace -q`.
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
+++ b/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 253 — read: compute lines without a second full-file scan"
 date: 2026-08-30
-status: planned
+status: in-progress
 tags:
   - iteration
   - agent-cli

--- a/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
+++ b/hyalo-knowledgebase/iterations/iteration-253-read-lines-single-pass.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 253 — read: compute lines without a second full-file scan"
 date: 2026-08-30
-status: in-progress
+status: completed
 tags:
   - iteration
   - agent-cli
@@ -39,7 +39,7 @@ feature exists to help with, and contradicts the "frontmatter-only queries
 pay zero cost for body scanning" principle ([[decision-log]], scanner
 section) for the one case still forced to eat a full second read anyway.
 
-## Tasks
+## Tasks [4/4]
 
 - [x] `read_body_lines` returns the frontmatter line count alongside the body
       lines (e.g. `(Vec<String>, usize)`), without adding I/O — it already
@@ -60,7 +60,7 @@ section) for the one case still forced to eat a full second read anyway.
       iteration only removes the *second* read on the already-body-reading
       paths).
 
-## Acceptance criteria
+## Acceptance criteria [3/3]
 
 - [x] `read` without `--frontmatter`-only reads the file's bytes once, not
       twice (verified by the new test comparing against the pre-253 double-


### PR DESCRIPTION
## Summary

- **`read` no longer reads the file twice.** Iteration 252 made `lines` unconditional on every `read` result, computed via `scanner::count_file_lines(&full_path)` — an unconditional second full read from disk, even though `read_body_lines` had *already* streamed the whole body into memory on every path that returns body content. `read_body_lines` now returns `(Vec<String>, usize)` — the body lines plus the frontmatter's line count, which `frontmatter::skip_frontmatter` already computed and simply was not propagating — and `commands/read.rs::run` captures `fm_lines + body_lines.len()` *before* `--section`/`--lines` narrow the vector.
- **`count_file_lines` survives for exactly one caller:** the `--frontmatter`-only path (`need_body == false`), which deliberately never touches the body and so has nothing to derive from. Reporting `lines` there requires reading the file no matter what — that is the DEC-252 contract, and out of scope here.
- **Output is byte-identical.** This is a pure how-computed change: no flag, no field, no number moves. The invariant it rests on is that `scanner::read_line_capped` consumes exactly one logical line per call — an over-quota or invalid-UTF-8 line is drained to the next `\n` and still occupies exactly one placeholder slot — which is the same rule `count_lines` applies, so `fm_lines + body.len()` is the same count by construction rather than an approximation.
- **Docs:** DEC-253 records the decision, the invariant, and why the `--frontmatter` scan stays; `count_file_lines`'s doc comment now names its single remaining caller instead of claiming `read` at large.

## Test plan

- [x] New unit test `derived_line_count_matches_a_whole_file_scan` (`crates/hyalo-cli/src/commands/read.rs`): 17 inputs — empty, lone newline, with/without frontmatter, with/without trailing newline, CRLF throughout, multi-byte UTF-8, invalid UTF-8 in the first/middle/final line, and an over-1 MiB line in the first/middle/final position — each asserted equal to both `scanner::count_lines` over the raw bytes and `scanner::count_file_lines` over the file.
- [x] New e2e `read_lines_match_disk_for_every_read_mode` (`tests/e2e/find_result_shape.rs`): 8 pathological files x 5 read modes (whole, `--frontmatter`, `--section`, `--lines`, `--frontmatter --lines`) compared against the suite's existing independent `on_disk` baseline counter, reusing it rather than duplicating it.
- [x] New e2e `read_lines_are_identical_across_narrowing_modes`: narrowing must not move the count, and the `--frontmatter`-only path (still scanning) must agree with the paths that derive it.
- [x] Mutation-checked: dropping `fm_lines` from the sum makes `read_lines_match_disk_for_every_read_mode` fail, so the new tests actually bite.
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` — all green.
- [x] Every `xtask check-*` gate exits 0 (feature-fanout, help-drift, command-reference, bundled-skills, pi-package-sync, dead-primitives, todo-annotations, mutation-journal).
- [x] Dogfooded with `target/release/hyalo`: `read --frontmatter` and `read --section Goal` on the iteration file both report `4099 B / 88 lines`, matching an independent byte count.

## Carry-over

- Iteration 253's tasks and acceptance criteria are all complete (verified against the landed diff; iteration file status set to `completed`). Local review (`/review-pr local-only`) found no issues to fix.
- The one item the PR body and DEC-253 call out as "not done" — removing the `--frontmatter`-only path's dedicated `scanner::count_file_lines` scan — is not a deferral: DEC-252's contract requires `read --frontmatter` to report `lines`, which requires reading the file at least once, so that scan is the floor, not a shortcut left for later. No follow-up plan needed.
- No other unticked ACs, `[deferred ...]` annotations, or out-of-scope findings were raised in this iteration's plan, PR body, or milestones. Iteration 254's plan (`iteration-254-dogfood-v0220-help-and-shape-fixes.md`) already exists, already links back to this iteration, and already lists its own carry-over items from the v0.22.0 dogfood report — nothing from iter-253 needed to be folded into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS
