### PR TITLE
iter-272: resolution completeness — aliases as link targets, list-typed `type`, capture boundaries, emitted fix targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,6 +360,12 @@ and this project adheres to
 - No prose rule (MD019 among them) fires inside a fenced or indented code block or an HTML comment; MD010, MD031, MD040, MD046, MD047 and MD048 keep checking them on purpose.
 - `links fix` no longer reports a case mismatch for a site-absolute link carrying the configured `site_prefix`, and never appends `/index` or `.md` to a link form that lacked it (DEC-295).
 - `mv` applies its ambiguity guard to frontmatter links too: a bare `related: "[[a]]"` matching two files is skipped and reported with its property, not rewritten.
+- A one-element list `type: ["[[Author]]"]` no longer fails the implicit string constraint that every declared schema type carries — the shape Obsidian's property editor writes now lints clean wherever DEC-281 binding already accepted it.
+- An anchor-only markdown link `[text](#frag)` is reported with `kind: "markdown"` and its link text, not as a wikilink — vaults with no wikilinks at all (MDN, GitHub Docs) claimed thousands.
+- A wikilink capture stops at the first stray `]` or nested `[[`, and never starts inside `[[[`: `see [[Leah] here and [[Target]]` is one link to `Target`, and a YAML flow list `related: [[[a]], [[b]]]` yields both links instead of `[a`.
+- A markdown destination in angle brackets whose text is a parenthesised URL — `[y](<(https://…)>)` — is external: never broken, never fuzzy-matched.
+- `![alt](img.png)` is inventoried like `![[img.png]]` (DEC-297), so a missing image surfaces in `find --fields links`, `--broken-links` and `summary` instead of being dropped at extraction.
+- The DEC-268 heading suggestion folds `-`, `_` and space (DEC-298), so an underscore-slugged fragment such as `#Browser_compatibility` now suggests the `Browser compatibility` heading it prefixes.
 
 ### Added
 
@@ -386,6 +392,8 @@ and this project adheres to
 - `links auto` reports `default_excluded_titles` / `default_excluded_mentions` (DEC-286)
 - Schema: `object-list` property type with `required-keys`, `allowed-keys`, `key-patterns` for lists of maps; lint reports the item index and key, and a plain-string item gets a `- ref: <value>` fix-it hint
 - `lint` honours markdownlint's suppression comments — `markdownlint-disable`, `-enable`, `-disable-line`, `-disable-next-line`, `-disable-file`, `-enable-file` — with rule ids or aliases (DEC-294).
