### PR TITLE
iter-258: zero-result property-regex queries point at body search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,16 @@ and this project adheres to
   is now an ordinary code comment.
 - `hyalo-cli` crates.io publish (v0.21.0) failed at the tarball verify step because the pi integration files were embedded via `include_str!` reaching outside the crate into the top-level `pi-package/` directory, which `cargo package` cannot see. The four files are now vendored inside `crates/hyalo-cli/templates/pi/`, kept in sync with `pi-package/` by a new `check-pi-package-sync` CI gate (`just sync-pi-package` to fix drift).
 
+### Added
+
+- **A zero-result `--property K~=RE` query now points at body search when the
+  same regex matches body prose.** `hyalo find --property 'title~=/DEC-25/'`
+  against a decision log whose `DEC-NNN` ids are `##` headings was correct and
+  useless; the empty result now leads with `hyalo find -e 'DEC-25'`. The hint
+  is emitted only after a bounded probe (512 files / 8 MiB, first match wins)
+  confirmed the suggested command returns something, and only on the
+  zero-result path — no new flag, and no cost on any query that matched.
+
 ## [0.21.0] - 2026-08-28
 
 ### Added

--- a/crates/hyalo-cli/src/commands/find/run.rs
+++ b/crates/hyalo-cli/src/commands/find/run.rs
@@ -547,6 +547,120 @@ mod tests {
         }
     }
 
