### PR TITLE
iter-259: characterize the snapshot-index load floor (76% is BM25 nobody reads)

### DIFF
--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -308,37 +308,6 @@ struct SnapshotData {
     bm25_index: Option<Bm25InvertedIndex>,
 }
 
-#[derive(Deserialize)]
-struct SnapshotDataNoBm25 {
-    header: SnapshotHeader,
-    entries: Vec<IndexEntry>,
-    graph: LinkGraph,
-    #[serde(default)]
-    bm25_index: Option<serde::de::IgnoredAny>,
-}
-
-#[derive(Deserialize)]
-struct SnapshotDataAllIgnored {
-    #[serde(default)]
-    header: Option<serde::de::IgnoredAny>,
-    #[serde(default)]
-    entries: Option<serde::de::IgnoredAny>,
-    #[serde(default)]
-    graph: Option<serde::de::IgnoredAny>,
-    #[serde(default)]
-    bm25_index: Option<serde::de::IgnoredAny>,
-}
-
-#[derive(Deserialize)]
-struct SnapshotDataEntriesOnly {
-    header: SnapshotHeader,
-    entries: Vec<IndexEntry>,
-    #[serde(default)]
-    graph: Option<serde::de::IgnoredAny>,
-    #[serde(default)]
-    bm25_index: Option<serde::de::IgnoredAny>,
-}
-
 /// Borrowed variant used only for serialization — avoids cloning all entries.
 #[derive(Serialize)]
 struct SnapshotDataRef<'a> {
