### PR TITLE
fix(iter-282): separate directory prefix admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to
 
 ### Changed
 
+- Directory overlap in fuzzy link confidence now admits a shared prefix that
+  outweighs its leftover in the shorter token, while basename tokens retain
+  the stricter factor of two. The GitHub Docs SAML directory relocation returns
+  from 0.795 to 0.804, above the default apply floor; `Mathjax` still does not
+  match `mathpad`. Both features retain the 0.85 Jaro-Winkler token floor.
 - **Loading a `.hyalo-index` snapshot no longer decodes the BM25 inverted
   index.** On a MDN-scale vault (14 375 entries, 116 MiB index) the BM25
   section is 76 % of the file, and a `find` with no text query spent ~230 ms of

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -2953,9 +2953,11 @@ pub(crate) enum LinksAction {
             location, so only its basename is scored.\n\n\
             The basename term compares words, not characters: a slug is split on separators\n\
             AND at camelCase boundaries (CatMuse -> cat + muse), two words count as the same\n\
-            word only if they are close enough on Jaro alone (a shared prefix sharpens a\n\
-            match but cannot create one, so paulbricman does not match paultreanor), and a\n\
-            word neither name accounts for costs its share of their characters. So a rename\n\
+            word if they clear 0.85 on Jaro, or on Jaro-Winkler when their shared prefix\n\
+            is more than twice its leftover in the shorter word. Directory tokens instead\n\
+            require the prefix to outweigh its leftover (management/managing qualifies);\n\
+            both retain the 0.85 Jaro-Winkler floor. Basename mathjax/mathpad stays unmatched.\n\
+            A word neither name accounts for costs its share of their characters. So a rename\n\
             that ADDS OR DROPS A WHOLE WORD lands below the default floor (decision-log ->\n\
             decision-log-archive scores 0.607) and is reported rather than written; a typo,\n\
             a punctuation change or a pure relocation is unaffected.\n\n\

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -417,9 +417,12 @@ Prefer `hyalo` CLI for operations on files in this directory:
   lowercased, rejoined with `-`. `[[my-long-note]]` therefore fixes to `MyLongNote.md` at 1.0.
   A plain lowercase-hyphen slug is its own key byte for byte, so a documentation corpus is
   untouched — GitHub Docs and MDN produce byte-identical `links fix` output, at the same wall
-  time. Widening candidacy exposes the scorer as it is: on the Obsidian Hub `[[Mathjax]]` now
-  offers `mathpad.md` at 0.886 (one token each, admitted by the shared `math` prefix), which is
-  wrong and is a known carry-over.
+  time. DEC-326 (iter-281) closed the exposed `[[Mathjax]]` → `mathpad.md` false match:
+  a basename prefix must exceed twice its leftover in the shorter token. Directory overlap
+  uses its own looser rule (DEC-329, iter-282): the prefix must outweigh the leftover, so
+  `management`/`managing` qualifies. Both features retain the 0.85 Jaro-Winkler floor.
+  The SAML directory relocation returns from 0.795 to 0.804, above the default apply floor;
+  basename `Mathjax`/`mathpad` stays closed.
 - **Hints keep `--site-prefix`** (iter-277): a `--site-prefix` given on the CLI is threaded
   into every hint, like `--dir`, `--format` and `--index-file`, so the follow-up answers the
   same question. `hyalo config` reports `site_prefix_source`, and `links fix` says

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -578,10 +578,12 @@ What follows is only what those pages do not say — the behaviour that surprise
   `--apply-fuzzy` writes it. A plain lowercase-hyphen slug is its own normal form byte for
   byte, so a documentation vault sees nothing change: GitHub Docs (5,476 fuzzy proposals) and
   MDN produce byte-identical `links fix` output at the same wall time. What a wider gate does
-  expose is the scorer as it stands — on the Obsidian Hub `[[Mathjax]]`, which names no note,
-  now offers `mathpad.md` at 0.886 on the strength of a shared `math` prefix. That one is
-  wrong, is recorded as a carry-over, and is a reason to read `fuzzy_fixes` before
-  `--apply-fuzzy` on a prose-cased vault.
+  expose is the scorer as it stands. DEC-326 (iter-281) closed the exposed `[[Mathjax]]` →
+  `mathpad.md` false match: a basename prefix must exceed twice its leftover in the shorter
+  token. Directory overlap deliberately uses a looser rule (DEC-329, iter-282): the prefix
+  must outweigh the leftover, so `management`/`managing` qualifies. Both features still need
+  0.85 on Jaro-Winkler. The SAML directory relocation returns from 0.795 to 0.804, above the
+  default apply floor, while basename `Mathjax`/`mathpad` stays closed.
 - **`links fix`'s two site-prefix warnings count the same set** (iter-277), and the
   "stripped 0 of N" one says "derived from the directory name" when nothing configured the
   prefix it is blaming.

--- a/crates/hyalo-cli/tests/e2e/iteration282_directory_token_dominance.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration282_directory_token_dominance.rs
@@ -1,0 +1,112 @@
+//! Directory overlap has its own majority-prefix admission (DEC-329).
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const OLD: &str = "/admin/identity-and-access-management/using-saml-for-enterprise-iam/saml-configuration-reference";
+const NEW: &str = "admin/managing-iam/iam-configuration-reference/saml-configuration-reference.md";
+
+fn fixture(body: &str) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let target = tmp.path().join(NEW);
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::fs::write(target, "# SAML\n\n## Attributes\n").unwrap();
+    std::fs::write(tmp.path().join("src.md"), body).unwrap();
+    tmp
+}
+
+fn command(tmp: &TempDir, indexed: bool) -> Command {
+    let mut cmd = crate::common::hyalo_no_hints();
+    cmd.arg("--dir").arg(tmp.path()).args(["--site-prefix", ""]);
+    if indexed {
+        cmd.arg("--index-file").arg(tmp.path().join(".hyalo-index"));
+    }
+    cmd
+}
+
+fn json(tmp: &TempDir, indexed: bool, args: &[&str]) -> Value {
+    let output = command(tmp, indexed)
+        .args(args)
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn minimal_saml_fixture_restores_point_804_on_disk_and_index() {
+    for indexed in [false, true] {
+        let original = format!("[AUTOTITLE]({OLD})\n");
+        let tmp = fixture(&original);
+        if indexed {
+            json(&tmp, false, &["create-index"]);
+        }
+        let plan = json(&tmp, indexed, &["links", "fix", "--dry-run"]);
+        let fixes = plan["results"]["fuzzy_fixes"].as_array().unwrap();
+        assert_eq!(fixes.len(), 1, "{plan}");
+        assert_eq!(fixes[0]["new_target"], NEW);
+        assert_eq!(
+            format!("{:.3}", fixes[0]["confidence"].as_f64().unwrap()),
+            "0.804"
+        );
+        assert_eq!(fixes[0]["below_floor"], false);
+        assert_eq!(plan["results"]["fuzzy_below_floor"], 0);
+        command(&tmp, indexed)
+            .args(["links", "fix", "--dry-run", "--format", "text"])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("0.80"));
+        // Immediately above the recovered confidence it is still withheld.
+        let high_floor = json(
+            &tmp,
+            indexed,
+            &["links", "fix", "--apply", "--min-confidence", "0.805"],
+        );
+        assert_eq!(high_floor["results"]["fuzzy_fixes"][0]["below_floor"], true);
+        json(&tmp, indexed, &["links", "fix", "--apply"]);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("src.md")).unwrap(),
+            original
+        );
+        let applied = json(&tmp, indexed, &["links", "fix", "--apply", "--apply-fuzzy"]);
+        assert_eq!(applied["results"]["fuzzy"], 1, "{applied}");
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("src.md")).unwrap(),
+            format!("[AUTOTITLE](/{})\n", NEW.trim_end_matches(".md"))
+        );
+        let after = json(&tmp, indexed, &["links", "fix", "--dry-run"]);
+        assert_eq!(after["results"]["broken"], 0, "{after}");
+    }
+}
+
+#[test]
+fn renamed_directory_rewrites_supported_link_forms_and_preserves_protected_bytes() {
+    for indexed in [false, true] {
+        let links = format!("[inline]({OLD}#attributes \"title\")\n[[{OLD}#Attributes|label]]\n");
+        // Reference links are currently outside links fix's inventory.
+        let protected = format!(
+            "\n[reference][saml]\n\n[saml]: {OLD}#attributes \"title\"\n\n`[code]({OLD})`\n\n```md\n[code]({OLD})\n```\n"
+        );
+        let tmp = fixture(&format!("{links}{protected}"));
+        if indexed {
+            json(&tmp, false, &["create-index"]);
+        }
+        let applied = json(&tmp, indexed, &["links", "fix", "--apply", "--apply-fuzzy"]);
+        assert_eq!(applied["results"]["failed"], 0, "{applied}");
+        let new = NEW.trim_end_matches(".md");
+        let expected =
+            format!("[inline](/{new}#attributes \"title\")\n[[{new}#Attributes|label]]\n");
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("src.md")).unwrap(),
+            format!("{expected}{protected}")
+        );
+        let after = json(&tmp, indexed, &["links", "fix", "--dry-run"]);
+        assert_eq!(after["results"]["broken"], 0, "{after}");
+        assert_eq!(after["results"]["broken_anchors"], 0, "{after}");
+    }
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -61,6 +61,7 @@ mod iteration278_literal_probe_from_index;
 mod iteration279_fuzzy_near_neighbours;
 mod iteration280_fuzzy_candidacy_gate;
 mod iteration281_dominant_prefix_exemption;