+    // --- iter-258: the zero-result body probe -------------------------------
+
+    fn probe_vault(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for (rel, body) in files {
+            std::fs::write(tmp.path().join(rel), body).unwrap();
+        }
+        tmp
+    }
+
+    fn probe_index(dir: &std::path::Path) -> hyalo_core::index::ScannedIndex {
+        let files = hyalo_core::discovery::discover_files(dir).unwrap();
+        let pairs: Vec<(std::path::PathBuf, String)> = files
+            .iter()
+            .map(|p| (p.clone(), hyalo_core::discovery::relative_path(dir, p)))
+            .collect();
+        hyalo_core::index::ScannedIndex::build(
+            &pairs,
+            None,
+            &hyalo_core::index::ScanOptions {
+                scan_body: false,
+                bm25_tokenize: false,
+                default_language: None,
+                frontmatter_link_props: None,
+            },
+        )
+        .unwrap()
+        .index
+    }
+
+    fn probe(dir: &std::path::Path, filter: &str, already_searched_body: bool) -> Option<String> {
+        let index = probe_index(dir);
+        let filters = vec![hyalo_core::filter::parse_property_filter(filter).unwrap()];
+        zero_result_body_search(&index, dir, &filters, already_searched_body)
+            .map(|s| format!("{}:{}", s.key, s.pattern))
+    }
+
+    /// The motivating case: `DEC-NNN` lives in `##` headings, not in `title`.
+    #[test]
+    fn body_probe_fires_when_only_the_body_matches() {
+        let tmp = probe_vault(&[(
+            "decision-log.md",
+            "---\ntitle: Decision log\n---\n\n## DEC-251 — something\n",
+        )]);
+        assert_eq!(
+            probe(tmp.path(), "title~=/DEC-25/", false).as_deref(),
+            Some("title:DEC-25")
+        );
+    }
+
+    /// The absence half of the same rule: no body match ⇒ no promise.
+    #[test]
+    fn body_probe_stays_silent_when_the_body_does_not_match_either() {
+        let tmp = probe_vault(&[(
+            "decision-log.md",
+            "---\ntitle: Decision log\n---\n\n## DEC-251 — something\n",
+        )]);
+        assert_eq!(probe(tmp.path(), "title~=/NOSUCHTHING/", false), None);
+    }
+
+    #[test]
+    fn body_probe_skips_a_query_that_already_searched_bodies() {
+        let tmp = probe_vault(&[("a.md", "---\ntitle: A\n---\n\n## DEC-251\n")]);
+        assert_eq!(
+            probe(tmp.path(), "title~=/DEC-25/", true),
+            None,
+            "a caller who already passed PATTERN / -e needs no body-search hint"
+        );
+    }
+
+    #[test]
+    fn body_probe_ignores_non_regex_property_filters() {
+        let tmp = probe_vault(&[("a.md", "---\ntitle: A\n---\n\n## DEC-251\n")]);
+        let index = probe_index(tmp.path());
+        let filters = vec![
+            hyalo_core::filter::parse_property_filter("status=draft").unwrap(),
+            hyalo_core::filter::parse_property_filter("!archived").unwrap(),
+        ];
+        assert!(zero_result_body_search(&index, tmp.path(), &filters, false).is_none());
+    }
+
+    /// An empty regex matches the first body line of the first file, which
+    /// would suggest the useless `hyalo find -e ''`.
+    #[test]
+    fn body_probe_refuses_an_empty_pattern() {
+        let tmp = probe_vault(&[("a.md", "---\ntitle: A\n---\n\nbody\n")]);
+        assert_eq!(probe(tmp.path(), "title~=", false), None);
+    }
+
+    /// The probe matches fenced code, because `find -e` does.
+    #[test]
+    fn body_probe_matches_inside_fenced_code() {
+        let tmp = probe_vault(&[(
+            "a.md",
+            "---\ntitle: A\n---\n\n```sh\nhyalo find -e DEC-251\n```\n",
+        )]);
+        assert_eq!(
+            probe(tmp.path(), "title~=/DEC-251/", false).as_deref(),
+            Some("title:DEC-251")
+        );
+    }
+
+    /// `find -e` is case-insensitive, so the probe must be too — otherwise a
+    /// case-sensitive property regex could suppress a hint whose suggested
+    /// command would in fact have found something.
+    #[test]
+    fn body_probe_is_case_insensitive_like_find_e() {
+        let tmp = probe_vault(&[("a.md", "---\ntitle: A\n---\n\n## dec-251\n")]);
+        assert_eq!(
+            probe(tmp.path(), "title~=/DEC-251/", false).as_deref(),
+            Some("title:DEC-251")
+        );
+    }
+
     /// Previously e2e-only: `--strict` with findings ⇒ exit 1 (UX-2).
     #[test]
     fn strict_exit_code_policy() {

--- a/crates/hyalo-cli/src/commands/find/run.rs
+++ b/crates/hyalo-cli/src/commands/find/run.rs
@@ -425,11 +425,13 @@ fn zero_result_body_search(
     let mut files_left = BODY_PROBE_MAX_FILES;
     let mut bytes_left = BODY_PROBE_MAX_BYTES;
     for entry in index.entries() {
-        if files_left == 0 || bytes_left == 0 {
+        // Both ceilings are checked *before* the read, so the budget is a real
+        // bound rather than one the last file is allowed to overrun.
+        if files_left == 0 || entry.size > bytes_left {
             return None;
         }
         files_left -= 1;
-        bytes_left = bytes_left.saturating_sub(entry.size);
+        bytes_left -= entry.size;
         let mut visitor = BodyProbeVisitor {
             re: &probe,
             hit: false,

--- a/crates/hyalo-cli/src/commands/find/run.rs
+++ b/crates/hyalo-cli/src/commands/find/run.rs
@@ -282,6 +282,16 @@ pub(crate) fn run(
             if matches!(outcome, CommandOutcome::Success { total: Some(0), .. }) {
                 ctx.zero_result_values =
                     observed_property_values(resolved.as_index(), &prop_filters);
+                // iter-258: `--property 'title~=/DEC-25/'` against a vault whose
+                // `DEC-NNN` ids are `##` body headings is correct *and* useless:
+                // the caller wanted `find -e 'DEC-25'`. Probe (bounded, and only
+                // here) whether body text actually matches before saying so.
+                ctx.zero_result_body_search = zero_result_body_search(
+                    resolved.as_index(),
+                    dir,
+                    &prop_filters,
+                    pattern.is_some() || regexp.is_some(),
+                );
             }
             // iter-235: `--filenames-only` projects the find result
             // set onto raw file paths (one per line, no envelope,
@@ -305,6 +315,140 @@ pub(crate) fn run(
         }
         IndexResolution::Outcome(outcome) => Ok(outcome),
     }
+}
+
+/// Files the zero-result body probe will open before giving up (iter-258).
+///
+/// The probe runs only when a `find` matched nothing *and* filtered on a
+/// property regex, so the ceiling bounds a path that is already the cheapest
+/// one in the command: a vault larger than this simply does not get the hint,
+/// which is the right trade against turning every empty query into a full body
+/// scan.
+const BODY_PROBE_MAX_FILES: usize = 512;
+
+/// Bytes the zero-result body probe will read before giving up (iter-258).
+///
+/// Accounted from [`hyalo_core::index::IndexEntry::size`], which a snapshot
+/// written before iteration 252 reports as `0`; against such an index only
+/// [`BODY_PROBE_MAX_FILES`] bounds the probe.
+const BODY_PROBE_MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Body-line visitor that answers one question — "does this regex match
+/// anywhere in this file?" — and stops the scan the moment it knows.
+///
+/// Deliberately not [`hyalo_core::content_search::ContentSearchVisitor`]: that
+/// one collects every match with its section context, which is exactly the
+/// work a yes/no probe must not do.
+struct BodyProbeVisitor<'a> {
+    re: &'a regex::Regex,
+    hit: bool,
+}
+
+impl hyalo_core::scanner::FileVisitor for BodyProbeVisitor<'_> {
+    fn on_body_line(
+        &mut self,
+        raw: &str,
+        _cleaned: &str,
+        _line_num: usize,
+    ) -> hyalo_core::scanner::ScanAction {
+        self.probe(raw)
+    }
+
+    fn on_code_block_line(
+        &mut self,
+        raw: &str,
+        _line_num: usize,
+    ) -> hyalo_core::scanner::ScanAction {
+        // `find -e` searches fenced code too, so the probe must agree.
+        self.probe(raw)
+    }
+
+    fn needs_frontmatter(&self) -> bool {
+        false
+    }
+}
+
+impl BodyProbeVisitor<'_> {
+    fn probe(&mut self, raw: &str) -> hyalo_core::scanner::ScanAction {
+        if self.re.is_match(raw) {
+            self.hit = true;
+            hyalo_core::scanner::ScanAction::Stop
+        } else {
+            hyalo_core::scanner::ScanAction::Continue
+        }
+    }
+}
+
+/// Whether a zero-result `--property K~=RE` query's regex matches body prose,
+/// and so deserves a "search bodies instead" hint (iter-258).
+///
+/// Returns `None` — no hint — unless every one of these holds:
+///
+/// * the query did not already search bodies (`PATTERN` / `-e`), because a
+///   caller who did needs no lesson about body search;
+/// * some `--property K~=RE` filter is active, with a non-empty pattern (an
+///   empty regex matches the first line of the first file and would suggest
+///   `find -e ''`);
+/// * the regex, compiled the way `find -e` compiles it, matches a body line
+///   within [`BODY_PROBE_MAX_FILES`] / [`BODY_PROBE_MAX_BYTES`].
+///
+/// The last point is why the hint can be stated as a fact: it is only emitted
+/// after the suggested command has been shown to return something. The probe
+/// deliberately ignores `--file` / `--glob` scoping and every other filter, and
+/// the suggested command drops them to match — a hint that promised results
+/// inside a narrower scope than it checked would be a lie.
+fn zero_result_body_search(
+    index: &dyn hyalo_core::index::VaultIndex,
+    dir: &std::path::Path,
+    filters: &[hyalo_core::filter::PropertyFilter],
+    already_searched_body: bool,
+) -> Option<crate::hints::BodySearchSuggestion> {
+    use hyalo_core::filter::PropertyFilter;
+
+    if already_searched_body {
+        return None;
+    }
+    let (key, pattern) = filters.iter().find_map(|f| match f {
+        PropertyFilter::RegexMatch { key, pattern } => Some((key.as_str(), pattern.as_str())),
+        _ => None,
+    })?;
+    if pattern.is_empty() {
+        return None;
+    }
+    // Compile exactly what `hyalo find -e <pattern>` compiles — case-insensitive
+    // by default — so the hint and the command it suggests cannot disagree.
+    let probe = regex::RegexBuilder::new(&format!("(?i){pattern}"))
+        .size_limit(1 << 20)
+        .build()
+        .ok()?;
+
+    let mut files_left = BODY_PROBE_MAX_FILES;
+    let mut bytes_left = BODY_PROBE_MAX_BYTES;
+    for entry in index.entries() {
+        if files_left == 0 || bytes_left == 0 {
+            return None;
+        }
+        files_left -= 1;
+        bytes_left = bytes_left.saturating_sub(entry.size);
+        let mut visitor = BodyProbeVisitor {
+            re: &probe,
+            hit: false,
+        };
+        // A file the index knows but the filesystem does not (a snapshot built
+        // elsewhere) is skipped, not escalated: this is a hint, not a query.
+        if hyalo_core::scanner::scan_file_multi(&dir.join(&entry.rel_path), &mut [&mut visitor])
+            .is_err()
+        {
+            continue;
+        }
+        if visitor.hit {
+            return Some(crate::hints::BodySearchSuggestion {
+                key: key.to_owned(),
+                pattern: pattern.to_owned(),
+            });
+        }
+    }
+    None
 }
 
 /// Maximum distinct values collected per property key for the zero-result

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -215,6 +215,13 @@ pub(crate) struct CommandContext<'a> {
     /// zero-result did-you-mean can be computed without a second scan. Empty
     /// for every command other than an empty `find`.
     pub zero_result_values: std::collections::BTreeMap<String, Vec<String>>,
+    /// A `--property K~=RE` filter whose regex matched no frontmatter value but
+    /// *does* match body prose, confirmed by the bounded probe `find` runs on
+    /// the zero-result path (iter-258). `run.rs` moves it into the hint context
+    /// so the empty result can point at `find -e` instead of leaving the caller
+    /// to guess that the text lives in bodies. `None` for every other command
+    /// and for any empty `find` without a property regex filter.
+    pub zero_result_body_search: Option<crate::hints::BodySearchSuggestion>,
 }
 
 /// Resolve the effective limit for a list command.

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -33,6 +33,23 @@ const SITE_URL_MIN_BROKEN: u64 = 500;
 /// unresolved absolute site URLs, not fixable file references.
 const SITE_URL_BROKEN_PERCENT: u64 = 95;
 
