### PR TITLE
feat(iter-288): add Codex skills and plugin integration

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "hyalo",
+  "interface": {
+    "displayName": "Hyalo"
+  },
+  "plugins": [
+    {
+      "name": "hyalo",
+      "source": {
+        "source": "local",
+        "path": "./plugins/hyalo"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -27,6 +27,8 @@ jobs:
         run: cargo run -p xtask -- check-bundled-skills
       - name: Check pi-package vendored copies are in sync
         run: cargo run -p xtask -- check-pi-package-sync
+      - name: Check Codex plugin assets and metadata
+        run: cargo run -p xtask -- check-codex-package
       - name: Check every shipped --jq recipe executes
         run: cargo run -p xtask -- check-jq-recipes
       - name: Check mutating commands go through MutationJournal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Codex project integration with `hyalo init --codex`: managed `AGENTS.md`
+  guidance, skills under `.agents/skills/`, active profile workflows, and clean
+  removal through `deinit`. A skills-only plugin ships under `plugins/hyalo/`;
+  `--codex-plugin` configures projects without duplicate local skill copies.
+- Agent Skills validation now includes `.agents/skills/**` as well as Claude's
+  skill directory. CI checks Codex plugin metadata and embedded asset parity.
+
 ### Changed
 
 - **Loading a `.hyalo-index` snapshot no longer decodes the BM25 inverted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "anyhow",
  "clap",
  "serde",
+ "serde-saphyr",
  "serde_json",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Hyalo is the tooling layer that makes this practical. An LLM agent can use `hyal
 
 - **Fast.** Parallel scanning, streaming I/O, optional snapshot index. Handles 10,000+ file vaults in under a second.
 - **Structured output.** TTY-aware: compact `text` for terminals, `json` when piped — with built-in `--jq` support. Easy to pipe into scripts, CI, or AI agents.
-- **AI-agent friendly.** Designed as a tool for [Claude Code](https://claude.ai/claude-code) and other LLM coding agents. One command sets up the integration: `hyalo init --claude`.
+- **AI-agent friendly.** Integrates with Claude Code, Codex, and Pi. Set up project workflows with `hyalo init --claude`, `hyalo init --codex`, or `hyalo init --pi`; Codex and Pi also have installable packages.
 - **Safe mutations.** Dry-run mode on all write operations. Preview before committing changes.
 - **Cross-platform.** Works on macOS, Linux, and Windows. No runtime dependencies.
 
@@ -205,6 +205,39 @@ This installs two [skills](https://docs.anthropic.com/en/docs/claude-code/skills
 **`knowledgebase` rule** — Scoped to `<your-vault>/**`. Reminds Claude to prefer hyalo CLI commands over built-in file tools whenever it touches vault files.
 
 All artifacts are idempotent — re-running `hyalo init --claude` updates to the latest versions. `hyalo deinit` removes everything cleanly.
+
+## Install the Codex integration
+
+For project-local skills and knowledgebase guidance:
+
+```bash
+hyalo init --codex
+hyalo init --codex --profile okf
+```
+
+This installs skills under `.agents/skills/` and a managed section in `AGENTS.md`.
+Existing configuration selects the vault; `--dir` explicitly selects another one.
+The flags compose with `--claude` and `--pi`. Re-run after upgrading Hyalo to
+refresh generated skills. `hyalo deinit` removes managed project artifacts while
+preserving unrelated skills and instruction text.
+
+For use across projects, this repository also ships a skills-only Codex plugin:
+
+```bash
+# From a checkout containing the Codex integration:
+codex plugin marketplace add .
+codex plugin add hyalo@hyalo
+hyalo init --codex --codex-plugin
+```
+
+Plugin mode configures the project and removes managed project skill copies to
+avoid duplicate discovery. It does not install the plugin or modify global Codex
+settings. Keep `--codex-plugin` on subsequent init runs. Start a new Codex session
+after setup. The plugin requires `hyalo` on PATH; post-edit lint is skill guidance,
+not an automatic hook. Project skills also serve clients without plugin support.
+
+See [Codex integration](hyalo-knowledgebase/docs/codex-integration.md) for update,
+removal, profiles, and maintainer verification instructions.
 
 ## Install the pi integration
 

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -40,6 +40,7 @@ strsim = { workspace = true }
 toml = { workspace = true }
 rayon = { workspace = true }
 toml_edit = { workspace = true }
+tempfile = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
@@ -47,7 +48,6 @@ libc = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
-tempfile = { workspace = true }
 
 [package.metadata.deb]
 maintainer = "ractive"

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -1604,10 +1604,14 @@ Repeatable (AND).\n\
     },
     /// Initialize hyalo configuration and optional tool integrations
     #[command(
-        long_about = "Create .hyalo.toml and optionally set up Claude Code and pi integrations.\n\n\
+        long_about = "Create .hyalo.toml and optionally set up Claude Code, Codex, and pi integrations.\n\n\
             Without flags, creates a .hyalo.toml config file.\n\
             With --claude, also installs the hyalo skill for Claude Code.\n\
             With --pi, also installs the hyalo skill for pi.\n\
+            With --codex, installs project skills in .agents/skills and a managed AGENTS.md block.\n\
+            Add --codex-plugin if the Hyalo plugin is installed: writes project guidance and\n\
+            removes managed project skills to avoid duplicates. Neither option installs Codex\n\
+            or modifies global settings. Re-run init after upgrading Hyalo to refresh skills.\n\
             With --profile <name>, scaffolds a preset vault flavour by merging an\n\
             embedded config fragment into .hyalo.toml (available: okf, madr, skills,\n\
             changelog). Multiple profiles compose in one vault: array keys (exempt,\n\
@@ -1615,6 +1619,7 @@ Repeatable (AND).\n\
             re-running is idempotent. A changed scalar prints a `conflict:` line to\n\
             stderr — nothing is lost silently.\n\
             With --profile <name> --claude, also installs the bundled skill for it.\n\n\
+            With --codex, installs Codex workflows for all active known profiles.\n\n\
             Use the global --dir flag to name the markdown directory. A vault at or below the\n\
             current directory keeps .hyalo.toml here and records `dir` relative to it; a vault\n\
             outside it (an absolute path elsewhere, ../sibling) makes that tree its own project\n\
@@ -1629,6 +1634,9 @@ Repeatable (AND).\n\
             hyalo init --dir kb --format json\n\
             hyalo --dir kb init --claude\n\
             hyalo --dir kb init --pi\n\
+            hyalo init --codex\n\
+            hyalo init --codex --codex-plugin\n\
+            hyalo init --codex --profile okf\n\
             hyalo init --profile okf\n\
             hyalo init --profile okf --claude\n\
             hyalo init --profile madr\n\
@@ -1642,6 +1650,12 @@ Repeatable (AND).\n\
         /// Set up pi integration (skill + extension)
         #[arg(long)]
         pi: bool,
+        /// Set up Codex project skills and managed AGENTS.md guidance
+        #[arg(long)]
+        codex: bool,
+        /// Use the installed Hyalo plugin instead of project skills
+        #[arg(long, requires = "codex")]
+        codex_plugin: bool,
         /// Scaffold a preset vault flavour: okf, madr, skills, or changelog
         ///
         /// Merges the profile's embedded config fragment into .hyalo.toml.
@@ -1650,8 +1664,10 @@ Repeatable (AND).\n\
     },
     /// Remove hyalo configuration and tool integration artifacts
     #[command(
-        long_about = "Remove .hyalo.toml and all Claude Code / pi integration artifacts created by `init`.\n\n\
+        long_about = "Remove .hyalo.toml and all Claude Code / Codex / pi integration artifacts created by `init`.\n\n\
             Removes skills, rules, and the managed section from .claude/CLAUDE.md, and .pi/ directory.\n\
+            Removes managed Codex skills and the managed AGENTS.md block, preserving user content.\n\
+            Installed plugins and global Codex settings are not changed.\n\
             Safe to run when artifacts are already absent (idempotent).\n\n\
             The global --dir flag selects the tree to clean, exactly as it does for `init`: a\n\
             vault inside the current directory still cleans the current project, while --dir\n\

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -20,7 +20,7 @@ COMMANDS \u{2014} write (mutates files):
   links new           fix broken / auto-link mentions | scaffold from a type
   madr okf changelog  ADR toc | OKF index+log | Keep a Changelog add/release
 COMMANDS \u{2014} setup (writes config/index, not your notes):
-  init deinit              Create/remove .hyalo.toml (--claude --pi --profile)
+  init deinit              Create/remove config (--claude --codex --pi --profile)
   types lint-rules views   Schemas | lint rule catalog | saved find queries
   create-index drop-index  Snapshot index for faster repeated queries
   completions              Shell completion script";
@@ -324,7 +324,8 @@ const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
     hyalo config [--raw] [-d/--dir DIR]                    # --raw also prints the .hyalo.toml text
 
   Init (configuration, one-time setup):
-    hyalo init [--claude] [--pi] [--profile <PROFILE>] [-d/--dir DIR]   # a vault outside CWD roots there
+    hyalo init [--claude] [--pi] [--codex] [--codex-plugin] [--profile <PROFILE>] [-d/--dir DIR]
+      # --codex-plugin requires --codex; use a separately installed plugin instead of local skills
 
   Deinit (remove hyalo configuration):
     hyalo deinit [-d/--dir DIR]                            # picks the tree to clean; default CWD

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -6,6 +6,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml::Value as TomlValue;
 
+mod codex;
+pub use codex::CodexMode;
+
 // ---------------------------------------------------------------------------
 // Embedded skill content
 // ---------------------------------------------------------------------------
@@ -125,7 +128,7 @@ pub struct Report {
     /// `"init"` or `"deinit"`.
     command: &'static str,
     /// Absolute path of the directory holding the `.hyalo.toml` and the
-    /// `.claude`/`.pi` integration files this run touched.
+    /// `.claude`/`.pi`/`.agents` integration files this run touched.
     root: String,
     /// The `dir = "…"` value written to `.hyalo.toml` (`init` only).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -348,7 +351,7 @@ fn normalize_lexically(path: &Path) -> PathBuf {
 // Public command entry point
 // ---------------------------------------------------------------------------
 
-/// Initialize hyalo configuration and optional Claude Code and pi integrations.
+/// Initialize hyalo configuration and optional Claude Code, Codex, and pi integrations.
 ///
 /// - `dir`: explicit value for the `dir` key in `.hyalo.toml`; when `None` the
 ///   function auto-detects a common doc directory.
@@ -356,6 +359,7 @@ fn normalize_lexically(path: &Path) -> PathBuf {
 ///   writes a managed section to `.claude/CLAUDE.md`.
 /// - `pi`: when `true`, also installs the hyalo and hyalo-tidy skills for pi,
 ///   the hyalo extension, and a package.json.
+/// - `codex`: project skills or guidance for a separately installed plugin.
 ///
 /// When `dir` names a tree outside CWD, the whole run moves into that tree
 /// (see [`Scope`]) instead of writing a CWD-local config pointing at it.
@@ -364,17 +368,30 @@ pub fn run_init(
     claude: bool,
     pi: bool,
     profile: Option<&str>,
+    codex: CodexMode,
 ) -> Result<Report> {
     let cwd = std::env::current_dir().context("failed to determine current working directory")?;
-    run_init_in(dir, claude, pi, profile, &cwd)
+    initialize_in(dir, claude, pi, profile, &cwd, codex)
 }
 
+#[cfg(test)]
 fn run_init_in(
     dir: Option<&str>,
     claude: bool,
     pi: bool,
     profile: Option<&str>,
     cwd: &Path,
+) -> Result<Report> {
+    initialize_in(dir, claude, pi, profile, cwd, CodexMode::None)
+}
+
+fn initialize_in(
+    dir: Option<&str>,
+    claude: bool,
+    pi: bool,
+    profile: Option<&str>,
+    cwd: &Path,
+    codex: CodexMode,
 ) -> Result<Report> {
     // Resolve the profile up front so an unknown name errors before any files
     // are written.
@@ -391,6 +408,10 @@ fn run_init_in(
     let dir_value = scope.dir_value.clone();
     let mut report = Report::new("init", &scope, Some(dir_value.clone()));
     let root = scope.root.as_path();
+
+    if codex != CodexMode::None {
+        codex::preflight(root)?;
+    }
 
     if root.is_file() {
         anyhow::bail!("--dir path '{}' is a file, not a directory", root.display());
@@ -540,6 +561,10 @@ fn run_init_in(
                 }
             }
         }
+    }
+
+    if codex != CodexMode::None {
+        codex::install(root, codex, &mut report)?;
     }
 
     if !claude && !pi {
@@ -810,6 +835,9 @@ fn run_deinit_in(dir: Option<&str>, cwd: &Path) -> Result<Report> {
     let scope = resolve_scope(dir, cwd);
     let mut report = Report::new("deinit", &scope, None);
     let root = scope.root.as_path();
+
+    codex::preflight_removal(root)?;
+    codex::remove(root, &mut report)?;
 
     // Step 1: Remove .claude/skills/hyalo/SKILL.md and parent dir if empty.
     let skill_path = root

--- a/crates/hyalo-cli/src/commands/init/codex.rs
+++ b/crates/hyalo-cli/src/commands/init/codex.rs
@@ -1,0 +1,329 @@
+//! Project Codex installation. Plugin and embedded assets are checked for drift by xtask.
+use super::{Report, active_profiles_from_config, relative_within, remove_dir_if_empty};
+use anyhow::{Context, Result, bail};
+use std::fmt::Write as _;
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CodexMode {
+    None,
+    Local,
+    Plugin,
+}
+
+const MANAGED: &str = "<!-- hyalo:managed -->";
+const YAML_MANAGED: &str = "# hyalo:managed";
+const START: &str = "<!-- hyalo:start -->";
+const END: &str = "<!-- hyalo:end -->";
+
+struct Skill {
+    name: &'static str,
+    profile: Option<&'static str>,
+    body: &'static str,
+    metadata: &'static str,
+}
+
+macro_rules! skill {
+    ($name:literal, $profile:expr) => {
+        Skill {
+            name: $name,
+            profile: $profile,
+            body: include_str!(concat!(
+                "../../../templates/codex/skills/",
+                $name,
+                "/SKILL.md"
+            )),
+            metadata: include_str!(concat!(
+                "../../../templates/codex/skills/",
+                $name,
+                "/agents/openai.yaml"
+            )),
+        }
+    };
+}
+
+const SKILLS: &[Skill] = &[
+    skill!("hyalo", None),
+    skill!("hyalo-tidy", None),
+    skill!("hyalo-okf", Some("okf")),
+    skill!("hyalo-madr", Some("madr")),
+    skill!("hyalo-skills", Some("skills")),
+    skill!("hyalo-changelog", Some("changelog")),
+];
+
+// Check every existing component: even an in-root symlink may refer to user-owned
+// guidance. Refuse it rather than overwriting the referent or following it on removal.
+fn check_path(root: &Path, relative: &str) -> Result<()> {
+    let mut path = root.to_path_buf();
+    for part in Path::new(relative).components() {
+        path.push(part);
+        match fs::symlink_metadata(&path) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                bail!("Codex artifact path is a symlink: {}", path.display());
+            }
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).with_context(|| format!("checking {}", path.display())),
+        }
+    }
+    Ok(())
+}
+
+fn read_optional(path: &Path) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(text) => Ok(Some(text)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("reading {}", path.display())),
+    }
+}
+
+fn owned(text: &str) -> bool {
+    text.lines()
+        .any(|line| line == MANAGED || line == YAML_MANAGED)
+}
+
+/// Return byte offsets so surrounding user text, including CRLF, stays unchanged.
+fn managed_range(text: &str) -> Result<Option<std::ops::Range<usize>>> {
+    let mut start = None;
+    let mut range = None;
+    let mut offset = 0;
+    for line in text.split_inclusive('\n') {
+        match line.trim_end_matches(['\r', '\n']) {
+            START => {
+                if start.is_some() || range.is_some() {
+                    bail!(
+                        "AGENTS.md has duplicate or nested hyalo markers; repair them before running init/deinit"
+                    );
+                }
+                start = Some(offset);
+            }
+            END => {
+                let Some(begin) = start.take() else {
+                    bail!("AGENTS.md has an unmatched hyalo end marker");
+                };
+                range = Some(begin..offset + line.len());
+            }
+            _ => {}
+        }
+        offset += line.len();
+    }
+    if start.is_some() {
+        bail!("AGENTS.md has an unmatched hyalo start marker");
+    }
+    Ok(range)
+}
+
+pub(super) fn preflight_removal(root: &Path) -> Result<()> {
+    check_path(root, "AGENTS.md")?;
+    if let Some(text) = read_optional(&root.join("AGENTS.md"))? {
+        managed_range(&text)?;
+    }
+    for skill in SKILLS {
+        for suffix in ["SKILL.md", "agents/openai.yaml"] {
+            check_path(root, &format!(".agents/skills/{}/{suffix}", skill.name))?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn preflight(root: &Path) -> Result<()> {
+    preflight_removal(root)?;
+    check_path(root, ".hyalo.toml")?;
+    if let Some(text) = read_optional(&root.join(".hyalo.toml"))? {
+        let _: toml::Value =
+            toml::from_str(&text).context("invalid .hyalo.toml for Codex setup")?;
+    }
+    for skill in SKILLS {
+        for suffix in ["SKILL.md", "agents/openai.yaml"] {
+            let relative = format!(".agents/skills/{}/{suffix}", skill.name);
+            if let Some(text) = read_optional(&root.join(&relative))?
+                && !owned(&text)
+            {
+                bail!(
+                    "Codex skill conflict: {relative} is not managed by hyalo; move or rename it before init"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_asset(root: &Path, relative: &str, text: &str, report: &mut Report) -> Result<()> {
+    let path = root.join(relative);
+    let old = read_optional(&path)?;
+    if old.as_deref() == Some(text) {
+        report.push("unchanged", relative);
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let parent = path.parent().context("Codex artifact has no parent")?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("creating temporary file in {}", parent.display()))?;
+    if old.is_some() {
+        temporary
+            .as_file()
+            .set_permissions(fs::metadata(&path)?.permissions())?;
+    }
+    temporary.write_all(text.as_bytes())?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist(&path)
+        .with_context(|| format!("writing {}", path.display()))?;
+    report.push(if old.is_some() { "updated" } else { "created" }, relative);
+    Ok(())
+}
+
+pub(super) fn install(root: &Path, mode: CodexMode, report: &mut Report) -> Result<()> {
+    let config_path = root.join(".hyalo.toml");
+    let raw = fs::read_to_string(&config_path).context("reading Codex vault configuration")?;
+    let config: toml::Value = toml::from_str(&raw).context("parsing Codex vault configuration")?;
+    let configured_dir = config
+        .get("dir")
+        .and_then(toml::Value::as_str)
+        .unwrap_or(".");
+    if Path::new(configured_dir).is_absolute()
+        || relative_within(root, &root.join(configured_dir)).is_none()
+    {
+        bail!("Codex vault dir must stay inside the project root: {configured_dir}");
+    }
+    let active = active_profiles_from_config(&config_path);
+    // The retained config, not auto-detection, is authoritative on repeated init.
+    report.dir = Some(configured_dir.to_owned());
+    if mode == CodexMode::Plugin {
+        remove_skills(root, report)?;
+        report.notes.push("Codex plugin mode: install the Hyalo plugin separately; project skills were removed to avoid duplicate discovery. Use --codex-plugin on subsequent init runs.".to_owned());
+    } else {
+        for skill in SKILLS
+            .iter()
+            .filter(|s| s.profile.is_none_or(|p| active.iter().any(|a| a == p)))
+        {
+            write_asset(
+                root,
+                &format!(".agents/skills/{}/SKILL.md", skill.name),
+                skill.body,
+                report,
+            )?;
+            write_asset(
+                root,
+                &format!(".agents/skills/{}/agents/openai.yaml", skill.name),
+                skill.metadata,
+                report,
+            )?;
+        }
+        report.notes.push("Codex project skills installed. If you also install the Hyalo plugin, rerun init --codex --codex-plugin to avoid duplicate skills.".to_owned());
+    }
+    let skill_location = if mode == CodexMode::Plugin {
+        "Use the installed Hyalo plugin's skills."
+    } else {
+        "Use the hyalo and hyalo-tidy skills in .agents/skills/."
+    };
+    // JSON quoting prevents paths with backticks/newlines from turning into instructions.
+    let quoted_dir = serde_json::to_string(configured_dir)?;
+    let mut block = format!(
+        "{START}\nHyalo manages the markdown vault at {quoted_dir}, relative to this project's .hyalo.toml.\n\
+         {skill_location}\n\
+         Use the hyalo CLI for knowledgebase search, reading, frontmatter, tags, tasks, and links.\n\
+         Run hyalo config to inspect the effective vault; file arguments are vault-relative.\n\
+         Run commands from this project or its descendants so configuration is discovered.\n\
+         Use normal editing tools for body prose; run hyalo lint on changed markdown before handoff.\n\
+         An audit request authorizes inspection; apply repairs only within the user's requested scope.\n"
+    );
+    for profile in &active {
+        if SKILLS.iter().any(|s| s.profile == Some(profile.as_str())) {
+            writeln!(
+                block,
+                "Active profile: {profile}; consult the hyalo-{profile} skill for its workflow."
+            )?;
+        }
+    }
+    writeln!(block, "{END}")?;
+    let old = read_optional(&root.join("AGENTS.md"))?.unwrap_or_default();
+    let updated = if let Some(range) = managed_range(&old)? {
+        format!("{}{}{}", &old[..range.start], block, &old[range.end..])
+    } else if old.is_empty() || old.ends_with('\n') {
+        format!("{old}{block}")
+    } else {
+        // Prepend rather than changing the final newline of user-owned text.
+        format!("{block}{old}")
+    };
+    write_asset(root, "AGENTS.md", &updated, report)?;
+    if root.join("AGENTS.override.md").exists() {
+        report.push_detail("warning", "AGENTS.override.md", "Codex prefers this file over AGENTS.md; merge the Hyalo guidance into it manually if wanted");
+    }
+    report.notes.push("Start a new Codex session to load the project guidance. Post-edit lint is skill guidance, not an automatic hook.".to_owned());
+    Ok(())
+}
+
+fn remove_skills(root: &Path, report: &mut Report) -> Result<()> {
+    for skill in SKILLS {
+        for suffix in ["SKILL.md", "agents/openai.yaml"] {
+            let relative = format!(".agents/skills/{}/{suffix}", skill.name);
+            if let Some(text) = read_optional(&root.join(&relative))? {
+                if owned(&text) {
+                    fs::remove_file(root.join(&relative))
+                        .with_context(|| format!("removing {relative}"))?;
+                    report.push("removed", &relative);
+                } else {
+                    report.push_detail("skipped", &relative, "not managed by hyalo");
+                }
+            }
+        }
+        for relative in [
+            format!(".agents/skills/{}/agents", skill.name),
+            format!(".agents/skills/{}", skill.name),
+        ] {
+            remove_dir_if_empty(&root.join(&relative), &relative, report)?;
+        }
+    }
+    remove_dir_if_empty(&root.join(".agents/skills"), ".agents/skills/", report)?;
+    remove_dir_if_empty(&root.join(".agents"), ".agents/", report)?;
+    Ok(())
+}
+
+pub(super) fn remove(root: &Path, report: &mut Report) -> Result<()> {
+    remove_skills(root, report)?;
+    if let Some(text) = read_optional(&root.join("AGENTS.md"))?
+        && let Some(range) = managed_range(&text)?
+    {
+        let stripped = format!("{}{}", &text[..range.start], &text[range.end..]);
+        if stripped.is_empty() {
+            fs::remove_file(root.join("AGENTS.md")).context("removing empty AGENTS.md")?;
+            report.push("removed", "AGENTS.md");
+        } else {
+            write_asset(root, "AGENTS.md", &stripped, report)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markers_preserve_surrounding_bytes_and_reject_ambiguous_input() {
+        let original = format!("user\r\n{START}\r\nmanaged\r\n{END}\r\ntail\r\n");
+        let range = managed_range(&original).unwrap().unwrap();
+        assert_eq!(
+            format!("{}{}", &original[..range.start], &original[range.end..]),
+            "user\r\ntail\r\n"
+        );
+        for text in [
+            START.to_owned(),
+            END.to_owned(),
+            format!("{START}\n{START}\n{END}"),
+            format!("{START}\n{END}\n{START}\n{END}"),
+        ] {
+            assert!(managed_range(&text).is_err());
+        }
+        assert!(
+            managed_range("Mention <!-- hyalo:start --> in prose")
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/hyalo-cli/src/commands/init/codex.rs
+++ b/crates/hyalo-cli/src/commands/init/codex.rs
@@ -161,18 +161,26 @@ fn write_asset(root: &Path, relative: &str, text: &str, report: &mut Report) -> 
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
     let parent = path.parent().context("Codex artifact has no parent")?;
+    let existing_permissions = if old.is_some() {
+        Some(fs::metadata(&path)?.permissions())
+    } else {
+        None
+    };
     let mut temporary = tempfile::NamedTempFile::new_in(parent)
         .with_context(|| format!("creating temporary file in {}", parent.display()))?;
-    if old.is_some() {
-        temporary
-            .as_file()
-            .set_permissions(fs::metadata(&path)?.permissions())?;
-    }
     temporary.write_all(text.as_bytes())?;
+    // Writing can clear set-ID bits. Apply permissions only after all content.
+    if let Some(permissions) = &existing_permissions {
+        temporary.as_file().set_permissions(permissions.clone())?;
+    }
     temporary.as_file().sync_all()?;
-    temporary
+    let persisted = temporary
         .persist(&path)
         .with_context(|| format!("writing {}", path.display()))?;
+    // Match the core atomic writer: persist can alter platform attributes.
+    if let Some(permissions) = existing_permissions {
+        persisted.set_permissions(permissions)?;
+    }
     report.push(if old.is_some() { "updated" } else { "created" }, relative);
     Ok(())
 }
@@ -228,7 +236,8 @@ pub(super) fn install(root: &Path, mode: CodexMode, report: &mut Report) -> Resu
          {skill_location}\n\
          Use the hyalo CLI for knowledgebase search, reading, frontmatter, tags, tasks, and links.\n\
          Run hyalo config to inspect the effective vault; file arguments are vault-relative.\n\
-         Run commands from this project or its descendants so configuration is discovered.\n\
+         Run commands from the project root containing .hyalo.toml or inside the configured vault.\n\
+         Other project subdirectories do not inherit this vault configuration; return to the project root first.\n\
          Use normal editing tools for body prose; run hyalo lint on changed markdown before handoff.\n\
          An audit request authorizes inspection; apply repairs only within the user's requested scope.\n"
     );

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1043,12 +1043,22 @@ fn run_inner() -> Result<(), AppError> {
     if let Commands::Init {
         claude,
         pi,
+        codex,
+        codex_plugin,
         profile,
     } = &mut cli.command
     {
         let init_dir = cli.dir.as_deref().and_then(|p| p.to_str());
-        let report = init_commands::run_init(init_dir, *claude, *pi, profile.as_deref())
-            .map_err(AppError::Internal)?;
+        let codex_mode = if *codex_plugin {
+            init_commands::CodexMode::Plugin
+        } else if *codex {
+            init_commands::CodexMode::Local
+        } else {
+            init_commands::CodexMode::None
+        };
+        let report =
+            init_commands::run_init(init_dir, *claude, *pi, profile.as_deref(), codex_mode)
+                .map_err(AppError::Internal)?;
         return emit_init_report(&report, cli.format, cli.jq.as_deref());
     }
     if let Commands::Deinit = &mut cli.command {

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-changelog/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-changelog/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: hyalo-changelog
+description: Maintain Keep a Changelog files with Hyalo's changelog profile and add/release commands.
+---
+
+<!-- hyalo:managed -->
+
+# Changelog maintenance
+
+Inspect `hyalo config` and `hyalo changelog --help` before editing.
+The configured changelog may be outside the notes directory, relative to the project
+configuration. Follow that path rather than assuming a vault-local CHANGELOG.md.
+
+Use `hyalo changelog add --help` or `hyalo changelog release --help` for the exact
+arguments. Preserve the existing Keep a Changelog sections and release history.
+Moving entries into a release requires the requested version and release scope;
+do not invent a release or publish artifacts while writing release notes.
+Use `hyalo lint --profile changelog --format text` to inspect conformance.

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-changelog/agents/openai.yaml
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-changelog/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo Changelog"
+  short_description: "Maintain Keep a Changelog release notes"
+  default_prompt: "Use $hyalo-changelog to inspect the unreleased changes."
+policy:
+  allow_implicit_invocation: true

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-madr/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-madr/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: hyalo-madr
+description: Maintain Markdown Architecture Decision Records with Hyalo's MADR profile and table-of-contents commands.
+---
+
+<!-- hyalo:managed -->
+
+# Architecture decision records
+
+Inspect `hyalo config`, `hyalo types show adr`, and `hyalo madr --help`.
+Use `hyalo lint --profile madr --format text` for conformance and
+`hyalo madr toc --dry-run` to inspect table-of-contents drift.
+
+Keep numbering, status transitions, supersession links, and the configured ADR path
+consistent with the existing collection. Use the relevant command's help before creating
+or superseding records. Do not infer that an accepted decision is superseded from age alone.
+Apply requested metadata changes with Hyalo and prose with ordinary editing tools.
+After edits, lint affected records and preview the table of contents again.

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-madr/agents/openai.yaml
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-madr/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo MADR"
+  short_description: "Maintain architecture decision records"
+  default_prompt: "Use $hyalo-madr to check the architecture decision records."
+policy:
+  allow_implicit_invocation: true

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-okf/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-okf/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: hyalo-okf
+description: Maintain Open Knowledge Format vaults with Hyalo's OKF index, log, and conformance commands.
+---
+
+<!-- hyalo:managed -->
+
+# Open Knowledge Format
+
+Use `hyalo config` to locate the vault and confirm the `okf` profile.
+For a read-only check, use `hyalo lint --profile okf --format text` and
+`hyalo okf index --dry-run`. Inspect `hyalo okf --help` and the relevant subcommand
+help before generating indexes or logs. Dry-run output is a proposal, not a completed edit.
+
+Preserve reserved index/log files and the vault's schemas. Use Hyalo's OKF generators
+for their managed sections and normal editing tools for prose outside them.
+Apply generated changes only when requested, then check conformance and index drift again.

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-okf/agents/openai.yaml
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-okf/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo OKF"
+  short_description: "Maintain Open Knowledge Format vaults"
+  default_prompt: "Use $hyalo-okf to check this OKF vault."
+policy:
+  allow_implicit_invocation: true

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-skills/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-skills/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: hyalo-skills
+description: Validate and maintain Agent Skills collections using Hyalo's skills profile, including Codex and Claude skill directories.
+---
+
+<!-- hyalo:managed -->
+
+# Agent Skills collections
+
+Use `hyalo lint --profile skills --format text` from the collection root.
+The profile binds `**/SKILL.md` to its skill schema and includes hidden
+`.agents/skills/**` and `.claude/skills/**` subtrees under the selected vault.
+A project whose configured vault is a separate notes directory requires an explicit
+`--dir .` to validate project-root skills. Do not rewrite its configuration to run a check.
+
+Required frontmatter is `name` and `description`; the name must match the directory.
+Use `hyalo types show skill` on an initialized skills vault and command help for
+schema details. Keep descriptions focused on actual triggers. Preserve host-specific
+metadata where supported; Codex appearance and invocation policy live in
+`agents/openai.yaml`, which markdown lint does not validate.
+
+Make requested edits, then rerun conformance on the affected files. A clean lint result
+checks structure, not whether a skill follows user intent or makes good decisions.

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-skills/agents/openai.yaml
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-skills/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo Skills"
+  short_description: "Validate Agent Skills markdown collections"
+  default_prompt: "Use $hyalo-skills to validate this skill collection."
+policy:
+  allow_implicit_invocation: true

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-tidy/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-tidy/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: hyalo-tidy
+description: Audit or tidy a Hyalo knowledgebase for broken links, orphan documents, stale content, and inconsistent metadata.
+---
+
+<!-- hyalo:managed -->
+
+# Knowledgebase maintenance
+
+Resolve the installed `hyalo` executable and run `hyalo config --format json`.
+Use the configured vault and existing schemas. If the executable or configuration is
+missing, report what is needed before doing maintenance.
+
+An audit or health question is read-only. A request to tidy or repair authorizes relevant
+changes, not deletion of notes based only on age or orphan status.
+
+Orient with `hyalo summary --format text`, `hyalo lint --format text`, and
+`hyalo find --broken-links --format text`. Inspect individual files with `hyalo read`.
+Check schemas with `hyalo types list` before proposing metadata normalization.
+An orphan can be a legitimate entry point; stale status requires evidence from its content.
+
+Prioritize concrete findings. When authorized to repair, preview applicable fixes
+(`hyalo lint --fix --dry-run`; consult `hyalo links --help` for link repairs).
+Use Hyalo for frontmatter and tasks, normal editing tools for prose, and preserve meaning.
+Do not apply uncertain fuzzy link replacements without inspecting the candidates.
+
+Run lint on changed files and recheck the original findings. Report what changed,
+what remains unresolved, and any skipped or failed checks. Keep audit-only runs free
+of writes, including creating or dropping snapshot indexes.

--- a/crates/hyalo-cli/templates/codex/skills/hyalo-tidy/agents/openai.yaml
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo-tidy/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo Tidy"
+  short_description: "Audit knowledgebase health and scoped repairs"
+  default_prompt: "Use $hyalo-tidy to audit this knowledgebase and report findings."
+policy:
+  allow_implicit_invocation: false

--- a/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: hyalo
+description: "Search and edit structured markdown knowledgebases with the Hyalo CLI: frontmatter, tags, tasks, links, and document structure."
+---
+
+<!-- hyalo:managed -->
+
+# Hyalo knowledgebase workflow
+
+Use the installed `hyalo` executable. In a Hyalo source checkout, `target/release/hyalo`
+is an alternative when present. If unavailable, report that and suggest the project's
+documented installation (`cargo install hyalo-cli`); do not install software as a
+side effect of a knowledgebase query.
+
+Start with `hyalo config --format json` to locate the vault and its configuration.
+Run from the project or a descendant directory. Do not assume the vault is named
+`hyalo-knowledgebase` and do not repeat `--dir` when configuration already selects it.
+File arguments are relative to the vault, including when launched from a nested folder.
+
+Use `hyalo summary --format text` for orientation. Then select the smallest query
+that answers the request:
+
+```sh
+hyalo find "release blockers" --format text
+hyalo find --property status=planned --tag iteration --format text
+hyalo read iterations/example.md --section Tasks --format text
+hyalo backlinks iterations/example.md --format text
+hyalo set iterations/example.md --property status=in-progress
+hyalo task toggle iterations/example.md --line 12
+hyalo lint iterations/example.md --format text
+```
+
+The paths above are examples: resolve actual files before running mutations.
+Use `hyalo <command> --help` for exact syntax, advanced filters, links, or bulk operations.
+`find`'s positional query is ranked search; `-e` is regex. Quote filter expressions
+and paths as single arguments using the active shell's quoting rules.
+
+Pass `--format text` for compact reading or `--format json` for structured output.
+JSON is an envelope; results live in `.results`. `--jq` operates on that envelope
+and cannot be combined with text format. Respect reported truncation; narrow the query
+or increase `--limit` only when needed. Read diagnostics and exit status before treating
+an empty result as success. Hints marked as writes require the same scope as any mutation.
+
+Prefer Hyalo for structured metadata changes and task toggles. Use normal editing
+tools for body prose and new document bodies; preserve frontmatter and wikilinks.
+Lint the changed files before handoff. This is an instruction, not an automatic hook.
+
+For an audit, inspect and report. When repairs are requested, apply only those in scope.
+Preview bulk or link repairs with the command's dry-run mechanism before applying them.
+Avoid snapshot indexing for a small one-off query. For repeated work on a large vault,
+`create-index` and `--index` help; rebuild after external edits and drop the index
+when done. Never ignore an index staleness warning.
+
+Profile skills describe OKF, MADR, Agent Skills, and changelog conventions. Use only
+the profile relevant to the task and active configuration. Plugin and project installations
+contain the same workflows; use one copy, and do not execute a task twice.

--- a/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
@@ -12,8 +12,11 @@ is an alternative when present. If unavailable, report that and suggest the proj
 documented installation (`cargo install hyalo-cli`); do not install software as a
 side effect of a knowledgebase query.
 
-Start with `hyalo config --format json` to locate the vault and its configuration.
-Run from the project or a descendant directory. Do not assume the vault is named
+Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
+to locate and confirm the vault. Commands also work inside that configured vault,
+including its nested folders. Other project subdirectories (for example `src/`
+beside a `notes/` vault) do not inherit the vault configuration: return to the
+project root before querying or editing. Do not assume the vault is named
 `hyalo-knowledgebase` and do not repeat `--dir` when configuration already selects it.
 File arguments are relative to the vault, including when launched from a nested folder.
 

--- a/crates/hyalo-cli/templates/codex/skills/hyalo/agents/openai.yaml
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo"
+  short_description: "Search and maintain markdown knowledgebases"
+  default_prompt: "Use $hyalo to find planned work in this knowledgebase."
+policy:
+  allow_implicit_invocation: true

--- a/crates/hyalo-cli/templates/profile-skills.toml
+++ b/crates/hyalo-cli/templates/profile-skills.toml
@@ -9,13 +9,13 @@
 # Validate skill frontmatter against the schema on write.
 validate_on_write = true
 
-# Reach the canonical Claude Code skill location. The vault walker skips hidden
+# Reach the Claude Code and Codex skill locations. The vault walker skips hidden
 # dot-directories by default, so `.claude/skills/**/SKILL.md` would be invisible
 # to every command. This opts that one subtree back in (never `.git`, which is
 # always excluded) so the `**/SKILL.md` bind above can actually see and lint
 # skills where Claude Code stores them — without relocating any files.
 [scan]
-include = [".claude/skills/**"]
+include = [".claude/skills/**", ".agents/skills/**"]
 
 # Mark this vault as skills-flavoured so plain `hyalo lint` runs the Agent Skills
 # advisory rules (name↔dirname coupling, 500-line body budget) without

--- a/crates/hyalo-cli/templates/skill-hyalo-skills.md
+++ b/crates/hyalo-cli/templates/skill-hyalo-skills.md
@@ -43,9 +43,9 @@ anywhere in the tree is validated as a skill without needing explicit `type: ski
 frontmatter (in fact `hyalo new --type skill` omits the redundant `type:` key for a
 bound path, since SKILL.md carries none per the spec). Explicit frontmatter always wins.
 
-The profile also ships `[scan] include = [".claude/skills/**"]`, which re-admits the
-canonical (hidden) Claude Code skill location to the vault walker (`.git` stays
-excluded). Without it, `.claude/skills/**/SKILL.md` would be invisible to `find`/`lint`;
+The profile also ships `[scan] include = [".claude/skills/**", ".agents/skills/**"]`,
+which re-admits the hidden Claude Code and Codex skill locations to the vault walker
+(`.git` stays excluded). Without it, their `SKILL.md` files would be invisible to `find`/`lint`;
 with it, skills lint in place — no relocation.
 
 ## Validate

--- a/crates/hyalo-cli/tests/e2e/codex_init.rs
+++ b/crates/hyalo-cli/tests/e2e/codex_init.rs
@@ -219,6 +219,69 @@ fn codex_override_warning_is_part_of_the_json_report() {
 
 #[cfg(unix)]
 #[test]
+fn codex_updates_preserve_existing_permission_bits() {
+    use std::os::unix::fs::PermissionsExt;
+
+    for mode in [0o640, 0o444, 0o4755, 0o2755] {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        ok(root, &["init", "--codex"]);
+        let paths = ["AGENTS.md", ".agents/skills/hyalo/SKILL.md"];
+        for relative in paths {
+            let path = root.join(relative);
+            let stale = if relative == "AGENTS.md" {
+                "<!-- hyalo:start -->\nold\n<!-- hyalo:end -->\n"
+            } else {
+                "<!-- hyalo:managed -->\nold\n"
+            };
+            fs::write(&path, stale).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(mode)).unwrap();
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o7777,
+                mode,
+                "fixture permissions"
+            );
+        }
+        ok(root, &["init", "--codex"]);
+        for relative in paths {
+            let actual = fs::metadata(root.join(relative))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o7777;
+            assert_eq!(actual, mode, "permissions changed for {relative}");
+        }
+    }
+}
+
+#[test]
+fn codex_guidance_uses_the_project_root_or_configured_vault() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("notes/nested")).unwrap();
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join(".hyalo.toml"), "dir = \"notes\"\n").unwrap();
+    fs::write(
+        root.join("notes/note.md"),
+        "---\ntitle: Note\nstatus: planned\n---\n",
+    )
+    .unwrap();
+    ok(root, &["init", "--codex"]);
+    for cwd in [root.to_path_buf(), root.join("notes/nested")] {
+        let found = ok(&cwd, &["find", "--property", "status=planned"]);
+        assert_eq!(found["results"].as_array().unwrap().len(), 1);
+    }
+    let outside = ok(&root.join("src"), &["find", "--property", "status=planned"]);
+    assert!(outside["results"].as_array().unwrap().is_empty());
+    let agents = fs::read_to_string(root.join("AGENTS.md")).unwrap();
+    assert!(agents.contains(
+        "Run commands from the project root containing .hyalo.toml or inside the configured vault."
+    ));
+    assert!(!agents.contains("this project or its descendants"));
+}
+
+#[cfg(unix)]
+#[test]
 fn codex_symlink_destinations_never_modify_the_referent() {
     use std::os::unix::fs::symlink;
     for relative in ["AGENTS.md", ".agents", ".hyalo.toml"] {

--- a/crates/hyalo-cli/tests/e2e/codex_init.rs
+++ b/crates/hyalo-cli/tests/e2e/codex_init.rs
@@ -1,0 +1,243 @@
+use super::common::hyalo_no_hints;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Output;
+use tempfile::TempDir;
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    hyalo_no_hints()
+        .current_dir(root)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn ok(root: &Path, args: &[&str]) -> Value {
+    let mut args = args.to_vec();
+    args.extend(["--format", "json"]);
+    let out = run(root, &args);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+#[test]
+fn codex_install_update_remove_preserves_config_and_user_content() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir(root.join("custom notes")).unwrap();
+    let config = "# keep this\ndir = \"custom notes\"\nformat = \"text\"\n";
+    fs::write(root.join(".hyalo.toml"), config).unwrap();
+    let user = "# User guidance\r\nPreserve this.\r\n";
+    fs::write(root.join("AGENTS.md"), user).unwrap();
+    let first = ok(root, &["init", "--codex"]);
+    assert_eq!(first["dir"], "custom notes");
+    assert_eq!(
+        fs::read_to_string(root.join(".hyalo.toml")).unwrap(),
+        config
+    );
+    let agents = fs::read_to_string(root.join("AGENTS.md")).unwrap();
+    assert!(agents.starts_with(user));
+    assert!(agents.contains("custom notes"));
+    let skill = root.join(".agents/skills/hyalo/SKILL.md");
+    assert!(skill.is_file());
+    fs::write(&skill, "<!-- hyalo:managed -->\nold version").unwrap();
+    let second = ok(root, &["init", "--codex"]);
+    assert!(
+        second["results"]["actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|a| a["action"] == "updated" && a["target"] == ".agents/skills/hyalo/SKILL.md")
+    );
+    assert_eq!(fs::read_to_string(root.join("AGENTS.md")).unwrap(), agents);
+    fs::write(root.join(".agents/skills/hyalo/personal.txt"), "keep").unwrap();
+    ok(root, &["deinit"]);
+    assert!(!skill.exists());
+    assert!(root.join(".agents/skills/hyalo/personal.txt").exists());
+    assert_eq!(fs::read_to_string(root.join("AGENTS.md")).unwrap(), user);
+    ok(root, &["deinit"]);
+}
+
+#[test]
+fn codex_profiles_are_recovered_and_scanned_in_their_real_location() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    ok(root, &["init", "--dir", ".", "--profile", "skills"]);
+    ok(root, &["init", "--profile", "okf"]);
+    ok(root, &["init", "--codex"]);
+    assert!(root.join(".agents/skills/hyalo-skills/SKILL.md").exists());
+    assert!(root.join(".agents/skills/hyalo-okf/SKILL.md").exists());
+    assert!(!root.join(".agents/skills/hyalo-madr/SKILL.md").exists());
+    let scan = ok(root, &["find", "--glob", ".agents/skills/**/SKILL.md"]);
+    assert_eq!(scan["results"].as_array().unwrap().len(), 4);
+    let lint = run(
+        root,
+        &[
+            "lint",
+            ".agents/skills/hyalo/SKILL.md",
+            "--profile",
+            "skills",
+            "--format",
+            "text",
+        ],
+    );
+    assert!(
+        lint.status.success(),
+        "{}{}",
+        String::from_utf8_lossy(&lint.stdout),
+        String::from_utf8_lossy(&lint.stderr)
+    );
+}
+
+#[test]
+fn codex_flag_combinations_and_plugin_mode_have_no_duplicate_local_skills() {
+    for mask in 0..8 {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let mut args = vec!["init"];
+        for (bit, flag) in [(1, "--claude"), (2, "--pi"), (4, "--codex")] {
+            if mask & bit != 0 {
+                args.push(flag);
+            }
+        }
+        ok(root, &args);
+        assert_eq!(
+            root.join(".claude/skills/hyalo/SKILL.md").exists(),
+            mask & 1 != 0
+        );
+        assert_eq!(root.join(".pi/extensions/hyalo.ts").exists(), mask & 2 != 0);
+        assert_eq!(
+            root.join(".agents/skills/hyalo/SKILL.md").exists(),
+            mask & 4 != 0
+        );
+    }
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    assert!(!run(root, &["init", "--codex-plugin"]).status.success());
+    assert!(!root.join(".hyalo.toml").exists());
+    ok(root, &["init", "--codex"]);
+    ok(root, &["init", "--codex", "--codex-plugin"]);
+    assert!(!root.join(".agents/skills").exists());
+    assert!(
+        fs::read_to_string(root.join("AGENTS.md"))
+            .unwrap()
+            .contains("installed Hyalo plugin")
+    );
+    ok(root, &["init", "--codex", "--codex-plugin"]);
+    ok(root, &["init", "--codex"]);
+    assert!(root.join(".agents/skills/hyalo/SKILL.md").is_file());
+}
+
+#[test]
+fn codex_external_scope_and_nested_queries_use_the_selected_vault() {
+    let caller = TempDir::new().unwrap();
+    let external = TempDir::new().unwrap();
+    fs::write(caller.path().join("AGENTS.md"), "caller").unwrap();
+    ok(
+        caller.path(),
+        &[
+            "init",
+            "--codex",
+            "--dir",
+            external.path().to_str().unwrap(),
+        ],
+    );
+    fs::create_dir(external.path().join("nested")).unwrap();
+    fs::write(
+        external.path().join("note.md"),
+        "---\ntitle: Note\nstatus: planned\n---\n",
+    )
+    .unwrap();
+    let found = ok(
+        &external.path().join("nested"),
+        &["find", "--property", "status=planned"],
+    );
+    assert_eq!(found["results"].as_array().unwrap().len(), 1);
+    ok(
+        caller.path(),
+        &["deinit", "--dir", external.path().to_str().unwrap()],
+    );
+    assert!(!external.path().join("AGENTS.md").exists());
+    assert_eq!(
+        fs::read_to_string(caller.path().join("AGENTS.md")).unwrap(),
+        "caller"
+    );
+}
+
+#[test]
+fn codex_conflicts_and_malformed_markers_fail_before_writes() {
+    for content in ["<!-- hyalo:start -->", "<!-- hyalo:end -->"] {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("AGENTS.md"), content).unwrap();
+        assert!(!run(tmp.path(), &["init", "--codex"]).status.success());
+        assert!(!tmp.path().join(".hyalo.toml").exists());
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("AGENTS.md")).unwrap(),
+            content
+        );
+    }
+    let tmp = TempDir::new().unwrap();
+    let skill = tmp.path().join(".agents/skills/hyalo/SKILL.md");
+    fs::create_dir_all(skill.parent().unwrap()).unwrap();
+    fs::write(&skill, "user owned").unwrap();
+    let out = run(tmp.path(), &["init", "--codex"]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("conflict"));
+    assert!(!tmp.path().join(".hyalo.toml").exists());
+    ok(tmp.path(), &["deinit"]);
+    assert_eq!(fs::read_to_string(&skill).unwrap(), "user owned");
+    assert!(
+        !run(tmp.path(), &["init", "--codex", "--profile", "unknown"])
+            .status
+            .success()
+    );
+    assert!(!tmp.path().join(".hyalo.toml").exists());
+}
+
+#[test]
+fn codex_override_warning_is_part_of_the_json_report() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("AGENTS.override.md"), "override").unwrap();
+    let report = ok(tmp.path(), &["init", "--codex"]);
+    assert!(
+        report["results"]["actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|a| a["action"] == "warning" && a["target"] == "AGENTS.override.md")
+    );
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("AGENTS.override.md")).unwrap(),
+        "override"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_symlink_destinations_never_modify_the_referent() {
+    use std::os::unix::fs::symlink;
+    for relative in ["AGENTS.md", ".agents", ".hyalo.toml"] {
+        let tmp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let target = if relative == ".agents" {
+            outside.path().to_path_buf()
+        } else {
+            outside.path().join("user.md")
+        };
+        if relative != ".agents" {
+            fs::write(&target, "user").unwrap();
+        }
+        symlink(&target, tmp.path().join(relative)).unwrap();
+        assert!(!run(tmp.path(), &["init", "--codex"]).status.success());
+        if relative == ".agents" {
+            assert_eq!(fs::read_dir(outside.path()).unwrap().count(), 0);
+        } else {
+            assert_eq!(fs::read_to_string(&target).unwrap(), "user");
+        }
+    }
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -8,6 +8,7 @@ mod bm25;
 mod broken_pipe;
 mod bundled_recipes;
 mod changelog_profile;
+mod codex_init;
 mod completion;
 mod concurrent_writes;
 mod config;

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde-saphyr = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/xtask/src/bundled_skills.rs
+++ b/crates/xtask/src/bundled_skills.rs
@@ -52,6 +52,13 @@ pub fn run() -> Result<bool> {
         }
         Err(e) => return Err(e).with_context(|| format!("reading {pi_skills_dir:?}")),
     }