+mod iteration282_directory_token_dominance;
 mod iteration_ergonomics;
 mod jq;
 mod json_errors;

--- a/crates/hyalo-core/src/link_score.rs
+++ b/crates/hyalo-core/src/link_score.rs
@@ -228,6 +228,12 @@ pub fn gate_key(stem: &str) -> String {
 /// doubles it.
 const PREFIX_DOMINANCE: usize = 2;
 
+/// Directory levels describe location, so their shared prefix need only
+/// outweigh the leftover, rather than double it (iter-282, DEC-329).
+/// `management`/`managing` shares five characters and leaves three in the
+/// shorter token. Basenames retain the stricter morphological rule.
+const DIRECTORY_PREFIX_DOMINANCE: usize = 1;
+
 /// `true` when the two tokens' common prefix outweighs what it leaves over of
 /// the shorter one by more than a factor of [`PREFIX_DOMINANCE`].
 ///
@@ -282,9 +288,13 @@ const PREFIX_DOMINANCE: usize = 2;
 ///
 /// Both arguments come from [`tokenize`] and are already lowercase.
 fn shares_dominant_prefix(a: &str, b: &str) -> bool {
+    shares_prefix_with_dominance(a, b, PREFIX_DOMINANCE)
+}
+
+fn shares_prefix_with_dominance(a: &str, b: &str, dominance: usize) -> bool {
     let common = a.chars().zip(b.chars()).take_while(|(x, y)| x == y).count();
     let shorter = a.chars().count().min(b.chars().count());
-    shorter > 0 && common > PREFIX_DOMINANCE * (shorter - common)
+    shorter > 0 && common > dominance * (shorter - common)
 }
 
 /// Similarity of two slug tokens, `0.0` when they are not the same token.
@@ -309,6 +319,16 @@ fn shares_dominant_prefix(a: &str, b: &str) -> bool {
 ///
 /// The reported score is Jaro-Winkler either way; only admission changes.
 fn token_similarity(a: &str, b: &str) -> f64 {
+    token_similarity_with_prefix(a, b, shares_dominant_prefix)
+}
+
+fn directory_token_similarity(a: &str, b: &str) -> f64 {
+    token_similarity_with_prefix(a, b, |a, b| {
+        shares_prefix_with_dominance(a, b, DIRECTORY_PREFIX_DOMINANCE)
+    })
+}
+
+fn token_similarity_with_prefix(a: &str, b: &str, prefix: fn(&str, &str) -> bool) -> f64 {
     if a == b {
         return 1.0;
     }
@@ -316,20 +336,20 @@ fn token_similarity(a: &str, b: &str) -> f64 {
     if winkler < TOKEN_MATCH_FLOOR {
         return 0.0;
     }
-    let admitted = strsim::jaro(a, b) >= TOKEN_MATCH_FLOOR || shares_dominant_prefix(a, b);
+    let admitted = strsim::jaro(a, b) >= TOKEN_MATCH_FLOOR || prefix(a, b);
     if admitted { winkler } else { 0.0 }
 }
 
 /// Best match for `token` among `others`, or `0.0` when nothing clears
 /// [`TOKEN_MATCH_FLOOR`].
-fn best_token_match(token: &str, others: &[String]) -> f64 {
+fn best_token_match(token: &str, others: &[String], similarity: fn(&str, &str) -> f64) -> f64 {
     others
         .iter()
-        .map(|o| token_similarity(token, o))
+        .map(|o| similarity(token, o))
         .fold(0.0_f64, f64::max)
 }
 
-/// Soft token F1: the harmonic mean of how well each side is covered by the
+/// Directory soft token F1: the harmonic mean of how well each side is covered by the
 /// other, where coverage is the mean best-match score per token.
 ///
 /// Two empty token lists are identical (`1.0`); exactly one empty list is a
@@ -338,15 +358,12 @@ fn best_token_match(token: &str, others: &[String]) -> f64 {
 /// `actions` is fully covered by `actions-limits` (recall 1.0) but only covers
 /// half of it (precision 0.5), giving 0.67 instead of 0.75.
 ///
-/// The result is then scaled by its explained mass (iter-279), which charges
-/// for whole tokens the pairing leaves unmatched in proportion to how much of
-/// the two names they are — 0.47 for that same `actions` / `actions-limits`
-/// pair, where `limits` is six of the twenty characters in play.
+/// Directory overlap uses its own prefix admission and no character charge.
 fn soft_token_f1(a: &[String], b: &[String]) -> f64 {
-    scored_token_f1(a, b).0
+    scored_token_f1_with(a, b, directory_token_similarity).0
 }
 
-/// [`soft_token_f1`] together with the pairing's **explained mass**: `1 −` the
+/// Basename soft token F1 together with the pairing's **explained mass**: `1 −` the
 /// share of characters living in tokens left *entirely* unmatched, counted
 /// across both sides.
 ///
@@ -367,8 +384,16 @@ fn soft_token_f1(a: &[String], b: &[String]) -> f64 {
 /// share pushed 828 GitHub Docs fixes whose basename matched byte-for-byte
 /// below the apply floor. A dropped word in the *name* changes which document
 /// is meant; a dropped word in the *path* is the move being described.
-#[allow(clippy::cast_precision_loss)]
 fn scored_token_f1(a: &[String], b: &[String]) -> (f64, f64) {
+    scored_token_f1_with(a, b, token_similarity)
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn scored_token_f1_with(
+    a: &[String],
+    b: &[String],
+    similarity: fn(&str, &str) -> f64,
+) -> (f64, f64) {
     if a.is_empty() && b.is_empty() {
         return (1.0, 1.0);
     }
@@ -382,7 +407,7 @@ fn scored_token_f1(a: &[String], b: &[String]) -> (f64, f64) {
     let mut side = |xs: &[String], ys: &[String]| -> f64 {
         let mut sum = 0.0;
         for x in xs {
-            let score = best_token_match(x, ys);
+            let score = best_token_match(x, ys, similarity);
             sum += score;
             let len = x.chars().count();
             total_chars += len;
@@ -454,9 +479,12 @@ fn common_prefix_ratio(a_dirs: &[&str], b_dirs: &[&str]) -> f64 {
 /// * **shared leading components** ([`DIR_PREFIX_WEIGHT`]) — `a/b/c` and
 ///   `a/b/d` share two of three levels. This is the term that separates a
 ///   relocation *within* a section from a substitution *across* sections.
-/// * **unordered token overlap** — the same soft token F1 used for basenames,
-///   over the flattened components. It keeps a reorganisation that inserts or
-///   reorders a level from collapsing to zero.
+/// * **unordered token overlap** — soft token F1 over the flattened components,
+///   without the basename's unmatched-character charge. The prefix exemption
+///   requires the common prefix to outweigh its leftover in the shorter token
+///   (factor one), while basenames require more than twice the leftover. Both
+///   still require Jaro-Winkler to clear the token floor. It keeps a directory
+///   rename such as `management`/`managing` from losing its overlap evidence.
 #[must_use]
 pub fn directory_similarity(a_dirs: &[&str], b_dirs: &[&str]) -> f64 {
     if a_dirs.is_empty() && b_dirs.is_empty() {
@@ -527,6 +555,66 @@ pub fn candidate_confidence_with_claim(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn directory_prefix_admission_is_deliberately_looser_than_basename() {
+        assert!(strsim::jaro("management", "managing") < TOKEN_MATCH_FLOOR);
+        assert!(strsim::jaro_winkler("management", "managing") >= TOKEN_MATCH_FLOOR);
+        assert!(approx(token_similarity("management", "managing"), 0.0));
+        for (a, b) in [("management", "managing"), ("managing", "management")] {
+            assert!(approx(
+                directory_token_similarity(a, b),
+                strsim::jaro_winkler(a, b)
+            ));
+        }
+        // A majority must beat, not tie, the leftover; count Unicode characters.
+        for (a, b, admitted) in [
+            ("abcdxy", "abcdzz", true),
+            ("abcxyz", "abcuvw", false),
+            ("abxxxx", "abyyyy", false),
+            ("éabcxy", "éabczz", true),
+            ("éabxyz", "éabuvw", false),
+            ("", "", false),
+        ] {
+            assert_eq!(
+                shares_prefix_with_dominance(a, b, DIRECTORY_PREFIX_DOMINANCE),
+                admitted
+            );
+        }
+        // Majority alone does not bypass the Winkler floor.
+        assert!(shares_prefix_with_dominance(
+            "use",
+            "using",
+            DIRECTORY_PREFIX_DOMINANCE
+        ));
+        assert!(approx(directory_token_similarity("use", "using"), 0.0));
+        assert!(approx(
+            directory_token_similarity("paulbricman", "paultreanor"),
+            0.0
+        ));
+        assert!(approx(token_similarity("mathjax", "mathpad"), 0.0));
+        assert!(approx(basename_similarity("management", "managing"), 0.0));
+    }
+
+    #[test]
+    fn saml_directory_rename_restores_the_measured_apply_floor_crossing() {
+        let target = "admin/identity-and-access-management/using-saml-for-enterprise-iam/saml-configuration-reference";
+        let candidate =
+            "admin/managing-iam/iam-configuration-reference/saml-configuration-reference.md";
+        // These components have no duplicate tokens: the baseline's shared
+        // basename admission gives directory overlap 4/15 and confidence .795.
+        let old_tokens =
+            tokenize("admin-identity-and-access-management-using-saml-for-enterprise-iam");
+        let new_tokens = tokenize("admin-managing-iam-configuration-reference");
+        let old_overlap = scored_token_f1(&old_tokens, &new_tokens).0;
+        let before = 0.7 + 0.3 * (0.75 / 3.0 + 0.25 * old_overlap);
+        assert!((before - 0.795).abs() < 1e-12, "{before}");
+        let after = candidate_confidence(target, candidate);
+        assert_eq!(format!("{after:.3}"), "0.804");
+        assert!(before < DEFAULT_FUZZY_MIN_CONFIDENCE);
+        assert!(after >= DEFAULT_FUZZY_MIN_CONFIDENCE);
+        assert!(approx(candidate_confidence(candidate, target), after));
+    }
 
     fn approx(a: f64, b: f64) -> bool {
         (a - b).abs() < 1e-9

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -6221,3 +6221,54 @@ relocation.
 `PREFIX_DOMINANCE`),
 `crates/hyalo-cli/tests/e2e/iteration281_dominant_prefix_exemption.rs`.
 See [[iterations/iteration-281-dominant-prefix-equal-length-exemption]].
+
+## DEC-329: directory tokens use majority-prefix admission (2026-09-06)
+
+**Decision:** The directory-overlap feature uses a separate prefix dominance
+factor of **one**: the shared prefix must strictly outweigh the leftover in the
+shorter token. The basename retains DEC-326's factor of **two**. Both paths
+require Jaro-Winkler at least 0.85; plain Jaro at least 0.85 still admits a pair
+without an exemption. Tokenisation, leading-directory weighting, basename
+character charge, candidacy and runner-up damping are unchanged.
+
+**Why separate the rule.** Directory names describe where the same document
+moved; a basename names the document itself. DEC-324 already treats directory
+reorganisation more leniently by omitting unmatched-character charges. A
+majority prefix gives the directory feature bounded evidence of a renamed
+level: `management`/`managing` shares five characters and leaves three in the
+shorter word. Equal halves do not qualify. The token overlap contributes only
+one quarter of the 30% directory feature; shared leading components continue
+to carry the other three quarters. This is a deliberate heuristic, not a claim
+that majority-prefix words are semantically identical.
+
+**Alternatives weighed.** Keeping one factor-two rule is defensible if a
+0.004-margin relocation is deemed too uncertain, but it makes the directory
+feature inherit a restriction justified by basename false positives. Separate
+factor one restores that directory evidence without reopening `Mathjax` as a
+basename match. Removing the directory exemption while retaining plain-Jaro
+admission keeps `management`/`managing` rejected and also rejects genuine
+prefix extensions such as `get`/`getting`. Using Jaro-Winkler alone would
+restore them but admits `paulbricman`/`paultreanor` on a four-character given
+name; dropping the floor entirely would also credit unrelated-token noise.
+The chosen majority rule retains the floor and a length-relative bound. It is
+stricter than the pre-281 half-inclusive rule at the equal-half boundary.
+
+**Exact reproducer and consumer behavior.** A two-file vault contains
+`src.md` with `[AUTOTITLE]` linked to
+`/admin/identity-and-access-management/using-saml-for-enterprise-iam/saml-configuration-reference`
+and the sole candidate
+`admin/managing-iam/iam-configuration-reference/saml-configuration-reference.md`.
+Baseline confidence is **0.795**; the directory-only change restores **0.804**.
+The default dry-run switches `below_floor` from true to false. Plain `--apply`
+still withholds fuzzy fixes, while `--apply --apply-fuzzy` now writes this
+relocation. A floor of 0.805 still withholds it. These facts are covered on disk
+and index; inline Markdown and wikilinks preserve anchors, labels and titles
+while inline/fenced code remains byte-identical. Reference definitions remain
+unchanged: they are outside the current `links fix` inventory, not another
+rewrite path added by this iteration.
+Unit fixtures cover the strict majority boundary, Unicode character counting,
+Winkler-floor rejection and unchanged basename admission. Existing iteration
+279/280/281 fixtures are retained without edits.
+
+See [[iterations/iteration-282-directory-token-dominance-rule]] for the corpus
+comparison and validation outcome.

--- a/hyalo-knowledgebase/iterations/iteration-282-directory-token-dominance-rule.md
+++ b/hyalo-knowledgebase/iterations/iteration-282-directory-token-dominance-rule.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 282 — Give the directory-similarity feature its own dominant-prefix rule"
 date: 2026-09-06
-status: planned
+status: completed
 tags: [iteration, links, fuzzy-match]
 branch: iter-282/directory-token-dominance-rule
 priority: 3
@@ -37,13 +37,13 @@ segment. This iteration is scoped to answering that question — and only that q
 
 ## Tasks
 
-- [ ] TASK-1: confirm the regression still stands on GitHub Docs at HEAD (main, post iter-281):
+- [x] TASK-1: confirm the regression still stands on GitHub Docs at HEAD (main, post iter-281):
       `saml-configuration-reference`'s directory rename `management` → `managing` scores below
       the apply floor solely because of `shares_dominant_prefix`'s DEC-326 tightening. Build a
       minimal two-file fixture (mirroring iter-281's e2e style) that reproduces the exact
       before/after confidence numbers from DEC-326's writeup (0.804 → 0.795) without needing the
       full GitHub Docs corpus.
-- [ ] TASK-2: decide whether `link_score`'s directory-similarity path should call
+- [x] TASK-2: decide whether `link_score`'s directory-similarity path should call
       `shares_dominant_prefix` at all, or a directory-specific variant with its own dominance
       factor (or no floor at all, given DEC-324's basename-only character charge already treats
       directories more leniently in other ways). Weigh at least:
@@ -54,23 +54,23 @@ segment. This iteration is scoped to answering that question — and only that q
         relocation was never safely applicable" instead of changing the code.
       Whichever is chosen, re-run every iter-279/280/281 fixture that touches
       `shares_dominant_prefix` or directory scoring and confirm none regresses.
-- [ ] TASK-3: implement the decision, then re-measure the Obsidian Hub, MDN and GitHub Docs the
+- [x] TASK-3: implement the decision, then re-measure the Obsidian Hub, MDN and GitHub Docs the
       same way iter-281 did (`links fix --dry-run --format json`, this branch vs `main`) and
       record what moved — specifically whether `saml-configuration-reference` returns above the
       floor and whether `[[Mathjax]]`/`mathpad` (the pair DEC-326 closed) stays closed.
-- [ ] TASK-4: `cargo test --workspace -q`, every xtask `check-*` gate, `hyalo lint --strict` on
+- [x] TASK-4: `cargo test --workspace -q`, every xtask `check-*` gate, `hyalo lint --strict` on
       the knowledgebase.
 
 ## Acceptance criteria
 
-- [ ] The directory-similarity feature's admission rule for a shared-prefix token pair is a
+- [x] The directory-similarity feature's admission rule for a shared-prefix token pair is a
       documented, deliberate choice (a looser factor, no exemption, or "unchanged, and here is
       why") rather than an accidental side effect of a basename-motivated change.
-- [ ] Every iter-279/280/281 fixture (`get`/`getting`, `[[Mathjax]]`/`mathpad`, the
+- [x] Every iter-279/280/281 fixture (`get`/`getting`, `[[Mathjax]]`/`mathpad`, the
       `shares_dominant_prefix` unit tests) still passes unchanged.
-- [ ] The chosen rule is measured on all three corpora (Hub, MDN, GitHub Docs) against `main`,
+- [x] The chosen rule is measured on all three corpora (Hub, MDN, GitHub Docs) against `main`,
       with the `saml-configuration-reference` outcome explicitly reported either way.
-- [ ] Gates green.
+- [x] Gates green.
 
 ## Links
 
@@ -79,3 +79,89 @@ segment. This iteration is scoped to answering that question — and only that q
 - [[iterations/iteration-279-fuzzy-scorer-near-neighbor-stems]] — DEC-324, origin of the
   basename/directory split in `link_score` and the character-charge asymmetry between them
 - [[decision-log]] — DEC-324, DEC-326
+
+## Outcome
+
+Implemented as [[decision-log]] DEC-329. Directory tokens use a strict majority
+prefix: the common prefix must outweigh the leftover in the shorter token
+(factor one). Basenames retain DEC-326's factor two, and both features retain
+the 0.85 Jaro-Winkler floor. DEC-329 weighs the separate looser rule against
+plain-Jaro/no-exemption admission, unrestricted Winkler admission and leaving
+one shared rule unchanged.
+
+The two-file SAML fixture reproduces **0.795 → 0.8037** (displayed as **0.804**),
+exactly the regression in DEC-326. It verifies dry-run confidence and floor
+reporting, plain apply withholding, fuzzy apply rewriting, and below-floor
+reporting at a 0.805 threshold, on both disk and index. Additional fixtures cover
+inline Markdown/wikilink emission and protected code/reference bytes, strict
+majority boundaries, Unicode counting and the retained Winkler floor. The
+existing iteration 279/280/281 fixtures are unchanged.
+
+### Corpus comparison
+
+Baseline is `main` at `bfa47325328f997f6f0352d41448367a1f1a2b2a`, built before
+source edits and copied aside. Candidate uses this iteration's working tree.
+Both identify as `hyalo 0.22.0 (bfa47325328f+dirty 2026-09-06)`; baseline was
+only dirty because this plan had entered `in-progress`. Binary SHA-256:
+
+- Baseline: `7bddf4ef6cd21813bd4970356fe9bc387f6e96884c2b9c2aea472f00b4be7d77`
+- Candidate: `8d3233354907aed7439bc09a8911736b1aa5f1cf32c3db7cd71067dbdc5c9f63`
+
+Commands match iteration 281: each binary runs
+`--dir <corpus> links fix --dry-run --format json`, three times serially per
+corpus, without index or writes. Corpora are `/Users/james/devel/obsidian-hub`,
+`/Users/james/devel/mdn/files/en-us` and `/Users/james/devel/docs/content`.
+Full JSON, stderr/timings, binary copies, corpus revisions/status and the
+comparison script are retained under
+`.git/ralph-loop/run-20260906-284-287/282/`. Corpus heads and working-tree status
+are unchanged; each set of three outputs is byte-identical.
+
+| Corpus | Fuzzy proposals | Above floor | Unfixable | Median wall time |
+| --- | --- | --- | --- | --- |
+| Obsidian Hub | 18 → 18 | 1 → 1 | 36 → 36 | 0.47 → 0.48 s |
+| MDN (historical defaults) | 0 → 0 | 0 → 0 | 49784 → 49784 | 1.89 → 1.80 s |
+| GitHub Docs | 5483 → 5479 | 2168 → 2174 | 1868 → 1872 | 4.41 → 4.45 s |
+
+Hub output is byte-identical, so `[[Mathjax]]`/`mathpad` remains closed. On
+GitHub Docs, exactly the six SAML occurrences rise across the floor. No
+previously applicable proposal disappears or loses confidence, and no proposal
+crosses downward. There are 377 re-scored proposals: 373 rise and four fall;
+the four falling ones remain below the floor. Four proposals disappear, all
+previously below the floor at 0.039–0.133. No proposal is gained. Broken counts
+and deterministic case/alias/relocation results are unchanged.
+
+**MDN limitation and extra check.** The historical command's derived `en-us`
+prefix fails to resolve 49767 site-absolute links and skips their fuzzy scoring;
+its zero proposals are not evidence of scorer quality. An additional baseline
+and candidate run with `--site-prefix en-US/docs` is also byte-identical:
+522 broken, 521 unfixable and one applicable fuzzy proposal at 0.822461243
+(`Global_attributes/tabindex` → `global_attributes/index.md`). All 14375 MDN
+Markdown files are named `index.md`; the correctly configured run still
+exercises that one proposal. The Hub's existing one-file frontmatter warning
+and MDN's default-prefix warnings are preserved in the captures.
+
+### Validation
+
+`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, then
+`cargo test --workspace -q` passed sequentially: **4872 passed, 0 failed**, with
+two existing ignored doctest usage examples (`warn.rs` and
+`scanner/body_state.rs`). Candidate release build passed. Every discovered
+`xtask check-*` command exited 0: feature-fanout, help-drift,
+command-reference, bundled-skills, pi-package-sync, codex-package, jq-recipes,
+dead-primitives, todo-annotations and mutation-journal. The dead-primitives and
+todo-annotations commands explicitly report that they are **unimplemented
+stubs**, so their zero exits establish no coverage.
+
+Full `hyalo lint --strict` exits 0 with zero errors and four existing
+`HYALO002` warnings in iterations 270, 271, 277 and 281 (completed plans with
+unchecked work). Changed-file strict lint reports no findings.
+`git diff --check` passes. Initial new-fixture assumptions about index flag
+position, wikilink slash emission and inert reference definitions were corrected
+before the final complete gate run; no existing fixture was weakened.
+
+Independent read-only review found no actionable defects. On 2026-09-06 the
+supervisor reconciled every upcoming pending plan: 283, 285, 286, 287 and 288.
+No plan adaptation was needed: this change affects link-repair directory scoring,
+with no JSON shape, ranked-search, package or integration contract change.
+The external requirements in 286/287 remain required, and 288 desktop verification
+remains explicitly deferred.


### PR DESCRIPTION
## Summary

The basename prefix tightening also reduced directory overlap, putting six correct GitHub Docs SAML relocations below the default apply floor. Directory tokens now require a shared prefix to outweigh its leftover, while basenames keep the stricter factor of two. SAML confidence returns from 0.795 to 0.8037; Mathjax/mathpad stays closed.

Added boundary, disk/index and apply/rewrite coverage; documented the alternatives and corpus evidence in DEC-329. All upcoming plans were reconciled, with external prerequisites and iteration 288 desktop verification retained.

## Test plan

- [x] Ordered formatting, strict workspace Clippy and workspace tests: 4,872 passed, two existing ignored doctests.
- [x] All eight implemented xtask gates pass; two additional check commands remain explicitly unimplemented stubs.
- [x] Strict knowledgebase lint: zero errors, four existing warnings; changed knowledgebase files have no findings. Changelog lint has zero errors and one existing HYALO006 warning for `2022-04`. Whitespace checks pass.
- [x] Saved baseline/candidate corpus comparison: Hub byte-identical; Docs gains exactly six applicable SAML fixes, loses no applicable fix; MDN byte-identical under both historical and corrected prefixes. Median Hub/Docs times remain effectively unchanged.
- [x] Fresh independent implementation review: no actionable defects.
- [x] Final documentation review.
- [x] GitHub CI: formatting, Clippy, quality gates, changed-file lint, and Ubuntu/macOS/Windows tests pass. Full-vault lint is push-only and skipped on this PR.

The historical MDN prefix skips most site-absolute fuzzy scoring; its zero proposals are not treated as positive quality evidence. The corrected-prefix comparison covers its one existing applicable proposal. All existing 279–281 fixtures remain unchanged. The jq gate's existing MADR-directory recipe is not exercisable in this vault.

## Review

Independent review covers final head `b76e4577b7d238c1c34ef13e6831cf13ac74f033`. The initial fresh review found no implementation defects; the same read-only reviewer verified the final metadata delta against archived bytes and hashes. One reporting finding was fixed here: changelog lint has one existing warning, rather than being clean. No code changed after the full review or successful local gates.
