### PR TITLE
iter-270: --validate refuses an unloadable [schema]; object-list item syntax closed as won't-do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ and this project adheres to
 - Text-mode errors use the lowercase `error:` prefix, matching clap and anyhow
 - `hyalo config` reports the effective output format plus `format_source`, and an effective `hints` boolean
 - `lint --format github` summary counts files checked: `N errors, M warnings in K of T files checked`
+- `set`/`append` with `--validate` (or `[schema] validate_on_write`) now refuse with exit 1 when `[schema]` exists but cannot be loaded, instead of falling back to an empty schema and writing unvalidated (DEC-290). Writes without `--validate`, and every other command, are unaffected.
 
 ### Removed
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1328,6 +1328,11 @@ pub(crate) enum Commands {
             `hyalo append`, which adds to a list instead of replacing it. With --validate (or \
             validate_on_write), a schema declaring the property as `list` rejects the scalar \
             before anything is written.\n\
+            UNUSABLE SCHEMA: when [schema] is present but could not be loaded (an uncompilable \
+            regex, a key on the wrong property type), --validate and validate_on_write REFUSE \
+            with exit 1 and write nothing — the schema fell back to empty, so validating \
+            against it would reject nothing. Fix [schema] (hyalo lint reports it as \
+            schema/malformed) or drop --validate to write unvalidated.\n\
             FILTERS (optional, narrow which files are mutated):\n\
             - --where-property FILTER: only mutate files whose frontmatter matches (same syntax as find --property: \
 K=V, K!=V, K>=V, K<=V, K>V, K<V, K for existence, K~=/re/ for a regex, K=null / K=[] for a null or \
@@ -1397,6 +1402,10 @@ Repeatable (AND).\n\
         ///
         /// Validates the new values against the schema before writing. Implied by
         /// `validate_on_write = true` in the [schema] config.
+        ///
+        /// Refuses with exit 1 (writing nothing) when `[schema]` exists but could
+        /// not be loaded: the schema falls back to empty, so validating against
+        /// it would reject nothing.
         #[arg(long, alias = "strict")]
         validate: bool,
         #[command(flatten)]
@@ -1663,6 +1672,11 @@ Repeatable (AND).\n\
             naming the file and the reason.\n\
             SIZE LIMIT: frontmatter is limited to 64 KiB / 2000 lines. A write that would exceed \
             this limit is rejected with exit 1 and a JSON error (see `hyalo set --help`).\n\
+            UNUSABLE SCHEMA: when [schema] is present but could not be loaded (an uncompilable \
+            regex, a key on the wrong property type), --validate and validate_on_write REFUSE \
+            with exit 1 and write nothing — the schema fell back to empty, so validating \
+            against it would reject nothing. Fix [schema] (hyalo lint reports it as \
+            schema/malformed) or drop --validate to write unvalidated.\n\
             USE WHEN: You need to append items to list-type properties such as 'aliases' or 'authors' \
             without overwriting the existing list.\n\n\
             EXAMPLES:\n\
@@ -1706,6 +1720,10 @@ Repeatable (AND).\n\
         ///
         /// Validates the new values against the schema before writing. Implied by
         /// `validate_on_write = true` in the [schema] config.
+        ///
+        /// Refuses with exit 1 (writing nothing) when `[schema]` exists but could
+        /// not be loaded: the schema falls back to empty, so validating against
+        /// it would reject nothing.
         #[arg(long, alias = "strict")]
         validate: bool,
         #[command(flatten)]

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -1179,7 +1179,7 @@ pub(crate) fn run(
         }
     };
     let do_validate = validate || ctx.validate_on_write;
-    // DEC-289: same refusal as `set` — validating against a schema that failed
+    // DEC-290: same refusal as `set` — validating against a schema that failed
     // to load rejects nothing, so the promise is kept by refusing instead.
     if let Some(outcome) = crate::commands::reject_write_with_unloadable_schema(
         do_validate,

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -1179,6 +1179,15 @@ pub(crate) fn run(
         }
     };
     let do_validate = validate || ctx.validate_on_write;
+    // DEC-289: same refusal as `set` — validating against a schema that failed
+    // to load rejects nothing, so the promise is kept by refusing instead.
+    if let Some(outcome) = crate::commands::reject_write_with_unloadable_schema(
+        do_validate,
+        ctx.schema_invalid,
+        effective_format,
+    ) {
+        return Ok(outcome);
+    }
     append(
         dir,
         &properties,

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -601,6 +601,44 @@ pub fn reject_filter_in_mutation_property(key: &str, format: Format) -> Option<C
 /// rejected; a dotted key with no colliding map is unchanged (still a
 /// literal flat key) — nested-path support itself is out of scope.
 #[must_use]
+/// Refuse a write that asked for schema validation while `[schema]` could not
+/// be loaded (DEC-289).
+///
+/// `--validate` (and `[schema] validate_on_write`) promise that a value the
+/// schema forbids is rejected before anything is written. When
+/// `SchemaConfig::try_from` fails, the run falls back to an *empty* schema,
+/// which forbids nothing — so the promise silently becomes vacuous exactly
+/// when a user leaned on it. Refusing keeps `--validate`'s guarantee honest;
+/// a plain `set`/`append` makes no such promise and still writes, with the
+/// unsuppressible warning the config loader already printed.
+///
+/// Returns `None` when validation was not requested, or when the schema loaded
+/// fine — in both cases the write proceeds.
+pub(crate) fn reject_write_with_unloadable_schema(
+    do_validate: bool,
+    schema_invalid: Option<&str>,
+    format: Format,
+) -> Option<CommandOutcome> {
+    if !do_validate {
+        return None;
+    }
+    let diagnostic = schema_invalid?;
+    let out = crate::output::format_error(
+        format,
+        &format!(
+            "refusing to validate against an unusable [schema]: {diagnostic}; \
+             the schema could not be loaded, so --validate would reject nothing"
+        ),
+        None,
+        Some(
+            "Fix the [schema] section in .hyalo.toml (`hyalo lint` reports it as \
+             schema/malformed), or rerun without --validate to write unvalidated.",
+        ),
+        None,
+    );
+    Some(CommandOutcome::UserError(out))
+}
+
 pub fn reject_dotted_property_collision(
     name: &str,
     props: &indexmap::IndexMap<String, serde_json::Value>,

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -601,6 +601,34 @@ pub fn reject_filter_in_mutation_property(key: &str, format: Format) -> Option<C
 /// rejected; a dotted key with no colliding map is unchanged (still a
 /// literal flat key) — nested-path support itself is out of scope.
 #[must_use]
+pub fn reject_dotted_property_collision(
+    name: &str,
+    props: &indexmap::IndexMap<String, serde_json::Value>,
+    rel_path: &str,
+    format: Format,
+) -> Option<CommandOutcome> {
+    let (prefix, _) = name.split_once('.')?;
+    if !matches!(props.get(prefix), Some(serde_json::Value::Object(_))) {
+        return None;
+    }
+    let out = crate::output::format_error(
+        format,
+        &format!(
+            "{rel_path}: invalid property name '{name}': '{prefix}' already exists as a \
+             mapping in this file's frontmatter"
+        ),
+        None,
+        Some(&format!(
+            "hyalo does not support dotted path syntax for nested properties — --property \
+             sets a literal top-level key only, which would sit beside '{prefix}' rather than \
+             nesting into it; edit the file directly to change a value inside '{prefix}', or \
+             choose a key name that does not collide with it"
+        )),
+        None,
+    );
+    Some(CommandOutcome::UserError(out))
+}
+
 /// Refuse a write that asked for schema validation while `[schema]` could not
 /// be loaded (DEC-290).
 ///
@@ -634,34 +662,6 @@ pub(crate) fn reject_write_with_unloadable_schema(
             "Fix the [schema] section in .hyalo.toml (`hyalo lint` reports it as \
              schema/malformed), or rerun without --validate to write unvalidated.",
         ),
-        None,
-    );
-    Some(CommandOutcome::UserError(out))
-}
-
-pub fn reject_dotted_property_collision(
-    name: &str,
-    props: &indexmap::IndexMap<String, serde_json::Value>,
-    rel_path: &str,
-    format: Format,
-) -> Option<CommandOutcome> {
-    let (prefix, _) = name.split_once('.')?;
-    if !matches!(props.get(prefix), Some(serde_json::Value::Object(_))) {
-        return None;
-    }
-    let out = crate::output::format_error(
-        format,
-        &format!(
-            "{rel_path}: invalid property name '{name}': '{prefix}' already exists as a \
-             mapping in this file's frontmatter"
-        ),
-        None,
-        Some(&format!(
-            "hyalo does not support dotted path syntax for nested properties — --property \
-             sets a literal top-level key only, which would sit beside '{prefix}' rather than \
-             nesting into it; edit the file directly to change a value inside '{prefix}', or \
-             choose a key name that does not collide with it"
-        )),
         None,
     );
     Some(CommandOutcome::UserError(out))

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -602,7 +602,7 @@ pub fn reject_filter_in_mutation_property(key: &str, format: Format) -> Option<C
 /// literal flat key) — nested-path support itself is out of scope.
 #[must_use]
 /// Refuse a write that asked for schema validation while `[schema]` could not
-/// be loaded (DEC-289).
+/// be loaded (DEC-290).
 ///
 /// `--validate` (and `[schema] validate_on_write`) promise that a value the
 /// schema forbids is rejected before anything is written. When

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -1714,7 +1714,7 @@ pub(crate) fn run(
         }
     };
     let do_validate = validate || ctx.validate_on_write;
-    // DEC-289: `--validate` (or `validate_on_write`) against a `[schema]` that
+    // DEC-290: `--validate` (or `validate_on_write`) against a `[schema]` that
     // failed to load would validate against an empty schema and reject nothing.
     if let Some(outcome) = crate::commands::reject_write_with_unloadable_schema(
         do_validate,

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -1714,6 +1714,15 @@ pub(crate) fn run(
         }
     };
     let do_validate = validate || ctx.validate_on_write;
+    // DEC-289: `--validate` (or `validate_on_write`) against a `[schema]` that
+    // failed to load would validate against an empty schema and reject nothing.
+    if let Some(outcome) = crate::commands::reject_write_with_unloadable_schema(
+        do_validate,
+        ctx.schema_invalid,
+        effective_format,
+    ) {
+        return Ok(outcome);
+    }
     set(
         dir,
         &properties,

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -353,7 +353,7 @@ pub(crate) struct ResolvedDefaults {
     /// Parsed schema configuration from `[schema.*]` sections.
     pub(crate) schema: SchemaConfig,
     /// The diagnostic when a `[schema]` section **existed** but could not be
-    /// turned into a [`SchemaConfig`] (DEC-289), `None` otherwise.
+    /// turned into a [`SchemaConfig`] (DEC-290), `None` otherwise.
     ///
     /// Distinct from [`Self::malformed`]: the `.hyalo.toml` parsed fine as
     /// TOML, so `dir`, `[lint] ignore` and the views are all intact — only the
@@ -1194,7 +1194,7 @@ pub(crate) fn try_parse_schema_from_toml(
 /// since a stderr warning alone let `lint --strict` exit 0 on a vault whose
 /// schema validation was silently disabled.
 ///
-/// The returned diagnostic is what makes DEC-289 possible: the empty schema is
+/// The returned diagnostic is what makes DEC-290 possible: the empty schema is
 /// a fine basis for a read or a plain write, but a caller that asked for
 /// validation needs to know the schema it is validating against is not the
 /// vault's.

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -1214,7 +1214,7 @@ fn parse_schema_from_toml(raw: Option<&toml::Value>) -> (SchemaConfig, Option<St
         }
         Ok(None) => (SchemaConfig::default(), None),
         Err(e) => {
-            crate::warn::warn(e.clone());
+            crate::warn::warn(&e);
             (SchemaConfig::default(), Some(e))
         }
     }

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -352,6 +352,17 @@ pub(crate) struct ResolvedDefaults {
     pub(crate) md_lint: hyalo_mdlint::LintConfig,
     /// Parsed schema configuration from `[schema.*]` sections.
     pub(crate) schema: SchemaConfig,
+    /// The diagnostic when a `[schema]` section **existed** but could not be
+    /// turned into a [`SchemaConfig`] (DEC-289), `None` otherwise.
+    ///
+    /// Distinct from [`Self::malformed`]: the `.hyalo.toml` parsed fine as
+    /// TOML, so `dir`, `[lint] ignore` and the views are all intact — only the
+    /// schema is gone, and [`Self::schema`] above is the empty fallback rather
+    /// than what the user wrote. Reads and plain writes continue on that
+    /// fallback (the stderr warning is `-q`-proof); a write that *promised*
+    /// validation (`--validate`, or `[schema] validate_on_write`) must refuse
+    /// instead, because validating against an empty schema rejects nothing.
+    pub(crate) schema_invalid: Option<String>,
     /// Default output limit for list commands.
     /// `None` = use hardcoded default (50).
     /// `Some(0)` = unlimited.
@@ -478,6 +489,7 @@ impl ResolvedDefaults {
             changelog_path: None,
             md_lint: hyalo_mdlint::LintConfig::default(),
             schema: SchemaConfig::default(),
+            schema_invalid: None,
             default_limit: None,
             pi_session_summary: false,
             case_insensitive_mode: CaseInsensitiveMode::Auto,
@@ -1028,7 +1040,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
     let validate_on_write = schema_validate_on_write
         .or(cfg.validate_on_write)
         .unwrap_or(false);
-    let schema = parse_schema_from_toml(cfg.schema.as_ref());
+    let (schema, schema_invalid) = parse_schema_from_toml(cfg.schema.as_ref());
 
     // Parse [links] fields — borrow before moving.
     let (case_insensitive_mode, case_insensitive_resolve) = match parse_case_insensitive_setting(
@@ -1121,6 +1133,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
             .unwrap_or(false),
         md_lint: parse_md_lint_config(cfg.lint.as_ref()),
         schema,
+        schema_invalid,
         default_limit: cfg.default_limit,
         case_insensitive_mode,
         case_insensitive_resolve,
@@ -1169,7 +1182,8 @@ pub(crate) fn try_parse_schema_from_toml(
     Ok(Some(cfg))
 }
 
-/// Parse a `SchemaConfig` from the raw `[schema]` TOML value.
+/// Parse a `SchemaConfig` from the raw `[schema]` TOML value, returning the
+/// schema plus the diagnostic when it could not be loaded.
 ///
 /// On malformed schema TOML (or invalid field combinations like `pattern` on a
 /// non-string property), emits a warning and returns an empty schema (no
@@ -1179,7 +1193,12 @@ pub(crate) fn try_parse_schema_from_toml(
 /// round finding 2) via `try_parse_schema_from_toml` + `validate_schema_config`,
 /// since a stderr warning alone let `lint --strict` exit 0 on a vault whose
 /// schema validation was silently disabled.
-fn parse_schema_from_toml(raw: Option<&toml::Value>) -> SchemaConfig {
+///
+/// The returned diagnostic is what makes DEC-289 possible: the empty schema is
+/// a fine basis for a read or a plain write, but a caller that asked for
+/// validation needs to know the schema it is validating against is not the
+/// vault's.
+fn parse_schema_from_toml(raw: Option<&toml::Value>) -> (SchemaConfig, Option<String>) {
     match try_parse_schema_from_toml(raw) {
         Ok(Some(cfg)) => {
             // A `[[schema.bind]]` whose target names an undeclared type binds
@@ -1191,12 +1210,12 @@ fn parse_schema_from_toml(raw: Option<&toml::Value>) -> SchemaConfig {
                     unknown.join(", ")
                 ));
             }
-            cfg
+            (cfg, None)
         }
-        Ok(None) => SchemaConfig::default(),
+        Ok(None) => (SchemaConfig::default(), None),
         Err(e) => {
-            crate::warn::warn(e);
-            SchemaConfig::default()
+            crate::warn::warn(e.clone());
+            (SchemaConfig::default(), Some(e))
         }
     }
 }
@@ -1313,7 +1332,10 @@ pub(crate) fn overlay_profile(
     let validate_on_write = schema_validate_on_write
         .or(cfg.validate_on_write)
         .unwrap_or(false);
-    let schema = parse_schema_from_toml(cfg.schema.as_ref());
+    // A `--profile` overlay only ever feeds `lint`, which reports an unloadable
+    // schema as a `schema/malformed` violation of its own, so the diagnostic is
+    // not carried on this path.
+    let (schema, _schema_invalid) = parse_schema_from_toml(cfg.schema.as_ref());
     let md_lint = parse_md_lint_config(cfg.lint.as_ref());
     let lint_strict = cfg.lint.as_ref().is_some_and(|l| l.strict);
     // The fragment contributes its name to `[lint] profiles`; ensure the

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -165,7 +165,7 @@ pub(crate) struct CommandContext<'a> {
     pub schema: &'a SchemaConfig,
     /// The diagnostic when `[schema]` existed but could not be loaded, so
     /// [`Self::schema`] above is the empty fallback rather than the vault's
-    /// (DEC-289). `set`/`append` refuse when validation was asked for and this
+    /// (DEC-290). `set`/`append` refuse when validation was asked for and this
     /// is `Some`; everything else keeps running on the fallback.
     pub schema_invalid: Option<&'a str>,
     /// When `true`, schema validation runs on every `set`/`append` operation even

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -163,6 +163,11 @@ pub(crate) struct CommandContext<'a> {
     pub frontmatter_link_props: Option<&'a [String]>,
     /// Parsed schema configuration from `[schema.*]` sections in `.hyalo.toml`.
     pub schema: &'a SchemaConfig,
+    /// The diagnostic when `[schema]` existed but could not be loaded, so
+    /// [`Self::schema`] above is the empty fallback rather than the vault's
+    /// (DEC-289). `set`/`append` refuse when validation was asked for and this
+    /// is `Some`; everything else keeps running on the fallback.
+    pub schema_invalid: Option<&'a str>,
     /// When `true`, schema validation runs on every `set`/`append` operation even
     /// without `--validate`. Comes from `validate_on_write = true` in `.hyalo.toml`.
     pub validate_on_write: bool,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -2103,7 +2103,7 @@ fn run_inner() -> Result<(), AppError> {
     let config_language_owned = config.search_language.clone();
     let config_default_limit = config.default_limit;
     let mut schema = config.schema;
-    // DEC-289: `[schema]` was present but unloadable, so `schema` above is the
+    // DEC-290: `[schema]` was present but unloadable, so `schema` above is the
     // empty fallback. `set`/`append` refuse when validation was requested.
     let schema_invalid = config.schema_invalid;
     let frontmatter_link_props_owned = config.frontmatter_link_props;

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -2103,6 +2103,9 @@ fn run_inner() -> Result<(), AppError> {
     let config_language_owned = config.search_language.clone();
     let config_default_limit = config.default_limit;
     let mut schema = config.schema;
+    // DEC-289: `[schema]` was present but unloadable, so `schema` above is the
+    // empty fallback. `set`/`append` refuse when validation was requested.
+    let schema_invalid = config.schema_invalid;
     let frontmatter_link_props_owned = config.frontmatter_link_props;
     let mut validate_on_write = config.validate_on_write;
     let lint_ignore = config.lint_ignore;
@@ -2296,6 +2299,7 @@ fn run_inner() -> Result<(), AppError> {
         config_language: config_language_owned.as_deref(),
         frontmatter_link_props: frontmatter_link_props_owned.as_deref(),
         schema: &schema,
+        schema_invalid: schema_invalid.as_deref(),
         validate_on_write,
         lint_ignore: &lint_ignore,
         okf_ignore: &okf_ignore,

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -600,6 +600,14 @@ When no `[schema]` block exists, lint exits 0 with zero violations (backwards co
 **Validate on write:** `hyalo set` and `hyalo append` accept `--validate` to reject values
 that would fail lint. Enable globally via `[schema] validate_on_write = true` in `.hyalo.toml`.
 
+**A `--validate` write refuses when the schema itself is broken (DEC-290).** If `[schema]`
+is present but cannot be loaded — an uncompilable regex, a key on the wrong property type —
+the schema falls back to empty, so validating against it would reject nothing. `set` /
+`append` therefore exit 1 and write nothing whenever validation was asked for (`--validate`
+or `validate_on_write`), `--dry-run` included. The same write *without* `--validate` still
+proceeds, and `mv`, `remove`, `task toggle` and every read are unaffected — fix `[schema]`
+(`hyalo lint` reports it as `schema/malformed`) or drop `--validate` for that one write.
+
 **Ignore known-bad files:** add `[lint] ignore = ["legacy/known-bad.md", "vendor/**/*.md"]`
 to `.hyalo.toml` to skip listed files during `hyalo lint` (plain strings match literally;
 glob meta-characters use `--glob` semantics). Read-only commands still count them among the

--- a/crates/hyalo-cli/tests/e2e/config_trust.rs
+++ b/crates/hyalo-cli/tests/e2e/config_trust.rs
@@ -926,7 +926,14 @@ fn set_validate_dry_run_refuses_too() {
 
     let output = hyalo_no_hints()
         .current_dir(tmp.path())
-        .args(["set", "a.md", "-p", "status=draft", "--validate", "--dry-run"])
+        .args([
+            "set",
+            "a.md",
+            "-p",
+            "status=draft",
+            "--validate",
+            "--dry-run",
+        ])
         .output()
         .unwrap();
     assert_eq!(output.status.code().unwrap(), 1);
@@ -955,7 +962,11 @@ min-length = 3
 "#),
     )
     .unwrap();
-    write_md(tmp.path(), "a.md", "---\ntitle: A\ntype: note\n---\n\nBody.\n");
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\ntype: note\n---\n\nBody.\n",
+    );
 
     let output = hyalo_no_hints()
         .current_dir(tmp.path())

--- a/crates/hyalo-cli/tests/e2e/config_trust.rs
+++ b/crates/hyalo-cli/tests/e2e/config_trust.rs
@@ -834,3 +834,183 @@ fn dir_to_a_healthy_vault_drops_the_malformed_cwd_warning() {
         "the switch itself is still announced: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// iter-270 / DEC-289 — a write that *promised* validation refuses when
+// `[schema]` cannot be loaded
+// ---------------------------------------------------------------------------
+//
+// This is the narrower sibling of the M-2 gate above. There the whole
+// `.hyalo.toml` failed to parse, so every setting was gone and every mutation
+// refused. Here the TOML parses fine — `dir`, `[lint] ignore` and the views all
+// apply — and only `SchemaConfig::try_from` fails, leaving an *empty* schema
+// behind. A plain write is unaffected by that; a `--validate` write is not,
+// because validating against an empty schema rejects nothing.
+
+/// A vault whose `.hyalo.toml` parses as TOML but whose `[schema]` is rejected:
+/// `min-length` is only valid on `string` properties, so `TryFrom` fails while
+/// the file itself is perfectly well-formed.
+fn build_unloadable_schema_project(tmp: &TempDir) {
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        md!(r#"
+dir = "."
+
+[schema.types.note.properties.rating]
+type = "number"
+min-length = 3
+"#),
+    )
+    .unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\ntype: note\ntags: [one]\n---\n\nBody.\n",
+    );
+}
+
+#[test]
+fn set_validate_refuses_when_the_schema_could_not_be_loaded() {
+    let tmp = TempDir::new().unwrap();
+    build_unloadable_schema_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["set", "a.md", "-p", "status=draft", "--validate"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code().unwrap(),
+        1,
+        "--validate must not silently degrade to validating against nothing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to validate against an unusable [schema]"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("min-length"),
+        "the refusal must carry the schema diagnostic: {stderr}"
+    );
+    let body = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(!body.contains("status"), "nothing may be written: {body}");
+}
+
+#[test]
+fn append_validate_refuses_when_the_schema_could_not_be_loaded() {
+    let tmp = TempDir::new().unwrap();
+    build_unloadable_schema_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["append", "a.md", "-p", "tags=two", "--validate"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap(), 1, "append gates like set");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to validate against an unusable [schema]"),
+        "{stderr}"
+    );
+    let body = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(!body.contains("two"), "nothing may be appended: {body}");
+}
+
+/// `--dry-run` is still a validation request: reporting "would write" from a
+/// schema that rejects nothing is the same false assurance, minus the write.
+#[test]
+fn set_validate_dry_run_refuses_too() {
+    let tmp = TempDir::new().unwrap();
+    build_unloadable_schema_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["set", "a.md", "-p", "status=draft", "--validate", "--dry-run"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap(), 1);
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("refusing to validate against an unusable [schema]")
+    );
+}
+
+/// `[schema] validate_on_write = true` is the same promise made once in the
+/// config instead of per invocation, so a bare `set` refuses under it.
+#[test]
+fn validate_on_write_refuses_when_the_schema_could_not_be_loaded() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join(".hyalo.toml"),
+        md!(r#"
+dir = "."
+
+[schema]
+validate_on_write = true
+
+[schema.types.note.properties.rating]
+type = "number"
+min-length = 3
+"#),
+    )
+    .unwrap();
+    write_md(tmp.path(), "a.md", "---\ntitle: A\ntype: note\n---\n\nBody.\n");
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["set", "a.md", "-p", "status=draft"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code().unwrap(),
+        1,
+        "a vault that opted into validate_on_write asked for the same guarantee"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("refusing to validate against an unusable [schema]")
+    );
+}
+
+/// The blast radius stops at the two commands that promise validation: a write
+/// that claims nothing still writes, and every read still answers. Widening the
+/// refusal further would make a vault mid-schema-edit unusable.
+#[test]
+fn an_unloadable_schema_leaves_plain_writes_and_reads_alone() {
+    let tmp = TempDir::new().unwrap();
+    build_unloadable_schema_project(&tmp);
+
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["set", "a.md", "-p", "status=draft"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap(), 0, "a plain write proceeds");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid [schema] in .hyalo.toml"),
+        "and is still loudly warned about: {stderr}"
+    );
+    let body = fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(body.contains("status: draft"), "{body}");
+
+    // `mv`, `task toggle` and friends never claimed schema validation either —
+    // check one of them plus a read to pin that the gate is not command-wide.
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["remove", "a.md", "-p", "status"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code().unwrap(),
+        0,
+        "a mutation with no --validate flag at all is untouched"
+    );
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["find", "--format", "json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code().unwrap(), 0, "reads still answer");
+}

--- a/crates/hyalo-cli/tests/e2e/config_trust.rs
+++ b/crates/hyalo-cli/tests/e2e/config_trust.rs
@@ -836,7 +836,7 @@ fn dir_to_a_healthy_vault_drops_the_malformed_cwd_warning() {
 }
 
 // ---------------------------------------------------------------------------
-// iter-270 / DEC-289 — a write that *promised* validation refuses when
+// iter-270 / DEC-290 — a write that *promised* validation refuses when
 // `[schema]` cannot be loaded
 // ---------------------------------------------------------------------------
 //

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -882,7 +882,7 @@ commit = "["
         "the TOML parses; it is the schema that is invalid"
     );
 
-    // DEC-289: `set --validate` against an unloadable `[schema]` now refuses.
+    // DEC-290: `set --validate` against an unloadable `[schema]` now refuses.
     // The schema fell back to empty, so validating against it would reject
     // nothing — the flag's promise, not the command's kind, is what makes this
     // a gate (DEC-279 widened the broken-*config* gate by exit code; this one
@@ -920,7 +920,7 @@ commit = "["
     assert_eq!(
         output.status.code().unwrap(),
         0,
-        "a plain write claims no validation and is unaffected by DEC-289"
+        "a plain write claims no validation and is unaffected by DEC-290"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/crates/hyalo-cli/tests/e2e/lint.rs
+++ b/crates/hyalo-cli/tests/e2e/lint.rs
@@ -882,13 +882,11 @@ commit = "["
         "the TOML parses; it is the schema that is invalid"
     );
 
-    // `set --validate` against a malformed `[schema]` proceeds, with a
-    // `-q`-proof stderr warning naming the error. DEC-279 (iter-265) scoped the
-    // broken-config *gate* to `lint`, `find --strict` and `views run`; a write
-    // is not in that set, and a `[schema]` that fails `TryFrom` (as opposed to
-    // a `.hyalo.toml` that fails to parse at all) does not block mutations.
-    // The consequence is that `--validate` is vacuous here — pinned rather than
-    // changed, because gating writes on it is a decision of its own (DEC-287).
+    // DEC-289: `set --validate` against an unloadable `[schema]` now refuses.
+    // The schema fell back to empty, so validating against it would reject
+    // nothing — the flag's promise, not the command's kind, is what makes this
+    // a gate (DEC-279 widened the broken-*config* gate by exit code; this one
+    // is scoped by what `--validate` claims).
     let output = hyalo_no_hints()
         .current_dir(tmp.path())
         .args(["set", "a.md", "-p", "title=B", "--validate"])
@@ -896,15 +894,42 @@ commit = "["
         .unwrap();
     assert_eq!(
         output.status.code().unwrap(),
+        1,
+        "--validate against an unusable [schema] must refuse, not write unvalidated"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to validate against an unusable [schema]")
+            && stderr.contains("key-patterns.commit"),
+        "the refusal must name the schema error, got:\n{stderr}"
+    );
+    // Nothing was written: the file still carries its original title.
+    let body = std::fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(
+        body.contains("title: A"),
+        "the refused write must not have touched the file, got:\n{body}"
+    );
+
+    // The same write without `--validate` promises nothing and still proceeds,
+    // with the `-q`-proof warning the config loader prints.
+    let output = hyalo_no_hints()
+        .current_dir(tmp.path())
+        .args(["set", "a.md", "-p", "title=B"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code().unwrap(),
         0,
-        "a malformed [schema] warns but does not block a write today"
+        "a plain write claims no validation and is unaffected by DEC-289"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("invalid [schema] in .hyalo.toml")
             && stderr.contains("key-patterns.commit"),
-        "the write must at least be loudly warned about, got:\n{stderr}"
+        "the unvalidated write must still be loudly warned about, got:\n{stderr}"
     );
+    let body = std::fs::read_to_string(tmp.path().join("a.md")).unwrap();
+    assert!(body.contains("title: B"), "got:\n{body}");
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,26 @@ An unknown key or a type error anywhere in the file — including inside
 `hyalo init` and `hyalo deinit` are never blocked — they are how a broken config
 gets repaired.
 
+### When only `[schema]` cannot be loaded
+
+A `[schema]` section can be valid TOML and still be rejected — an uncompilable
+regex, `min-length` on a `number` property, `values` outside an `enum`. The file
+itself parses, so `dir`, `[lint] ignore` and the saved views all still apply;
+only the schema is gone, replaced by an empty one. hyalo then:
+
+- prints the `invalid [schema] in .hyalo.toml: …` diagnostic, again `--quiet`-proof;
+- reports it as a `schema/malformed` violation from `hyalo lint`, so a
+  `lint --strict` gate fails rather than passing against no schema at all;
+- **refuses `set` / `append` when validation was requested** — `--validate`, or
+  `[schema] validate_on_write = true` — with exit code 1, writing nothing,
+  because validating against an empty schema rejects nothing and the flag's
+  guarantee would be silently vacuous. `--dry-run` refuses too: it is the same
+  claim without the write;
+- leaves everything else alone. A `set`/`append` without `--validate` promises no
+  validation and still writes (warned), and every other command — `mv`,
+  `remove`, `task toggle`, all reads — is unaffected, so a vault mid-schema-edit
+  stays usable.
+
 ## Case-insensitive link resolution
 
 `[links] case_insensitive` controls whether a link whose target differs only in

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -4899,6 +4899,12 @@ recovery paths are all short and none of them require a flag that does not
 exist: fix the section, drop `--validate` for the one write, or `--dir` a vault
 whose config is sound.
 
+**`hyalo new` needed nothing.** It is the other command that reads the schema to
+produce a write, and it already refuses: with the schema empty, `new --type X`
+exits 1 with `type 'X' not found`. The message is indirect but the outcome is
+right — no file is scaffolded from a schema that is not the vault's — so it is
+left alone rather than given a second refusal path.
+
 **No new CLI surface.** The behaviour rides entirely on the existing
 `--validate` flag and the existing `validate_on_write` key; nothing is added to
 the CLI.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -4843,3 +4843,127 @@ non-empty body genuinely missing its terminator still fires and still fixes.
 (`bare_url_len_before_html`), `crates/hyalo-mdlint/src/engine.rs`
 (`narrow_md034_autolink_fix`, the MD047 empty-body guard, `DESCRIPTION_SUFFIX`),
 `hyalo-knowledgebase/docs/schema-and-lint.md` (Obsidian-grammar table).
+
+## DEC-290: `--validate` refuses when the schema it names cannot be loaded (2026-09-04)
+
+**Decision:** `set --validate` / `append --validate` — and a bare `set`/`append`
+under `[schema] validate_on_write = true` — exit 1 and write nothing when a
+`[schema]` section exists but fails `SchemaConfig::try_from`. `--dry-run` under
+`--validate` refuses too. Every other command is unchanged: a `set`/`append`
+*without* `--validate` still writes with the `-q`-proof
+`invalid [schema] in .hyalo.toml: …` warning, and `mv`, `remove`,
+`task toggle`, `links auto --apply` and all reads keep working on the empty
+fallback schema.
+
+This resolves DEC-287's "belongs to its own decision" note.
+
+**The gate is scoped by the promise, not by the command.** DEC-279 defined its
+gate by exit code — a command whose answer is *yes or no* cannot caveat that
+answer, so `lint`, `find --strict` and `views run` refuse on a config that does
+not parse. The same reasoning applied one level down picks out `--validate`
+rather than "every write": the flag's entire content is "reject a value the
+schema forbids before writing it". When `try_from` fails the run falls back to
+an **empty** schema, which forbids nothing, so `--validate` returned 0 having
+checked precisely nothing — the same vacuous-green failure DEC-279 was written
+to stop, in the one place a user reaches for when they specifically do not
+trust the value they are writing. A plain `set` makes no such claim and is not
+lying when it writes.
+
+**Rejected: gating every write on a broken `[schema]`.** That was the plan's
+option 1 read literally, and it is materially different from the DEC-279 case
+it looks like. A `.hyalo.toml` that does not parse loses `dir` itself — the
+mutation would touch a tree the user never configured, which is why *every*
+mutation refuses there. A rejected `[schema]` loses only the schema: `dir`,
+`[lint] ignore` and the views are all intact, so `hyalo mv` still moves the
+right file and `task toggle` still ticks the right box. Refusing those would
+make a vault unusable for unrelated work while its schema is half-edited, and
+`hyalo set` is one of the tools used to *do* that editing.
+
+**Rejected: the plan's option 2 (keep writing, surface `schema_invalid: true`
+in the result JSON).** It fixes detectability for a scripted caller while
+leaving the default — a human at a terminal typing `--validate` — exactly as
+wrong as before, and it asks every caller to add a check to get the guarantee
+the flag already advertised. A result field is the right shape for information
+the command *chose* not to act on; here there is a correct action available.
+
+**Blast radius, checked rather than assumed.** Every `SchemaConfig::try_from`
+rejection is a *config authoring* error, not a data error: mutually exclusive
+`pattern`/`item_pattern`, `values` off an `enum`, `min-length`/`max-length` off
+a `string` (or inverted), `minimum`/`maximum` off a `number`, the
+`required-keys`/`allowed-keys`/`key-patterns` trio off an `object-list`, an
+`allowed-keys` list that omits a name used elsewhere, an empty key name, an
+uncompilable `pattern`/`item_pattern`/`key-patterns` regex, and an unknown type
+name. None of them can be reached by editing a *note*: the vault always gets
+into this state by editing `.hyalo.toml`, and gets out the same way. The
+recovery paths are all short and none of them require a flag that does not
+exist: fix the section, drop `--validate` for the one write, or `--dir` a vault
+whose config is sound.
+
+**No new CLI surface.** The behaviour rides entirely on the existing
+`--validate` flag and the existing `validate_on_write` key; nothing is added to
+the CLI.
+
+**Where:** `crates/hyalo-cli/src/config.rs` (`parse_schema_from_toml` now
+returns the diagnostic alongside the fallback schema;
+`ResolvedDefaults::schema_invalid`), `crates/hyalo-cli/src/run.rs`,
+`crates/hyalo-cli/src/dispatch.rs` (`CommandContext::schema_invalid`),
+`crates/hyalo-cli/src/commands/mod.rs`
+(`reject_write_with_unloadable_schema`), `crates/hyalo-cli/src/commands/set.rs`,
+`crates/hyalo-cli/src/commands/append.rs`,
+`crates/hyalo-cli/tests/e2e/config_trust.rs`,
+`crates/hyalo-cli/tests/e2e/lint.rs`
+(`lint_reports_schema_malformed_for_an_invalid_key_pattern_regex` re-pinned from
+the vacuous write to the refusal).
+
+## DEC-291: authoring `object-list` items stays an editor concern (2026-09-04)
+
+**Decision:** `hyalo set` / `hyalo append` gain **no** syntax for writing a map
+item into an `object-list` property. DEC-287's sketch
+(`set --property 'sources[]=ref=…'`) is closed as won't-do, not deferred; no
+backlog item is filed. Validation of object-list values on write is unchanged
+and already works through the shared validator.
+
+**No demand was found.** The plan made this conditional on evidence, and the
+search came up empty: `object-list` appears in zero `.hyalo.toml` files across
+this repo's own vault and both dogfooding testbeds (`../obsidian-hub`,
+`../kepano-obsidian`), and no object-list property has been hand-edited in a
+dogfooded vault since iteration 268 landed. The one real user — the
+mapl-memory `sources:` migration that motivated the type — did the migration in
+an editor and said so in its own request: *"`hyalo set --property` support for
+appending object items is a separate concern; the type only needs lint +
+`types show` output."* The feature request that produced `object-list` explicitly
+did not ask for this.
+
+**The symmetry argument fails on inspection.** The plan asked whether `find`'s
+dot-path reads (`--property sources.ref=…`) could be reused for writes. They
+cannot, and the reason is already settled in the code: `--property` on the write
+side sets a *literal top-level key*, and `reject_dotted_property_collision`
+exists precisely to refuse `set --property a.b=v` when `a` is a mapping, with a
+hint saying hyalo does not support dotted paths for nested writes. Reads and
+writes are not symmetric here because a read *addresses an existing value* while
+a write must also say **which item** — the third one, the one whose `ref`
+matches, or a new one — and that selector has no expression in the read syntax.
+Reusing the syntax would either contradict an existing documented refusal or
+silently pick an item for the user.
+
+**The bespoke syntax is worse than the editor it replaces.** A flat
+`sources[]=ref=…,commit=…` packs a second key/value mini-language into the value
+half of a `K=V` argument that already infers types from `V`, and inherits its
+own quoting problem: `key-patterns` regexes in the motivating example match
+values containing `:`, `/` and `-`, and any item value containing a `,` or `=`
+needs escaping rules that `set` has never had. That is a real parser and a real
+error-message surface, added against the standing no-new-CLI-surface bar
+(DEC-287, and the rule that already killed `--iteration` and `--strict-index`),
+for a shape one `$EDITOR` invocation writes correctly the first time.
+
+**What the user is left with is the half that catches mistakes.** `hyalo new`
+scaffolds the property as `[]`, the editor writes the items, and `hyalo lint`
+plus `set/append --validate` enforce `required-keys` / `allowed-keys` /
+`key-patterns` afterwards — including the plain-string item that would otherwise
+vanish from every `sources.ref=` query. Authoring was never the risky step;
+drift was, and drift is covered. If a vault later shows repeated scripted
+authoring of object items, this can be revisited with that evidence in hand —
+which is exactly what it lacked here.
+
+**Where:** no code. `hyalo-knowledgebase/docs/schema-and-lint.md` states the
+outcome where it previously said "not supported" without saying why.

--- a/hyalo-knowledgebase/docs/schema-and-lint.md
+++ b/hyalo-knowledgebase/docs/schema-and-lint.md
@@ -110,9 +110,35 @@ matches and is silently absent from every query — lint is what reports it.
 
 `object-list` is **config-only**: `hyalo types set --property-type` does not accept it
 (as with `string-list`), and `--fix` has no fixer for its violations, so they report
-`autofixable: false`. Writing object items with `hyalo set` / `hyalo append` is not
-supported; `--validate` does reject a scalar or string-item value for an
-`object-list` property.
+`autofixable: false`. Writing object *items* with `hyalo set` / `hyalo append` is not
+supported and will not be (DEC-291): a write must say *which* item it means, which the
+dot-path syntax `find` uses for reads cannot express, and `--property` on the write side
+is a literal top-level key by design. Author items in an editor; `hyalo new` scaffolds
+the property as `[]`, and `lint` plus `--validate` enforce the shape afterwards —
+`--validate` already rejects a scalar or string-item value for an `object-list` property.
+
+### When the schema itself cannot be loaded (DEC-290)
+
+A `[schema]` block can be valid TOML and still be rejected — an uncompilable
+`key-patterns` regex, `min-length` on a `number`, `values` outside an `enum`.
+The rest of `.hyalo.toml` still applies; the schema is replaced by an empty one.
+
+`hyalo lint` reports that as a `schema/malformed` violation (an error under
+`--strict`), and `set` / `append` **refuse with exit 1 when validation was
+asked for** — `--validate`, or `[schema] validate_on_write = true` — including
+under `--dry-run`, because validating against an empty schema rejects nothing
+and the promise would be silently vacuous:
+
+```text
+error: refusing to validate against an unusable [schema]: invalid [schema] in
+.hyalo.toml: property 'sources': key-patterns.commit: invalid regex …; the
+schema could not be loaded, so --validate would reject nothing
+```
+
+The gate is scoped to the promise, not to the command: a `set`/`append` without
+`--validate` claims no validation and still writes (with the `-q`-proof
+warning), and `mv`, `remove`, `task toggle` and every read are untouched — so a
+vault whose schema is briefly broken mid-edit stays usable.
 
 ### Schema Merging
 

--- a/hyalo-knowledgebase/iterations/iteration-270-schema-write-semantics.md
+++ b/hyalo-knowledgebase/iterations/iteration-270-schema-write-semantics.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 270 — Schema write-side semantics: what set/append --validate promise"
 date: 2026-09-04
-status: in-progress
+status: completed
 tags:
   - iteration
   - schema
@@ -131,7 +131,7 @@ concern" unless evidence of real need turns up.
 
 - [x] DEC(s) recorded in [[decision-log]] covering both decisions.
 - [x] Changelog entry via `hyalo changelog add` for every behaviour that changed.
-- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, `hyalo lint --strict` on the KB, all xtask `check-*`
       gates (help drift in particular if any `--help` text changed).
 
@@ -148,7 +148,7 @@ concern" unless evidence of real need turns up.
       refuses an item missing a `required-keys` key and accepts one that satisfies
       `required-keys`/`allowed-keys`/`key-patterns`.
 - [x] No new CLI flag lands without an explicit justification in the DEC.
-- [ ] Gates green.
+- [x] Gates green.
 
 ## Outcome
 

--- a/hyalo-knowledgebase/iterations/iteration-270-schema-write-semantics.md
+++ b/hyalo-knowledgebase/iterations/iteration-270-schema-write-semantics.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 270 — Schema write-side semantics: what set/append --validate promise"
 date: 2026-09-04
-status: planned
+status: in-progress
 tags:
   - iteration
   - schema
@@ -70,18 +70,18 @@ start refusing.
 
 ### GATE-1: decide and implement
 
-- [ ] Re-read DEC-279 in full for why the gate was scoped to `lint`/`find --strict`/
+- [x] Re-read DEC-279 in full for why the gate was scoped to `lint`/`find --strict`/
       `views run` and not writes originally.
-- [ ] Enumerate every `SchemaConfig::TryFrom` rejection path
+- [x] Enumerate every `SchemaConfig::TryFrom` rejection path
       (`crates/hyalo-core/src/schema.rs`) to know the full blast radius of gating writes
       on it — this is not `object-list`-specific.
-- [ ] Decide (1), (2), or a third option research surfaces; record the choice and
+- [x] Decide (1), (2), or a third option research surfaces; record the choice and
       reasoning as a new DEC in [[decision-log]], explicitly resolving DEC-287's "belongs
       to its own decision" note.
-- [ ] Implement the chosen behaviour in `set.rs` and `append.rs`; update
+- [x] Implement the chosen behaviour in `set.rs` and `append.rs`; update
       `lint_reports_schema_malformed_for_an_invalid_key_pattern_regex` (it currently pins
       the vacuous case and must change either way).
-- [ ] Update `set --help` / `append --help` if behaviour changes; update
+- [x] Update `set --help` / `append --help` if behaviour changes; update
       `docs/configuration.md` and [[docs/schema-and-lint]] where they describe
       `--validate`'s guarantees.
 
@@ -103,56 +103,87 @@ concern" unless evidence of real need turns up.
 
 ### Scope questions to resolve before writing any parser
 
-- [ ] Does a second dogfooding cycle, or the mapl-memory `sources:` migration that
+- [x] Does a second dogfooding cycle, or the mapl-memory `sources:` migration that
       motivated iteration 268, actually hit this gap in practice? Check the mapl-memory PR
       referenced in [[backlog/done/object-list-schema-type]] and any hand edits to
       object-list properties in dogfooded vaults since 268 landed.
-- [ ] If a syntax is warranted: one flat `key=value,key2=value2` item per invocation is
+- [x] If a syntax is warranted: one flat `key=value,key2=value2` item per invocation is
       the minimum useful shape — an item needs `required-keys` satisfied in one write, not
       accumulated field-by-field.
-- [ ] Interaction with `--validate` (and with Part A's decision): a partially-specified
+- [x] Interaction with `--validate` (and with Part A's decision): a partially-specified
       item must refuse exactly like today's scalar-item case.
-- [ ] Can the existing `-p`/`--property` dotted-path syntax `find` already understands for
+- [x] Can the existing `-p`/`--property` dotted-path syntax `find` already understands for
       reads be reused for writes (symmetry argument), avoiding any new flag? Investigate
       before proposing a bespoke syntax.
 
 ### ITEM-1: decide and (maybe) implement
 
-- [ ] Decide: implement a syntax, or close as won't-do. Record the reasoning in the same
+- [x] Decide: implement a syntax, or close as won't-do. Record the reasoning in the same
       DEC as Part A or its own DEC in [[decision-log]] — there is no "silently dropped"
       outcome.
 - [ ] If implementing: design the syntax, justify it against the no-new-CLI-surface bar,
       implement in `set.rs` and `append.rs`, validate against
       `required-keys`/`allowed-keys`/`key-patterns` before writing, update `--help`,
       `docs/configuration.md`, [[docs/schema-and-lint]], the skill file, and CHANGELOG.
-- [ ] If won't-do: no code lands for Part B; the DEC is the deliverable.
+- [x] If won't-do: no code lands for Part B; the DEC is the deliverable.
 
 ## Shared closing tasks
 
-- [ ] DEC(s) recorded in [[decision-log]] covering both decisions.
-- [ ] Changelog entry via `hyalo changelog add` for every behaviour that changed.
+- [x] DEC(s) recorded in [[decision-log]] covering both decisions.
+- [x] Changelog entry via `hyalo changelog add` for every behaviour that changed.
 - [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, `hyalo lint --strict` on the KB, all xtask `check-*`
       gates (help drift in particular if any `--help` text changed).
 
 ## Acceptance criteria
 
-- [ ] A DEC resolves DEC-287's "belongs to its own decision" note: either writes now gate
+- [x] A DEC resolves DEC-287's "belongs to its own decision" note: either writes now gate
       on a broken `[schema]`, or the asymmetry is kept but made discoverable in the result
       JSON, with reasoning either way.
-- [ ] `lint_reports_schema_malformed_for_an_invalid_key_pattern_regex` (or its
+- [x] `lint_reports_schema_malformed_for_an_invalid_key_pattern_regex` (or its
       replacement) reflects the new behaviour, not the old vacuous-write pin.
-- [ ] A decision is recorded for the object-list item syntax either way — a working
+- [x] A decision is recorded for the object-list item syntax either way — a working
       `set`/`append` syntax with tests, or a DEC explaining why it stays an editor concern.
 - [ ] If a syntax is implemented: `hyalo set f.md --property '<chosen syntax>' --validate`
       refuses an item missing a `required-keys` key and accepts one that satisfies
       `required-keys`/`allowed-keys`/`key-patterns`.
-- [ ] No new CLI flag lands without an explicit justification in the DEC.
+- [x] No new CLI flag lands without an explicit justification in the DEC.
 - [ ] Gates green.
+
+## Outcome
+
+**Part A → DEC-290, implemented.** Neither of the plan's two options as written.
+The gate is scoped by *what `--validate` promises*, not by command kind: `set` /
+`append` refuse with exit 1 (writing nothing, `--dry-run` included) when
+`[schema]` fails `SchemaConfig::try_from` **and** validation was requested —
+`--validate` or `[schema] validate_on_write`. A write that made no such claim
+still proceeds on the empty fallback with the `-q`-proof warning, and `mv`,
+`remove`, `task toggle` and every read are untouched, so a vault whose schema is
+half-edited stays usable. Option 1 read literally (gate *every* write) was
+rejected because a rejected `[schema]` — unlike an unparsable `.hyalo.toml` —
+still leaves `dir`, `[lint] ignore` and the views intact; option 2
+(`schema_invalid: true` in the result JSON) was rejected because it leaves the
+default case as wrong as before and charges every caller a check for a guarantee
+the flag already advertised. All 13 `try_from` rejection paths are config
+authoring errors reachable only by editing `.hyalo.toml`, never by editing a
+note.
+
+**Part B → DEC-291, won't-do, no code.** No demand: `object-list` appears in zero
+`.hyalo.toml` files across this vault and both dogfood testbeds, and the one real
+user (mapl-memory `sources:`) migrated in an editor and said in its own request
+that `set --property` support was out of scope. The symmetry argument fails —
+`--property` on the write side is a literal top-level key by design
+(`reject_dotted_property_collision` exists to refuse dotted writes), and a write
+needs an item selector the read syntax cannot express. A bespoke `sources[]=k=v`
+item syntax would pack a second key/value language, with its own escaping rules,
+into a value position that already infers types — against the standing
+no-new-CLI-surface bar, for a shape one editor invocation writes correctly.
+
+No new CLI flag landed.
 
 ## Links
 
 - [[iterations/iteration-268-object-list-schema-type]] — found and deferred both questions
 - [[iterations/iteration-265-scan-exclude-and-skipped-files]] — DEC-279, original gate scope
 - [[backlog/done/object-list-schema-type]]
-- [[decision-log]] — DEC-279, DEC-287
+- [[decision-log]] — DEC-279, DEC-287, DEC-290, DEC-291

--- a/hyalo-knowledgebase/iterations/iteration-270-schema-write-semantics.md
+++ b/hyalo-knowledgebase/iterations/iteration-270-schema-write-semantics.md
@@ -68,7 +68,7 @@ deliberately narrower than "every command", so widening it needs the same rigour
 breaks for a vault whose `[schema]` briefly goes invalid mid-edit if writes suddenly
 start refusing.
 
-### GATE-1: decide and implement
+### GATE-1: decide and implement [5/5]
 
 - [x] Re-read DEC-279 in full for why the gate was scoped to `lint`/`find --strict`/
       `views run` and not writes originally.
@@ -101,7 +101,7 @@ DEC-287 sketched one candidate shape, `set --property 'sources[]=ref=…'`, unte
 real usage — a starting point, not a commitment. The default answer is "stays an editor
 concern" unless evidence of real need turns up.
 
-### Scope questions to resolve before writing any parser
+### Scope questions to resolve before writing any parser [4/4]
 
 - [x] Does a second dogfooding cycle, or the mapl-memory `sources:` migration that
       motivated iteration 268, actually hit this gap in practice? Check the mapl-memory PR
@@ -116,7 +116,7 @@ concern" unless evidence of real need turns up.
       reads be reused for writes (symmetry argument), avoiding any new flag? Investigate
       before proposing a bespoke syntax.
 
-### ITEM-1: decide and (maybe) implement
+### ITEM-1: decide and (maybe) implement [2/3]
 
 - [x] Decide: implement a syntax, or close as won't-do. Record the reasoning in the same
       DEC as Part A or its own DEC in [[decision-log]] — there is no "silently dropped"
@@ -125,9 +125,10 @@ concern" unless evidence of real need turns up.
       implement in `set.rs` and `append.rs`, validate against
       `required-keys`/`allowed-keys`/`key-patterns` before writing, update `--help`,
       `docs/configuration.md`, [[docs/schema-and-lint]], the skill file, and CHANGELOG.
+      N/A — DEC-291 closed Part B as won't-do, so there is no syntax to implement.
 - [x] If won't-do: no code lands for Part B; the DEC is the deliverable.
 
-## Shared closing tasks
+## Shared closing tasks [3/3]
 
 - [x] DEC(s) recorded in [[decision-log]] covering both decisions.
 - [x] Changelog entry via `hyalo changelog add` for every behaviour that changed.
@@ -135,7 +136,7 @@ concern" unless evidence of real need turns up.
       `cargo test --workspace -q`, `hyalo lint --strict` on the KB, all xtask `check-*`
       gates (help drift in particular if any `--help` text changed).
 
-## Acceptance criteria
+## Acceptance criteria [5/6]
 
 - [x] A DEC resolves DEC-287's "belongs to its own decision" note: either writes now gate
       on a broken `[schema]`, or the asymmetry is kept but made discoverable in the result
@@ -147,6 +148,7 @@ concern" unless evidence of real need turns up.
 - [ ] If a syntax is implemented: `hyalo set f.md --property '<chosen syntax>' --validate`
       refuses an item missing a `required-keys` key and accepts one that satisfies
       `required-keys`/`allowed-keys`/`key-patterns`.
+      N/A — no syntax was implemented (DEC-291, won't-do).
 - [x] No new CLI flag lands without an explicit justification in the DEC.
 - [x] Gates green.
 


### PR DESCRIPTION
## Summary

Iteration 270 answers the two write-side schema questions iteration 268 deferred (DEC-287's "belongs to its own decision"). One ends in code, one ends in a won't-do.

- **DEC-290 — `--validate` refuses when the schema it names cannot be loaded.** A `[schema]` that parses as TOML but fails `SchemaConfig::try_from` (uncompilable regex, `min-length` on a `number`, …) used to fall back to an *empty* schema and let `set --validate` / `append --validate` write anyway, exiting 0 having checked nothing — the flag was silently vacuous exactly when a user leaned on it. Those writes now exit 1 and write nothing, `--dry-run` included, whether validation was asked for per-invocation (`--validate`) or once in config (`[schema] validate_on_write`).
- **The gate is scoped by the promise, not by command kind.** DEC-279 defined its gate by exit code; the same reasoning one level down picks out `--validate` rather than "every write". A `set`/`append` *without* `--validate` claims no validation and still writes on the fallback with the existing `-q`-proof warning, and `mv`, `remove`, `task toggle` and every read are untouched — so a vault whose schema is half-edited stays usable, and `hyalo set` remains usable for doing that editing. Rejected: gating every write (an unparsable `.hyalo.toml` loses `dir` itself, a rejected `[schema]` does not), and surfacing `schema_invalid: true` in the result JSON while still writing (leaves the default case as wrong as before).
- **DEC-291 — object-list item authoring stays an editor concern, no code.** `object-list` appears in zero `.hyalo.toml` files across this vault and both dogfood testbeds, and the one real user (mapl-memory `sources:`) migrated in an editor and said in its own request that `set --property` support was out of scope. The symmetry argument fails on inspection: `--property` on the write side is a literal top-level key by design (`reject_dotted_property_collision` exists to refuse dotted writes), and a write must name *which item* — a selector the read-side dot-path syntax cannot express. A bespoke `sources[]=k=v` shape would pack a second key/value language, with its own escaping rules for values containing `,`/`=`, into a value position that already infers types.
- **No new CLI flag.** The behaviour rides entirely on the existing `--validate` flag and `validate_on_write` key.

Implementation: `parse_schema_from_toml` now returns the diagnostic alongside the fallback schema, carried as `ResolvedDefaults::schema_invalid` → `CommandContext::schema_invalid` → `reject_write_with_unloadable_schema` in `commands/mod.rs`, called from both `set::run` and `append::run` before any file is touched.

## Test plan

- [x] `lint_reports_schema_malformed_for_an_invalid_key_pattern_regex` re-pinned from the vacuous write to the refusal, and extended to assert the file is untouched and that the same write *without* `--validate` still succeeds.
- [x] Five new e2e tests in `tests/e2e/config_trust.rs`: `set --validate` refuses; `append --validate` refuses; `--validate --dry-run` refuses; `validate_on_write = true` makes a bare `set` refuse; and a blast-radius test pinning that a plain `set`, a `remove` and a `find` are all unaffected.
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` all green.
- [x] All six xtask `check-*` gates exit 0 (`check-help-drift` and `check-bundled-skills` cover the `--help` and skill-template edits).
- [x] `hyalo lint --strict` clean on the knowledgebase.

Docs updated in the same PR: `set`/`append` `--help` (long_about + the `--validate` flag doc), `docs/configuration.md` (new "When only `[schema]` cannot be loaded" section), `hyalo-knowledgebase/docs/schema-and-lint.md` (DEC-290 section, plus the object-list paragraph now says *why* item authoring is unsupported), the bundled hyalo skill template, CHANGELOG, decision-log and the iteration plan's outcome.

## Carry-over

Iteration 270 fully resolves both questions iteration 268 deferred (DEC-287); nothing here needed folding forward or filing as a new plan.

- **The two "if implementing" plan checkboxes** (object-list write syntax design, and its `--validate` test) stay unticked. **Disposition: N/A, not deferred** — DEC-291 closed Part B as won't-do, so there is no syntax to design or test. Noted inline in the plan rather than left as a bare unchecked box.
- **DEC-291's revisit condition** ("if a vault later shows repeated scripted authoring of object items, this can be revisited with that evidence in hand") is a standing condition on the won't-do decision, not an open task — there is no current evidence to act on. **Disposition: closed, nothing to file.**
- No other out-of-scope findings were flagged in the plan, this PR, or a milestone during this iteration.