+    let codex_skills = root.join("plugins/hyalo/skills");
+    for entry in std::fs::read_dir(&codex_skills).context("reading Codex skills")? {
+        let file = entry?.path().join("SKILL.md");
+        if file.is_file() {
+            skill_files.push(file);
+        }
+    }
     skill_files.sort();
 
     if skill_files.is_empty() {
@@ -72,13 +79,18 @@ pub fn run() -> Result<bool> {
         // Install the skills profile config (writes .hyalo.toml + [scan] include).
         init_skills_profile(&root, vault)?;
         // Place the template as installed: `.claude/skills/<name>/SKILL.md`.
-        let skill_dir = vault.join(".claude").join("skills").join(&name);
+        let host = if file.starts_with(&codex_skills) {
+            ".agents"
+        } else {
+            ".claude"
+        };
+        let skill_dir = vault.join(host).join("skills").join(&name);
         std::fs::create_dir_all(&skill_dir)
             .with_context(|| format!("creating skill dir {skill_dir:?}"))?;
         std::fs::write(skill_dir.join("SKILL.md"), &body)
             .context("writing SKILL.md into scratch vault")?;
 
-        let rel = format!(".claude/skills/{name}/SKILL.md");
+        let rel = format!("{host}/skills/{name}/SKILL.md");
         let (ok, output) = lint_skill(&root, vault, &rel)?;
         checked += 1;
         if !ok {

--- a/crates/xtask/src/codex_package.rs
+++ b/crates/xtask/src/codex_package.rs
@@ -1,0 +1,104 @@
+//! Codex plugin assets are canonical; embedded copies keep cargo package self-contained.
+use anyhow::{Context, Result, ensure};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn files(root: &Path) -> Result<BTreeSet<PathBuf>> {
+    let mut paths = BTreeSet::new();
+    for entry in walkdir::WalkDir::new(root) {
+        let entry = entry.with_context(|| format!("walking {}", root.display()))?;
+        ensure!(
+            !entry.file_type().is_symlink(),
+            "symlink in Codex package: {}",
+            entry.path().display()
+        );
+        if entry.file_type().is_file() {
+            paths.insert(entry.path().strip_prefix(root)?.to_path_buf());
+        }
+    }
+    Ok(paths)
+}
+
+pub fn run(sync: bool) -> Result<bool> {
+    let root = crate::workspace::workspace_root()?;
+    let source = root.join("plugins/hyalo/skills");
+    let embedded = root.join("crates/hyalo-cli/templates/codex/skills");
+    let paths = files(&source)?;
+    ensure!(!paths.is_empty(), "Codex package has no skills");
+    for path in &paths {
+        let bytes = fs::read(source.join(path))?;
+        if sync {
+            let target = embedded.join(path);
+            fs::create_dir_all(target.parent().context("asset parent")?)?;
+            fs::write(target, &bytes)?;
+        }
+        ensure!(
+            fs::read(embedded.join(path)).ok().as_deref() == Some(bytes.as_slice()),
+            "Codex asset drift at {}; run just sync-codex-package",
+            path.display()
+        );
+        if path.file_name().is_some_and(|p| p == "openai.yaml") {
+            let metadata: Value = serde_saphyr::from_str(std::str::from_utf8(&bytes)?)?;
+            let name = path
+                .components()
+                .next()
+                .context("skill name")?
+                .as_os_str()
+                .to_string_lossy();
+            let interface = &metadata["interface"];
+            for field in ["display_name", "short_description", "default_prompt"] {
+                ensure!(
+                    interface[field].as_str().is_some_and(|v| !v.is_empty()),
+                    "{name}: missing {field}"
+                );
+            }
+            let short = interface["short_description"]
+                .as_str()
+                .context("short description")?;
+            ensure!(
+                (25..=64).contains(&short.chars().count()),
+                "{name}: description length"
+            );
+            ensure!(
+                interface["default_prompt"]
+                    .as_str()
+                    .is_some_and(|s| s.contains(&format!("${name}"))),
+                "{name}: prompt must mention skill"
+            );
+            ensure!(
+                metadata["policy"]["allow_implicit_invocation"].as_bool()
+                    == Some(name != "hyalo-tidy"),
+                "{name}: invocation policy"
+            );
+        }
+    }
+    ensure!(
+        paths == files(&embedded)?,
+        "orphaned embedded Codex assets; remove stale copies explicitly"
+    );
+    let plugin: Value = serde_json::from_str(&fs::read_to_string(
+        root.join("plugins/hyalo/.codex-plugin/plugin.json"),
+    )?)?;
+    ensure!(
+        plugin["name"] == "hyalo" && plugin["skills"] == "./skills/",
+        "invalid Hyalo plugin layout"
+    );
+    let marketplace: Value = serde_json::from_str(&fs::read_to_string(
+        root.join(".agents/plugins/marketplace.json"),
+    )?)?;
+    ensure!(
+        marketplace["plugins"]
+            .as_array()
+            .is_some_and(|entries| entries
+                .iter()
+                .any(|e| e["name"] == "hyalo" && e["source"]["path"] == "./plugins/hyalo")),
+        "marketplace must point at plugins/hyalo"
+    );
+    println!(
+        "check-codex-package: {} assets match; metadata and marketplace valid",
+        paths.len()
+    );
+    Ok(true)
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod bench_scale;
 mod bundled_skills;
+mod codex_package;
 mod command_reference;
 mod feature_fanout;
 mod help_drift;
@@ -35,6 +36,10 @@ enum Commands {
     /// Gate: verify the vendored `crates/hyalo-cli/templates/pi/` copies
     /// match the canonical `pi-package/` files byte-for-byte.
     CheckPiPackageSync,
+    /// Verify Codex plugin assets, metadata, and embedded-copy parity.
+    CheckCodexPackage,
+    /// Refresh the embedded Codex skills from plugins/hyalo/skills.
+    SyncCodexPackage,
     /// Gate (iter-274, BUG-29): every `--jq` recipe in a shipped document
     /// executes against this repo's own knowledgebase without a jq error.
     CheckJqRecipes,
@@ -59,6 +64,8 @@ fn main() {
         Commands::CheckCommandReference => command_reference::run(),
         Commands::CheckBundledSkills => bundled_skills::run(),
         Commands::CheckPiPackageSync => pi_package_sync::run(),
+        Commands::CheckCodexPackage => codex_package::run(false),
+        Commands::SyncCodexPackage => codex_package::run(true),
         Commands::CheckJqRecipes => jq_recipes::run(),
         Commands::CheckDeadPrimitives(_) => stubs::check_dead_primitives(),
         Commands::CheckTodoAnnotations(_) => stubs::check_todo_annotations(),

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -10,6 +10,24 @@ status: reference
 
 # Decision Log
 
+## DEC-327: Codex skills and plugin share one canonical package (2026-09-06)
+
+**Decision:** Ship Codex skills in `plugins/hyalo/skills/` and mirror them inside
+the CLI crate for embedding. `check-codex-package` verifies both directions and
+metadata; `sync-codex-package` refreshes the mirror. The plugin has its own version.
+
+`init --codex` installs project skills and managed `AGENTS.md` guidance.
+`init --codex --codex-plugin` uses the separately installed plugin and removes
+managed local copies to avoid duplicate discovery. Neither changes global Codex
+settings. Deinit removes only managed project artifacts. Runtime integrations
+continue to invoke the existing CLI; MCP tools and hooks remain out of scope.
+
+**Why:** Share established workflows across projects without duplicating their
+maintenance, retain project-local installation for clients without plugin support,
+and keep `cargo package` independent of files outside the crate. Live Codex
+installation, update, and discovery verification follow the Pi package precedent.
+See [[iterations/iteration-288-codex-integration]].
+
 ## DEC-001: CLI Flag Style (2026-03-20)
 
 **Decision:** Use idiomatic `--flag` style with clap subcommands, not Obsidian's `key=value` style.

--- a/hyalo-knowledgebase/docs/codex-integration.md
+++ b/hyalo-knowledgebase/docs/codex-integration.md
@@ -1,0 +1,99 @@
+---
+type: docs
+title: Codex integration
+date: 2026-09-06
+status: active
+---
+
+# Codex integration
+
+Hyalo provides two installation routes backed by the same skills: project files
+created by `hyalo init --codex`, and a reusable Codex plugin. Both invoke the Hyalo
+CLI. Install a Hyalo build containing [[iterations/iteration-288-codex-integration]]
+for the new init flags; the skills' core query workflows use the 0.22 CLI surface.
+
+## Project installation
+
+```sh
+hyalo init --codex
+hyalo init --codex --profile okf
+hyalo init --claude --pi --codex
+```
+
+The installer reads the existing `.hyalo.toml` vault selection and writes a short
+managed block in `AGENTS.md`. Project skills live under `.agents/skills/`:
+`hyalo`, `hyalo-tidy`, and workflows for every active known profile. Run commands
+from the project or its descendants so Hyalo discovers the configuration.
+
+The main skill supports automatic selection. Tidy is explicitly selected, with an
+audit-only starter prompt. A requested audit does not authorize repairs. Skills
+request lint after edits; no automatic write hook is installed.
+
+Re-run init after upgrading Hyalo. Generated files carry a managed marker and are
+replaced on update. Keep personal guidance outside them. An unmarked file at an
+installation path causes a conflict before writes; symlinks and malformed managed
+markers are refused. A root `AGENTS.override.md` produces a warning because it can
+shadow the generated guidance; the installer leaves it intact.
+
+## Plugin installation and coexistence
+
+From a checkout of Hyalo containing the integration:
+
+```sh
+codex plugin marketplace add .
+codex plugin add hyalo@hyalo
+hyalo init --codex --codex-plugin
+```
+
+The marketplace manifest points to `plugins/hyalo`. The plugin bundles the two main
+workflows and all four profiles, each with a focused description. It requires a
+Hyalo executable on PATH and does not bundle a binary, MCP server, or hooks.
+
+Use `--codex-plugin` when configuring each project for the installed plugin. This
+removes installer-owned project skill copies and retains project-specific guidance
+in `AGENTS.md`. It does not inspect or change user-level plugin configuration.
+Keep this flag on subsequent init runs. To switch back to project skills, disable
+or remove the plugin in Codex and run `hyalo init --codex`.
+
+Start a new session after setup. Explicit skill selection uses `$hyalo` or
+`$hyalo-tidy` for project skills; select the corresponding namespaced entry when
+using plugin skills. A nested session inside a Git repository should still
+discover root skills and guidance. A standalone directory should be opened as the
+workspace root. Plugin availability depends on the client; standalone project
+skills provide the IDE route.
+
+## Updates and removal
+
+For a local marketplace checkout, update the checkout, then reinstall with
+`codex plugin add hyalo@hyalo` and start a new session. The plugin has its own
+version in `.codex-plugin/plugin.json`; maintainers bump it when distributing skill
+changes. Do not assume that replacing files refreshes an already-running session.
+
+`hyalo deinit` removes configuration and all managed project integrations, including
+Codex. It retains unrelated skills, user-added companion files, and instruction
+text outside the managed block. It does not uninstall a globally installed plugin.
+Use `codex plugin remove --help` for the installed client's plugin removal command.
+
+## Maintaining the assets
+
+Canonical Codex skills live in `plugins/hyalo/skills/`. Run
+`just sync-codex-package` after editing them to refresh the byte-identical embedded
+copies under `crates/hyalo-cli/templates/codex/skills/`. Both directions are checked:
+missing copies, changed files, and orphaned embedded assets fail CI.
+
+`cargo run -p xtask -- check-codex-package` also checks UI metadata and the marketplace
+path. `check-bundled-skills` lints skills in their actual installed `.agents/skills`
+location. The crate embeds only files within its own package, so crates.io builds
+do not depend on the repository's plugin directory.
+
+Validate actual loading using a fresh Codex session and a scratch vault. Check a
+natural-language search, a requested metadata change followed by lint, and an
+audit-only tidy run. Compare the executed commands and resulting files. Installation
+and static lint alone do not establish model behaviour. Record client versions and
+unavailable surfaces in the iteration results.
+
+## References
+
+- [OpenAI: Build skills](https://learn.chatgpt.com/docs/build-skills)
+- [OpenAI: Build plugins](https://learn.chatgpt.com/docs/build-plugins)
+- [[iterations/iteration-288-codex-integration]]

--- a/hyalo-knowledgebase/iterations/iteration-288-codex-integration.md
+++ b/hyalo-knowledgebase/iterations/iteration-288-codex-integration.md
@@ -1,0 +1,275 @@
+---
+type: iteration
+title: "Iteration 288 — First-class Codex integration via hyalo init --codex"
+date: 2026-09-06
+status: in-progress
+tags: [iteration, codex, integration, skills, cli]
+branch: iter-288/codex-integration
+related:
+  - "[[iterations/iteration-159-pi-integration]]"
+  - "[[iterations/iteration-236-typed-pi-tools]]"
+  - "[[iterations/iteration-237-pi-package-distribution]]"
+  - "[[iterations/iteration-239-pi-install-verification]]"
+  - "[[iterations/iteration-257-init-deinit-dir-scope-and-json-envelope]]"
+  - "[[iterations/iteration-168-skills-profile]]"
+  - "[[decision-log]]"
+---
+
+# Iteration 288 — First-class Codex integration via hyalo init --codex
+
+## Goal
+
+Run `hyalo init --codex` in a project and make Codex discover and use Hyalo for
+knowledgebase search, reading, metadata changes, tasks, and maintenance. Install
+project skills and a small managed `AGENTS.md` section, with the same configuration,
+update, and removal workflow as the existing integrations. The executable remains
+`hyalo`; the request's `hylo` spelling is treated as a typo, not a new alias.
+
+This iteration delivers both project integration and a skills-only plugin, sharing
+the same workflows. There is no dependency on the planned npm distribution or
+TypeScript API iterations. Public directory submission remains a follow-up.
+
+## Existing integrations
+
+Findings from the current code and repository documentation, checked 2026-09-06:
+
+| Surface | What ships today | Implication for Codex |
+| --- | --- | --- |
+| `init --claude` | Two skills, `.claude/rules/knowledgebase.md`, a managed block in `.claude/CLAUDE.md`, and skills for an explicitly selected profile | Match the workflow using Codex's project discovery locations |
+| `init --pi` | Two skills, `.pi/extensions/hyalo.ts`, and `.pi/package.json` | Reuse CLI workflows; the extension itself depends on Pi APIs |
+| Pi package | Root `package.json` points into canonical `pi-package/`; five tools, session setup, and a post-write lint hook | Package installation and live loading need separate verification |
+| Claude plugin proposal | `backlog/done/claude-plugin-distribution.md` still has unchecked acceptance criteria; no plugin manifest ships in this checkout | Do not assume that a working Claude plugin can simply be converted |
+
+Implementation centres on `crates/hyalo-cli/src/commands/init.rs`, with flag parsing
+in `src/cli/args.rs` and dispatch in `src/run.rs`. `Scope` already decides where
+configuration and integration files belong; `Report` already exposes actions in
+text and JSON. Reuse both contracts from
+[[iterations/iteration-257-init-deinit-dir-scope-and-json-envelope]].
+
+Pi's canonical package is mirrored under `crates/hyalo-cli/templates/pi/`, checked
+by `check-pi-package-sync`. The mirror exists because `cargo package` cannot build
+an `include_str!` that reaches outside the published crate. Preserve that lesson
+when choosing Codex template locations. The live-install failure and fix in
+[[iterations/iteration-239-pi-install-verification]] also show why merely checking
+that generated files exist is insufficient.
+
+## Integration choice
+
+Codex discovers project skills under `.agents/skills`, scanning from CWD toward the
+repository root. Skills support explicit invocation and description-based matching;
+optional `agents/openai.yaml` supplies display metadata and invocation policy.
+These are documented local extension points, suitable for this installer.
+([OpenAI: Build skills](https://learn.chatgpt.com/docs/build-skills))
+
+`AGENTS.md` provides persistent project guidance. Codex prefers an
+`AGENTS.override.md` in the same directory and composes instructions along the path
+to CWD, so installation must account for overrides and nested launches.
+([OpenAI: AGENTS.md](https://learn.chatgpt.com/docs/agent-configuration/agents-md))
+
+Plugins can package skills without an MCP server, using
+`.codex-plugin/plugin.json` and a skills directory. They are a viable distribution
+layer, with installation and update mechanics beyond copying project files.
+([OpenAI: Build plugins](https://learn.chatgpt.com/docs/build-plugins))
+
+Chosen design: support project skills and a reusable skills-only plugin, execute
+the existing Rust CLI through Codex's shell, and provide a concise project reminder.
+A new MCP server, TypeScript adapter, or custom tool
+transport would add another maintained API without being necessary for this goal.
+
+## Generated files and behaviour
+
+Paths below are relative to the existing resolved `Scope.root`:
+
+```text
+.hyalo.toml
+AGENTS.md                         # upsert only the hyalo-managed section
+.agents/skills/hyalo/
+  SKILL.md
+  agents/openai.yaml
+.agents/skills/hyalo-tidy/
+  SKILL.md
+  agents/openai.yaml
+.agents/skills/<profile-skill>/    # when the corresponding profile is active
+  SKILL.md
+```
+
+`--codex`, `--claude`, and `--pi` compose independently. Plain `init` retains its
+configuration-only behaviour. A vault below CWD keeps integration files at CWD;
+an external `--dir` places them in that external tree, following existing scope
+resolution. Preserve an existing configured vault when `--dir` is omitted: resolve
+the effective `dir` from the retained configuration before rendering Codex content,
+not from directory auto-detection. Quote paths safely, including spaces.
+
+`init --codex --codex-plugin` writes project guidance and removes managed local
+skill copies, for projects using the separately installed plugin. It never changes
+global Codex configuration. Canonical assets live under `plugins/hyalo/skills/`;
+crate-local copies are synchronized by a Rust xtask and checked in CI. The root
+marketplace manifest points at `plugins/hyalo`. The plugin carries its own version.
+
+The managed instruction block identifies the configured vault, points to the
+installed skills, prefers Hyalo for supported structured operations, permits body
+editing with normal editing tools, and requires linting changed markdown before
+handoff. Include brief reminders for active profiles. Keep the block small; command
+details belong in the skills and `hyalo <command> --help`.
+
+Re-running `init --codex` refreshes installer-owned files. Mark generated Codex
+assets as managed; document that custom guidance belongs outside those files.
+Preserve an existing unmarked skill at a colliding path and report the conflict.
+Use `<!-- hyalo:start -->` / `<!-- hyalo:end -->` for the instruction block,
+preserving all surrounding content. Report a same-directory `AGENTS.override.md`
+as a discovery warning; do not modify it automatically.
+
+`deinit` retains its current all-integrations meaning and adds removal of managed
+Codex files and the managed `AGENTS.md` block. Remove directories only when empty;
+retain unrelated skills, user-added companion files, and instruction text. Neither
+command edits global Codex settings, installs packages, or changes approvals.
+
+## Tasks
+
+- [x] Add `codex: bool` to `Commands::Init`, wire it through `run.rs` and the init
+      entry points, and include it in the early-return condition. Extend help,
+      examples, and `Report` path descriptions. Keep JSON advice inside the report
+      rather than printing extra text on stdout.
+- [x] Ship the plugin manifest and repository marketplace entry; verify installation,
+      updates, and switching between local skills and plugin mode without duplicates.
+- [x] Add embedded Codex assets under `crates/hyalo-cli/templates/codex/`, with no
+      references outside the published crate. Adapt the Hyalo and tidy workflows:
+      remove Claude-specific fields (`user_invocable`, `context: fork`,
+      `disable-model-invocation`) and tool names; use accurate CLI examples and
+      explicit text/JSON formats. Keep common command guidance reusable or covered
+      by the existing drift checks so Codex does not become a stale third manual.
+- [x] Give the main skill a focused knowledgebase description and allow implicit
+      invocation. Make tidy explicitly invoked via its Codex policy, with a clear
+      default prompt. Distinguish an audit request from authorization to repair;
+      preserve dry-run/review steps for bulk changes. Include binary discovery,
+      configuration inspection, vault-relative paths, limits, error handling, and
+      post-edit linting. If the executable is missing, explain installation using
+      supported release channels rather than downloading it silently.
+- [x] Implement the installer and managed instruction block using `Scope` and
+      `Report`. Check Codex destinations before writing: unowned collisions,
+      malformed markers, and symlinks must not overwrite unrelated content or
+      write outside the selected root. Return actionable diagnostics; filesystem
+      failures retain the existing init/deinit error-envelope contract.
+- [x] Install Codex-compatible profile skills for all active known profiles in
+      the resulting configuration, including profiles enabled before Codex was
+      added. Reuse `profiles::PROFILES` and common bodies where compatible; adapt
+      host-specific wording and metadata explicitly. Refresh profile reminders
+      on each run without changing profile merge semantics.
+- [x] Extend the skills profile's `[scan] include` to reach `.agents/skills/**`,
+      preserving `.claude/skills/**` and user scan settings. Update the associated
+      profile guidance. Extend `check-bundled-skills` to discover Codex templates
+      and validate the actual installed `.agents/skills` layout, not only copies
+      placed in a Claude directory. Validate `openai.yaml` metadata separately.
+- [x] Extend deinit to remove only the managed Codex assets and instruction block,
+      including profile assets and metadata. Preserve unowned collisions and
+      user-added files. Test repeated removal and removal scoped to an external
+      vault without touching the invoking checkout.
+- [x] Add Rust unit/e2e coverage in the existing init suites: fresh install,
+      repeat/update, all flag combinations, existing custom config without
+      `--dir`, relative/absolute/external paths and spaces, profile composition,
+      JSON reporting, content preservation, collisions, malformed markers,
+      symlinks, and deinit. Include unknown-profile failure before artifact writes.
+- [x] Update README agent support and installation instructions, init/deinit help,
+      affected bundled guidance, and CHANGELOG. Record the local-skills decision
+      in [[decision-log]] during implementation. Explain that vendored skills update
+      when Hyalo is upgraded and init is rerun; linting is a skill instruction in
+      this version, not Pi's automatic post-write hook.
+- [ ] Verify discovery and actual use in fresh Codex CLI and desktop sessions in
+      a scratch Git project, from its root and a nested directory. Test an ordinary
+      knowledgebase search prompt, explicit skill selection, a requested property
+      change followed by lint, and an audit-only tidy request. Inspect the commands
+      actually executed and the resulting diff. Record client versions and results;
+      leave an unavailable surface unchecked with a concrete follow-up.
+- [x] Run implementation gates: `cargo fmt`,
+      `cargo clippy --workspace --all-targets -- -D warnings`,
+      `cargo test --workspace -q`, all `xtask check-*`, and `hyalo lint --strict`.
+      Verify the CLI's package build contains every embedded Codex asset. Build
+      the release binary and dogfood the new integration on a scratch copy of this
+      knowledgebase, preserving the working checkout's own agent configuration.
+
+## Acceptance criteria
+
+- [x] `hyalo init --codex` installs the documented project artifacts offline,
+      without requiring Codex to be installed to generate them.
+- [ ] Fresh Codex sessions discover the skills and use the installed Hyalo CLI for
+      representative knowledgebase work; versions and observed behaviour are recorded.
+- [x] Repeat init refreshes managed content without duplicate instruction blocks,
+      preserves unrelated content, and uses the configured vault consistently.
+- [x] Codex works alone and alongside Claude/Pi; active profile skills are available
+      and installed Codex skills pass Hyalo's skills-profile validation.
+- [x] `deinit` removes the managed Codex integration while retaining user content;
+      external-vault operations leave the invoking checkout untouched.
+- [x] JSON init/deinit reports remain parseable and accurately name affected paths,
+      actions, and any conflicts or discovery warnings.
+- [ ] Audit-only requests do not mutate notes; requested edits are followed by lint.
+- [x] Rust, drift, package-build, and documentation gates pass.
+
+## Implementation results
+
+Implemented on `iter-288/codex-integration`, verified on macOS with Codex CLI
+`0.153.4` on 2026-09-06. Project installation, plugin mode, profile workflows,
+managed removal, documentation, and CI drift checks are implemented.
+
+### Automated checks
+
+- `cargo fmt`, strict workspace Clippy, and `cargo test --workspace -q` pass:
+  4,866 tests passed and two doctests were ignored. This includes all 2,150 CLI
+  end-to-end tests and the new Codex install/remove safety coverage.
+- All implemented `xtask check-*` gates pass: feature fanout, help drift, command
+  reference, 14 bundled skills, 12 synchronized Codex assets, Pi package parity,
+  executable jq recipes, and the mutation-journal guard. The dead-primitives and
+  TODO-annotations commands still report their existing unimplemented status.
+- The jq gate exercised 42 recipes; its existing MADR TOC recipe was not
+  exercisable because this vault has no `docs/decisions` directory.
+- Strict knowledgebase lint exits successfully. The new iteration, integration
+  documentation, and decision-log entry have no findings; the full vault retains
+  four existing warnings about unchecked tasks in completed iterations 270, 271,
+  277, and 281. `git diff --check` passes.
+
+### Installation and discovery
+
+- The official plugin validator and all six skill validators pass. The plugin
+  manifest remains version `0.1.0`; no global user installation was changed.
+- Installed the repository marketplace and `hyalo@hyalo` into an isolated scratch
+  Codex profile. The CLI app-server's `skills/list` reports all six plugin skills,
+  with display metadata and no loading errors.
+- After switching a scratch Git project to `--codex-plugin`, fresh app-server
+  discovery from both root and nested directories reports exactly six Hyalo
+  skills, all owned by the plugin, with no duplicate project copies.
+- Copied the marketplace into a scratch tree, applied the official cachebuster
+  update helper there, and reinstalled. Codex loaded version
+  `0.1.0+codex.20260906181244` from the updated cache in both launch locations.
+- Built the release executable and ran project installation and a vault-relative
+  query against a scratch copy of this knowledgebase. The working checkout's
+  own project instructions and user-level Codex configuration were untouched.
+
+### Packaged build
+
+Cargo's normal offline package verification could not resolve the unpublished
+workspace crates; workspace verification also hit Cargo's temporary-registry
+`no hash listed for hyalo-core` error. As a separate verification, packaged the
+workspace with `--no-verify`, extracted the three `.crate` archives, and built the
+extracted CLI offline with dependency overrides pointing only to its extracted
+core and markdown-lint siblings. That build succeeded and its executable installed
+the Codex integration successfully. No repository plugin path was used by the
+extracted build, confirming the embedded assets are self-contained.
+
+### Remaining live verification
+
+Discovery is verified, but model-driven execution is not: no fresh model was asked
+to choose a skill, search, change a property and lint, or perform an audit-only
+tidy run. An attended desktop session was also not exercised. Keep the iteration
+in progress until those checks are performed in a scratch project, recording
+the desktop version, actual commands, and before/after file diffs. In particular,
+the audit-only and post-edit lint acceptance criteria remain unchecked; static
+skill instructions are not evidence that a model followed them.
+
+## Non-goals and follow-up
+
+- No global install mode, CLI rename, custom Codex tool server, or changes to
+  sandbox and approval policy.
+- No automatic hook enforcement in this iteration. Consider it only after a
+  separate, tested Codex hook design with clear parity and failure behaviour.
+- Public directory submission and remote publication are separate from this
+  iteration. Plugin packaging, local installation/update verification, and shared
+  asset maintenance are in scope.

--- a/justfile
+++ b/justfile
@@ -12,6 +12,10 @@ check:
 fmt:
     cargo fmt --all
 
+# Refresh crate-local embedded assets from the canonical Codex plugin skills.
+sync-codex-package:
+    cargo run -p xtask -- sync-codex-package
+
 # Run Miri against the parsing surface of hyalo-core to detect UB.
 # Targets modules that don't touch the filesystem (Miri can't shim chmod/symlinks
 # on macOS, which breaks tempfile-based tests). Covers the scanner, YAML

--- a/plugins/hyalo/.codex-plugin/plugin.json
+++ b/plugins/hyalo/.codex-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "hyalo",
+  "version": "0.1.0",
+  "description": "Search, maintain, and lint markdown knowledgebases with the Hyalo CLI.",
+  "author": {
+    "name": "ractive",
+    "url": "https://github.com/ractive"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Hyalo",
+    "shortDescription": "Search and maintain markdown knowledgebases.",
+    "longDescription": "Hyalo CLI workflows for structured markdown, knowledgebase maintenance, OKF, MADR, Agent Skills, and changelogs. Requires the Hyalo CLI on PATH.",
+    "developerName": "ractive",
+    "category": "Productivity",
+    "capabilities": [],
+    "defaultPrompt": "Use Hyalo to find planned work in this knowledgebase."
+  }
+}

--- a/plugins/hyalo/skills/hyalo-changelog/SKILL.md
+++ b/plugins/hyalo/skills/hyalo-changelog/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: hyalo-changelog
+description: Maintain Keep a Changelog files with Hyalo's changelog profile and add/release commands.
+---
+
+<!-- hyalo:managed -->
+
+# Changelog maintenance
+
+Inspect `hyalo config` and `hyalo changelog --help` before editing.
+The configured changelog may be outside the notes directory, relative to the project
+configuration. Follow that path rather than assuming a vault-local CHANGELOG.md.
+
+Use `hyalo changelog add --help` or `hyalo changelog release --help` for the exact
+arguments. Preserve the existing Keep a Changelog sections and release history.
+Moving entries into a release requires the requested version and release scope;
+do not invent a release or publish artifacts while writing release notes.
+Use `hyalo lint --profile changelog --format text` to inspect conformance.

--- a/plugins/hyalo/skills/hyalo-changelog/agents/openai.yaml
+++ b/plugins/hyalo/skills/hyalo-changelog/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo Changelog"
+  short_description: "Maintain Keep a Changelog release notes"
+  default_prompt: "Use $hyalo-changelog to inspect the unreleased changes."
+policy:
+  allow_implicit_invocation: true

--- a/plugins/hyalo/skills/hyalo-madr/SKILL.md
+++ b/plugins/hyalo/skills/hyalo-madr/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: hyalo-madr
+description: Maintain Markdown Architecture Decision Records with Hyalo's MADR profile and table-of-contents commands.
+---
+
+<!-- hyalo:managed -->
+
+# Architecture decision records
+
+Inspect `hyalo config`, `hyalo types show adr`, and `hyalo madr --help`.
+Use `hyalo lint --profile madr --format text` for conformance and
+`hyalo madr toc --dry-run` to inspect table-of-contents drift.
+
+Keep numbering, status transitions, supersession links, and the configured ADR path
+consistent with the existing collection. Use the relevant command's help before creating
+or superseding records. Do not infer that an accepted decision is superseded from age alone.
+Apply requested metadata changes with Hyalo and prose with ordinary editing tools.
+After edits, lint affected records and preview the table of contents again.

--- a/plugins/hyalo/skills/hyalo-madr/agents/openai.yaml
+++ b/plugins/hyalo/skills/hyalo-madr/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo MADR"
+  short_description: "Maintain architecture decision records"
+  default_prompt: "Use $hyalo-madr to check the architecture decision records."
+policy:
+  allow_implicit_invocation: true

--- a/plugins/hyalo/skills/hyalo-okf/SKILL.md
+++ b/plugins/hyalo/skills/hyalo-okf/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: hyalo-okf
+description: Maintain Open Knowledge Format vaults with Hyalo's OKF index, log, and conformance commands.
+---
+
+<!-- hyalo:managed -->
+
+# Open Knowledge Format
+
+Use `hyalo config` to locate the vault and confirm the `okf` profile.
+For a read-only check, use `hyalo lint --profile okf --format text` and
+`hyalo okf index --dry-run`. Inspect `hyalo okf --help` and the relevant subcommand
+help before generating indexes or logs. Dry-run output is a proposal, not a completed edit.
+
+Preserve reserved index/log files and the vault's schemas. Use Hyalo's OKF generators
+for their managed sections and normal editing tools for prose outside them.
+Apply generated changes only when requested, then check conformance and index drift again.

--- a/plugins/hyalo/skills/hyalo-okf/agents/openai.yaml
+++ b/plugins/hyalo/skills/hyalo-okf/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo OKF"
+  short_description: "Maintain Open Knowledge Format vaults"
+  default_prompt: "Use $hyalo-okf to check this OKF vault."
+policy:
+  allow_implicit_invocation: true

--- a/plugins/hyalo/skills/hyalo-skills/SKILL.md
+++ b/plugins/hyalo/skills/hyalo-skills/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: hyalo-skills
+description: Validate and maintain Agent Skills collections using Hyalo's skills profile, including Codex and Claude skill directories.
+---
+
+<!-- hyalo:managed -->
+
+# Agent Skills collections
+
+Use `hyalo lint --profile skills --format text` from the collection root.
+The profile binds `**/SKILL.md` to its skill schema and includes hidden
+`.agents/skills/**` and `.claude/skills/**` subtrees under the selected vault.
+A project whose configured vault is a separate notes directory requires an explicit
+`--dir .` to validate project-root skills. Do not rewrite its configuration to run a check.
+
+Required frontmatter is `name` and `description`; the name must match the directory.
+Use `hyalo types show skill` on an initialized skills vault and command help for
+schema details. Keep descriptions focused on actual triggers. Preserve host-specific
+metadata where supported; Codex appearance and invocation policy live in
+`agents/openai.yaml`, which markdown lint does not validate.
+
+Make requested edits, then rerun conformance on the affected files. A clean lint result
+checks structure, not whether a skill follows user intent or makes good decisions.

--- a/plugins/hyalo/skills/hyalo-skills/agents/openai.yaml
+++ b/plugins/hyalo/skills/hyalo-skills/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo Skills"
+  short_description: "Validate Agent Skills markdown collections"
+  default_prompt: "Use $hyalo-skills to validate this skill collection."
+policy:
+  allow_implicit_invocation: true

--- a/plugins/hyalo/skills/hyalo-tidy/SKILL.md
+++ b/plugins/hyalo/skills/hyalo-tidy/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: hyalo-tidy
+description: Audit or tidy a Hyalo knowledgebase for broken links, orphan documents, stale content, and inconsistent metadata.
+---
+
+<!-- hyalo:managed -->
+
+# Knowledgebase maintenance
+
+Resolve the installed `hyalo` executable and run `hyalo config --format json`.
+Use the configured vault and existing schemas. If the executable or configuration is
+missing, report what is needed before doing maintenance.
+
+An audit or health question is read-only. A request to tidy or repair authorizes relevant
+changes, not deletion of notes based only on age or orphan status.
+
+Orient with `hyalo summary --format text`, `hyalo lint --format text`, and
+`hyalo find --broken-links --format text`. Inspect individual files with `hyalo read`.
+Check schemas with `hyalo types list` before proposing metadata normalization.
+An orphan can be a legitimate entry point; stale status requires evidence from its content.
+
+Prioritize concrete findings. When authorized to repair, preview applicable fixes
+(`hyalo lint --fix --dry-run`; consult `hyalo links --help` for link repairs).
+Use Hyalo for frontmatter and tasks, normal editing tools for prose, and preserve meaning.
+Do not apply uncertain fuzzy link replacements without inspecting the candidates.
+
+Run lint on changed files and recheck the original findings. Report what changed,
+what remains unresolved, and any skipped or failed checks. Keep audit-only runs free
+of writes, including creating or dropping snapshot indexes.

--- a/plugins/hyalo/skills/hyalo-tidy/agents/openai.yaml
+++ b/plugins/hyalo/skills/hyalo-tidy/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo Tidy"
+  short_description: "Audit knowledgebase health and scoped repairs"
+  default_prompt: "Use $hyalo-tidy to audit this knowledgebase and report findings."
+policy:
+  allow_implicit_invocation: false

--- a/plugins/hyalo/skills/hyalo/SKILL.md
+++ b/plugins/hyalo/skills/hyalo/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: hyalo
+description: "Search and edit structured markdown knowledgebases with the Hyalo CLI: frontmatter, tags, tasks, links, and document structure."
+---
+
+<!-- hyalo:managed -->
+
+# Hyalo knowledgebase workflow
+
+Use the installed `hyalo` executable. In a Hyalo source checkout, `target/release/hyalo`
+is an alternative when present. If unavailable, report that and suggest the project's
+documented installation (`cargo install hyalo-cli`); do not install software as a
+side effect of a knowledgebase query.
+
+Start with `hyalo config --format json` to locate the vault and its configuration.
+Run from the project or a descendant directory. Do not assume the vault is named
+`hyalo-knowledgebase` and do not repeat `--dir` when configuration already selects it.
+File arguments are relative to the vault, including when launched from a nested folder.
+
+Use `hyalo summary --format text` for orientation. Then select the smallest query
+that answers the request:
+
+```sh
+hyalo find "release blockers" --format text
+hyalo find --property status=planned --tag iteration --format text
+hyalo read iterations/example.md --section Tasks --format text
+hyalo backlinks iterations/example.md --format text
+hyalo set iterations/example.md --property status=in-progress
+hyalo task toggle iterations/example.md --line 12
+hyalo lint iterations/example.md --format text
+```
+
+The paths above are examples: resolve actual files before running mutations.
+Use `hyalo <command> --help` for exact syntax, advanced filters, links, or bulk operations.
+`find`'s positional query is ranked search; `-e` is regex. Quote filter expressions
+and paths as single arguments using the active shell's quoting rules.
+
+Pass `--format text` for compact reading or `--format json` for structured output.
+JSON is an envelope; results live in `.results`. `--jq` operates on that envelope
+and cannot be combined with text format. Respect reported truncation; narrow the query
+or increase `--limit` only when needed. Read diagnostics and exit status before treating
+an empty result as success. Hints marked as writes require the same scope as any mutation.
+
+Prefer Hyalo for structured metadata changes and task toggles. Use normal editing
+tools for body prose and new document bodies; preserve frontmatter and wikilinks.
+Lint the changed files before handoff. This is an instruction, not an automatic hook.
+
+For an audit, inspect and report. When repairs are requested, apply only those in scope.
+Preview bulk or link repairs with the command's dry-run mechanism before applying them.
+Avoid snapshot indexing for a small one-off query. For repeated work on a large vault,
+`create-index` and `--index` help; rebuild after external edits and drop the index
+when done. Never ignore an index staleness warning.
+
+Profile skills describe OKF, MADR, Agent Skills, and changelog conventions. Use only
+the profile relevant to the task and active configuration. Plugin and project installations
+contain the same workflows; use one copy, and do not execute a task twice.

--- a/plugins/hyalo/skills/hyalo/SKILL.md
+++ b/plugins/hyalo/skills/hyalo/SKILL.md
@@ -12,8 +12,11 @@ is an alternative when present. If unavailable, report that and suggest the proj
 documented installation (`cargo install hyalo-cli`); do not install software as a
 side effect of a knowledgebase query.
 
-Start with `hyalo config --format json` to locate the vault and its configuration.
-Run from the project or a descendant directory. Do not assume the vault is named
+Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
+to locate and confirm the vault. Commands also work inside that configured vault,
+including its nested folders. Other project subdirectories (for example `src/`
+beside a `notes/` vault) do not inherit the vault configuration: return to the
+project root before querying or editing. Do not assume the vault is named
 `hyalo-knowledgebase` and do not repeat `--dir` when configuration already selects it.
 File arguments are relative to the vault, including when launched from a nested folder.
 

--- a/plugins/hyalo/skills/hyalo/agents/openai.yaml
+++ b/plugins/hyalo/skills/hyalo/agents/openai.yaml
@@ -1,0 +1,7 @@
+# hyalo:managed
+interface:
+  display_name: "Hyalo"
+  short_description: "Search and maintain markdown knowledgebases"
+  default_prompt: "Use $hyalo to find planned work in this knowledgebase."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

- Add `hyalo init --codex` with project-local skills, active profile workflows, and managed `AGENTS.md` guidance. Preserve existing configuration and user content, reject unsafe destinations, and remove only managed Codex artifacts during deinit.
- Ship a skills-only Hyalo plugin and repository marketplace. Add `--codex-plugin` to keep project guidance without duplicate local skill discovery, plus synchronized crate-local assets for packaged builds.
- Add installer regression tests, skill/package quality gates, CLI help, README instructions, integration documentation, and iteration 288 implementation results (DEC-327).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -q`: 4,868 passed; two doctests ignored, including all 2,152 CLI end-to-end tests.
- [x] All implemented `xtask check-*` gates: feature fanout, help drift, command reference, bundled skills, Pi parity, Codex package, jq recipes, and mutation journal.
- [x] `hyalo lint --strict`: no errors; the three changed knowledgebase files have no findings.
- [x] Release build and scratch-knowledgebase installation/query smoke tests.
- [x] Official plugin and six skill validators; isolated Codex CLI 0.153.4 plugin installation, update, and root/nested discovery without duplicate local skills.
- [x] Extracted `.crate` build and installation smoke test using only extracted sibling workspace dependencies.
- [x] Fresh interactive Codex CLI 0.153.4 session: ordinary skill selection, root/nested-vault searches, requested metadata edit followed by lint, and explicit audit-only tidy. Only the requested status changed; audit file hashes were unchanged.
- [ ] Attended Codex desktop-app verification — explicitly deferred by the user on 2026-09-06 for this partial merge.

## Verification notes

Iteration 288 remains **in progress** only for the deferred desktop-app follow-up. The attended CLI smoke test in cmux verified actual model behavior with project skills generated at `1607edc6` and the existing installed compatible Hyalo 0.22.0 CLI. The fresh interactive session launched at the project root and executed the nested query with a changed command CWD; a separate nested interactive launch was not performed. Post-edit lint is guidance, not an automatic hook.

The full knowledgebase retains four existing warnings about unchecked tasks in completed iterations 270, 271, 277, and 281. The jq gate exercises 42 recipes and skips its existing MADR TOC recipe because the fixture has no `docs/decisions`. The dead-primitives and TODO-annotations gate commands are existing stubs, not substantive checks.

Normal offline package verification encountered unpublished workspace dependencies and Cargo's temporary-registry `no hash listed for hyalo-core` error. Packaging with `--no-verify`, extracting all three archives, and building the extracted CLI with overrides to the extracted siblings succeeded; the CLI did not rely on the repository plugin directory.

Local checks are separate from GitHub CI. The user explicitly requested merging and branch cleanup on 2026-09-06, accepting the deferred desktop check. No release or installation into the user's normal Hyalo plugin profile is included.

## Review

Independent local Codex and Copilot reviews covered head `c43479b81f890170897cf7e14488351203745c3d` against base `0bc89576794ac4053db8170bb5e6cf9e0734318a`. Copilot review [5126373443](https://github.com/ractive/hyalo/pull/331#pullrequestreview-5126373443) completed on that exact head.

| Source | File / original line | Severity | Finding and disposition |
| --- | --- | --- | --- |
| Local | `crates/hyalo-cli/src/commands/init/codex.rs:231` | Medium (P2) | **Fixed.** With `dir = "notes"`, commands from sibling `src/` do not discover the notes configuration. Generated AGENTS guidance and canonical/embedded Hyalo skills now direct execution from the project root or inside the configured vault. Regression coverage checks root/nested-vault queries, sibling exclusion, and installed guidance. |
| Copilot | `crates/hyalo-cli/src/commands/init/codex.rs:163–176` | Low | **Fixed related verified permission loss.** The specific claim that persist resets an existing destination's permissions was not reproduced. However, the original binary demonstrably drops set-ID bits on macOS when content is written after copying permissions. Permissions are now applied after writing and reapplied after persist, matching the core writer's defensive pattern. Regression coverage checks both AGENTS.md and SKILL.md with modes 0640, 0444, 4755, and 2755 and verifies fixture permissions before invocation. |

Follow-up implementation fixes: `1607edc665c74ed880a11b555cbd6c568cede5da`. Final-head independent review: original independent review findings were rechecked against the fixes at this head and are addressed as documented below. No second independent full review was run after the fixes.

Validation after fixes:

- Required sequence completed successfully: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace -q`: **4,868 passed, two doctests ignored**, including 2,152 CLI end-to-end tests.
- All eight implemented xtask quality gates passed, including bundled-skill lint and Codex embedded-asset parity. The existing MADR TOC recipe remains not exercisable in this vault.
- Official skill validation passed for the changed canonical Hyalo skill.
- The final workspace test run was serial: an earlier attempt overlapped a package-check rebuild and two tests could not find the temporarily replaced CLI binary. No failures were suppressed.
- Permission tests ran outside the outer workspace sandbox because it strips set-ID bits during fixture creation. The original-binary reproduction and passing fixed-binary test both verified actual fixture bits first.
- Independent local review completed read-only without builds/tests. Its initial launch was stopped after CLI 0.153.4 ignored the top-level approval flag; explicit review configuration was verified to start with `approval: never` and `sandbox: read-only`. No global permission settings changed.

Final-head GitHub CI: all seven executed checks passed on `1607edc665c74ed880a11b555cbd6c568cede5da`; `lint-kb-full` was intentionally skipped. The interactive CLI behavior checks passed; only the explicitly deferred desktop-app check remains outstanding. The user requested a merge commit through GitHub after verification, without force-push or auto-merge.



Finalization: the user explicitly requested no repeated full test suite for the documentation-only smoke-test record and authorized publishing that small knowledgebase update directly to main after merging. That update passed strict file lint and `git diff --check`; the redundant local Rust validation was stopped during Clippy, before the test phase.
