### PR TITLE
docs: DEC-292 — concurrent writers won't be serialised (closes dogfood BUG-1)

### DIFF
--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -4973,3 +4973,39 @@ which is exactly what it lacked here.
 
 **Where:** no code. `hyalo-knowledgebase/docs/schema-and-lint.md` states the
 outcome where it previously said "not supported" without saying why.
+
+## DEC-292: concurrent writers to one file are not serialised — won't fix (2026-09-05)
+
+**Decision:** hyalo does not serialise two of its own processes mutating the same
+file at the same instant, and will not gain a lock to do so. Closed won't-fix by
+the repo owner on the dogfood finding
+[[dogfood-results/dogfood-v0220-post-batch-261-270]] BUG-1.
+
+**The behaviour.** Every mutation is read → modify → write-temp → rename, guarded
+by an `(mtime, size)` fingerprint taken at read time and re-checked before the
+rename. Twenty parallel `hyalo set p.md --property kN=vN` processes all read the
+same fingerprint before any renames, all pass the check, and the last rename
+wins: 2–3 keys survive while 16–19 processes exit 0. A content hash would not
+fix it — the window between check and rename stays open — only a lock would.
+
+**Why won't-fix.** The race needs two hyalo processes writing *the same file* in
+the same tens of milliseconds. None of the ways hyalo is actually used produce
+that: a person on a PC in a repo runs one command at a time; a GitHub workflow
+runs one job's steps sequentially; the iteration loop's agents never share a
+file. Reaching it takes deliberate parallelism (`xargs -P`, `&` in a loop, two
+agents pointed at one vault), and a caller who does that is outside the
+contract. A lock would buy correctness for a case nobody has, at the cost of a
+new failure mode everybody has: a stale lock after a crash, or a platform
+dependency for the kernel-cleaned variant.
+
+**Declined alternative, recorded so it is not re-proposed blind:** an
+exclusive-create sidecar (`File::create_new` of `.<file>.hyalo-lock` around the
+read-modify-rename) would turn the silent loss into a hard error for the losing
+writer in ~20 lines with no global state, but needs a stale-lock rule of its own.
+The `fd-lock` crate (`flock` / `LockFileEx`) avoids stale locks at the price of a
+dependency. Either is the fix if a real workflow ever needs concurrent writers;
+neither is worth carrying for a hypothetical one.
+
+**Where:** no code. `hyalo --help` and the skill file may state "run mutations
+sequentially; concurrent writers to one file are not serialised" if the
+question comes up again; not added pre-emptively.

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0220-post-batch-261-270.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0220-post-batch-261-270.md
@@ -48,7 +48,7 @@ fixed, 2 partially, 1 never scheduled, **0 regressed**. The Hub's broken-link co
 parity is byte-identical on all nine MDN commands including BM25 scores, and no command is more
 than 1.5× its baseline.
 
