### PR TITLE
iter-263: lint autofix safety on Obsidian content (MD018/MD034/MD042/MD001 + conflict detail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,8 @@ and this project adheres to
   of a hard-coded LF. Where a file's endings are mixed, the terminator of the
   line immediately before EOF wins.
 - Link resolution folds ASCII case on every platform, not only on a case-insensitive filesystem (DEC-267). `links fix --case-insensitive` no longer changes what resolves; it only suppresses the cosmetic case-mismatch rewrite plans.
+- lint: MD001 (heading-increment) is reported but no longer autofixable — renumbering a deliberate `######` caption rewrites authored structure (DEC-272). `lint-rules list` shows `autofixable: false`
+- lint --fix: each deferred fix now prints `conflict <RULE> line <N>: range overlap with <RULE>` in text output (first 20 per file, `--detailed` for all) instead of a bare `conflicts N`; JSON `conflicts[]` entries gain `line` and each file gains `conflicts_total`
 
 ### Removed
 
@@ -311,6 +313,7 @@ and this project adheres to
 - `links fix` never matches a target across an explicit extension (DEC-266), so a broken `Companies.base` is no longer offered `Company Template.md`, and no fuzzy candidate is reported at confidence 0.0.
 - `hyalo mv` now rewrites frontmatter wikilinks that name the moved file by bare stem (`categories: ["[[Books]]"]` → `Categories/Books.md`), instead of reporting `links updated: 0` and leaving the reference dangling. Quoting style and every other byte of the block are preserved; a `[[…]]` spanning a line break is left alone, warned about on stderr and listed under `frontmatter_links_skipped`.
 - A frontmatter list of wikilinks renders as `["[[Futurism]]", "[[Nonfiction]]"]` in text output instead of the unreadable `[[[Futurism]], [[Nonfiction]]]`; plain lists keep their compact unquoted form.
+- lint: MD018 no longer rewrites an Obsidian tag line (`#todo`) into a heading; MD034 no longer wraps a URL that is already a link destination; MD042 accepts an image as link text (`[![](img.png)](https://…)`) (DEC-271)
 
 ### Added
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1754,6 +1754,18 @@ Repeatable (AND).\n\
             \u{00a0}            profile downgrades it.\n\
             Severity is hyalo-controlled. Manage rule enable/severity with `hyalo lint-rules`.\n\
             Override defaults via `[lint]` and `[lint.rules]` in `.hyalo.toml`.\n\n\
+            OBSIDIAN GRAMMAR: four stock rules are narrowed so `--fix` cannot corrupt a vault\n\
+            (`hyalo lint-rules show <ID>` spells each one out):\n\
+            \u{00a0} - MD018 exempts tag lines — a single `#` plus a tag token (letters, digits,\n\
+            \u{00a0}          `_`, `-`, `/`, non-ASCII word chars, at least one non-digit) is\n\
+            \u{00a0}          `#todo`, not a heading missing its space. `##Heading`, `#1` and a\n\
+            \u{00a0}          capitalized word followed by prose (`#Heading typo`) still fire.\n\
+            \u{00a0} - MD034 ignores URLs already inside link markup (a markdown link or image\n\
+            \u{00a0}          destination, an autolink, a wikilink, a reference definition).\n\
+            \u{00a0} - MD042 accepts an image as link text (`[![](img.png)](https://…)`).\n\
+            \u{00a0} - MD001 reports skipped heading levels but never autofixes them: renumbering\n\
+            \u{00a0}          a deliberate `######` caption rewrites authored structure. Turn the\n\
+            \u{00a0}          warning off with `hyalo lint-rules set MD001 --enabled false`.\n\n\
             INPUT: Optional FILE (positional or --file) or --glob to narrow scope.\n\
             Without any file arguments, the entire vault is linted.\n\n\
             OUTPUT: Text by default — summary mode groups violations by `(file, rule)` and caps\n\
@@ -1827,7 +1839,9 @@ Repeatable (AND).\n\
             AUTO-FIX: With --fix, hyalo applies frontmatter fixes (insert defaults, correct enum\n\
             typos, normalize dates, infer type) and body fixes from autofixable rules. Body fixes\n\
             are applied in `(start, end, rule_id)` order; overlapping fixes are deferred and\n\
-            reported as conflicts. Use --fix-rule <ID> (repeatable) to limit which rules autofix,\n\
+            reported as conflicts — text output prints one `conflict <RULE> line <N>: range\n\
+            overlap with <RULE>` line per deferred fix (first 20 per file; --detailed shows all).\n\
+            Use --fix-rule <ID> (repeatable) to limit which rules autofix,\n\
             or --dry-run to preview without writing. JSON under --fix uses `total_fixed`,\n\
             `total_remaining`, and `total_conflicts` in place of plain lint's `total` —\n\
             all three, like every counter above, describe the WHOLE run and are identical at\n\

--- a/crates/hyalo-cli/src/commands/lint/engine.rs
+++ b/crates/hyalo-cli/src/commands/lint/engine.rs
@@ -206,7 +206,7 @@ pub fn lint_files_extended(
             // violations of the same rule can lose to two different blocking
             // rules on two different lines, and collapsing them to one entry
             // was exactly why `conflicts N` could not be explained.
-            let mut conflict_by_rule: indexmap::IndexMap<(String, usize), String> =
+            let mut conflict_by_violation: indexmap::IndexMap<(String, usize), String> =
                 indexmap::IndexMap::new();
 
             for (rule_id, line, outcome) in &r.body_fix_outcomes {
@@ -215,7 +215,7 @@ pub fn lint_files_extended(
                         applied_by_rule.entry(rule_id.clone()).or_default();
                     }
                     FixOutcome::Conflict { blocking_rule } => {
-                        conflict_by_rule
+                        conflict_by_violation
                             .entry((rule_id.clone(), *line))
                             .or_insert_with(|| blocking_rule.clone());
                     }
@@ -392,7 +392,7 @@ pub fn lint_files_extended(
 
             // conflicts: one entry per (rule, line) whose fix was skipped.
             let mut conflicts: Vec<ConflictEntry> = Vec::new();
-            for ((rule_id, line), blocking_rule) in &conflict_by_rule {
+            for ((rule_id, line), blocking_rule) in &conflict_by_violation {
                 conflicts.push(ConflictEntry {
                     rule: rule_id.clone(),
                     line: *line,
@@ -602,8 +602,10 @@ pub(super) struct PerFileLintResult {
     pub(super) body_modified: bool,
     /// Frontmatter fix actions applied or previewed.
     pub(super) fix_actions: Vec<FixAction>,
-    /// Fix outcomes keyed by (rule_id, index_within_rule).
-    /// Only populated in fix-mode.
+    /// One `(rule_id, line, outcome)` per fixable diagnostic the fix loop
+    /// considered, in pass order. The line is the diagnostic's own 1-based
+    /// line, carried so a conflict can be explained as `<rule> line <n>`
+    /// (iteration 263). Only populated in fix-mode.
     pub(super) body_fix_outcomes: Vec<(String, usize, FixOutcome)>,
     /// SCHEMA (frontmatter) violations remaining *after* applying fixes,
     /// computed by re-running `validate_properties` against the mutated

--- a/crates/hyalo-cli/src/commands/lint/engine.rs
+++ b/crates/hyalo-cli/src/commands/lint/engine.rs
@@ -622,14 +622,18 @@ pub(super) struct PerFileLintResult {
 /// even when the listing is truncated (iter-218 NEW-6).
 pub(super) fn fix_mode_file_totals(r: &PerFileLintResult) -> (usize, usize, usize) {
     let mut applied_rules: HashSet<&str> = HashSet::new();
-    let mut conflict_rules: HashSet<&str> = HashSet::new();
-    for (rule_id, _line, outcome) in &r.body_fix_outcomes {
+    // Keyed by (rule, line), matching the per-violation `conflicts` array the
+    // display loop builds (iteration 263). Counting distinct *rules* here
+    // made the summary's `conflicts N` smaller than the number of `conflict`
+    // lines printed above it, which reads as an accounting bug.
+    let mut conflict_violations: HashSet<(&str, usize)> = HashSet::new();
+    for (rule_id, line, outcome) in &r.body_fix_outcomes {
         match outcome {
             FixOutcome::Applied => {
                 applied_rules.insert(rule_id.as_str());
             }
             FixOutcome::Conflict { .. } => {
-                conflict_rules.insert(rule_id.as_str());
+                conflict_violations.insert((rule_id.as_str(), *line));
             }
             FixOutcome::NoFix => {}
         }
@@ -657,7 +661,7 @@ pub(super) fn fix_mode_file_totals(r: &PerFileLintResult) -> (usize, usize, usiz
         remaining += violations.iter().filter(|v| !v.fixed).count();
     }
 
-    (fixed, remaining, conflict_rules.len())
+    (fixed, remaining, conflict_violations.len())
 }
 
 /// Count the error- and warning-severity violations across every result,

--- a/crates/hyalo-cli/src/commands/lint/engine.rs
+++ b/crates/hyalo-cli/src/commands/lint/engine.rs
@@ -16,6 +16,14 @@ use hyalo_core::schema::SchemaConfig;
 use hyalo_mdlint::schema::{FileFixResult, FixAction, FixMode, LintCounts};
 use std::collections::HashSet;
 
+/// How many per-conflict explanation lines one file lists before the output
+/// switches to `… and N more (use --detailed)` (iteration 263, UX-16).
+///
+/// A file with a pathological overlap can produce hundreds of conflicts;
+/// listing them all would bury the fixed/remaining sections that describe what
+/// actually changed. `--detailed` prints the full list.
+const MAX_CONFLICT_LINES: usize = 20;
+
 /// Run the extended lint (frontmatter + body) and return the new output shape.
 #[allow(clippy::too_many_arguments)]
 pub fn lint_files_extended(
@@ -194,17 +202,21 @@ pub fn lint_files_extended(
             // Easier to just build maps indexed by rule.
             let mut applied_by_rule: indexmap::IndexMap<String, Vec<BodyViolation>> =
                 indexmap::IndexMap::new();
-            let mut conflict_by_rule: indexmap::IndexMap<String, String> =
+            // Keyed by (rule, line) rather than by rule alone (UX-16): two
+            // violations of the same rule can lose to two different blocking
+            // rules on two different lines, and collapsing them to one entry
+            // was exactly why `conflicts N` could not be explained.
+            let mut conflict_by_rule: indexmap::IndexMap<(String, usize), String> =
                 indexmap::IndexMap::new();
 
-            for (rule_id, outcome) in &r.body_fix_outcomes {
+            for (rule_id, line, outcome) in &r.body_fix_outcomes {
                 match outcome {
                     FixOutcome::Applied => {
                         applied_by_rule.entry(rule_id.clone()).or_default();
                     }
                     FixOutcome::Conflict { blocking_rule } => {
                         conflict_by_rule
-                            .entry(rule_id.clone())
+                            .entry((rule_id.clone(), *line))
                             .or_insert_with(|| blocking_rule.clone());
                     }
                     FixOutcome::NoFix => {}
@@ -378,13 +390,22 @@ pub fn lint_files_extended(
             }
             remaining_groups.sort_by_key(|g| std::cmp::Reverse(g.count));
 
-            // conflicts: rules with at least one conflicting fix.
+            // conflicts: one entry per (rule, line) whose fix was skipped.
             let mut conflicts: Vec<ConflictEntry> = Vec::new();
-            for (rule_id, blocking_rule) in &conflict_by_rule {
+            for ((rule_id, line), blocking_rule) in &conflict_by_rule {
                 conflicts.push(ConflictEntry {
                     rule: rule_id.clone(),
+                    line: *line,
                     reason: format!("range overlap with {blocking_rule}"),
                 });
+            }
+            conflicts.sort_by(|a, b| a.rule.cmp(&b.rule).then(a.line.cmp(&b.line)));
+            // The listing is capped the same way the remaining-violation
+            // listing is; `--detailed` lifts it. `conflicts_total` keeps the
+            // "… and N more" line honest.
+            let conflicts_total = conflicts.len();
+            if !opts.detailed && conflicts_total > MAX_CONFLICT_LINES {
+                conflicts.truncate(MAX_CONFLICT_LINES);
             }
 
             if !fixed_groups.is_empty() || !remaining_groups.is_empty() || !conflicts.is_empty() {
@@ -394,6 +415,7 @@ pub fn lint_files_extended(
                     fixed_groups,
                     remaining_groups,
                     conflicts,
+                    conflicts_total,
                 });
             }
         }
@@ -582,7 +604,7 @@ pub(super) struct PerFileLintResult {
     pub(super) fix_actions: Vec<FixAction>,
     /// Fix outcomes keyed by (rule_id, index_within_rule).
     /// Only populated in fix-mode.
-    pub(super) body_fix_outcomes: Vec<(String, FixOutcome)>,
+    pub(super) body_fix_outcomes: Vec<(String, usize, FixOutcome)>,
     /// SCHEMA (frontmatter) violations remaining *after* applying fixes,
     /// computed by re-running `validate_properties` against the mutated
     /// frontmatter. `Some(vec![])` means all SCHEMA violations were resolved;
@@ -601,7 +623,7 @@ pub(super) struct PerFileLintResult {
 pub(super) fn fix_mode_file_totals(r: &PerFileLintResult) -> (usize, usize, usize) {
     let mut applied_rules: HashSet<&str> = HashSet::new();
     let mut conflict_rules: HashSet<&str> = HashSet::new();
-    for (rule_id, outcome) in &r.body_fix_outcomes {
+    for (rule_id, _line, outcome) in &r.body_fix_outcomes {
         match outcome {
             FixOutcome::Applied => {
                 applied_rules.insert(rule_id.as_str());

--- a/crates/hyalo-cli/src/commands/lint/file.rs
+++ b/crates/hyalo-cli/src/commands/lint/file.rs
@@ -510,7 +510,7 @@ pub(super) fn lint_one_file_extended(
         .map(str::to_owned);
 
     // Track per-diagnostic outcomes for the new fix-mode JSON shape.
-    let mut body_fix_outcomes: Vec<(String, FixOutcome)> = Vec::new();
+    let mut body_fix_outcomes: Vec<(String, usize, FixOutcome)> = Vec::new();
     // Diagnostics that were fixed, accumulated across every pass below
     // (each carries its own line/column, valid against the body revision it
     // was found in — fine for display, since only `fixed`-derived counts
@@ -561,20 +561,28 @@ pub(super) fn lint_one_file_extended(
                 std::collections::HashSet::new();
             for (slot, &orig_idx) in fixable_indices.iter().enumerate() {
                 let rule_id = current_diagnostics[orig_idx].rule_id.clone();
+                // The diagnostic's own line travels with the outcome so a
+                // conflict can be explained as `<rule> line <n>` instead of
+                // the bare `conflicts N` the text output used to print
+                // (dogfood v0.22.0 UX-16).
+                let line = current_diagnostics[orig_idx].line;
                 match &outcomes[slot] {
                     FixOutcome::Applied => {
                         applied_this_pass.insert(orig_idx);
-                        body_fix_outcomes.push((rule_id, FixOutcome::Applied));
+                        body_fix_outcomes.push((rule_id, line, FixOutcome::Applied));
                     }
                     FixOutcome::Conflict { blocking_rule } => {
                         body_fix_outcomes.push((
                             rule_id,
+                            line,
                             FixOutcome::Conflict {
                                 blocking_rule: blocking_rule.clone(),
                             },
                         ));
                     }
-                    FixOutcome::NoFix => body_fix_outcomes.push((rule_id, FixOutcome::NoFix)),
+                    FixOutcome::NoFix => {
+                        body_fix_outcomes.push((rule_id, line, FixOutcome::NoFix));
+                    }
                 }
             }
 
@@ -972,7 +980,7 @@ pub(super) fn lint_one_file_extended(
     // PR #254) — otherwise fix-mode's totals (`fix_mode_file_totals`) would
     // count a change that was never persisted.
     if body_write_failed {
-        for (_, outcome) in &mut body_fix_outcomes {
+        for (_, _, outcome) in &mut body_fix_outcomes {
             if matches!(outcome, FixOutcome::Applied) {
                 *outcome = FixOutcome::NoFix;
             }

--- a/crates/hyalo-cli/src/commands/lint/types.rs
+++ b/crates/hyalo-cli/src/commands/lint/types.rs
@@ -66,9 +66,16 @@ pub struct FixedGroup {
 }
 
 /// One entry in `conflicts`: a rule whose fix was skipped due to range overlap.
+///
+/// One entry per *violation* (rule + line), not per rule: the same rule can
+/// lose two different overlaps on two different lines, and collapsing those
+/// was why `lint --fix` could only print `conflicts N` with nothing to point
+/// at (iteration 263, dogfood v0.22.0 UX-16).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ConflictEntry {
     pub rule: String,
+    /// 1-based line of the violation whose fix was skipped.
+    pub line: usize,
     pub reason: String,
 }
 
@@ -85,8 +92,11 @@ pub struct ExtFileLintFixResult {
     pub fixed_groups: Vec<FixedGroup>,
     /// Rules with violations that remain after fixing.
     pub remaining_groups: Vec<RuleGroup>,
-    /// Rules whose fixes were skipped due to conflicts.
+    /// Violations whose fixes were skipped due to conflicts. Capped for
+    /// display unless `--detailed`; see `conflicts_total`.
     pub conflicts: Vec<ConflictEntry>,
+    /// How many conflicts this file actually had, before the display cap.
+    pub conflicts_total: usize,
 }
 
 /// Full extended lint output (read-only mode).

--- a/crates/hyalo-cli/src/output/tests.rs
+++ b/crates/hyalo-cli/src/output/tests.rs
@@ -48,10 +48,70 @@ fn fix_output(fixed_rule: Option<&str>, conflict_rule: &str) -> String {
             "file": "a.md",
             "fixed_groups": fixed_groups,
             "remaining_groups": [],
-            "conflicts": [{"rule": conflict_rule, "reason": "range overlap with MD009"}],
+            "conflicts": [{"rule": conflict_rule, "line": 12, "reason": "range overlap with MD009"}],
+            "conflicts_total": 1,
         }],
     });
     format_lint_fix_output_text(value.as_object().expect("object"))
+}
+
+/// Fix-mode output with `n` conflicts listed out of `total` — the shape the
+/// engine emits once the per-file display cap kicks in.
+fn fix_output_with_conflicts(n: usize, total: usize) -> String {
+    let conflicts: Vec<serde_json::Value> = (0..n)
+        .map(|i| json!({"rule": "MD013", "line": i + 1, "reason": "range overlap with MD009"}))
+        .collect();
+    let value = json!({
+        "dry_run": true,
+        "files_checked": 1,
+        "total_fixed": 0,
+        "total_remaining": 0,
+        "total_conflicts": total,
+        "files": [{
+            "file": "a.md",
+            "fixed_groups": [],
+            "remaining_groups": [],
+            "conflicts": conflicts,
+            "conflicts_total": total,
+        }],
+    });
+    format_lint_fix_output_text(value.as_object().expect("object"))
+}
+
+// -----------------------------------------------------------------------
+// iter-263 UX-16 — `conflicts N` is explained, one line per conflict
+// -----------------------------------------------------------------------
+
+#[test]
+fn fix_text_explains_each_conflict_with_its_line() {
+    let out = fix_output(None, "MD047");
+    assert!(
+        out.contains("conflict  MD047  line 12: range overlap with MD009"),
+        "a conflict must name the line and the blocking rule: {out}"
+    );
+}
+
+#[test]
+fn fix_text_caps_the_conflict_listing_and_points_at_detailed() {
+    let out = fix_output_with_conflicts(20, 57);
+    assert_eq!(
+        out.matches("conflict  MD013").count(),
+        20,
+        "only the capped listing is printed: {out}"
+    );
+    assert!(
+        out.contains("… and 37 more (use --detailed)"),
+        "the remainder must be counted and the escape hatch named: {out}"
+    );
+}
+
+#[test]
+fn fix_text_omits_the_more_line_when_nothing_was_capped() {
+    let out = fix_output_with_conflicts(3, 3);
+    assert!(
+        !out.contains("more (use --detailed)"),
+        "an uncapped listing must not claim there is more: {out}"
+    );
 }
 
 #[test]

--- a/crates/hyalo-cli/src/output/text_lint.rs
+++ b/crates/hyalo-cli/src/output/text_lint.rs
@@ -401,8 +401,7 @@ pub(super) fn format_lint_fix_output_text(
             // second was the whole reason `conflicts N` could go unexplained
             // (UX-16). A fixed group that lists no violations carries no
             // lines to compare, so it still suppresses its rule wholesale.
-            let mut fixed_rules: std::collections::HashSet<&str> =
-                std::collections::HashSet::new();
+            let mut fixed_rules: std::collections::HashSet<&str> = std::collections::HashSet::new();
             let mut fixed_at: std::collections::HashSet<(&str, u64)> =
                 std::collections::HashSet::new();
             if let Some(groups) = file_entry.get("fixed_groups").and_then(|g| g.as_array()) {
@@ -415,9 +414,7 @@ pub(super) fn format_lint_fix_output_text(
                         .and_then(|v| v.as_array())
                         .map(|vs| {
                             vs.iter()
-                                .filter_map(|v| {
-                                    v.get("line").and_then(serde_json::Value::as_u64)
-                                })
+                                .filter_map(|v| v.get("line").and_then(serde_json::Value::as_u64))
                                 .collect()
                         })
                         .unwrap_or_default();
@@ -464,7 +461,9 @@ pub(super) fn format_lint_fix_output_text(
                 let total = file_entry
                     .get("conflicts_total")
                     .and_then(serde_json::Value::as_u64)
-                    .map_or(conflicts.len(), |t| usize::try_from(t).unwrap_or(usize::MAX));
+                    .map_or(conflicts.len(), |t| {
+                        usize::try_from(t).unwrap_or(usize::MAX)
+                    });
                 if shown > 0 && total > conflicts.len() {
                     let _ = writeln!(
                         s,

--- a/crates/hyalo-cli/src/output/text_lint.rs
+++ b/crates/hyalo-cli/src/output/text_lint.rs
@@ -393,16 +393,43 @@ pub(super) fn format_lint_fix_output_text(
             // rule already appears there. The JSON keeps both: `conflicts` is
             // how a consumer learns a fix was skipped, and dropping entries
             // from it would lose that.
-            let fixed_rules: std::collections::HashSet<&str> = file_entry
-                .get("fixed_groups")
-                .and_then(|g| g.as_array())
-                .map(|groups| {
-                    groups
-                        .iter()
-                        .filter_map(|g| g.get("rule").and_then(serde_json::Value::as_str))
-                        .collect()
-                })
-                .unwrap_or_default();
+            //
+            // Iteration 263 narrows that suppression to the *same violation*
+            // (rule + line): once a conflict names its line, `fixed MD047
+            // line 6` beside `conflict MD047 line 9` reads as two different
+            // violations rather than a contradiction, and suppressing the
+            // second was the whole reason `conflicts N` could go unexplained
+            // (UX-16). A fixed group that lists no violations carries no
+            // lines to compare, so it still suppresses its rule wholesale.
+            let mut fixed_rules: std::collections::HashSet<&str> =
+                std::collections::HashSet::new();
+            let mut fixed_at: std::collections::HashSet<(&str, u64)> =
+                std::collections::HashSet::new();
+            if let Some(groups) = file_entry.get("fixed_groups").and_then(|g| g.as_array()) {
+                for group in groups {
+                    let Some(rule) = group.get("rule").and_then(serde_json::Value::as_str) else {
+                        continue;
+                    };
+                    let lines: Vec<u64> = group
+                        .get("violations")
+                        .and_then(|v| v.as_array())
+                        .map(|vs| {
+                            vs.iter()
+                                .filter_map(|v| {
+                                    v.get("line").and_then(serde_json::Value::as_u64)
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if lines.is_empty() {
+                        fixed_rules.insert(rule);
+                    } else {
+                        for line in lines {
+                            fixed_at.insert((rule, line));
+                        }
+                    }
+                }
+            }
             if let Some(conflicts) = file_entry.get("conflicts").and_then(|c| c.as_array()) {
                 let mut shown = 0usize;
                 for conflict in conflicts {
@@ -410,13 +437,6 @@ pub(super) fn format_lint_fix_output_text(
                         .get("rule")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("?");
-                    if fixed_rules.contains(rule) {
-                        continue;
-                    }
-                    let reason = conflict
-                        .get("reason")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("");
                     // The line is what turns `conflicts 2` into something a
                     // reader can act on (iteration 263, dogfood UX-16). A
                     // conflict without one still prints, just without the
@@ -425,6 +445,13 @@ pub(super) fn format_lint_fix_output_text(
                         .get("line")
                         .and_then(serde_json::Value::as_u64)
                         .unwrap_or(0);
+                    if fixed_rules.contains(rule) || fixed_at.contains(&(rule, line)) {
+                        continue;
+                    }
+                    let reason = conflict
+                        .get("reason")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("");
                     if line > 0 {
                         let _ = writeln!(s, "  conflict  {rule}  line {line}: {reason}");
                     } else {

--- a/crates/hyalo-cli/src/output/text_lint.rs
+++ b/crates/hyalo-cli/src/output/text_lint.rs
@@ -404,6 +404,7 @@ pub(super) fn format_lint_fix_output_text(
                 })
                 .unwrap_or_default();
             if let Some(conflicts) = file_entry.get("conflicts").and_then(|c| c.as_array()) {
+                let mut shown = 0usize;
                 for conflict in conflicts {
                     let rule = conflict
                         .get("rule")
@@ -416,7 +417,33 @@ pub(super) fn format_lint_fix_output_text(
                         .get("reason")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("");
-                    let _ = writeln!(s, "  conflict  {rule}  {reason}");
+                    // The line is what turns `conflicts 2` into something a
+                    // reader can act on (iteration 263, dogfood UX-16). A
+                    // conflict without one still prints, just without the
+                    // position.
+                    let line = conflict
+                        .get("line")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0);
+                    if line > 0 {
+                        let _ = writeln!(s, "  conflict  {rule}  line {line}: {reason}");
+                    } else {
+                        let _ = writeln!(s, "  conflict  {rule}  {reason}");
+                    }
+                    shown += 1;
+                }
+                // `conflicts_total` counts what the file really had; the
+                // array itself is capped unless `--detailed` was passed.
+                let total = file_entry
+                    .get("conflicts_total")
+                    .and_then(serde_json::Value::as_u64)
+                    .map_or(conflicts.len(), |t| usize::try_from(t).unwrap_or(usize::MAX));
+                if shown > 0 && total > conflicts.len() {
+                    let _ = writeln!(
+                        s,
+                        "  … and {} more (use --detailed)",
+                        total - conflicts.len()
+                    );
                 }
             }
         }

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -428,6 +428,23 @@ hyalo lint --fix --dry-run               # preview autofixes
 hyalo lint --fix                         # apply
 ```
 
+**Obsidian grammar (autofix safety).** Four stock rules are narrowed so `--fix` cannot
+corrupt a vault; `hyalo lint-rules show <ID>` states each deviation:
+
+- **MD018** exempts tag lines — a single `#` plus a tag token is `#todo`, not a heading
+  missing its space. `##Heading`, `#1`, and a capitalized word followed by prose
+  (`#Heading typo`) still fire.
+- **MD034** ignores URLs that already sit inside link markup (link/image destination,
+  autolink, wikilink, reference definition).
+- **MD042** accepts an image as link text (`[![](img.png)](https://…)`).
+- **MD001** reports a skipped heading level but is **not autofixable**: renumbering a
+  deliberate `######` caption rewrites authored structure. Silence the warning with
+  `hyalo lint-rules set MD001 --enabled false`.
+
+When two fixes want the same bytes one is deferred and reported as a conflict;
+`--fix` text output names it as `conflict <RULE> line <N>: range overlap with <RULE>`
+(first 20 per file, `--detailed` for all).
+
 Use `hyalo lint --help` for narrowing flags (`--rule`, `--rule-prefix`, `--detailed`, `--max-per-rule`, `--fix-rule`, etc.). The snapshot index does **not** accelerate the body pass.
 
 **Strict mode:** `hyalo lint --strict` (or `[lint] strict = true` in `.hyalo.toml`)

--- a/crates/hyalo-cli/tests/e2e/iteration263_obsidian_lint_safety.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration263_obsidian_lint_safety.rs
@@ -1,0 +1,273 @@
+//! Iteration 263 — `lint --fix` must never corrupt Obsidian content.
+//!
+//! Each test pins one of the destructive autofixes the v0.22.0 Obsidian-vault
+//! dogfood run found (BUG-3, BUG-9, UX-10) plus the conflict explanation the
+//! same run asked for (UX-16). The shared shape is deliberate: run the fix
+//! for real and compare the file byte-for-byte, because the failure mode
+//! being guarded against is a *silent* rewrite, not a wrong exit code.
+
+use super::common::{hyalo_no_hints, typed_results, write_md};
+use hyalo_cli::commands::lint::{ExtLintFixOutput, ExtLintOutput};
+use tempfile::TempDir;
+
+/// A vault with no schema requirements, so only body rules speak.
+fn vault(files: &[(&str, &str)]) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join(".hyalo.toml"), "dir = \".\"\n").unwrap();
+    for (name, content) in files {
+        write_md(tmp.path(), name, content);
+    }
+    tmp
+}
+
+// ---------------------------------------------------------------------------
+// BUG-3 — MD018 vs Obsidian tags
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lint_fix_md018_leaves_an_obsidian_tag_line_byte_identical() {
+    let body = "---\ntitle: Daily Log\n---\n\nWoke up late.\n\n#todo\n\nCalled the vet.\n\n#todo/next follow up\n";
+    let tmp = vault(&[("log.md", body)]);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD018", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let after = std::fs::read_to_string(tmp.path().join("log.md")).unwrap();
+    assert_eq!(after, body, "a tag line must survive `--fix` untouched");
+
+    let results: ExtLintFixOutput = typed_results(&output.stdout);
+    assert_eq!(
+        results.total_fixed, 0,
+        "no MD018 fix may be reported for tag lines"
+    );
+}
+
+#[test]
+fn lint_fix_md018_still_fixes_a_real_heading_typo() {
+    let tmp = vault(&[(
+        "note.md",
+        "---\ntitle: Note\n---\n\n#Heading typo\n\nprose\n",
+    )]);
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD018"])
+        .output()
+        .unwrap();
+
+    let after = std::fs::read_to_string(tmp.path().join("note.md")).unwrap();
+    assert!(
+        after.contains("# Heading typo"),
+        "a capitalized word followed by prose is still a heading typo: {after:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// BUG-9 — MD034 / MD042 vs image-as-link-text
+// ---------------------------------------------------------------------------
+
+/// The report's fixture: a badge whose link text is an image and whose
+/// destination MD034 wrapped in angle brackets.
+const BADGE: &str =
+    "---\ntitle: Embed Adjustments\n---\n\n[![](img/badge.png)](https://example.com/snippet.png)\n";
+
+#[test]
+fn lint_fix_md034_leaves_a_link_destination_alone() {
+    let tmp = vault(&[("badge.md", BADGE)]);
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--fix-rule", "MD034"])
+        .output()
+        .unwrap();
+
+    let after = std::fs::read_to_string(tmp.path().join("badge.md")).unwrap();
+    assert_eq!(
+        after, BADGE,
+        "a URL that is already a link destination must not be wrapped"
+    );
+}
+
+#[test]
+fn lint_md042_accepts_an_image_as_link_text() {
+    let tmp = vault(&[("badge.md", BADGE)]);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--rule", "MD042", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let results: ExtLintOutput = typed_results(&output.stdout);
+    let hits: usize = results
+        .files
+        .iter()
+        .flat_map(|f| &f.rule_groups)
+        .filter(|g| g.rule == "MD042")
+        .map(|g| g.count)
+        .sum();
+    assert_eq!(hits, 0, "the badge idiom is not an empty link: {results:?}");
+}
+
+#[test]
+fn lint_md042_still_reports_a_genuinely_empty_link() {
+    let tmp = vault(&[(
+        "empty.md",
+        "---\ntitle: Empty\n---\n\nsee [](https://example.com/) here\n",
+    )]);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--rule", "MD042", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let results: ExtLintOutput = typed_results(&output.stdout);
+    let hits: usize = results
+        .files
+        .iter()
+        .flat_map(|f| &f.rule_groups)
+        .filter(|g| g.rule == "MD042")
+        .map(|g| g.count)
+        .sum();
+    assert_eq!(hits, 1, "`[](url)` is still empty: {results:?}");
+}
+
+// ---------------------------------------------------------------------------
+// UX-10 — MD001 reports, never rewrites
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lint_md001_warns_but_proposes_no_fix() {
+    let body = "---\ntitle: Snippet\n---\n\n## Section\n\nprose\n\n###### Caption\n";
+    let tmp = vault(&[("snippet.md", body)]);
+
+    // Read-only lint still reports the skipped level.
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--rule", "MD001", "--format", "json"])
+        .output()
+        .unwrap();
+    let results: ExtLintOutput = typed_results(&output.stdout);
+    assert!(
+        results
+            .files
+            .iter()
+            .flat_map(|f| &f.rule_groups)
+            .any(|g| g.rule == "MD001"),
+        "MD001 must still warn: {results:?}"
+    );
+
+    // `--fix --dry-run` proposes nothing, and `--fix` changes nothing.
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "lint",
+            "--fix",
+            "--dry-run",
+            "--rule",
+            "MD001",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let fix_results: ExtLintFixOutput = typed_results(&output.stdout);
+    assert_eq!(
+        fix_results.total_fixed, 0,
+        "MD001 is report-only (DEC-272): {fix_results:?}"
+    );
+
+    hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--rule", "MD001"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("snippet.md")).unwrap(),
+        body,
+        "a deliberate `######` caption must survive `--fix`"
+    );
+}
+
+#[test]
+fn lint_rules_list_shows_md001_as_not_autofixable() {
+    let tmp = vault(&[]);
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args([
+            "lint-rules",
+            "list",
+            "--format",
+            "json",
+            "--jq",
+            r#".results[] | select(.id=="MD001") | .autofixable"#,
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "false",
+        "MD001 must advertise AUTOFIX no: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// UX-16 — `conflicts N` is explained
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lint_fix_text_explains_each_conflict() {
+    // MD012 (collapse multiple blanks) and MD047 (single trailing newline)
+    // both want the run of blank lines at EOF, so one of them loses.
+    let tmp = vault(&[("conflict.md", "---\ntitle: C\n---\n\nbody\n\n\n\n")]);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--dry-run", "--format", "text"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("conflicts 1"),
+        "the fixture must actually produce an overlap: {stdout}"
+    );
+    // Before iteration 263 this printed `conflicts 1` and nothing else: the
+    // per-file conflict line existed but was suppressed because MD047 also
+    // appeared under `would fix`, and it carried no line to tell the two
+    // violations apart.
+    assert!(
+        stdout.contains("conflict  MD047  line 5: range overlap with MD012"),
+        "a conflict must name its rule, line and blocker: {stdout}"
+    );
+}
+
+#[test]
+fn lint_fix_json_carries_the_conflict_line() {
+    let tmp = vault(&[("conflict.md", "---\ntitle: C\n---\n\nbody\n\n\n\n")]);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["lint", "--fix", "--dry-run", "--format", "json"])
+        .output()
+        .unwrap();
+    let results: ExtLintFixOutput = typed_results(&output.stdout);
+    for file in &results.files {
+        assert_eq!(
+            file.conflicts_total,
+            file.conflicts.len(),
+            "an uncapped run reports every conflict it listed"
+        );
+        for conflict in &file.conflicts {
+            assert!(
+                conflict.line > 0,
+                "every conflict carries a 1-based line: {conflict:?}"
+            );
+        }
+    }
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -43,6 +43,7 @@ mod iteration255_followups;
 mod iteration257_init_scope;
 mod iteration261_link_kinds;
 mod iteration262_frontmatter_links;
+mod iteration263_obsidian_lint_safety;
 mod iteration_ergonomics;
 mod jq;
 mod json_errors;

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -61,6 +61,54 @@ static DEFAULT_ON: &[&str] = &[
     "HYALO001", "HYALO002", "HYALO003", "HYALO004", "HYALO005", "HYALO006", "HYALO007",
 ];
 
+/// Stock rules whose upstream autofix hyalo **refuses to offer**, however the
+/// upstream `Rule::can_fix()` answers.
+///
+/// A rule lands here when its fix is not a mechanical correction but a
+/// rewrite of authored content — applying it silently changes meaning, and
+/// the by-hand correction is trivial. The diagnostic is still reported (and
+/// still counted by `lint`), it just carries no `fix`, so `lint --fix` never
+/// touches it and `lint-rules list` shows `AUTOFIX no`.
+///
+/// - `MD001` (heading-increment, DEC-272, dogfood v0.22.0 UX-10): the fix
+///   renumbers the heading — `###### Caption` under an `## H2` becomes
+///   `### Caption`. On the Obsidian Hub vault that proposed 17 rewrites of
+///   deliberate small-caption headings. `lint-rules set MD001 --enabled false`
+///   remains the per-vault opt-out for the warning itself.
+static NON_AUTOFIXABLE: &[&str] = &["MD001"];
+
+/// Extra sentences appended to a stock rule's upstream description so
+/// `hyalo lint-rules show <id>` documents hyalo's deviation from it.
+///
+/// Kept as a suffix rather than a replacement: the upstream one-liner stays
+/// the primary description, and a version bump that rewords it does not
+/// silently drop hyalo's note.
+static DESCRIPTION_SUFFIX: &[(&str, &str)] = &[
+    (
+        "MD001",
+        "Reported but not autofixed by hyalo: renumbering a heading rewrites authored structure \
+         (a deliberate `######` caption would become `##`). Fix by hand, or turn the warning off \
+         with `hyalo lint-rules set MD001 --enabled false`.",
+    ),
+    (
+        "MD018",
+        "Obsidian tag lines are exempt in hyalo: a single `#` followed by a tag token (letters, \
+         digits, `_`, `-`, `/`, non-ASCII word characters, at least one non-digit) is a tag, not \
+         a malformed heading. `##Heading`, `#1` and `#!bang` still fire.",
+    ),
+    (
+        "MD034",
+        "hyalo suppresses URLs that already sit inside link markup — a markdown link or image \
+         destination, an autolink, a wikilink or a reference definition. Only a URL in plain \
+         prose is bare.",
+    ),
+    (
+        "MD042",
+        "hyalo does not treat an image as empty link text: the badge idiom \
+         `[![alt](img.png)](https://…)` is deliberate markup. `[](url)` and `[ ](url)` still fire.",
+    ),
+];
+
 // ---------------------------------------------------------------------------
 // HYALO rule provider
 // ---------------------------------------------------------------------------
@@ -103,14 +151,22 @@ impl HyaloLintEngine {
                     .registry()
                     .get_rule(id)
                     .map_or(("unknown", ""), |r| (r.name(), r.description()));
-                let autofixable = inner
-                    .registry()
-                    .get_rule(id)
-                    .is_some_and(mdbook_lint_core::rule::Rule::can_fix);
+                let autofixable = !NON_AUTOFIXABLE.contains(id)
+                    && inner
+                        .registry()
+                        .get_rule(id)
+                        .is_some_and(mdbook_lint_core::rule::Rule::can_fix);
+                let description = DESCRIPTION_SUFFIX
+                    .iter()
+                    .find(|(rule, _)| rule == id)
+                    .map_or_else(
+                        || description.to_owned(),
+                        |(_, extra)| format!("{description}. {extra}"),
+                    );
                 RuleCatalogEntry {
                     id: id.to_string(),
                     name: name.to_owned(),
-                    description: description.to_owned(),
+                    description,
                     default_severity: sev,
                     default_enabled: enabled,
                     autofixable,
@@ -729,6 +785,21 @@ impl HyaloLintEngine {
                     if *rule_id == "MD011" && is_regex_false_positive(&v.message) {
                         continue;
                     }
+                    // BUG-3 (dogfood v0.22.0): a line-leading `#todo` is an
+                    // Obsidian tag, not a malformed heading. MD018's autofix
+                    // would rewrite it to `# todo` — silent content
+                    // corruption on any vault that uses tags. See
+                    // `rules::obsidian` and DEC-271.
+                    if *rule_id == "MD018"
+                        && v.line
+                            .checked_sub(1)
+                            .and_then(|i| doc.lines.get(i))
+                            .is_some_and(|line| {
+                                crate::rules::obsidian::is_obsidian_tag_line(line)
+                            })
+                    {
+                        continue;
+                    }
                     let fix = convert_fix(&v, body_content);
                     // A handful of upstream rules report `column` as a byte
                     // offset, not a Unicode scalar one — see
@@ -748,6 +819,39 @@ impl HyaloLintEngine {
                             .map_or(v.column, |line| byte_col_to_scalar_col(line, v.column))
                     } else {
                         v.column
+                    };
+                    // BUG-9 (dogfood v0.22.0): both of these need the
+                    // *scalar* column, so they run after the conversion
+                    // above. MD034 wraps a URL that is already a link
+                    // destination in angle brackets (its own `[`-skipping
+                    // scan cannot see the nested brackets of the badge idiom
+                    // `[![](img)](url)`), and MD042 calls a link whose text
+                    // is an image "empty".
+                    let line_text = v.line.checked_sub(1).and_then(|i| doc.lines.get(i));
+                    if *rule_id == "MD034"
+                        && line_text.is_some_and(|line| {
+                            crate::rules::obsidian::url_is_inside_link_markup(line, column)
+                        })
+                    {
+                        continue;
+                    }
+                    if *rule_id == "MD042"
+                        && line_text.is_some_and(|line| {
+                            crate::rules::obsidian::link_text_is_image(line, column)
+                        })
+                    {
+                        continue;
+                    }
+                    // UX-10 (dogfood v0.22.0) / DEC-272: MD001 keeps
+                    // *reporting* a skipped heading level but is no longer
+                    // autofixable — rewriting a deliberate `######` caption
+                    // to `##` changes what the author meant, and the manual
+                    // fix is a one-character edit. `RuleCatalogEntry` reports
+                    // `autofixable: false` to match (see `NON_AUTOFIXABLE`).
+                    let fix = if NON_AUTOFIXABLE.contains(rule_id) {
+                        None
+                    } else {
+                        fix
                     };
                     diagnostics.push(Diagnostic {
                         rule_id: rule_id.to_string(),

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -1701,13 +1701,17 @@ mod tests {
 
     /// Upstream #492 (our issue #491): a paragraph continuation line that
     /// starts with an issue reference such as `#472` is prose, not a
-    /// malformed ATX heading, and must not be flagged. A genuinely standalone
-    /// `#foo` still is, and a mid-line `PR #472` never was.
+    /// malformed ATX heading, and must not be flagged. A genuine heading typo
+    /// still is, and a mid-line `PR #472` never was.
+    ///
+    /// The standalone case used to be `#standalone`, which iteration 263 now
+    /// reads as an Obsidian tag (DEC-271); `#Standalone typo` — a capitalized
+    /// word followed by prose — is the shape that still means "heading".
     #[test]
     fn md018_ignores_paragraph_continuation_lines() {
         let config = LintConfig::default();
         let engine = HyaloLintEngine::create().unwrap();
-        let body = "Upstream tracked this in\n#472 which is a continuation line.\n\nSee PR #472 for the fix.\n\n#standalone\n";
+        let body = "Upstream tracked this in\n#472 which is a continuation line.\n\nSee PR #472 for the fix.\n\n#Standalone typo\n";
         let diagnostics = engine
             .lint_body(body, "test.md", None, false, &config, &["MD018".to_owned()])
             .unwrap();
@@ -1726,7 +1730,7 @@ mod tests {
         );
         assert!(
             lines.contains(&6),
-            "a standalone `#standalone` is still a malformed heading: {lines:?}"
+            "`#Standalone typo` is still a malformed heading: {lines:?}"
         );
     }
 
@@ -1789,5 +1793,155 @@ mod tests {
             .expect("MD009 should fire on the trailing spaces");
         let fix = d.fix.as_ref().expect("MD009 fix should not be dropped");
         assert_eq!(apply(body, fix), "café — naïve\r\nsecond ünïcode line\r\n");
+    }
+
+    // -----------------------------------------------------------------
+    // Obsidian-grammar guards (iteration 263, dogfood v0.22.0)
+    // -----------------------------------------------------------------
+
+    /// BUG-3: MD018 must not read an Obsidian tag line as a broken heading.
+    /// The two `#todo`-shaped lines mirror `T - Thecookiemomma's Daily
+    /// Log.md` lines 31/36 from the report.
+    #[test]
+    fn md018_exempts_obsidian_tag_lines() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "Notes for today.\n\n#todo\n\nMore prose.\n\n#todo/next call the vet\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD018".to_owned()])
+            .unwrap();
+        assert!(
+            diagnostics.iter().all(|d| d.rule_id != "MD018"),
+            "tag lines must not be flagged: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn md018_still_fires_on_real_heading_typos() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        // `#!bang` is left out: upstream MD018 skips shebang lines outright,
+        // so there is no diagnostic either way (the token-level grammar is
+        // pinned in `rules::obsidian`'s own tests).
+        for (body, should_fire) in [
+            ("#Heading typo\n", true),
+            ("##todo\n", true),
+            ("#1 item\n", true),
+            ("#日本語 heading?\n", false),
+            ("#todo/next\n", false),
+        ] {
+            let diagnostics = engine
+                .lint_body(body, "test.md", None, false, &config, &["MD018".to_owned()])
+                .unwrap();
+            let fires = diagnostics.iter().any(|d| d.rule_id == "MD018");
+            assert_eq!(fires, should_fire, "MD018 on {body:?}");
+        }
+    }
+
+    /// BUG-9: a URL that is already a link destination is not bare, so no
+    /// angle-bracket fix may be proposed for it.
+    #[test]
+    fn md034_ignores_urls_inside_link_destinations() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "[![](img.png)](https://example.com/y.png)\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD034".to_owned()])
+            .unwrap();
+        assert!(
+            diagnostics.iter().all(|d| d.rule_id != "MD034"),
+            "a link destination is not a bare URL: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn md034_still_fires_on_a_bare_url_next_to_a_link() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "see [docs](https://a.example/) and https://b.example/ too\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD034".to_owned()])
+            .unwrap();
+        let hits: Vec<_> = diagnostics.iter().filter(|d| d.rule_id == "MD034").collect();
+        assert_eq!(hits.len(), 1, "only the prose URL is bare: {diagnostics:?}");
+        let fix = hits[0].fix.as_ref().expect("the bare URL keeps its fix");
+        assert_eq!(
+            apply(body, fix),
+            "see [docs](https://a.example/) and <https://b.example/> too\n"
+        );
+    }
+
+    #[test]
+    fn md034_ignores_urls_in_fenced_code_blocks() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "```text\nhttps://example.com/in-code\n```\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD034".to_owned()])
+            .unwrap();
+        assert!(
+            diagnostics.iter().all(|d| d.rule_id != "MD034"),
+            "code-block URLs are not bare: {diagnostics:?}"
+        );
+    }
+
+    /// BUG-9: an image is link text, not emptiness.
+    #[test]
+    fn md042_accepts_an_image_as_link_text() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "[![](img.png)](https://example.com/y.png)\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD042".to_owned()])
+            .unwrap();
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.rule_id == "MD042" && d.message.contains("empty link")),
+            "an image is not empty link text: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn md042_still_fires_on_genuinely_empty_links() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        for body in ["[](https://example.com/)\n", "[ ](https://example.com/)\n"] {
+            let diagnostics = engine
+                .lint_body(body, "test.md", None, false, &config, &["MD042".to_owned()])
+                .unwrap();
+            assert!(
+                diagnostics.iter().any(|d| d.rule_id == "MD042"),
+                "MD042 must still fire on {body:?}: {diagnostics:?}"
+            );
+        }
+    }
+
+    /// UX-10 / DEC-272: MD001 keeps reporting, never fixes.
+    #[test]
+    fn md001_reports_but_offers_no_fix() {
+        let config = LintConfig::default();
+        let engine = HyaloLintEngine::create().unwrap();
+        let body = "## Section\n\nprose\n\n###### Caption\n";
+        let diagnostics = engine
+            .lint_body(body, "test.md", None, false, &config, &["MD001".to_owned()])
+            .unwrap();
+        let d = diagnostics
+            .iter()
+            .find(|d| d.rule_id == "MD001")
+            .expect("MD001 must still warn about the skipped level");
+        assert!(d.fix.is_none(), "MD001 must not carry an autofix: {d:?}");
+    }
+
+    #[test]
+    fn md001_is_reported_as_not_autofixable_in_the_catalog() {
+        let engine = HyaloLintEngine::create().unwrap();
+        let entry = engine.rule_entry("MD001").expect("MD001 is in the catalog");
+        assert!(!entry.autofixable);
+        assert!(
+            entry.description.contains("not autofixed"),
+            "the catalog description must explain why: {}",
+            entry.description
+        );
     }
 }

--- a/crates/hyalo-mdlint/src/engine.rs
+++ b/crates/hyalo-mdlint/src/engine.rs
@@ -794,9 +794,7 @@ impl HyaloLintEngine {
                         && v.line
                             .checked_sub(1)
                             .and_then(|i| doc.lines.get(i))
-                            .is_some_and(|line| {
-                                crate::rules::obsidian::is_obsidian_tag_line(line)
-                            })
+                            .is_some_and(|line| crate::rules::obsidian::is_obsidian_tag_line(line))
                     {
                         continue;
                     }
@@ -1862,7 +1860,10 @@ mod tests {
         let diagnostics = engine
             .lint_body(body, "test.md", None, false, &config, &["MD034".to_owned()])
             .unwrap();
-        let hits: Vec<_> = diagnostics.iter().filter(|d| d.rule_id == "MD034").collect();
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule_id == "MD034")
+            .collect();
         assert_eq!(hits.len(), 1, "only the prose URL is bare: {diagnostics:?}");
         let fix = hits[0].fix.as_ref().expect("the bare URL keeps its fix");
         assert_eq!(

--- a/crates/hyalo-mdlint/src/rules/mod.rs
+++ b/crates/hyalo-mdlint/src/rules/mod.rs
@@ -6,9 +6,13 @@ pub mod hyalo002;
 pub mod hyalo003;
 pub mod hyalo004;
 pub mod hyalo007;
+pub mod obsidian;
 
 pub use hyalo001::Hyalo001;
 pub use hyalo002::Hyalo002;
 pub use hyalo003::check_date_keys;
 pub use hyalo004::check_datetime_properties;
 pub use hyalo007::non_scalar_title_kind;
+pub use obsidian::{
+    is_obsidian_tag_line, is_obsidian_tag_token, link_text_is_image, url_is_inside_link_markup,
+};

--- a/crates/hyalo-mdlint/src/rules/obsidian.rs
+++ b/crates/hyalo-mdlint/src/rules/obsidian.rs
@@ -167,7 +167,11 @@ fn link_markup_spans(line: &str) -> Vec<(usize, usize)> {
                 if let Some(&close) = close_of.get(&i) {
                     // `![alt](src)` — start the span at the `!` so the whole
                     // image is one region.
-                    let start = if i > 0 && bytes[i - 1] == b'!' { i - 1 } else { i };
+                    let start = if i > 0 && bytes[i - 1] == b'!' {
+                        i - 1
+                    } else {
+                        i
+                    };
                     let mut end = close + 1;
                     match bytes.get(end) {
                         // Inline destination `(...)`, nesting-aware so a

--- a/crates/hyalo-mdlint/src/rules/obsidian.rs
+++ b/crates/hyalo-mdlint/src/rules/obsidian.rs
@@ -230,24 +230,37 @@ fn matching_paren(bytes: &[u8], open: usize) -> Option<usize> {
     None
 }
 
-/// Whether the link starting at `column` (1-based, Unicode-scalar) on `line`
-/// has an image for its link text — `[![alt](img)](url)` or `[![[img]]](url)`.
+/// Whether the MD042 diagnostic reported at `column` (1-based,
+/// Unicode-scalar) on `line` is really the badge idiom
+/// `[![alt](img)](url)` — an image used as a link's text.
 ///
-/// MD042 calls such a link empty because it only concatenates `Text`/`Code`
-/// descendants. The badge idiom is deliberate markup, not a broken link, so
-/// the diagnostic is suppressed; a genuinely empty `[](url)` or `[ ](url)`
-/// still fires because neither starts its label with an image.
+/// MD042 emits *two* diagnostics for that one construct, and both are
+/// suppressed here:
+///
+/// - on the enclosing **link**, "Found empty link", because the rule only
+///   concatenates `Text`/`Code` descendants and so never sees the image;
+/// - on the **image**, "Found image with empty alt text", because in this
+///   position the alt text would duplicate the link it wraps — the link, not
+///   the image, is what a reader follows.
+///
+/// A standalone `![](img.png)` still gets the alt-text warning, and a
+/// genuinely empty `[](url)` or `[ ](url)` still gets the empty-link error:
+/// neither has an image at the start of a link label.
 #[must_use]
 pub fn link_text_is_image(line: &str, column: usize) -> bool {
     let Some(offset) = scalar_col_to_byte_offset(line, column) else {
         return false;
     };
-    let rest = &line[offset..];
-    let Some(label) = rest.strip_prefix('[') else {
-        return false;
-    };
-    // Covers both `![alt](img)` and the Obsidian embed `![[img]]`.
-    label.trim_start().starts_with("![")
+    // The link diagnostic points at the `[` opening the label. Covers both
+    // `![alt](img)` and the Obsidian embed `![[img]]`.
+    if let Some(label) = line[offset..].strip_prefix('[')
+        && label.trim_start().starts_with("![")
+    {
+        return true;
+    }
+    // The image diagnostic points at the `!`; it is link text exactly when a
+    // link label opens immediately before it.
+    line[offset..].starts_with("![") && line[..offset].ends_with('[')
 }
 
 /// 1-based Unicode-scalar column → byte offset within `line`.
@@ -334,6 +347,10 @@ mod tests {
         assert!(!link_text_is_image("[](https://example.com/)", 1));
         assert!(!link_text_is_image("[ ](https://example.com/)", 1));
         assert!(link_text_is_image("prefix [![alt](i.png)](u)", 8));
+        // The image half of the same construct (column of the `!`).
+        assert!(link_text_is_image(line, 2));
+        // A standalone image keeps its empty-alt warning.
+        assert!(!link_text_is_image("![](img.png)", 1));
     }
 
     #[test]

--- a/crates/hyalo-mdlint/src/rules/obsidian.rs
+++ b/crates/hyalo-mdlint/src/rules/obsidian.rs
@@ -21,7 +21,7 @@
 //! numbering the upstream rules use, so a diagnostic can be checked without
 //! re-parsing the document.
 
-use hyalo_core::links::inert_link_zones;
+use std::collections::HashMap;
 
 /// Whether `token` is a valid Obsidian tag body (the text after the `#`).
 ///
@@ -57,11 +57,20 @@ pub fn is_obsidian_tag_token(token: &str) -> bool {
 
 /// Whether `line` is an Obsidian tag line rather than a malformed ATX heading.
 ///
-/// True only for a **single** leading `#` immediately followed by a valid tag
-/// token (`##todo` is not a tag in Obsidian, and `## Heading` is a real
-/// heading). Trailing prose after the tag is fine — `#todo call the vet` is
-/// still a tag line, which is exactly the shape MD018 would rewrite into an
-/// H1 sentence.
+/// True for a **single** leading `#` immediately followed by a valid tag
+/// token — `##todo` is not a tag in Obsidian, and `## Heading` is a real
+/// heading. Trailing prose after the tag is fine (`#todo call the vet` is
+/// still a tag line), with one deliberate exception, which is the whole
+/// difficulty of the rule: `#Heading typo` parses as the tag `#Heading`
+/// followed by prose, and is also exactly what a missing space after a `#`
+/// looks like. DEC-271 breaks the tie by capitalization — a token that is a
+/// **plain capitalized ASCII word** (initial upper-case letter, then letters
+/// only: no digit, `-`, `_`, `/`, no non-ASCII) *and* is followed by more
+/// text on the line reads as a heading and stays flagged. `#Project/alpha
+/// notes`, `#todo call the vet` and a bare `#Someday` are tags.
+///
+/// The bias is deliberate: a missed heading typo leaves the file untouched,
+/// while a mis-fixed tag silently rewrites the author's content.
 ///
 /// Leading indentation is ignored, matching MD018's own `trim_start`.
 #[must_use]
@@ -78,19 +87,37 @@ pub fn is_obsidian_tag_line(line: &str) -> bool {
         .split(|c: char| c.is_whitespace())
         .next()
         .unwrap_or_default();
-    is_obsidian_tag_token(token)
+    if !is_obsidian_tag_token(token) {
+        return false;
+    }
+    let has_trailing_text = !rest[token.len()..].trim().is_empty();
+    !(has_trailing_text && looks_like_a_heading_word(token))
+}
+
+/// Whether `token` reads as the first word of a prose heading: an initial
+/// ASCII upper-case letter followed by ASCII letters only.
+///
+/// Anything a tag namespace would carry — a digit, `-`, `_`, `/`, or a
+/// non-ASCII character — disqualifies it, because heading prose does not
+/// start with `Project/alpha` but tags routinely do.
+fn looks_like_a_heading_word(token: &str) -> bool {
+    let mut chars = token.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_uppercase() && chars.all(|c| c.is_ascii_alphabetic())
 }
 
 /// Whether the URL MD034 flagged at `column` (1-based, Unicode-scalar) on
 /// `line` actually sits inside link markup — a markdown link/image
 /// destination, an autolink, or a wikilink — rather than in plain prose.
 ///
-/// Reuses [`inert_link_zones`], the same span map the auto-linker uses to
-/// decide where it must not inject `[[…]]`, so "text that is already markup"
-/// has one definition across the codebase. A *bare* URL is itself an inert
-/// zone there, and such a zone starts exactly at the URL; markup that
-/// *contains* a URL always opens earlier (`[`, `<`, `!`). So the test is
-/// simply: is the offset covered by a zone that began before it?
+/// Deliberately does **not** reuse `hyalo_core::links::inert_link_zones`.
+/// That map answers a different question ("may the auto-linker inject
+/// `[[…]]` here?") and matches a link label with the *first* closing `]`, so
+/// on `[![](img.png)](url)` it ends the label at the image's `]` and the
+/// destination falls outside every zone — precisely the shape BUG-9 is
+/// about. [`link_markup_spans`] matches brackets by nesting instead.
 #[must_use]
 pub fn url_is_inside_link_markup(line: &str, column: usize) -> bool {
     let Some(offset) = scalar_col_to_byte_offset(line, column) else {
@@ -98,9 +125,109 @@ pub fn url_is_inside_link_markup(line: &str, column: usize) -> bool {
         // match up; suppressing on a guess would hide real findings.
         return false;
     };
-    inert_link_zones(line)
+    link_markup_spans(line)
         .into_iter()
         .any(|(start, end)| start < offset && offset < end)
+}
+
+/// Byte spans of the link markup on `line`: markdown links and images
+/// (`[label](dest)`, `![alt](src)`, including the reference forms
+/// `[text][ref]`), Obsidian wikilinks and embeds (`[[…]]`, `![[…]]`), and
+/// autolinks / raw HTML (`<…>`).
+///
+/// Brackets are matched by **nesting**, so the label of `[![](img)](url)` is
+/// the whole `[![](img)]` and the span covers the destination too. Escapes
+/// are not honoured (`\[` counts as a bracket) — the map is used to decide
+/// "is this position inside markup", where treating bracket-shaped text as
+/// markup errs toward reporting less, which is the safe direction for an
+/// autofix.
+fn link_markup_spans(line: &str) -> Vec<(usize, usize)> {
+    let bytes = line.as_bytes();
+    let mut close_of: HashMap<usize, usize> = HashMap::new();
+    if bytes.contains(&b'[') {
+        let mut stack: Vec<usize> = Vec::new();
+        for (i, &b) in bytes.iter().enumerate() {
+            match b {
+                b'[' => stack.push(i),
+                b']' => {
+                    if let Some(open) = stack.pop() {
+                        close_of.insert(open, i);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'[' => {
+                if let Some(&close) = close_of.get(&i) {
+                    // `![alt](src)` — start the span at the `!` so the whole
+                    // image is one region.
+                    let start = if i > 0 && bytes[i - 1] == b'!' { i - 1 } else { i };
+                    let mut end = close + 1;
+                    match bytes.get(end) {
+                        // Inline destination `(...)`, nesting-aware so a
+                        // parenthesised URL does not truncate the span.
+                        Some(&b'(') => {
+                            if let Some(paren) = matching_paren(bytes, end) {
+                                end = paren + 1;
+                            }
+                        }
+                        // Full reference form `[text][ref]`.
+                        Some(&b'[') => {
+                            if let Some(&ref_close) = close_of.get(&end) {
+                                end = ref_close + 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                    spans.push((start, end));
+                    i = end;
+                    continue;
+                }
+                i += 1;
+            }
+            b'<' => {
+                // Autolink `<https://…>` or a raw HTML tag: either way the
+                // URL inside it is not bare.
+                if let Some(rel) = line[i + 1..].find('>') {
+                    let end = i + 1 + rel + 1;
+                    spans.push((i, end));
+                    i = end;
+                    continue;
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    spans
+}
+
+/// Byte index of the `)` closing the `(` at `open`, counting nesting.
+///
+/// `None` when the parenthesis never closes on this line.
+fn matching_paren(bytes: &[u8], open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (i, &b) in bytes.iter().enumerate().skip(open) {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                // `depth` is always ≥ 1 here for a caller that passes the
+                // index of a `(`; the guard keeps a misuse from underflowing.
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Whether the link starting at `column` (1-based, Unicode-scalar) on `line`
@@ -159,14 +286,19 @@ mod tests {
             "  #todo",
             "#todo trailing text",
             "#todo\t and more",
+            // Capitalized, but namespaced or bare — still a tag.
+            "#Project/alpha notes",
+            "#Someday",
         ] {
             assert!(is_obsidian_tag_line(good), "{good:?} should be a tag line");
         }
         for bad in [
             "##todo",
             "#1",
+            "#2024 review",
             "#!bang",
             "#Heading typo",
+            "#Standalone typo",
             "# todo",
             "#",
             "text #todo",

--- a/crates/hyalo-mdlint/src/rules/obsidian.rs
+++ b/crates/hyalo-mdlint/src/rules/obsidian.rs
@@ -1,0 +1,213 @@
+//! Obsidian-grammar guards for the stock `MD*` rules (iteration 263).
+//!
+//! The upstream `mdbook-lint-rulesets` rules are written for mdBook, whose
+//! Markdown has no `#tag` grammar and whose link scanner is line-based. On a
+//! real Obsidian vault that produces *destructive* autofixes, so hyalo
+//! post-processes the upstream diagnostics rather than forking the rules:
+//!
+//! - [`is_obsidian_tag_line`] — MD018 (`no-missing-space-atx`) reads a
+//!   line-leading `#todo` as a malformed heading and "fixes" it to `# todo`,
+//!   silently turning a tag into an H1 (dogfood v0.22.0 BUG-3, 162 proposals
+//!   on the Obsidian Hub vault).
+//! - [`url_is_inside_link_markup`] — MD034 (`no-bare-urls`) skips `[...](...)`
+//!   with a character scan that cannot see the nested brackets in the badge
+//!   idiom `[![](img.png)](https://…)`, so it wraps a *link destination* in
+//!   angle brackets and breaks the link (BUG-9, 209 proposals).
+//! - [`link_text_is_image`] — MD042 (`no-empty-links`) collects only `Text`
+//!   and `Code` children, so a link whose text is an image reads as empty
+//!   (BUG-9, 55 hits).
+//!
+//! Everything here works on the *body* text with the same 1-based line
+//! numbering the upstream rules use, so a diagnostic can be checked without
+//! re-parsing the document.
+
+use hyalo_core::links::inert_link_zones;
+
+/// Whether `token` is a valid Obsidian tag body (the text after the `#`).
+///
+/// Obsidian's grammar (DEC-271): a tag is made of letters, digits, `_`, `-`,
+/// `/` or non-ASCII word characters, and must contain at least one character
+/// that is not an ASCII digit — `#1984` is a number, not a tag. An empty
+/// token is not a tag.
+///
+/// Kept public so a future dedicated tag rule (`find --tag` parity, tag
+/// linting) reuses exactly the grammar MD018 is exempted against instead of
+/// growing a second, subtly different definition.
+#[must_use]
+pub fn is_obsidian_tag_token(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+    let mut has_non_digit = false;
+    for c in token.chars() {
+        let ok = c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/') || {
+            // Non-ASCII word characters (`#日本語`, `#übung`). Anything
+            // ASCII that got here is punctuation and disqualifies the token.
+            !c.is_ascii() && (c.is_alphanumeric() || c == '\u{200d}')
+        };
+        if !ok {
+            return false;
+        }
+        if !c.is_ascii_digit() {
+            has_non_digit = true;
+        }
+    }
+    has_non_digit
+}
+
+/// Whether `line` is an Obsidian tag line rather than a malformed ATX heading.
+///
+/// True only for a **single** leading `#` immediately followed by a valid tag
+/// token (`##todo` is not a tag in Obsidian, and `## Heading` is a real
+/// heading). Trailing prose after the tag is fine — `#todo call the vet` is
+/// still a tag line, which is exactly the shape MD018 would rewrite into an
+/// H1 sentence.
+///
+/// Leading indentation is ignored, matching MD018's own `trim_start`.
+#[must_use]
+pub fn is_obsidian_tag_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some(rest) = trimmed.strip_prefix('#') else {
+        return false;
+    };
+    // A second `#` means an ATX heading (or nothing Obsidian recognises).
+    if rest.starts_with('#') {
+        return false;
+    }
+    let token = rest
+        .split(|c: char| c.is_whitespace())
+        .next()
+        .unwrap_or_default();
+    is_obsidian_tag_token(token)
+}
+
+/// Whether the URL MD034 flagged at `column` (1-based, Unicode-scalar) on
+/// `line` actually sits inside link markup — a markdown link/image
+/// destination, an autolink, or a wikilink — rather than in plain prose.
+///
+/// Reuses [`inert_link_zones`], the same span map the auto-linker uses to
+/// decide where it must not inject `[[…]]`, so "text that is already markup"
+/// has one definition across the codebase. A *bare* URL is itself an inert
+/// zone there, and such a zone starts exactly at the URL; markup that
+/// *contains* a URL always opens earlier (`[`, `<`, `!`). So the test is
+/// simply: is the offset covered by a zone that began before it?
+#[must_use]
+pub fn url_is_inside_link_markup(line: &str, column: usize) -> bool {
+    let Some(offset) = scalar_col_to_byte_offset(line, column) else {
+        // An out-of-range column means the diagnostic and the line do not
+        // match up; suppressing on a guess would hide real findings.
+        return false;
+    };
+    inert_link_zones(line)
+        .into_iter()
+        .any(|(start, end)| start < offset && offset < end)
+}
+
+/// Whether the link starting at `column` (1-based, Unicode-scalar) on `line`
+/// has an image for its link text — `[![alt](img)](url)` or `[![[img]]](url)`.
+///
+/// MD042 calls such a link empty because it only concatenates `Text`/`Code`
+/// descendants. The badge idiom is deliberate markup, not a broken link, so
+/// the diagnostic is suppressed; a genuinely empty `[](url)` or `[ ](url)`
+/// still fires because neither starts its label with an image.
+#[must_use]
+pub fn link_text_is_image(line: &str, column: usize) -> bool {
+    let Some(offset) = scalar_col_to_byte_offset(line, column) else {
+        return false;
+    };
+    let rest = &line[offset..];
+    let Some(label) = rest.strip_prefix('[') else {
+        return false;
+    };
+    // Covers both `![alt](img)` and the Obsidian embed `![[img]]`.
+    label.trim_start().starts_with("![")
+}
+
+/// 1-based Unicode-scalar column → byte offset within `line`.
+///
+/// `None` when the column is past the end of the line (or zero), which the
+/// callers treat as "cannot judge, keep the diagnostic".
+fn scalar_col_to_byte_offset(line: &str, column: usize) -> Option<usize> {
+    let idx = column.checked_sub(1)?;
+    if idx == 0 {
+        return Some(0);
+    }
+    line.char_indices().nth(idx).map(|(byte, _)| byte)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_tokens_follow_obsidian_grammar() {
+        for good in ["todo", "todo/next", "2024-goals", "日本語", "a", "x_y-z/w"] {
+            assert!(is_obsidian_tag_token(good), "{good} should be a tag");
+        }
+        for bad in ["", "1", "2024", "!bang", "a b", "a.b", "a,b", "a#b"] {
+            assert!(!is_obsidian_tag_token(bad), "{bad} should not be a tag");
+        }
+    }
+
+    #[test]
+    fn tag_lines_are_recognised() {
+        for good in [
+            "#todo",
+            "#todo/next",
+            "#2024-goals",
+            "#日本語",
+            "  #todo",
+            "#todo trailing text",
+            "#todo\t and more",
+        ] {
+            assert!(is_obsidian_tag_line(good), "{good:?} should be a tag line");
+        }
+        for bad in [
+            "##todo",
+            "#1",
+            "#!bang",
+            "#Heading typo",
+            "# todo",
+            "#",
+            "text #todo",
+            "###",
+        ] {
+            assert!(
+                !is_obsidian_tag_line(bad),
+                "{bad:?} should not be a tag line"
+            );
+        }
+    }
+
+    #[test]
+    fn urls_inside_link_destinations_are_markup() {
+        let line = "[![](img.png)](https://example.com/y.png)";
+        let col = line.find("https").expect("url present") + 1;
+        assert!(url_is_inside_link_markup(line, col));
+    }
+
+    #[test]
+    fn a_bare_url_after_a_link_is_still_bare() {
+        let line = "see [docs](https://a.example/) and https://b.example/ too";
+        let bare = line.rfind("https://b").expect("bare url present") + 1;
+        assert!(!url_is_inside_link_markup(line, bare));
+        let inside = line.find("https://a").expect("dest present") + 1;
+        assert!(url_is_inside_link_markup(line, inside));
+    }
+
+    #[test]
+    fn image_link_text_is_not_empty() {
+        let line = "[![](img.png)](https://example.com/y.png)";
+        assert!(link_text_is_image(line, 1));
+        assert!(!link_text_is_image("[](https://example.com/)", 1));
+        assert!(!link_text_is_image("[ ](https://example.com/)", 1));
+        assert!(link_text_is_image("prefix [![alt](i.png)](u)", 8));
+    }
+
+    #[test]
+    fn multibyte_columns_resolve_to_the_right_offset() {
+        let line = "日本語 [![](i.png)](https://example.com/)";
+        let col = line[..line.find("https").expect("url")].chars().count() + 1;
+        assert!(url_is_inside_link_markup(line, col));
+    }
+}

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -4127,3 +4127,61 @@ it gives no way to *deliberately* turn a list into a scalar.
 **Rejected: a `--keep-list` flag.** The project rule is no new CLI flags from
 dogfood pressure, and `hyalo append` is already the command that keeps a list a
 list.
+
+## DEC-271: MD018 defers to Obsidian tag grammar, with a capitalization tiebreak (2026-09-04)
+
+**Decision:** MD018 (`no-missing-space-atx`) does not fire on a line whose
+single leading `#` is followed by a valid Obsidian tag token — letters, digits,
+`_`, `-`, `/` or non-ASCII word characters, with at least one non-digit
+character. Two or more hashes (`##todo`), a purely numeric token (`#1`,
+`#2024`) and a punctuation token (`#!bang`) are not tags and keep firing.
+
+Where the two grammars genuinely collide — `#Word more prose`, which is both a
+tag followed by text and exactly what a heading missing its space looks like —
+the tiebreak is capitalization: a **plain capitalized ASCII word** (initial
+upper-case letter, then letters only: no digit, `-`, `_`, `/`, nothing
+non-ASCII) followed by more text on the line stays flagged as a heading typo.
+`#todo call the vet`, `#Project/alpha notes` and a bare `#Someday` are tags.
+
+**Why:** the two errors are not symmetric. A missed heading typo leaves the file
+byte-identical and costs a warning; a mis-"fixed" tag silently rewrites the
+author's content and, on the Obsidian Hub vault, would have done so 162 times in
+one `--fix` run. So the rule is biased toward exemption, and the one heuristic
+that keeps the rule useful at all is the one that only affects the ambiguous
+shape.
+
+**Rejected: exempting only whole-line tags (`#todo` alone).** `#todo call the
+vet` is the commonest daily-note shape in the corpus and is corrupted just as
+badly.
+
+**Rejected: dropping MD018 entirely, or default-disabling it.** It catches a
+real typo class in prose-first vaults, and turning it off vault-wide is already
+available as `hyalo lint-rules set MD018 --enabled false`.
+
+**Where:** `crates/hyalo-mdlint/src/rules/obsidian.rs`
+(`is_obsidian_tag_token` / `is_obsidian_tag_line`), applied as a post-filter in
+`lint_body` next to the MD011 regex suppression. The token predicate is public
+so a future tag rule reuses one definition of the grammar.
+
+## DEC-272: MD001 is reported, never autofixed (2026-09-04)
+
+**Decision:** MD001 (`heading-increment`) keeps warning about a skipped heading
+level but carries no `fix`, so `lint --fix` never rewrites one. `hyalo
+lint-rules list` reports `autofixable: false` for it, and the per-vault opt-out
+for the warning itself stays `hyalo lint-rules set MD001 --enabled false`.
+Implemented as a `NON_AUTOFIXABLE` table in `hyalo-mdlint`'s engine — a general
+mechanism, not an MD001 special case — that both strips the fix and answers the
+catalog.
+
+**Why:** the fix renumbers a heading. On the Obsidian Hub vault it proposed 17
+rewrites of deliberate `###### Caption` lines on CSS-snippet notes, turning them
+into `##`. Correct per markdownlint, wrong for the author, and unlike a trailing
+space there is no way to tell the two apart from the text. A skipped level is
+still worth a warning, and the manual correction is a one-character edit.
+
+**Rejected: default-disabling MD001 (option (b) in the plan).** That loses the
+warning too, and the warning is the useful half.
+
+**Rejected: a `--no-fix-rule` flag or an autofix allowlist in config.** No new
+CLI surface from dogfood pressure; `--fix-rule` already restricts a run to named
+rules, which covers the opposite need.

--- a/hyalo-knowledgebase/docs/schema-and-lint.md
+++ b/hyalo-knowledgebase/docs/schema-and-lint.md
@@ -154,11 +154,31 @@ hyalo lint --fix iterations/iteration-101-bm25.md
   fixes and changes no bytes. `--dry-run` previews the fully converged result.
 - **Severity wins conflicts.** When two rules' fixes overlap on the same byte
   range, the higher-severity fix (error over warn) is applied and the other is
-  reported as a conflict.
+  reported as a conflict. Text output explains each one —
+  `conflict  MD047  line 5: range overlap with MD012` — capped at 20 lines per
+  file, with `… and N more (use --detailed)` beyond that (iter-263).
 - **Line endings are preserved.** Fixes on CRLF files emit CRLF; a fix never
   flips a file's line-ending style.
 - **Size cap.** Files larger than 100 MiB are skipped with a warning (reported
   as a `FILE` group) instead of being read into memory.
+
+### Obsidian grammar (autofix safety, iter-263)
+
+The bundled `MD*` rules come from `mdbook-lint`, which targets mdBook — no `#tag`
+grammar, and a line-based link scanner. On a real Obsidian vault that produced
+destructive autofixes, so four rules are narrowed. Each deviation is stated in
+`hyalo lint-rules show <ID>`.
+
+| Rule | Narrowed to |
+|------|-------------|
+| **MD018** | A single `#` followed by a tag token — letters, digits, `_`, `-`, `/`, non-ASCII word characters, at least one non-digit — is an Obsidian tag, not a heading missing its space (DEC-271). `##Heading`, `#1`, `#!bang` and a capitalized word followed by prose (`#Heading typo`) still fire. |
+| **MD034** | A URL already inside link markup — a markdown link or image destination, an autolink, a wikilink, a reference definition — is not bare. Only prose URLs are flagged. |
+| **MD042** | An image is valid link text: `[![](img.png)](https://…)` is neither an empty link nor a missing-alt warning. A standalone `![](img.png)` still warns, and `[](url)` / `[ ](url)` still error. |
+| **MD001** | Reported, never autofixed (DEC-272): renumbering a deliberate `###### Caption` to `##` rewrites authored structure. `hyalo lint-rules list` shows `AUTOFIX no`; silence the warning with `hyalo lint-rules set MD001 --enabled false`. |
+
+Measured on the Obsidian Hub vault (6,520 files): MD018 fix proposals 162 → 0,
+MD034 209 → 116 (all remaining ones are prose URLs), MD001 17 → 0, and MD042's
+"Found empty link" hits 55 → 0.
 
 ### Fix categories
 

--- a/hyalo-knowledgebase/iterations/iteration-263-lint-autofix-obsidian-safety.md
+++ b/hyalo-knowledgebase/iterations/iteration-263-lint-autofix-obsidian-safety.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 263 — Lint autofix safety on Obsidian content
 date: 2026-09-03
-status: planned
+status: completed
 tags:
   - iteration
   - lint
@@ -62,96 +62,145 @@ No change to this plan's own scope as a result.
 
 ### FIX-1: MD018 respects Obsidian tag grammar (BUG-3)
 
-- [ ] Define the rule precisely and record it as DEC-271 (tentative). Proposal:
+- [x] Define the rule precisely and record it as DEC-271 (tentative). Proposal:
       a line matching `^#+\S` is exempt from MD018 when the token after the
       hashes is a valid Obsidian tag, meaning it consists of letters, digits,
       `_`, `-`, `/` or non-ASCII word characters, contains at least one
       non-digit, and uses a single `#` (a `##tag` line is not a tag in
       Obsidian). MD018 keeps firing on `#1 item` (digits only), `#` followed by
       punctuation, and on `##Heading` with two or more hashes.
-- [ ] hyalo-mdlint MD018: implement the exemption in both detection and
+- [x] hyalo-mdlint MD018: implement the exemption in both detection and
       autofix; add a shared `is_obsidian_tag_token` helper so a future tag rule
       reuses it.
-- [ ] Unit tests: `#todo`, `#todo/next`, `#2024-goals`, `#日本語`, `#1`,
+- [x] Unit tests: `#todo`, `#todo/next`, `#2024-goals`, `#日本語`, `#1`,
       `#!bang`, `##todo`, `#todo trailing text` (still a tag line in
       Obsidian), plus the two lines from `T - Thecookiemomma's Daily Log.md`
       quoted in the report.
-- [ ] e2e in `crates/hyalo-cli/tests/e2e`: `lint --fix --rule MD018` on a file
+- [x] e2e in `crates/hyalo-cli/tests/e2e`: `lint --fix --rule MD018` on a file
       with `#todo` leaves it byte-identical and reports no fix.
-- [ ] Docs: `hyalo lint-rules show MD018` description mentions the exemption;
+- [x] Docs: `hyalo lint-rules show MD018` description mentions the exemption;
       changelog entry.
 
 ### FIX-2: MD034 and MD042 understand link destinations and image link text (BUG-9)
 
-- [ ] hyalo-mdlint MD034: skip any URL that sits inside a markdown link or
+- [x] hyalo-mdlint MD034: skip any URL that sits inside a markdown link or
       image destination `](…)`, an autolink `<…>`, a reference definition, or a
       wikilink; only a URL in plain prose is bare. Use the same span map the
       auto-linker uses for inert regions if one exists in hyalo-core.
-- [ ] hyalo-mdlint MD042: link text consisting of an image `![…](…)` or
+- [x] hyalo-mdlint MD042: link text consisting of an image `![…](…)` or
       `![[…]]` is not empty. Keep flagging `[](url)` and `[ ](url)`.
-- [ ] Unit tests for both rules with `[![](img.png)](https://x/y.png)`, a bare
+- [x] Unit tests for both rules with `[![](img.png)](https://x/y.png)`, a bare
       URL after a link on the same line (must still fire), and a URL in a
       fenced code block (must not).
-- [ ] e2e: `lint --fix --fix-rule MD034` on the report's fixture line makes no
+- [x] e2e: `lint --fix --fix-rule MD034` on the report's fixture line makes no
       change; `lint --rule MD042` reports 0 on it.
-- [ ] Docs: rule descriptions, changelog.
+- [x] Docs: rule descriptions, changelog.
 
 ### FIX-3: MD001 stops autofixing deliberate heading jumps (UX-10)
 
-- [ ] DEC-272 (tentative): choose between (a) MD001 stays enabled but is no
+- [x] DEC-272 (tentative): choose between (a) MD001 stays enabled but is no
       longer autofixable (report only), or (b) MD001 default-disabled in the
       built-in rule table. Recommend (a): a skipped heading level is worth a
       warning, but rewriting `######` to `##` changes what the author meant,
       and the fix is trivially applied by hand. Keep `lint-rules set MD001
       --enabled false` as the per-vault opt-out.
-- [ ] Implement in hyalo-mdlint (drop the fixer, keep the check) and update the
+- [x] Implement in hyalo-mdlint (drop the fixer, keep the check) and update the
       built-in defaults table; `hyalo lint-rules list` shows `AUTOFIX no` for
       MD001.
-- [ ] e2e: `lint --fix --dry-run` on a `######` caption file proposes nothing
+- [x] e2e: `lint --fix --dry-run` on a `######` caption file proposes nothing
       for MD001 but `lint` still reports it as a warning.
-- [ ] Docs: `hyalo lint-rules show MD001`, `lint --help` autofix list, the
+- [x] Docs: `hyalo lint-rules show MD001`, `lint --help` autofix list, the
       `hyalo-knowledgebase/` lint docs page, changelog.
 
 ### FIX-4: explain autofix conflicts in text mode (UX-16)
 
-- [ ] hyalo-cli `lint --fix` text output: after `conflicts N`, print one line
+- [x] hyalo-cli `lint --fix` text output: after `conflicts N`, print one line
       per conflict in the form `conflict  <file>  <rule> line <n>: range
       overlap with <other rule>` (the same data JSON already carries), capped
       at 20 lines with `… and N more (use --detailed)`. `--detailed` prints
       all.
-- [ ] e2e: a fixture producing an MD012/MD047 overlap shows the explanation
+- [x] e2e: a fixture producing an MD012/MD047 overlap shows the explanation
       line in text and unchanged JSON.
-- [ ] Docs: `lint -h/--help` output section, changelog.
+- [x] Docs: `lint -h/--help` output section, changelog.
 
 ## Acceptance criteria
 
-- [ ] Obsidian Hub, cwd `../obsidian-hub`, clean checkout: before the change
+- [x] Obsidian Hub, cwd `../obsidian-hub`, clean checkout: before the change
       `hyalo lint --fix --dry-run --format json --jq '[.results.fixes[] |
       .rule] | group_by(.) | map({(.[0]): length}) | add'` records the per-rule
       baseline (MD018 162, MD034 209, MD001 17 per the report); after the
       change MD018 proposals on tag lines are 0 (verify with `--rule MD018
       --detailed` that every remaining proposal is a real `#Heading` typo),
       MD034 proposals on link destinations are 0, MD001 proposals are 0.
-- [ ] `../obsidian-hub`: `hyalo lint --rule MD042 --count` → 0 for the
+- [x] `../obsidian-hub`: `hyalo lint --rule MD042 --count` → 0 for the
       image-as-link-text pattern (was 55); any remaining MD042 hit is a
       genuine `[](…)`.
-- [ ] `../obsidian-hub`: `hyalo lint --fix --fix-rule MD034 "02 - Community
+- [x] `../obsidian-hub`: `hyalo lint --fix --fix-rule MD034 "02 - Community
       Expansions/02.05 All Community Expansions/CSS Snippets/Embed
       Adjustments.md"` followed by `git diff --exit-code` → exit 0.
-- [ ] `../obsidian-hub`: `hyalo lint --fix --dry-run --format text | grep -A3
+- [x] `../obsidian-hub`: `hyalo lint --fix --dry-run --format text | grep -A3
       conflicts` shows a per-conflict explanation line.
-- [ ] Scratch vault: body line `#todo`, `hyalo lint --fix --rule MD018 <file>`
+- [x] Scratch vault: body line `#todo`, `hyalo lint --fix --rule MD018 <file>`
       → file unchanged, `fixed 0`; body line `#Heading typo` → still fixed.
-- [ ] `hyalo lint-rules list --format json --jq '.results[] |
+- [x] `hyalo lint-rules list --format json --jq '.results[] |
       select(.id=="MD001") | .autofixable'` → `false`.
-- [ ] Own KB: `hyalo lint --strict` result unchanged; `hyalo lint --fix
+- [x] Own KB: `hyalo lint --strict` result unchanged; `hyalo lint --fix
       --dry-run --count` unchanged or lower, with any difference explained.
-- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D
+- [x] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D
       warnings`, `cargo test --workspace -q`, `hyalo lint --strict` on the KB,
       xtask help-drift check.
-- [ ] Changelog entry via `hyalo changelog add`; DEC-271 and DEC-272 recorded
+- [x] Changelog entry via `hyalo changelog add`; DEC-271 and DEC-272 recorded
       in [[decision-log]]; `.claude/skills/hyalo/SKILL.md` lint paragraph
       updated where it lists autofixable rules.
+
+## Outcome (2026-09-04)
+
+Landed on `iter-263/lint-autofix-obsidian-safety`. Measured on `../obsidian-hub`
+(6,520 files) with the release binary:
+
+| Rule | `--fix --dry-run` proposals before | after |
+|------|-----------------------------------|-------|
+| MD018 | 162 | **0** |
+| MD034 | 209 | **116** (all remaining are prose URLs) |
+| MD001 | 17 | **0** |
+| MD042 "Found empty link" | 55 | **0** |
+
+Three deviations from the plan as written, each recorded in the decision log:
+
+- **MD018 needed a tiebreak the plan did not anticipate.** `#todo trailing
+  text` (exempt per the plan) and `#Heading typo` (still fixed per the
+  acceptance criteria) are the same grammatical shape — a tag token followed by
+  prose. DEC-271 resolves it by capitalization: a plain capitalized ASCII word
+  followed by more text stays flagged. This retired the old
+  `md018_ignores_paragraph_continuation_lines` assertion that `#standalone` is a
+  heading; the test now uses `#Standalone typo`.
+- **MD034 could not reuse `hyalo_core::links::inert_link_zones`.** That map
+  closes a link label at the *first* `]`, so on `[![](img)](url)` the
+  destination falls outside every zone — exactly the BUG-9 shape. `hyalo-mdlint`
+  grew its own nesting-aware `link_markup_spans` instead; the auto-linker is
+  unaffected because a bare URL is inert there on its own.
+- **MD042 emits two diagnostics for one badge**, "Found empty link" on the link
+  and "Found image with empty alt text" on the image. Both are suppressed when
+  the image opens a link label, which is what gets the vault's count to 0 for
+  the pattern. A standalone `![](img.png)` keeps its empty-alt warning — 21 of
+  those remain on the Hub, in 6 files, and they are genuine.
+
+Two things beyond the plan's four items, both forced by FIX-4:
+
+- The iter-213 UX-5 dedup (never show a rule as both `fixed` and `conflict`)
+  suppressed *every* conflict line in the MD012/MD047 fixture, which is why
+  UX-16 saw `conflicts 2` and nothing else. Now that a conflict carries its
+  line, the dedup is narrowed to the same *violation* (rule + line); a fixed
+  group that lists no violations still suppresses its rule wholesale.
+- `fix_mode_file_totals` counted distinct conflicting *rules* per file while the
+  listing prints one line per violation, so the Hub showed 11 `conflict` lines
+  under `conflicts 9`. Both now count `(rule, line)`.
+
+Noticed while verifying, out of scope, worth a dogfood item: MD034's URL
+boundary scan swallows a following `<br` in HTML-ish prose
+(`Themes/Retroma.md:65`), so its autofix would emit
+`<https://github.com/emarpiee/Retroma<br>`. Upstream boundary bug, three
+occurrences vault-wide.
 
 ## Links
 

--- a/hyalo-knowledgebase/iterations/iteration-270-md034-boundary-br-tag.md
+++ b/hyalo-knowledgebase/iterations/iteration-270-md034-boundary-br-tag.md
@@ -1,0 +1,109 @@
+---
+type: iteration
+title: "Iteration 270 — MD034: URL boundary scan must stop before a following HTML tag"
+date: 2026-09-04
+status: planned
+tags:
+  - iteration
+  - lint
+  - obsidian
+  - dogfooding
+branch: iter-270/md034-boundary-br-tag
+priority: 10
+related:
+  - "[[iterations/iteration-263-lint-autofix-obsidian-safety]]"
+  - "[[dogfood-results/dogfood-v0220-obsidian-vaults]]"
+---
+
+# Iteration 270 — MD034: URL boundary scan must stop before a following HTML tag
+
+## Goal
+
+Carry-over from [[iterations/iteration-263-lint-autofix-obsidian-safety]] (found
+while verifying that iteration's MD034 fix, out of scope there since it is a
+distinct upstream boundary bug rather than the Obsidian-tag-line or
+link-destination corruption that iteration targeted): MD034's bare-URL
+end-of-match boundary scan does not stop at a following HTML tag. On
+`../obsidian-hub`, `Themes/Retroma.md:65` has a bare URL immediately followed
+by `<br` (an unclosed/self-closing HTML line break used inline in prose), and
+`hyalo lint --fix --fix-rule MD034` on that line would wrap it as
+`<https://github.com/emarpiee/Retroma<br>` — swallowing the `<br` into the
+angle-bracket autolink and corrupting the markup, one more variant of the
+same "MD034's autofix rewrites something it should have left alone" failure
+class iteration 263 closed for the link-destination and reference-definition
+cases. Three occurrences vault-wide on the Hub as of iter-263's dogfood run.
+
+Constraint: **no new CLI flags** from dogfood pressure (project rule). This is
+a boundary-detection fix inside the existing MD034 post-processing added in
+iteration 263
+(`crates/hyalo-mdlint/src/rules/obsidian.rs`), not a new flag or rule. Out of
+scope: any other MD034 boundary case not yet observed in the corpus — fix the
+`<tag` case this iteration and note in the outcome whether the same scan
+mismeasures a boundary against other adjacent punctuation (e.g. `>`, `)`
+outside a link) so a follow-up can be filed if the corpus turns up more.
+
+## Tasks
+
+### FIX-1: stop the bare-URL span before a following HTML tag
+
+- [ ] Confirm the repro: reduce `Themes/Retroma.md:65` (or an equivalent
+      fixture) to a minimal line — bare URL immediately followed by `<br` (no
+      space) — and show `lint --fix --dry-run --rule MD034` proposes wrapping
+      the `<br` into the autolink.
+- [ ] Root-cause in upstream `mdbook-lint-rulesets`' MD034 URL-boundary scan
+      (the same rule iteration 263 already post-processes, not a fork): does
+      it stop at whitespace/EOL only, missing `<` as a boundary character? If
+      the boundary bug is upstream-only and not reachable through hyalo's own
+      `rules::obsidian` code, the fix belongs in `rules::obsidian` as another
+      post-filter (like the iteration-263 ones), narrowing the span hyalo
+      accepts from the diagnostic rather than patching upstream.
+- [ ] Implement: MD034's proposed URL end boundary must not extend past a
+      literal `<` that starts an HTML tag (self-closing or not) immediately
+      following the URL, so `https://…/Retroma<br>` fixes to
+      `<https://…/Retroma><br>` (or, if simpler and still correct, the fix is
+      suppressed entirely for this shape and the diagnostic still fires as a
+      warning per iter-263's own bias toward under-fixing over corrupting).
+- [ ] Unit test in `rules::obsidian` (or wherever the fix lands) for
+      `https://a.example/<br>`, `https://a.example/<br/>`, and a bare URL
+      immediately followed by `>` alone (confirm that shape, if it exists in
+      the corpus, is unaffected or also handled) plus the existing
+      already-fixed shapes from iteration 263 (regression guard).
+- [ ] e2e in `crates/hyalo-cli/tests/e2e`: the reduced Retroma-style fixture,
+      `lint --fix --fix-rule MD034`, assert the file either keeps the `<br`
+      outside the autolink or is left unchanged with the diagnostic still
+      reported.
+- [ ] Docs: update the MD034 description suffix
+      (`crates/hyalo-mdlint/src/engine.rs::DESCRIPTION_SUFFIX`) and
+      `hyalo-knowledgebase/docs/schema-and-lint.md`'s Obsidian-grammar table if
+      the fix changes what MD034 is documented to skip; changelog entry.
+
+## Acceptance criteria
+
+- [ ] `../obsidian-hub`: `hyalo lint --fix --dry-run --rule MD034 --format
+      json --jq '[.results.fixes[] | select(.file | test("Retroma"))]'` no
+      longer proposes a fix that would embed `<br` inside the autolink's angle
+      brackets (proposes nothing for that line, or proposes a fix whose result
+      keeps `<br` outside the brackets — pick one and match it in the e2e
+      test).
+- [ ] `../obsidian-hub`: `git diff --exit-code` after `hyalo lint --fix
+      --fix-rule MD034` on the three known-affected files (or the whole vault)
+      → either exit 0 (fix suppressed) or a diff that leaves `<br` intact
+      outside the wrapped URL.
+- [ ] Every other MD034 fixture from iteration 263
+      (`md034_ignores_urls_inside_link_destinations`,
+      `md034_still_fires_on_a_bare_url_next_to_a_link`,
+      `md034_ignores_urls_in_fenced_code_blocks`) still passes unchanged —
+      this iteration narrows a boundary, it does not touch the iter-263
+      exemptions.
+- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D
+      warnings`, `cargo test --workspace -q`, `hyalo lint --strict` on the KB,
+      xtask help-drift check.
+- [ ] Changelog entry via `hyalo changelog add`; a DEC recorded in
+      [[decision-log]] if the fix is non-obvious (e.g. suppress-vs-narrow
+      choice).
+
+## Links
+
+- [[iterations/iteration-263-lint-autofix-obsidian-safety]]
+- [[dogfood-results/dogfood-v0220-obsidian-vaults]]
+- [[decision-log]]


### PR DESCRIPTION
## Summary

`hyalo lint --fix` could silently corrupt an Obsidian vault. Implements
[iteration 263](hyalo-knowledgebase/iterations/iteration-263-lint-autofix-obsidian-safety.md),
closing BUG-3 / BUG-9 / UX-10 / UX-16 from the v0.22.0 Obsidian-vault dogfood run.
No new CLI flags.

- **MD018 no longer rewrites an Obsidian tag into a heading.** A single `#`
  followed by a tag token (letters, digits, `_`, `-`, `/`, non-ASCII word
  characters, at least one non-digit) is `#todo`, not a heading missing its
  space. `##todo`, `#1` and `#!bang` still fire. Where the grammars genuinely
  collide — `#Word more prose` — **DEC-271** breaks the tie by capitalization:
  a plain capitalized ASCII word followed by prose stays flagged, so
  `#Heading typo` is still fixed while `#todo call the vet` and
  `#Project/alpha notes` are not.
- **MD034 no longer wraps a link destination in angle brackets**, and **MD042
  no longer calls `[![](img.png)](https://…)` an empty link.** Upstream's
  line scanner closes a link label at the first `]`, so the badge idiom's
  destination looked like prose. New `crates/hyalo-mdlint/src/rules/obsidian.rs`
  carries a nesting-aware `link_markup_spans`; `hyalo_core`'s `inert_link_zones`
  has the same first-`]` limitation and is deliberately *not* reused (the
  auto-linker is unaffected because a bare URL is inert there on its own).
- **MD001 is reported, never autofixed (DEC-272).** Renumbering a deliberate
  `###### Caption` to `##` rewrites authored structure. Implemented as a
  general `NON_AUTOFIXABLE` table in the mdlint engine that strips the fix and
  answers `lint-rules list` (`autofixable: false`). The warning stays; the
  opt-out stays `hyalo lint-rules set MD001 --enabled false`.
- **`lint --fix` explains its conflicts (UX-16).** Text output prints
  `conflict  MD047  line 5: range overlap with MD012` per deferred fix, capped
  at 20 per file with `… and N more (use --detailed)`. This needed two
  supporting fixes: the iter-213 fixed-vs-conflict dedup suppressed *every*
  conflict line and is now narrowed to the same violation (rule + line), and
  `fix_mode_file_totals` counted distinct rules while the listing counts
  violations, so `conflicts 9` sat above 11 printed lines.

JSON additions (all additive): `conflicts[].line` and per-file
`conflicts_total`.

Measured on `../obsidian-hub` (6,520 files), release build:

| Rule | `--fix --dry-run` proposals before | after |
|------|-----------------------------------|-------|
| MD018 | 162 | **0** |
| MD034 | 209 | **116** (all remaining are prose URLs) |
| MD001 | 17 | **0** |
| MD042 "Found empty link" | 55 | **0** |

The 21 MD042 hits that remain are `Found image with empty alt text` on
standalone `![](img.png)` images in 6 files — genuine, and outside the badge
idiom.

## Test plan

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace -q` — all green.
- Every `xtask check-*` gate exits 0 (feature-fanout, help-drift,
  command-reference, bundled-skills, pi-package-sync, mutation-journal;
  dead-primitives and todo-annotations are stubs).
- New e2e suite `crates/hyalo-cli/tests/e2e/iteration263_obsidian_lint_safety.rs`
  (9 tests): tag line survives `--fix` byte-identical; `#Heading typo` still
  fixed; the badge fixture is unchanged by `--fix --fix-rule MD034`; MD042 is
  0 on it and 1 on `[](url)`; MD001 warns, proposes nothing and writes nothing;
  `lint-rules list` reports `autofixable: false`; conflicts print rule + line +
  blocker in text and carry `line` in JSON.
- 6 unit tests in `rules::obsidian` (tag grammar incl. `#日本語`, multibyte
  columns, bare-URL-next-to-a-link, standalone-image alt text) and 8 in the
  mdlint engine.
- 3 new output-layer tests for the conflict listing (line form, the 20-line
  cap and its `… and N more`, and no false "more" line).
- Own KB: `hyalo lint --strict` clean, `hyalo lint --fix --dry-run --count` 0 —
  unchanged from before.
- Docs updated in the same PR: `lint --help` (Obsidian grammar + conflict
  format), `hyalo lint-rules show MD001/MD018/MD034/MD042` descriptions,
  `templates/skill-hyalo.md`, `hyalo-knowledgebase/docs/schema-and-lint.md`,
  DEC-271/DEC-272, and three CHANGELOG entries.

## Carry-over

All of iteration 263's own tasks and acceptance criteria are ticked against
the real diff — nothing deferred inside its plan. The local `/review-pr` pass
found no issues (fmt/clippy/tests/xtask gates all green with no fixes
needed). One out-of-scope item surfaced while verifying the iteration:

- **MD034's URL boundary scan swallows a following `<br` in HTML-ish prose**
  (`Themes/Retroma.md:65` on `../obsidian-hub`, 3 occurrences vault-wide) — its
  autofix would emit `<https://…/Retroma<br>`, corrupting the markup. A
  distinct upstream boundary bug from the link-destination/reference-definition
  cases this PR fixes, not fixed here.
  **Disposition:** filed as its own plan,
  [iteration 270](hyalo-knowledgebase/iterations/iteration-270-md034-boundary-br-tag.md)
  (`iter-270/md034-boundary-br-tag`), rather than folded into iteration 264
  (`find` sort/filter consistency — unrelated surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