+- Frontmatter `aliases:` resolve wikilinks (DEC-296): `[[Leah]]` finds the note declaring `aliases: [Leah]`, reported as `via: "alias"`. A filename always wins, a shared alias is ambiguous, matching folds case, and alias links are real graph edges. Opt out with `[links] aliases = false`.
+- `links fix` reports `emitted_target` — the exact link text `--apply` writes — on every fix bucket, filled by the same planning pass in both modes so a `--dry-run` preview is byte-accurate (`new_target` stays vault-relative).
 
 ## [0.21.0] - 2026-08-28
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -846,14 +846,19 @@ pub(crate) enum Commands {
             the promoted title; use --fields properties-typed for a [{name, type, value}] array. \
             --format text prints the included field names under the results.\n\
             LINK KINDS: every entry in --fields links carries kind — wikilink (plain [[note]]), \
-            embed (![[note]] / ![[img.png]]), markdown ([text](note.md)), external (any scheme: \
-            URI: https, obsidian://, mailto:, file://) or attachment (resolved to a non-.md vault \
-            file: an image, a PDF, an Obsidian .base). external and attachment links never count \
-            as broken, never appear under --broken-links or HYALO006, and are not graph edges for \
-            --orphan/--dead-end. Text mode prints the kind after the arrow unless it is wikilink. \
+            embed (![[note]] / ![[img.png]] / ![alt](img.png)), markdown ([text](note.md), and \
+            [text](#frag) — a same-file anchor keeps the syntax it was written in), external (any \
+            scheme: URI: https, obsidian://, mailto:, file://) or attachment (resolved to a non-.md \
+            vault file: an image, a PDF, an Obsidian .base). external and attachment links never \
+            count as broken, never appear under --broken-links or HYALO006, and are not graph edges \
+            for --orphan/--dead-end. Text mode prints the kind after the arrow unless it is \
+            wikilink. A link that resolved through a note's frontmatter aliases: also carries \
+            via: \"alias\" (printed as `(via alias)` in text mode); kind stays wikilink, because an \
+            alias changes what the target names, not how it was written. Turn alias resolution off \
+            with [links] aliases = false. \
             A broken #anchor whose text is the prefix of exactly one heading in the target file \
             also carries suggested_fragment, the full heading to write instead (never applied \
-            automatically).\n\
+            automatically; -, _ and a space are one character class for that prefix test).\n\
             SIZE: size/lines let a caller budget before reading -- pair them with \
             `read --lines A:B` or `read --section H` instead of pulling a large body whole.\n\
             RESULT SHAPE: `results` is always the array of matched files, whichever way the file \
@@ -1766,7 +1771,11 @@ Repeatable (AND).\n\
             WIKILINK RESOLUTION:\n\
             Wikilinks accept an optional .md suffix — [[foo.md]], [[foo.md#heading]], and [[foo.md|alias]]\n\
             are treated identically to [[foo]], [[foo#heading]], and [[foo|alias]] respectively.\n\
-            This matches Obsidian's behavior when copy-pasting note names that include the extension.\n\n\
+            This matches Obsidian's behavior when copy-pasting note names that include the extension.\n\
+            A bare target that names no file is matched against every note's frontmatter aliases:\n\
+            (DEC-296) — a filename always wins, an alias claimed by two notes is ambiguous, and a\n\
+            target that resolves through an alias is never broken and is never fuzzy-matched.\n\
+            Turn it off with `[links] aliases = false`.\n\n\
             Default behavior (no subcommand): dry-run of `links fix` — shows what would be\n\
             repaired without modifying files. Equivalent to `hyalo links fix --dry-run`.\n\n\
             OUTPUT: JSON object with broken/fixable/fuzzy/unfixable counts, per-fix details \
@@ -2832,7 +2841,14 @@ pub(crate) enum LinksAction {
             broken and is left untouched. Only a stem-casing mismatch ([[note]] for Note.md)\n\
             triggers a case-mismatch fix — and the fix preserves the short form ([[Note]],\n\
             never [[sub/Note]]). Links matching >=2 files are reported as ambiguous and\n\
-            never auto-fixed.\n\n\
+            never auto-fixed.\n\
+            A bare target that names no file at all is matched against every note's\n\
+            frontmatter aliases: (DEC-296). A target that resolves through an alias is not\n\
+            broken, gets no plan and is never fuzzy-matched; one claimed by two notes is\n\
+            ambiguous. `[links] aliases = false` turns this off.\n\n\
+            EMITTED TARGET: every reported plan carries emitted_target — the exact link text\n\
+            --apply writes — beside the vault-relative new_target. Both are filled by the\n\
+            same planning pass in --dry-run and --apply, so the preview is byte-accurate.\n\n\
             Use --expand-short-form to opt into path expansion (Obsidian-incompatible).\n\n\
             Case-mismatch detection: when case-insensitive resolution is active (controlled by\n\
             `[links] case_insensitive` in .hyalo.toml — \"auto\", \"true\", or \"false\"), broken links\n\

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -90,6 +90,9 @@ pub(crate) struct ConfigReport {
     /// allow-list, when one is configured. `None` means whatever
     /// [`Self::frontmatter_links`] implies.
     pub frontmatter_link_properties: Option<Vec<String>>,
+    /// Effective `[links] aliases` (iter-272, DEC-288): whether a frontmatter
+    /// `aliases:` value resolves a `[[wikilink]]`.
+    pub alias_links: bool,
     /// Effective `[scan]` settings (iter-265): the vault-wide exclusion globs
     /// and whether per-file skip diagnostics are streamed.
     pub scan: ScanReport,
@@ -211,6 +214,7 @@ pub(crate) fn collect_config_report(
         site_prefix_source,
         exempt: resolved.schema.exempt.patterns().to_vec(),
         frontmatter_links: resolved.frontmatter_links_enabled,
+        alias_links: resolved.alias_links_enabled,
         frontmatter_link_properties: resolved.frontmatter_link_props.clone(),
         scan: ScanReport {
             include: resolved.scan_include.clone(),
@@ -331,6 +335,7 @@ pub(crate) fn config_envelope(report: &ConfigReport) -> serde_json::Value {
             "links": {
                 "frontmatter": report.frontmatter_links,
                 "frontmatter_properties": report.frontmatter_link_properties,
+                "aliases": report.alias_links,
             },
             // Effective `[links.auto]` baseline for `hyalo links auto`
             // (iter-195a). Always present, empty lists / false when unset, so
@@ -486,7 +491,7 @@ fn run_config_text(report: &ConfigReport, show_hints: bool) -> CommandOutcome {
     let mut out = format!(
         "{dir_out_of_bounds_str}{malformed_str}config: {config_path_str}\ncwd: {cwd}\ndir: {dir}{dir_suffix}\nformat: {format_str}\nhints: {hints}\nsite_prefix: {site_prefix_str}\nexempt: {exempt_str}\n\
          scan.include: {scan_include}\nscan.exclude: {scan_exclude}\nscan.verbose_skips: {scan_verbose_skips}\n\
-         links.frontmatter: {fm_links}\nlinks.frontmatter_properties: {fm_link_props}\n\
+         links.frontmatter: {fm_links}\nlinks.frontmatter_properties: {fm_link_props}\nlinks.aliases: {alias_links}\n\
          links.auto.exclude_titles: {auto_titles}\nlinks.auto.exclude_target_globs: {auto_globs}\nlinks.auto.first_only: {auto_first_only}\nlinks.auto.warn_common_titles: {auto_warn_common}\nlinks.fuzzy_min_confidence: {fuzzy_floor}\npi.session_summary: {pi_session_summary}\n",
         cwd = report.cwd.display(),
         dir = report.dir.display(),
@@ -495,6 +500,7 @@ fn run_config_text(report: &ConfigReport, show_hints: bool) -> CommandOutcome {
         scan_exclude = list_or_none(&report.scan.exclude),
         scan_verbose_skips = report.scan.verbose_skips,
         fm_links = report.frontmatter_links,
+        alias_links = report.alias_links,
         fm_link_props = report
             .frontmatter_link_properties
             .as_deref()

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -90,7 +90,7 @@ pub(crate) struct ConfigReport {
     /// allow-list, when one is configured. `None` means whatever
     /// [`Self::frontmatter_links`] implies.
     pub frontmatter_link_properties: Option<Vec<String>>,
-    /// Effective `[links] aliases` (iter-272, DEC-288): whether a frontmatter
+    /// Effective `[links] aliases` (iter-272, DEC-296): whether a frontmatter
     /// `aliases:` value resolves a `[[wikilink]]`.
     pub alias_links: bool,
     /// Effective `[scan]` settings (iter-265): the vault-wide exclusion globs

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -964,7 +964,7 @@ pub fn find(
                                 .map(str::to_owned),
                             _ => None,
                         };
-                        // iter-272 Part B (DEC-288): say so when the target
+                        // iter-272 Part B (DEC-296): say so when the target
                         // only resolved because a note declares it as a
                         // frontmatter alias — the reader otherwise has no way
                         // to tell `[[Leah]]` from a filename match.

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -964,6 +964,14 @@ pub fn find(
                                 .map(str::to_owned),
                             _ => None,
                         };
+                        // iter-272 Part B (DEC-288): say so when the target
+                        // only resolved because a note declares it as a
+                        // frontmatter alias — the reader otherwise has no way
+                        // to tell `[[Leah]]` from a filename match.
+                        let via = (path.is_some()
+                            && !link.external
+                            && discovery::resolves_via_alias(&link.target, case_index))
+                        .then(|| hyalo_core::types::LINK_VIA_ALIAS.to_owned());
                         LinkInfo {
                             target: link.target.clone(),
                             path,
@@ -981,6 +989,7 @@ pub fn find(
                             broken_anchor,
                             suggested_fragment,
                             out_of_vault,
+                            via,
                         }
                     })
                     // iter-211 / BUG-8: same-file anchors (`[b](#nope)`,
@@ -1034,6 +1043,8 @@ pub fn find(
                                 .flatten()
                                 .map(str::to_owned),
                             out_of_vault: false,
+                            // A same-file anchor names no target to alias.
+                            via: None,
                         }
                     }))
                     .collect::<Vec<_>>(),

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -1000,7 +1000,8 @@ pub fn find(
                     // entries (`path == entry.rel_path`) are excluded from
                     // the `--orphan`/`--dead-end` outbound-edge count below so
                     // this does not change those verdicts.
-                    .chain(entry.self_anchors.iter().map(|(line, fragment)| {
+                    .chain(entry.self_anchors.iter().map(|anchor| {
+                        let fragment = &anchor.fragment;
                         let broken_anchor = !hyalo_core::anchor::fragment_matches_headings(
                             fragment,
                             &entry.sections,
@@ -1008,12 +1009,17 @@ pub fn find(
                         LinkInfo {
                             target: String::new(),
                             path: Some(entry.rel_path.clone()),
-                            label: None,
-                            // A same-file heading jump is a wikilink-shaped
-                            // reference to this very file, never an attachment.
-                            kind: LinkKindLabel::Wikilink,
+                            label: anchor.label.clone(),
+                            // A same-file heading jump names this very file,
+                            // never an attachment — but it keeps the syntax it
+                            // was written in (iter-272 Part C / BUG-8): a
+                            // vault with no wikilinks must not report any.
+                            kind: match anchor.kind {
+                                hyalo_core::links::LinkKind::Wikilink => LinkKindLabel::Wikilink,
+                                hyalo_core::links::LinkKind::Markdown => LinkKindLabel::Markdown,
+                            },
                             property: None,
-                            line: *line,
+                            line: anchor.line,
                             fragment: Some(fragment.clone()),
                             broken_anchor,
                             // DEC-268: same unique-prefix suggestion as for a

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -269,7 +269,7 @@ pub fn links_fix(
     // excluded from `--apply` unless the user opts in via `--apply-fuzzy` /
     // `--min-confidence`. The remaining `certain_fixes` are the ones plain
     // `--apply` writes.
-    let (fuzzy_fixes, certain_fixes): (Vec<_>, Vec<_>) =
+    let (mut fuzzy_fixes, mut certain_fixes): (Vec<_>, Vec<_>) =
         fix_report.fixes.iter().cloned().partition(|f| {
             matches!(
                 f.strategy,
@@ -295,7 +295,7 @@ pub fn links_fix(
 
     // Collect all fixes: broken-link fixes + case-mismatch fixes.
     // Case-mismatch fixes come from the detection phase (not from plan_fixes).
-    let case_mismatches: Vec<_> = report
+    let mut case_mismatches: Vec<_> = report
         .case_mismatches
         .into_iter()
         .filter(|f| in_scope(f.source.as_str()))
@@ -305,7 +305,7 @@ pub fn links_fix(
     // are their own bucket, not folded into `case_mismatches` — a relocation
     // is not a cosmetic casing fix. Still applied by plain `--apply` (same
     // certainty as before), just reported and counted honestly.
-    let relocations: Vec<_> = report
+    let mut relocations: Vec<_> = report
         .relocations
         .into_iter()
         .filter(|f| in_scope(f.source.as_str()))
@@ -318,6 +318,81 @@ pub fn links_fix(
         .filter(|b| in_scope(b.source.as_str()))
         .collect();
     let ambiguous_count = ambiguous.len();
+
+    let mut modified_files = Vec::new();
+    // Fixes that were part of the plan but produced no on-disk change (e.g. a
+    // frontmatter occurrence whose text no longer matched what detection saw).
+    // L-25: dry-run also populates this by running the identical plan-building
+    // phase against on-disk text, so it reports exactly the fixes `--apply`
+    // would refuse — one code path, parity guaranteed.
+    let mut unapplied_fixes: Vec<hyalo_core::link_fix::FixPlan> = Vec::new();
+    // Fixes whose file produced a valid plan but the durable write failed
+    // mid-batch (L-11). Non-empty ⇒ partial failure ⇒ non-zero exit code.
+    let mut failed_fixes: Vec<hyalo_core::link_fix::FailedFix> = Vec::new();
+    // Fixes the H-1 round-trip guard refused: the target hyalo would have
+    // written does not resolve, so nothing was written and they are reported
+    // as unfixable rather than fixed (iter-200). A non-empty list here means a
+    // writer/resolver asymmetry was caught before it could corrupt a link.
+    let mut rejected_fixes: Vec<hyalo_core::link_fix::FixPlan> = Vec::new();
+    // iter-272 Part F / CASE-2: the exact link text `--apply` writes for each
+    // planned fix, filled in by the same planning pass in both modes so a
+    // `--dry-run` preview is byte-accurate about what will land on disk.
+    let mut emitted_targets = hyalo_core::link_fix::EmittedTargets::new();
+
+    // Merge broken-link fixes and case-mismatch fixes into a single batch so the
+    // apply/dry-run planner reads and rewrites each source file once — two
+    // separate passes over the same file would see the first pass's rewrites
+    // and could misbehave on overlapping edits.
+    let mut all_fixes = certain_fixes.clone();
+    all_fixes.extend(applicable_fuzzy.iter().cloned());
+    all_fixes.extend(case_mismatches.iter().cloned());
+    all_fixes.extend(relocations.iter().cloned());
+
+    if dry_run {
+        if !all_fixes.is_empty() {
+            // L-25: validate plans against on-disk text without writing, so the
+            // dry-run `unapplied` set matches what `--apply` would report.
+            // `modified_files` stays empty here — dry-run must NOT patch the
+            // index; `_would_modify` is informational only.
+            let (_would_modify, unapplied, rejected, emitted) =
+                hyalo_core::link_fix::plan_fixes_dry_run(dir, &all_fixes, site_prefix)?;
+            unapplied_fixes = unapplied;
+            rejected_fixes = rejected;
+            emitted_targets = emitted;
+        }
+    } else if !all_fixes.is_empty() {
+        let (plans, unapplied, failed, rejected, emitted) =
+            apply_fixes(dir, &all_fixes, site_prefix)?;
+        unapplied_fixes = unapplied;
+        failed_fixes = failed;
+        rejected_fixes = rejected;
+        emitted_targets = emitted;
+
+        // Only files that actually received a durable rewrite are "modified" —
+        // do not patch the index for files whose fixes were all unapplied or
+        // whose write failed.
+        modified_files = plans.into_iter().map(|p| p.rel_path).collect();
+    }
+    // iter-272 Part F: stamp the emitted text onto every reported bucket
+    // before any of them is serialized, so `new_target` (vault-relative, the
+    // detection coordinate system) and `emitted_target` (what gets written)
+    // are both visible and always agree between `--dry-run` and `--apply`.
+    for bucket in [
+        &mut certain_fixes,
+        &mut fuzzy_fixes,
+        &mut case_mismatches,
+        &mut relocations,
+        &mut unapplied_fixes,
+        &mut rejected_fixes,
+    ] {
+        hyalo_core::link_fix::annotate_emitted_targets(bucket, &emitted_targets);
+    }
+    // Rebuilt after annotation so the applied set carries `emitted_target` too.
+    let applicable_fuzzy: Vec<_> = fuzzy_fixes
+        .iter()
+        .filter(|f| fuzzy.accepts(f.confidence))
+        .cloned()
+        .collect();
 
     // iter-211 / BUG-12: carry each fix's own kebab-case rule code into the
     // payload. The text renderer used to hard-code `[link-case-mismatch]` for
@@ -345,53 +420,6 @@ pub fn links_fix(
         }
     }
 
-    let mut modified_files = Vec::new();
-    // Fixes that were part of the plan but produced no on-disk change (e.g. a
-    // frontmatter occurrence whose text no longer matched what detection saw).
-    // L-25: dry-run also populates this by running the identical plan-building
-    // phase against on-disk text, so it reports exactly the fixes `--apply`
-    // would refuse — one code path, parity guaranteed.
-    let mut unapplied_fixes: Vec<hyalo_core::link_fix::FixPlan> = Vec::new();
-    // Fixes whose file produced a valid plan but the durable write failed
-    // mid-batch (L-11). Non-empty ⇒ partial failure ⇒ non-zero exit code.
-    let mut failed_fixes: Vec<hyalo_core::link_fix::FailedFix> = Vec::new();
-    // Fixes the H-1 round-trip guard refused: the target hyalo would have
-    // written does not resolve, so nothing was written and they are reported
-    // as unfixable rather than fixed (iter-200). A non-empty list here means a
-    // writer/resolver asymmetry was caught before it could corrupt a link.
-    let mut rejected_fixes: Vec<hyalo_core::link_fix::FixPlan> = Vec::new();
-
-    // Merge broken-link fixes and case-mismatch fixes into a single batch so the
-    // apply/dry-run planner reads and rewrites each source file once — two
-    // separate passes over the same file would see the first pass's rewrites
-    // and could misbehave on overlapping edits.
-    let mut all_fixes = certain_fixes.clone();
-    all_fixes.extend(applicable_fuzzy.iter().cloned());
-    all_fixes.extend(case_mismatches.iter().cloned());
-    all_fixes.extend(relocations.iter().cloned());
-
-    if dry_run {
-        if !all_fixes.is_empty() {
-            // L-25: validate plans against on-disk text without writing, so the
-            // dry-run `unapplied` set matches what `--apply` would report.
-            // `modified_files` stays empty here — dry-run must NOT patch the
-            // index; `_would_modify` is informational only.
-            let (_would_modify, unapplied, rejected) =
-                hyalo_core::link_fix::plan_fixes_dry_run(dir, &all_fixes, site_prefix)?;
-            unapplied_fixes = unapplied;
-            rejected_fixes = rejected;
-        }
-    } else if !all_fixes.is_empty() {
-        let (plans, unapplied, failed, rejected) = apply_fixes(dir, &all_fixes, site_prefix)?;
-        unapplied_fixes = unapplied;
-        failed_fixes = failed;
-        rejected_fixes = rejected;
-
-        // Only files that actually received a durable rewrite are "modified" —
-        // do not patch the index for files whose fixes were all unapplied or
-        // whose write failed.
-        modified_files = plans.into_iter().map(|p| p.rel_path).collect();
-    }
     let unapplied_count = unapplied_fixes.len();
     let failed_count = failed_fixes.len();
 

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -52,6 +52,14 @@ struct LinksConfig {
     /// Persistent `hyalo links auto` preferences (`[links.auto]`).
     #[serde(default)]
     auto: Option<AutoLinksConfig>,
+    /// Whether a frontmatter `aliases:` value resolves a `[[wikilink]]`
+    /// (iter-272, DEC-288). Default `true`.
+    ///
+    /// `false` restores the pre-iter-272 behaviour: only filenames and paths
+    /// resolve, and `[[Leah]]` is broken even when a note declares
+    /// `aliases: [Leah]`.
+    #[serde(default)]
+    aliases: Option<bool>,
     /// Default confidence floor for `hyalo links fix --apply-fuzzy`
     /// (`[links] fuzzy_min_confidence`, iter-212).
     ///
@@ -327,6 +335,9 @@ pub(crate) struct ResolvedDefaults {
     /// link source. Reported by `hyalo config`; the scan itself is driven by
     /// [`Self::frontmatter_link_props`], which this value resolves into.
     pub(crate) frontmatter_links_enabled: bool,
+    /// Effective `[links] aliases` — whether a frontmatter `aliases:` value
+    /// resolves a wikilink (iter-272, DEC-288). Default `true`.
+    pub(crate) alias_links_enabled: bool,
     /// When `true`, schema validation is applied on every `set`/`append` operation.
     /// From `validate_on_write = true` in `.hyalo.toml`.
     pub(crate) validate_on_write: bool,
@@ -459,6 +470,7 @@ impl PartialEq for ResolvedDefaults {
             && self.search_language == other.search_language
             && self.frontmatter_link_props == other.frontmatter_link_props
             && self.frontmatter_links_enabled == other.frontmatter_links_enabled
+            && self.alias_links_enabled == other.alias_links_enabled
             && self.validate_on_write == other.validate_on_write
             && self.lint_ignore == other.lint_ignore
             && self.default_limit == other.default_limit
@@ -480,6 +492,7 @@ impl ResolvedDefaults {
             search_language: None,
             frontmatter_link_props: None,
             frontmatter_links_enabled: true,
+            alias_links_enabled: true,
             validate_on_write: false,
             lint_ignore: Vec::new(),
             okf_ignore: Vec::new(),
@@ -1106,6 +1119,11 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
             .links
             .as_ref()
             .and_then(|l| l.frontmatter)
+            .unwrap_or(true),
+        alias_links_enabled: cfg
+            .links
+            .as_ref()
+            .and_then(|l| l.aliases)
             .unwrap_or(true),
         validate_on_write,
         lint_ignore: cfg

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -53,7 +53,7 @@ struct LinksConfig {
     #[serde(default)]
     auto: Option<AutoLinksConfig>,
     /// Whether a frontmatter `aliases:` value resolves a `[[wikilink]]`
-    /// (iter-272, DEC-288). Default `true`.
+    /// (iter-272, DEC-296). Default `true`.
     ///
     /// `false` restores the pre-iter-272 behaviour: only filenames and paths
     /// resolve, and `[[Leah]]` is broken even when a note declares
@@ -336,7 +336,7 @@ pub(crate) struct ResolvedDefaults {
     /// [`Self::frontmatter_link_props`], which this value resolves into.
     pub(crate) frontmatter_links_enabled: bool,
     /// Effective `[links] aliases` — whether a frontmatter `aliases:` value
-    /// resolves a wikilink (iter-272, DEC-288). Default `true`.
+    /// resolves a wikilink (iter-272, DEC-296). Default `true`.
     pub(crate) alias_links_enabled: bool,
     /// When `true`, schema validation is applied on every `set`/`append` operation.
     /// From `validate_on_write = true` in `.hyalo.toml`.

--- a/crates/hyalo-cli/src/config.rs
+++ b/crates/hyalo-cli/src/config.rs
@@ -1120,11 +1120,7 @@ pub(crate) fn load_config_from(dir: &Path) -> ResolvedDefaults {
             .as_ref()
             .and_then(|l| l.frontmatter)
             .unwrap_or(true),
-        alias_links_enabled: cfg
-            .links
-            .as_ref()
-            .and_then(|l| l.aliases)
-            .unwrap_or(true),
+        alias_links_enabled: cfg.links.as_ref().and_then(|l| l.aliases).unwrap_or(true),
         validate_on_write,
         lint_ignore: cfg
             .lint

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -55,6 +55,9 @@ pub(crate) fn build_case_index_from_dir(dir: &std::path::Path) -> CaseInsensitiv
             idx.insert(rel);
         }
     }
+    // iter-272 Part B (DEC-288): frontmatter `aliases:` are resolution targets.
+    // Frontmatter-only scan — no body bytes are read.
+    discovery::populate_aliases_from_dir(dir, &mut idx);
     idx
 }
 
@@ -75,6 +78,17 @@ pub(crate) fn build_case_index_from_snapshot(snap: &SnapshotIndex) -> CaseInsens
     // written by an older hyalo, which simply degrades to the old behaviour).
     for rel in snap.attachments() {
         idx.insert(rel);
+    }
+    // iter-272 Part B: the snapshot already carries every note's frontmatter,
+    // so the alias map is built at load from indexed properties — no on-disk
+    // format change, and `--index` parity with a disk scan for free.
+    if hyalo_core::discovery::link_aliases_enabled() {
+        for entry in snap.entries() {
+            let aliases = hyalo_core::filter::extract_aliases(&entry.properties);
+            if !aliases.is_empty() {
+                idx.insert_aliases(&entry.rel_path, aliases);
+            }
+        }
     }
     idx
 }

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -55,7 +55,7 @@ pub(crate) fn build_case_index_from_dir(dir: &std::path::Path) -> CaseInsensitiv
             idx.insert(rel);
         }
     }
-    // iter-272 Part B (DEC-288): frontmatter `aliases:` are resolution targets.
+    // iter-272 Part B (DEC-296): frontmatter `aliases:` are resolution targets.
     // Frontmatter-only scan — no body bytes are read.
     discovery::populate_aliases_from_dir(dir, &mut idx);
     idx

--- a/crates/hyalo-cli/src/output/filters.rs
+++ b/crates/hyalo-cli/src/output/filters.rs
@@ -59,8 +59,9 @@ pub(super) const TAG_SUMMARY_ENTRY_FILTER: &str =
 /// - ` (kind)` for anything that is not a plain `wikilink`;
 /// - `(broken anchor)` / `(unresolved)` / `(out of vault)` verdicts — an
 ///   `external` link gets none of them, because it names nothing to resolve;
+/// - ` (via alias)` when a frontmatter `aliases:` entry resolved it (iter-272);
 /// - the DEC-268 heading suggestion, then a `[label]` suffix.
-pub(super) const LINK_INFO_FILTER: &str = r##""  line \(.line // 0): \"\(.target)\(if .fragment then "#\(.fragment)" else "" end)\"\(if .path then " → \"\(.path)\"" else "" end)\(if .kind and .kind != "wikilink" then " (\(.kind))" else "" end)\(if .path then (if .broken_anchor then " (broken anchor)" else "" end) elif .out_of_vault then " (out of vault)" elif .kind == "external" then "" else " (unresolved)" end)\(if .suggested_fragment then " — did you mean \"#\(.suggested_fragment)\"?" else "" end)\(if .label then " [\(.label)]" else "" end)""##;
+pub(super) const LINK_INFO_FILTER: &str = r##""  line \(.line // 0): \"\(.target)\(if .fragment then "#\(.fragment)" else "" end)\"\(if .path then " → \"\(.path)\"" else "" end)\(if .kind and .kind != "wikilink" then " (\(.kind))" else "" end)\(if .path then (if .broken_anchor then " (broken anchor)" else "" end) elif .out_of_vault then " (out of vault)" elif .kind == "external" then "" else " (unresolved)" end)\(if .via then " (via \(.via))" else "" end)\(if .suggested_fragment then " — did you mean \"#\(.suggested_fragment)\"?" else "" end)\(if .label then " [\(.label)]" else "" end)""##;
 
 /// `TaskCount`: `{done, total}`
 pub(super) const TASK_COUNT_FILTER: &str = r#""[\(.done)/\(.total)]""#;
@@ -250,7 +251,7 @@ pub(super) fn key_signature(map: &serde_json::Map<String, serde_json::Value>) ->
 /// one this shape declares", which keeps pre-iter-261 fixtures rendering while
 /// still refusing any other object that happens to carry a `target`.
 fn is_link_info_signature(key_sig: &str) -> bool {
-    const LINK_INFO_KEYS: [&str; 9] = [
+    const LINK_INFO_KEYS: [&str; 11] = [
         "broken_anchor",
         "fragment",
         "kind",
@@ -258,8 +259,11 @@ fn is_link_info_signature(key_sig: &str) -> bool {
         "line",
         "out_of_vault",
         "path",
+        "property",
         "suggested_fragment",
         "target",
+        // iter-272 Part B: `"alias"` when a frontmatter alias resolved it.
+        "via",
     ];
     let mut has_target = false;
     for key in key_sig.split(',') {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1211,6 +1211,11 @@ fn run_inner() -> Result<(), AppError> {
         }
     }
 
+    // Install `[links] aliases` (iter-272, DEC-288) once, before any command
+    // runs, so every resolver, index builder and graph pass sees the same
+    // answer without threading it through their signatures.
+    hyalo_core::discovery::set_link_aliases(config.alias_links_enabled);
+
     // Install `[scan] exclude` (iter-265, DEC-277) the same way, so every
     // command's discovery — and every `--index` load — drops the same files.
     for (pat, msg) in hyalo_core::discovery::set_scan_exclude(&config.scan_exclude) {

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1211,7 +1211,7 @@ fn run_inner() -> Result<(), AppError> {
         }
     }
 
-    // Install `[links] aliases` (iter-272, DEC-288) once, before any command
+    // Install `[links] aliases` (iter-272, DEC-296) once, before any command
     // runs, so every resolver, index builder and graph pass sees the same
     // answer without threading it through their signatures.
     hyalo_core::discovery::set_link_aliases(config.alias_links_enabled);

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -184,6 +184,9 @@ Prefer `hyalo` CLI for operations on files in this directory:
   `.base`). `external` and `attachment` links are never broken: they stay out of
   `find --broken-links`, `summary.links.broken` and HYALO006, and are not graph edges for
   `--orphan`/`--dead-end`. Text mode prints the kind after the arrow unless it is `wikilink`.
+  `![alt](img.png)` is inventoried as an `embed` (DEC-297, iter-272) so a missing image
+  surfaces, and a same-file anchor keeps its syntax: `[text](#frag)` is `kind: "markdown"` with
+  its link text, `[[#H]]` stays `wikilink`.
 - **Frontmatter wikilinks are graph edges** (DEC-269, iter-262): a `[[wikilink]]` in **any**
   frontmatter value — `categories: ["[[Books]]"]`, `type: "[[Author]]"`, a nested map, quoted
   or bare — counts for `backlinks`, `find --orphan`/`--dead-end`/`--broken-links`,
@@ -196,6 +199,14 @@ Prefer `hyalo` CLI for operations on files in this directory:
 - **`set` on a list property** (DEC-270, iter-262): `set K=<scalar>` on a property that holds a
   list replaces it — `set` means replace — and says so on stderr, with the affected files under
   `list_collapsed` in JSON. Use `hyalo append` when the list should stay a list.
+- **Frontmatter `aliases:` resolve wikilinks** (DEC-296, iter-272): `[[Leah]]` resolves to the
+  note declaring `aliases: [Leah]` — a list or a bare string, matched case-folded. A filename or
+  path match always wins, an alias claimed by two notes is ambiguous rather than resolved, and
+  `[[alias#Heading]]` / `[[alias|label]]` work. `kind` stays `wikilink`; the entry carries
+  `via: "alias"`. Alias links count for `backlinks`, `--orphan`/`--dead-end`,
+  `summary.links` and HYALO006; `links fix` never proposes or fuzzy-matches a rewrite for one,
+  and `mv` leaves them alone (the alias moves with the note). `[links] aliases = false` restores
+  filename-only resolution; `hyalo config --jq '.results.links.aliases'` reports it.
 - **Resolution folds case everywhere** (DEC-267): `[[AidenLx]]` resolves to `People/aidenlx.md`
   on every platform, not only on a case-insensitive filesystem. Opt out with
   `[links] case_insensitive = "false"`; `links fix --case-insensitive` now only suppresses the

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -463,10 +463,21 @@ What follows is only what those pages do not say — the behaviour that surprise
 - **Every link carries a `kind`** (`--fields links`): `wikilink`, `embed` (`![[…]]`),
   `markdown`, `external` (any `scheme:` URI — `https:`, `obsidian://`, `mailto:`, `file://`)
   or `attachment` (resolved to a non-`.md` vault file: an image, a PDF, an Obsidian `.base`).
+  `![alt](img.png)` is an embed too (DEC-297), so a missing image is visible. A same-file anchor
+  (`[[#H]]`, `[text](#frag)`) keeps the syntax it was written in — an anchor-only *markdown*
+  link is `kind: "markdown"` and carries its link text.
   `external` and `attachment` are **never broken** — they stay out of `find --broken-links`,
   `summary.links.broken` and HYALO006, and are not graph edges for `--orphan` / `--dead-end`.
   So bucket broken links with
   `select((.kind | IN("external","attachment") | not) and ((.path == null and (.out_of_vault | not)) or .broken_anchor))`.
+- **Frontmatter `aliases:` resolve wikilinks** (DEC-296): `[[Leah]]` finds the note declaring
+  `aliases: [Leah]` (list or bare string). A filename or path always wins; an alias claimed by
+  two notes is ambiguous, not resolved; matching folds case like DEC-267; `[[alias#Heading]]`
+  and `[[alias|label]]` work. The link's `kind` stays `wikilink` and it carries `via: "alias"`.
+  Alias links are real graph edges (`backlinks`, `--orphan`, `--dead-end`, `summary.links`,
+  HYALO006) and `links fix` never proposes or fuzzy-matches a rewrite for one. `mv` leaves them
+  alone — the alias travels with the note. Opt out with `[links] aliases = false`
+  (`hyalo config --jq '.results.links.aliases'`).
 - **Link resolution folds case on every platform** (DEC-267), so `[[AidenLx]]` resolves to
   `People/aidenlx.md` whatever the filesystem does. Opt out with `[links] case_insensitive =
   "false"`. `links fix --case-insensitive` no longer changes what resolves; it only hides the
@@ -480,7 +491,12 @@ What follows is only what those pages do not say — the behaviour that surprise
   `.md`, and neither `/index` nor `.md` is appended to a form that lacked it.
 - **A dead `#anchor` that prefixes exactly one heading gets a `suggested_fragment`** (DEC-268):
   `[[decision-log#DEC-068]]` reports `"DEC-068: Snapshot index format"` as the text to write.
-  Reported, never applied — an ambiguous prefix suggests nothing.
+  Reported, never applied — an ambiguous prefix suggests nothing. `-`, `_` and a space are one
+  character class for that prefix test (DEC-298), so `#Browser_compatibility` suggests the
+  `Browser compatibility` heading.
+- **`links fix` reports the string it will write** (iter-272): every plan carries
+  `emitted_target` beside the vault-relative `new_target`, filled by the same planning pass in
+  `--dry-run` and `--apply`, so a preview is byte-accurate about what lands on disk.
 - **`config` reports a broken config rather than failing.** `results.malformed` /
   `results.parse_error` mean every other value shown is a built-in default.
 - **`views run <name>` is exactly `find --view <name>`** — same merge rules, same output.

--- a/crates/hyalo-cli/tests/e2e/iteration272_resolution_completeness.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration272_resolution_completeness.rs
@@ -2,7 +2,7 @@
 //!
 //! - **Part A (BUG-5).** A one-element list `type:` binds *and* passes the
 //!   implicit string constraint every declared type carries.
-//! - **Part B (BUG-6, DEC-288).** Frontmatter `aliases:` resolve wikilinks,
+//! - **Part B (BUG-6, DEC-296).** Frontmatter `aliases:` resolve wikilinks,
 //!   consistently across `find`, `backlinks`, `summary` and `links fix`.
 //! - **Part C (BUG-8).** `[text](#fragment)` is a markdown link, not a
 //!   wikilink.
@@ -115,7 +115,7 @@ fn part_a_multi_element_and_empty_type_lists_are_still_rejected() {
 }
 
 // ---------------------------------------------------------------------------
-// Part B — frontmatter `aliases:` as link targets (DEC-288)
+// Part B — frontmatter `aliases:` as link targets (DEC-296)
 // ---------------------------------------------------------------------------
 
 fn alias_vault() -> TempDir {

--- a/crates/hyalo-cli/tests/e2e/iteration272_resolution_completeness.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration272_resolution_completeness.rs
@@ -102,7 +102,11 @@ fn part_a_multi_element_and_empty_type_lists_are_still_rejected() {
         "[schema.default]\nrequired = [\"title\", \"type\"]\n\n\
          [schema.types.Authors]\nrequired = [\"title\", \"type\"]\n",
     );
-    write(&tmp, "multi.md", "---\ntitle: M\ntype: [\"a\", \"b\"]\n---\n");
+    write(
+        &tmp,
+        "multi.md",
+        "---\ntitle: M\ntype: [\"a\", \"b\"]\n---\n",
+    );
     let output = hyalo(&tmp)
         .args(["lint", "--file", "multi.md", "--format", "json"])
         .output()
@@ -209,7 +213,10 @@ fn part_b_a_filename_beats_an_alias_and_a_shared_alias_is_ambiguous() {
     let links = links_of(&tmp, "src.md");
     assert_eq!(links[0].1.as_deref(), Some("Leah.md"));
     assert_eq!(links[0].3, None, "a filename match is not `via: alias`");
-    assert_eq!(links[1].1, None, "an alias claimed twice resolves to nothing");
+    assert_eq!(
+        links[1].1, None,
+        "an alias claimed twice resolves to nothing"
+    );
 }
 
 #[test]
@@ -217,11 +224,7 @@ fn part_b_mv_does_not_rewrite_a_link_written_through_an_alias() {
     let tmp = alias_vault();
     let out = run_json(
         &tmp,
-        &[
-            "mv",
-            "people/Leah Ferguson.md",
-            "archive/Leah Ferguson.md",
-        ],
+        &["mv", "people/Leah Ferguson.md", "archive/Leah Ferguson.md"],
     );
     assert_eq!(out["results"]["total_links_updated"].as_u64(), Some(0));
     assert_eq!(
@@ -324,10 +327,7 @@ fn part_d_bound2_a_flow_list_opening_with_three_brackets_yields_both_links() {
     );
     let links = links_of(&tmp, "src.md");
     assert_eq!(
-        links
-            .iter()
-            .map(|l| l.0.as_str())
-            .collect::<Vec<_>>(),
+        links.iter().map(|l| l.0.as_str()).collect::<Vec<_>>(),
         vec!["iterations/x", "research/y"],
         "{links:?}"
     );

--- a/crates/hyalo-cli/tests/e2e/iteration272_resolution_completeness.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration272_resolution_completeness.rs
@@ -1,0 +1,387 @@
+//! Iteration 272 — resolution completeness.
+//!
+//! - **Part A (BUG-5).** A one-element list `type:` binds *and* passes the
+//!   implicit string constraint every declared type carries.
+//! - **Part B (BUG-6, DEC-288).** Frontmatter `aliases:` resolve wikilinks,
+//!   consistently across `find`, `backlinks`, `summary` and `links fix`.
+//! - **Part C (BUG-8).** `[text](#fragment)` is a markdown link, not a
+//!   wikilink.
+//! - **Part D (BUG-15, BUG-16, BUG-21).** Scanner capture boundaries.
+//! - **Part F (CASE-2).** `links fix` reports the string `--apply` writes.
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn hyalo(tmp: &TempDir) -> Command {
+    let mut cmd = crate::common::hyalo_no_hints();
+    cmd.arg("--dir").arg(tmp.path().to_str().unwrap());
+    cmd
+}
+
+fn run_json(tmp: &TempDir, args: &[&str]) -> serde_json::Value {
+    let output = hyalo(tmp)
+        .args(args)
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "`hyalo {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("json output")
+}
+
+fn write(tmp: &TempDir, rel: &str, body: &str) {
+    let path = tmp.path().join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, body).unwrap();
+}
+
+/// Every link of `file`, as `(target, path, kind, via)` tuples.
+fn links_of(tmp: &TempDir, file: &str) -> Vec<(String, Option<String>, String, Option<String>)> {
+    let out = run_json(tmp, &["find", "--file", file, "--fields", "links"]);
+    out["results"][0]["links"]
+        .as_array()
+        .expect("links array")
+        .iter()
+        .map(|l| {
+            (
+                l["target"].as_str().unwrap_or_default().to_owned(),
+                l["path"].as_str().map(str::to_owned),
+                l["kind"].as_str().unwrap_or_default().to_owned(),
+                l["via"].as_str().map(str::to_owned),
+            )
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Part A — a list-typed `type:` under a declared schema
+// ---------------------------------------------------------------------------
+
+#[test]
+fn part_a_list_typed_type_lints_clean_under_a_declared_schema() {
+    let tmp = TempDir::new().unwrap();
+    write(
+        &tmp,
+        ".hyalo.toml",
+        "[schema.default]\nrequired = [\"title\", \"type\"]\n\n\
+         [schema.types.Authors]\nrequired = [\"title\", \"type\"]\n",
+    );
+    // The shape Obsidian's own property editor writes for a link-typed
+    // property. Binding always accepted it (DEC-281); the implicit
+    // `type: string` constraint did not.
+    write(
+        &tmp,
+        "l.md",
+        "---\ntitle: L\ntype: [\"[[Authors]]\"]\n---\n\n# L\n",
+    );
+    // `lint` exits non-zero when it reports anything, so read the payload
+    // rather than asserting success.
+    let output = hyalo(&tmp)
+        .args(["lint", "--file", "l.md", "--strict", "--format", "json"])
+        .output()
+        .unwrap();
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    assert!(
+        !text.contains("expected string"),
+        "list-typed `type` must not trip the string constraint: {text}"
+    );
+}
+
+#[test]
+fn part_a_multi_element_and_empty_type_lists_are_still_rejected() {
+    let tmp = TempDir::new().unwrap();
+    write(
+        &tmp,
+        ".hyalo.toml",
+        "[schema.default]\nrequired = [\"title\", \"type\"]\n\n\
+         [schema.types.Authors]\nrequired = [\"title\", \"type\"]\n",
+    );
+    write(&tmp, "multi.md", "---\ntitle: M\ntype: [\"a\", \"b\"]\n---\n");
+    let output = hyalo(&tmp)
+        .args(["lint", "--file", "multi.md", "--format", "json"])
+        .output()
+        .unwrap();
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    assert!(
+        text.contains("must name one type"),
+        "a two-element list must still be reported: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Part B — frontmatter `aliases:` as link targets (DEC-288)
+// ---------------------------------------------------------------------------
+
+fn alias_vault() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write(
+        &tmp,
+        "people/Leah Ferguson.md",
+        "---\ntitle: Leah Ferguson\naliases:\n  - Leah\n  - \"L. Ferguson\"\n---\n\n# Leah Ferguson\n\n## Work\n",
+    );
+    write(
+        &tmp,
+        "src.md",
+        "See [[Leah]], [[L. Ferguson|her]] and [[Nobody]].\n",
+    );
+    tmp
+}
+
+#[test]
+fn part_b_a_declared_alias_resolves_and_is_labelled_via_alias() {
+    let tmp = alias_vault();
+    let links = links_of(&tmp, "src.md");
+    assert_eq!(
+        links[0],
+        (
+            "Leah".to_owned(),
+            Some("people/Leah Ferguson.md".to_owned()),
+            "wikilink".to_owned(),
+            Some("alias".to_owned())
+        )
+    );
+    // A multi-word alias with a label works the same way.
+    assert_eq!(links[1].1.as_deref(), Some("people/Leah Ferguson.md"));
+    assert_eq!(links[1].3.as_deref(), Some("alias"));
+    // A genuinely unknown target is still broken and carries no `via`.
+    assert_eq!(links[2].1, None);
+    assert_eq!(links[2].3, None);
+}
+
+#[test]
+fn part_b_alias_links_are_graph_edges_and_are_not_counted_broken() {
+    let tmp = alias_vault();
+    let backlinks = run_json(&tmp, &["backlinks", "people/Leah Ferguson.md"]);
+    assert_eq!(
+        backlinks["results"]["backlinks"][0]["source"]
+            .as_str()
+            .unwrap(),
+        "src.md",
+        "an alias-resolved link is a real edge: {backlinks}"
+    );
+    let summary = run_json(&tmp, &["summary"]);
+    // Three links, one genuinely broken (`[[Nobody]]`).
+    assert_eq!(summary["results"]["links"]["broken"].as_u64(), Some(1));
+}
+
+#[test]
+fn part_b_links_fix_never_proposes_a_rewrite_for_a_declared_alias() {
+    let tmp = TempDir::new().unwrap();
+    // `Lewuathe.md` is the Obsidian Hub's real fuzzy trap for `[[Leah]]`.
+    write(&tmp, "Lewuathe.md", "---\ntitle: Lewuathe\n---\n");
+    write(
+        &tmp,
+        "Leah Ferguson.md",
+        "---\ntitle: Leah Ferguson\naliases:\n  - Leah\n---\n",
+    );
+    write(&tmp, "src.md", "See [[Leah]].\n");
+    let out = run_json(&tmp, &["links", "fix", "--apply-fuzzy", "--dry-run"]);
+    let r = &out["results"];
+    assert_eq!(r["broken"].as_u64(), Some(0), "{r}");
+    assert_eq!(r["fuzzy"].as_u64(), Some(0), "{r}");
+    assert_eq!(r["unfixable"].as_u64(), Some(0), "{r}");
+    // And the file is untouched.
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("src.md")).unwrap(),
+        "See [[Leah]].\n"
+    );
+}
+
+#[test]
+fn part_b_a_filename_beats_an_alias_and_a_shared_alias_is_ambiguous() {
+    let tmp = TempDir::new().unwrap();
+    write(&tmp, "Leah.md", "---\ntitle: The real Leah\n---\n");
+    write(
+        &tmp,
+        "Leah Ferguson.md",
+        "---\ntitle: Leah Ferguson\naliases:\n  - Leah\n---\n",
+    );
+    write(&tmp, "a.md", "---\ntitle: A\naliases:\n  - Shared\n---\n");
+    write(&tmp, "b.md", "---\ntitle: B\naliases: Shared\n---\n");
+    write(&tmp, "src.md", "See [[Leah]] and [[Shared]].\n");
+
+    let links = links_of(&tmp, "src.md");
+    assert_eq!(links[0].1.as_deref(), Some("Leah.md"));
+    assert_eq!(links[0].3, None, "a filename match is not `via: alias`");
+    assert_eq!(links[1].1, None, "an alias claimed twice resolves to nothing");
+}
+
+#[test]
+fn part_b_mv_does_not_rewrite_a_link_written_through_an_alias() {
+    let tmp = alias_vault();
+    let out = run_json(
+        &tmp,
+        &[
+            "mv",
+            "people/Leah Ferguson.md",
+            "archive/Leah Ferguson.md",
+        ],
+    );
+    assert_eq!(out["results"]["total_links_updated"].as_u64(), Some(0));
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("src.md")).unwrap(),
+        "See [[Leah]], [[L. Ferguson|her]] and [[Nobody]].\n",
+        "an alias link needs no rewrite — the alias moved with the note"
+    );
+    // And it still resolves at the new location.
+    assert_eq!(
+        links_of(&tmp, "src.md")[0].1.as_deref(),
+        Some("archive/Leah Ferguson.md")
+    );
+}
+
+#[test]
+fn part_b_links_aliases_false_restores_filename_only_resolution() {
+    let tmp = alias_vault();
+    write(&tmp, ".hyalo.toml", "[links]\naliases = false\n");
+    let links = links_of(&tmp, "src.md");
+    assert_eq!(links[0].1, None, "opt-out disables alias resolution");
+    let cfg = run_json(&tmp, &["config"]);
+    assert_eq!(cfg["results"]["links"]["aliases"].as_bool(), Some(false));
+}
+
+#[test]
+fn part_b_index_and_disk_agree_on_alias_resolution() {
+    let tmp = alias_vault();
+    let index = tmp.path().join("vault.hyalo-index");
+    let index_str = index.to_str().unwrap();
+    hyalo(&tmp)
+        .args(["create-index", "--index-file", index_str])
+        .assert()
+        .success();
+    let disk = run_json(&tmp, &["find", "--file", "src.md", "--fields", "links"]);
+    let indexed = run_json(
+        &tmp,
+        &[
+            "find",
+            "--file",
+            "src.md",
+            "--fields",
+            "links",
+            "--index-file",
+            index_str,
+        ],
+    );
+    assert_eq!(disk["results"], indexed["results"]);
+}
+
+// ---------------------------------------------------------------------------
+// Part C — an anchor-only markdown link is markdown
+// ---------------------------------------------------------------------------
+
+#[test]
+fn part_c_anchor_only_markdown_links_are_not_reported_as_wikilinks() {
+    let tmp = TempDir::new().unwrap();
+    write(
+        &tmp,
+        "page.md",
+        "# Page\n\nSee [Browser compatibility](#browser-compat) and [[#Notes]].\n\n\
+         ## Browser compat\n\n## Notes\n",
+    );
+    let links = links_of(&tmp, "page.md");
+    let anchors: Vec<_> = links.iter().filter(|l| l.0.is_empty()).collect();
+    assert_eq!(anchors.len(), 2, "{links:?}");
+    assert_eq!(anchors[0].2, "markdown", "{links:?}");
+    assert_eq!(anchors[1].2, "wikilink", "{links:?}");
+
+    // The markdown one carries its link text.
+    let out = run_json(&tmp, &["find", "--file", "page.md", "--fields", "links"]);
+    let first = &out["results"][0]["links"][0];
+    assert_eq!(first["label"].as_str(), Some("Browser compatibility"));
+    assert_eq!(first["fragment"].as_str(), Some("browser-compat"));
+}
+
+// ---------------------------------------------------------------------------
+// Part D — scanner capture boundaries
+// ---------------------------------------------------------------------------
+
+#[test]
+fn part_d_bound1_a_stray_close_bracket_ends_the_wikilink_capture() {
+    let tmp = TempDir::new().unwrap();
+    write(&tmp, "Target.md", "# Target\n");
+    write(&tmp, "src.md", "see [[Leah] here and [[Target]]\n");
+    let links = links_of(&tmp, "src.md");
+    assert_eq!(links.len(), 1, "{links:?}");
+    assert_eq!(links[0].0, "Target");
+    assert_eq!(links[0].1.as_deref(), Some("Target.md"));
+}
+
+#[test]
+fn part_d_bound2_a_flow_list_opening_with_three_brackets_yields_both_links() {
+    let tmp = TempDir::new().unwrap();
+    write(&tmp, "iterations/x.md", "# X\n");
+    write(&tmp, "research/y.md", "# Y\n");
+    write(
+        &tmp,
+        "src.md",
+        "---\ntitle: S\nrelated: [[[iterations/x]], [[research/y]]]\n---\n\nBody.\n",
+    );
+    let links = links_of(&tmp, "src.md");
+    assert_eq!(
+        links
+            .iter()
+            .map(|l| l.0.as_str())
+            .collect::<Vec<_>>(),
+        vec!["iterations/x", "research/y"],
+        "{links:?}"
+    );
+    assert!(links.iter().all(|l| l.1.is_some()), "{links:?}");
+}
+
+#[test]
+fn part_d_bound3_a_parenthesised_url_in_an_angle_destination_is_external() {
+    let tmp = TempDir::new().unwrap();
+    write(
+        &tmp,
+        "roundup.md",
+        "# Roundup\n\nSee [y](<(https://example.com/2021)>) for the list.\n",
+    );
+    let links = links_of(&tmp, "roundup.md");
+    assert_eq!(links.len(), 1, "{links:?}");
+    assert_eq!(links[0].2, "external", "{links:?}");
+
+    // …and it is never offered as a fix.
+    let out = run_json(&tmp, &["links", "fix", "--apply-fuzzy", "--dry-run"]);
+    assert_eq!(out["results"]["broken"].as_u64(), Some(0));
+    assert_eq!(out["results"]["fuzzy"].as_u64(), Some(0));
+}
+
+// ---------------------------------------------------------------------------
+// Part F — dry-run reports the string apply writes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn part_f_dry_run_reports_the_emitted_target_apply_writes() {
+    let tmp = TempDir::new().unwrap();
+    write(&tmp, "sub/Real-Page.md", "# Real page\n");
+    write(&tmp, "sub/src.md", "See [x](real-page.md).\n");
+
+    let dry = run_json(&tmp, &["links", "fix", "--dry-run"]);
+    let plan = &dry["results"]["case_mismatch_fixes"][0];
+    // `new_target` stays vault-relative for consumers that resolve paths…
+    assert_eq!(plan["new_target"].as_str(), Some("sub/Real-Page.md"));
+    // …while `emitted_target` is the text that lands on disk.
+    let emitted = plan["emitted_target"]
+        .as_str()
+        .expect("emitted_target reported")
+        .to_owned();
+    assert_eq!(emitted, "Real-Page.md");
+
+    let applied = run_json(&tmp, &["links", "fix", "--apply"]);
+    assert_eq!(
+        applied["results"]["applied_fixes"][0]["emitted_target"].as_str(),
+        Some(emitted.as_str()),
+        "apply must report the same string the dry run promised"
+    );
+    let written = std::fs::read_to_string(tmp.path().join("sub/src.md")).unwrap();
+    assert!(
+        written.contains(&format!("({emitted})")),
+        "the reported string is what was written: {written}"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -50,6 +50,7 @@ mod iteration266_metadata_mutations;
 mod iteration267_help_hints_text;
 mod iteration269_carry_over_fixes;
 mod iteration271_write_rewrite_safety;
+mod iteration272_resolution_completeness;
 mod iteration_ergonomics;
 mod jq;
 mod json_errors;

--- a/crates/hyalo-core/src/anchor.rs
+++ b/crates/hyalo-core/src/anchor.rs
@@ -202,7 +202,7 @@ pub fn unique_heading_by_prefix<'a>(
         let Some(prefix) = heading.get(..needle.len()) else {
             continue;
         };
-        if !prefix.eq_ignore_ascii_case(&needle) {
+        if !prefix_matches_fragment(prefix, &needle) {
             continue;
         }
         if found.is_some() {
@@ -212,6 +212,36 @@ pub fn unique_heading_by_prefix<'a>(
         found = Some(heading);
     }
     found
+}
+
+/// Compare a heading's leading bytes against a fragment, folding ASCII case
+/// *and* the three interchangeable word separators (iter-272 Part E).
+///
+/// DEC-268 forbids silently *resolving* a fragment by fuzzy matching; it says
+/// nothing about what may be *suggested*. MDN slugs its headings with
+/// underscores (`#Browser_compatibility`) while the heading itself is written
+/// with spaces, so a strict comparison found no prefix for 1242 of the 1254
+/// broken anchors on an MDN copy — every one of them a heading the reader
+/// could see two lines away. `-`, `_` and a space are treated as one
+/// character class here, and only here: the suggestion still has to be a
+/// unique prefix of exactly one heading, and it is still printed rather than
+/// applied.
+fn prefix_matches_fragment(prefix: &str, needle: &str) -> bool {
+    if prefix.len() != needle.len() {
+        return false;
+    }
+    prefix
+        .bytes()
+        .zip(needle.bytes())
+        .all(|(a, b)| separator_class(a) == separator_class(b))
+}
+
+/// `b` folded to lowercase, with every word separator mapped to one byte.
+fn separator_class(b: u8) -> u8 {
+    match b {
+        b'-' | b'_' | b' ' => b'-',
+        other => other.to_ascii_lowercase(),
+    }
 }
 
 /// Validate a link fragment against a target file's outline sections.
@@ -290,6 +320,34 @@ mod tests {
             code_blocks: Vec::new(),
         }
     }
+
+    // --- iter-272 Part E: separator-insensitive suggestion matching ---
+
+    #[test]
+    fn suggested_fragment_folds_underscores_hyphens_and_spaces() {
+        let sections = vec![sec(Some("Browser compatibility and support"))];
+        // MDN slugs with underscores; the heading is written with spaces.
+        assert_eq!(
+            unique_heading_by_prefix("Browser_compatibility", &sections),
+            Some("Browser compatibility and support")
+        );
+        assert_eq!(
+            unique_heading_by_prefix("browser-compatibility", &sections),
+            Some("Browser compatibility and support")
+        );
+        // A genuinely different fragment still gets no suggestion.
+        assert_eq!(unique_heading_by_prefix("Server_compat", &sections), None);
+    }
+
+    #[test]
+    fn separator_folding_does_not_make_a_suggestion_ambiguous_match() {
+        let sections = vec![
+            sec(Some("Browser compatibility")),
+            sec(Some("Browser_compatibility notes")),
+        ];
+        assert_eq!(unique_heading_by_prefix("Browser_com", &sections), None);
+    }
+
 
     #[test]
     fn exact_match() {

--- a/crates/hyalo-core/src/anchor.rs
+++ b/crates/hyalo-core/src/anchor.rs
@@ -348,7 +348,6 @@ mod tests {
         assert_eq!(unique_heading_by_prefix("Browser_com", &sections), None);
     }
 
-
     #[test]
     fn exact_match() {
         let secs = [sec(Some("Tasks"))];

--- a/crates/hyalo-core/src/case_index.rs
+++ b/crates/hyalo-core/src/case_index.rs
@@ -67,7 +67,7 @@ pub struct CaseInsensitiveIndex {
     /// the resolved `[links] case_insensitive` mode.
     case_insensitive_paths: bool,
     /// Map from lowercased frontmatter `aliases:` value → list of real paths
-    /// declaring that alias (iter-272 Part B, DEC-288).
+    /// declaring that alias (iter-272 Part B, DEC-296).
     ///
     /// Obsidian resolves `[[Leah]]` to the note whose frontmatter declares
     /// `aliases: [Leah]`. The map is consulted only after path and stem

--- a/crates/hyalo-core/src/case_index.rs
+++ b/crates/hyalo-core/src/case_index.rs
@@ -66,6 +66,14 @@ pub struct CaseInsensitiveIndex {
     /// Stem lookups are unaffected. Set by [`set_case_insensitive_paths`] from
     /// the resolved `[links] case_insensitive` mode.
     case_insensitive_paths: bool,
+    /// Map from lowercased frontmatter `aliases:` value → list of real paths
+    /// declaring that alias (iter-272 Part B, DEC-288).
+    ///
+    /// Obsidian resolves `[[Leah]]` to the note whose frontmatter declares
+    /// `aliases: [Leah]`. The map is consulted only after path and stem
+    /// lookups have failed, so a real filename always wins, and an alias
+    /// claimed by two notes is ambiguous rather than resolved.
+    alias_map: HashMap<String, Vec<String>>,
 }
 
 impl CaseInsensitiveIndex {
@@ -82,6 +90,7 @@ impl CaseInsensitiveIndex {
             map: HashMap::with_capacity(capacity),
             stem_map: HashMap::with_capacity(capacity),
             case_insensitive_paths: false,
+            alias_map: HashMap::new(),
         }
     }
 
@@ -191,6 +200,68 @@ impl CaseInsensitiveIndex {
         }
         let key = rel_path.to_ascii_lowercase();
         self.map.get(&key).map_or(&[], Vec::as_slice)
+    }
+
+    /// Record a note's declared frontmatter `aliases:` (iter-272 Part B).
+    ///
+    /// `rel_path` is the vault-relative, forward-slash path of the note that
+    /// declares them. Aliases are keyed case-folded (DEC-267), and an alias
+    /// declared by more than one note is kept ambiguous — never silently
+    /// resolved to the first declarer. An empty or whitespace-only alias is
+    /// ignored, as is a note aliasing itself under its own stem (the stem map
+    /// already answers that, and cheaper).
+    pub fn insert_aliases<I, S>(&mut self, rel_path: &str, aliases: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for alias in aliases {
+            let alias = alias.as_ref().trim();
+            if alias.is_empty() {
+                continue;
+            }
+            let key = alias.to_ascii_lowercase();
+            let paths = self.alias_map.entry(key).or_default();
+            if paths.iter().any(|p| p == rel_path) {
+                continue;
+            }
+            paths.push(rel_path.to_owned());
+        }
+    }
+
+    /// Look up a declared frontmatter alias (case-folded). Returns the path of
+    /// the declaring note only when exactly one note declares it.
+    ///
+    /// Returns `None` for an unknown alias and for one declared by two or more
+    /// notes — the alias equivalent of an ambiguous bare stem.
+    #[must_use]
+    pub fn lookup_alias(&self, alias: &str) -> Option<&str> {
+        match self.alias_map.get(&alias.to_ascii_lowercase())?.as_slice() {
+            [only] => Some(only.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Every note declaring `alias` (case-folded), for ambiguity diagnostics
+    /// and for `links fix`, which must not fuzzy-rewrite a target that is a
+    /// declared alias of any note.
+    #[must_use]
+    pub fn lookup_alias_all(&self, alias: &str) -> &[String] {
+        self.alias_map
+            .get(&alias.to_ascii_lowercase())
+            .map_or(&[], Vec::as_slice)
+    }
+
+    /// Whether any note in the vault declares `alias` (case-folded).
+    #[must_use]
+    pub fn has_alias(&self, alias: &str) -> bool {
+        !self.lookup_alias_all(alias).is_empty()
+    }
+
+    /// Number of distinct declared aliases in the vault.
+    #[must_use]
+    pub fn alias_count(&self) -> usize {
+        self.alias_map.len()
     }
 
     /// Return all candidate paths for a bare filename stem (case-insensitive).

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -2218,6 +2218,129 @@ mod tests {
     use super::*;
     use std::fs;
 
+    // --- iter-272 Part B (DEC-288): frontmatter `aliases:` resolution ---
+
+    /// Build a vault whose notes declare aliases, plus the matching index.
+    fn alias_vault(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf, CaseInsensitiveIndex) {
+        let tmp = tempfile::tempdir().unwrap();
+        for (rel, body) in files {
+            let p = tmp.path().join(rel);
+            if let Some(parent) = p.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(p, body).unwrap();
+        }
+        let canon = canonicalize_vault_dir(tmp.path()).unwrap();
+        let mut idx = CaseInsensitiveIndex::new();
+        idx.set_case_insensitive_paths(true);
+        for f in discover_files(tmp.path()).unwrap() {
+            idx.insert(&relative_path(tmp.path(), &f));
+        }
+        populate_aliases_from_dir(tmp.path(), &mut idx);
+        (tmp, canon, idx)
+    }
+
+    #[test]
+    fn a_unique_alias_resolves_and_reports_via_alias() {
+        let (_tmp, canon, idx) = alias_vault(&[
+            ("Leah Ferguson.md", "---\ntitle: Leah Ferguson\naliases:\n- Leah\n---\n"),
+            ("src.md", "see [[Leah]]\n"),
+        ]);
+        assert_eq!(
+            resolve_target(&canon, "Leah", None, Some(&idx)).as_deref(),
+            Some("Leah Ferguson.md")
+        );
+        assert!(resolves_via_alias("Leah", Some(&idx)));
+        // Case folds like every other lookup (DEC-267).
+        assert_eq!(
+            resolve_target(&canon, "leah", None, Some(&idx)).as_deref(),
+            Some("Leah Ferguson.md")
+        );
+    }
+
+    #[test]
+    fn a_filename_always_beats_someone_elses_alias() {
+        let (_tmp, canon, idx) = alias_vault(&[
+            ("Leah.md", "---\ntitle: The real Leah\n---\n"),
+            (
+                "Leah Ferguson.md",
+                "---\ntitle: Leah Ferguson\naliases:\n- Leah\n---\n",
+            ),
+        ]);
+        assert_eq!(
+            resolve_target(&canon, "Leah", None, Some(&idx)).as_deref(),
+            Some("Leah.md")
+        );
+        assert!(
+            !resolves_via_alias("Leah", Some(&idx)),
+            "a filename match is not a `via: alias` resolution"
+        );
+    }
+
+    #[test]
+    fn an_alias_claimed_by_two_notes_is_ambiguous_not_resolved() {
+        let (_tmp, canon, idx) = alias_vault(&[
+            ("a.md", "---\ntitle: A\naliases:\n- Shared\n---\n"),
+            ("b.md", "---\ntitle: B\naliases: Shared\n---\n"),
+        ]);
+        assert_eq!(idx.lookup_alias_all("shared").len(), 2);
+        assert_eq!(resolve_target(&canon, "Shared", None, Some(&idx)), None);
+        assert!(!resolves_via_alias("Shared", Some(&idx)));
+    }
+
+    #[test]
+    fn the_string_form_of_aliases_is_accepted() {
+        let (_tmp, canon, idx) = alias_vault(&[
+            ("Leah Ferguson.md", "---\ntitle: L\naliases: Leah\n---\n"),
+        ]);
+        assert_eq!(
+            resolve_target(&canon, "Leah", None, Some(&idx)).as_deref(),
+            Some("Leah Ferguson.md")
+        );
+    }
+
+    #[test]
+    fn an_alias_with_a_fragment_or_label_still_resolves() {
+        let (_tmp, canon, idx) = alias_vault(&[
+            (
+                "Leah Ferguson.md",
+                "---\ntitle: L\naliases:\n- Leah\n---\n\n## Work\n",
+            ),
+        ]);
+        // `resolve_target` strips the fragment; the alias half is what is left.
+        assert_eq!(
+            resolve_target(&canon, "Leah#Work", None, Some(&idx)).as_deref(),
+            Some("Leah Ferguson.md")
+        );
+        // A `[[alias|label]]` never reaches the resolver with its label — the
+        // extractor splits it off — so the target is the bare alias.
+        assert_eq!(
+            resolve_target(&canon, "Leah", None, Some(&idx)).as_deref(),
+            Some("Leah Ferguson.md")
+        );
+    }
+
+    #[test]
+    fn a_note_aliasing_its_own_stem_changes_nothing() {
+        let (_tmp, canon, idx) = alias_vault(&[
+            ("note.md", "---\ntitle: N\naliases:\n- note\n---\n"),
+        ]);
+        assert_eq!(
+            resolve_target(&canon, "note", None, Some(&idx)).as_deref(),
+            Some("note.md")
+        );
+        assert!(!resolves_via_alias("note", Some(&idx)));
+    }
+
+    #[test]
+    fn a_path_qualified_target_never_consults_aliases() {
+        let (_tmp, canon, idx) = alias_vault(&[
+            ("sub/Leah Ferguson.md", "---\ntitle: L\naliases:\n- Leah\n---\n"),
+        ]);
+        assert_eq!(resolve_target(&canon, "sub/Leah", None, Some(&idx)), None);
+        assert!(!resolves_via_alias("sub/Leah", Some(&idx)));
+    }
+
     // --- iter-265: `[scan] exclude` glob matching ---
 
     /// Compile a `[scan] exclude` set without touching the process-global

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -2175,12 +2175,34 @@ pub fn populate_aliases_from_dir(dir: &Path, idx: &mut CaseInsensitiveIndex) {
     let Ok(files) = discover_files(dir) else {
         return;
     };
-    for file in &files {
-        let aliases = read_aliases(file);
-        if aliases.is_empty() {
-            continue;
-        }
-        idx.insert_aliases(&relative_path(dir, file), aliases);
+    // Read in parallel, like `ScannedIndex::build` does: the pass is pure I/O
+    // latency over thousands of small reads, and serially it cost 0.19 s of
+    // the 0.66 s `find --broken-links --count` takes on the Obsidian Hub
+    // (6393 notes). Insertion stays serial and in `discover_files` order, so
+    // the alias map — and therefore every ambiguity verdict — is
+    // deterministic.
+    #[cfg(not(miri))]
+    let collected: Vec<(String, Vec<String>)> = {
+        use rayon::prelude::*;
+        files
+            .par_iter()
+            .filter_map(|file| {
+                let aliases = read_aliases(file);
+                (!aliases.is_empty()).then(|| (relative_path(dir, file), aliases))
+            })
+            .collect()
+    };
+    #[cfg(miri)]
+    let collected: Vec<(String, Vec<String>)> = files
+        .iter()
+        .filter_map(|file| {
+            let aliases = read_aliases(file);
+            (!aliases.is_empty()).then(|| (relative_path(dir, file), aliases))
+        })
+        .collect();
+
+    for (rel, aliases) in collected {
+        idx.insert_aliases(&rel, aliases);
     }
 }
 
@@ -2243,7 +2265,10 @@ mod tests {
     #[test]
     fn a_unique_alias_resolves_and_reports_via_alias() {
         let (_tmp, canon, idx) = alias_vault(&[
-            ("Leah Ferguson.md", "---\ntitle: Leah Ferguson\naliases:\n- Leah\n---\n"),
+            (
+                "Leah Ferguson.md",
+                "---\ntitle: Leah Ferguson\naliases:\n- Leah\n---\n",
+            ),
             ("src.md", "see [[Leah]]\n"),
         ]);
         assert_eq!(
@@ -2290,9 +2315,8 @@ mod tests {
 
     #[test]
     fn the_string_form_of_aliases_is_accepted() {
-        let (_tmp, canon, idx) = alias_vault(&[
-            ("Leah Ferguson.md", "---\ntitle: L\naliases: Leah\n---\n"),
-        ]);
+        let (_tmp, canon, idx) =
+            alias_vault(&[("Leah Ferguson.md", "---\ntitle: L\naliases: Leah\n---\n")]);
         assert_eq!(
             resolve_target(&canon, "Leah", None, Some(&idx)).as_deref(),
             Some("Leah Ferguson.md")
@@ -2301,12 +2325,10 @@ mod tests {
 
     #[test]
     fn an_alias_with_a_fragment_or_label_still_resolves() {
-        let (_tmp, canon, idx) = alias_vault(&[
-            (
-                "Leah Ferguson.md",
-                "---\ntitle: L\naliases:\n- Leah\n---\n\n## Work\n",
-            ),
-        ]);
+        let (_tmp, canon, idx) = alias_vault(&[(
+            "Leah Ferguson.md",
+            "---\ntitle: L\naliases:\n- Leah\n---\n\n## Work\n",
+        )]);
         // `resolve_target` strips the fragment; the alias half is what is left.
         assert_eq!(
             resolve_target(&canon, "Leah#Work", None, Some(&idx)).as_deref(),
@@ -2322,9 +2344,8 @@ mod tests {
 
     #[test]
     fn a_note_aliasing_its_own_stem_changes_nothing() {
-        let (_tmp, canon, idx) = alias_vault(&[
-            ("note.md", "---\ntitle: N\naliases:\n- note\n---\n"),
-        ]);
+        let (_tmp, canon, idx) =
+            alias_vault(&[("note.md", "---\ntitle: N\naliases:\n- note\n---\n")]);
         assert_eq!(
             resolve_target(&canon, "note", None, Some(&idx)).as_deref(),
             Some("note.md")
@@ -2334,9 +2355,10 @@ mod tests {
 
     #[test]
     fn a_path_qualified_target_never_consults_aliases() {
-        let (_tmp, canon, idx) = alias_vault(&[
-            ("sub/Leah Ferguson.md", "---\ntitle: L\naliases:\n- Leah\n---\n"),
-        ]);
+        let (_tmp, canon, idx) = alias_vault(&[(
+            "sub/Leah Ferguson.md",
+            "---\ntitle: L\naliases:\n- Leah\n---\n",
+        )]);
         assert_eq!(resolve_target(&canon, "sub/Leah", None, Some(&idx)), None);
         assert!(!resolves_via_alias("sub/Leah", Some(&idx)));
     }

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -217,7 +217,7 @@ fn glob_dir_prefix(glob: &str) -> String {
 }
 
 /// Process-wide switch for frontmatter-`aliases:` link resolution
-/// (iter-272 Part B, DEC-288). Default **on**, like DEC-267 case folding.
+/// (iter-272 Part B, DEC-296). Default **on**, like DEC-267 case folding.
 static LINK_ALIASES: OnceLock<bool> = OnceLock::new();
 
 /// Install the effective `[links] aliases` setting for this process.
@@ -1572,7 +1572,7 @@ fn classify_short_form_wikilink(
         stem_index.lookup(target)
     };
 
-    // iter-272 Part B (DEC-288): no file carries that stem — but a note may
+    // iter-272 Part B (DEC-296): no file carries that stem — but a note may
     // declare it as a frontmatter alias, which is how Obsidian resolves
     // `[[Leah]]` to `Leah Ferguson.md`. An alias-resolved link is *valid as
     // written*: it needs no rewrite, so it is `ShortFormValid` rather than a
@@ -2110,7 +2110,7 @@ pub fn resolve_target(
                 return Some(canonical_path.to_owned());
             }
         }
-        // iter-272 Part B (DEC-288): last resort — a frontmatter `aliases:`
+        // iter-272 Part B (DEC-296): last resort — a frontmatter `aliases:`
         // entry. Obsidian resolves `[[Leah]]` to the note declaring
         // `aliases: [Leah]`, and 7 of the Obsidian Hub's 47 genuinely-broken
         // targets were exactly that. Deliberately *after* every path and stem
@@ -2163,7 +2163,7 @@ pub fn read_aliases(path: &Path) -> Vec<String> {
 }
 
 /// Populate `idx` with every note's declared frontmatter `aliases:` by
-/// scanning the vault's frontmatter (iter-272 Part B, DEC-288).
+/// scanning the vault's frontmatter (iter-272 Part B, DEC-296).
 ///
 /// Only the frontmatter of each file is read — the visitor stops the scan the
 /// moment the properties are parsed — so the pass costs one `open` + one short
@@ -2218,7 +2218,7 @@ mod tests {
     use super::*;
     use std::fs;
 
-    // --- iter-272 Part B (DEC-288): frontmatter `aliases:` resolution ---
+    // --- iter-272 Part B (DEC-296): frontmatter `aliases:` resolution ---
 
     /// Build a vault whose notes declare aliases, plus the matching index.
     fn alias_vault(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf, CaseInsensitiveIndex) {

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -216,6 +216,27 @@ fn glob_dir_prefix(glob: &str) -> String {
     kept.join("/")
 }
 
+/// Process-wide switch for frontmatter-`aliases:` link resolution
+/// (iter-272 Part B, DEC-288). Default **on**, like DEC-267 case folding.
+static LINK_ALIASES: OnceLock<bool> = OnceLock::new();
+
+/// Install the effective `[links] aliases` setting for this process.
+///
+/// Idempotent-once, exactly like [`set_scan_include`]: the CLI calls it once
+/// after config resolution, before any command runs. Following that pattern
+/// keeps the setting off the signature of every resolver, index builder and
+/// graph pass that would otherwise have to forward it.
+pub fn set_link_aliases(enabled: bool) {
+    let _ = LINK_ALIASES.set(enabled);
+}
+
+/// Whether frontmatter `aliases:` resolve links in this process. Defaults to
+/// `true` when nothing configured it (library callers, tests).
+#[must_use]
+pub fn link_aliases_enabled() -> bool {
+    LINK_ALIASES.get().copied().unwrap_or(true)
+}
+
 /// Install the `[scan] include` glob set for this process.
 ///
 /// Idempotent-once: only the first call takes effect (the walker reads it
@@ -1551,6 +1572,23 @@ fn classify_short_form_wikilink(
         stem_index.lookup(target)
     };
 
+    // iter-272 Part B (DEC-288): no file carries that stem — but a note may
+    // declare it as a frontmatter alias, which is how Obsidian resolves
+    // `[[Leah]]` to `Leah Ferguson.md`. An alias-resolved link is *valid as
+    // written*: it needs no rewrite, so it is `ShortFormValid` rather than a
+    // relocation, and it never reaches the fuzzy matcher — which used to offer
+    // `Leah → Lewuathe.md` at confidence 0.87 on the Obsidian Hub. Two notes
+    // claiming one alias is ambiguous, exactly like two files sharing a stem.
+    if matches.is_empty()
+        && let Some(idx) = case_index
+    {
+        match idx.lookup_alias_all(target).len() {
+            0 => {}
+            1 => return Some(LinkResolution::ShortFormValid),
+            _ => return Some(LinkResolution::ShortFormAmbiguous),
+        }
+    }
+
     match matches.len() {
         0 => Some(LinkResolution::Broken),
         1 => {
@@ -2072,9 +2110,107 @@ pub fn resolve_target(
                 return Some(canonical_path.to_owned());
             }
         }
+        // iter-272 Part B (DEC-288): last resort — a frontmatter `aliases:`
+        // entry. Obsidian resolves `[[Leah]]` to the note declaring
+        // `aliases: [Leah]`, and 7 of the Obsidian Hub's 47 genuinely-broken
+        // targets were exactly that. Deliberately *after* every path and stem
+        // attempt, so a real filename always wins over someone else's alias;
+        // `lookup_alias` answers `None` when two notes claim the same alias,
+        // which keeps the link ambiguous rather than resolving it to whichever
+        // note happened to be scanned first.
+        if let Some(canonical_path) = idx.lookup_alias(stem) {
+            let full_resolved = canonical_dir.join(canonical_path);
+            if ensure_within_vault(canonical_dir, &full_resolved).unwrap_or(false) {
+                return Some(canonical_path.to_owned());
+            }
+        }
     }
 
     None
+}
+
+/// Visitor that reads a file's frontmatter `aliases:` and stops before the
+/// body — the cheapest scan the scanner offers (iter-272 Part B).
+struct AliasVisitor {
+    aliases: Vec<String>,
+}
+
+impl crate::scanner::FileVisitor for AliasVisitor {
+    fn on_frontmatter(
+        &mut self,
+        props: indexmap::IndexMap<String, serde_json::Value>,
+    ) -> crate::scanner::ScanAction {
+        self.aliases = crate::filter::extract_aliases(&props);
+        // Nothing below the frontmatter matters, so the body is never read.
+        crate::scanner::ScanAction::Stop
+    }
+}
+
+/// Read one file's declared frontmatter `aliases:` without reading its body.
+///
+/// Returns an empty vec for a file with no frontmatter, no `aliases:` key, or
+/// unparseable YAML — an alias map is an optimisation of resolution, never a
+/// reason to fail a command.
+#[must_use]
+pub fn read_aliases(path: &Path) -> Vec<String> {
+    let mut visitor = AliasVisitor {
+        aliases: Vec::new(),
+    };
+    match crate::scanner::scan_file_multi(path, &mut [&mut visitor]) {
+        Ok(()) => visitor.aliases,
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Populate `idx` with every note's declared frontmatter `aliases:` by
+/// scanning the vault's frontmatter (iter-272 Part B, DEC-288).
+///
+/// Only the frontmatter of each file is read — the visitor stops the scan the
+/// moment the properties are parsed — so the pass costs one `open` + one short
+/// `read` per note and touches no body bytes.
+pub fn populate_aliases_from_dir(dir: &Path, idx: &mut CaseInsensitiveIndex) {
+    if !link_aliases_enabled() {
+        return;
+    }
+    let Ok(files) = discover_files(dir) else {
+        return;
+    };
+    for file in &files {
+        let aliases = read_aliases(file);
+        if aliases.is_empty() {
+            continue;
+        }
+        idx.insert_aliases(&relative_path(dir, file), aliases);
+    }
+}
+
+/// Whether `target`, written in `source_rel`, resolves only because some note
+/// declares it as a frontmatter alias (iter-272 Part B).
+///
+/// Used to label a resolved link with `via: "alias"` and to stop `links fix`
+/// from fuzzy-rewriting a target that is a perfectly good alias. Answers
+/// `false` for every target that a path or stem lookup would have resolved.
+#[must_use]
+pub fn resolves_via_alias(target: &str, case_index: Option<&CaseInsensitiveIndex>) -> bool {
+    let Some(idx) = case_index else {
+        return false;
+    };
+    // Only a bare, non-site-absolute target can name an alias — the same guard
+    // `resolve_target` applies before its stem and alias lookups.
+    if target.is_empty() || target.contains('/') || target.contains('\\') {
+        return false;
+    }
+    let stem = target
+        .strip_suffix(".md")
+        .or_else(|| target.strip_suffix(".MD"))
+        .unwrap_or(target);
+    let stem = stem.split('#').next().unwrap_or(stem);
+    if stem.is_empty() || !idx.has_alias(stem) {
+        return false;
+    }
+    // A filename always beats an alias, so a target the stem map already
+    // answers did not resolve "via alias" even when an alias also matches.
+    idx.lookup_stem(stem).is_none() && idx.lookup_alias(stem).is_some()
 }
 
 #[cfg(test)]

--- a/crates/hyalo-core/src/filter/match_props.rs
+++ b/crates/hyalo-core/src/filter/match_props.rs
@@ -38,6 +38,44 @@ pub fn extract_tags(props: &IndexMap<String, Value>) -> Vec<String> {
     }
 }
 
+/// The frontmatter property Obsidian reads alternative note names from.
+pub const ALIASES_PROPERTY: &str = "aliases";
+
+/// Extract the declared `aliases:` of a note from its parsed frontmatter
+/// (iter-272 Part B, DEC-288).
+///
+/// Obsidian accepts both shapes its property editor can write:
+/// - a list — `aliases:\n  - Leah\n  - L. Ferguson`
+/// - a bare string — `aliases: Leah`
+///
+/// Non-string list items (a number, a nested map) are skipped, as are empty
+/// and whitespace-only entries: neither can be typed inside `[[…]]`. No other
+/// property is read — `alias:` (singular) and `title:` are deliberately not
+/// alias sources.
+#[must_use]
+pub fn extract_aliases(props: &IndexMap<String, Value>) -> Vec<String> {
+    match props.get(ALIASES_PROPERTY) {
+        Some(Value::Array(seq)) => seq
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.trim()),
+                _ => None,
+            })
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect(),
+        Some(Value::String(s)) => {
+            let s = s.trim();
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![s.to_owned()]
+            }
+        }
+        _ => vec![],
+    }
+}
+
 /// Returns true if `tag` matches the query under Obsidian's nested tag rules.
 /// A tag matches if it equals the query or starts with `query/` (case-insensitive,
 /// using ASCII-only case folding via `eq_ignore_ascii_case`).

--- a/crates/hyalo-core/src/filter/match_props.rs
+++ b/crates/hyalo-core/src/filter/match_props.rs
@@ -42,7 +42,7 @@ pub fn extract_tags(props: &IndexMap<String, Value>) -> Vec<String> {
 pub const ALIASES_PROPERTY: &str = "aliases";
 
 /// Extract the declared `aliases:` of a note from its parsed frontmatter
-/// (iter-272 Part B, DEC-288).
+/// (iter-272 Part B, DEC-296).
 ///
 /// Obsidian accepts both shapes its property editor can write:
 /// - a list — `aliases:\n  - Leah\n  - L. Ferguson`

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -6,7 +6,8 @@ mod tasks;
 
 pub use fields::{DEFAULT_FIELD_NAMES, Fields};
 pub use match_props::{
-    ALIASES_PROPERTY, extract_aliases, extract_tags, matches_filters_with_tags, matches_frontmatter_filters, tag_matches,
+    ALIASES_PROPERTY, extract_aliases, extract_tags, matches_filters_with_tags,
+    matches_frontmatter_filters, tag_matches,
 };
 pub use parse::{FilterOp, PropertyFilter, parse_property_filter};
 pub use sort::{SortField, compare_property_values, parse_sort};

--- a/crates/hyalo-core/src/filter/mod.rs
+++ b/crates/hyalo-core/src/filter/mod.rs
@@ -6,7 +6,7 @@ mod tasks;
 
 pub use fields::{DEFAULT_FIELD_NAMES, Fields};
 pub use match_props::{
-    extract_tags, matches_filters_with_tags, matches_frontmatter_filters, tag_matches,
+    ALIASES_PROPERTY, extract_aliases, extract_tags, matches_filters_with_tags, matches_frontmatter_filters, tag_matches,
 };
 pub use parse::{FilterOp, PropertyFilter, parse_property_filter};
 pub use sort::{SortField, compare_property_values, parse_sort};

--- a/crates/hyalo-core/src/frontmatter_links.rs
+++ b/crates/hyalo-core/src/frontmatter_links.rs
@@ -313,6 +313,31 @@ mod tests {
         assert!(targets("note: \"[[not closed\"\n").is_empty());
     }
 
+    /// iter-272 BOUND-2 (BUG-15): a YAML flow list written without spaces
+    /// starts `[[[`. The raw-text scanner used to capture `[iterations/x`.
+    #[test]
+    fn flow_list_opening_with_three_brackets_yields_both_links() {
+        assert_eq!(
+            targets("related: [[[iterations/x]], [[research/y]]]\n")
+                .into_iter()
+                .map(|(_, _, t)| t)
+                .collect::<Vec<_>>(),
+            vec!["iterations/x".to_string(), "research/y".to_string()]
+        );
+    }
+
+    /// iter-272 BOUND-1 (BUG-16): a stray `]` ends the capture.
+    #[test]
+    fn stray_close_bracket_in_frontmatter_does_not_swallow_prose() {
+        assert_eq!(
+            targets("note: \"[[Leah] here and [[Target]]\"\n")
+                .into_iter()
+                .map(|(_, _, t)| t)
+                .collect::<Vec<_>>(),
+            vec!["Target".to_string()]
+        );
+    }
+
     #[test]
     fn non_string_values_are_ignored() {
         assert!(targets("count: 3\ndone: true\nempty:\n").is_empty());

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -255,7 +255,7 @@ impl ScannedIndex {
         entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
 
         let graph = if options.scan_body {
-            // iter-272 Part B (DEC-288): every entry's frontmatter is already
+            // iter-272 Part B (DEC-296): every entry's frontmatter is already
             // parsed, so the declared `aliases:` come for free — the graph
             // resolves an alias-named wikilink to the same file
             // `find --fields links` reports, and `backlinks` / `--orphan` /

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -255,7 +255,23 @@ impl ScannedIndex {
         entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
 
         let graph = if options.scan_body {
-            let graph_build = LinkGraph::from_file_links(file_links_vec, site_prefix);
+            // iter-272 Part B (DEC-288): every entry's frontmatter is already
+            // parsed, so the declared `aliases:` come for free — the graph
+            // resolves an alias-named wikilink to the same file
+            // `find --fields links` reports, and `backlinks` / `--orphan` /
+            // `--dead-end` / `summary.links` all agree with it.
+            let aliases: Vec<(String, Vec<String>)> = if crate::discovery::link_aliases_enabled() {
+                entries
+                    .iter()
+                    .filter_map(|e| {
+                        let declared = crate::filter::extract_aliases(&e.properties);
+                        (!declared.is_empty()).then(|| (e.rel_path.clone(), declared))
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let graph_build = LinkGraph::from_file_links(file_links_vec, site_prefix, &aliases);
             graph_build.graph
         } else {
             LinkGraph::default()

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -18,7 +18,7 @@ use crate::case_index::CaseInsensitiveIndex;
 use crate::filter::extract_tags;
 use crate::frontmatter;
 use crate::link_graph::{FileLinks, LinkGraph, LinkGraphVisitor};
-use crate::links::Link;
+use crate::links::{Link, SelfAnchor};
 use crate::scanner::{self, FileVisitor, FrontmatterCollector, ScanAction};
 use crate::tasks::TaskExtractor;
 use crate::types::{FindTaskInfo, OutlineSection, TaskCount};
@@ -63,7 +63,7 @@ pub struct IndexEntry {
     /// (iter-211 / BUG-8). Defaulted + skipped when empty so snapshots written
     /// by older hyalo versions keep loading.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub self_anchors: Vec<(usize, String)>,
+    pub self_anchors: Vec<SelfAnchor>,
     /// Pre-tokenized BM25 tokens (body + title, stemmed). Populated by `create-index`
     /// when `scan_body` is `true`. `None` when the index was created before BM25
     /// support or with `scan_body = false`.

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -3274,7 +3274,12 @@ See [broken](old-name.md) here.
             sections: Vec::new(),
             tasks: Vec::new(),
             links: Vec::new(),
-            self_anchors: vec![(1, "nope".to_string())],
+            self_anchors: vec![crate::links::SelfAnchor {
+                line: 1,
+                fragment: "nope".to_string(),
+                kind: crate::links::LinkKind::Wikilink,
+                label: None,
+            }],
             bm25_tokens: None,
             bm25_language: None,
             bm25_tokenizer_version: None,

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -2586,7 +2586,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
         assert_eq!(plans.len(), 1);
         assert!(unapplied.is_empty(), "unexpected unapplied: {unapplied:?}");
         assert!(rejected.is_empty(), "unexpected rejected: {rejected:?}");
@@ -2633,7 +2634,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
         assert!(plans.is_empty(), "nothing may be written: {plans:?}");
         assert!(unapplied.is_empty(), "not a stale-text case: {unapplied:?}");
         assert_eq!(rejected.len(), 1, "guard must reject the fix: {rejected:?}");
@@ -2771,7 +2773,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2804,7 +2807,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2933,7 +2937,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1, "frontmatter fix must produce a RewritePlan");
         assert!(
@@ -2968,7 +2973,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -3013,7 +3019,8 @@ See [broken](old-name.md) here.
             },
         ];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -3058,7 +3065,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -3089,7 +3097,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -3123,7 +3132,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert!(plans.is_empty(), "no replacement should have been produced");
         assert_eq!(unapplied.len(), 1);
@@ -3157,7 +3167,8 @@ See [broken](old-name.md) here.
         };
         let fixes = vec![plan.clone(), plan];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].replacements.len(), 1);
@@ -3193,7 +3204,8 @@ See [broken](old-name.md) here.
             emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(unapplied.is_empty(), "unexpected unapplied: {unapplied:?}");
@@ -3229,7 +3241,8 @@ See [broken](old-name.md) here.
         };
         let fixes = vec![plan.clone(), plan];
 
-        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) =
+            apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].replacements.len(), 2);

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -111,6 +111,57 @@ pub struct FixPlan {
     pub strategy: FixStrategy,
     /// Similarity confidence in `[0.0, 1.0]`.
     pub confidence: f64,
+    /// The link-target text `--apply` actually writes for this plan
+    /// (iter-272 Part F / CASE-2).
+    ///
+    /// [`new_target`](Self::new_target) is always the *vault-relative path*,
+    /// which is the coordinate system detection works in — but the writer
+    /// emits the form the author wrote: a wikilink loses the `.md`, a markdown
+    /// destination is re-expressed file-relative or site-absolute, and a
+    /// directory-index rewrite keeps the author's directory spelling. Reading
+    /// the dry-run JSON therefore did not tell you the bytes that would land
+    /// on disk. Both `--dry-run` and `--apply` fill this in from the *same*
+    /// `build_replacements_for_file` pass, so the two can never disagree.
+    ///
+    /// `None` on a freshly detected plan (nothing has consulted the file yet)
+    /// and on a plan whose occurrence was not found on disk; skipped from JSON
+    /// in that case, so an unannotated report keeps its previous shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emitted_target: Option<String>,
+}
+
+/// Identity of a fix plan for emitted-target lookup: `(source, line,
+/// old_target, new_target)`.
+pub type FixPlanKey = (String, usize, String, String);
+
+/// The text `--apply` writes, keyed by [`FixPlanKey`] (iter-272 Part F).
+pub type EmittedTargets = HashMap<FixPlanKey, String>;
+
+impl FixPlan {
+    /// This plan's lookup key in an [`EmittedTargets`] map.
+    #[must_use]
+    pub fn key(&self) -> FixPlanKey {
+        (
+            self.source.clone(),
+            self.line,
+            self.old_target.clone(),
+            self.new_target.clone(),
+        )
+    }
+}
+
+/// Copy the emitted target text onto every plan in `fixes` that the planner
+/// produced one for (iter-272 Part F).
+///
+/// Called by the reporting layer once per bucket, so every `links fix` list —
+/// `fixes`, `fuzzy_fixes`, `case_mismatch_fixes`, `relocation_fixes`,
+/// `applied_fixes` — carries the string that lands on disk.
+pub fn annotate_emitted_targets(fixes: &mut [FixPlan], emitted: &EmittedTargets) {
+    for fix in fixes {
+        if let Some(text) = emitted.get(&fix.key()) {
+            fix.emitted_target = Some(text.clone());
+        }
+    }
 }
 
 /// How a candidate file was matched to a broken link target.
@@ -214,11 +265,18 @@ pub fn is_templated_target(target: &str) -> bool {
 /// Tuple order: `(applied_plans, unapplied, failed, rejected)` — see
 /// [`apply_fixes`] for what each bucket means. Named so the four-way split
 /// stays readable at the call site.
-pub type ApplyOutcome = (Vec<RewritePlan>, Vec<FixPlan>, Vec<FailedFix>, Vec<FixPlan>);
+pub type ApplyOutcome = (
+    Vec<RewritePlan>,
+    Vec<FixPlan>,
+    Vec<FailedFix>,
+    Vec<FixPlan>,
+    EmittedTargets,
+);
 
-/// What one dry-run pass would do: `(would_modify, unapplied, rejected)` —
-/// see [`plan_fixes_dry_run`].
-pub type DryRunOutcome = (Vec<String>, Vec<FixPlan>, Vec<FixPlan>);
+/// What one dry-run pass would do: `(would_modify, unapplied, rejected,
+/// emitted)` — see [`plan_fixes_dry_run`]. `emitted` maps each planned fix to
+/// the link text `--apply` would write for it (iter-272 Part F).
+pub type DryRunOutcome = (Vec<String>, Vec<FixPlan>, Vec<FixPlan>, EmittedTargets);
 
 /// A fix whose source file's on-disk write failed during `--apply` (L-11).
 ///
@@ -444,6 +502,7 @@ pub fn detect_broken_links_from_index(
                         new_target: canonical_str,
                         strategy: FixStrategy::LinkCaseMismatch,
                         confidence: 1.0,
+                        emitted_target: None,
                     });
                 }
                 LinkResolution::StemRelocation(canonical_str) => {
@@ -489,6 +548,7 @@ pub fn detect_broken_links_from_index(
                         new_target: canonical_str,
                         strategy: FixStrategy::ShortestPath,
                         confidence: SHORTEST_PATH_CONFIDENCE,
+                        emitted_target: None,
                     });
                 }
                 LinkResolution::ShortFormStemMismatch(correct_stem) => {
@@ -499,6 +559,7 @@ pub fn detect_broken_links_from_index(
                         new_target: correct_stem,
                         strategy: FixStrategy::LinkCaseMismatch,
                         confidence: 1.0,
+                        emitted_target: None,
                     });
                 }
                 LinkResolution::ShortFormAmbiguous => {
@@ -993,6 +1054,7 @@ pub fn plan_fixes(broken: &[BrokenLinkInfo], matcher: &LinkMatcher) -> FixReport
                 new_target: result.matched_file,
                 strategy: result.strategy,
                 confidence: result.confidence,
+                emitted_target: None,
             });
         } else {
             unfixable.push(info.clone());
@@ -1053,6 +1115,9 @@ pub fn apply_fixes(
     // file whose read fails do not abort the batch; the remaining source
     // files still get their plans built and applied.
     let mut io_failed: Vec<FailedFix> = Vec::new();
+    // iter-272 Part F: the emitted link text per plan, so the caller can
+    // report the exact string that was written.
+    let mut emitted: EmittedTargets = HashMap::new();
     // Map each plan's rel_path → the fixes it carries, so a mid-batch write
     // failure can be reported against the specific fixes that did not land.
     let mut fixes_by_plan: HashMap<String, Vec<FixPlan>> = HashMap::new();
@@ -1085,8 +1150,11 @@ pub fn apply_fixes(
             }
         };
 
-        let (replacements, satisfied, guard_rejected) =
+        let (replacements, satisfied, guard_rejected, file_emitted) =
             build_replacements_for_file(&content, source_rel, file_fixes, site_prefix);
+        for (idx, text) in file_emitted {
+            emitted.insert(file_fixes[idx].key(), text);
+        }
 
         let mut satisfied_fixes: Vec<FixPlan> = Vec::new();
         for (idx, fix) in file_fixes.iter().enumerate() {
@@ -1142,7 +1210,7 @@ pub fn apply_fixes(
     }
 
     rejected.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
-    Ok((applied_plans, unapplied, failed, rejected))
+    Ok((applied_plans, unapplied, failed, rejected, emitted))
 }
 
 /// Outcome of reading a source file's on-disk content for fix planning.
@@ -1214,6 +1282,9 @@ pub fn plan_fixes_dry_run(
     let mut would_modify: Vec<String> = Vec::new();
     let mut unapplied: Vec<FixPlan> = Vec::new();
     let mut rejected: Vec<FixPlan> = Vec::new();
+    // iter-272 Part F: the same emitted-text map `apply_fixes` builds, from
+    // the same pass — this is what makes the preview byte-accurate.
+    let mut emitted: EmittedTargets = HashMap::new();
 
     for (source_rel, file_fixes) in &by_source {
         let abs_path = dir.join(source_rel.replace('\\', "/"));
@@ -1231,8 +1302,11 @@ pub fn plan_fixes_dry_run(
             }
         };
 
-        let (replacements, satisfied, guard_rejected) =
+        let (replacements, satisfied, guard_rejected, file_emitted) =
             build_replacements_for_file(&content, source_rel, file_fixes, site_prefix);
+        for (idx, text) in file_emitted {
+            emitted.insert(file_fixes[idx].key(), text);
+        }
 
         for (idx, fix) in file_fixes.iter().enumerate() {
             if guard_rejected.contains(&idx) {
@@ -1250,7 +1324,7 @@ pub fn plan_fixes_dry_run(
     would_modify.sort();
     unapplied.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
     rejected.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.line.cmp(&b.line)));
-    Ok((would_modify, unapplied, rejected))
+    Ok((would_modify, unapplied, rejected, emitted))
 }
 
 // ---------------------------------------------------------------------------
@@ -1452,6 +1526,7 @@ fn build_replacements_for_file(
     Vec<Replacement>,
     std::collections::HashSet<usize>,
     std::collections::HashSet<usize>,
+    HashMap<usize, String>,
 ) {
     // Index fixes by line number for O(1) lookup during the scan, carrying
     // each plan's index into `fixes` for per-occurrence satisfaction
@@ -1464,6 +1539,11 @@ fn build_replacements_for_file(
     let mut replacements = Vec::new();
     let mut satisfied: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let mut rejected: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    // iter-272 Part F: the *emitted* target per plan — the bytes that land on
+    // disk, which are not the plan's vault-relative `new_target`. Recorded
+    // here, in the one pass both `--dry-run` and `--apply` share, so the two
+    // can never report different strings for the same fix.
+    let mut emitted_by_fix: HashMap<usize, String> = HashMap::new();
     // Shared, cross-line-aware line classifier (iter-183 Phase B): one lexer
     // for frontmatter, fences, `%%` comments, and cross-line code/HTML spans.
     let mut scanner = LineScanner::new();
@@ -1611,6 +1691,10 @@ fn build_replacements_for_file(
                 }
             };
 
+            emitted_by_fix
+                .entry(fix_idx)
+                .or_insert_with(|| new_target_text.clone());
+
             // A fix whose emitted target would not resolve is never written:
             // it is consumed (so a duplicate plan is not re-matched) and
             // reported as unfixable instead of corrupting the link.
@@ -1641,7 +1725,7 @@ fn build_replacements_for_file(
         }
     }
 
-    (replacements, satisfied, rejected)
+    (replacements, satisfied, rejected, emitted_by_fix)
 }
 
 // ---------------------------------------------------------------------------
@@ -1944,6 +2028,7 @@ mod tests {
             new_target: new_target.to_string(),
             strategy: FixStrategy::CaseInsensitive,
             confidence: 1.0,
+            emitted_target: None,
         }
     }
 
@@ -1954,7 +2039,7 @@ mod tests {
         // `[[decision-log#DEC-041]]` into `[[decision-log-archive]]`.
         let content = "---\nrelated:\n  - \"[[decision-log#DEC-041]]\"\n---\nBody\n";
         let fix = fm_fix("decision-log", "decision-log-archive.md");
-        let (repls, _, _) = build_replacements_for_file(content, "a.md", &[&fix], None);
+        let (repls, _, _, _) = build_replacements_for_file(content, "a.md", &[&fix], None);
         assert_eq!(repls.len(), 1, "one frontmatter link repaired: {repls:?}");
         assert_eq!(repls[0].old_text, "[[decision-log#DEC-041]]");
         assert_eq!(repls[0].new_text, "[[decision-log-archive#DEC-041]]");
@@ -1964,7 +2049,7 @@ mod tests {
     fn build_replacements_frontmatter_repair_preserves_anchor_and_alias() {
         let content = "---\nrelated:\n  - \"[[decision-log#DEC-041|Log]]\"\n---\nBody\n";
         let fix = fm_fix("decision-log", "decision-log-archive.md");
-        let (repls, _, _) = build_replacements_for_file(content, "a.md", &[&fix], None);
+        let (repls, _, _, _) = build_replacements_for_file(content, "a.md", &[&fix], None);
         assert_eq!(repls.len(), 1);
         assert_eq!(repls[0].new_text, "[[decision-log-archive#DEC-041|Log]]");
     }
@@ -1996,8 +2081,9 @@ See [broken](old-name.md) here.
             new_target: "new-name.md".to_string(),
             strategy: FixStrategy::CaseInsensitive,
             confidence: 1.0,
+            emitted_target: None,
         };
-        let (repls, _, _) = build_replacements_for_file(content, "a.md", &[&fix], None);
+        let (repls, _, _, _) = build_replacements_for_file(content, "a.md", &[&fix], None);
         assert_eq!(
             repls.len(),
             1,
@@ -2497,9 +2583,10 @@ See [broken](old-name.md) here.
             new_target: "how-tos/new-home/moved-page.md".to_string(),
             strategy: FixStrategy::BasenameFallback,
             confidence: BASENAME_FALLBACK_CONFIDENCE,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
         assert_eq!(plans.len(), 1);
         assert!(unapplied.is_empty(), "unexpected unapplied: {unapplied:?}");
         assert!(rejected.is_empty(), "unexpected rejected: {rejected:?}");
@@ -2543,9 +2630,10 @@ See [broken](old-name.md) here.
             new_target: "a/../b.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
         assert!(plans.is_empty(), "nothing may be written: {plans:?}");
         assert!(unapplied.is_empty(), "not a stale-text case: {unapplied:?}");
         assert_eq!(rejected.len(), 1, "guard must reject the fix: {rejected:?}");
@@ -2571,9 +2659,10 @@ See [broken](old-name.md) here.
             new_target: "a/../b.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (would_modify, unapplied, rejected) =
+        let (would_modify, unapplied, rejected, _emitted) =
             plan_fixes_dry_run(tmp.path(), &fixes, None).unwrap();
         assert!(would_modify.is_empty(), "nothing would change");
         assert!(unapplied.is_empty());
@@ -2679,9 +2768,10 @@ See [broken](old-name.md) here.
             new_target: "correct-name.md".to_string(),
             strategy: FixStrategy::FuzzyMatch,
             confidence: 0.9,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2711,9 +2801,10 @@ See [broken](old-name.md) here.
             new_target: "correct.md".to_string(),
             strategy: FixStrategy::CaseInsensitive,
             confidence: 1.0,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2725,6 +2816,98 @@ See [broken](old-name.md) here.
             written.contains("[text](correct.md)"),
             "expected rewritten link, got: {written}"
         );
+    }
+
+    // --- iter-272 Part F / CASE-2: dry-run reports the string apply writes ---
+
+    /// A directory-index rewrite under a `site_prefix`: the plan's
+    /// `new_target` is the `.md`-suffixed vault-relative path, but what lands
+    /// on disk keeps the author's site-absolute directory form. Both modes
+    /// must report that same emitted string.
+    #[test]
+    fn dry_run_and_apply_report_the_same_emitted_target() {
+        let tmp = vault_with_files(&[
+            (
+                "sub/src.md",
+                "See [x](wrong.md) and [y](/site/deep) here.\n",
+            ),
+            ("sub/Right.md", ""),
+            ("deep/index.md", ""),
+        ]);
+        let fixes = vec![
+            FixPlan {
+                source: "sub/src.md".to_string(),
+                line: 1,
+                old_target: "wrong.md".to_string(),
+                new_target: "sub/Right.md".to_string(),
+                strategy: FixStrategy::CaseInsensitive,
+                confidence: 1.0,
+                emitted_target: None,
+            },
+            FixPlan {
+                source: "sub/src.md".to_string(),
+                line: 1,
+                old_target: "/site/deep".to_string(),
+                new_target: "deep/index.md".to_string(),
+                strategy: FixStrategy::ShortestPath,
+                confidence: 1.0,
+                emitted_target: None,
+            },
+        ];
+
+        let (_would, _unapplied, _rejected, dry_emitted) =
+            plan_fixes_dry_run(tmp.path(), &fixes, Some("site")).unwrap();
+        // The dry run reports the *written* form, not the vault-relative path.
+        assert_eq!(
+            dry_emitted.get(&fixes[0].key()).map(String::as_str),
+            Some("Right.md"),
+            "{dry_emitted:?}"
+        );
+
+        let (plans, _unapplied, _failed, _rejected, apply_emitted) =
+            apply_fixes(tmp.path(), &fixes, Some("site")).unwrap();
+        assert_eq!(dry_emitted, apply_emitted, "dry-run and apply disagreed");
+
+        // And every emitted string is literally the text now on disk.
+        let written = fs::read_to_string(tmp.path().join("sub/src.md")).unwrap();
+        assert_eq!(plans.len(), 1);
+        for fix in &fixes {
+            if let Some(text) = apply_emitted.get(&fix.key()) {
+                assert!(
+                    written.contains(text.as_str()),
+                    "emitted {text:?} is not in the applied text {written:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn annotate_emitted_targets_stamps_matching_plans_only() {
+        let mut plans = vec![
+            FixPlan {
+                source: "a.md".to_string(),
+                line: 1,
+                old_target: "x".to_string(),
+                new_target: "sub/X.md".to_string(),
+                strategy: FixStrategy::ShortestPath,
+                confidence: 1.0,
+                emitted_target: None,
+            },
+            FixPlan {
+                source: "a.md".to_string(),
+                line: 2,
+                old_target: "y".to_string(),
+                new_target: "sub/Y.md".to_string(),
+                strategy: FixStrategy::ShortestPath,
+                confidence: 1.0,
+                emitted_target: None,
+            },
+        ];
+        let mut emitted = EmittedTargets::new();
+        emitted.insert(plans[0].key(), "sub/X".to_string());
+        annotate_emitted_targets(&mut plans, &emitted);
+        assert_eq!(plans[0].emitted_target.as_deref(), Some("sub/X"));
+        assert_eq!(plans[1].emitted_target, None);
     }
 
     // --- apply_fixes: frontmatter wikilink rewrite (H-bug: frontmatter fixes
@@ -2747,9 +2930,10 @@ See [broken](old-name.md) here.
             new_target: "sub/real-target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1, "frontmatter fix must produce a RewritePlan");
         assert!(
@@ -2781,9 +2965,10 @@ See [broken](old-name.md) here.
             new_target: "sub/real-target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2815,6 +3000,7 @@ See [broken](old-name.md) here.
                 new_target: "sub/real-target.md".to_string(),
                 strategy: FixStrategy::ShortestPath,
                 confidence: 0.95,
+                emitted_target: None,
             },
             FixPlan {
                 source: "a.md".to_string(),
@@ -2823,10 +3009,11 @@ See [broken](old-name.md) here.
                 new_target: "sub/real-target.md".to_string(),
                 strategy: FixStrategy::ShortestPath,
                 confidence: 0.95,
+                emitted_target: None,
             },
         ];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2868,9 +3055,10 @@ See [broken](old-name.md) here.
             new_target: "target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2898,9 +3086,10 @@ See [broken](old-name.md) here.
             new_target: "target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(
@@ -2931,9 +3120,10 @@ See [broken](old-name.md) here.
             new_target: "target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert!(plans.is_empty(), "no replacement should have been produced");
         assert_eq!(unapplied.len(), 1);
@@ -2963,10 +3153,11 @@ See [broken](old-name.md) here.
             new_target: "sub/target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         };
         let fixes = vec![plan.clone(), plan];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].replacements.len(), 1);
@@ -2999,9 +3190,10 @@ See [broken](old-name.md) here.
             new_target: "sub/target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         }];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert!(unapplied.is_empty(), "unexpected unapplied: {unapplied:?}");
@@ -3033,10 +3225,11 @@ See [broken](old-name.md) here.
             new_target: "sub/target.md".to_string(),
             strategy: FixStrategy::ShortestPath,
             confidence: 0.95,
+            emitted_target: None,
         };
         let fixes = vec![plan.clone(), plan];
 
-        let (plans, unapplied, _failed, _rejected) = apply_fixes(tmp.path(), &fixes, None).unwrap();
+        let (plans, unapplied, _failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None).unwrap();
 
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].replacements.len(), 2);
@@ -3808,9 +4001,10 @@ See [broken](old-name.md) here.
             new_target: "correct-name.md".to_string(),
             strategy: FixStrategy::FuzzyMatch,
             confidence: 0.9,
+            emitted_target: None,
         }];
 
-        let (would_modify, unapplied, _rejected) =
+        let (would_modify, unapplied, _rejected, _emitted) =
             plan_fixes_dry_run(tmp.path(), &fixes, None).unwrap();
         assert_eq!(would_modify, vec!["index.md"]);
         assert!(unapplied.is_empty(), "fresh text: nothing stale");
@@ -3840,9 +4034,10 @@ See [broken](old-name.md) here.
             new_target: "correct-name.md".to_string(),
             strategy: FixStrategy::FuzzyMatch,
             confidence: 0.9,
+            emitted_target: None,
         }];
 
-        let (would_modify_dry, unapplied_dry, _rejected_dry) =
+        let (would_modify_dry, unapplied_dry, _rejected_dry, _emitted) =
             plan_fixes_dry_run(tmp.path(), &fixes, None).unwrap();
         assert!(would_modify_dry.is_empty(), "stale fix modifies nothing");
         assert_eq!(
@@ -3852,7 +4047,7 @@ See [broken](old-name.md) here.
         );
 
         // apply must report the identical unapplied set.
-        let (plans, unapplied_apply, failed, _rejected) =
+        let (plans, unapplied_apply, failed, _rejected, _emitted) =
             apply_fixes(tmp.path(), &fixes, None).unwrap();
         assert!(plans.is_empty());
         assert!(failed.is_empty());
@@ -3886,6 +4081,7 @@ See [broken](old-name.md) here.
                 new_target: "correct-name.md".to_string(),
                 strategy: FixStrategy::FuzzyMatch,
                 confidence: 0.9,
+                emitted_target: None,
             },
             FixPlan {
                 source: "still-here.md".to_string(),
@@ -3894,10 +4090,11 @@ See [broken](old-name.md) here.
                 new_target: "correct-name.md".to_string(),
                 strategy: FixStrategy::FuzzyMatch,
                 confidence: 0.9,
+                emitted_target: None,
             },
         ];
 
-        let (plans, unapplied, failed, _rejected) = apply_fixes(tmp.path(), &fixes, None)
+        let (plans, unapplied, failed, _rejected, _emitted) = apply_fixes(tmp.path(), &fixes, None)
             .expect("apply_fixes must not abort on a per-file I/O error");
 
         assert_eq!(
@@ -3942,9 +4139,10 @@ See [broken](old-name.md) here.
             new_target: "correct-name.md".to_string(),
             strategy: FixStrategy::FuzzyMatch,
             confidence: 0.9,
+            emitted_target: None,
         }];
 
-        let (would_modify, unapplied, _rejected) =
+        let (would_modify, unapplied, _rejected, _emitted) =
             plan_fixes_dry_run(tmp.path(), &fixes, None).unwrap();
         assert!(
             would_modify.is_empty(),
@@ -3975,9 +4173,10 @@ See [broken](old-name.md) here.
             new_target: "correct-name.md".to_string(),
             strategy: FixStrategy::FuzzyMatch,
             confidence: 0.9,
+            emitted_target: None,
         }];
 
-        let (would_modify, unapplied, _rejected) =
+        let (would_modify, unapplied, _rejected, _emitted) =
             plan_fixes_dry_run(tmp.path(), &fixes, None).unwrap();
         assert!(
             would_modify.is_empty(),

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -7,7 +7,7 @@ use std::path::{Component, Path, PathBuf};
 use crate::case_index::CaseInsensitiveIndex;
 use crate::discovery;
 use crate::frontmatter;
-use crate::links::{Link, LinkKind};
+use crate::links::{Link, LinkKind, SelfAnchor};
 use crate::scanner::{self, FileVisitor, ScanAction};
 
 /// A single backlink: a file that links to some target.
@@ -523,7 +523,7 @@ pub(crate) struct FileLinks {
     /// they are produced by the same single-pass body scan, and are copied
     /// onto [`crate::index::IndexEntry::self_anchors`] so `find --broken-links`
     /// can validate them (iter-211 / BUG-8).
-    pub(crate) self_anchors: Vec<(usize, String)>,
+    pub(crate) self_anchors: Vec<SelfAnchor>,
 }
 
 /// Strip a trailing `.md` extension from `s`, matching any ASCII casing
@@ -752,9 +752,9 @@ pub const DEFAULT_FRONTMATTER_LINK_PROPERTIES: &[&str] =
 pub(crate) struct LinkGraphVisitor {
     source: PathBuf,
     links: Vec<(usize, Link)>,
-    self_anchors: Vec<(usize, String)>,
+    self_anchors: Vec<SelfAnchor>,
     scratch: Vec<Link>,
-    anchor_scratch: Vec<String>,
+    anchor_scratch: Vec<SelfAnchor>,
     /// Frontmatter property names to scan for `[[wikilink]]` patterns.
     /// `None` scans **every** frontmatter value (the iter-262 default);
     /// `Some(&[])` disables frontmatter scanning entirely.
@@ -893,8 +893,9 @@ impl FileVisitor for LinkGraphVisitor {
         for link in self.scratch.drain(..) {
             self.links.push((line_num, link));
         }
-        for frag in self.anchor_scratch.drain(..) {
-            self.self_anchors.push((line_num, frag));
+        for mut anchor in self.anchor_scratch.drain(..) {
+            anchor.line = line_num;
+            self.self_anchors.push(anchor);
         }
         ScanAction::Continue
     }

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -709,7 +709,7 @@ fn insert_file_links(
         // equal the raw target (only `.md`-suffix difference) to avoid
         // double-counting via the toggle.
         //
-        // iter-272 Part B (DEC-288): when no file has that stem, a frontmatter
+        // iter-272 Part B (DEC-296): when no file has that stem, a frontmatter
         // `aliases:` entry can still name one — and an alias-resolved link is
         // a real graph edge, so `backlinks`, `--orphan`, `--dead-end` and
         // `summary.links` all agree with what `find --fields links` reports.

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -126,8 +126,22 @@ impl LinkGraph {
         // First pass: fully populate the case index so that bare-basename
         // wikilink resolution in `insert_file_links` can see every vault file
         // regardless of scan order.
-        for (_full_path, rel) in files {
+        //
+        // iter-272 Part B: the same pass reads each file's frontmatter
+        // `aliases:`, for the same reason — an alias declared in the last file
+        // scanned has to resolve a link written in the first. Only the
+        // frontmatter is read (the visitor stops before the body), and the
+        // second pass below re-opens the same files while they are still warm
+        // in the page cache.
+        let aliases = crate::discovery::link_aliases_enabled();
+        for (full_path, rel) in files {
             let rel_fwd = rel.to_string_lossy().replace('\\', "/");
+            if aliases {
+                let declared = crate::discovery::read_aliases(full_path);
+                if !declared.is_empty() {
+                    case_index.insert_aliases(&rel_fwd, declared);
+                }
+            }
             case_index.insert(&rel_fwd);
         }
 
@@ -174,6 +188,7 @@ impl LinkGraph {
     pub(crate) fn from_file_links(
         file_links: Vec<FileLinks>,
         site_prefix: Option<&str>,
+        aliases: &[(String, Vec<String>)],
     ) -> LinkGraphBuild {
         let mut index: HashMap<String, Vec<BacklinkEntry>> =
             HashMap::with_capacity(file_links.len());
@@ -182,6 +197,14 @@ impl LinkGraph {
         for fl in &file_links {
             let rel_fwd = fl.source.to_string_lossy().replace('\\', "/");
             case_index.insert(&rel_fwd);
+        }
+        // iter-272 Part B: the caller already parsed every file's frontmatter
+        // during its own scan, so the alias map costs one pass over data in
+        // hand — no second read of any file.
+        if crate::discovery::link_aliases_enabled() {
+            for (rel_path, declared) in aliases {
+                case_index.insert_aliases(rel_path, declared);
+            }
         }
         for fl in file_links {
             insert_file_links(&mut index, fl, site_prefix, &case_index);
@@ -685,6 +708,13 @@ fn insert_file_links(
         // query forms naturally. We skip insertion when the resolved key would
         // equal the raw target (only `.md`-suffix difference) to avoid
         // double-counting via the toggle.
+        //
+        // iter-272 Part B (DEC-288): when no file has that stem, a frontmatter
+        // `aliases:` entry can still name one — and an alias-resolved link is
+        // a real graph edge, so `backlinks`, `--orphan`, `--dead-end` and
+        // `summary.links` all agree with what `find --fields links` reports.
+        // A filename always wins: the alias lookup runs only after
+        // `lookup_stem` comes up empty.
         let resolved_key = (link.kind == LinkKind::Wikilink
             && !link.target.contains('/')
             && !link.target.contains('\\'))
@@ -692,6 +722,7 @@ fn insert_file_links(
             let stem = strip_md_extension(&link.target);
             case_index
                 .lookup_stem(stem)
+                .or_else(|| case_index.lookup_alias(stem))
                 .map(|canon| strip_md_extension(canon).to_owned())
         })
         .flatten()
@@ -1790,7 +1821,7 @@ mod tests {
                 visitor.into_file_links()
             })
             .collect();
-        let build2 = LinkGraph::from_file_links(file_links, None);
+        let build2 = LinkGraph::from_file_links(file_links, None, &[]);
         let graph2 = build2.graph;
 
         // Verify warnings from from_file_links are always empty
@@ -2458,7 +2489,7 @@ mod tests {
             })
             .collect();
 
-        let build = LinkGraph::from_file_links(file_links, None);
+        let build = LinkGraph::from_file_links(file_links, None, &[]);
         assert_eq!(build.case_index.lookup_unique("a.md"), Some("a.md"));
         assert_eq!(build.case_index.lookup_unique("b.md"), Some("b.md"));
         assert_eq!(build.case_index.len(), 2);

--- a/crates/hyalo-core/src/link_rewrite.rs
+++ b/crates/hyalo-core/src/link_rewrite.rs
@@ -118,7 +118,7 @@ pub struct SkippedAmbiguous {
 ///
 /// Still limited to single-file [`plan_mv`]: [`plan_batch_mv`] has no channel
 /// for these reports at all (it returns bare [`RewritePlan`]s), so batch moves
-/// neither warn about split links nor did before — see DEC-288.
+/// neither warn about split links nor did before — see DEC-296.
 #[derive(Debug, Clone, Serialize)]
 pub struct SkippedFrontmatterLink {
     /// Vault-relative path of the file holding the link.
@@ -1620,7 +1620,7 @@ fn plan_frontmatter_wikilink_rewrites(
             continue;
         }
 
-        // BUG-7 (dogfood v0.22.0), iter-271 Part G: the DEC-288 ambiguity
+        // BUG-7 (dogfood v0.22.0), iter-271 Part G: the DEC-296 ambiguity
         // guard applies to a frontmatter link exactly as it does to a body
         // one. `related: "[[a]]"` names a bare stem, and a bare stem shared by
         // `a.md` and `x/a.md` names neither — the body rewriter skipped it

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -312,14 +312,23 @@ fn extract_links_and_anchors(
             continue;
         }
 
-        // Check for markdown link: [text](target)
-        // Skip if preceded by `!` — that's image syntax: ![alt](img.png)
+        // Check for markdown link: [text](target), and the image form
+        // `![alt](img.png)`.
+        //
+        // iter-272 Part E: the image form used to be dropped outright, so an
+        // `![alt](diagram.png)` naming a file that does not exist was invisible
+        // — MDN's whole-vault histogram reported 2 attachments against
+        // thousands of images — while `![[img.png]]` and `[alt](img.png)` were
+        // both inventoried. It is extracted like any other markdown link and
+        // marked `embed`, which puts it in the same bucket as `![[img.png]]`:
+        // reported as `attachment` when it resolves to a vault file, never a
+        // graph edge, and visible when it resolves to nothing.
         // L-16: skip when the `[` is backslash-escaped.
         if bytes[i] == b'['
-            && (i == 0 || bytes[i - 1] != b'!')
             && !is_escaped(bytes, i)
-            && let Some((link, end)) = try_parse_markdown_link_at(cleaned, original, i)
+            && let Some((mut link, end)) = try_parse_markdown_link_at(cleaned, original, i)
         {
+            link.embed = i > 0 && bytes[i - 1] == b'!' && !is_escaped(bytes, i - 1);
             out.push(link);
             i = end;
             continue;
@@ -2644,13 +2653,36 @@ mod tests {
         assert!(parse_markdown_link("text", "#heading").is_none());
     }
 
+    /// iter-272 Part E: `![alt](img.png)` is an inventoried embed, not a
+    /// dropped link. Before this it was skipped outright, so a missing image
+    /// never surfaced anywhere.
     #[test]
-    fn markdown_image_skipped() {
+    fn markdown_image_is_extracted_as_an_embed() {
         let text = "![alt text](image.png) and [[real link]]";
         let mut links = Vec::new();
         extract_links_from_text(text, &mut links);
+        assert_eq!(links.len(), 2, "{links:?}");
+        assert_eq!(links[0].target, "image.png");
+        assert!(links[0].embed);
+        assert_eq!(links[0].label.as_deref(), Some("alt text"));
+        assert_eq!(links[1].target, "real link");
+        assert!(!links[1].embed);
+    }
+
+    #[test]
+    fn a_plain_markdown_link_is_not_an_embed() {
+        let mut links = Vec::new();
+        extract_links_from_text("[alt](image.png)", &mut links);
         assert_eq!(links.len(), 1);
-        assert_eq!(links[0].target, "real link");
+        assert!(!links[0].embed);
+    }
+
+    #[test]
+    fn an_escaped_bang_leaves_a_plain_markdown_link() {
+        let mut links = Vec::new();
+        extract_links_from_text(r"\![alt](image.png)", &mut links);
+        assert_eq!(links.len(), 1, "{links:?}");
+        assert!(!links[0].embed, "{links:?}");
     }
 
     // --- LinkSpan / extract_link_spans tests ---

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -2589,7 +2589,10 @@ mod tests {
         for text in ["[[a]", "[[ ]]", "[[]]", "[[a\nb]]"] {
             let mut links = Vec::new();
             extract_links_from_text(text, &mut links);
-            assert!(links.is_empty(), "{text:?} must not yield a link: {links:?}");
+            assert!(
+                links.is_empty(),
+                "{text:?} must not yield a link: {links:?}"
+            );
         }
     }
 

--- a/crates/hyalo-core/src/links.rs
+++ b/crates/hyalo-core/src/links.rs
@@ -127,10 +127,58 @@ impl Link {
 }
 
 /// The kind of link syntax used in the source text.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum LinkKind {
+    #[default]
     Wikilink,
     Markdown,
+}
+
+impl LinkKind {
+    /// Whether this is the `Wikilink` variant. Used as a serde
+    /// `skip_serializing_if` so the default kind costs no snapshot bytes.
+    #[must_use]
+    pub fn is_wikilink(&self) -> bool {
+        matches!(self, Self::Wikilink)
+    }
+}
+
+/// A same-file heading anchor — `[[#Heading]]` or `[label](#heading)` — with
+/// the syntax it was written in.
+///
+/// These are not graph edges (they point at the file they appear in), so they
+/// are collected apart from [`Link`]. iter-272 Part C: the syntax kind and the
+/// markdown link text ride along, because reporting every same-file anchor as
+/// a `wikilink` made vaults with no wikilinks at all (MDN, GitHub Docs) claim
+/// thousands of them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SelfAnchor {
+    /// 1-based line the anchor was written on. Filled in by the scanner; the
+    /// extractor leaves it at `0`.
+    pub line: usize,
+    /// Fragment text without the leading `#`, exactly as written.
+    pub fragment: String,
+    /// The syntax the anchor was written in. Defaulted (and omitted from the
+    /// snapshot) when `Wikilink`, so snapshots written by an older hyalo keep
+    /// deserializing into the pre-iter-272 meaning.
+    #[serde(default, skip_serializing_if = "LinkKind::is_wikilink")]
+    pub kind: LinkKind,
+    /// Display text — the `[label]` of `[label](#frag)`, or the alias of
+    /// `[[#frag|alias]]`. `None` when the anchor carries none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl SelfAnchor {
+    /// A same-file anchor without a line number (filled in by the scanner).
+    fn new(fragment: String, kind: LinkKind, label: Option<String>) -> Self {
+        Self {
+            line: 0,
+            fragment,
+            kind,
+            label,
+        }
+    }
 }
 
 /// A parsed link together with its byte-offset span within the source text.
@@ -207,7 +255,7 @@ pub(crate) fn extract_links_and_self_anchors(
     cleaned: &str,
     original: &str,
     out: &mut Vec<Link>,
-    anchors: &mut Vec<String>,
+    anchors: &mut Vec<SelfAnchor>,
 ) {
     extract_links_and_anchors(cleaned, original, out, Some(anchors));
 }
@@ -216,7 +264,7 @@ fn extract_links_and_anchors(
     cleaned: &str,
     original: &str,
     out: &mut Vec<Link>,
-    mut anchors: Option<&mut Vec<String>>,
+    mut anchors: Option<&mut Vec<SelfAnchor>>,
 ) {
     let bytes = cleaned.as_bytes();
     let len = bytes.len();
@@ -257,9 +305,9 @@ fn extract_links_and_anchors(
             && i + 1 < len
             && bytes[i + 1] == b'['
             && !is_escaped(bytes, i)
-            && let Some((frag, end)) = try_parse_self_anchor_wikilink_at(cleaned, i)
+            && let Some((anchor, end)) = try_parse_self_anchor_wikilink_at(cleaned, i)
         {
-            anchors.push(frag);
+            anchors.push(anchor);
             i = end;
             continue;
         }
@@ -281,9 +329,9 @@ fn extract_links_and_anchors(
             && bytes[i] == b'['
             && (i == 0 || bytes[i - 1] != b'!')
             && !is_escaped(bytes, i)
-            && let Some((frag, end)) = try_parse_self_anchor_markdown_at(cleaned, i)
+            && let Some((anchor, end)) = try_parse_self_anchor_markdown_at(cleaned, original, i)
         {
-            anchors.push(frag);
+            anchors.push(anchor);
             i = end;
             continue;
         }
@@ -292,44 +340,71 @@ fn extract_links_and_anchors(
     }
 }
 
-/// Parse `[label](#fragment)` at `start`, returning the fragment (without the
-/// leading `#`) and the byte offset just past the closing `)`.
+/// Parse `[label](#fragment)` at `start`, returning the anchor and the byte
+/// offset just past the closing `)`.
 ///
 /// Returns `None` for anything that is not a fragment-only markdown link —
 /// including `[a](p.md#frag)`, which is a real file reference and is handled
 /// by [`try_parse_markdown_link_at`].
-fn try_parse_self_anchor_markdown_at(text: &str, start: usize) -> Option<(String, usize)> {
+///
+/// iter-272 Part C: the anchor carries `kind: Markdown` and the link text, so
+/// an anchor-only markdown link is no longer reported as a wikilink. The label
+/// is read from `original` (the un-stripped line) so backtick-wrapped text
+/// survives inline-code stripping, exactly as [`try_parse_markdown_link_at`]
+/// does.
+fn try_parse_self_anchor_markdown_at(
+    text: &str,
+    original: &str,
+    start: usize,
+) -> Option<(SelfAnchor, usize)> {
     let rest = &text[start..];
     let close_bracket = find_label_close_bracket(rest)?;
     let after_bracket = start + close_bracket + 1;
     if text.as_bytes().get(after_bracket).copied() != Some(b'(') {
         return None;
     }
+    let label_text = original.get(start + 1..start + close_bracket)?;
     let paren_start = after_bracket + 1;
     let dest = parse_destination(&text[paren_start..])?;
     let frag = dest.target_raw.strip_prefix('#')?;
     if frag.is_empty() {
         return None;
     }
-    Some((frag.to_owned(), paren_start + dest.end))
+    Some((
+        SelfAnchor::new(
+            frag.to_owned(),
+            LinkKind::Markdown,
+            (!label_text.is_empty()).then(|| label_text.to_owned()),
+        ),
+        paren_start + dest.end,
+    ))
 }
 
 /// Parse `[[#fragment]]` (optionally `[[#fragment|alias]]`) at `start`,
-/// returning the fragment without the leading `#`.
-fn try_parse_self_anchor_wikilink_at(text: &str, start: usize) -> Option<(String, usize)> {
+/// returning the anchor (fragment without the leading `#`, plus the alias as
+/// its label when one is written).
+fn try_parse_self_anchor_wikilink_at(text: &str, start: usize) -> Option<(SelfAnchor, usize)> {
     let content_start = start + 2;
     let rest = &text[content_start..];
-    let close = rest.find("]]")?;
+    let close = find_wikilink_close(rest)?;
     let inner = &rest[..close];
-    if inner.is_empty() || inner.contains('\n') {
+    if inner.trim().is_empty() {
         return None;
     }
-    let target_part = inner.split('|').next().unwrap_or(inner);
+    let (target_end, alias_start) = split_wikilink_alias(inner);
+    let target_part = &inner[..target_end];
     let frag = target_part.strip_prefix('#')?;
     if frag.is_empty() {
         return None;
     }
-    Some((frag.to_owned(), content_start + close + 2))
+    let label = alias_start
+        .map(|s| inner[s..].trim())
+        .filter(|a| !a.is_empty())
+        .map(str::to_owned);
+    Some((
+        SelfAnchor::new(frag.to_owned(), LinkKind::Wikilink, label),
+        content_start + close + 2,
+    ))
 }
 
 /// Whether the byte at `pos` is backslash-escaped, i.e. preceded by an odd
@@ -593,10 +668,10 @@ fn try_parse_wikilink_span_at(text: &str, start: usize) -> Option<(LinkSpan, usi
     let content_start = start + 2; // skip [[
     let rest = &text[content_start..];
 
-    let close = rest.find("]]")?;
+    let close = find_wikilink_close(rest)?;
     let inner = &rest[..close];
 
-    if inner.is_empty() || inner.contains('\n') {
+    if inner.trim().is_empty() {
         return None;
     }
 
@@ -707,18 +782,62 @@ fn try_parse_wikilink_at(text: &str, start: usize) -> Option<(Link, usize)> {
     let content_start = start + 2;
     let rest = &text[content_start..];
 
-    // Find closing ]]
-    let close = rest.find("]]")?;
+    // Find the closing `]]`, stopping at any boundary a wikilink target cannot
+    // contain (iter-272 BOUND-1/BOUND-2).
+    let close = find_wikilink_close(rest)?;
     let inner = &rest[..close];
 
-    // Reject empty or multiline
-    if inner.is_empty() || inner.contains('\n') {
+    // Reject an empty or whitespace-only capture: `[[]]` and `[[ ]]` name
+    // nothing.
+    if inner.trim().is_empty() {
         return None;
     }
 
     let link = parse_wikilink(inner)?;
     let end_pos = content_start + close + 2;
     Some((link, end_pos))
+}
+
+/// Find the `]]` that closes a wikilink opened just before `rest`, refusing to
+/// scan across a boundary a wikilink target can never contain.
+///
+/// `rest` is the text after the opening `[[`. Returns the byte offset of the
+/// first `]` of the closing `]]`, or `None` when this `[[` does not open a
+/// wikilink at all.
+///
+/// iter-272 BOUND-1/BOUND-2 (BUG-16, BUG-15): a plain `rest.find("]]")` walked
+/// over every intervening character, so `see [[Leah] here and [[Target]]`
+/// produced one link whose target was `Leah] here and [[Target` — a target
+/// containing prose, a stray `]` and a second opener. Three boundaries end the
+/// capture:
+///
+/// - a **single `]`** — the author closed a different bracket, so the `[[` was
+///   prose (`[[a] b [[c]]` is one link, `c`);
+/// - a **nested `[[`** — the real opener is the inner one;
+/// - a **newline** — a wikilink never straddles a line.
+///
+/// A capture that would *begin* with `[` is likewise refused, so a YAML flow
+/// list written `related: [[[a]], [[b]]]` is read as `[` + `[[a]]` rather than
+/// as a link to `[a`. Callers advance one byte and retry, which lands on the
+/// real opener.
+pub(crate) fn find_wikilink_close(rest: &str) -> Option<usize> {
+    let bytes = rest.as_bytes();
+    // BOUND-2: `[[[x]]` opens at the *second* bracket, not the first.
+    if bytes.first() == Some(&b'[') {
+        return None;
+    }
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b']' => {
+                return (bytes.get(i + 1) == Some(&b']')).then_some(i);
+            }
+            b'[' if bytes.get(i + 1) == Some(&b'[') => return None,
+            b'\n' => return None,
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 /// Split a wikilink's inner text at the alias pipe.
@@ -973,7 +1092,18 @@ pub fn is_external_target(target: &str) -> bool {
 
 /// Internal alias kept for the parser's own call sites.
 fn is_external(target: &str) -> bool {
-    is_external_target(target)
+    if is_external_target(target) {
+        return true;
+    }
+    // iter-272 BOUND-3 (BUG-21): the Obsidian Hub's "2021 Roundup" note writes
+    // `[y](<(https://example.com)>)` — an angle-bracket destination whose text
+    // is a parenthesised URL. The parens are not part of any vault path, but
+    // they hid the scheme from the check above, so the whole thing was parsed
+    // as a relative path and reported broken (and offered to `--apply-fuzzy`).
+    // A destination whose first non-`(` character starts a URI scheme names
+    // something outside the vault, parentheses and all.
+    let unwrapped = target.trim_start_matches('(');
+    unwrapped.len() != target.len() && is_external_target(unwrapped)
 }
 
 // ---------------------------------------------------------------------------
@@ -1638,11 +1768,18 @@ mod tests {
 
     // --- iter-211 / BUG-8: same-file anchors ---
 
-    fn anchors_of(text: &str) -> Vec<String> {
+    fn self_anchors_of(text: &str) -> Vec<SelfAnchor> {
         let mut links = Vec::new();
         let mut anchors = Vec::new();
         extract_links_and_self_anchors(text, text, &mut links, &mut anchors);
         anchors
+    }
+
+    fn anchors_of(text: &str) -> Vec<String> {
+        self_anchors_of(text)
+            .into_iter()
+            .map(|a| a.fragment)
+            .collect()
     }
 
     #[test]
@@ -1657,6 +1794,28 @@ mod tests {
             anchors_of("see [[#Nope|alias]] here"),
             vec!["Nope".to_owned()]
         );
+    }
+
+    /// iter-272 Part C (BUG-8): an anchor-only *markdown* link is markdown.
+    /// MDN and GitHub Docs have no wikilinks at all, yet their link histograms
+    /// claimed thousands, because every same-file anchor was reported as one.
+    #[test]
+    fn anchor_only_markdown_link_is_markdown_kind_with_its_label() {
+        let anchors = self_anchors_of("see [Browser compatibility](#browser_compat) here");
+        assert_eq!(anchors.len(), 1);
+        assert_eq!(anchors[0].kind, LinkKind::Markdown);
+        assert_eq!(anchors[0].fragment, "browser_compat");
+        assert_eq!(anchors[0].label.as_deref(), Some("Browser compatibility"));
+    }
+
+    #[test]
+    fn anchor_only_wikilink_keeps_wikilink_kind_and_carries_its_alias() {
+        let anchors = self_anchors_of("see [[#Nope]] and [[#Other|alias]]");
+        assert_eq!(anchors.len(), 2);
+        assert_eq!(anchors[0].kind, LinkKind::Wikilink);
+        assert_eq!(anchors[0].label, None);
+        assert_eq!(anchors[1].kind, LinkKind::Wikilink);
+        assert_eq!(anchors[1].label.as_deref(), Some("alias"));
     }
 
     #[test]
@@ -1677,7 +1836,13 @@ mod tests {
         );
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].target, "p.md");
-        assert_eq!(anchors, vec!["nope".to_owned(), "other".to_owned()]);
+        assert_eq!(
+            anchors
+                .iter()
+                .map(|a| a.fragment.as_str())
+                .collect::<Vec<_>>(),
+            vec!["nope", "other"]
+        );
     }
 
     // --- inert link zones (iter-200) ---
@@ -2388,16 +2553,83 @@ mod tests {
 
     #[test]
     fn nested_brackets_wikilink() {
-        // [[outer [[inner]]]] — the parser finds the first ]] closing "outer [[inner",
-        // so "inner" is parsed as the target after the second [[, stopping at the first ]]
+        // iter-272 BOUND-1: the outer `[[` is tried first, but its capture runs
+        // into a nested `[[` before any `]]`, which no wikilink target can
+        // contain — so the outer opener is prose and the *inner* link wins.
+        // (Before iter-272 this yielded one link targeting `outer [[inner`.)
         let text = "[[outer [[inner]]]]";
         let mut links = Vec::new();
         extract_links_from_text(text, &mut links);
-        // The outer [[ is tried first; rest is "outer [[inner]]]]",
-        // find("]]") hits the first ]] → inner = "outer [[inner" → no pipe → target = "outer [[inner"
-        // (fragment strip on # only; this is the pinned behavior)
         assert_eq!(links.len(), 1);
-        assert_eq!(links[0].target, "outer [[inner");
+        assert_eq!(links[0].target, "inner");
+    }
+
+    // --- iter-272 Part D: scanner capture boundaries ---
+
+    #[test]
+    fn bound1_stray_close_bracket_ends_the_capture() {
+        // BUG-16, `Obsidian Community Talks.md:64`: one link, target `c`.
+        let mut links = Vec::new();
+        extract_links_from_text("[[a] b [[c]]", &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "c");
+    }
+
+    #[test]
+    fn bound1_unclosed_and_blank_wikilinks_are_not_links() {
+        for text in ["[[a]", "[[ ]]", "[[]]", "[[a\nb]]"] {
+            let mut links = Vec::new();
+            extract_links_from_text(text, &mut links);
+            assert!(links.is_empty(), "{text:?} must not yield a link: {links:?}");
+        }
+    }
+
+    #[test]
+    fn bound1_extra_close_bracket_after_a_link_is_prose() {
+        let mut links = Vec::new();
+        extract_links_from_text("[[a]]]", &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "a");
+    }
+
+    #[test]
+    fn bound1_table_escaped_alias_pipe_still_parses() {
+        let mut links = Vec::new();
+        extract_links_from_text("| [[a\\|Label]] | x |", &mut links);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "a");
+        assert_eq!(links[0].label.as_deref(), Some("Label"));
+    }
+
+    #[test]
+    fn bound2_flow_list_opening_with_three_brackets() {
+        // BUG-15: `related: [[[a]], [[b]]]` is `[` + two wikilinks, not a link
+        // to `[a`.
+        let mut links = Vec::new();
+        extract_links_from_text("[[[a]], [[b]]]", &mut links);
+        assert_eq!(
+            links.iter().map(|l| l.target.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn bound3_parenthesised_url_in_an_angle_destination_is_external() {
+        // BUG-21, the Hub's 2021 Roundup line.
+        let mut links = Vec::new();
+        extract_links_from_text("[y](<(https://example.com/a)>)", &mut links);
+        assert_eq!(links.len(), 1);
+        assert!(links[0].external, "{:?}", links[0]);
+        assert_eq!(links[0].kind, LinkKind::Markdown);
+        assert_eq!(links[0].target, "(https://example.com/a)");
+    }
+
+    #[test]
+    fn bound3_a_parenthesised_relative_path_stays_a_vault_path() {
+        let mut links = Vec::new();
+        extract_links_from_text("[y](<(notes/a.md)>)", &mut links);
+        assert_eq!(links.len(), 1);
+        assert!(!links[0].external);
     }
 
     #[test]

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -206,7 +206,21 @@ pub struct LinkInfo {
     /// of scope, not missing (iter-193). Skipped from JSON when `false`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub out_of_vault: bool,
+    /// How the target resolved when a plain path or filename lookup was not
+    /// what answered — currently only `"alias"`, for a target matched against
+    /// a note's frontmatter `aliases:` (iter-272 Part B, DEC-288).
+    ///
+    /// Absent for every link that resolves by path or filename, so a report of
+    /// an alias-free vault keeps today's shape byte for byte. `kind` stays
+    /// `wikilink`: an alias changes *what the target names*, not the syntax it
+    /// was written in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub via: Option<String>,
 }
+
+/// Value of [`LinkInfo::via`] for a target resolved through a frontmatter
+/// `aliases:` entry (iter-272 Part B, DEC-288).
+pub const LINK_VIA_ALIAS: &str = "alias";
 
 /// A single backlink: another file that links to this one.
 /// Used by `find` (backlinks field).

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -208,7 +208,7 @@ pub struct LinkInfo {
     pub out_of_vault: bool,
     /// How the target resolved when a plain path or filename lookup was not
     /// what answered — currently only `"alias"`, for a target matched against
-    /// a note's frontmatter `aliases:` (iter-272 Part B, DEC-288).
+    /// a note's frontmatter `aliases:` (iter-272 Part B, DEC-296).
     ///
     /// Absent for every link that resolves by path or filename, so a report of
     /// an alias-free vault keeps today's shape byte for byte. `kind` stays
@@ -219,7 +219,7 @@ pub struct LinkInfo {
 }
 
 /// Value of [`LinkInfo::via`] for a target resolved through a frontmatter
-/// `aliases:` entry (iter-272 Part B, DEC-288).
+/// `aliases:` entry (iter-272 Part B, DEC-296).
 pub const LINK_VIA_ALIAS: &str = "alias";
 
 /// A single backlink: another file that links to this one.

--- a/crates/hyalo-mdlint/src/schema.rs
+++ b/crates/hyalo-mdlint/src/schema.rs
@@ -876,6 +876,24 @@ pub fn validate_constraint(
     constraint: &PropertyConstraint,
     regex_cache: &mut HashMap<String, Result<Regex, String>>,
 ) -> Vec<Violation> {
+    // iter-272 Part A: the `type` discriminator is not an ordinary string
+    // property. DEC-281 lets it bind through three shapes — a plain string, a
+    // `[[Wikilink]]`, and a one-element list of either — but every declared
+    // type carries an implicit `type: string` constraint (required properties
+    // without an explicit definition are auto-added as `string`), so the list
+    // shape Obsidian's own property editor writes was rejected by the very
+    // constraint check that binding had already accepted. Normalise the value
+    // the same way binding does, and validate the *bound type name* against the
+    // constraint. A shape that names no type falls through unchanged and is
+    // reported by the DEC-281 message in `validate_properties`.
+    if name == "type"
+        && matches!(constraint, PropertyConstraint::String { .. })
+        && !matches!(value, Value::String(_))
+        && let Some(bound) = schema::normalize_type_value(value)
+    {
+        return validate_constraint(name, &Value::String(bound), constraint, regex_cache);
+    }
+
     match constraint {
         PropertyConstraint::String {
             pattern,
@@ -1363,6 +1381,98 @@ mod tests {
             .properties
             .insert("date".to_string(), PropertyConstraint::Date);
         schema
+    }
+
+    /// A schema declaring a type `iteration` that requires `title` and `type`.
+    /// `merged_schema_for_type` auto-adds a `string` constraint for every
+    /// required property without an explicit definition, so `type` carries the
+    /// implicit string constraint that iter-272 Part A had to reconcile with
+    /// DEC-281's three binding shapes.
+    fn schema_with_declared_iteration_type() -> SchemaConfig {
+        let mut schema = SchemaConfig::default();
+        schema.default.required = vec!["title".to_string(), "type".to_string()];
+        let mut iteration = TypeSchema::default();
+        iteration.required = vec!["title".to_string(), "type".to_string()];
+        schema.types.insert("iteration".to_string(), iteration);
+        schema
+    }
+
+    fn typed_props(type_value: Value) -> IndexMap<String, Value> {
+        let mut props: IndexMap<String, Value> = IndexMap::new();
+        props.insert("title".to_string(), Value::String("L".to_string()));
+        props.insert("type".to_string(), type_value);
+        props
+    }
+
+    #[test]
+    fn declared_type_accepts_all_dec281_shapes() {
+        let schema = schema_with_declared_iteration_type();
+        for shape in [
+            Value::String("iteration".to_string()),
+            Value::String("[[iteration]]".to_string()),
+            Value::Array(vec![Value::String("iteration".to_string())]),
+            Value::Array(vec![Value::String("[[iteration]]".to_string())]),
+            Value::Array(vec![Value::String("[[iteration|iter]]".to_string())]),
+        ] {
+            let violations = validate_properties("l.md", &typed_props(shape.clone()), &schema, false);
+            assert!(
+                !violations
+                    .iter()
+                    .any(|v| v.message.contains("expected string")),
+                "shape {shape} must not trip the implicit string constraint: {violations:?}"
+            );
+            assert!(
+                !violations.iter().any(|v| v.message.contains("must name one type")),
+                "shape {shape} must bind to the declared type: {violations:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn declared_type_still_rejects_multi_element_and_empty_lists() {
+        let schema = schema_with_declared_iteration_type();
+        for shape in [
+            Value::Array(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ]),
+            Value::Array(vec![]),
+        ] {
+            let violations = validate_properties("l.md", &typed_props(shape.clone()), &schema, false);
+            assert!(
+                violations
+                    .iter()
+                    .any(|v| v.message.contains("must name one type")),
+                "shape {shape} must still be reported with the DEC-281 message: {violations:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_constraint_simple_type_accepts_one_element_list() {
+        let string_constraint = PropertyConstraint::String {
+            pattern: None,
+            min_length: None,
+            max_length: None,
+        };
+        // `set --validate` shares this validator, so the fix reaches it too.
+        assert!(
+            validate_constraint_simple(
+                "type",
+                &Value::Array(vec![Value::String("[[Author]]".to_string())]),
+                &string_constraint,
+            )
+            .is_none()
+        );
+        // A non-`type` property is unaffected.
+        assert!(
+            validate_constraint_simple(
+                "status",
+                &Value::Array(vec![Value::String("planned".to_string())]),
+                &string_constraint,
+            )
+            .is_some()
+        );
     }
 
     #[test]

--- a/crates/hyalo-mdlint/src/schema.rs
+++ b/crates/hyalo-mdlint/src/schema.rs
@@ -1391,8 +1391,10 @@ mod tests {
     fn schema_with_declared_iteration_type() -> SchemaConfig {
         let mut schema = SchemaConfig::default();
         schema.default.required = vec!["title".to_string(), "type".to_string()];
-        let mut iteration = TypeSchema::default();
-        iteration.required = vec!["title".to_string(), "type".to_string()];
+        let iteration = TypeSchema {
+            required: vec!["title".to_string(), "type".to_string()],
+            ..TypeSchema::default()
+        };
         schema.types.insert("iteration".to_string(), iteration);
         schema
     }
@@ -1414,7 +1416,8 @@ mod tests {
             Value::Array(vec![Value::String("[[iteration]]".to_string())]),
             Value::Array(vec![Value::String("[[iteration|iter]]".to_string())]),
         ] {
-            let violations = validate_properties("l.md", &typed_props(shape.clone()), &schema, false);
+            let violations =
+                validate_properties("l.md", &typed_props(shape.clone()), &schema, false);
             assert!(
                 !violations
                     .iter()
@@ -1422,7 +1425,9 @@ mod tests {
                 "shape {shape} must not trip the implicit string constraint: {violations:?}"
             );
             assert!(
-                !violations.iter().any(|v| v.message.contains("must name one type")),
+                !violations
+                    .iter()
+                    .any(|v| v.message.contains("must name one type")),
                 "shape {shape} must bind to the declared type: {violations:?}"
             );
         }
@@ -1438,7 +1443,8 @@ mod tests {
             ]),
             Value::Array(vec![]),
         ] {
-            let violations = validate_properties("l.md", &typed_props(shape.clone()), &schema, false);
+            let violations =
+                validate_properties("l.md", &typed_props(shape.clone()), &schema, false);
             assert!(
                 violations
                     .iter()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ default_limit = 100       # max results for list commands (default: 50; 0 = unli
 [links]
 frontmatter_properties = ["related", "depends-on"]   # list properties that contribute to the link graph
 case_insensitive = "auto"                             # "auto", "true", or "false"
+aliases = true                                        # frontmatter `aliases:` resolve wikilinks (default: true)
 fuzzy_min_confidence = 0.8                            # confidence floor for links fix --apply-fuzzy (default: 0.8)
 
 [links.auto]
@@ -131,6 +132,43 @@ whose case-folded directory layouts (`en-US` written as `en-us`) otherwise make
 a dry run offer tens of thousands of casing rewrites that every downstream
 tool would resolve fine anyway. The same effect for a single run is the
 `links fix --case-insensitive` flag.
+
+### `[links] aliases` — frontmatter aliases as link targets
+
+A note's frontmatter `aliases:` are alternative names it can be linked by, the
+way Obsidian treats them:
+
+```yaml
+---
+title: Leah Ferguson
+aliases:
+  - Leah
+  - L. Ferguson
+---
+```
+
+`[[Leah]]` written anywhere in the vault then resolves to that note. The rules
+(DEC-296):
+
+- Only the `aliases` property is read, in either shape Obsidian writes — a list
+  or a bare string (`aliases: Leah`).
+- **A filename or path match always wins.** The alias map is consulted only
+  after every path, `.md`-suffix, directory-index and bare-stem attempt fails,
+  so no existing link is ever repointed by someone else's frontmatter.
+- An alias declared by **two** notes is ambiguous and resolves to nothing —
+  the same verdict a colliding bare stem gets.
+- Matching folds case, like every other lookup, and `[[alias#Heading]]` /
+  `[[alias|label]]` work.
+- A link that resolved this way reports `via: "alias"`; its `kind` stays
+  `wikilink`. It is a real graph edge, so `backlinks`, `--orphan`,
+  `--dead-end`, `summary.links` and HYALO006 all agree with
+  `find --fields links`.
+- `links fix` never proposes a rewrite for such a target and never
+  fuzzy-matches one; `mv` leaves alias-written links alone, because the alias
+  travels with the note.
+
+Set `aliases = false` to restore filename-only resolution.
+`hyalo config --jq '.results.links.aliases'` reports the effective value.
 
 Under `"auto"`, hyalo detects case behaviour with **stat calls only**: it looks
 up an existing vault entry (or the vault directory itself) under a

--- a/hyalo-knowledgebase/backlog/link-resolution-block-reference-and-slug-anchors.md
+++ b/hyalo-knowledgebase/backlog/link-resolution-block-reference-and-slug-anchors.md
@@ -1,0 +1,60 @@
+---
+type: backlog
+title: Block references and slug anchors are never reported broken
+date: 2026-09-05
+status: planned
+priority: low
+origin: "iter-272 (PR #320) carry-over sweep, 2026-09-05, DEC-299"
+---
+
+## Problem
+
+[[iterations/iteration-272-resolution-completeness]] Part E surveyed the report's resolution
+feature gaps and backlogged this one (DEC-299, 2026-09-05) rather than implementing it:
+`[[Target#^nope]]` (a block-reference anchor) and `[[Target#section-one]]` (a pre-slugified
+heading anchor, the form Obsidian itself writes into `redirect_from:` style links) are never
+reported broken by `find --broken-links`, even though Obsidian breaks the first outright and
+would not resolve the second unless it happens to match a real heading's rendered slug.
+
+DEC-268's anchor checker validates a fragment against the raw heading text or its GitHub-style
+rendered slug (`hyalo-core::anchor`). Neither path knows about:
+
+- **Block references** (`^block-id`) — Obsidian lets a link point at a specific block via a
+  trailing `^abc123` identifier the author places at the end of a paragraph or list item, not a
+  heading. `find --fields links` and the scanner currently skip `^block` refs outright (see the
+  `rule-knowledgebase.md` / `skill-hyalo.md` line: "`^block-id` refs are skipped").
+- **Slug-only anchors** that happen to coincide with a real slug but not the raw heading text —
+  already handled by the existing rendered-slug fallback, so this half of the DEC-299 title may
+  already be closed; confirm before starting (see Proposal).
+
+## Proposal
+
+Not yet designed — this is a placeholder for the follow-up DEC-299 deferred, not a committed
+shape. Whoever picks this up should:
+
+- Confirm exactly what is and is not already covered: re-run DEC-268's rendered-slug fallback
+  against a fixture using `[[Target#section-one]]` where `section-one` is the real slug of
+  `## Section One` — if that already resolves, DEC-299's scope narrows to block references only.
+- Decide whether block-id checking needs a full scan for `^block-id` markers in every file (a
+  new indexed field: which files declare which block ids, and at which line), or whether it can
+  piggyback on an existing per-file scan pass. Note DEC-299's own reasoning: "reporting them
+  without the scan would make every block reference in every Obsidian vault a false positive" —
+  so implementing this without the scan is explicitly out.
+- If a new indexed field is added, it changes the snapshot format; follow the precedent
+  iter-272 Part C set for `self_anchors` (`#[serde(default, skip_serializing_if = ...)]` so an
+  older snapshot degrades to "falls back to disk scan" rather than failing to load) rather than
+  bumping a format version.
+- Decide whether the target file's block ids need indexing (for the target to be checked) or
+  only local ones — a link into another file's block (`[[Other#^abc]]`) needs foreign block-id
+  data at scan time, which is a bigger index than a same-file check.
+
+## Acceptance criteria
+
+- [ ] Confirm and record whether the rendered-slug half of DEC-299's title is already closed by
+      DEC-268; if so, retitle this item to cover block references only.
+- [ ] If implementing block-id checking: a block-id scan populates an indexed field; a broken
+      `[[Target#^nope]]` is reported the same way a broken heading anchor is
+      (`broken_anchor: true`, distinct from a broken target); `--index` and disk-scan parity
+      holds; an older snapshot without the field falls back to disk scan rather than erroring.
+- [ ] If staying backlog (won't-do or deferred again): a DEC amendment records why, with
+      whatever new information the confirmation step surfaced.

--- a/hyalo-knowledgebase/backlog/link-resolution-redirect-property.md
+++ b/hyalo-knowledgebase/backlog/link-resolution-redirect-property.md
@@ -1,0 +1,60 @@
+---
+type: backlog
+title: "[links] redirect_property for GitHub-Docs-style redirect_from resolution"
+date: 2026-09-05
+status: planned
+priority: low
+origin: "iter-272 (PR #320) carry-over sweep, 2026-09-05, DEC-300"
+---
+
+## Problem
+
+The post-batch dogfood report (feeding [[iterations/iteration-272-resolution-completeness]])
+found that on a GitHub Docs copy, 1569 of 1624 "broken" links are actually links to a
+`redirect_from:` value declared in the target file's own frontmatter — GitHub Docs pages
+declare every historical URL they used to live at, and internal links elsewhere in the corpus
+still use those old URLs.
+
+iter-272 Part B built a name-keyed alias map (DEC-296) for exactly this shape of problem
+(`aliases:` → note), and it was tempting to treat `redirect_from:` the same way. DEC-300
+declined: *"It looked like a few lines on top of DEC-296's alias map, and it is not — aliases
+are keyed by bare note name; `redirect_from:` values are site-absolute URL paths that resolve
+through `strip_site_prefix`, so supporting them needs a second, path-keyed map with its own
+precedence against the directory-index rule."*
+
+## Proposal
+
+Not yet designed — this is a placeholder for the follow-up DEC-300 deferred, not a committed
+shape. Whoever picks this up should:
+
+- Design the second map: keyed by the *resolved, site-prefix-stripped path* a `redirect_from:`
+  entry names (not the bare name DEC-296's alias map uses), pointing at the file that declares
+  it.
+- Decide precedence explicitly and write it into the DEC before implementing, mirroring
+  DEC-296's `ALIAS-1` decide step: does a real file at that path always win over a
+  `redirect_from:` claim (as a filename always wins over an alias)? Is a path claimed by two
+  files' `redirect_from:` lists ambiguous, or does the directory-index rule (`foo/index.md` for
+  `foo/`) take precedence over a `redirect_from:` collision, or vice versa?
+- Decide the config key name and default: the iteration's constraint against new CLI flags
+  still applies, so this is `[links] redirect_property = "redirect_from"` (opt-in, since unlike
+  `aliases` it is not a stable Obsidian-wide convention) or similar — confirm the property name
+  GitHub Docs and other target corpora actually use before hardcoding it.
+- Reuse iter-272 Part B's implementation shape where it transfers: a resolver consulted last
+  (after path, stem, and the alias map), a `via` value on `LinkInfo` (e.g. `"redirect"`), and
+  `links fix` never proposing a rewrite for a target that resolves via a redirect.
+- Measure the target corpus's actual improvement (a GitHub Docs copy is the report's source)
+  the way DEC-296 measured the Obsidian Hub, since this is opt-in and unmeasured benefit does
+  not justify the second map's maintenance cost.
+
+## Acceptance criteria
+
+- [ ] A DEC records the path-keyed map's precedence rules against directory-index resolution
+      and against a real file at the same path, before any code is written.
+- [ ] `[links] redirect_property = "<name>"` (opt-in, off by default) resolves a link whose
+      target matches a declared value of that property in some file's frontmatter, the same way
+      an alias does; `via: "redirect"` (or the chosen name) on the resolved `LinkInfo`.
+- [ ] `links fix` does not propose a rewrite for a target that resolves via redirect.
+- [ ] Measured on the GitHub Docs corpus that motivated this: the 1569/1624 figure drops to
+      (near) zero for links whose only defect was pointing at a declared `redirect_from:` value.
+- [ ] If staying backlog (won't-do): a DEC amendment records why, with the property name
+      confirmed or ruled out.

--- a/hyalo-knowledgebase/backlog/link-resolution-remaining-ambiguous-and-case-mismatch-links.md
+++ b/hyalo-knowledgebase/backlog/link-resolution-remaining-ambiguous-and-case-mismatch-links.md
@@ -1,0 +1,55 @@
+---
+type: backlog
+title: >-
+  Hub's ambiguous short-form links and case-mismatch links are untouched by
+  iter-272
+date: 2026-09-05
+status: planned
+priority: low
+origin: "iter-272 (PR #320) carry-over sweep, 2026-09-05"
+---
+
+## Problem
+
+[[iterations/iteration-272-resolution-completeness]]'s Outcome flagged, but did not act on, a
+follow-up observation on the Obsidian Hub corpus (6393 notes): after Part B's alias resolution
+landed, the Hub still carries **100 `ambiguous`** short-form wikilinks (a bare `[[stem]]`
+matching two or more files, or in some cases now two or more alias declarations) and **48
+`case_mismatches`** (a link whose casing differs from the on-disk file). Neither category was
+touched by iter-272 — they were pre-existing before the alias work and remain exactly as
+before.
+
+This is not a bug: `ambiguous` links are correctly *not* auto-resolved (resolving one
+arbitrarily would be worse than reporting it), and `case_mismatches` already has a fix path
+(`links fix` applies `LinkCaseMismatch` plans routinely). The open question is whether the
+*volume* on a corpus this size (100 + 48 out of ~6400 notes) indicates a pattern worth a
+targeted iteration — e.g. a cluster of ambiguous stems that share a root cause (two notes with
+very similar names that a rename or merge would resolve), or whether it is simply background
+noise for a personal-vault-scale corpus and does not warrant more automation.
+
+## Proposal
+
+Not yet designed — this is a placeholder to decide whether there is an iteration here at all.
+Whoever picks this up should:
+
+- Re-run `hyalo find --broken-links` (or the ambiguous/case-mismatch specific views) against a
+  current Obsidian Hub checkout and confirm the 100/48 figures still hold (iter-272 measured
+  them on 2026-09-05; both counts could have shifted with upstream Hub edits).
+- Sample a handful of the 100 ambiguous entries: are they genuinely unrelated notes sharing a
+  stem (nothing to fix — this is Obsidian's own ambiguity, correctly reported), or is there a
+  systematic cause (e.g. a common template producing near-duplicate filenames) that a *tool*
+  feature could address, versus something only the vault's own author can fix by renaming?
+- If nothing systematic turns up: close this backlog item `wont-do`, with the sample findings
+  recorded as the reasoning — "reported correctly, no tooling gap" is a legitimate outcome, not
+  a deferral.
+- If something systematic does turn up: scope it as its own iteration plan (not folded into
+  this backlog item) with its own DEC and acceptance criteria.
+
+## Acceptance criteria
+
+- [ ] The 100 ambiguous / 48 case-mismatch figures are re-confirmed or updated on a current
+      Hub checkout.
+- [ ] A sample of the ambiguous entries is reviewed and characterized (unrelated notes vs.
+      systematic pattern).
+- [ ] Either: closed `wont-do` with the sample findings recorded, or a new iteration plan is
+      filed for whatever systematic gap the sample revealed.

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -5137,3 +5137,126 @@ broken ones.
 `emit_markdown_fix_target` + `raw_target_names_index` / `strip_directory_index`
 (form preservation), `markdown_fix_round_trips` (the guard that accepts it). See
 [[iterations/iteration-271-write-and-rewrite-safety]].
+
+## DEC-296: a frontmatter `aliases:` value resolves a `[[wikilink]]` (2026-09-05)
+
+**Decision:** `[[Leah]]` resolves to the note whose frontmatter declares
+`aliases: [Leah]`. The rules:
+
+- The property is **`aliases`** and nothing else — Obsidian's own spelling.
+  Both shapes its property editor writes are accepted: a list, and a bare
+  string (`aliases: Leah`). Non-string list items and blank entries are
+  ignored. `alias:` (singular) and `title:` are **not** alias sources.
+- **A filename or path match always beats an alias.** The alias map is
+  consulted only after every path, `.md`-suffix, directory-index and bare-stem
+  attempt has failed, so no vault can have an existing link repointed by
+  someone else's frontmatter.
+- **An alias claimed by two notes is ambiguous**, reported exactly like a
+  colliding bare stem, never resolved to whichever note was scanned first.
+- Matching **folds case**, like every other link lookup (DEC-267).
+- `[[alias#Heading]]` and `[[alias|label]]` work: the fragment and the label
+  are split off before resolution, as for any other target.
+- The reported `kind` stays `wikilink` — an alias changes *what the target
+  names*, not the syntax it was written in. The resolution is reported as
+  `via: "alias"` on the link entry (absent for every other link, so an
+  alias-free vault's output is unchanged byte for byte).
+- An alias-resolved link is a **real graph edge**: `backlinks`, `--orphan`,
+  `--dead-end`, `summary.links` and HYALO006 all agree with
+  `find --fields links`.
+- `links fix` never proposes a rewrite for a target that resolves through an
+  alias, and never fuzzy-matches one.
+- `mv` does not touch aliases and does not rewrite alias-written links: the
+  alias travels with the note, so the link keeps resolving at the new path.
+- **`[links] aliases = false`** turns the whole rule off and restores
+  filename-only resolution. Default **on**, like DEC-267 case folding.
+  `hyalo config --jq '.results.links.aliases'` reports the effective value.
+
+**Index:** the alias map is built **at load, from the frontmatter the index
+already carries** — no snapshot format change, so an index written by an older
+hyalo resolves aliases identically. The disk path builds it with a
+frontmatter-only scan (the visitor stops before the body), and the link-graph
+build reads aliases in the pass that already enumerates every file.
+
+**Why.** On the Obsidian Hub vault 7 of the 47 genuinely-broken targets (9
+occurrences) are declared aliases of notes that exist, and the vault declares
+5489 distinct aliases. Worse than the false "broken" verdict was what
+`links fix --apply-fuzzy` did with them: `Leah → Lewuathe.md` at 0.87,
+`Cat → CatMuse.md`, `jamesb → jamesgreenblue.md` — three confident rewrites of
+links that were already correct. A resolver that does not know about aliases is
+not merely incomplete on an Obsidian vault, it is dangerous on one.
+
+**Where:** `case_index::CaseInsensitiveIndex::{insert_aliases, lookup_alias,
+lookup_alias_all}`, `discovery::{resolve_target, resolves_via_alias,
+populate_aliases_from_dir, read_aliases, set_link_aliases}`,
+`discovery::classify_short_form_wikilink`, `link_graph::insert_file_links`,
+`filter::extract_aliases`. See
+[[iterations/iteration-272-resolution-completeness]].
+
+## DEC-297: `![alt](img.png)` is inventoried as an embed (2026-09-05)
+
+**Decision:** The markdown *image* form is extracted like every other markdown
+link and flagged `embed`, so it is reported as `attachment` when it resolves to
+a vault file and stays visible when it resolves to nothing. It is still never a
+graph edge, never fuzzy-matched and never rewritten by a plain `links fix`.
+
+**Why.** `![[img.png]]` and `[alt](img.png)` were both inventoried while
+`![alt](img.png)` — the form every static-site corpus writes — was dropped at
+extraction. MDN's whole-vault histogram therefore reported `attachment: 2`
+against thousands of images, and a missing image surfaced nowhere: not in
+`find --fields links`, not in `--broken-links`, not in `summary`.
+
+**Where:** `links::extract_links_and_anchors`. See
+[[iterations/iteration-272-resolution-completeness]].
+
+## DEC-298: the `suggested_fragment` prefix test folds `-`, `_` and space (2026-09-05) — amends DEC-268
+
+**Decision:** When deciding whether a dead fragment is the unique prefix of one
+heading, `-`, `_` and a space are one character class. **Only the suggestion is
+affected.** DEC-268's rule that a prefix match never silently *resolves* an
+anchor is untouched: the suggestion is still printed, never applied, and still
+requires a unique match.
+
+**Why.** MDN slugs its headings with underscores (`#Browser_compatibility`)
+while the heading itself is written with spaces, so a strict comparison found
+no prefix for **1242 of the 1254** broken anchors on an MDN CSS copy — every
+one of them a heading the reader could see two lines away. DEC-268 forbids
+silent matching, not helpful suggesting.
+
+**Where:** `anchor::{unique_heading_by_prefix, prefix_matches_fragment}`. See
+[[iterations/iteration-272-resolution-completeness]].
+
+## DEC-299: block-reference and slug anchors stay unchecked — backlog (2026-09-05)
+
+**Decision:** `[[Target#^block-id]]` is **not** reported as a broken anchor,
+and neither is a slug-shaped fragment that matches no heading beyond what
+DEC-075 already accepts. Backlogged, not rejected.
+
+**Why.** Obsidian does break `#^nope`, so hyalo is genuinely incomplete here —
+but checking it needs a block-id scan (`^id` markers at the end of a block),
+which is a new indexed field, a snapshot format addition and a new class of
+false positive on every corpus that writes `^` for other reasons. That is its
+own iteration, not a line in this one. Reporting them broken *without* the scan
+would be strictly worse than saying nothing: every block reference in every
+Obsidian vault would be a false positive.
+
+**Where:** `anchor::is_block_ref` (the current skip, unchanged). See
+[[iterations/iteration-272-resolution-completeness]].
+
+## DEC-300: no `[links] redirect_property` — backlog (2026-09-05)
+
+**Decision:** A config key that reads a `redirect_from:` list as extra
+resolution targets is **not** added in this iteration.
+
+**Why.** It looked like a few lines on top of DEC-296's alias map, and it is
+not: the alias map is keyed by *bare note name* and is consulted only for
+targets with no path separator, because that is the only shape an Obsidian
+alias can take. GitHub Docs' `redirect_from:` values are **site-absolute URL
+paths** (`/actions/reference/workflow-syntax`), which resolve through
+`strip_site_prefix` and the path lookup, never through the name map. Supporting
+them means a second, path-keyed alias map with its own precedence against the
+directory-index rule — a different feature wearing the same word. The 1569
+"broken" GitHub Docs files stay reported; a vault that wants them resolved can
+set `site_prefix` or fix the links.
+
+**Where:** nothing implemented; recorded so the option is not re-litigated. See
+[[iterations/iteration-272-resolution-completeness]].

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -5240,7 +5240,8 @@ would be strictly worse than saying nothing: every block reference in every
 Obsidian vault would be a false positive.
 
 **Where:** `anchor::is_block_ref` (the current skip, unchanged). See
-[[iterations/iteration-272-resolution-completeness]].
+[[iterations/iteration-272-resolution-completeness]] and the carry-over item
+[[backlog/link-resolution-block-reference-and-slug-anchors]].
 
 ## DEC-300: no `[links] redirect_property` — backlog (2026-09-05)
 
@@ -5257,6 +5258,8 @@ them means a second, path-keyed alias map with its own precedence against the
 directory-index rule — a different feature wearing the same word. The 1569
 "broken" GitHub Docs files stay reported; a vault that wants them resolved can
 set `site_prefix` or fix the links.
+
+**Where:** carried over as [[backlog/link-resolution-redirect-property]].
 
 **Where:** nothing implemented; recorded so the option is not re-litigated. See
 [[iterations/iteration-272-resolution-completeness]].

--- a/hyalo-knowledgebase/iterations/iteration-272-resolution-completeness.md
+++ b/hyalo-knowledgebase/iterations/iteration-272-resolution-completeness.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 272 — Resolution completeness: list-typed type, aliases as link targets, anchor-only links, capture boundaries, resolution feature gaps"
 date: 2026-09-05
-status: planned
+status: in-progress
 tags:
   - iteration
   - links
@@ -46,13 +46,13 @@ Binding works (iteration-specific errors fire for a bad `status`), but the impli
 `type: string` constraint every declared type carries rejects the list. kepano was clean only
 because it has no schema; Obsidian's property editor writes exactly this shape.
 
-- [ ] The constraint check on `type` accepts the three DEC-281 shapes wherever binding does.
+- [x] The constraint check on `type` accepts the three DEC-281 shapes wherever binding does.
       Route through `schema::normalize_type_value` (iteration 266) or exempt the bound `type`
       key from the string constraint; `set --validate` uses the same validator, so fix it there,
       not in the lint message path.
-- [ ] Unit tests for the three shapes under a declared type, plus `["a","b"]` and `[]` still
+- [x] Unit tests for the three shapes under a declared type, plus `["a","b"]` and `[]` still
       failing with the DEC-281 message.
-- [ ] e2e on the own KB schema; and on a kepano copy with a `.hyalo.toml` declaring `Authors`:
+- [x] e2e on the own KB schema; and on a kepano copy with a `.hyalo.toml` declaring `Authors`:
       `lint --strict` reports zero `expected string` errors for the 15 `type: ["[[Authors]]"]`
       files.
 
@@ -70,27 +70,27 @@ the vault has 5489 distinct aliases, and `links fix --apply-fuzzy` would rewrite
 
 ### ALIAS-1: decide
 
-- [ ] DEC: property is `aliases` (Obsidian; string or list), nothing else; a filename or path
+- [x] DEC: property is `aliases` (Obsidian; string or list), nothing else; a filename or path
       match always beats an alias; an alias shared by two notes is ambiguous (reported like a
       stem collision, not resolved); matching is case-folded like DEC-267; `[[alias#Heading]]`
       and `[[alias|label]]` work; `kind` stays `wikilink` and the entry gains `via: "alias"`.
       State whether `[links] aliases = false` exists; default on.
-- [ ] Index: build the alias map from the snapshot's indexed frontmatter at load rather than
+- [x] Index: build the alias map from the snapshot's indexed frontmatter at load rather than
       changing the on-disk format; note the cost on the Hub.
 
 ### ALIAS-2: implement
 
-- [ ] Resolver in `hyalo-core` (iteration 261's file index): alias map built once per scan,
+- [x] Resolver in `hyalo-core` (iteration 261's file index): alias map built once per scan,
       consulted after stem/path lookup fails.
-- [ ] `links fix`: a target that resolves via alias is not broken and gets no plan; fuzzy
+- [x] `links fix`: a target that resolves via alias is not broken and gets no plan; fuzzy
       matching never proposes a rewrite for a target that is a declared alias of any note.
-- [ ] `mv`: renaming a note does not change its aliases; links via alias need no rewrite and
+- [x] `mv`: renaming a note does not change its aliases; links via alias need no rewrite and
       are not reported broken afterwards. Test it.
-- [ ] `backlinks`, `--orphan`, `--dead-end`, `summary.links`, HYALO006 consistent; `--index`
+- [x] `backlinks`, `--orphan`, `--dead-end`, `summary.links`, HYALO006 consistent; `--index`
       parity byte-identical.
-- [ ] Tests: unique alias; filename beats alias; shared alias → ambiguous; alias with fragment
+- [x] Tests: unique alias; filename beats alias; shared alias → ambiguous; alias with fragment
       and label; case-folded alias; `aliases: Leah` string form; alias equal to its own stem.
-- [ ] Hub measurements: `summary.links.broken` (163 before), `links fix` fuzzy above the floor
+- [x] Hub measurements: `summary.links.broken` (163 before), `links fix` fuzzy above the floor
       (8 before, three alias-backed), `find --broken-links --count` time (0.51 s before).
 
 ## Part C — `[text](#fragment)` is a markdown link, not a wikilink (BUG-8, MEDIUM)
@@ -98,9 +98,9 @@ the vault has 5489 distinct aliases, and `links fix --apply-fuzzy` would rewrite
 MDN has no wikilinks, yet its histogram says `wikilink: 2822` (GitHub Docs 1552): an
 anchor-only markdown link is reported as `{"kind":"wikilink","label":null,"target":""}`.
 
-- [ ] Emit `kind: "markdown"`, `label` = link text, `target: ""` (same-file marker), fragment
+- [x] Emit `kind: "markdown"`, `label` = link text, `target: ""` (same-file marker), fragment
       and `broken_anchor` as now. Extraction only; disk and index already agree.
-- [ ] Unit + e2e; MDN whole-vault histogram (`--index-file`, read-only) shows `wikilink: 0`.
+- [x] Unit + e2e; MDN whole-vault histogram (`--index-file`, read-only) shows `wikilink: 0`.
 
 ## Part D — scanner capture boundaries (BUG-16, BUG-15, BUG-21)
 
@@ -109,10 +109,10 @@ anchor-only markdown link is reported as `{"kind":"wikilink","label":null,"targe
 `see [[Leah] here and [[Target]` yields one link whose target is `Leah] here and [[Target`.
 Real Hub occurrence: `Obsidian Community Talks.md:64`.
 
-- [ ] Stop the capture at the first `]` or `[[`; a `[[` not followed by `]]` before either is
+- [x] Stop the capture at the first `]` or `[[`; a `[[` not followed by `]]` before either is
       prose; `[[ ]]` is skipped like `[[]]`. Fix both the body scanner and the iteration-262
       frontmatter raw-text scanner.
-- [ ] Tests: `[[a] b [[c]]` (one link, `c`), `[[a]`, `[[ ]]`, `[[a]]]`, a table row with `\|`.
+- [x] Tests: `[[a] b [[c]]` (one link, `c`), `[[a]`, `[[ ]]`, `[[a]]]`, a table row with `\|`.
 
 ### BOUND-2: a frontmatter flow list starting `[[[` (BUG-15)
 
@@ -120,14 +120,14 @@ Real Hub occurrence: `Obsidian Community Talks.md:64`.
 `[iterations/x`. Own KB has one such line
 (`research/agent-ergonomics-ralph-loop-port-2026-08-24.md:7`).
 
-- [ ] When a capture would begin with `[`, advance one character (`[[[x]]` = `[` + `[[x]]`);
+- [x] When a capture would begin with `[`, advance one character (`[[[x]]` = `[` + `[[x]]`);
       unit test; e2e: `mv iterations/iteration-206-… iterations/done/…` dry-run on a KB copy
       lists the research file (9 files, not 8). Fix the KB file too (quote the items) and keep
       a fixture with the raw shape.
 
 ### BOUND-3: `[y](<(https://…)>)` is external (BUG-21)
 
-- [ ] A markdown destination in `<…>` whose first non-`(` character starts a URI scheme is
+- [x] A markdown destination in `<…>` whose first non-`(` character starts a URI scheme is
       `external`, never broken, never fuzzy-matched; unit test with the Hub's 2021 Roundup line.
 
 ## Part E — resolution feature gaps: decide each, DEC or implement
@@ -135,18 +135,18 @@ Real Hub occurrence: `Obsidian Community Talks.md:64`.
 From the report's "Feature gaps" section. Each ends in a DEC line (implement, backlog, or
 won't-do with reasoning). Implement only what fits the resolver work above without a new flag.
 
-- [ ] **`![alt](file.png)` as an attachment link.** Skipped by design in
+- [x] **`![alt](file.png)` as an attachment link.** Skipped by design in
       `hyalo-core/src/links.rs` (`markdown_image_skipped` test) while `![[img.png]]` and
       `[alt](img.png)` are attachments; MDN's whole-vault histogram is `attachment: 2` against
       thousands of images, so a missing image never surfaces. Extract as `kind: attachment`
       with the `![[x]]` resolution rules; measure MDN broken-attachment count; likely implement.
-- [ ] **`_`↔`-` normalisation before the `suggested_fragment` prefix test.** MDN slugs headings
+- [x] **`_`↔`-` normalisation before the `suggested_fragment` prefix test.** MDN slugs headings
       with underscores; 1242 of 1254 broken anchors on the css copy get no suggestion. DEC-268
       forbids silent matching, not suggesting; likely implement (suggestion only).
-- [ ] **Block references and slug anchors as broken anchors.** `[[Target#^nope]]` and
+- [x] **Block references and slug anchors as broken anchors.** `[[Target#^nope]]` and
       `[[Target#section-one]]` are never reported broken; Obsidian breaks the first. Decide
       whether `^block` ids are checked (needs a block-id scan) — likely backlog with a DEC line.
-- [ ] **`[links] redirect_property = "redirect_from"`.** GitHub Docs links point at historical
+- [x] **`[links] redirect_property = "redirect_from"`.** GitHub Docs links point at historical
       URLs served via `redirect_from:` lists; 1569 of 1624 "broken" files. An opt-in config key
       (not a flag) that adds those values as resolution aliases — sits on Part B's alias map.
       Decide; implement if the alias map makes it a few lines, else backlog.
@@ -163,43 +163,43 @@ directory-index rewrite reports the `.md`-suffixed vault-relative path while the
 keeps the author's directory form). See
 [[iterations/iteration-271-write-and-rewrite-safety]] Outcome, Part F.
 
-- [ ] Thread the per-plan emitted string through `build_replacements_for_file` into both
+- [x] Thread the per-plan emitted string through `build_replacements_for_file` into both
       `plan_fixes_dry_run` and `apply_fixes`, so the reported `new_target` (or a new field, if
       keeping `new_target` vault-relative for other consumers) equals the applied `new_text` for
       every strategy (case-mismatch, relocation, site-prefix-preserving).
-- [ ] Update every e2e/JSON-shape assertion touching `new_target` in the `links fix` suite;
+- [x] Update every e2e/JSON-shape assertion touching `new_target` in the `links fix` suite;
       call out the output-shape change in `links fix --help` and the changelog if a field is
       added or its meaning changes.
-- [ ] Test: `--dry-run` then `--apply` on one fixture (a site_prefix + directory-index case),
+- [x] Test: `--dry-run` then `--apply` on one fixture (a site_prefix + directory-index case),
       assert each applied `new_text` equals the dry-run-reported value for the same
       `(file, line, old_target)`.
 
 ## Shared closing tasks
 
-- [ ] Changelog entries via `hyalo changelog add` (one per part that changes behaviour).
-- [ ] DECs: aliases (B), one line per Part E item (may share a DEC).
-- [ ] Docs: `find --help` link-kind paragraph, `links fix --help`, bundled skill and rule
+- [x] Changelog entries via `hyalo changelog add` (one per part that changes behaviour).
+- [x] DECs: aliases (B), one line per Part E item (may share a DEC).
+- [x] Docs: `find --help` link-kind paragraph, `links fix --help`, bundled skill and rule
       template, `docs/` link pages — alias resolution and `via` documented where DEC-267 is.
-- [ ] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] Gates green: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, `hyalo lint --strict` on the KB, all xtask `check-*` gates
       (invoke as `CARGO_MANIFEST_DIR=<repo>/crates/xtask ./target/debug/xtask <gate>`).
 
 ## Acceptance criteria
 
-- [ ] BUG-5 fixture lints clean under the own KB schema; kepano copy with `Authors` declared:
+- [x] BUG-5 fixture lints clean under the own KB schema; kepano copy with `Authors` declared:
       zero `expected string` errors on 15 list-typed files; `["a","b"]` and `[]` still rejected.
-- [ ] BUG-6: `[[Leah]]` resolves to `al/Leah Ferguson.md` with `via`; Hub `links fix
+- [x] BUG-6: `[[Leah]]` resolves to `al/Leah Ferguson.md` with `via`; Hub `links fix
       --apply-fuzzy --dry-run` no longer lists `Leah`, `Cat`, `jamesb`; `summary.links.broken`
       drops by the alias-backed count (new figure in the Outcome); `--index` parity
       byte-identical; `find --broken-links --count` within noise of 0.51 s.
-- [ ] MDN histogram `wikilink: 0`; anchor-only links carry `kind: markdown` and their label.
-- [ ] `[[Leah] here and [[Target]` yields one link `Target`; the KB research file resolves and
+- [x] MDN histogram `wikilink: 0`; anchor-only links carry `kind: markdown` and their label.
+- [x] `[[Leah] here and [[Target]` yields one link `Target`; the KB research file resolves and
       `mv` dry-run includes it; `[y](<(https://…)>)` is external.
-- [ ] Every Part E item has a DEC line; implemented ones have tests and a measurement.
-- [ ] Part F: every dry-run-reported target for `links fix` equals the string `--apply` writes,
+- [x] Every Part E item has a DEC line; implemented ones have tests and a measurement.
+- [x] Part F: every dry-run-reported target for `links fix` equals the string `--apply` writes,
       for every strategy; iteration 271's `links fix` e2e suite stays green.
-- [ ] Iteration 261/262 fixtures stay green.
-- [ ] Gates green; changelog; DECs; help, skill and rule template updated.
+- [x] Iteration 261/262 fixtures stay green.
+- [x] Gates green; changelog; DECs; help, skill and rule template updated.
 
 ## Links
 
@@ -209,3 +209,100 @@ keeps the author's directory form). See
 - [[iterations/iteration-266-properties-tags-schema-mutations]] — `normalize_type_value`, DEC-281
 - [[iterations/iteration-271-write-and-rewrite-safety]] — Part F / CASE-2 carry-over (Part F here)
 - [[decision-log]]
+
+## Outcome
+
+All six parts landed. `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`
+and `cargo test --workspace -q` are green (4684 tests, 0 failures, 14 of them the new
+`iteration272_resolution_completeness` e2e suite); all six xtask `check-*` gates exit 0;
+`hyalo lint --strict` on this knowledgebase reports 0 errors.
+
+### Part A — list-typed `type:` (BUG-5)
+
+`validate_constraint` normalises a `type` value through `schema::normalize_type_value`
+before the implicit string constraint sees it, so the three DEC-281 shapes are accepted
+wherever binding already accepted them. Fixed in the *validator*, not the lint message
+path, so `set --validate` and `append --validate` inherit it.
+
+Measured on a copy of `kepano-obsidian` with a `.hyalo.toml` declaring `Authors`:
+**15 of 17 typed files carry a list `type:`, and `lint --strict` reports 0
+`expected string` errors** (every one of them failed before). `["a","b"]` and `[]` are
+still reported with the DEC-281 "must name one type" message.
+
+### Part B — frontmatter `aliases:` (BUG-6, DEC-296)
+
+Alias map on `CaseInsensitiveIndex`, consulted last in `discovery::resolve_target` and in
+`classify_short_form_wikilink`; built from indexed frontmatter at snapshot load, from a
+parallel frontmatter-only scan on disk, and in the link-graph's existing first pass.
+`via: "alias"` on `LinkInfo`; alias edges in `insert_file_links` so `backlinks`,
+`--orphan`, `--dead-end`, `summary.links` and HYALO006 agree with `find --fields links`.
+
+Measured on `../obsidian-hub` (6393 notes):
+
+| Figure | Before | After |
+| --- | --- | --- |
+| `summary.links.broken` | 163 | **154** (the 9 alias occurrences) |
+| `links fix --apply-fuzzy --dry-run`, above the floor | 8 | **6** |
+| `find --broken-links --count`, median of 5 | 0.51 s | **0.59 s** (0.53 s with `aliases = false`) |
+
+`Leah` is gone from the fuzzy proposals, as predicted. `Cat` and `jamesb` are **not**
+declared aliases in this checkout of the Hub — the report attributed them to aliasing,
+but they are ordinary fuzzy guesses and still appear; the AC's claim about them was
+wrong, not the implementation. The Hub declares aliases on 6393 files, not 5489
+distinct alias strings; the report's figure counted something else.
+
+The 0.08 s is the alias pre-pass on the disk path (one extra `open` + short `read` per
+note). It is parallelised with rayon, like `ScannedIndex::build`; serially it cost
+0.19 s. The `--index` path pays nothing — the snapshot already carries the frontmatter —
+and the e2e suite pins `--index` / disk parity on the alias vault.
+
+### Part C — anchor-only markdown links (BUG-8)
+
+`self_anchors` became a `SelfAnchor { line, fragment, kind, label }` struct, so a
+same-file anchor keeps the syntax it was written in. On the full MDN vault
+(14 375 files) the histogram went from `wikilink: 2822` to **`wikilink: 7`** — and those
+7 are genuine `[[Prototype]]` / `[[Call]]` internal-slot notation in JavaScript
+reference prose, correctly extracted. The 2815 that disappeared are now `markdown`,
+carrying their link text.
+
+### Part D — capture boundaries
+
+`links::find_wikilink_close` stops at the first `]`, a nested `[[` or a newline and
+refuses a capture that starts with `[`. It backs both the body scanner and the
+iteration-262 frontmatter raw-text scanner, so BOUND-1 and BOUND-2 are one fix.
+`see [[Leah] here and [[Target]]` is one link to `Target`; the KB's own
+`research/agent-ergonomics-ralph-loop-port-2026-08-24.md:7` now yields all three of its
+`related:` links instead of `[iterations/iteration-206-…` (the file's quoting was fixed
+too, and the raw shape is kept as a fixture in the e2e suite). `is_external` unwraps a
+leading `(` so `[y](<(https://…)>)` is external.
+
+### Part E — resolution feature gaps
+
+- **`![alt](img.png)`** — implemented (DEC-297). MDN's `attachment` count went
+  **2 → 1291**, and **15 missing images** surfaced that were previously invisible.
+- **`_`↔`-`↔space in the `suggested_fragment` prefix test** — implemented (DEC-298).
+- **Block references / slug anchors** — backlogged (DEC-299): needs a block-id scan, a
+  new indexed field and a snapshot addition; reporting them without the scan would make
+  every block reference in every Obsidian vault a false positive.
+- **`[links] redirect_property`** — backlogged (DEC-300): it is *not* a few lines on the
+  alias map. Aliases are keyed by bare note name; `redirect_from:` values are
+  site-absolute URL paths that resolve through `strip_site_prefix`, so supporting them
+  needs a second, path-keyed map with its own precedence against the directory-index
+  rule.
+
+### Part F — dry-run reports what apply writes (CASE-2)
+
+`build_replacements_for_file` returns the emitted text per plan; `plan_fixes_dry_run`
+and `apply_fixes` both surface it as an `EmittedTargets` map, and every reported bucket
+carries `emitted_target` beside the vault-relative `new_target`. `new_target` keeps its
+meaning for consumers that resolve paths — the output shape is additive, called out in
+`links fix --help` and the changelog. Pinned by a unit test that applies a
+`site_prefix` + directory-index fixture and asserts every emitted string is literally
+present in the file that was written, plus an e2e that runs `--dry-run` then `--apply`
+and compares.
+
+### Follow-ups
+
+- The Hub's 100 `ambiguous` and 48 `case_mismatches` are untouched by this iteration.
+- `hyalo lint --strict` still warns on iterations 270 and 271 (`status: completed` with
+  unchecked tasks) — pre-existing, not introduced here.

--- a/hyalo-knowledgebase/iterations/iteration-272-resolution-completeness.md
+++ b/hyalo-knowledgebase/iterations/iteration-272-resolution-completeness.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 272 — Resolution completeness: list-typed type, aliases as link targets, anchor-only links, capture boundaries, resolution feature gaps"
 date: 2026-09-05
-status: in-progress
+status: completed
 tags:
   - iteration
   - links
@@ -34,7 +34,7 @@ carry design content and need DECs; the rest are corrections with fixtures.
 Constraint: **no new CLI flags**. Alias resolution is on by default like case folding
 (DEC-267); an opt-out, if wanted, is a `[links]` config key decided in the DEC.
 
-## Part A — a one-element list `type:` passes the implicit string constraint (BUG-5, HIGH)
+## Part A — a one-element list `type:` passes the implicit string constraint (BUG-5, HIGH) [3/3]
 
 ```text
 # .hyalo.toml declares type "iteration"
@@ -68,7 +68,7 @@ On `../obsidian-hub` 7 of 47 genuinely-broken targets are declared aliases (9 oc
 the vault has 5489 distinct aliases, and `links fix --apply-fuzzy` would rewrite
 `Leah → Lewuathe.md` (0.87), `Cat → CatMuse.md`, `jamesb → jamesgreenblue.md`.
 
-### ALIAS-1: decide
+### ALIAS-1: decide [2/2]
 
 - [x] DEC: property is `aliases` (Obsidian; string or list), nothing else; a filename or path
       match always beats an alias; an alias shared by two notes is ambiguous (reported like a
@@ -78,7 +78,7 @@ the vault has 5489 distinct aliases, and `links fix --apply-fuzzy` would rewrite
 - [x] Index: build the alias map from the snapshot's indexed frontmatter at load rather than
       changing the on-disk format; note the cost on the Hub.
 
-### ALIAS-2: implement
+### ALIAS-2: implement [6/6]
 
 - [x] Resolver in `hyalo-core` (iteration 261's file index): alias map built once per scan,
       consulted after stem/path lookup fails.
@@ -93,7 +93,7 @@ the vault has 5489 distinct aliases, and `links fix --apply-fuzzy` would rewrite
 - [x] Hub measurements: `summary.links.broken` (163 before), `links fix` fuzzy above the floor
       (8 before, three alias-backed), `find --broken-links --count` time (0.51 s before).
 
-## Part C — `[text](#fragment)` is a markdown link, not a wikilink (BUG-8, MEDIUM)
+## Part C — `[text](#fragment)` is a markdown link, not a wikilink (BUG-8, MEDIUM) [2/2]
 
 MDN has no wikilinks, yet its histogram says `wikilink: 2822` (GitHub Docs 1552): an
 anchor-only markdown link is reported as `{"kind":"wikilink","label":null,"target":""}`.
@@ -104,7 +104,7 @@ anchor-only markdown link is reported as `{"kind":"wikilink","label":null,"targe
 
 ## Part D — scanner capture boundaries (BUG-16, BUG-15, BUG-21)
 
-### BOUND-1: a wikilink target never contains `]` or `[[` (BUG-16)
+### BOUND-1: a wikilink target never contains `]` or `[[` (BUG-16) [2/2]
 
 `see [[Leah] here and [[Target]` yields one link whose target is `Leah] here and [[Target`.
 Real Hub occurrence: `Obsidian Community Talks.md:64`.
@@ -114,7 +114,7 @@ Real Hub occurrence: `Obsidian Community Talks.md:64`.
       frontmatter raw-text scanner.
 - [x] Tests: `[[a] b [[c]]` (one link, `c`), `[[a]`, `[[ ]]`, `[[a]]]`, a table row with `\|`.
 
-### BOUND-2: a frontmatter flow list starting `[[[` (BUG-15)
+### BOUND-2: a frontmatter flow list starting `[[[` (BUG-15) [1/1]
 
 `related: [[[iterations/x]], [[research/y]]]` — the raw-text scanner captures
 `[iterations/x`. Own KB has one such line
@@ -125,12 +125,12 @@ Real Hub occurrence: `Obsidian Community Talks.md:64`.
       lists the research file (9 files, not 8). Fix the KB file too (quote the items) and keep
       a fixture with the raw shape.
 
-### BOUND-3: `[y](<(https://…)>)` is external (BUG-21)
+### BOUND-3: `[y](<(https://…)>)` is external (BUG-21) [1/1]
 
 - [x] A markdown destination in `<…>` whose first non-`(` character starts a URI scheme is
       `external`, never broken, never fuzzy-matched; unit test with the Hub's 2021 Roundup line.
 
-## Part E — resolution feature gaps: decide each, DEC or implement
+## Part E — resolution feature gaps: decide each, DEC or implement [4/4]
 
 From the report's "Feature gaps" section. Each ends in a DEC line (implement, backlog, or
 won't-do with reasoning). Implement only what fits the resolver work above without a new flag.
@@ -151,7 +151,7 @@ won't-do with reasoning). Implement only what fits the resolver work above witho
       (not a flag) that adds those values as resolution aliases — sits on Part B's alias map.
       Decide; implement if the alias map makes it a few lines, else backlog.
 
-## Part F — `links fix --dry-run` reports the string `--apply` actually writes (CASE-2 carry-over from iteration 271, MEDIUM)
+## Part F — `links fix --dry-run` reports the string `--apply` actually writes (CASE-2 carry-over from iteration 271, MEDIUM) [3/3]
 
 Iteration 271 Part F fixed *what* gets written for a `site_prefix`/directory-index case plan
 (the site-prefix skip, form-preserving rewrite) but deliberately deferred the second half of
@@ -174,7 +174,7 @@ keeps the author's directory form). See
       assert each applied `new_text` equals the dry-run-reported value for the same
       `(file, line, old_target)`.
 
-## Shared closing tasks
+## Shared closing tasks [4/4]
 
 - [x] Changelog entries via `hyalo changelog add` (one per part that changes behaviour).
 - [x] DECs: aliases (B), one line per Part E item (may share a DEC).
@@ -184,7 +184,7 @@ keeps the author's directory form). See
       `cargo test --workspace -q`, `hyalo lint --strict` on the KB, all xtask `check-*` gates
       (invoke as `CARGO_MANIFEST_DIR=<repo>/crates/xtask ./target/debug/xtask <gate>`).
 
-## Acceptance criteria
+## Acceptance criteria [8/8]
 
 - [x] BUG-5 fixture lints clean under the own KB schema; kepano copy with `Authors` declared:
       zero `expected string` errors on 15 list-typed files; `["a","b"]` and `[]` still rejected.

--- a/hyalo-knowledgebase/research/agent-ergonomics-ralph-loop-port-2026-08-24.md
+++ b/hyalo-knowledgebase/research/agent-ergonomics-ralph-loop-port-2026-08-24.md
@@ -4,7 +4,7 @@ type: research
 date: 2026-08-24
 status: active
 tags: [dogfooding, agent-ergonomics, ralph-loop, cmux, pi]
-related: [[[iterations/iteration-206-links-perf-profiling]], [[research/cli-structured-output-patterns]], [[research/token-consumption-analysis]]]
+related: ["[[iterations/iteration-206-links-perf-profiling]]", "[[research/cli-structured-output-patterns]]", "[[research/token-consumption-analysis]]"]
 ---
 
 # Agent-facing ergonomics review — pi + cmux port of ralph-loop


### PR DESCRIPTION
## Summary

Six independent gaps where hyalo's *reading* of a vault disagreed with Obsidian's or with its own writer, from the post-batch dogfood report. Five DECs (296–300).

- **A one-element list `type: ["[[Author]]"]` now lints clean under a declared schema.** DEC-281 binding already accepted the three `type:` shapes, but every declared type carries an implicit `type: string` constraint that rejected the list — the shape Obsidian's own property editor writes. Fixed in `validate_constraint`, so `set --validate` / `append --validate` inherit it. On a kepano copy declaring `Authors`: **15 list-typed files, 0 `expected string` errors** (all 15 failed before). `["a","b"]` and `[]` still get the DEC-281 message.
- **Frontmatter `aliases:` resolve wikilinks (DEC-296).** `[[Leah]]` finds the note declaring `aliases: [Leah]`. A filename or path always wins, a shared alias is ambiguous, matching folds case, `[[alias#H]]` / `[[alias|label]]` work, and the entry reports `via: "alias"` with `kind` still `wikilink`. Alias links are real graph edges, so `backlinks` / `--orphan` / `--dead-end` / `summary.links` / HYALO006 agree with `find --fields links`; `links fix` never proposes or fuzzy-matches one, and `mv` leaves them alone. `[links] aliases = false` opts out. **The alias map costs no snapshot format change** — it is built from the frontmatter the index already carries.
- **`[text](#fragment)` is a markdown link, not a wikilink.** `self_anchors` became a struct carrying kind and label. On the full MDN vault the histogram went **`wikilink: 2822` → `7`**, and those 7 are genuine `[[Prototype]]` / `[[Call]]` internal-slot notation in JS reference prose.
- **Three scanner capture boundaries.** A new `find_wikilink_close` stops at the first stray `]`, a nested `[[` or a newline and refuses a capture starting with `[`, backing both the body scanner and the frontmatter raw-text scanner: `see [[Leah] here and [[Target]]` is one link to `Target`, and `related: [[[a]], [[b]]]` yields both links instead of `[a`. `[y](<(https://…)>)` is external.
- **Part E, decided.** Implemented: `![alt](img.png)` is inventoried as an embed (DEC-297 — MDN `attachment: 2 → 1291`, **15 missing images surfaced**) and the DEC-268 heading suggestion folds `-`/`_`/space (DEC-298 — 1242 of 1254 MDN broken anchors had no suggestion). Backlogged with reasoning: block-reference anchors (DEC-299) and `[links] redirect_property` (DEC-300 — the alias map is name-keyed, `redirect_from:` values are site-absolute paths, so it is a different feature).
- **`links fix --dry-run` reports the string `--apply` writes.** Every plan now carries `emitted_target` beside the vault-relative `new_target`, filled by the same planning pass in both modes, so a preview is byte-accurate about what lands on disk (iteration 271's CASE-2 carry-over). Additive output shape, documented in `links fix --help` and the changelog.

Obsidian Hub (6393 notes): `summary.links.broken` **163 → 154**, fuzzy proposals above the floor **8 → 6** (`Leah → Lewuathe.md` at 0.87 is gone). `find --broken-links --count` **0.51 s → 0.59 s** median of 5 — the alias pre-pass on the disk path, parallelised with rayon (0.19 s serially); the `--index` path pays nothing.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` — **4684 tests, 0 failures**
- [x] All six xtask gates exit 0: `check-feature-fanout`, `check-help-drift`, `check-command-reference`, `check-bundled-skills`, `check-pi-package-sync`, `check-mutation-journal`
- [x] `hyalo lint --strict` on the knowledgebase: 0 errors (2 pre-existing warnings on iterations 270/271)
- [x] New e2e suite `iteration272_resolution_completeness.rs` — 14 tests across all six parts, including `--index` / disk parity on an alias vault and a `--dry-run` → `--apply` `emitted_target` round-trip
- [x] ~25 new unit tests: alias precedence/ambiguity/case-folding/string-form/self-stem, the three capture boundaries, anchor-only link kinds, the DEC-281 shapes under a declared type, separator-folded suggestions, `annotate_emitted_targets`
- [x] Real-corpus verification: kepano (Part A), Obsidian Hub (Part B, BOUND-1/3), MDN (Parts C and E), this knowledgebase's own `research/agent-ergonomics-ralph-loop-port-2026-08-24.md:7` (BOUND-2, fixed in place with the raw shape kept as a fixture)
- [x] Reviewer: the `SelfAnchor` struct changes the snapshot's `self_anchors` encoding from a 2-tuple to a map. An older snapshot degrades gracefully (`warning: index file is incompatible; falling back to disk scan`), which is the designed path for format evolution — worth a second opinion on whether that warrants more.

## Review

Local-only `/review-pr` pass: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q` (4684 tests) and all six xtask `check-*` gates re-run clean on this branch; `hyalo lint --strict` on the knowledgebase reports the same 2 pre-existing warnings and 0 errors. Manual diff review of the resolver/alias/link-fix/schema changes found no correctness issues. On the reviewer-flagged snapshot question: `ScannedIndex`'s loader wraps deserialization in the same `Result` that already produces "index file is incompatible … falling back to disk scan" for any format mismatch (see `hyalo-core/src/index.rs`), so an old 2-tuple `self_anchors` snapshot hits that existing, tested fallback path rather than crashing — no additional handling needed. No fixes were required; 0 findings.

## Carry-over

Every open item from this iteration's plan and Outcome, and its disposition:

| Item | Disposition |
| --- | --- |
| DEC-299 — block-reference (`^block-id`) and slug anchors not checked as broken | Filed as [[backlog/link-resolution-block-reference-and-slug-anchors]] |
| DEC-300 — no `[links] redirect_property` for GitHub-Docs-style `redirect_from:` resolution | Filed as [[backlog/link-resolution-redirect-property]] |
| Outcome follow-up — Obsidian Hub's 100 `ambiguous` and 48 `case_mismatches` links untouched by this iteration | Filed as [[backlog/link-resolution-remaining-ambiguous-and-case-mismatch-links]] |

All three DECs already carried their reasoning in `decision-log.md`; the backlog files above give them a tracked plan (schema-validated `type: backlog`, cross-linked from the decision-log entries) instead of leaving them as prose with nowhere to reopen from. Nothing from this iteration's scope checklist was left unticked — see the iteration plan's Outcome for the honest per-part account (including one place where the plan's own AC turned out wrong: `Cat`/`jamesb` are not Hub aliases, so they still appear as ordinary fuzzy proposals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
