### PR TITLE
fix(iter-257): init/deinit follow --dir, and answer --format json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,37 @@ and this project adheres to
 
 ### Fixed
 
+- **`hyalo init --dir <tree-outside-CWD>` wrote a config it then refused to
+  read.** The `.hyalo.toml` landed in the *current* directory with an
+  absolute `dir`, which a project-local config is not allowed to set
+  (iter-221 H-1, tightened in iter-243/244) — so the very next hyalo run
+  rejected the file `init` had just written. `--dir` now decides the project
+  root as well as the vault: a vault at or below CWD keeps `.hyalo.toml` here
+  and records `dir` relative to it, while a vault outside CWD makes that tree
+  its own root, written there with `dir = "."`. Containment is decided on
+  canonicalized paths, so an absolute spelling of a subdirectory, a
+  `sub/../kb` round-trip and macOS's `/tmp` → `/private/tmp` symlink all
+  resolve to "inside" — matching what the reader's own bounds check does
+  (DEC-261).
+- **`hyalo --dir <other-tree> deinit` deleted the *current* tree's
+  integration files.** `deinit` ignored `--dir` entirely and always targeted
+  CWD, so a probe aimed at a throwaway vault removed this repo's own
+  `.hyalo.toml`, `.claude/CLAUDE.md` and three `.claude` symlinks — under a
+  summary whose dozen interleaved `skipped … (not found)` lines read like a
+  no-op at a glance. `deinit` now follows the same root rule as `init` and
+  can no longer touch a tree the user did not name. Any run whose root is not
+  CWD leads its summary with a `target <path>` line (DEC-261).
+- **`init`/`deinit` ignored `--format json`.** Both printed their text
+  summary regardless, so an agent piping JSON got unparseable output. They
+  now answer an explicit `--format json` (or `--jq`, which implies it) with a
+  minimal envelope — `results.command`, `results.root`, `results.actions[]`
+  of `{action, target, detail?}`, plus a hoisted top-level `dir` for `init` —
+  and refuse `--format github` with the same message every other non-lint
+  command gives. They deliberately stay text when merely piped: the summary
+  is a setup progress report, not a result set, so `hyalo init | tee
+  setup.log` keeps working (DEC-262). Text and JSON are rendered from one
+  `Report` struct and cannot drift.
+
 - **Building the wikilink stem index was quadratic in vaults that reuse one
   basename.** `CaseInsensitiveIndex::insert` deduped by linear-scanning the
   *stem* bucket, so a docs tree naming every page `index.md` put its whole

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1370,10 +1370,18 @@ Repeatable (AND).\n\
             re-running is idempotent. A changed scalar prints a `conflict:` line to\n\
             stderr — nothing is lost silently.\n\
             With --profile <name> --claude, also installs the bundled skill for it.\n\n\
-            Use the global --dir flag to specify the markdown directory to record in .hyalo.toml.\n\n\
+            Use the global --dir flag to name the markdown directory. A vault at or below the\n\
+            current directory keeps .hyalo.toml here and records `dir` relative to it; a vault\n\
+            outside it (an absolute path elsewhere, ../sibling) makes that tree its own project\n\
+            root, writing .hyalo.toml there with dir = \".\" — so the config written is always\n\
+            one hyalo can read back (a project-local .hyalo.toml may not set an absolute dir).\n\n\
+            The summary prints as text even when piped; pass --format json (or --jq) for a\n\
+            machine-readable envelope of what was written.\n\n\
             EXAMPLES:\n\
             hyalo init\n\
             hyalo --dir kb init\n\
+            hyalo --dir /elsewhere/vault init\n\
+            hyalo init --dir kb --format json\n\
             hyalo --dir kb init --claude\n\
             hyalo --dir kb init --pi\n\
             hyalo init --profile okf\n\
@@ -1399,7 +1407,17 @@ Repeatable (AND).\n\
     #[command(
         long_about = "Remove .hyalo.toml and all Claude Code / pi integration artifacts created by `init`.\n\n\
             Removes skills, rules, and the managed section from .claude/CLAUDE.md, and .pi/ directory.\n\
-            Safe to run when artifacts are already absent (idempotent)."
+            Safe to run when artifacts are already absent (idempotent).\n\n\
+            The global --dir flag selects the tree to clean, exactly as it does for `init`: a\n\
+            vault inside the current directory still cleans the current project, while --dir\n\
+            naming a tree outside it cleans that tree instead (and the summary leads with a\n\
+            `target` line).\n\n\
+            The summary prints as text even when piped; pass --format json (or --jq) for a\n\
+            machine-readable envelope of what was removed.\n\n\
+            EXAMPLES:\n\
+            hyalo deinit\n\
+            hyalo --dir /elsewhere/vault deinit\n\
+            hyalo deinit --format json"
     )]
     Deinit,
     /// Build a snapshot index for faster repeated read-only queries

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -324,10 +324,10 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo config [--raw] [-d/--dir DIR]                    # --raw also prints the .hyalo.toml text
 
   Init (configuration, one-time setup):
-    hyalo init [--claude] [--pi] [--profile <PROFILE>] [-d/--dir DIR]
+    hyalo init [--claude] [--pi] [--profile <PROFILE>] [-d/--dir DIR]   # --dir outside CWD roots there
 
   Deinit (remove hyalo configuration):
-    hyalo deinit
+    hyalo deinit [-d/--dir DIR]                            # --dir picks the tree to clean; default CWD
 
   Create-index (build snapshot for faster queries):
     hyalo create-index [-o/--output PATH] [--allow-outside-vault]   # --path is an alias for --output

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -324,10 +324,10 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo config [--raw] [-d/--dir DIR]                    # --raw also prints the .hyalo.toml text
 
   Init (configuration, one-time setup):
-    hyalo init [--claude] [--pi] [--profile <PROFILE>] [-d/--dir DIR]   # --dir outside CWD roots there
+    hyalo init [--claude] [--pi] [--profile <PROFILE>] [-d/--dir DIR]   # a vault outside CWD roots there
 
   Deinit (remove hyalo configuration):
-    hyalo deinit [-d/--dir DIR]                            # --dir picks the tree to clean; default CWD
+    hyalo deinit [-d/--dir DIR]                            # picks the tree to clean; default CWD
 
   Create-index (build snapshot for faster queries):
     hyalo create-index [-o/--output PATH] [--allow-outside-vault]   # --path is an alias for --output

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -95,8 +95,12 @@ const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "con
 // ---------------------------------------------------------------------------
 
 /// One filesystem action an `init`/`deinit` run took — or deliberately did not.
+///
+/// Named `Step` rather than `Action` only because a struct may not carry a
+/// field named after itself (`clippy::struct_field_names`); the serialized
+/// field stays `action`, and the list stays `actions`.
 #[derive(Debug, Clone, Serialize)]