-The new round found **28 bugs (6 HIGH, 10 MEDIUM, 12 LOW; BUG-1 since closed won't-fix,
+The new round found **29 bugs (6 HIGH, 10 MEDIUM, 13 LOW; BUG-1 since closed won't-fix,
 DEC-292)** and 25 UX issues. Four of the five open HIGH ones can silently corrupt a vault with
 exit 0, and none of them is in code the batch touched:
 they are older gaps the batch's new testbeds and the adversarial pass exposed. Zero panics in
@@ -345,6 +345,21 @@ same destination`. One source collides with an existing file.
 field "score"`. DEC-275 promises the footer round-trips. Drop `score` from the footer the way
 `title_source` is (DEC-283), or accept it.
 
+### BUG-29: The shipped "locate a broken link" `--jq` recipe uses `IN(…)`, which the embedded jq engine does not implement (LOW)
+
+```text
+hyalo find --broken-links --jq '.results[] as $f | $f.links[] | select((.kind | IN("external","attachment") | not) and …'
+# {"cause": "jq filter error: undefined filter \"IN\"", "error": "jq filter failed"}
+```
+
+Found 2026-09-05 while checking DEC-292's wikilink. hyalo embeds jaq, which has no `IN`
+builtin; the recipe is copied verbatim into `crates/hyalo-cli/templates/rule-knowledgebase.md`,
+`crates/hyalo-cli/templates/skill-hyalo.md` and the repo's `.claude/CLAUDE.md`, so every vault
+that runs `hyalo init` ships a broken command. `(.kind == "external" or .kind == "attachment") |
+not` works. The xtask bundled-skill gate checks the skill's profile, not that its commands run;
+a fixture that executes every `--jq` recipe in the templates against the own KB would have caught
+it.
+
 ## UX issues
 
 ### UX-1: Exit-code taxonomy has three undocumented classes (LOW, judgement requested)
@@ -595,5 +610,7 @@ DEC-286 preview pass in `links auto`.
    `--broken-links` keeps anchor data; named unparsable and not-in-snapshot files are errors or
    upserts, never empty successes; newest per-file mtime in the stale probe; excluded count in the
    snapshot header.
-5. **Hint and contract polish** (BUG-17, BUG-22, BUG-25, BUG-27, UX-1, UX-2, UX-3, UX-13): the
-   `[site] prefix` hint, `--index-file` threading, exit-code taxonomy as a DEC, `rules_fixed`.
+5. **Hint and contract polish** (BUG-17, BUG-22, BUG-25, BUG-27, BUG-29, UX-1, UX-2, UX-3,
+   UX-13): the `[site] prefix` hint, the `IN()` recipe in three shipped templates plus an xtask
+   gate that executes every documented `--jq`, `--index-file` threading, exit-code taxonomy as a
+   DEC, `rules_fixed`.

--- a/hyalo-knowledgebase/dogfood-results/dogfood-v0220-post-batch-261-270.md
+++ b/hyalo-knowledgebase/dogfood-results/dogfood-v0220-post-batch-261-270.md
@@ -48,8 +48,9 @@ fixed, 2 partially, 1 never scheduled, **0 regressed**. The Hub's broken-link co
 parity is byte-identical on all nine MDN commands including BM25 scores, and no command is more
 than 1.5× its baseline.
 
-The new round found **28 bugs (6 HIGH, 10 MEDIUM, 12 LOW)** and 25 UX issues. Five of the six
-HIGH ones can silently corrupt a vault with exit 0, and none of them is in code the batch touched:
+The new round found **28 bugs (6 HIGH, 10 MEDIUM, 12 LOW; BUG-1 since closed won't-fix,
+DEC-292)** and 25 UX issues. Four of the five open HIGH ones can silently corrupt a vault with
+exit 0, and none of them is in code the batch touched:
 they are older gaps the batch's new testbeds and the adversarial pass exposed. Zero panics in
 roughly 150 hostile invocations with `RUST_BACKTRACE=1`, including truncated, zeroed and
 byte-flipped index files.
@@ -74,7 +75,12 @@ longer yields `expected string` there — but see BUG-5 for what happens once a 
 
 ## Bugs found
 
-### BUG-1: Concurrent `set`/`append` on one file loses updates while every process exits 0 (HIGH)
+### BUG-1: Concurrent `set`/`append` on one file loses updates while every process exits 0 (closed WON'T FIX, DEC-292)
+
+Closed 2026-09-05 by the repo owner: two hyalo processes writing the same file at the same
+instant needs deliberate parallelism that none of hyalo's real workflows (a PC in a repo, a
+GitHub workflow, the iteration loop) produce. Kept here as the record of the behaviour; see
+DEC-292 for the reasoning and the cheap detection option that was declined.
 
 ```text
 printf -- '---\ntitle: P3\n---\nbody\n' > p3.md
@@ -575,9 +581,8 @@ DEC-286 preview pass in `links auto`.
 
 ## Recommended next iterations
 
-1. **Write safety** (BUG-1, BUG-2, BUG-13): content-hash or lock around read-modify-rename;
-   column-0 closing fence plus an emitter guard; reject empty rename targets. Three fixes in
-   `hyalo-core`, one PR.
+1. **Write safety** (BUG-2, BUG-13): column-0 closing fence plus an emitter guard; reject empty
+   rename targets. Two fixes in `hyalo-core`, one PR. (BUG-1 closed won't-fix, DEC-292.)
 2. **Autofix and link-rewrite corruption** (BUG-3, BUG-28, BUG-4, BUG-7): MD031 on unterminated
    fences and MD019 inside code blocks, plus an audit of every autofixable rule against a
    fenced-block fixture;


### PR DESCRIPTION
## Summary
- Closes the dogfood report's BUG-1 (parallel `hyalo set`/`append` on one file lose updates while every process exits 0) as **won't-fix**, per the repo owner: the race needs deliberate parallelism that no real hyalo workflow (PC in a repo, GitHub workflow, iteration loop) produces.
- DEC-292 records the behaviour, the reasoning, and the declined alternatives (exclusive-create sidecar lock, `fd-lock`) so the question is not re-opened blind.
- Report headline counts and recommended iteration 1 updated accordingly.

Docs only.

## Test plan
- [x] `hyalo lint --strict` clean on decision-log.md
- [x] `hyalo find --broken-links` clean on both files
- [ ] CI `lint-kb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)