@@ -816,24 +785,8 @@ impl SnapshotIndex {
     ///
     /// Returns `Ok(Some(index))` on success, `Ok(None)` on schema mismatch.
     fn load_inner(bytes: &[u8], warn: bool) -> Option<Self> {
-        let __t0 = std::time::Instant::now();
         match rmp_serde::from_slice::<SnapshotData>(bytes) {
             Ok(data) => {
-                eprintln!("[T] rmp decode: {:?}", __t0.elapsed());
-                {
-                    let eb = rmp_serde::to_vec_named(&data.entries).unwrap();
-                    let gb = rmp_serde::to_vec_named(&data.graph).unwrap();
-                    let bb = data.bm25_index.as_ref().map(|b| rmp_serde::to_vec_named(b).unwrap().len()).unwrap_or(0);
-                    eprintln!("[T] SIZE entries={} MiB graph={} MiB bm25={} MiB", eb.len()/1048576, gb.len()/1048576, bb/1048576);
-                    let t = std::time::Instant::now();
-                    let d: Vec<IndexEntry> = rmp_serde::from_slice(&eb).unwrap();
-                    eprintln!("[T] SIZE entries-alone decode: {:?} ({})", t.elapsed(), d.len());
-                    let t = std::time::Instant::now();
-                    let d2: serde::de::IgnoredAny = rmp_serde::from_slice(&eb).unwrap();
-                    eprintln!("[T] SIZE entries-alone walk: {:?}", t.elapsed());
-                    drop((d, d2));
-                }
-                let __t1 = std::time::Instant::now();
                 // Limits used by the SEC-2 and SEC-3 defense-in-depth checks below.
                 // All consts are hoisted to the top of the arm so they appear before
                 // any statements (clippy::items_after_statements).
@@ -911,8 +864,6 @@ impl SnapshotIndex {
                     }
                 }
 
-                eprintln!("[T] sec1 path validation: {:?}", __t1.elapsed());
-                let __t2 = std::time::Instant::now();
                 // SEC-3 (defense-in-depth): reject snapshots whose link graph or
                 // BM25 index would expand to an implausibly large in-memory
                 // structure.  A crafted snapshot could claim a plausible number
@@ -955,8 +906,6 @@ impl SnapshotIndex {
                     return None;
                 }
 
-                eprintln!("[T] sec3+bm25 validation: {:?}", __t2.elapsed());
-                let __t3 = std::time::Instant::now();
                 // Entries are stored in sorted order (ScannedIndex::build sorts
                 // before saving).  Re-sort here to guarantee the invariant even
                 // if an older snapshot was created without sorting.
@@ -971,13 +920,9 @@ impl SnapshotIndex {
                 // The graph's lowercased companion map is `#[serde(skip)]`, so a
                 // freshly-deserialized graph has an empty one — rebuild it from
                 // the restored index keys so `backlinks_ci` works off snapshots.
-                eprintln!("[T] sort + path_index: {:?}", __t3.elapsed());
-                let __t4 = std::time::Instant::now();
                 let mut graph = data.graph;
                 graph.rebuild_lower_index();
-                eprintln!("[T] rebuild_lower_index: {:?}", __t4.elapsed());
-                let __t5 = std::time::Instant::now();
-                let __r = Some(Self {
+                Some(Self {
                     entries,
                     path_index,
                     graph,
@@ -985,9 +930,7 @@ impl SnapshotIndex {
                     bm25_index: data.bm25_index,
                     frontmatter_link_props: None,
                     case_index_cache: None,
-                });
-                eprintln!("[T] construct: {:?}", __t5.elapsed());
-                __r
+                })
             }
             Err(e) => {
                 if warn {
@@ -1008,38 +951,10 @@ impl SnapshotIndex {
     /// fall back to a disk scan. A warning is printed to stderr in this case.
     /// Returns `Err` only for hard I/O failures.
     pub fn load(path: &Path) -> Result<Option<Self>> {
-        let __tr = std::time::Instant::now();
         let Some(bytes) = read_index_bytes(path, true)? else {
             return Ok(None);
         };
-        eprintln!("[T] read bytes ({} MiB): {:?}", bytes.len() / 1048576, __tr.elapsed());
-        {
-            let t = std::time::Instant::now();
-            let d = rmp_serde::from_slice::<SnapshotDataAllIgnored>(&bytes).unwrap();
-            eprintln!("[T] EXP walk-only (all ignored): {:?}", t.elapsed());
-            drop(d);
-        }
-        {
-            let t = std::time::Instant::now();
-            let d = rmp_serde::from_slice::<SnapshotDataNoBm25>(&bytes).unwrap();
-            eprintln!("[T] EXP decode skipping bm25: {:?} (entries={})", t.elapsed(), d.entries.len());
-            let t2 = std::time::Instant::now();
-            drop(d);
-            eprintln!("[T] EXP drop no-bm25 data: {:?}", t2.elapsed());
-        }
-        {
-            let t = std::time::Instant::now();
-            let d = rmp_serde::from_slice::<SnapshotDataEntriesOnly>(&bytes).unwrap();
-            eprintln!("[T] EXP decode entries only: {:?} (entries={})", t.elapsed(), d.entries.len());
-            drop(d);
-        }
-        let __ta = std::time::Instant::now();
-        let __r = Ok(Self::load_inner(&bytes, true));
-        eprintln!("[T] load_inner total: {:?}", __ta.elapsed());
-        let __td = std::time::Instant::now();
-        drop(bytes);
-        eprintln!("[T] drop bytes: {:?}", __td.elapsed());
-        __r
+        Ok(Self::load_inner(&bytes, true))
     }
 
     /// Load a snapshot silently — identical to [`load`] but suppresses the

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -308,6 +308,37 @@ struct SnapshotData {
     bm25_index: Option<Bm25InvertedIndex>,
 }
 
+#[derive(Deserialize)]
+struct SnapshotDataNoBm25 {
+    header: SnapshotHeader,
+    entries: Vec<IndexEntry>,
+    graph: LinkGraph,
+    #[serde(default)]
+    bm25_index: Option<serde::de::IgnoredAny>,
+}
+
+#[derive(Deserialize)]
+struct SnapshotDataAllIgnored {
+    #[serde(default)]
+    header: Option<serde::de::IgnoredAny>,
+    #[serde(default)]
+    entries: Option<serde::de::IgnoredAny>,
+    #[serde(default)]
+    graph: Option<serde::de::IgnoredAny>,
+    #[serde(default)]
+    bm25_index: Option<serde::de::IgnoredAny>,
+}
+
+#[derive(Deserialize)]
+struct SnapshotDataEntriesOnly {
+    header: SnapshotHeader,
+    entries: Vec<IndexEntry>,
+    #[serde(default)]
+    graph: Option<serde::de::IgnoredAny>,
+    #[serde(default)]
+    bm25_index: Option<serde::de::IgnoredAny>,
+}
+
 /// Borrowed variant used only for serialization — avoids cloning all entries.
 #[derive(Serialize)]
 struct SnapshotDataRef<'a> {
@@ -785,8 +816,24 @@ impl SnapshotIndex {
     ///
     /// Returns `Ok(Some(index))` on success, `Ok(None)` on schema mismatch.
     fn load_inner(bytes: &[u8], warn: bool) -> Option<Self> {
+        let __t0 = std::time::Instant::now();
         match rmp_serde::from_slice::<SnapshotData>(bytes) {
             Ok(data) => {
+                eprintln!("[T] rmp decode: {:?}", __t0.elapsed());
+                {
+                    let eb = rmp_serde::to_vec_named(&data.entries).unwrap();
+                    let gb = rmp_serde::to_vec_named(&data.graph).unwrap();
+                    let bb = data.bm25_index.as_ref().map(|b| rmp_serde::to_vec_named(b).unwrap().len()).unwrap_or(0);
+                    eprintln!("[T] SIZE entries={} MiB graph={} MiB bm25={} MiB", eb.len()/1048576, gb.len()/1048576, bb/1048576);
+                    let t = std::time::Instant::now();
+                    let d: Vec<IndexEntry> = rmp_serde::from_slice(&eb).unwrap();
+                    eprintln!("[T] SIZE entries-alone decode: {:?} ({})", t.elapsed(), d.len());
+                    let t = std::time::Instant::now();
+                    let d2: serde::de::IgnoredAny = rmp_serde::from_slice(&eb).unwrap();
+                    eprintln!("[T] SIZE entries-alone walk: {:?}", t.elapsed());
+                    drop((d, d2));
+                }
+                let __t1 = std::time::Instant::now();
                 // Limits used by the SEC-2 and SEC-3 defense-in-depth checks below.
                 // All consts are hoisted to the top of the arm so they appear before
                 // any statements (clippy::items_after_statements).
@@ -864,6 +911,8 @@ impl SnapshotIndex {
                     }
                 }
 
+                eprintln!("[T] sec1 path validation: {:?}", __t1.elapsed());
+                let __t2 = std::time::Instant::now();
                 // SEC-3 (defense-in-depth): reject snapshots whose link graph or
                 // BM25 index would expand to an implausibly large in-memory
                 // structure.  A crafted snapshot could claim a plausible number
@@ -906,6 +955,8 @@ impl SnapshotIndex {
                     return None;
                 }
 
+                eprintln!("[T] sec3+bm25 validation: {:?}", __t2.elapsed());
+                let __t3 = std::time::Instant::now();
                 // Entries are stored in sorted order (ScannedIndex::build sorts
                 // before saving).  Re-sort here to guarantee the invariant even
                 // if an older snapshot was created without sorting.
@@ -920,9 +971,13 @@ impl SnapshotIndex {
                 // The graph's lowercased companion map is `#[serde(skip)]`, so a
                 // freshly-deserialized graph has an empty one — rebuild it from
                 // the restored index keys so `backlinks_ci` works off snapshots.
+                eprintln!("[T] sort + path_index: {:?}", __t3.elapsed());
+                let __t4 = std::time::Instant::now();
                 let mut graph = data.graph;
                 graph.rebuild_lower_index();
-                Some(Self {
+                eprintln!("[T] rebuild_lower_index: {:?}", __t4.elapsed());
+                let __t5 = std::time::Instant::now();
+                let __r = Some(Self {
                     entries,
                     path_index,
                     graph,
@@ -930,7 +985,9 @@ impl SnapshotIndex {
                     bm25_index: data.bm25_index,
                     frontmatter_link_props: None,
                     case_index_cache: None,
-                })
+                });
+                eprintln!("[T] construct: {:?}", __t5.elapsed());
+                __r
             }
             Err(e) => {
                 if warn {
@@ -951,10 +1008,38 @@ impl SnapshotIndex {
     /// fall back to a disk scan. A warning is printed to stderr in this case.
     /// Returns `Err` only for hard I/O failures.
     pub fn load(path: &Path) -> Result<Option<Self>> {
+        let __tr = std::time::Instant::now();
         let Some(bytes) = read_index_bytes(path, true)? else {
             return Ok(None);
         };
-        Ok(Self::load_inner(&bytes, true))
+        eprintln!("[T] read bytes ({} MiB): {:?}", bytes.len() / 1048576, __tr.elapsed());
+        {
+            let t = std::time::Instant::now();
+            let d = rmp_serde::from_slice::<SnapshotDataAllIgnored>(&bytes).unwrap();
+            eprintln!("[T] EXP walk-only (all ignored): {:?}", t.elapsed());
+            drop(d);
+        }
+        {
+            let t = std::time::Instant::now();
+            let d = rmp_serde::from_slice::<SnapshotDataNoBm25>(&bytes).unwrap();
+            eprintln!("[T] EXP decode skipping bm25: {:?} (entries={})", t.elapsed(), d.entries.len());
+            let t2 = std::time::Instant::now();
+            drop(d);
+            eprintln!("[T] EXP drop no-bm25 data: {:?}", t2.elapsed());
+        }
+        {
+            let t = std::time::Instant::now();
+            let d = rmp_serde::from_slice::<SnapshotDataEntriesOnly>(&bytes).unwrap();
+            eprintln!("[T] EXP decode entries only: {:?} (entries={})", t.elapsed(), d.entries.len());
+            drop(d);
+        }
+        let __ta = std::time::Instant::now();
+        let __r = Ok(Self::load_inner(&bytes, true));
+        eprintln!("[T] load_inner total: {:?}", __ta.elapsed());
+        let __td = std::time::Instant::now();
+        drop(bytes);
+        eprintln!("[T] drop bytes: {:?}", __td.elapsed());
+        __r
     }
 
     /// Load a snapshot silently — identical to [`load`] but suppresses the

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -3835,3 +3835,66 @@ scan.
 **Rejected:** a `--search-bodies` / `--also-body` flag, and a config key for the
 probe budget. Both grow the CLI surface under dogfood pressure, which
 `feedback_no_cli_surface_growth` rules out; the hint text is the whole feature.
+
+## DEC-264: the snapshot floor is BM25 traversal, and it is worth fixing (2026-09-01)
+
+**Decision:** The ~0.37 s snapshot-load floor 256 flagged is **not** inherent.
+76 % of a 116 MiB `.hyalo-index` is the BM25 inverted index, and a `find` with
+no text query spends ~230 ms of its ~360 ms on that section without ever
+reading it. The fix — stop the MessagePack parse at the `bm25_index` key and
+decode it only on demand — is wire-compatible and measured at 240 ms → 61.5 ms
+for the decode. It is scoped to
+[[iterations/iteration-260-lazy-bm25-snapshot-load]] rather than landed in 259,
+because making it *safe* is a design problem, not a patch. Full numbers:
+[[research/snapshot-load-floor-2026-09-01]].
+
+**Why the floor is not I/O:** reading the whole 116 MiB is 19 ms warm
+(6.0 GiB/s) and 59 ms cold with `F_NOCACHE` (1.9 GiB/s) — 5–17 % of the
+command. Every "read fewer bytes / stream the read / mmap it" idea is aimed at
+the smallest term in the sum. mmap was already rejected on macOS in
+[[research/performance-parallelization]]; nothing here reopens that.
+
+**Why the floor is not the entries either:** the plan's stated suspects —
+allocation shape and post-decode reconstruction — do not survive measurement.
+All 14 375 `IndexEntry` values materialize from their own 19 MiB buffer in
+41 ms. The re-sort, `path_index` rebuild and `rebuild_lower_index` together
+cost 2 ms. DEC-259 already removed the one genuinely quadratic piece.
+
+**Why `IgnoredAny` is not the answer:** the obvious lazy-field trick — mark
+`bm25_index` as `IgnoredAny` — saves 35 ms of 240 ms. Decoding the whole
+document while materializing *nothing at all* still costs 179 ms. Three
+quarters of the decode is serde token-walking 87 MiB of `Posting` maps and
+`positions: Vec<u32>` arrays; skipping construction while still walking the
+bytes buys almost nothing. This is the finding that redirects the work: the
+target is traversal, not materialization.
+
+**Why early-stop rather than a format change:** `rmp_serde::to_vec_named`
+writes the snapshot as a map with string keys and emits `bm25_index` last, so a
+hand-written `Deserialize` that `break`s on that key skips all 87 MiB without
+reading them, and `from_slice` accepts the unconsumed tail. The bytes on disk
+do not change, every existing index stays readable, and the iteration's own
+non-goal against uncovered wire-format changes is respected. An opaque
+length-prefixed BM25 blob would be the more robust shape, but it breaks every
+index in the field to buy the same 180 ms — so it stays on the shelf unless
+early-stop proves unworkable.
+
+**Why 260 and not 259:** the load-side change is small; the blast radius is
+not. `write_snapshot` re-serializes `self.bm25_index`, so a snapshot loaded
+lazily and then saved by `set` / `remove` / `append` / `task toggle` / `mv` /
+`lint --fix --index` would silently drop the search index. SEC-3
+(`total_postings`) and MED-1 (`validate_doc_ids`) currently run before the
+index is exposed and reject the *whole* snapshot on failure — a contract that
+does not compose with a section that fails at first use mid-query. And
+early-stop is load-bearing on `bm25_index` being the last derive-emitted field,
+an invariant no test pins today. Those are three decisions and a regression
+test, which is an iteration, not a patch.
+
+**Also recorded:** teardown is a real 59 ms of every indexed command — 43 ms of
+it freeing the BM25 index's millions of small `Vec<u32>` allocations at process
+exit. It is invisible to any measurement that stops when the command prints,
+and it disappears for free alongside the decode saving.
+
+**Rejected:** recording the floor as inherent and closing 259 with a "not worth
+chasing" DEC. That was the plan's other permitted outcome and it would have
+been wrong — a 2.4× win on the most common indexed command, at zero format
+cost, is not noise.

--- a/hyalo-knowledgebase/iterations/iteration-259-index-snapshot-load-perf.md
+++ b/hyalo-knowledgebase/iterations/iteration-259-index-snapshot-load-perf.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 259 — snapshot-index load/deserialize floor
 date: 2026-08-31
-status: planned
+status: completed
 tags: [iteration, performance, carry-over]
 branch: iter-259/index-snapshot-load-perf
 depends-on: "[[iterations/iteration-256-envelope-help-forwarding-and-index-cost]]"
@@ -38,9 +38,9 @@ advance.
 
 ## Tasks
 
-### PERF-1: characterize the snapshot-load floor [0/1]
+### PERF-1: characterize the snapshot-load floor [1/1]
 
-- [ ] Reproduce 256's measurement independently: build (or reuse, if still
+- [x] Reproduce 256's measurement independently: build (or reuse, if still
       available) a large synthetic or real vault (MDN-scale, ~14k files /
       ~120 MB index) and profile `hyalo find --limit 1` end to end,
       isolating snapshot read + deserialize from everything downstream.
@@ -48,12 +48,12 @@ advance.
       characteristics may have shifted since 256). Use `xtask bench-scale`
       if it fits this vault size, or a dedicated one-off harness if not —
       note which, and why, in the outcome.
-- [ ] Break the floor down: how much is reading bytes off disk (cold vs warm
+- [x] Break the floor down: how much is reading bytes off disk (cold vs warm
       cache), how much is MessagePack decode, how much is post-decode
       reconstruction (e.g., rebuilding in-memory indexes/maps from the
       flat snapshot). Use a profiler or manual instrumentation — whichever
       gives trustworthy numbers fastest.
-- [ ] Decide, with evidence, whether there is a reducible cost here at all
+- [x] Decide, with evidence, whether there is a reducible cost here at all
       (e.g., streaming decode instead of whole-buffer deserialize, avoiding
       an intermediate allocation, lazy-loading index sections that most
       `find` invocations don't touch) or whether the floor is inherent to
@@ -63,14 +63,14 @@ advance.
 
 ## Acceptance criteria
 
-- [ ] PERF-1 produces a written, numbers-backed characterization of the
+- [x] PERF-1 produces a written, numbers-backed characterization of the
       snapshot-load floor (where the time goes, on what vault size), checked
       into this file's Outcome section or a `research/` note it links to.
-- [ ] Either a concrete, scoped follow-up fix is identified (and filed as its
+- [x] Either a concrete, scoped follow-up fix is identified (and filed as its
       own iteration if it's more than a small patch) or the floor is
       recorded as inherent/not-worth-chasing with a DEC explaining why —
       not left as an open question.
-- [ ] If any code changes are made in this iteration, gates green: `cargo
+- [x] If any code changes are made in this iteration, gates green: `cargo
       fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, all `xtask check-*`, `hyalo lint --strict`.
 
@@ -85,3 +85,75 @@ advance.
 ## Links
 
 - [[iterations/iteration-256-envelope-help-forwarding-and-index-cost]]
+
+## Outcome
+
+Characterized, decided, and the decision is *not* "inherent". One decision
+recorded — [[decision-log#DEC-264]] — and one follow-up filed,
+[[iterations/iteration-260-lazy-bm25-snapshot-load]]. No production code
+changed in this iteration; the instrumentation used to get the numbers was
+temporary and was reverted before commit. Full write-up with every measurement:
+[[research/snapshot-load-floor-2026-09-01]].
+
+### The floor reproduces, and it is bigger than its label
+
+256's ~0.37 s holds exactly on current `main`: `find --limit 1 --index` against
+MDN (14 399 files, 14 375 indexed, 121 614 239-byte index) runs in 0.36 s,
+against < 0.01 s on an empty vault. But "snapshot load and deserialization" was
+undercounting it — teardown adds another 59 ms at process exit that no
+stopwatch around the command's output ever sees.
+
+### Where the 360 ms goes
+
+| stage | ms |
+|---|---:|
+| read 116 MiB, warm page cache (6.0 GiB/s) | 19 |
+| read 116 MiB, cold via `F_NOCACHE` (1.9 GiB/s) | 59 |
+| MessagePack decode, whole document | **240** |
+| SEC-1 path validation | 2 |
+| SEC-3 + MED-1 BM25 validation | 6–12 |
+| entries re-sort + `path_index` | 1.3 |
+| `rebuild_lower_index` | 0.7 |
+| teardown (drop at exit) | 59 |
+
+`xtask bench-scale` was not the right tool and was not used — it generates its
+own synthetic vault and times whole commands, with no way to express
+sub-command probes inside the load path on a specific real 116 MiB index. A
+one-off instrumented release build was faster and more trustworthy.
+
+### Every suspect in the plan was wrong
+
+The plan named disk I/O, MessagePack decode, allocation shape, and post-decode
+reconstruction. Three of the four are noise:
+
+- **I/O** is 5 % warm, 17 % cold.
+- **Allocation shape** in the entries: all 14 375 `IndexEntry` values decode
+  from their own 19 MiB buffer in 41 ms.
+- **Post-decode reconstruction** — re-sort, `path_index`, `rebuild_lower_index`
+  — is 2 ms combined. DEC-259 already took the quadratic piece.
+
+Decode is the cost, and the *shape* of the decode cost is the finding: the
+on-disk split is entries 19 MiB / graph 8 MiB / **bm25_index 87 MiB (76 %)**,
+and decoding the whole document while materializing *nothing at all*
+(`IgnoredAny` everywhere) still costs 179 ms of the 240 ms. Three quarters of
+the decode is serde token-walking BM25 postings. That kills the obvious fix —
+marking `bm25_index` as `IgnoredAny` saves only 35 ms — and points at the real
+one.
+
+### The fix, measured rather than proposed
+
+`rmp_serde::to_vec_named` writes a map with string keys and emits `bm25_index`
+last, so a hand-written `Deserialize` that `break`s on that key skips all 87 MiB
+without reading them, and `from_slice` accepts the unconsumed tail. Measured:
+**240 ms → 61.5 ms**. With the skipped BM25 validation and the 43 ms of skipped
+teardown, `find --limit 1 --index` projects from ~360 ms to ~150 ms — a ~2.4×
+win on the most common indexed command, with the snapshot bytes unchanged and
+every existing index still readable. The iteration's non-goal on wire
+compatibility is untouched.
+
+It is filed as 260 rather than landed here because the load-side change is
+small and its blast radius is not: `write_snapshot` would silently drop the
+BM25 section on any mutating command's save, the SEC-3/MED-1 "reject the whole
+snapshot" contract does not compose with a section that fails mid-query, and
+early-stop is load-bearing on a derive field order that no test pins. Three
+decisions and a regression test — an iteration, not a patch.

--- a/hyalo-knowledgebase/iterations/iteration-260-lazy-bm25-snapshot-load.md
+++ b/hyalo-knowledgebase/iterations/iteration-260-lazy-bm25-snapshot-load.md
@@ -1,0 +1,109 @@
+---
+type: iteration
+title: Iteration 260 — lazy BM25 section in snapshot load
+date: 2026-09-01
+status: planned
+tags: [iteration, performance, index, bm25]
+depends-on: "[[iterations/iteration-259-index-snapshot-load-perf]]"
+branch: iter-260/lazy-bm25-snapshot-load
+---
+
+# Iteration 260 — lazy BM25 section in snapshot load
+
+## Goal
+
+Land the fix [[iterations/iteration-259-index-snapshot-load-perf]] measured and
+[[decision-log#DEC-264]] approved: stop decoding the BM25 inverted index when
+loading a `.hyalo-index` snapshot, and decode it only when a command actually
+searches text.
+
+Measured ceiling on the MDN vault (14 375 entries, 116 MiB index, release
+build): whole-document decode 240 ms → early-stop decode 61.5 ms, plus ~6–12 ms
+of skipped BM25 validation and ~43 ms of skipped teardown. Projected
+`find --limit 1 --index`: ~360 ms → ~150 ms. The snapshot format does not
+change — see [[research/snapshot-load-floor-2026-09-01]] for the full
+breakdown and for why every other candidate (I/O, allocation shape,
+`IgnoredAny` lazy fields, post-decode reconstruction) was ruled out.
+
+## Tasks
+
+### LAZY-1: early-stop deserialization [0/1]
+
+- [ ] Replace the derived `Deserialize` on the snapshot envelope with a
+      hand-written impl that visits the top-level MessagePack map and stops
+      when it reaches the `bm25_index` key, without reading its value.
+      `rmp_serde::from_slice` accepts the unconsumed tail — verified in 259.
+- [ ] Add a test pinning the invariant this depends on: `bm25_index` must be
+      the **last** key `rmp_serde::to_vec_named` emits for the snapshot
+      envelope. A future field reorder must fail loudly, not silently cost
+      180 ms again.
+
+### LAZY-2: on-demand BM25 access without losing it on save [0/1]
+
+- [ ] Decide and implement how `SnapshotIndex::bm25_index()` gets its data
+      after an early-stopped load. Two candidates, both viable: (a) a
+      `load_with(bm25: bool)` decision made at the call site, or (b) a lazy
+      re-read keyed off the stored index path plus a `OnceCell`. Whichever
+      wins, record the reasoning — the queries that *do* search text must not
+      regress by more than the cost of one extra read.
+- [ ] Close the save hazard. `write_snapshot` re-serializes
+      `self.bm25_index`; after a lazy load that field is absent, so `set`,
+      `remove`, `append`, `task toggle`, `mv` and `lint --fix --index` would
+      write a snapshot with the BM25 section silently deleted. Either load
+      eagerly whenever a save is possible, or carry the raw BM25 bytes through
+      a save unchanged.
+- [ ] Regression test the hazard directly: build an index with BM25, run a
+      mutating command against it, then assert a text `find --index` still
+      returns BM25-ranked results from the rewritten snapshot.
+
+### LAZY-3: preserve the security contract [0/1]
+
+- [ ] SEC-3 (`Bm25InvertedIndex::total_postings` posting cap) and MED-1
+      (`validate_doc_ids` bounds check) run today *before* the index is
+      exposed, and `load_inner` rejects the entire snapshot on failure,
+      falling back to a disk scan. Under lazy decoding they fire at first use,
+      mid-query, where that fallback no longer composes. Decide the new
+      contract and implement it so a crafted snapshot is still refused.
+- [ ] Keep the existing `load_inner_rejects_bm25_*` tests passing, adapting
+      them to the new control flow rather than weakening them.
+
+### LAZY-4: measure and record [0/1]
+
+- [ ] Re-measure `find --limit 1 --index` and a text `find <query> --index` on
+      the MDN vault, before and after, release build, median of ≥ 5 runs.
+      Confirm the projected ~2.4× on the non-text path and quantify whatever
+      the text path now pays.
+- [ ] Record the result in [[research/snapshot-load-floor-2026-09-01]] and in
+      the changelog.
+
+## Acceptance criteria
+
+- [ ] `.hyalo-index` files written before this iteration load unchanged, and
+      files written after it are readable by the previous release — the wire
+      format is byte-identical.
+- [ ] No mutating command can drop the BM25 section from a snapshot it
+      rewrites, proven by a test.
+- [ ] The SEC-3 / MED-1 rejections still refuse a crafted snapshot.
+- [ ] `find --limit 1 --index` on a MDN-scale vault is measurably faster, with
+      numbers in the outcome; a text `find --index` is not materially slower.
+- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D
+      warnings`, `cargo test --workspace -q`, all `xtask check-*`,
+      `hyalo lint --strict`.
+
+## Non-goals
+
+- Changing the on-disk snapshot format. DEC-264 explicitly parked the
+  "opaque length-prefixed BM25 blob" design: it is the more robust shape but
+  breaks every index in the field to buy the same 180 ms.
+- Shrinking the BM25 index itself (e.g. dropping or delta-encoding
+  `Posting::positions`). That is a separate size/latency trade with its own
+  correctness surface — phrase matching depends on those offsets.
+- Re-opening mmap. Already rejected on macOS in
+  [[research/performance-parallelization]], and I/O is 5–17 % of this floor
+  anyway.
+
+## Links
+
+- [[iterations/iteration-259-index-snapshot-load-perf]]
+- [[research/snapshot-load-floor-2026-09-01]]
+- [[decision-log#DEC-264]]

--- a/hyalo-knowledgebase/research/snapshot-load-floor-2026-09-01.md
+++ b/hyalo-knowledgebase/research/snapshot-load-floor-2026-09-01.md
@@ -2,7 +2,7 @@
 title: "Where the snapshot-index load floor goes: 87 of 116 MiB is BM25 nobody reads"
 type: research
 date: 2026-09-01
-status: done
+status: completed
 tags: [research, performance, index, bm25, messagepack]
 related:
   - "[[iterations/iteration-259-index-snapshot-load-perf]]"

--- a/hyalo-knowledgebase/research/snapshot-load-floor-2026-09-01.md
+++ b/hyalo-knowledgebase/research/snapshot-load-floor-2026-09-01.md
@@ -1,0 +1,195 @@
+---
+title: "Where the snapshot-index load floor goes: 87 of 116 MiB is BM25 nobody reads"
+type: research
+date: 2026-09-01
+status: done
+tags: [research, performance, index, bm25, messagepack]
+related:
+  - "[[iterations/iteration-259-index-snapshot-load-perf]]"
+  - "[[iterations/iteration-256-envelope-help-forwarding-and-index-cost]]"
+  - "[[iterations/iteration-260-lazy-bm25-snapshot-load]]"
+  - "[[decision-log#DEC-264]]"
+---
+
+# Where the snapshot-index load floor goes
+
+Iteration 256 recorded a ~0.37 s floor on `find` against an indexed MDN vault
+and stopped there, noting only that it "dwarfs everything `find` does
+afterwards". This note is the breakdown it did not have: what the floor is made
+of, measured stage by stage, and which part of it is avoidable.
+
+The short answer: it is not I/O, and it is not the entries. **76 % of the
+snapshot file, and roughly 62 % of the whole command's wall time, is the BM25
+inverted index — which a `find` with no text query never reads.**
+
+## Method
+
+- Vault: `~/devel/mdn` (`files/en-us`, 14 399 `.md` files, 14 375 indexed).
+- Index: `files/en-us/.hyalo-index`, 121 614 239 bytes (116.0 MiB), rebuilt
+  from current `main` with `hyalo create-index` (3.4 s).
+- Binary: `cargo build --release`, hyalo 0.22.0, macOS 25.5 (Darwin), Apple
+  silicon, APFS/NVMe.
+- Command under test: `hyalo find --limit 1 --index --format json`, chosen
+  because it does the least possible work downstream of the load, so anything
+  it spends is floor.
+- Instrumentation: temporary `Instant::elapsed` probes inserted directly into
+  `SnapshotIndex::load` / `load_inner` in `crates/hyalo-core/src/index.rs`,
+  plus throwaway `Deserialize` variants to isolate decode phases. All of it was
+  reverted before this iteration's commit — none of it ships.
+- `xtask bench-scale` was **not** used. It generates its own synthetic vault
+  and times whole commands end to end; this question needed sub-command-level
+  probes inside the load path on a *specific* real 116 MiB index, which
+  bench-scale has no way to express. A one-off instrumented build was the
+  faster and more trustworthy tool.
+- Every figure below is the median of at least two runs that agreed to within
+  a few per cent. Warm page cache unless stated otherwise.
+
+## Baseline
+
+| command | wall |
+|---|---|
+| `find --limit 1 --index` (MDN) | **0.36 s** |
+| `find --limit 1` without the index (disk scan) | 0.57 s |
+| `hyalo --version` | < 0.01 s |
+| `find --limit 1` on an empty vault | < 0.01 s |
+
+256's ~0.37 s reproduces exactly on current `main`. Process startup, config
+resolution and arg parsing are together under 10 ms, so essentially all of the
+0.36 s is the index.
+
+## Stage breakdown
+
+For one `find --limit 1 --index`, warm cache:
+
+| stage | ms | share |
+|---|---:|---:|
+| read 116 MiB off disk (warm page cache, 6.0 GiB/s) | 19 | 5 % |
+| MessagePack decode of the whole document | **240** | **67 %** |
+| SEC-1 path validation (14 375 paths) | 2 | 1 % |
+| SEC-3 + MED-1 BM25 validation (walks every posting) | 6–12 | 2 % |
+| entries re-sort + `path_index` build | 1.3 | < 1 % |
+| `graph.rebuild_lower_index` | 0.7 | < 1 % |
+| filter + JSON output | small | — |
+| teardown (drop at process exit) | 59 | 16 % |
+
+`load_inner` totals 244–250 ms of that; `SnapshotIndex::load` including the
+file read totals ~265 ms.
+
+Cold cache changes little. Reading the same file with `F_NOCACHE` set gives
+59–61 ms (1.9 GiB/s) against 19 ms warm — a cold run costs ~40 ms more, which
+moves the total from 0.36 s to ~0.40 s. **Disk I/O is 5–17 % of this floor. It
+is not the problem.**
+
+## Inside the decode
+
+Re-serializing each field of a decoded snapshot gives the on-disk split:
+
+| section | size | share of file |
+|---|---:|---:|
+| `entries` (14 375 × `IndexEntry`) | 19 MiB | 16 % |
+| `graph` (`LinkGraph`) | 8 MiB | 7 % |
+| `bm25_index` (`Bm25InvertedIndex`) | **87 MiB** | **76 %** |
+
+Note that `write_snapshot` already strips per-entry `bm25_tokens` when an
+inverted index is present, so the entries above are the *slim* form. The
+inverted index is large because every `Posting` carries a `positions: Vec<u32>`
+of token offsets for phrase matching — millions of small vectors, each its own
+MessagePack array.
+
+Decode costs, isolated:
+
+| what was decoded | ms |
+|---|---:|
+| whole document, fully materialized (production path) | **240** |
+| whole document with everything as `IgnoredAny` (walk, materialize nothing) | **179** |
+| whole document, `bm25_index` as `IgnoredAny` | 205 |
+| whole document, `graph` **and** `bm25_index` as `IgnoredAny` | 197 |
+| `entries` alone, from its own 19 MiB buffer — materialized | 41 |
+| `entries` alone, from its own 19 MiB buffer — walk only | 20 |
+
+Two things fall out of that table.
+
+**First: three quarters of the decode is byte traversal, not construction.**
+Walking the document while building nothing still costs 179 ms of the 240 ms.
+Materializing every structure adds only ~60 ms on top. So the usual
+suspects — allocation shape, intermediate buffers, `String` copies — are the
+minority cost. `entries` in particular is cheap: 41 ms to materialize all
+14 375 of them.
+
+**Second: `IgnoredAny` is not a fix.** Marking `bm25_index` as ignored saves
+only 35 ms (240 → 205), because serde still has to token-walk all 87 MiB of
+postings to find the end of the value. Skipping the *materialization* is nearly
+worthless while the *traversal* remains.
+
+## Teardown is real, and it is also BM25
+
+Dropping the decoded snapshot costs 59 ms, split 16 ms for entries + graph and
+**43 ms for the BM25 index** — freeing several million individual `Vec<u32>`
+allocations. This is paid at process exit on every single indexed command,
+and no profiler that stops at "the command finished" attributes it.
+
+## The avoidable part
+
+Adding up what a text-query-free `find` spends on a BM25 index it never
+touches: ~180 ms of decode traversal, ~6–12 ms of SEC-3/MED-1 validation, and
+~43 ms of teardown — **~230 ms of a ~360 ms command.**
+
+`rmp_serde::to_vec_named` writes the snapshot as a MessagePack **map with
+string keys**, and `bm25_index` is the last key. So the section can be skipped
+by simply *stopping the parse* when that key is reached, without reading its
+value and without changing a single byte on disk. Measured, with a hand-written
+`Deserialize` impl that visits the top-level map and `break`s on `"bm25_index"`:
+
+| decode | ms |
+|---|---:|
+| production, full document | 240 |
+| early-stop at `bm25_index` | **61.5** |
+
+`rmp_serde::from_slice` accepts the unconsumed tail without error. Together
+with the skipped validation and teardown this projects `find --limit 1 --index`
+from ~360 ms to **~150 ms**, a ~2.4× improvement on the whole command, with the
+snapshot format byte-identical and every existing index still readable.
+
+## Why this is not a small patch
+
+The measurement is done; the fix is not a one-liner, for four reasons — each
+of which is a design decision, not a coding chore:
+
+1. **`save_to` would destroy search data.** `write_snapshot` re-serializes
+   `self.bm25_index`. Every mutating command that patches a loaded snapshot —
+   `set`, `remove`, `append`, `task toggle`, `mv`, `lint --fix --index` —
+   would then write a snapshot with the BM25 section silently gone. Any lazy
+   design must either load eagerly whenever a save is possible, or carry the
+   raw BM25 bytes through a save unchanged.
+2. **The security checks move.** SEC-3 (`total_postings`) and MED-1
+   (`validate_doc_ids`) run today *before* the index is exposed, and
+   `load_inner`'s contract on failure is "reject the whole snapshot, fall back
+   to a disk scan". A lazily-decoded section fails at first *use*, mid-query,
+   where that fallback no longer composes. The guarantee has to be preserved
+   under a different control flow.
+3. **Someone has to decide when BM25 is needed.** `find <text>` needs it;
+   `find --property` does not; `links`, `lint`, `summary`, `properties`, `tags`
+   do not. That is either a parameter threaded through the load call sites or a
+   lazy re-read keyed off the stored index path — with a measurable cost either
+   way for the queries that *do* search text.
+4. **Early-stop depends on field order.** It works only because `bm25_index`
+   is derive-emitted last. That is an implicit invariant of a `#[derive]` field
+   list, which a future edit could silently break with no test failing. It
+   needs to be pinned by a test, or replaced by an offset-based skip that does
+   not care.
+
+Filed as [[iterations/iteration-260-lazy-bm25-snapshot-load]]. The decision to
+pursue it rather than record the floor as inherent is [[decision-log#DEC-264]].
+
+## What was ruled out
+
+- **I/O.** 5 % warm, 17 % cold. Streaming the read, `mmap` (already rejected on
+  macOS — see [[research/performance-parallelization]]), or a faster disk
+  changes nothing material.
+- **Allocation shape in `entries`.** 41 ms to materialize 14 375 entries. There
+  is no win hiding there.
+- **`IgnoredAny`-based lazy fields.** 35 ms of 240 ms. Traversal, not
+  materialization, is the cost.
+- **The post-decode reconstruction the plan suspected** — re-sort,
+  `path_index`, `rebuild_lower_index` — is 2 ms combined. 256's DEC-259 already
+  removed the one genuinely quadratic piece (`CaseInsensitiveIndex::insert`).


### PR DESCRIPTION
## Summary

Docs-only. Iteration 259 was a "characterize and decide" iteration — no production code changed; the instrumentation used to take the measurements was temporary and was reverted before the final commit.

- **Reproduced and broke down** the ~0.37 s snapshot-load floor iteration 256 flagged but never explained. Measured on MDN (14 399 files, 14 375 indexed, 121 614 239-byte index, release build, Apple silicon): `find --limit 1 --index` = 0.36 s. Read 19 ms warm (6.0 GiB/s) / 59 ms cold via `F_NOCACHE` (1.9 GiB/s); MessagePack decode 240 ms; SEC checks 8 ms; sort + `path_index` + `rebuild_lower_index` 2 ms; **teardown at process exit 59 ms** — a cost no measurement that stops at the command's output ever attributed.
- **Every suspect the plan named was wrong except decode.** I/O is 5 % warm / 17 % cold. All 14 375 `IndexEntry` values materialize in 41 ms. Post-decode reconstruction is 2 ms. The on-disk split is entries 19 MiB / graph 8 MiB / **`bm25_index` 87 MiB (76 %)**, and a `find` with no text query never reads it.
- **`IgnoredAny` is not the fix**, which is the finding that redirects the work: marking `bm25_index` as ignored saves 35 ms of 240 ms, because decoding the whole document while materializing *nothing at all* still costs 179 ms. Three quarters of the decode is serde token-walking `Posting` maps and `positions: Vec<u32>` arrays. The target is traversal, not materialization.
- **The fix is measured, not proposed, and is wire-compatible.** `rmp_serde::to_vec_named` writes a map with string keys and emits `bm25_index` last, so a hand-written `Deserialize` that `break`s on that key skips all 87 MiB unread; `from_slice` accepts the unconsumed tail. **240 ms → 61.5 ms.** With the skipped BM25 validation and 43 ms of skipped teardown, `find --limit 1 --index` projects from ~360 ms to ~150 ms (~2.4×) with the snapshot bytes unchanged.
- **Filed as iteration 260, not landed here**, per this iteration's own non-goal on scope: `write_snapshot` re-serializes `self.bm25_index`, so a lazily-loaded snapshot saved by `set` / `remove` / `append` / `task toggle` / `mv` / `lint --fix --index` would silently drop the search index; SEC-3 / MED-1's "reject the whole snapshot, fall back to a disk scan" contract does not compose with a section that fails at first use mid-query; and early-stop is load-bearing on a derive field order no test pins.

Files: `research/snapshot-load-floor-2026-09-01.md` (full write-up), `decision-log.md` DEC-264, `iterations/iteration-260-lazy-bm25-snapshot-load.md` (scoped follow-up), and iteration 259's Outcome section with `status: completed`.

`xtask bench-scale` was deliberately not used and the outcome says why: it generates its own synthetic vault and times whole commands, with no way to express sub-command probes inside the load path on a specific real 116 MiB index.

## Test plan

- [x] `cargo fmt` — clean, no files changed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace -q` — all pass, 0 failures
- [x] All 8 `xtask check-*` gates exit 0 (`check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`, `check-pi-package-sync`, `check-dead-primitives`, `check-todo-annotations`, `check-mutation-journal`)
- [x] `hyalo lint --strict` — 0 errors, 0 warnings across 113 files
- [x] `hyalo links` — 0 broken links. The 5 new `[[decision-log#DEC-264]]` anchor references follow the existing convention (main already carries 15 such anchors) and are not CI-gated
- [x] Instrumentation fully reverted — `git diff main...HEAD` touches `hyalo-knowledgebase/` only, no `crates/` changes
- [ ] No behaviour to verify: this PR changes no code

## Carry-over

- **The measured fix (early-stop BM25 decode, 240 ms → 61.5 ms)** — not landed in this PR by design (259's own non-goal on scope; see DEC-264). Disposition: filed as a new iteration plan, [[iterations/iteration-260-lazy-bm25-snapshot-load]] (`hyalo-knowledgebase/iterations/iteration-260-lazy-bm25-snapshot-load.md`, status `planned`), which scopes the four sub-problems (early-stop deserialization, on-demand BM25 access without losing it on save, preserving the SEC-3/MED-1 security contract, and re-measurement).
- **No other unticked ACs, deferrals, or out-of-scope findings** were raised by this iteration's plan, tasks, or Outcome section — all three ACs and all three PERF-1 tasks are ticked and verified against the actual diff (docs-only; no `crates/` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFQXS5nUXg2qoDsccuEgwS