+/// A zero-result `--property K~=REGEX` query whose regex nevertheless matches
+/// body prose somewhere in the vault (iteration 258).
+///
+/// The canonical case is `--property 'title~=/DEC-25/'` run against a decision
+/// log whose `DEC-NNN` identifiers are `##` body headings rather than
+/// frontmatter titles: the filter is correct, the empty answer is correct, and
+/// the thing the caller was actually after is one flag away. `find` sets this
+/// only after a bounded probe *confirmed* a body match, so the hint reports a
+/// fact rather than speculating.
+#[derive(Debug, Clone)]
+pub struct BodySearchSuggestion {
+    /// Property key whose regex filter matched nothing (`title`, …).
+    pub key: String,
+    /// Regex source to hand to `find -e`, exactly as the user wrote it.
+    pub pattern: String,
+}
+
 /// A single drill-down hint: a concrete command plus a short human-readable description.
 #[derive(Debug, Clone)]
 pub struct Hint {
@@ -213,6 +230,12 @@ pub struct HintContext {
     /// nothing (iter-251). Feeds the zero-result did-you-mean and the
     /// "values of `K` in this vault" hint; empty on every non-empty result.
     pub observed_property_values: std::collections::BTreeMap<String, Vec<String>>,
+    /// Set when a zero-result `find` carried a `--property K~=RE` filter whose
+    /// regex matches body text somewhere in the vault (iteration 258).
+    /// Confirmed by a bounded body probe on the zero-result path, never
+    /// guessed; `None` on every non-empty result and whenever the probe found
+    /// nothing within its budget.
+    pub body_search_suggestion: Option<BodySearchSuggestion>,
 }
 
 /// Common global flags captured once per command dispatch and threaded into
@@ -270,6 +293,7 @@ impl HintContext {
             lint_fix_rules: vec![],
             okf_profile_active: false,
             observed_property_values: std::collections::BTreeMap::new(),
+            body_search_suggestion: None,
         }
     }
 