-pub struct Action {
+pub struct Step {
     /// What happened: `created`, `updated`, `unchanged`, `removed`, `skipped`
     /// or `warning`.
     action: &'static str,
@@ -127,7 +131,7 @@ pub struct Report {
     #[serde(skip_serializing_if = "Option::is_none")]
     dir: Option<String>,
     /// Every action, in the order the run performed them.
-    actions: Vec<Action>,
+    actions: Vec<Step>,
     /// Trailing advice that is not about one specific file (currently only the
     /// pi install hint).
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -153,7 +157,7 @@ impl Report {
 
     /// Record an action whose verb says everything (`created  .hyalo.toml`).
     fn push(&mut self, action: &'static str, target: impl Into<String>) {
-        self.actions.push(Action {
+        self.actions.push(Step {
             action,
             target: target.into(),
             detail: None,
@@ -167,7 +171,7 @@ impl Report {
         target: impl Into<String>,
         detail: impl Into<String>,
     ) {
-        self.actions.push(Action {
+        self.actions.push(Step {
             action,
             target: target.into(),
             detail: Some(detail.into()),
@@ -820,11 +824,7 @@ fn run_deinit_in(dir: Option<&str>, cwd: &Path) -> Result<Report> {
             let label = format!(".claude/skills/{skill_dir}/SKILL.md");
             remove_artifact(&profile_skill_path, &label, &mut report)?;
             if let Some(parent) = profile_skill_path.parent() {
-                remove_dir_if_empty(
-                    parent,
-                    &format!(".claude/skills/{skill_dir}/"),
-                    &mut report,
-                )?;
+                remove_dir_if_empty(parent, &format!(".claude/skills/{skill_dir}/"), &mut report)?;
             }
         }
     }
@@ -1772,7 +1772,9 @@ mod tests {
     #[test]
     fn run_init_okf_profile_merges_config() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let out = run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap().to_text();
+        let out = run_init_in(Some("."), false, false, Some("okf"), tmp.path())
+            .unwrap()
+            .to_text();
         assert!(out.contains("merged 'okf' profile"), "summary: {out}");
 
         let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
@@ -1791,7 +1793,9 @@ mod tests {
     #[test]
     fn run_init_okf_profile_claude_installs_skill() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let out = run_init_in(Some("."), true, false, Some("okf"), tmp.path()).unwrap().to_text();
+        let out = run_init_in(Some("."), true, false, Some("okf"), tmp.path())
+            .unwrap()
+            .to_text();
         assert!(
             out.contains("created  .claude/skills/okf/SKILL.md"),
             "{out}"
@@ -1832,7 +1836,9 @@ mod tests {
         run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap();
         // A second run makes no change → the summary should say "unchanged",
         // not "updated".
-        let out = run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap().to_text();
+        let out = run_init_in(Some("."), false, false, Some("okf"), tmp.path())
+            .unwrap()
+            .to_text();
         assert!(
             out.contains("unchanged  .hyalo.toml  ('okf' profile already applied)"),
             "re-run summary should report unchanged: {out}"
@@ -1867,13 +1873,17 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
 
         // First run
-        let out1 = run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap().to_text();
+        let out1 = run_init_in(Some("docs"), true, false, None, tmp.path())
+            .unwrap()
+            .to_text();
         assert!(out1.contains("created  .claude/skills/hyalo/SKILL.md"));
         assert!(out1.contains("created  .claude/skills/hyalo-tidy/SKILL.md"));
         assert!(out1.contains("created  .claude/rules/knowledgebase.md"));
 
         // Second run — should say "updated", not "created"
-        let out2 = run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap().to_text();
+        let out2 = run_init_in(Some("docs"), true, false, None, tmp.path())
+            .unwrap()
+            .to_text();
         assert!(out2.contains("updated  .claude/skills/hyalo/SKILL.md"));
         assert!(out2.contains("updated  .claude/skills/hyalo-tidy/SKILL.md"));
         assert!(out2.contains("updated  .claude/rules/knowledgebase.md"));
@@ -1886,7 +1896,9 @@ mod tests {
         // Create initial .hyalo.toml
         fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
 
-        let out = run_init_in(Some("newdir"), false, false, None, tmp.path()).unwrap().to_text();
+        let out = run_init_in(Some("newdir"), false, false, None, tmp.path())
+            .unwrap()
+            .to_text();
         assert!(out.contains(".hyalo.toml"));
 
         let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
@@ -1920,7 +1932,9 @@ mod tests {
 
         fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
 
-        let out = run_init_in(None, false, false, None, tmp.path()).unwrap().to_text();
+        let out = run_init_in(None, false, false, None, tmp.path())
+            .unwrap()
+            .to_text();
         assert!(out.contains("skipped  .hyalo.toml"));
 
         // Content unchanged
@@ -2017,7 +2031,9 @@ mod tests {
     #[test]
     fn run_init_creates_missing_dir_when_explicit() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let out = run_init_in(Some("my-new-docs"), false, false, None, tmp.path()).unwrap().to_text();
+        let out = run_init_in(Some("my-new-docs"), false, false, None, tmp.path())
+            .unwrap()
+            .to_text();
         assert!(
             out.contains("created  my-new-docs/"),
             "summary mentions created dir"
@@ -2032,7 +2048,9 @@ mod tests {
     fn run_init_does_not_create_dir_when_auto_detected() {
         let tmp = tempfile::TempDir::new().unwrap();
         // No --dir flag, auto-detection falls back to "."
-        let out = run_init_in(None, false, false, None, tmp.path()).unwrap().to_text();
+        let out = run_init_in(None, false, false, None, tmp.path())
+            .unwrap()
+            .to_text();
         // No directory creation line — only the .hyalo.toml line.
         // The dir creation line always ends with "/" so check for that form.
         assert!(
@@ -2047,7 +2065,9 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         fs::write(tmp.path().join(".hyalo.toml"), "\"just a string\"\n").unwrap();
 
-        let out = run_init_in(Some("docs"), false, false, None, tmp.path()).unwrap().to_text();
+        let out = run_init_in(Some("docs"), false, false, None, tmp.path())
+            .unwrap()
+            .to_text();
         // Warning emitted.
         assert!(
             out.contains("warning  .hyalo.toml  (was malformed"),
@@ -2202,5 +2222,129 @@ mod tests {
             "managed section removed"
         );
         assert!(!remaining.contains(SECTION_END), "managed section removed");
+    }
+
+    // -----------------------------------------------------------------
+    // `--dir` scoping (iter-257, DEC-261)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn scope_without_dir_stays_in_cwd() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let scope = resolve_scope(None, tmp.path());
+        assert_eq!(scope.root, tmp.path());
+        assert!(!scope.external);
+    }
+
+    #[test]
+    fn scope_relative_dir_stays_in_cwd() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        for (arg, expected) in [
+            (".", "."),
+            ("docs", "docs"),
+            ("docs/", "docs"),
+            ("sub/../kb", "kb"),
+            ("./notes", "notes"),
+        ] {
+            let scope = resolve_scope(Some(arg), tmp.path());
+            assert_eq!(scope.dir_value, expected, "--dir {arg}");
+            assert_eq!(scope.root, tmp.path(), "--dir {arg}");
+            assert!(!scope.external, "--dir {arg}");
+        }
+    }
+
+    #[test]
+    fn scope_absolute_dir_under_cwd_is_relativized() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let docs = tmp.path().join("docs");
+        let scope = resolve_scope(Some(docs.to_str().unwrap()), tmp.path());
+        assert_eq!(scope.dir_value, "docs");
+        assert_eq!(scope.root, tmp.path());
+        assert!(!scope.external);
+    }
+
+    #[test]
+    fn scope_dir_outside_cwd_moves_the_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        let vault = tmp.path().join("vault");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::create_dir_all(&vault).unwrap();
+
+        for arg in [vault.to_str().unwrap(), "../vault"] {
+            let scope = resolve_scope(Some(arg), &cwd);
+            assert!(scope.external, "--dir {arg}");
+            assert_eq!(scope.dir_value, ".", "--dir {arg}");
+            assert_eq!(
+                real_path(&scope.root),
+                real_path(&vault),
+                "--dir {arg} roots at the named tree"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_lexically_collapses_dot_segments() {
+        assert_eq!(
+            normalize_lexically(Path::new("a/./b/../c")),
+            Path::new("a/c")
+        );
+        assert_eq!(normalize_lexically(Path::new("./")), Path::new("."));
+    }
+
+    #[test]
+    fn init_dir_outside_cwd_writes_into_that_tree() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        let vault = tmp.path().join("vault");
+        fs::create_dir_all(&cwd).unwrap();
+
+        let out = run_init_in(Some(vault.to_str().unwrap()), false, false, None, &cwd)
+            .unwrap()
+            .to_text();
+        assert!(
+            !cwd.join(".hyalo.toml").exists(),
+            "CWD keeps no config: {out}"
+        );
+        let written = fs::read_to_string(vault.join(".hyalo.toml")).unwrap();
+        assert!(written.contains(r#"dir = ".""#), "config: {written}");
+        assert!(out.starts_with("target   "), "summary: {out}");
+    }
+
+    #[test]
+    fn deinit_dir_outside_cwd_does_not_touch_cwd() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        let other = tmp.path().join("other");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::create_dir_all(&other).unwrap();
+        run_init_in(Some("."), true, false, None, &cwd).unwrap();
+        run_init_in(Some("."), true, false, None, &other).unwrap();
+
+        let out = run_deinit_in(Some(other.to_str().unwrap()), &cwd)
+            .unwrap()
+            .to_text();
+        assert!(cwd.join(".hyalo.toml").exists(), "CWD untouched: {out}");
+        assert!(
+            cwd.join(".claude").join("CLAUDE.md").exists(),
+            "CWD untouched: {out}"
+        );
+        assert!(!other.join(".hyalo.toml").exists(), "target cleaned: {out}");
+    }
+
+    #[test]
+    fn report_json_carries_actions() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let report = run_init_in(Some("docs"), false, false, None, tmp.path()).unwrap();
+        let json = report.to_json();
+        assert_eq!(json["command"], "init");
+        assert_eq!(json["dir"], "docs");
+        let actions = json["actions"].as_array().unwrap();
+        assert!(
+            actions
+                .iter()
+                .any(|a| a["action"] == "created" && a["target"] == ".hyalo.toml"),
+            "json: {json}"
+        );
     }
 }

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::missing_errors_doc)]
 use anyhow::{Context, Result};
+use serde::Serialize;
 use std::fmt::Write as _;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use toml::Value as TomlValue;
-
-use crate::output::CommandOutcome;
 
 // ---------------------------------------------------------------------------
 // Embedded skill content
@@ -92,6 +91,256 @@ fn active_profiles_from_config(toml_path: &Path) -> Vec<String> {
 const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "content", "pages"];
 
 // ---------------------------------------------------------------------------
+// Structured report
+// ---------------------------------------------------------------------------
+
+/// One filesystem action an `init`/`deinit` run took — or deliberately did not.
+#[derive(Debug, Clone, Serialize)]
+pub struct Action {
+    /// What happened: `created`, `updated`, `unchanged`, `removed`, `skipped`
+    /// or `warning`.
+    action: &'static str,
+    /// The file or directory, relative to [`Report::root`], exactly as the
+    /// text summary prints it.
+    target: String,
+    /// Why, when the verb alone does not say it (`already exists`,
+    /// `not found`, `stripped managed section`, …).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+/// What an `init`/`deinit` run did, rendered either as the human summary or as
+/// the `--format json` body (DEC-262).
+///
+/// Both commands write config and integration files rather than notes, so they
+/// stay outside the mutation-envelope contract (DEC-257) — but they are no
+/// longer text-only: an agent that asks for `--format json` now gets this
+/// structure instead of a summary it cannot parse.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    /// `"init"` or `"deinit"`.
+    command: &'static str,
+    /// Absolute path of the directory holding the `.hyalo.toml` and the
+    /// `.claude`/`.pi` integration files this run touched.
+    root: String,
+    /// The `dir = "…"` value written to `.hyalo.toml` (`init` only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dir: Option<String>,
+    /// Every action, in the order the run performed them.
+    actions: Vec<Action>,
+    /// Trailing advice that is not about one specific file (currently only the
+    /// pi install hint).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    notes: Vec<String>,
+    /// Whether `root` is not the process CWD, because `--dir` named a tree
+    /// outside it. The text rendering then leads with a `target` line so the
+    /// summary can never be misread as one about CWD (DEC-261).
+    #[serde(skip_serializing)]
+    external_root: bool,
+}
+
+impl Report {
+    fn new(command: &'static str, scope: &Scope, dir: Option<String>) -> Self {
+        Self {
+            command,
+            root: scope.root.display().to_string(),
+            dir,
+            actions: Vec::new(),
+            notes: Vec::new(),
+            external_root: scope.external,
+        }
+    }
+
+    /// Record an action whose verb says everything (`created  .hyalo.toml`).
+    fn push(&mut self, action: &'static str, target: impl Into<String>) {
+        self.actions.push(Action {
+            action,
+            target: target.into(),
+            detail: None,
+        });
+    }
+
+    /// Record an action that needs a parenthesised reason.
+    fn push_detail(
+        &mut self,
+        action: &'static str,
+        target: impl Into<String>,
+        detail: impl Into<String>,
+    ) {
+        self.actions.push(Action {
+            action,
+            target: target.into(),
+            detail: Some(detail.into()),
+        });
+    }
+
+    /// The human summary — one line per action, in order.
+    #[must_use]
+    pub fn to_text(&self) -> String {
+        let mut out = String::new();
+        // A run whose root is not CWD says so first: without it the body reads
+        // exactly like a run against the current directory, which is how a
+        // `--dir`-scoped `deinit` used to look while deleting the wrong tree.
+        if self.external_root {
+            let _ = writeln!(out, "target   {}", self.root);
+        }
+        for action in &self.actions {
+            match &action.detail {
+                Some(detail) => {
+                    let _ = writeln!(out, "{}  {}  ({detail})", action.action, action.target);
+                }
+                None => {
+                    let _ = writeln!(out, "{}  {}", action.action, action.target);
+                }
+            }
+        }
+        for note in &self.notes {
+            let _ = writeln!(out, "\n{note}");
+        }
+        out.trim_end().to_owned()
+    }
+
+    /// The `--format json` body. Serialization of a plain struct of owned
+    /// strings cannot fail; an empty object is returned instead of panicking.
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `--dir` scoping
+// ---------------------------------------------------------------------------
+
+/// Where an `init`/`deinit` run puts — or looks for — a project's hyalo files.
+///
+/// `--dir` names the *vault*; the vault decides the *root* (the directory that
+/// holds `.hyalo.toml` and the `.claude`/`.pi` integration files):
+///
+/// - vault at or below CWD (`--dir docs`, `--dir /repo/docs` from `/repo`, or
+///   no `--dir` at all) → root stays CWD, `dir` is written CWD-relative;
+/// - vault outside CWD (`--dir /elsewhere/vault`, `--dir ../sibling`) → the
+///   root moves into that tree and `dir` becomes `"."`.
+///
+/// This is what keeps `init` from writing a config it would refuse to read on
+/// the next run (a project-local `.hyalo.toml` may not set an absolute `dir`,
+/// nor one that escapes its own directory — iter-221/243), and what stops a
+/// `--dir`-scoped `deinit` from deleting CWD's integration files. See DEC-261.
+struct Scope {
+    /// Directory holding `.hyalo.toml` and the integration files.
+    root: PathBuf,
+    /// Value for the `dir` key — always relative to [`Self::root`].
+    dir_value: String,
+    /// True when [`Self::root`] is not CWD.
+    external: bool,
+}
+
+fn resolve_scope(dir: Option<&str>, cwd: &Path) -> Scope {
+    let Some(raw) = dir else {
+        return Scope {
+            root: cwd.to_path_buf(),
+            dir_value: auto_detect_dir(cwd),
+            external: false,
+        };
+    };
+    let requested = {
+        let p = Path::new(raw);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            cwd.join(p)
+        }
+    };
+    match relative_within(cwd, &requested) {
+        Some(rel) => Scope {
+            root: cwd.to_path_buf(),
+            dir_value: rel,
+            external: false,
+        },
+        None => Scope {
+            root: requested,
+            dir_value: ".".to_owned(),
+            external: true,
+        },
+    }
+}
+
+/// `target` expressed relative to `base` with forward slashes, or `None` when
+/// it does not lie at or below `base`.
+///
+/// Both sides go through [`real_path`] first, so a target that only *looks*
+/// outside (an absolute spelling of a subdirectory, `sub/../kb`, a `/tmp`
+/// symlink into `/private/tmp` on macOS) is still recognised as inside — and a
+/// symlink that genuinely points out of the tree is recognised as outside.
+fn relative_within(base: &Path, target: &Path) -> Option<String> {
+    let target_real = real_path(target);
+    let rel = target_real.strip_prefix(real_path(base)).ok()?;
+    let parts: Vec<String> = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    Some(if parts.is_empty() {
+        ".".to_owned()
+    } else {
+        parts.join("/")
+    })
+}
+
+/// Canonicalize as much of `path` as exists on disk, keeping the rest verbatim.
+///
+/// Plain `canonicalize` is not enough here: `init --dir docs` names a directory
+/// that usually does not exist yet, and comparing a canonicalized CWD against a
+/// merely-lexical target would misfile every `/tmp`-rooted vault on macOS
+/// (`/tmp` is a symlink to `/private/tmp`). Canonicalizing the deepest existing
+/// ancestor puts both sides in the same spelling.
+fn real_path(path: &Path) -> PathBuf {
+    let normalized = normalize_lexically(path);
+    let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+    let mut current = normalized.clone();
+    loop {
+        if let Ok(canonical) = dunce::canonicalize(&current) {
+            let mut out = canonical;
+            for part in suffix.iter().rev() {
+                out.push(part);
+            }
+            return out;
+        }
+        let (Some(name), Some(parent)) = (
+            current.file_name().map(std::ffi::OsStr::to_os_string),
+            current.parent().map(Path::to_path_buf),
+        ) else {
+            return normalized;
+        };
+        if parent.as_os_str().is_empty() {
+            return normalized;
+        }
+        suffix.push(name);
+        current = parent;
+    }
+}
+
+/// Resolve `.` and `..` components without touching the filesystem.
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !out.pop() {
+                    out.push("..");
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    if out.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Public command entry point
 // ---------------------------------------------------------------------------
 
@@ -103,12 +352,15 @@ const CANDIDATE_DIRS: &[&str] = &["docs", "knowledgebase", "wiki", "notes", "con
 ///   writes a managed section to `.claude/CLAUDE.md`.
 /// - `pi`: when `true`, also installs the hyalo and hyalo-tidy skills for pi,
 ///   the hyalo extension, and a package.json.
+///
+/// When `dir` names a tree outside CWD, the whole run moves into that tree
+/// (see [`Scope`]) instead of writing a CWD-local config pointing at it.
 pub fn run_init(
     dir: Option<&str>,
     claude: bool,
     pi: bool,
     profile: Option<&str>,
-) -> Result<CommandOutcome> {
+) -> Result<Report> {
     let cwd = std::env::current_dir().context("failed to determine current working directory")?;
     run_init_in(dir, claude, pi, profile, &cwd)
 }
@@ -119,7 +371,7 @@ fn run_init_in(
     pi: bool,
     profile: Option<&str>,
     cwd: &Path,
-) -> Result<CommandOutcome> {
+) -> Result<Report> {
     // Resolve the profile up front so an unknown name errors before any files
     // are written.
     let profile = match profile {
@@ -127,20 +379,30 @@ fn run_init_in(
         None => None,
     };
 
-    let mut summary = String::new();
-
-    // Resolve the directory value once, so we can use it both for .hyalo.toml
-    // and for the rules file path substitution.
+    // Resolve, once, both the value written as `dir` and the root everything
+    // else is written under (DEC-261). `dir_value` is always root-relative, so
+    // the config this run writes is one the next run can actually read.
+    let scope = resolve_scope(dir, cwd);
     let dir_explicit = dir.is_some();
-    let dir_value = match dir {
-        Some(d) => d.to_owned(),
-        None => auto_detect_dir(cwd),
-    };
+    let dir_value = scope.dir_value.clone();
+    let mut report = Report::new("init", &scope, Some(dir_value.clone()));
+    let root = scope.root.as_path();
 
-    // Create the target directory if it doesn't exist and --dir was explicit.
-    // Skip "." since the current directory always exists.
+    if root.is_file() {
+        anyhow::bail!("--dir path '{}' is a file, not a directory", root.display());
+    }
+    // A vault outside CWD becomes its own project root, so create the tree
+    // itself before writing `.hyalo.toml` into it.
+    if scope.external && !root.exists() {
+        fs::create_dir_all(root)
+            .with_context(|| format!("failed to create directory {}", root.display()))?;
+        report.push("created", format!("{}/", root.display()));
+    }
+
+    // Create the vault directory if it doesn't exist and --dir was explicit.
+    // Skip "." since the root directory always exists by now.
     if dir_explicit && dir_value != "." {
-        let target = cwd.join(&dir_value);
+        let target = root.join(&dir_value);
         if target.is_file() {
             anyhow::bail!(
                 "--dir path '{}' is a file, not a directory",
@@ -150,17 +412,17 @@ fn run_init_in(
         if !target.exists() {
             fs::create_dir_all(&target)
                 .with_context(|| format!("failed to create directory {}", target.display()))?;
-            let _ = writeln!(summary, "created  {dir_value}/");
+            report.push("created", format!("{dir_value}/"));
         }
     }
 
     // ------------------------------------------------------------------
     // Step 1: create or update .hyalo.toml
     // ------------------------------------------------------------------
-    let toml_path = cwd.join(".hyalo.toml");
+    let toml_path = root.join(".hyalo.toml");
     let toml_existed = toml_path.exists();
     if toml_existed && !dir_explicit {
-        let _ = writeln!(summary, "skipped  .hyalo.toml (already exists)");
+        report.push_detail("skipped", ".hyalo.toml", "already exists");
     } else {
         let toml_content = if toml_existed {
             // Read and parse the existing file; update only the `dir` key so
@@ -177,9 +439,10 @@ fn run_init_in(
                 doc.to_string()
             } else {
                 // Malformed existing file — overwrite with just dir and note it.
-                let _ = writeln!(
-                    summary,
-                    "warning  .hyalo.toml was malformed; existing content replaced"
+                report.push_detail(
+                    "warning",
+                    ".hyalo.toml",
+                    "was malformed; existing content replaced",
                 );
                 minimal_toml_dir(&dir_value)
             }
@@ -189,9 +452,9 @@ fn run_init_in(
         fs::write(&toml_path, &toml_content)
             .with_context(|| format!("failed to write {}", toml_path.display()))?;
         if toml_existed {
-            let _ = writeln!(summary, "updated  .hyalo.toml  (dir = \"{dir_value}\")");
+            report.push_detail("updated", ".hyalo.toml", format!("dir = \"{dir_value}\""));
         } else {
-            let _ = writeln!(summary, "created  .hyalo.toml  (dir = \"{dir_value}\")");
+            report.push_detail("created", ".hyalo.toml", format!("dir = \"{dir_value}\""));
         }
     }
 
@@ -221,16 +484,16 @@ fn run_init_in(
             crate::warn::warn(conflict.line(profile.name));
         }
         if profile_unchanged {
-            let _ = writeln!(
-                summary,
-                "unchanged  .hyalo.toml  ('{}' profile already applied)",
-                profile.name
+            report.push_detail(
+                "unchanged",
+                ".hyalo.toml",
+                format!("'{}' profile already applied", profile.name),
             );
         } else {
-            let _ = writeln!(
-                summary,
-                "updated  .hyalo.toml  (merged '{}' profile)",
-                profile.name
+            report.push_detail(
+                "updated",
+                ".hyalo.toml",
+                format!("merged '{}' profile", profile.name),
             );
         }
 
@@ -242,8 +505,8 @@ fn run_init_in(
         // not already set (idempotent, never clobbers a user override) and the
         // root file actually exists but the vault-local one does not.
         if profile.name == "changelog" && dir_value != "." {
-            let root_changelog = cwd.join("CHANGELOG.md");
-            let vault_changelog = cwd.join(&dir_value).join("CHANGELOG.md");
+            let root_changelog = root.join("CHANGELOG.md");
+            let vault_changelog = root.join(&dir_value).join("CHANGELOG.md");
             if root_changelog.is_file() && !vault_changelog.is_file() {
                 let existing_raw = fs::read_to_string(&toml_path)
                     .with_context(|| format!("failed to read {}", toml_path.display()))?;
@@ -264,9 +527,10 @@ fn run_init_in(
                         }
                         fs::write(&toml_path, doc.to_string())
                             .with_context(|| format!("failed to write {}", toml_path.display()))?;
-                        let _ = writeln!(
-                            summary,
-                            "updated  .hyalo.toml  ([changelog] path = \"CHANGELOG.md\")"
+                        report.push_detail(
+                            "updated",
+                            ".hyalo.toml",
+                            "[changelog] path = \"CHANGELOG.md\"",
                         );
                     }
                 }
@@ -275,7 +539,7 @@ fn run_init_in(
     }
 
     if !claude && !pi {
-        return Ok(CommandOutcome::RawOutput(summary.trim_end().to_owned()));
+        return Ok(report);
     }
 
     // ------------------------------------------------------------------
@@ -283,7 +547,7 @@ fn run_init_in(
     // ------------------------------------------------------------------
     if claude {
         // Step 2: write (overwrite) .claude/skills/hyalo/SKILL.md
-        let skill_path = cwd
+        let skill_path = root
             .join(".claude")
             .join("skills")
             .join("hyalo")
@@ -300,13 +564,13 @@ fn run_init_in(
         )
         .with_context(|| format!("failed to write {}", skill_path.display()))?;
         if skill_existed {
-            let _ = writeln!(summary, "updated  .claude/skills/hyalo/SKILL.md");
+            report.push("updated", ".claude/skills/hyalo/SKILL.md");
         } else {
-            let _ = writeln!(summary, "created  .claude/skills/hyalo/SKILL.md");
+            report.push("created", ".claude/skills/hyalo/SKILL.md");
         }
 
         // Step 3: write (overwrite) .claude/skills/hyalo-tidy/SKILL.md
-        let tidy_skill_path = cwd
+        let tidy_skill_path = root
             .join(".claude")
             .join("skills")
             .join("hyalo-tidy")
@@ -323,13 +587,13 @@ fn run_init_in(
         )
         .with_context(|| format!("failed to write {}", tidy_skill_path.display()))?;
         if tidy_skill_existed {
-            let _ = writeln!(summary, "updated  .claude/skills/hyalo-tidy/SKILL.md");
+            report.push("updated", ".claude/skills/hyalo-tidy/SKILL.md");
         } else {
-            let _ = writeln!(summary, "created  .claude/skills/hyalo-tidy/SKILL.md");
+            report.push("created", ".claude/skills/hyalo-tidy/SKILL.md");
         }
 
         // Step 4: write (overwrite) .claude/rules/knowledgebase.md
-        let rules_path = cwd.join(".claude").join("rules").join("knowledgebase.md");
+        let rules_path = root.join(".claude").join("rules").join("knowledgebase.md");
         let rules_existed = rules_path.exists();
         let rules_dir = rules_path
             .parent()
@@ -340,9 +604,9 @@ fn run_init_in(
         fs::write(&rules_path, &rule_content)
             .with_context(|| format!("failed to write {}", rules_path.display()))?;
         if rules_existed {
-            let _ = writeln!(summary, "updated  .claude/rules/knowledgebase.md");
+            report.push("updated", ".claude/rules/knowledgebase.md");
         } else {
-            let _ = writeln!(summary, "created  .claude/rules/knowledgebase.md");
+            report.push("created", ".claude/rules/knowledgebase.md");
         }
 
         // Step 5: upsert the hyalo managed section in .claude/CLAUDE.md.
@@ -351,7 +615,7 @@ fn run_init_in(
         // several profiles carries a drift-check reminder for each — and the
         // lines survive across `init --profile` runs because they are rebuilt
         // from the config each time, not just from the current `--profile`.
-        let claude_md_path = cwd.join(".claude").join("CLAUDE.md");
+        let claude_md_path = root.join(".claude").join("CLAUDE.md");
         let managed_section = {
             let active = active_profiles_from_config(&toml_path);
             let mut body = String::from(CLAUDE_MD_HINT);
@@ -367,7 +631,7 @@ fn run_init_in(
             let (new_content, action) = upsert_managed_section(&existing, &managed_section);
             fs::write(&claude_md_path, &new_content)
                 .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
-            let _ = writeln!(summary, "updated  .claude/CLAUDE.md ({action})");
+            report.push_detail("updated", ".claude/CLAUDE.md", action);
         } else {
             // Create the file and any parent directories.
             let claude_dir = claude_md_path
@@ -378,13 +642,13 @@ fn run_init_in(
             let content = format!("{managed_section}\n");
             fs::write(&claude_md_path, content)
                 .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
-            let _ = writeln!(summary, "created  .claude/CLAUDE.md (with managed section)");
+            report.push_detail("created", ".claude/CLAUDE.md", "with managed section");
         }
 
         // Step 6: install any profile-specific skills (e.g. `okf`).
         if let Some(profile) = profile {
             for (skill_dir, skill_body) in profile.skills {
-                let profile_skill_path = cwd
+                let profile_skill_path = root
                     .join(".claude")
                     .join("skills")
                     .join(skill_dir)
@@ -398,7 +662,7 @@ fn run_init_in(
                 fs::write(&profile_skill_path, skill_body)
                     .with_context(|| format!("failed to write {}", profile_skill_path.display()))?;
                 let verb = if existed { "updated" } else { "created" };
-                let _ = writeln!(summary, "{verb}  .claude/skills/{skill_dir}/SKILL.md");
+                report.push(verb, format!(".claude/skills/{skill_dir}/SKILL.md"));
             }
         }
     }
@@ -408,7 +672,7 @@ fn run_init_in(
     // ------------------------------------------------------------------
     if pi {
         // Step 6: write (overwrite) .pi/skills/hyalo/SKILL.md
-        let pi_skill_path = cwd
+        let pi_skill_path = root
             .join(".pi")
             .join("skills")
             .join("hyalo")
@@ -425,13 +689,13 @@ fn run_init_in(
         )
         .with_context(|| format!("failed to write {}", pi_skill_path.display()))?;
         if pi_skill_existed {
-            let _ = writeln!(summary, "updated  .pi/skills/hyalo/SKILL.md");
+            report.push("updated", ".pi/skills/hyalo/SKILL.md");
         } else {
-            let _ = writeln!(summary, "created  .pi/skills/hyalo/SKILL.md");
+            report.push("created", ".pi/skills/hyalo/SKILL.md");
         }
 
         // Step 7: write (overwrite) .pi/skills/hyalo-tidy/SKILL.md
-        let pi_tidy_skill_path = cwd
+        let pi_tidy_skill_path = root
             .join(".pi")
             .join("skills")
             .join("hyalo-tidy")
@@ -449,13 +713,13 @@ fn run_init_in(
         )
         .with_context(|| format!("failed to write {}", pi_tidy_skill_path.display()))?;
         if pi_tidy_skill_existed {
-            let _ = writeln!(summary, "updated  .pi/skills/hyalo-tidy/SKILL.md");
+            report.push("updated", ".pi/skills/hyalo-tidy/SKILL.md");
         } else {
-            let _ = writeln!(summary, "created  .pi/skills/hyalo-tidy/SKILL.md");
+            report.push("created", ".pi/skills/hyalo-tidy/SKILL.md");
         }
 
         // Step 8: write (overwrite) .pi/extensions/hyalo.ts
-        let pi_extension_path = cwd.join(".pi").join("extensions").join("hyalo.ts");
+        let pi_extension_path = root.join(".pi").join("extensions").join("hyalo.ts");
         let pi_extension_existed = pi_extension_path.exists();
         let pi_extension_dir = pi_extension_path
             .parent()
@@ -466,13 +730,13 @@ fn run_init_in(
         fs::write(&pi_extension_path, PI_EXTENSION_CONTENT)
             .with_context(|| format!("failed to write {}", pi_extension_path.display()))?;
         if pi_extension_existed {
-            let _ = writeln!(summary, "updated  .pi/extensions/hyalo.ts");
+            report.push("updated", ".pi/extensions/hyalo.ts");
         } else {
-            let _ = writeln!(summary, "created  .pi/extensions/hyalo.ts");
+            report.push("created", ".pi/extensions/hyalo.ts");
         }
 
         // Step 9: write (overwrite) .pi/package.json
-        let pi_package_path = cwd.join(".pi").join("package.json");
+        let pi_package_path = root.join(".pi").join("package.json");
         let pi_package_existed = pi_package_path.exists();
         let pi_package_dir = pi_package_path
             .parent()
@@ -482,16 +746,16 @@ fn run_init_in(
         fs::write(&pi_package_path, PI_PACKAGE_JSON_CONTENT)
             .with_context(|| format!("failed to write {}", pi_package_path.display()))?;
         if pi_package_existed {
-            let _ = writeln!(summary, "updated  .pi/package.json");
+            report.push("updated", ".pi/package.json");
         } else {
-            let _ = writeln!(summary, "created  .pi/package.json");
+            report.push("created", ".pi/package.json");
             // One-time hint: the vendored copy never updates itself. Suggest
             // the git package source so `pi update` delivers fixes.
-            let _ = writeln!(summary, "\n{PI_INSTALL_HINT}");
+            report.notes.push(PI_INSTALL_HINT.to_owned());
         }
     }
 
-    Ok(CommandOutcome::RawOutput(summary.trim_end().to_owned()))
+    Ok(report)
 }
 
 // ---------------------------------------------------------------------------
@@ -499,28 +763,38 @@ fn run_init_in(
 // ---------------------------------------------------------------------------
 
 /// Remove hyalo configuration and Claude Code / pi integration artifacts.
-pub fn run_deinit() -> Result<CommandOutcome> {
+///
+/// `dir` is the global `--dir` value. It is honoured exactly as `init` honours
+/// it (see [`Scope`]): a vault at or below CWD leaves the root at CWD, while a
+/// vault outside CWD moves the whole removal into that tree. Before iter-257
+/// `--dir` was ignored here, so `hyalo --dir /elsewhere deinit` deleted CWD's
+/// `.hyalo.toml` and `.claude` integration files instead — DEC-261.
+pub fn run_deinit(dir: Option<&str>) -> Result<Report> {
     let cwd = std::env::current_dir().context("failed to determine current working directory")?;
-    run_deinit_in(&cwd)
+    run_deinit_in(dir, &cwd)
 }
 
-fn run_deinit_in(cwd: &Path) -> Result<CommandOutcome> {
-    let mut summary = String::new();
+fn run_deinit_in(dir: Option<&str>, cwd: &Path) -> Result<Report> {
+    // `deinit` removes integration files, never the vault itself, so the vault
+    // value resolved here only decides *which tree* is the target.
+    let scope = resolve_scope(dir, cwd);
+    let root = scope.root.as_path();
+    let mut report = Report::new("deinit", &scope, None);
 
     // Step 1: Remove .claude/skills/hyalo/SKILL.md and parent dir if empty.
-    let skill_path = cwd
+    let skill_path = root
         .join(".claude")
         .join("skills")
         .join("hyalo")
         .join("SKILL.md");
-    remove_artifact(&skill_path, ".claude/skills/hyalo/SKILL.md", &mut summary)?;
+    remove_artifact(&skill_path, ".claude/skills/hyalo/SKILL.md", &mut report)?;
     let skill_dir = skill_path
         .parent()
         .context("skill path has no parent directory")?;
-    remove_dir_if_empty(skill_dir, ".claude/skills/hyalo/", &mut summary)?;
+    remove_dir_if_empty(skill_dir, ".claude/skills/hyalo/", &mut report)?;
 
     // Step 2: Remove .claude/skills/hyalo-tidy/SKILL.md and parent dir if empty.
-    let tidy_skill_path = cwd
+    let tidy_skill_path = root
         .join(".claude")
         .join("skills")
         .join("hyalo-tidy")
@@ -528,47 +802,47 @@ fn run_deinit_in(cwd: &Path) -> Result<CommandOutcome> {
     remove_artifact(
         &tidy_skill_path,
         ".claude/skills/hyalo-tidy/SKILL.md",
-        &mut summary,
+        &mut report,
     )?;
     let tidy_skill_dir = tidy_skill_path
         .parent()
         .context("tidy skill path has no parent directory")?;
-    remove_dir_if_empty(tidy_skill_dir, ".claude/skills/hyalo-tidy/", &mut summary)?;
+    remove_dir_if_empty(tidy_skill_dir, ".claude/skills/hyalo-tidy/", &mut report)?;
 
     // Step 2b: Remove profile skills (e.g. `okf`) and their parent dirs if empty.
     for profile in crate::commands::profiles::PROFILES {
         for (skill_dir, _body) in profile.skills {
-            let profile_skill_path = cwd
+            let profile_skill_path = root
                 .join(".claude")
                 .join("skills")
                 .join(skill_dir)
                 .join("SKILL.md");
             let label = format!(".claude/skills/{skill_dir}/SKILL.md");
-            remove_artifact(&profile_skill_path, &label, &mut summary)?;
+            remove_artifact(&profile_skill_path, &label, &mut report)?;
             if let Some(parent) = profile_skill_path.parent() {
                 remove_dir_if_empty(
                     parent,
                     &format!(".claude/skills/{skill_dir}/"),
-                    &mut summary,
+                    &mut report,
                 )?;
             }
         }
     }
 
     // Step 3: Remove .claude/rules/knowledgebase.md and parent dir if empty.
-    let rules_path = cwd.join(".claude").join("rules").join("knowledgebase.md");
-    remove_artifact(&rules_path, ".claude/rules/knowledgebase.md", &mut summary)?;
+    let rules_path = root.join(".claude").join("rules").join("knowledgebase.md");
+    remove_artifact(&rules_path, ".claude/rules/knowledgebase.md", &mut report)?;
     let rules_dir = rules_path
         .parent()
         .context("rules path has no parent directory")?;
-    remove_dir_if_empty(rules_dir, ".claude/rules/", &mut summary)?;
+    remove_dir_if_empty(rules_dir, ".claude/rules/", &mut report)?;
 
     // Step 4: Remove .claude/skills/ if empty.
-    let all_skills_dir = cwd.join(".claude").join("skills");
-    remove_dir_if_empty(&all_skills_dir, ".claude/skills/", &mut summary)?;
+    let all_skills_dir = root.join(".claude").join("skills");
+    remove_dir_if_empty(&all_skills_dir, ".claude/skills/", &mut report)?;
 
     // Step 5: Strip the managed section from .claude/CLAUDE.md.
-    let claude_md_path = cwd.join(".claude").join("CLAUDE.md");
+    let claude_md_path = root.join(".claude").join("CLAUDE.md");
     if claude_md_path.exists() {
         let content = fs::read_to_string(&claude_md_path)
             .with_context(|| format!("failed to read {}", claude_md_path.display()))?;
@@ -577,44 +851,38 @@ fn run_deinit_in(cwd: &Path) -> Result<CommandOutcome> {
             if stripped.is_empty() {
                 fs::remove_file(&claude_md_path)
                     .with_context(|| format!("failed to remove {}", claude_md_path.display()))?;
-                let _ = writeln!(
-                    summary,
-                    "removed  .claude/CLAUDE.md (empty after stripping)"
-                );
+                report.push_detail("removed", ".claude/CLAUDE.md", "empty after stripping");
             } else {
                 fs::write(&claude_md_path, &stripped)
                     .with_context(|| format!("failed to write {}", claude_md_path.display()))?;
-                let _ = writeln!(
-                    summary,
-                    "updated  .claude/CLAUDE.md (stripped managed section)"
-                );
+                report.push_detail("updated", ".claude/CLAUDE.md", "stripped managed section");
             }
         } else {
-            let _ = writeln!(summary, "skipped  .claude/CLAUDE.md (no managed section)");
+            report.push_detail("skipped", ".claude/CLAUDE.md", "no managed section");
         }
     } else {
-        let _ = writeln!(summary, "skipped  .claude/CLAUDE.md (not found)");
+        report.push_detail("skipped", ".claude/CLAUDE.md", "not found");
     }
 
     // Clean up .claude/ itself if now empty.
-    let claude_dir = cwd.join(".claude");
-    remove_dir_if_empty(&claude_dir, ".claude/", &mut summary)?;
+    let claude_dir = root.join(".claude");
+    remove_dir_if_empty(&claude_dir, ".claude/", &mut report)?;
 
     // Step 6: Remove pi artifacts
     // Remove .pi/skills/hyalo/SKILL.md and parent dir if empty.
-    let pi_skill_path = cwd
+    let pi_skill_path = root
         .join(".pi")
         .join("skills")
         .join("hyalo")
         .join("SKILL.md");
-    remove_artifact(&pi_skill_path, ".pi/skills/hyalo/SKILL.md", &mut summary)?;
+    remove_artifact(&pi_skill_path, ".pi/skills/hyalo/SKILL.md", &mut report)?;
     let pi_skill_dir = pi_skill_path
         .parent()
         .context("pi skill path has no parent directory")?;
-    remove_dir_if_empty(pi_skill_dir, ".pi/skills/hyalo/", &mut summary)?;
+    remove_dir_if_empty(pi_skill_dir, ".pi/skills/hyalo/", &mut report)?;
 
     // Remove .pi/skills/hyalo-tidy/SKILL.md and parent dir if empty.
-    let pi_tidy_skill_path = cwd
+    let pi_tidy_skill_path = root
         .join(".pi")
         .join("skills")
         .join("hyalo-tidy")
@@ -622,62 +890,62 @@ fn run_deinit_in(cwd: &Path) -> Result<CommandOutcome> {
     remove_artifact(
         &pi_tidy_skill_path,
         ".pi/skills/hyalo-tidy/SKILL.md",
-        &mut summary,
+        &mut report,
     )?;
     let pi_tidy_skill_dir = pi_tidy_skill_path
         .parent()
         .context("pi tidy skill path has no parent directory")?;
-    remove_dir_if_empty(pi_tidy_skill_dir, ".pi/skills/hyalo-tidy/", &mut summary)?;
+    remove_dir_if_empty(pi_tidy_skill_dir, ".pi/skills/hyalo-tidy/", &mut report)?;
 
     // Remove .pi/skills/ if empty (after removing hyalo and hyalo-tidy subdirectories)
-    let pi_skills_parent_dir = cwd.join(".pi").join("skills");
-    remove_dir_if_empty(&pi_skills_parent_dir, ".pi/skills/", &mut summary)?;
+    let pi_skills_parent_dir = root.join(".pi").join("skills");
+    remove_dir_if_empty(&pi_skills_parent_dir, ".pi/skills/", &mut report)?;
 
     // Remove .pi/extensions/hyalo.ts
-    let pi_extension_path = cwd.join(".pi").join("extensions").join("hyalo.ts");
-    remove_artifact(&pi_extension_path, ".pi/extensions/hyalo.ts", &mut summary)?;
+    let pi_extension_path = root.join(".pi").join("extensions").join("hyalo.ts");
+    remove_artifact(&pi_extension_path, ".pi/extensions/hyalo.ts", &mut report)?;
     let pi_extension_dir = pi_extension_path
         .parent()
         .context("pi extension path has no parent directory")?;
-    remove_dir_if_empty(pi_extension_dir, ".pi/extensions/", &mut summary)?;
+    remove_dir_if_empty(pi_extension_dir, ".pi/extensions/", &mut report)?;
 
     // Remove .pi/package.json
-    let pi_package_path = cwd.join(".pi").join("package.json");
-    remove_artifact(&pi_package_path, ".pi/package.json", &mut summary)?;
+    let pi_package_path = root.join(".pi").join("package.json");
+    remove_artifact(&pi_package_path, ".pi/package.json", &mut report)?;
     let pi_package_dir = pi_package_path
         .parent()
         .context("pi package.json path has no parent directory")?;
-    remove_dir_if_empty(pi_package_dir, ".pi/", &mut summary)?;
+    remove_dir_if_empty(pi_package_dir, ".pi/", &mut report)?;
 
     // Remove .pi/ if empty.
-    let pi_dir = cwd.join(".pi");
-    remove_dir_if_empty(&pi_dir, ".pi/", &mut summary)?;
+    let pi_dir = root.join(".pi");
+    remove_dir_if_empty(&pi_dir, ".pi/", &mut report)?;
 
     // Step 7: Remove .hyalo.toml.
-    let toml_path = cwd.join(".hyalo.toml");
-    remove_artifact(&toml_path, ".hyalo.toml", &mut summary)?;
+    let toml_path = root.join(".hyalo.toml");
+    remove_artifact(&toml_path, ".hyalo.toml", &mut report)?;
 
-    Ok(CommandOutcome::RawOutput(summary.trim_end().to_owned()))
+    Ok(report)
 }
 
-/// Remove `path` if it exists and append a status line to `summary`.
+/// Remove `path` if it exists and record the outcome on `report`.
 /// Returns `Ok(true)` if the file was actually removed.
-fn remove_artifact(path: &Path, label: &str, summary: &mut String) -> Result<bool> {
+fn remove_artifact(path: &Path, label: &str, report: &mut Report) -> Result<bool> {
     match fs::remove_file(path) {
         Ok(()) => {
-            let _ = writeln!(summary, "removed  {label}");
+            report.push("removed", label);
             Ok(true)
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            let _ = writeln!(summary, "skipped  {label} (not found)");
+            report.push_detail("skipped", label, "not found");
             Ok(false)
         }
         Err(e) => Err(e).with_context(|| format!("failed to remove {}", path.display())),
     }
 }
 
-/// Remove `dir` if it exists and is empty. Appends a status line to `summary` only if removed.
-fn remove_dir_if_empty(dir: &Path, label: &str, summary: &mut String) -> Result<()> {
+/// Remove `dir` if it exists and is empty. Records an action only if removed.
+fn remove_dir_if_empty(dir: &Path, label: &str, report: &mut Report) -> Result<()> {
     if dir.is_dir() {
         let is_empty = fs::read_dir(dir)
             .with_context(|| format!("failed to read directory {}", dir.display()))?
@@ -686,7 +954,7 @@ fn remove_dir_if_empty(dir: &Path, label: &str, summary: &mut String) -> Result<
         if is_empty {
             fs::remove_dir(dir)
                 .with_context(|| format!("failed to remove directory {}", dir.display()))?;
-            let _ = writeln!(summary, "removed  {label}");
+            report.push("removed", label);
         }
     }
     Ok(())

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -1772,10 +1772,7 @@ mod tests {
     #[test]
     fn run_init_okf_profile_merges_config() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let outcome = run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected success");
-        };
+        let out = run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap().to_text();
         assert!(out.contains("merged 'okf' profile"), "summary: {out}");
 
         let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
@@ -1794,10 +1791,7 @@ mod tests {
     #[test]
     fn run_init_okf_profile_claude_installs_skill() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let outcome = run_init_in(Some("."), true, false, Some("okf"), tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected success");
-        };
+        let out = run_init_in(Some("."), true, false, Some("okf"), tmp.path()).unwrap().to_text();
         assert!(
             out.contains("created  .claude/skills/okf/SKILL.md"),
             "{out}"
@@ -1838,10 +1832,7 @@ mod tests {
         run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap();
         // A second run makes no change → the summary should say "unchanged",
         // not "updated".
-        let outcome = run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected RawOutput");
-        };
+        let out = run_init_in(Some("."), false, false, Some("okf"), tmp.path()).unwrap().to_text();
         assert!(
             out.contains("unchanged  .hyalo.toml  ('okf' profile already applied)"),
             "re-run summary should report unchanged: {out}"
@@ -1856,10 +1847,7 @@ mod tests {
     fn run_deinit_removes_okf_skill() {
         let tmp = tempfile::TempDir::new().unwrap();
         run_init_in(Some("."), true, false, Some("okf"), tmp.path()).unwrap();
-        let outcome = run_deinit_in(tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected RawOutput");
-        };
+        let out = run_deinit_in(None, tmp.path()).unwrap().to_text();
         assert!(
             out.contains("removed  .claude/skills/okf/SKILL.md"),
             "{out}"
@@ -1879,19 +1867,13 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
 
         // First run
-        let outcome1 = run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out1) = outcome1 else {
-            panic!("expected success");
-        };
+        let out1 = run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap().to_text();
         assert!(out1.contains("created  .claude/skills/hyalo/SKILL.md"));
         assert!(out1.contains("created  .claude/skills/hyalo-tidy/SKILL.md"));
         assert!(out1.contains("created  .claude/rules/knowledgebase.md"));
 
         // Second run — should say "updated", not "created"
-        let outcome2 = run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out2) = outcome2 else {
-            panic!("expected success");
-        };
+        let out2 = run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap().to_text();
         assert!(out2.contains("updated  .claude/skills/hyalo/SKILL.md"));
         assert!(out2.contains("updated  .claude/skills/hyalo-tidy/SKILL.md"));
         assert!(out2.contains("updated  .claude/rules/knowledgebase.md"));
@@ -1904,10 +1886,7 @@ mod tests {
         // Create initial .hyalo.toml
         fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
 
-        let outcome = run_init_in(Some("newdir"), false, false, None, tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected success");
-        };
+        let out = run_init_in(Some("newdir"), false, false, None, tmp.path()).unwrap().to_text();
         assert!(out.contains(".hyalo.toml"));
 
         let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
@@ -1926,8 +1905,7 @@ mod tests {
         )
         .unwrap();
 
-        let outcome = run_init_in(Some("newdir"), false, false, None, tmp.path()).unwrap();
-        assert!(matches!(outcome, CommandOutcome::RawOutput(_)));
+        run_init_in(Some("newdir"), false, false, None, tmp.path()).unwrap();
 
         let content = fs::read_to_string(tmp.path().join(".hyalo.toml")).unwrap();
         // dir updated, other keys preserved.
@@ -1942,10 +1920,7 @@ mod tests {
 
         fs::write(tmp.path().join(".hyalo.toml"), "dir = \"old\"\n").unwrap();
 
-        let outcome = run_init_in(None, false, false, None, tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected success");
-        };
+        let out = run_init_in(None, false, false, None, tmp.path()).unwrap().to_text();
         assert!(out.contains("skipped  .hyalo.toml"));
 
         // Content unchanged
@@ -1957,8 +1932,7 @@ mod tests {
     fn run_init_rule_uses_detected_dir() {
         let tmp = tempfile::TempDir::new().unwrap();
 
-        let outcome = run_init_in(Some("my-notes"), true, false, None, tmp.path()).unwrap();
-        assert!(matches!(outcome, CommandOutcome::RawOutput(_)));
+        run_init_in(Some("my-notes"), true, false, None, tmp.path()).unwrap();
 
         let rule_content = fs::read_to_string(
             tmp.path()
@@ -2043,10 +2017,7 @@ mod tests {
     #[test]
     fn run_init_creates_missing_dir_when_explicit() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let outcome = run_init_in(Some("my-new-docs"), false, false, None, tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected RawOutput");
-        };
+        let out = run_init_in(Some("my-new-docs"), false, false, None, tmp.path()).unwrap().to_text();
         assert!(
             out.contains("created  my-new-docs/"),
             "summary mentions created dir"
@@ -2061,10 +2032,7 @@ mod tests {
     fn run_init_does_not_create_dir_when_auto_detected() {
         let tmp = tempfile::TempDir::new().unwrap();
         // No --dir flag, auto-detection falls back to "."
-        let outcome = run_init_in(None, false, false, None, tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected RawOutput");
-        };
+        let out = run_init_in(None, false, false, None, tmp.path()).unwrap().to_text();
         // No directory creation line — only the .hyalo.toml line.
         // The dir creation line always ends with "/" so check for that form.
         assert!(
@@ -2079,13 +2047,10 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         fs::write(tmp.path().join(".hyalo.toml"), "\"just a string\"\n").unwrap();
 
-        let outcome = run_init_in(Some("docs"), false, false, None, tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected success");
-        };
+        let out = run_init_in(Some("docs"), false, false, None, tmp.path()).unwrap().to_text();
         // Warning emitted.
         assert!(
-            out.contains("warning  .hyalo.toml was malformed"),
+            out.contains("warning  .hyalo.toml  (was malformed"),
             "malformed warning present"
         );
         // File overwritten with a valid table.
@@ -2154,17 +2119,14 @@ mod tests {
         // Set up all artifacts that init --claude would create.
         run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap();
 
-        let outcome = run_deinit_in(tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected RawOutput");
-        };
+        let out = run_deinit_in(None, tmp.path()).unwrap().to_text();
 
         assert!(out.contains("removed  .claude/skills/hyalo/SKILL.md"));
         assert!(out.contains("removed  .claude/skills/hyalo-tidy/SKILL.md"));
         assert!(out.contains("removed  .claude/rules/knowledgebase.md"));
         assert!(
-            out.contains("removed  .claude/CLAUDE.md (empty after stripping)")
-                || out.contains("updated  .claude/CLAUDE.md (stripped managed section)")
+            out.contains("removed  .claude/CLAUDE.md  (empty after stripping)")
+                || out.contains("updated  .claude/CLAUDE.md  (stripped managed section)")
         );
         assert!(out.contains("removed  .hyalo.toml"));
 
@@ -2201,17 +2163,14 @@ mod tests {
 
         // First run with artifacts present.
         run_init_in(Some("docs"), true, false, None, tmp.path()).unwrap();
-        run_deinit_in(tmp.path()).unwrap();
+        run_deinit_in(None, tmp.path()).unwrap();
 
         // Second run — no artifacts; must not error and must say "skipped".
-        let outcome = run_deinit_in(tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected RawOutput");
-        };
-        assert!(out.contains("skipped  .claude/skills/hyalo/SKILL.md (not found)"));
-        assert!(out.contains("skipped  .claude/skills/hyalo-tidy/SKILL.md (not found)"));
-        assert!(out.contains("skipped  .claude/rules/knowledgebase.md (not found)"));
-        assert!(out.contains("skipped  .hyalo.toml (not found)"));
+        let out = run_deinit_in(None, tmp.path()).unwrap().to_text();
+        assert!(out.contains("skipped  .claude/skills/hyalo/SKILL.md  (not found)"));
+        assert!(out.contains("skipped  .claude/skills/hyalo-tidy/SKILL.md  (not found)"));
+        assert!(out.contains("skipped  .claude/rules/knowledgebase.md  (not found)"));
+        assert!(out.contains("skipped  .hyalo.toml  (not found)"));
     }
 
     #[test]
@@ -2226,11 +2185,8 @@ mod tests {
         );
         fs::write(claude_dir.join("CLAUDE.md"), &content).unwrap();
 
-        let outcome = run_deinit_in(tmp.path()).unwrap();
-        let CommandOutcome::RawOutput(out) = outcome else {
-            panic!("expected RawOutput");
-        };
-        assert!(out.contains("updated  .claude/CLAUDE.md (stripped managed section)"));
+        let out = run_deinit_in(None, tmp.path()).unwrap().to_text();
+        assert!(out.contains("updated  .claude/CLAUDE.md  (stripped managed section)"));
 
         let remaining = fs::read_to_string(claude_dir.join("CLAUDE.md")).unwrap();
         assert!(

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -64,6 +64,60 @@ fn early_format(
         .unwrap_or_else(|| resolve_format_by_tty(std::io::stdout().is_terminal()))
 }
 
+/// Print an `init`/`deinit` report in the requested format (DEC-262).
+///
+/// These two do **not** flip to JSON just because stdout is a pipe, unlike the
+/// pipeline commands: their summary is a human progress report, the same stance
+/// `read` takes for note bodies. `--format json` — or `--jq`, which implies it —
+/// opts in; everything else prints the text summary.
+fn emit_init_report(
+    report: &crate::commands::init::Report,
+    format: Option<Format>,
+    jq: Option<&str>,
+) -> Result<(), AppError> {
+    let json = match format {
+        Some(f) => f == Format::Json,
+        None => jq.is_some(),
+    };
+    if !json {
+        // Sanitized because the summary can echo vault-derived strings (a `dir`
+        // value, a profile skill directory) that never pass through the JSON
+        // pipeline's own sanitization.
+        println!(
+            "{}",
+            crate::output::sanitize_control_chars(&report.to_text())
+        );
+        return Ok(());
+    }
+    let envelope = crate::output::build_envelope_value(&report.to_json(), None, &[]);
+    if let Some(filter) = jq {
+        return match crate::output::apply_jq_filter_result(filter, &envelope) {
+            Ok(filtered) => {
+                println!("{}", crate::output::sanitize_control_chars(&filtered));
+                Ok(())
+            }
+            Err(e) => Err(AppError::User(crate::output::format_error(
+                Format::Json,
+                "jq filter failed",
+                None,
+                None,
+                Some(&e),
+            ))),
+        };
+    }
+    println!(
+        "{}",
+        crate::output::sanitize_control_chars(&crate::output::format_prebuilt_envelope(
+            Format::Json,
+            &envelope,
+            None,
+            &[],
+            &envelope,
+        ))
+    );
+    Ok(())
+}
+
 /// Express the resolved vault `dir` as a path relative to `cwd`, using
 /// forward slashes, for `--format github` annotation prefixing.
 ///
@@ -827,6 +881,24 @@ fn run_inner() -> Result<(), AppError> {
         // (2 is reserved for internal errors — iter-181 task 2).
         return Err(AppError::Exit(1));
     }
+    // `--format github` is lint-only everywhere else (see the rejection further
+    // down, which `init`/`deinit` never reach because they dispatch here first).
+    // Reject it with the identical message rather than silently printing text.
+    if cli.format == Some(Format::Github)
+        && matches!(&cli.command, Commands::Init { .. } | Commands::Deinit)
+    {
+        eprintln!(
+            "{}",
+            crate::output::format_error(
+                Format::Text,
+                "--format github is only supported by `hyalo lint`",
+                None,
+                Some("valid formats for this command are: json, text"),
+                None,
+            )
+        );
+        return Err(AppError::Exit(1));
+    }
     if let Commands::Init {
         claude,
         pi,
@@ -834,38 +906,14 @@ fn run_inner() -> Result<(), AppError> {
     } = &mut cli.command
     {
         let init_dir = cli.dir.as_deref().and_then(|p| p.to_str());
-        match init_commands::run_init(init_dir, *claude, *pi, profile.as_deref()) {
-            Ok(CommandOutcome::RawBytes(_)) => {
-                // init/deinit never produce RawBytes; handled for exhaustiveness.
-                unreachable!("init/deinit do not emit RawBytes")
-            }
-            Ok(CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output)) => {
-                // Sanitized because RawOutput content may echo raw file text (init/deinit
-                // summaries can include vault-derived strings) that never passes through
-                // the JSON pipeline's own sanitization.
-                println!("{}", crate::output::sanitize_control_chars(&output));
-                return Ok(());
-            }
-            Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
-            Err(e) => return Err(AppError::Internal(e)),
-        }
+        let report = init_commands::run_init(init_dir, *claude, *pi, profile.as_deref())
+            .map_err(AppError::Internal)?;
+        return emit_init_report(&report, cli.format, cli.jq.as_deref());
     }
     if let Commands::Deinit = &mut cli.command {
-        match init_commands::run_deinit() {
-            Ok(CommandOutcome::RawBytes(_)) => {
-                // init/deinit never produce RawBytes; handled for exhaustiveness.
-                unreachable!("init/deinit do not emit RawBytes")
-            }
-            Ok(CommandOutcome::Success { output, .. } | CommandOutcome::RawOutput(output)) => {
-                // Sanitized because RawOutput content may echo raw file text (init/deinit
-                // summaries can include vault-derived strings) that never passes through
-                // the JSON pipeline's own sanitization.
-                println!("{}", crate::output::sanitize_control_chars(&output));
-                return Ok(());
-            }
-            Ok(CommandOutcome::UserError(output)) => return Err(AppError::User(output)),
-            Err(e) => return Err(AppError::Internal(e)),
-        }
+        let deinit_dir = cli.dir.as_deref().and_then(|p| p.to_str());
+        let report = init_commands::run_deinit(deinit_dir).map_err(AppError::Internal)?;
+        return emit_init_report(&report, cli.format, cli.jq.as_deref());
     }
     if let Commands::Completion { shell } = &mut cli.command {
         let mut cmd = Cli::command();

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -29,9 +29,17 @@ Prefer `hyalo` CLI for operations on files in this directory:
   command has no scanned-but-unchanged set. `task toggle`/`task set` return an array of per-task
   records with no top-level object: their dry-run records carry `old_status`, applied records do
   not. `init`/`deinit` and `create-index`/`drop-index` write config/index rather than notes and are
-  outside this contract.
+  outside this contract. `init`/`deinit` still answer `--format json` (and `--jq`) with their own
+  minimal envelope — `results.command`, `results.root`, `results.actions[]` of
+  `{action, target, detail?}`, plus a hoisted top-level `dir` for `init` — but stay text when
+  merely piped, because their summary is a progress report, not a result set.
 - **Config discovery**: `.hyalo.toml` is read from the current directory, or from the nearest
   parent whose configured vault contains it — running from inside the vault keeps the config.
+- **`init`/`deinit` follow `--dir` too**: a vault at or below the current directory leaves the
+  project root at CWD (`init` records `dir` relative to it, `deinit` cleans CWD); a `--dir` naming
+  a tree *outside* CWD moves the whole operation into that tree — `init` writes its `.hyalo.toml`
+  there with `dir = "."`, `deinit` removes that tree's integration files and never CWD's. Both
+  lead their summary with a `target <path>` line whenever the root is not CWD.
 - **`--dir` is a vault, not a config**: `--dir <configured-vault>` keeps `.hyalo.toml` in effect
   (the flag is just redundant); `--dir <other-tree>` switches to that tree's own `.hyalo.toml` — or
   built-in defaults — and says so on stderr. A `.hyalo.toml` that fails to parse blocks every

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -544,6 +544,12 @@ Pass `--format text` or `--format json` to override, or set a default in `.hyalo
 `text` is the compact, low-token format designed for LLM consumption — less noise than
 JSON, fewer tokens. Use it when orienting yourself or scanning results.
 
+**`init` and `deinit` are the exception to auto-detection.** Their summary is a human
+progress report, so it stays text even when piped; pass `--format json` (or `--jq`) to get
+`{results: {command, root, actions: [{action, target, detail?}], notes?}, hints, dir}`
+instead. `--dir` scopes them like every other command: naming a tree outside the current
+directory initializes — or cleans — *that* tree, not this one.
+
 **`--format text` and `--jq` are mutually exclusive.** `--jq` operates on JSON, so it
 requires JSON output. Piping naturally produces JSON, so `--jq` works without an
 explicit flag in most contexts. If you need to filter/reshape output, just pipe through

--- a/crates/hyalo-cli/tests/e2e/iteration257_init_scope.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration257_init_scope.rs
@@ -1,0 +1,357 @@
+//! Iteration 257: `init`/`deinit` honour `--dir`, and both speak JSON.
+//!
+//! Three bugs, all hit live during iteration 256's dogfooding pass, where an
+//! `init --dir <other-tree>` / `deinit` probe run from the hyalo repo wrote a
+//! self-refusing `.hyalo.toml` into the repo and then deleted the repo's own
+//! `.claude` integration files:
+//!
+//! - BUG-1: `init --dir <other-tree>` wrote `dir = "<absolute path>"` into
+//!   CWD's `.hyalo.toml` — a value every later run refuses, because a
+//!   project-local config may not set an absolute `dir` (iter-221/243).
+//! - BUG-2: `deinit` ignored `--dir` entirely and always deleted CWD's files.
+//! - BUG-3: `--format json` was silently ignored by both.
+//!
+//! See DEC-261 (scoping) and DEC-262 (JSON envelope).
+
+use super::common::hyalo_no_hints;
+use std::fs;
+use tempfile::TempDir;
+
+/// `init --claude` inside `dir`, with the vault at `dir` itself.
+fn init_claude(dir: &std::path::Path) {
+    let output = hyalo_no_hints()
+        .current_dir(dir)
+        .args(["init", "--claude", "--dir", "."])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "setup init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// BUG-1: `--dir` outside CWD must not produce a config that refuses itself
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_dir_outside_cwd_moves_the_root_into_that_tree() {
+    let cwd = TempDir::new().unwrap();
+    let elsewhere = TempDir::new().unwrap();
+    let vault = elsewhere.path().join("vault");
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--dir", vault.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The config lands in the named tree, not in CWD.
+    assert!(
+        !cwd.path().join(".hyalo.toml").exists(),
+        "CWD must not gain a config for a vault it does not contain; got: {stdout}"
+    );
+    let config = fs::read_to_string(vault.join(".hyalo.toml")).unwrap();
+    assert!(
+        config.contains("dir = \".\""),
+        "the vault tree's config points at itself; got: {config}"
+    );
+    assert!(
+        !config.contains(vault.to_str().unwrap()),
+        "no absolute path is ever written as `dir`; got: {config}"
+    );
+    // The summary says which tree it acted on, so it cannot be read as CWD's.
+    assert!(
+        stdout.contains("target   "),
+        "an out-of-CWD run names its target; got: {stdout}"
+    );
+}
+
+#[test]
+fn config_written_for_an_outside_dir_is_readable_afterwards() {
+    // The regression that made BUG-1 worth fixing: the old `init` wrote an
+    // absolute `dir`, which every subsequent run refused.
+    let cwd = TempDir::new().unwrap();
+    let elsewhere = TempDir::new().unwrap();
+    let vault = elsewhere.path().join("vault");
+
+    hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--dir", vault.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(&vault)
+        .args(["config", "--format", "json"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("not allowed to set") && !stderr.contains("above the config directory"),
+        "the config `init` wrote must not be refused on the next run; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn init_absolute_dir_under_cwd_is_recorded_relative() {
+    // An absolute spelling of a subdirectory is still a subdirectory: the root
+    // stays at CWD and `dir` is written relative, exactly as `--dir docs` does.
+    let cwd = TempDir::new().unwrap();
+    let docs = cwd.path().join("docs");
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--dir", docs.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config = fs::read_to_string(cwd.path().join(".hyalo.toml")).unwrap();
+    assert!(
+        config.contains("dir = \"docs\""),
+        "absolute --dir under CWD is recorded relative; got: {config}"
+    );
+    assert!(docs.is_dir(), "the vault directory is still created");
+}
+
+// ---------------------------------------------------------------------------
+// BUG-2: a `--dir`-scoped `deinit` must not touch CWD
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deinit_with_dir_outside_cwd_leaves_cwd_untouched() {
+    let cwd = TempDir::new().unwrap();
+    let target = TempDir::new().unwrap();
+    init_claude(cwd.path());
+    init_claude(target.path());
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["--dir", target.path().to_str().unwrap(), "deinit"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // CWD keeps everything.
+    assert!(
+        cwd.path().join(".hyalo.toml").exists(),
+        "CWD's config must survive a --dir-scoped deinit; got: {stdout}"
+    );
+    assert!(
+        cwd.path().join(".claude").join("CLAUDE.md").exists(),
+        "CWD's CLAUDE.md must survive a --dir-scoped deinit; got: {stdout}"
+    );
+    assert!(
+        cwd.path().join(".claude/skills/hyalo/SKILL.md").exists(),
+        "CWD's skill must survive a --dir-scoped deinit; got: {stdout}"
+    );
+
+    // The named tree is the one that was cleaned.
+    assert!(
+        !target.path().join(".hyalo.toml").exists(),
+        "the --dir tree's config should be removed; got: {stdout}"
+    );
+    assert!(
+        !target.path().join(".claude").exists(),
+        "the --dir tree's .claude should be removed; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("target   "),
+        "an out-of-CWD deinit names its target; got: {stdout}"
+    );
+}
+
+#[test]
+fn deinit_with_dir_inside_cwd_still_cleans_cwd() {
+    // `--dir docs` names a vault *inside* the project, so the project root —
+    // and therefore the integration files to remove — is still CWD.
+    let cwd = TempDir::new().unwrap();
+    fs::create_dir(cwd.path().join("docs")).unwrap();
+    hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--claude", "--dir", "docs"])
+        .output()
+        .unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["--dir", "docs", "deinit"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !cwd.path().join(".hyalo.toml").exists(),
+        "a vault-scoped deinit still cleans its own project root; got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("target   "),
+        "no target line when the root is CWD; got: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// BUG-3: `--format json`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn init_format_json_emits_an_envelope() {
+    let cwd = TempDir::new().unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--dir", "docs", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(value["results"]["command"], "init");
+    // `dir` is hoisted to the top level by the shared envelope builder.
+    assert_eq!(value["dir"], "docs");
+    assert!(
+        value["hints"].is_array(),
+        "the standard envelope carries hints; got: {stdout}"
+    );
+    let actions = value["results"]["actions"].as_array().unwrap();
+    assert!(
+        actions
+            .iter()
+            .any(|a| { a["action"] == "created" && a["target"] == ".hyalo.toml" }),
+        "the config write is reported as a structured action; got: {stdout}"
+    );
+    assert!(
+        value["results"]["root"].as_str().is_some(),
+        "the envelope names the root it wrote under; got: {stdout}"
+    );
+}
+
+#[test]
+fn deinit_format_json_emits_an_envelope() {
+    let cwd = TempDir::new().unwrap();
+    init_claude(cwd.path());
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["deinit", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("not JSON ({e}): {stdout}"));
+    assert_eq!(value["results"]["command"], "deinit");
+    assert!(
+        value["results"].get("dir").is_none(),
+        "deinit reports no vault dir; got: {stdout}"
+    );
+    let actions = value["results"]["actions"].as_array().unwrap();
+    assert!(
+        actions
+            .iter()
+            .any(|a| a["action"] == "removed" && a["target"] == ".hyalo.toml"),
+        "the config removal is reported as a structured action; got: {stdout}"
+    );
+    assert!(
+        actions
+            .iter()
+            .any(|a| a["action"] == "skipped" && a["detail"] == "not found"),
+        "skips carry their reason as a field, not as prose; got: {stdout}"
+    );
+}
+
+#[test]
+fn init_jq_filters_the_envelope() {
+    let cwd = TempDir::new().unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--dir", "docs", "--jq", ".results.command"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(stdout.trim(), "init", "got: {stdout}");
+}
+
+#[test]
+fn init_piped_output_stays_text_without_an_explicit_format() {
+    // Unlike the pipeline commands, `init`/`deinit` do not flip to JSON just
+    // because stdout is a pipe — their summary is a human progress report
+    // (DEC-262). This test's stdout *is* a pipe.
+    let cwd = TempDir::new().unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--dir", "docs"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(
+        !stdout.trim_start().starts_with('{'),
+        "piped init stays text; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("created  .hyalo.toml"),
+        "the text summary is unchanged; got: {stdout}"
+    );
+}
+
+#[test]
+fn init_rejects_format_github() {
+    let cwd = TempDir::new().unwrap();
+
+    let output = hyalo_no_hints()
+        .current_dir(cwd.path())
+        .args(["init", "--dir", "docs", "--format", "github"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "github format must be refused");
+    assert!(
+        stderr.contains("only supported by `hyalo lint`"),
+        "same message every other command gives; got: {stderr}"
+    );
+    assert!(
+        !cwd.path().join(".hyalo.toml").exists(),
+        "nothing is written when the format is refused"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -40,6 +40,7 @@ mod iteration245_followups;
 mod iteration249_followups;
 mod iteration254_shape;
 mod iteration255_followups;
+mod iteration257_init_scope;
 mod iteration_ergonomics;
 mod jq;
 mod json_errors;

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3688,3 +3688,108 @@ deciding whether a command can touch their markdown.
 `help` earns no COMMANDS row: the footer names it directly
 (`hyalo <cmd> -h (== hyalo help <cmd>)`), and a row would cost a line of a
 page held to a 2 560-byte ceiling to say what the footer already says.
+
+## DEC-261: `init`/`deinit` follow `--dir`; a vault outside CWD moves the root (2026-08-31)
+
+**Decision:** `--dir` names the *vault*, and the vault decides the *root* — the
+directory that holds `.hyalo.toml` and the `.claude`/`.pi` integration files.
+One rule, shared by both commands:
+
+- vault at or below CWD (`--dir docs`, `--dir /repo/docs` run from `/repo`, no
+  `--dir` at all) → root stays CWD; `init` records `dir` **relative** to it,
+  `deinit` cleans CWD;
+- vault outside CWD (`--dir /elsewhere/vault`, `--dir ../sibling`) → the root
+  moves into that tree: `init` writes `.hyalo.toml` *there* with `dir = "."`,
+  `deinit` removes *that* tree's files and never CWD's.
+
+A run whose root is not CWD leads its summary with `target   <path>`.
+
+**What was broken.** Both bugs were hit live during iteration 256's own
+dogfooding pass, from inside this repo, and had to be repaired by hand
+(commits `78fc09b5`, `0c96ec77`):
+
+- `init --dir <other-tree>` wrote `.hyalo.toml` into **CWD** with `dir =
+  "<absolute path>"`. A project-local config may not set an absolute `dir`
+  (iter-221 H-1, tightened in iter-243/244), so the very next hyalo run refused
+  the file it had just written — an `init` that produces a config `config`
+  rejects.
+- `deinit` ignored `--dir` outright and always targeted CWD, so
+  `hyalo --dir <temp-vault> deinit` deleted this repo's `.hyalo.toml`,
+  `.claude/CLAUDE.md` and three `.claude` symlinks while its summary looked, at
+  a glance, like a no-op (a dozen `skipped … (not found)` lines around the real
+  removals).
+
+**Why this rule and not the alternatives.** Three were on the table for
+`init`: write `dir` relative to the config file, write the config into the
+other tree, or refuse the combination. Relative-to-config only works while the
+target is *inside* the config's directory — `../..`-style values are refused by
+the same boundary rule, so it fixes `--dir /repo/docs` and nothing else. It is
+therefore kept, but only as the in-bounds half of the rule. Refusal was
+rejected because `hyalo --dir /elsewhere/vault init` has an obvious intent and
+no other spelling; making the user `cd` first is a worse CLI. Moving the root
+is what the user asked for in every reading of the flag.
+
+For `deinit` the choice was honour-or-refuse. Honouring wins for the same
+reason, and it is strictly safer than the status quo either way: the failure
+mode being fixed is *deleting the tree the user did not name*.
+
+**Implementation note.** Containment is decided on canonicalized paths — the
+deepest existing ancestor is canonicalized and the not-yet-created remainder
+re-appended — so an absolute spelling of a subdirectory, a `sub/../kb`
+round-trip, and macOS's `/tmp` → `/private/tmp` symlink all resolve to
+"inside", while a symlink that genuinely leaves the tree resolves to "outside".
+This mirrors what `validate_project_local_dir` already does for reads, so
+`init` cannot write a `dir` that the reader would then refuse.
+
+**Non-goal:** the rest of `init`/`deinit`'s UX. The interleaved
+`skipped … (not found)` noise in `deinit`'s summary is unchanged apart from the
+`target` header; it is now structured in JSON (DEC-262), which is the fix that
+matters for agents.
+
+## DEC-262: `init`/`deinit` answer `--format json`, but stay text when merely piped (2026-08-31)
+
+**Decision:** both commands emit a minimal envelope on an explicit
+`--format json` (or `--jq`, which implies it), and the text summary in every
+other case — including when stdout is a pipe. `--format github` is refused with
+the same message every non-lint command gives.
+
+```json
+{
+  "results": {
+    "command": "init",
+    "root": "/abs/path/to/project",
+    "actions": [
+      {"action": "created", "target": ".hyalo.toml", "detail": "dir = \"docs\""},
+      {"action": "skipped", "target": ".claude/CLAUDE.md", "detail": "not found"}
+    ],
+    "notes": ["…pi install hint…"]
+  },
+  "hints": [],
+  "dir": "docs"
+}
+```
+
+`action` is one of `created`, `updated`, `unchanged`, `removed`, `skipped`,
+`warning`; `detail` is present only when the verb alone is ambiguous; `dir` is
+hoisted to the top level by the shared envelope builder and is absent for
+`deinit`, which has no vault value to report.
+
+**Why not the full mutation-envelope contract.** DEC-257 put `init`/`deinit`
+outside it: they write config and integration files, not notes, so
+`dry_run`/`skipped_count`/per-file records have nothing to describe. That
+stands. What did not stand was answering `--format json` with unparseable text.
+
+**Why text still wins a bare pipe.** Every list/mutation command flips to JSON
+when stdout is not a terminal, and `init`/`deinit` deliberately do not. Their
+output is a progress report a human reads while setting a project up — the same
+argument that keeps `read`'s results raw text under a pipe (DEC-256) — and
+`hyalo init | tee setup.log` should not start emitting JSON. An agent that
+wants structure asks for it, which is one flag, and the flag is now documented
+in both help pages.
+
+**Implementation note.** The summary is no longer built as a string. Both
+commands accumulate a `Report { command, root, dir, actions, notes }`; the text
+rendering is one line per action and the JSON body is `serde_json::to_value` of
+the same struct, so the two can never drift. Text lines are now uniformly
+`verb  target  (detail)` — previously some details were separated by one space
+and some by two.

--- a/hyalo-knowledgebase/iterations/iteration-257-init-deinit-dir-scope-and-json-envelope.md
+++ b/hyalo-knowledgebase/iterations/iteration-257-init-deinit-dir-scope-and-json-envelope.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 257 — init/deinit --dir scoping and JSON envelope gap"
 date: 2026-08-31
-status: in-progress
+status: completed
 tags:
   - iteration
   - dogfood-fixes

--- a/hyalo-knowledgebase/iterations/iteration-257-init-deinit-dir-scope-and-json-envelope.md
+++ b/hyalo-knowledgebase/iterations/iteration-257-init-deinit-dir-scope-and-json-envelope.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 257 — init/deinit --dir scoping and JSON envelope gap"
 date: 2026-08-31
-status: planned
+status: in-progress
 tags:
   - iteration
   - dogfood-fixes
@@ -26,9 +26,9 @@ branch (commits `78fc09b5`, `0c96ec77`).
 
 ## Tasks
 
-### BUG-1: `init --dir <other-tree>` writes an absolute, self-refusing `dir` [0/2]
+### BUG-1: `init --dir <other-tree>` writes an absolute, self-refusing `dir` [2/2]
 
-- [ ] Reproduce: from a directory with no `.hyalo.toml`, run
+- [x] Reproduce: from a directory with no `.hyalo.toml`, run
       `hyalo init --dir <some-other-tree>`. Confirm it writes `.hyalo.toml`
       into the **current** directory (not `<some-other-tree>`) with
       `dir = "<absolute path to some-other-tree>"` — a value `hyalo config`
@@ -36,7 +36,7 @@ branch (commits `78fc09b5`, `0c96ec77`).
       project-local `.hyalo.toml` is not allowed to set", per the
       project-local-`dir`-must-stay-at-or-below-config-directory rule added
       in iter-243/244).
-- [ ] Fix `init` so it never writes a config it will immediately refuse to
+- [x] Fix `init` so it never writes a config it will immediately refuse to
       read: either write `dir` as a path relative to the config file's own
       directory (matching how a hand-written `.hyalo.toml` is expected to
       look), or write the config into `<other-tree>` instead of CWD, or
@@ -44,16 +44,16 @@ branch (commits `78fc09b5`, `0c96ec77`).
       constraint. Pick one and record it as a DEC — this is a behavior
       decision, not a one-line fix. Add an e2e test pinning the choice.
 
-### BUG-2: `deinit` ignores `--dir` and always targets CWD [0/2]
+### BUG-2: `deinit` ignores `--dir` and always targets CWD [2/2]
 
-- [ ] Reproduce: from this repo, run `hyalo --dir <temp-vault> deinit` and
+- [x] Reproduce: from this repo, run `hyalo --dir <temp-vault> deinit` and
       confirm it deletes **this repo's** `.hyalo.toml`, `.claude/CLAUDE.md`,
       and the three `.claude` symlinks into
       `crates/hyalo-cli/templates/` — not anything under `<temp-vault>` —
       with no warning, and a summary that interleaves the real removals with
       a dozen `skipped … (not found)` lines in a way that reads like a
       no-op at a glance.
-- [ ] Fix: either honour `--dir` for `deinit`'s target the same way other
+- [x] Fix: either honour `--dir` for `deinit`'s target the same way other
       commands do, or refuse to run when `--dir` names a tree other than
       CWD (erring on the side of not silently deleting the wrong tree's
       integration files). Record as a DEC alongside BUG-1's — the two share
@@ -62,9 +62,9 @@ branch (commits `78fc09b5`, `0c96ec77`).
       Add an e2e test that a `--dir`-scoped `deinit` cannot touch CWD's
       files (or is refused).
 
-### BUG-3: `--format json` is ignored by `init`/`deinit` [0/1]
+### BUG-3: `--format json` is ignored by `init`/`deinit` [1/1]
 
-- [ ] `init` and `deinit` always print their text summary regardless of
+- [x] `init` and `deinit` always print their text summary regardless of
       `--format json`, unlike every other command. DEC-257 (iter-256) named
       them as outside the mutation-envelope contract entirely (they write
       config, not notes), so this is not a COH-9 violation — but an agent
@@ -77,14 +77,14 @@ branch (commits `78fc09b5`, `0c96ec77`).
 
 ## Acceptance criteria
 
-- [ ] BUG-1 is fixed or explicitly won't-fixed with a DEC; `init --dir
+- [x] BUG-1 is fixed or explicitly won't-fixed with a DEC; `init --dir
       <other-tree>` no longer produces a `.hyalo.toml` that refuses itself
       on the next run.
-- [ ] BUG-2 is fixed or explicitly won't-fixed with a DEC; a `--dir`-scoped
+- [x] BUG-2 is fixed or explicitly won't-fixed with a DEC; a `--dir`-scoped
       `deinit` cannot silently delete a different tree's integration files.
-- [ ] BUG-3 has a recorded decision (JSON envelope added, or documented as
+- [x] BUG-3 has a recorded decision (JSON envelope added, or documented as
       out of scope for `--format`) — not left ambiguous.
-- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, all `xtask check-*`, `hyalo lint --strict`.
 
 ## Non-goals


### PR DESCRIPTION
## Summary

Fixes three `init`/`deinit` bugs carried over from iteration 256's dogfooding pass
(filed in PR #298 under "findings, not fixed here"). Both `--dir` bugs were hit live
from inside this repo and had to be repaired by hand there (`78fc09b5`, `0c96ec77`).

- **BUG-1 — `init --dir <tree-outside-CWD>` wrote a config it then refused to read.**
  The `.hyalo.toml` landed in the *current* directory with an absolute `dir`, which a
  project-local config may not set (iter-221 H-1, tightened in iter-243/244) — so the
  next hyalo run rejected the file `init` had just written. `--dir` now decides the
  project *root* as well as the vault: a vault at or below CWD keeps `.hyalo.toml` here
  and records `dir` relative to it; a vault outside CWD makes that tree its own root,
  written there with `dir = "."`. Containment is decided on canonicalized paths, so an
  absolute spelling of a subdirectory, a `sub/../kb` round-trip and macOS's
  `/tmp` → `/private/tmp` symlink all resolve to "inside" — mirroring
  `validate_project_local_dir`, so `init` cannot write a `dir` the reader would refuse.
- **BUG-2 — `deinit` ignored `--dir` and always targeted CWD**, so a probe aimed at a
  throwaway vault deleted *this* repo's `.hyalo.toml`, `.claude/CLAUDE.md` and three
  `.claude` symlinks, under a summary whose interleaved `skipped … (not found)` lines
  read like a no-op. It now follows the same root rule as `init` and cannot touch a tree
  the user did not name. Any run whose root is not CWD leads with a `target <path>` line.
- **BUG-3 — `--format json` was ignored by both.** They now answer an explicit
  `--format json` (or `--jq`, which implies it) with a minimal envelope —
  `results.command`, `results.root`, `results.actions[]` of `{action, target, detail?}`,
  plus a hoisted top-level `dir` for `init` — and refuse `--format github` with the same
  message every other non-lint command gives. They deliberately stay **text** when merely
  piped: the summary is a setup progress report, not a result set, so `hyalo init | tee
  setup.log` keeps working. Text and JSON render from one `Report` struct and cannot drift.

Decisions recorded as **DEC-261** (`--dir` root rule, with the rejected alternatives) and
**DEC-262** (envelope shape, and why a bare pipe stays text). `rule-knowledgebase.md`,
`skill-hyalo.md`, both `long_about` pages, the COMMAND REFERENCE lines and the CHANGELOG
are updated to match.

## Test plan

- [x] 10 new e2e tests in `crates/hyalo-cli/tests/e2e/iteration257_init_scope.rs` pin
      every decision: outside-`--dir` moves the root; the written config is readable
      afterwards; an absolute `--dir` *under* CWD is recorded relative; `--dir`-scoped
      `deinit` leaves CWD untouched; inside-`--dir` `deinit` still cleans CWD; both
      commands' JSON envelopes; `--jq` filtering; a bare pipe staying text;
      `--format github` refused.
- [x] `init.rs` unit tests reworked onto the `Report` struct (64 `#[test]` in the module).
- [x] `cargo fmt` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean;
      `cargo test --workspace -q` — 1250 + 204 + 36 pass, 0 failures.
- [x] All six `xtask check-*` gates exit 0 (feature-fanout, help-drift, command-reference,
      bundled-skills, pi-package-sync, mutation-journal).
- [x] `hyalo lint --strict` — 111 files, no issues.
- [x] Manually re-verified all three bugs against the release binary in a scratch tree:
      config lands in the target with `dir = "."` and reads back clean; a `--dir`-scoped
      `deinit` run from a configured project leaves that project's `.hyalo.toml` and
      `.claude/` intact while removing only the target's; JSON/`--jq`/piped-text/
      `--format github` (exit 1) all behave as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS

## Carry-over

Sweep of this iteration's scope: all three BUG items and every acceptance
criterion in `iteration-257-init-deinit-dir-scope-and-json-envelope.md` are
ticked and verified against the actual diff (`init`/`deinit` `--dir` scoping,
JSON envelope, all gates green) — no unticked ACs remain, and the plan's
`status` has been set to `completed`.

One out-of-scope item was explicitly flagged during this iteration:

- **`deinit`'s interleaved `skipped … (not found)` text-summary noise**
  (DEC-262, "Non-goal" section) — the text rendering still mixes real
  removals with a dozen skip lines in a way that reads like a no-op at a
  glance, unchanged from before this PR except for the new `target` header
  on out-of-CWD runs. Disposition: **won't-fix, resolved by design** — the
  JSON envelope this PR adds (`results.actions[]`, one structured record per
  action) is the fix that matters for agents/scripting, which was the actual
  pain point; the text-summary readability is cosmetic and not worth a
  further iteration on its own. No new plan filed.

No other deferred annotations or out-of-scope findings were raised in this
iteration's plan, commits, or DEC-261/262. Iteration 258
(`iteration-258-zero-result-title-regex-hint.md`) is an unrelated carry-over
from iteration 256 and needs no changes as a result of this sweep.