--- a/crates/hyalo-cli/src/hints/zero_result.rs
+++ b/crates/hyalo-cli/src/hints/zero_result.rs
@@ -457,6 +457,34 @@ mod tests {
     }
 
     #[test]
+    fn body_search_suggestion_leads_the_hints() {
+        let mut ctx = ctx_with(&["title~=/DEC-25/"], &[]);
+        ctx.body_search_suggestion = Some(crate::hints::BodySearchSuggestion {
+            key: "title".to_owned(),
+            pattern: "DEC-25".to_owned(),
+        });
+        let hints = zero_result_hints(&ctx);
+        assert_eq!(
+            hints[0].description,
+            "No `title` matches that regex, but body text does — search bodies instead"
+        );
+        assert_eq!(hints[0].cmd, "hyalo find -e DEC-25");
+        assert!(!hints[0].writes, "a body search never mutates the vault");
+    }
+
+    #[test]
+    fn no_body_search_hint_without_a_confirmed_match() {
+        let ctx = ctx_with(&["title~=/DEC-25/"], &[]);
+        let hints = zero_result_hints(&ctx);
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.description.contains("search bodies instead")),
+            "the hint is only emitted when the probe actually matched: {hints:?}"
+        );
+    }
+
+    #[test]
     fn unknown_key_points_at_the_properties_listing() {
         let ctx = ctx_with(&["nosuchkey=1"], &[]);
         let hints = zero_result_hints(&ctx);

--- a/crates/hyalo-cli/src/hints/zero_result.rs
+++ b/crates/hyalo-cli/src/hints/zero_result.rs
@@ -12,6 +12,15 @@
 //! 3. *Which filter killed the query?* — the same query with its most
 //!    selective filter dropped, ready to paste.
 //!
+//! Iteration 258 added a fourth, ahead of the others because it is the only
+//! one backed by a confirmed match: *was the text I searched for in the body
+//! rather than the frontmatter?* — fired when a `--property K~=RE` filter
+//! matched no property value but the same regex matches body prose, as
+//! `--property 'title~=/DEC-25/'` does against a decision log whose `DEC-NNN`
+//! ids are `##` headings. See
+//! [`crate::commands::find::run`]'s `zero_result_body_search` for the probe
+//! and its budget.
+//!
 //! The observed values come from the `find` scan itself
 //! ([`crate::dispatch::CommandContext::zero_result_values`]): the index was
 //! already walked to evaluate the filter, so collecting the distinct values of
@@ -227,6 +236,22 @@ pub(super) fn zero_result_hints(ctx: &HintContext) -> Vec<Hint> {
     let observed: &BTreeMap<String, Vec<String>> = &ctx.observed_property_values;
     let mut hints: Vec<Hint> = Vec::new();
     let filters = active_filters(ctx);
+
+    // 0. The property regex matched no frontmatter value, but the same regex
+    //    does match body prose — which is almost always what the caller meant.
+    //    Leads the list because it is the only zero-result hint backed by a
+    //    confirmed match rather than a heuristic (iter-258).
+    if let Some(suggestion) = &ctx.body_search_suggestion {
+        hints.push(Hint::new(
+            format!(
+                "No `{}` matches that regex, but body text does — search bodies instead",
+                suggestion.key
+            ),
+            HintBuilder::cmd("find")
+                .flag_value("-e", &suggestion.pattern)
+                .finish(ctx),
+        ));
+    }
 
     // 1. Did-you-mean over the observed values of each filtered key.
     for (key, value) in equality_property_filters(ctx) {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -2154,6 +2154,7 @@ fn run_inner() -> Result<(), AppError> {
         lint_profiles: lint_profiles_active,
         files_from_counters: None,
         zero_result_values: std::collections::BTreeMap::new(),
+        zero_result_body_search: None,
     };
 
     // When --files-from resolved to zero files (all entries filtered/missing),
@@ -2196,6 +2197,10 @@ fn run_inner() -> Result<(), AppError> {
         // paid for. Hand them to the hint layer so the zero-result
         // did-you-mean names real values instead of guessing.
         hctx.observed_property_values = std::mem::take(&mut ctx.zero_result_values);
+        // iter-258: same trip, one more answer — when the empty query filtered
+        // on a property *regex* that body text does match, the hint layer can
+        // say so and hand over the equivalent `find -e`.
+        hctx.body_search_suggestion = ctx.zero_result_body_search.take();
     }
 
     let exit_code_override = ctx.exit_code_override;

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -8,7 +8,10 @@ Prefer `hyalo` CLI for operations on files in this directory:
   full syntax reference (operators, sort keys, `--fields` values, output shapes, cookbook).
 - **Empty result sets are self-documenting**: a `find` that matches nothing echoes the filters it
   applied and hints at the next step (did-you-mean over the values the property really has, and the
-  same query with its most selective filter dropped).
+  same query with its most selective filter dropped). When the empty query filtered on a property
+  regex (`--property 'title~=/DEC-25/'`) whose pattern *does* occur in body prose, the hints lead
+  with the equivalent body search (`hyalo find -e 'DEC-25'`) — read them before re-guessing the
+  filter, because identifiers that live in `##` headings are never frontmatter titles.
 - **Search/filter**: `hyalo find --property status=planned --tag iteration`
 - **Body search**: `hyalo find "broken links"`
 - **Title regex**: `hyalo find --property 'title~=link'`

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -86,6 +86,12 @@ hyalo find --title "meeting"           # substring match on displayed title
 hyalo find --title "/^Design/i"        # regex on displayed title
 ```
 
+Neither one sees body prose. An identifier that lives in a `##` heading — `DEC-251` in a
+decision log, say — is not a title, so `--property 'title~=/DEC-25/'` correctly returns
+nothing. When that happens hyalo checks whether the same regex occurs in body text and, if
+it does, leads the zero-result hints with the body search that works
+(`hyalo find -e 'DEC-25'`). Read the hints before re-guessing the filter.
+
 `--section` uses case-insensitive **substring** matching by default — `"Tasks"` matches
 `"Tasks [4/4]"`, `"My Tasks"`, etc. Use `"/regex/"` for regex. Prefix `##` to pin heading level.
 

--- a/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
+++ b/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
@@ -333,6 +333,100 @@ fn a_second_filter_earns_a_drop_the_most_selective_hint() {
     );
 }
 
+// --- iter-258: zero-result `title~=` points at body search -----------------
+
+/// A vault shaped like the decision log that motivated iteration 258: the
+/// `DEC-NNN` identifiers are `##` body headings, so `--property title~=` is
+/// correct and empty while `find -e` is what the caller wanted.
+fn dec_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "decision-log.md",
+        "---\ntitle: Decision log\n---\n\n## DEC-251 — hints\n\ntext\n",
+    );
+    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n\nunrelated\n");
+    tmp
+}
+
+fn body_search_hint(parsed: &serde_json::Value) -> Option<&serde_json::Value> {
+    parsed["hints"].as_array()?.iter().find(|h| {
+        h["description"]
+            .as_str()
+            .is_some_and(|d| d.contains("search bodies instead"))
+    })
+}
+
+fn find_json(tmp: &TempDir, args: &[&str]) -> serde_json::Value {
+    let output = hyalo()
+        .args(["--dir", tmp.path().to_str().unwrap()])
+        .arg("find")
+        .args(args)
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn a_title_regex_that_only_matches_body_text_suggests_find_e() {
+    let tmp = dec_vault();
+    let parsed = find_json(&tmp, &["--property", "title~=/DEC-25/"]);
+    assert_eq!(parsed["total"], 0);
+    let hint =
+        body_search_hint(&parsed).unwrap_or_else(|| panic!("no body-search hint: {parsed}"));
+    assert_eq!(
+        hint["description"],
+        "No `title` matches that regex, but body text does — search bodies instead"
+    );
+    let cmd = hint["cmd"].as_str().unwrap();
+    assert!(
+        cmd.contains("find -e DEC-25"),
+        "the hint hands over the equivalent body search: {cmd}"
+    );
+    assert_eq!(hint["writes"], false);
+
+    // The promise the hint makes must hold: running it returns results.
+    // The hint already carries `--dir` and `--format json` from this run.
+    let args = shell_split(cmd);
+    let rerun = hyalo().args(&args[1..]).output().unwrap();
+    let rerun: serde_json::Value = serde_json::from_slice(&rerun.stdout).unwrap();
+    assert_eq!(
+        rerun["total"], 1,
+        "the suggested command must actually find something: {rerun}"
+    );
+}
+
+#[test]
+fn no_body_search_hint_when_the_body_does_not_match_either() {
+    let tmp = dec_vault();
+    let parsed = find_json(&tmp, &["--property", "title~=/NOSUCHTHING/"]);
+    assert_eq!(parsed["total"], 0);
+    assert!(
+        body_search_hint(&parsed).is_none(),
+        "nothing in the body matches, so there is nothing to suggest: {parsed}"
+    );
+    assert!(
+        !parsed["hints"].as_array().unwrap().is_empty(),
+        "the other zero-result hints still fire: {parsed}"
+    );
+}
+
+#[test]
+fn no_body_search_hint_when_the_query_already_searched_bodies() {
+    let tmp = dec_vault();
+    let parsed = find_json(
+        &tmp,
+        &["-e", "DEC-25", "--property", "title~=/DEC-25/", "--tag", "nope"],
+    );
+    assert_eq!(parsed["total"], 0);
+    assert!(
+        body_search_hint(&parsed).is_none(),
+        "a caller who already passed -e needs no body-search lesson: {parsed}"
+    );
+}
+
 #[test]
 fn a_zero_result_hint_is_a_runnable_command() {
     let tmp = vault();

--- a/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
+++ b/crates/hyalo-cli/tests/e2e/agent_discoverability.rs
@@ -345,7 +345,11 @@ fn dec_vault() -> TempDir {
         "decision-log.md",
         "---\ntitle: Decision log\n---\n\n## DEC-251 — hints\n\ntext\n",
     );
-    write_md(tmp.path(), "note.md", "---\ntitle: Note\n---\n\nunrelated\n");
+    write_md(
+        tmp.path(),
+        "note.md",
+        "---\ntitle: Note\n---\n\nunrelated\n",
+    );
     tmp
 }
 
@@ -374,8 +378,7 @@ fn a_title_regex_that_only_matches_body_text_suggests_find_e() {
     let tmp = dec_vault();
     let parsed = find_json(&tmp, &["--property", "title~=/DEC-25/"]);
     assert_eq!(parsed["total"], 0);
-    let hint =
-        body_search_hint(&parsed).unwrap_or_else(|| panic!("no body-search hint: {parsed}"));
+    let hint = body_search_hint(&parsed).unwrap_or_else(|| panic!("no body-search hint: {parsed}"));
     assert_eq!(
         hint["description"],
         "No `title` matches that regex, but body text does — search bodies instead"
@@ -418,7 +421,14 @@ fn no_body_search_hint_when_the_query_already_searched_bodies() {
     let tmp = dec_vault();
     let parsed = find_json(
         &tmp,
-        &["-e", "DEC-25", "--property", "title~=/DEC-25/", "--tag", "nope"],
+        &[
+            "-e",
+            "DEC-25",
+            "--property",
+            "title~=/DEC-25/",
+            "--tag",
+            "nope",
+        ],
     );
     assert_eq!(parsed["total"], 0);
     assert!(

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3793,3 +3793,45 @@ rendering is one line per action and the JSON body is `serde_json::to_value` of
 the same struct, so the two can never drift. Text lines are now uniformly
 `verb  target  (detail)` — previously some details were separated by one space
 and some by two.
+
+## DEC-263: a zero-result property-regex query probes the body before hinting (2026-08-31)
+
+**Decision:** When a `find` returns nothing and carried a `--property K~=RE`
+filter, hyalo probes whether the same regex matches body prose and — only if it
+does — leads the zero-result hints with `hyalo find -e '<RE>'`. The probe is
+bounded at 512 files / 8 MiB with a first-match early exit, runs on the
+zero-result path only, and never on a query that already searched bodies
+(`PATTERN` / `-e`). No new flag, no new config key.
+
+**Why:** Iteration 256's dogfooding hit `hyalo find --property 'title~=/DEC-25/'`
+against this decision log, whose `DEC-NNN` identifiers are `##` body headings.
+The query is correct, the empty answer is correct, and the useful command
+(`hyalo find -e 'DEC-25'`) is one flag away — but nothing on the zero-result
+path said so. That is precisely the gap iteration 251's hint machinery exists to
+close, so this is an addition to it, not a special case bolted on beside it.
+
+**Why a probe rather than unconditional advice:** an unconditional "try body
+search" line costs nothing but is wrong about as often as it is right, and a
+hint that is sometimes wrong is a hint agents learn to skip (see
+[[iterations/iteration-180-hint-trust]]). Confirming the match first makes the
+hint a statement of fact: the command it prints is known to return something.
+The probe compiles `(?i)<RE>` — exactly what `find -e` compiles — and matches
+body and fenced-code lines, so the hint and the command it suggests cannot
+disagree. For the same reason the probe ignores `--file`/`--glob` scoping and
+every other filter, and the suggested command drops them: promising results
+inside a narrower scope than was checked would be the lie this design is
+avoiding.
+
+**Why the budget is affordable:** the probe reads bodies, which a
+frontmatter-only query otherwise never does — so it is bounded rather than
+trusted to be small. Measured on this vault (437 files, 4 MB, release build) the
+worst case, a regex that matches nothing anywhere, added ~10 ms to a ~20 ms
+query; a match short-circuits far earlier. It fires only when a query already
+returned zero *and* filtered on a property regex, so no query that found
+anything pays for it. A vault above the ceiling simply does not get the hint,
+which is the right trade against turning every empty query into a full body
+scan.
+
+**Rejected:** a `--search-bodies` / `--also-body` flag, and a config key for the
+probe budget. Both grow the CLI surface under dogfood pressure, which
+`feedback_no_cli_surface_growth` rules out; the hint text is the whole feature.

--- a/hyalo-knowledgebase/iterations/iteration-258-zero-result-title-regex-hint.md
+++ b/hyalo-knowledgebase/iterations/iteration-258-zero-result-title-regex-hint.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 258 — zero-result title~= hint toward body search"
 date: 2026-08-31
-status: in-progress
+status: completed
 tags:
   - iteration
   - dogfood-fixes
@@ -32,7 +32,7 @@ doesn't fit cleanly, close as won't-fix rather than growing a special case.
 
 ## Tasks
 
-### HINT-1: zero-result `--property 'title~=...'` hint [0/1]
+### HINT-1: zero-result `--property 'title~=...'` hint [1/1]
 
 - [x] Read how the existing zero-result hint logic works (did-you-mean over
       property values, filter-dropping suggestion) and decide whether a
@@ -57,6 +57,32 @@ doesn't fit cleanly, close as won't-fix rather than growing a special case.
 
 - Any new CLI flag. This is a hint-text change at most — see
   `feedback_no_cli_surface_growth`.
+
+## Outcome
+
+Implemented, not closed as won't-fix — it fitted the existing machinery. A
+zero-result `find` that carried a `--property K~=RE` filter now probes whether
+the same regex matches body prose and, only when it does, leads the zero-result
+hints with the equivalent `hyalo find -e '<RE>'`. See
+[[decision-log#DEC-263: a zero-result property-regex query probes the body before hinting (2026-08-31)]]
+for why the probe confirms the match instead of offering unconditional advice,
+and for the budget that keeps it affordable.
+
+- The probe is bounded at 512 files / 8 MiB with a first-match early exit, runs
+  only on the zero-result path, only when a property regex filter is active, and
+  never when the query already searched bodies (`PATTERN` / `-e`).
+- Measured on this vault (437 files, 4 MB, release build): the worst case — a
+  regex matching nothing anywhere, so the whole vault is probed — added ~10 ms
+  to a ~20 ms query. A match short-circuits far earlier.
+- No new flag and no new config key, per the non-goal below.
+- Verified live: `hyalo find --property 'title~=/DEC-25/'` against this vault,
+  whose `DEC-NNN` ids are `##` headings, now emits
+  `-> hyalo find -e DEC-25  # No \`title\` matches that regex, but body text does — search bodies instead`.
+
+Touched: `crates/hyalo-cli/src/commands/find/run.rs` (probe),
+`crates/hyalo-cli/src/hints.rs` + `hints/zero_result.rs` (hint),
+`dispatch.rs`/`run.rs` (plumbing), `templates/rule-knowledgebase.md`,
+`.claude/skills/hyalo/SKILL.md`, `CHANGELOG.md`, `decision-log.md`.
 
 ## Links
 

--- a/hyalo-knowledgebase/iterations/iteration-258-zero-result-title-regex-hint.md
+++ b/hyalo-knowledgebase/iterations/iteration-258-zero-result-title-regex-hint.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 258 — zero-result title~= hint toward body search"
 date: 2026-08-31
-status: planned
+status: in-progress
 tags:
   - iteration
   - dogfood-fixes
@@ -34,7 +34,7 @@ doesn't fit cleanly, close as won't-fix rather than growing a special case.
 
 ### HINT-1: zero-result `--property 'title~=...'` hint [0/1]
 
-- [ ] Read how the existing zero-result hint logic works (did-you-mean over
+- [x] Read how the existing zero-result hint logic works (did-you-mean over
       property values, filter-dropping suggestion) and decide whether a
       `title~=` query that matches nothing can cheaply also check whether
       the same regex matches body text anywhere in the vault, and if so,
@@ -47,10 +47,10 @@ doesn't fit cleanly, close as won't-fix rather than growing a special case.
 
 ## Acceptance criteria
 
-- [ ] HINT-1 is either implemented (with a test covering the new hint
+- [x] HINT-1 is either implemented (with a test covering the new hint
       trigger and its absence when body search also finds nothing) or
       explicitly closed as won't-fix with a DEC recorded.
-- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, all `xtask check-*`, `hyalo lint --strict`.
 
 ## Non-goals

--- a/hyalo-knowledgebase/iterations/iteration-259-index-snapshot-load-perf.md
+++ b/hyalo-knowledgebase/iterations/iteration-259-index-snapshot-load-perf.md
@@ -1,0 +1,87 @@
+---
+type: iteration
+title: Iteration 259 — snapshot-index load/deserialize floor
+date: 2026-08-31
+status: planned
+tags: [iteration, performance, carry-over]
+branch: iter-259/index-snapshot-load-perf
+depends-on: "[[iterations/iteration-256-envelope-help-forwarding-and-index-cost]]"
+---
+
+# Iteration 259 — snapshot-index load/deserialize floor
+
+## Goal
+
+Carry-over from [[iterations/iteration-256-envelope-help-forwarding-and-index-cost]]'s
+FIND-8 investigation, never folded into 257 or 258 (both were bug/UX-shaped,
+not perf). Quoting that iteration's Outcomes section verbatim:
+
+> Worth noting for future perf work: the remaining ~0.37 s floor on this
+> vault is snapshot load and deserialization of a 123 MB index, which dwarfs
+> everything `find` does afterwards. Any further `--fields` micro-optimisation
+> on an indexed vault is measuring noise until that is addressed.
+
+256 fixed the *specific* quadratic dedupe bug it found (DEC-259,
+`CaseInsensitiveIndex::insert`, 62.4 ms → 4.2 ms) but explicitly did not
+touch the much larger fixed cost underneath it: loading and deserializing a
+`.hyalo-index` snapshot before any `find` filtering happens at all. On the
+14 399-file / 123 MB MDN vault used for that measurement, this floor was
+~0.37 s — the majority of total `find` latency on that vault, and the reason
+127's author flagged that further per-field timing work would be measuring
+noise rather than signal until this is addressed.
+
+This iteration is about locating *where* that floor comes from (MessagePack
+deserialization itself, disk I/O, allocation shape, or something else) and
+whether any of it is reducible without changing the on-disk snapshot format
+in a way that breaks compatibility — not about a specific fix committed in
+advance.
+
+## Tasks
+
+### PERF-1: characterize the snapshot-load floor [0/1]
+
+- [ ] Reproduce 256's measurement independently: build (or reuse, if still
+      available) a large synthetic or real vault (MDN-scale, ~14k files /
+      ~120 MB index) and profile `hyalo find --limit 1` end to end,
+      isolating snapshot read + deserialize from everything downstream.
+      Confirm the ~0.37 s figure still holds against current `main` (perf
+      characteristics may have shifted since 256). Use `xtask bench-scale`
+      if it fits this vault size, or a dedicated one-off harness if not —
+      note which, and why, in the outcome.
+- [ ] Break the floor down: how much is reading bytes off disk (cold vs warm
+      cache), how much is MessagePack decode, how much is post-decode
+      reconstruction (e.g., rebuilding in-memory indexes/maps from the
+      flat snapshot). Use a profiler or manual instrumentation — whichever
+      gives trustworthy numbers fastest.
+- [ ] Decide, with evidence, whether there is a reducible cost here at all
+      (e.g., streaming decode instead of whole-buffer deserialize, avoiding
+      an intermediate allocation, lazy-loading index sections that most
+      `find` invocations don't touch) or whether the floor is inherent to
+      "read N megabytes and materialize M structures" and not worth chasing
+      further. Either finding is a valid outcome — this task is
+      "characterize and decide", not "must ship a speedup".
+
+## Acceptance criteria
+
+- [ ] PERF-1 produces a written, numbers-backed characterization of the
+      snapshot-load floor (where the time goes, on what vault size), checked
+      into this file's Outcome section or a `research/` note it links to.
+- [ ] Either a concrete, scoped follow-up fix is identified (and filed as its
+      own iteration if it's more than a small patch) or the floor is
+      recorded as inherent/not-worth-chasing with a DEC explaining why —
+      not left as an open question.
+- [ ] If any code changes are made in this iteration, gates green: `cargo
+      fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+      `cargo test --workspace -q`, all `xtask check-*`, `hyalo lint --strict`.
+
+## Non-goals
+
+- Changing the on-disk snapshot format's wire compatibility without a
+  clear DEC covering migration — this iteration characterizes the cost
+  first; a format change (if warranted) is its own follow-up iteration.
+- Re-litigating DEC-259's `CaseInsensitiveIndex::insert` fix — that
+  quadratic bug is already fixed; this is the cost *underneath* it.
+
+## Links
+
+- [[iterations/iteration-256-envelope-help-forwarding-and-index-cost]]


### PR DESCRIPTION
## Summary

- **A zero-result `--property K~=RE` query now hints at the body search that works.** Iteration 256's dogfooding hit `hyalo find --property 'title~=/DEC-25/'` against `decision-log.md`, whose `DEC-NNN` ids are `##` body headings rather than frontmatter titles. The query is correct, the empty answer is correct, and the useful command (`hyalo find -e 'DEC-25'`) is one flag away — but nothing on the zero-result path said so. It now leads the hints:

  ```
  -> hyalo find -e DEC-25  # No `title` matches that regex, but body text does — search bodies instead
  ```

- **The hint is a fact, not advice.** `find` runs a bounded probe (512 files / 8 MiB, first-match early exit) that compiles `(?i)<RE>` — exactly what `find -e` compiles — and matches body *and* fenced-code lines, so the hint and the command it prints cannot disagree. It fires only when the probe actually found a body match, so the suggested command is known to return something. An unconditional "try body search" line would be wrong about as often as it is right, and a hint that is sometimes wrong is one agents learn to skip (iteration 180's hint-trust rule).

- **It stays cheap.** The probe runs only on the zero-result path, only when a property regex filter is active, and never when the query already searched bodies (`PATTERN` / `-e`) — so nothing that found results pays for it. Measured on `hyalo-knowledgebase` (437 files, 4 MB, release build), the worst case — a regex matching nothing anywhere, so the whole vault is probed — added ~10 ms to a ~20 ms query. Both ceilings are checked before each read, so the budget is a real bound. A vault above it simply does not get the hint.

- **No new CLI surface**, per the iteration's non-goal and `feedback_no_cli_surface_growth`: no flag, no config key. The whole feature is one line of hint text plus the probe that earns it. Recorded as DEC-263, including why the probe deliberately ignores `--file`/`--glob` scoping and every other filter — and why the suggested command drops them to match, rather than promising results inside a narrower scope than was checked.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q` (all green)
- [x] Every `xtask check-*` gate: `check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`, `check-pi-package-sync`, `check-dead-primitives`, `check-todo-annotations`, `check-mutation-journal` — all exit 0
- [x] `hyalo lint --strict` — 111 files checked, no issues
- [x] 7 new unit tests on the probe (`crates/hyalo-cli/src/commands/find/run.rs`): fires on a body-only match; silent when the body does not match either; silent when the query already searched bodies; ignores non-regex property filters; refuses an empty pattern; matches inside fenced code; case-insensitive like `find -e`
- [x] 2 new unit tests on the hint (`crates/hyalo-cli/src/hints/zero_result.rs`): it leads the hint list and is read-only; absent without a confirmed match
- [x] 3 new e2e tests (`crates/hyalo-cli/tests/e2e/agent_discoverability.rs`) against a decision-log-shaped vault — including one that shell-splits the emitted hint, re-runs it, and asserts it returns 1 result, so the promise the hint makes is enforced
- [x] Verified live against the real `hyalo-knowledgebase`, and measured the worst-case probe cost quoted above
- [x] Docs updated in the same PR: `CHANGELOG.md`, `templates/rule-knowledgebase.md`, `templates/skill-hyalo.md`, DEC-263 in `decision-log.md`, iteration 258 marked completed with an outcome section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS

## Carry-over

Review pass for PR #300 (2026-08-31) swept this iteration and its predecessor
(256) for anything left unaddressed:

- **iteration-258's own ACs/tasks**: all ticked, verified against the real
  diff — HINT-1 was implemented (not won't-fixed), nothing deferred.
- **iteration-256's dogfooding findings** (the three items filed under
  "Dogfooding findings (filed, not fixed here)"): `init`/`deinit` `--dir`
  scoping bugs → fixed in #299 (iteration 257, BUG-1/BUG-2). `--format json`
  ignored by `init`/`deinit` → decided in #299 (iteration 257, BUG-3). The
  `title~=` zero-result hint → this PR (iteration 258). All three closed.
- **iteration-256's Outcomes note on the snapshot-load floor** ("the
  remaining ~0.37s floor on this vault is snapshot load and deserialization
  of a 123 MB index... any further `--fields` micro-optimisation is
  measuring noise until that is addressed") was never folded into 257 or
  258 — both were bug/UX-shaped, not perf. This is the last iteration of
  the run, so it gets its own new plan rather than a fold-in:
  **filed as [[iterations/iteration-259-index-snapshot-load-perf]]**
  (`hyalo-knowledgebase/iterations/iteration-259-index-snapshot-load-perf.md`,
  status `planned`) — characterize where the deserialize-floor time goes and
  decide whether it's reducible, before any further `find`-path micro-opts.

No other unticked ACs, `[deferred …]` annotations, or out-of-scope findings
were found in this iteration's plan, PR body, or milestones.
