### PR TITLE
Add body snippets to ranked search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
   `--codex-plugin` configures projects without duplicate local skill copies.
 - Agent Skills validation now includes `.agents/skills/**` as well as Claude's
   skill directory. CI checks Codex plugin metadata and embedded asset parity.
+- Ranked find results now include up to three body snippets with line numbers and
+  section context, alongside their relevance score. Snippets share stemming, phrase, OR
+  and CJK rules with ranked search; indexed queries read only final selected files after
+  the result limit.
 
 ### Changed
 
@@ -439,6 +443,13 @@ and this project adheres to
 - Hints thread `--site-prefix` when it was given on the CLI, so a follow-up command answers the same question as the one that printed it.
 - The `find --broken-links` hint no longer offers `links fix` when every genuinely broken link is site-absolute: external URIs carry a null `path` but are not broken and used to out-vote them.
 - `find --index --file <missing>` reports the missing file without a spurious "index older than vault" warning first, and the stale-index warning names which probe fired (a directory mtime, or a specific file).
+- Disk and indexed ranked search now use the same authored title tokens. Disk scores can
+  change in corpora containing notes without a string title or H1: displayed filename
+  fallbacks no longer enter the disk corpus. Indexed scores, displayed titles and
+  snapshot format are unchanged.
+- Streaming reads preserve UTF-8 characters split across buffer boundaries. Frontmatter
+  skipping now uses the same normalized CRLF byte budget as scanning, so ranked snippets
+  no longer disappear or abort on these boundaries.
 
 ### Added
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -822,10 +822,13 @@ pub(crate) enum Commands {
             SEARCH MODES:\n\
             - PATTERN (positional): BM25 ranked full-text search with stemming. Results are sorted by \
             relevance score (highest first) unless --sort is specified. Each result includes a numeric \
-            'score' field in the output. Stemming normalises words to their root: 'running' matches \
+            'score' and a 'matches' array with up to 3 body snippets ({line, section, text}). Snippets \
+            rank by distinct query tokens, then line number; quoted phrases must fit on one line. \
+            --section scopes snippets; title-only hits may have an empty array. Stemming normalises \
+            words to their root: 'running' matches \
             documents containing 'run', 'runner', 'running', etc.\n\
             - --regexp/-e REGEX: regex body text search (case-insensitive by default; unranked; \
-            results include per-line 'matches' instead of 'score'). Mutually exclusive with PATTERN.\n\n\
+            results include all per-line 'matches' and no 'score'). Mutually exclusive with PATTERN.\n\n\
             QUERY SYNTAX (for PATTERN):\n\
             - Multiple words: implicit AND — all terms required (e.g. 'rust programming' returns \
             only documents containing both words)\n\

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -232,6 +232,8 @@ pub(crate) const HELP_EXAMPLES: &str = "EXAMPLES:
 /// [`help_long`]. Never hand-write the list-command enumeration here (iter-192).
 const HELP_LONG_TEMPLATE: &str = "COMMAND REFERENCE:
   Find (search and filter, read-only):
+    PATTERN returns score and up to 3 body matches {line, section, text}, ranked by distinct query
+    tokens then line number; --section scopes matches. Regex returns all matching lines, unranked.
     hyalo find [PATTERN | -e/--regexp REGEX] [-p/--property K=V ...] [-t/--tag T ...] [--task STATUS]
                [-s/--section HEADING ...] [--title PAT] [--broken-links] [--orphan] [--dead-end]
                [-f/--file F | -g/--glob G] [--filenames-only | --filenames0] [--fields ...] [--sort ...] [--reverse] [--strict] [--language LANG] [-n/--limit N]

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -659,9 +659,9 @@ pub fn find(
                         raw_body.to_owned()
                     };
 
-                    let title_val =
-                        extract_title(&entry.properties, Some(&entry.sections), &entry.rel_path);
-                    let title_str = title_val.as_str().unwrap_or("").to_owned();
+                    let title_str =
+                        hyalo_core::bm25::document_title(&entry.properties, &entry.sections)
+                            .to_owned();
                     let fm_lang = entry.properties.get("language").and_then(|v| v.as_str());
                     let lang = resolve_language(fm_lang, language, config_language);
                     doc_inputs.push(DocumentInput {
@@ -1460,6 +1460,46 @@ pub fn find(
         }
         t
     };
+
+    // Snapshot tokens cannot recover original lines. Read only final results,
+    // after every filter, sort and limit (including an explicit zero limit).
+    if let Some(pat) = pattern.filter(|_| has_bm25_search) {
+        use rayon::prelude::*;
+        let query = hyalo_core::bm25::SnippetQuery::new(
+            pat,
+            resolve_language(None, language, config_language),
+        );
+        // Gather references before parallel I/O: VaultIndex need not be Sync,
+        // and each worker owns one distinct result slot. Output order is kept.
+        let selected: Vec<_> = results
+            .iter_mut()
+            .filter_map(|obj| index.get(&obj.file).map(|entry| (obj, entry)))
+            .collect();
+        let outcomes: Vec<Result<()>> = selected
+            .into_par_iter()
+            .map(|(obj, entry)| {
+                let scope = build_section_scope(&entry.sections, section_filters, usize::MAX);
+                let doc_language = resolve_language(
+                    entry
+                        .properties
+                        .get("language")
+                        .and_then(serde_json::Value::as_str),
+                    language,
+                    config_language,
+                );
+                obj.matches = Some(
+                    query
+                        .snippets(&dir.join(&obj.file), doc_language, &entry.sections, &scope)
+                        .with_context(|| format!("reading ranked snippets for {}", obj.file))?,
+                );
+                Ok(())
+            })
+            .collect();
+        // Report the first failure in result order, independent of scheduling.
+        for outcome in outcomes {
+            outcome?;
+        }
+    }
 
     // --- Fuzzy suggestions when results are empty (BUG-C) ---
     if total == 0 {

--- a/crates/hyalo-cli/src/commands/find/tests.rs
+++ b/crates/hyalo-cli/src/commands/find/tests.rs
@@ -2,6 +2,65 @@ use super::*;
 use hyalo_core::index::{ScanOptions, ScannedIndex};
 use std::fs;
 
+#[test]
+fn ranked_snippets_read_only_results_after_limit() {
+    let tmp = tempfile::tempdir().unwrap();
+    for name in ["a.md", "b.md"] {
+        fs::write(tmp.path().join(name), "# Guide\nrust\n").unwrap();
+    }
+    let pairs = ["a.md", "b.md"].map(|name| (tmp.path().join(name), name.to_owned()));
+    let build = ScannedIndex::build(
+        &pairs,
+        None,
+        &ScanOptions {
+            scan_body: true,
+            bm25_tokenize: true,
+            default_language: None,
+            frontmatter_link_props: None,
+        },
+    )
+    .unwrap();
+    // Keep the already-built token cache, but make non-selected body reads fail.
+    fs::remove_file(tmp.path().join("b.md")).unwrap();
+    let run = |limit| {
+        find(
+            &build.index,
+            tmp.path(),
+            None,
+            Some("rust"),
+            None,
+            &[],
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &Fields::default(),
+            Some(&SortField::File),
+            false,
+            Some(limit),
+            false,
+            false,
+            false,
+            None,
+            Format::Json,
+            None,
+            None,
+            None,
+        )
+    };
+    let json: serde_json::Value = serde_json::from_str(&unwrap_success(run(1).unwrap())).unwrap();
+    assert_eq!(json[0]["file"], "a.md");
+    assert_eq!(json[0]["matches"][0]["line"], 2);
+    fs::remove_file(tmp.path().join("a.md")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&unwrap_success(run(0).unwrap())).unwrap();
+    assert_eq!(json, serde_json::json!([]));
+    assert!(
+        run(1).is_err(),
+        "a selected missing body must actually be read"
+    );
+}
+
 /// Build a `ScannedIndex` from `dir` and call `find`.
 /// Mirrors the old disk-scan helper signature used in pre-Phase-5 tests.
 #[allow(clippy::too_many_arguments)]
@@ -1728,7 +1787,7 @@ fn content_search_works_with_frontmatter_only_index() {
     let arr = parsed.as_array().unwrap();
     assert_eq!(arr.len(), 1, "should find beta.md via BM25 content search");
     assert!(arr[0]["file"].as_str().unwrap().contains("beta"));
-    // BM25 search produces a relevance score (no line-level matches)
+    // BM25 search produces both a relevance score and body snippets.
     let score = arr[0]["score"].as_f64();
     assert!(
         score.is_some(),

--- a/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
@@ -38,6 +38,12 @@ Use `hyalo <command> --help` for exact syntax, advanced filters, links, or bulk 
 `find`'s positional query is ranked search; `-e` is regex. Quote filter expressions
 and paths as single arguments using the active shell's quoting rules.
 
+Ranked results include `score` and up to three body `matches` with `line`, `section`,
+and `text`. Snippets rank by distinct query tokens then line number, share BM25
+stemming/OR/CJK rules, and honor `--section`. Quoted phrases must fit on one line;
+frontmatter is excluded and title-only hits can have an empty array. Indexed queries
+read snippet text only for final results after `--limit`.
+
 Pass `--format text` for compact reading or `--format json` for structured output.
 JSON is an envelope; results live in `.results`. `--jq` operates on that envelope
 and cannot be combined with text format. Respect reported truncation; narrow the query

--- a/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
+++ b/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
@@ -267,7 +267,8 @@ export default function (pi: ExtensionAPI) {
     label: "Hyalo Find",
     description:
       "Search/filter a markdown knowledgebase by full-text query, frontmatter " +
-      "properties, tags, glob, or task status. Preferred over the generic hyalo tool for queries.",
+      "properties, tags, glob, or task status. Ranked queries include score and up to 3 body matches " +
+      "with line, section, text. Preferred over the generic hyalo tool for queries.",
     promptSnippet: "hyalo_find: search/filter knowledgebase files (query, property, tag, task status)",
     parameters: hyaloFindParams,
     async execute(_toolCallId, params: Static<typeof hyaloFindParams>, signal) {

--- a/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
@@ -19,6 +19,13 @@ description: >
 
 # Hyalo CLI — Prime Tool for Markdown Knowledgebases in pi
 
+Ranked queries return `score` and up to three body `matches` with `line`, `section`,
+and `text`; text output displays that context directly. Snippets rank by distinct query
+tokens then line number and share stemming, OR and CJK rules with scoring. Quoted
+phrases must fit on one line. `--section` scopes snippets; frontmatter is excluded,
+so title-only hits can have an empty array. Indexed queries read snippet text only
+for final results after `--limit`.
+
 Hyalo is a fast CLI for querying and mutating YAML frontmatter, tags, tasks, and structure
 in directories of markdown files. If the hyalo pi extension is installed
 (`.pi/extensions/hyalo.ts`), prefer its **typed tools** for the common operations —

--- a/crates/hyalo-cli/templates/rule-knowledgebase.md
+++ b/crates/hyalo-cli/templates/rule-knowledgebase.md
@@ -14,6 +14,11 @@ Prefer `hyalo` CLI for operations on files in this directory:
   filter, because identifiers that live in `##` headings are never frontmatter titles.
 - **Search/filter**: `hyalo find --property status=planned --tag iteration`
 - **Body search**: `hyalo find "broken links"`
+- **Ranked snippets**: positional searches return `score` and up to 3 `matches` with
+  `{line, section, text}`, ordered by distinct query tokens then line number. They share
+  BM25 stemming, OR and CJK semantics; phrases must fit on one line. `--section` scopes
+  snippets and frontmatter never qualifies. Title-only hits can have `matches: []`.
+  Indexed searches read snippet text only for final results, after `--limit`.
 - **Title regex**: `hyalo find --property 'title~=link'`
 - **Inspect config**: `hyalo config` — shows effective dir, config path, hints, format, site_prefix,
   the `[links.auto]` auto-link settings, and `links.fuzzy_min_confidence` (the confidence floor

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -36,6 +36,14 @@ The positional argument to `find` triggers BM25 ranked full-text search with aut
 stemming ("running" matches "run", "runner", etc.). Results are sorted by relevance score
 by default (unless `--sort` is specified).
 
+Each ranked result includes `score` and `matches`: up to 3 body snippets with
+`{line, section, text}`, ordered by distinct query tokens then line number. Tokens use
+the same stemming/CJK rules as ranking; quoted phrases must be consecutive on one line,
+and OR accepts either side. `--section` scopes snippets. Frontmatter is excluded;
+title-only hits and phrases spanning lines can have `matches: []`. Text mode prints
+the same line/section context as regex. Indexed queries read only final selected files
+after `--limit` to recover original snippet text.
+
 ```bash
 hyalo find "rust"                        # single term, stemmed
 hyalo find "rust programming"            # AND: both terms required (implicit)

--- a/crates/hyalo-cli/tests/e2e/bm25.rs
+++ b/crates/hyalo-cli/tests/e2e/bm25.rs
@@ -1,6 +1,202 @@
 use super::common::{hyalo_no_hints, md, write_md};
 use tempfile::TempDir;
 
+#[test]
+fn ranked_snippets_streaming_unicode_and_crlf_boundaries() {
+    let tmp = TempDir::new().unwrap();
+    let prefix = "---\ntitle: Boundary\n---\n";
+    let padding = "a".repeat(8191 - prefix.len());
+    let unicode_line = format!("{padding}日本語");
+    write_md(
+        tmp.path(),
+        "unicode.md",
+        &format!("{prefix}{unicode_line}\n"),
+    );
+    let comments = format!("#{}\r\n", "a".repeat(63)).repeat(1000);
+    write_md(
+        tmp.path(),
+        "crlf.md",
+        &format!("---\r\ntitle: Near budget\r\n{comments}---\r\nrust\r\n"),
+    );
+    let index = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(index.status.success(), "{index:?}");
+    for (query, file, line, expected) in [
+        ("日本語", "unicode.md", 4, unicode_line.as_str()),
+        ("rust", "crlf.md", 1004, "rust"),
+    ] {
+        let mut previous = None;
+        for indexed in [false, true] {
+            let mut command = hyalo_no_hints();
+            command
+                .arg("--dir")
+                .arg(tmp.path())
+                .args(["find", query, "--format", "json"]);
+            if indexed {
+                command.arg("--index");
+            }
+            let output = command.output().unwrap();
+            assert!(output.status.success(), "{output:?}");
+            let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(json["total"], 1);
+            assert_eq!(json["results"][0]["file"], file);
+            assert_eq!(
+                json["results"][0]["matches"],
+                serde_json::json!([
+                    {"line": line, "section": "", "text": expected}
+                ])
+            );
+            if let Some(previous) = previous {
+                assert_eq!(output.stdout, previous);
+            }
+            previous = Some(output.stdout);
+        }
+    }
+}
+
+#[test]
+fn ranked_snippets_semantics_and_complete_index_parity() {
+    let tmp = TempDir::new().unwrap();
+    let body = "---\ntitle: titleonly rust\n---\n# Guide\nrun\nrust rust rust\nrust golang\ngolang rust\nrust\n## Other\nrun fast\nfast run\n日本語Docker入門\n```rust\n# rust code\n```\n%% rust comment %%\n";
+    write_md(tmp.path(), "guide.md", body);
+    write_md(
+        tmp.path(),
+        "title.md",
+        "---\ntitle: titleonly\n---\nUnrelated body.\n",
+    );
+    write_md(tmp.path(), "crossline.md", "# Crossline\nalpha\nbeta\n");
+    write_md(
+        tmp.path(),
+        "german.md",
+        "\u{feff}---\r\nlanguage: german\r\n---\r\nHaus\r\n",
+    );
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    for args in [
+        vec!["rust"],
+        vec!["running"],
+        vec!["rust OR golang"],
+        vec!["rust golang"],
+        vec!["\"run fast\""],
+        vec!["\"run fast\" OR golang"],
+        vec!["日本語"],
+        vec!["Docker"],
+        vec!["Häuser", "--language", "german"],
+        vec!["rust", "--section", "Other"],
+        vec!["titleonly"],
+        vec!["\"alpha beta\""],
+        vec!["rust", "--limit", "0"],
+        vec![
+            "rust OR titleonly",
+            "--limit",
+            "1",
+            "--sort",
+            "file",
+            "--reverse",
+        ],
+    ] {
+        let disk = hyalo_no_hints()
+            .arg("--dir")
+            .arg(tmp.path())
+            .args(["--format", "json", "find"])
+            .args(&args)
+            .output()
+            .unwrap();
+        let indexed = hyalo_no_hints()
+            .arg("--dir")
+            .arg(tmp.path())
+            .args(["--format", "json", "find", "--index"])
+            .args(&args)
+            .output()
+            .unwrap();
+        assert!(disk.status.success(), "{args:?}: {disk:?}");
+        assert!(indexed.status.success(), "{args:?}: {indexed:?}");
+        assert_eq!(
+            disk.stdout, indexed.stdout,
+            "whole envelope parity: {args:?}"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&disk.stdout).unwrap();
+        for result in json["results"].as_array().unwrap() {
+            let matches = result["matches"].as_array().unwrap();
+            assert!(matches.len() <= 3);
+            for m in matches {
+                assert_eq!(m.as_object().unwrap().len(), 3);
+                let content =
+                    std::fs::read_to_string(tmp.path().join(result["file"].as_str().unwrap()))
+                        .unwrap();
+                let line = usize::try_from(m["line"].as_u64().unwrap()).unwrap();
+                assert_eq!(
+                    content.lines().nth(line - 1).unwrap(),
+                    m["text"].as_str().unwrap()
+                );
+                if result["file"] == "guide.md" {
+                    assert!(line > 3);
+                }
+            }
+        }
+    }
+    let (_, json, _) = find_json(&tmp, &["rust OR golang"]);
+    assert_eq!(
+        json["results"][0]["matches"],
+        serde_json::json!([
+            {"line": 7, "section": "# Guide", "text": "rust golang"},
+            {"line": 8, "section": "# Guide", "text": "golang rust"},
+            {"line": 6, "section": "# Guide", "text": "rust rust rust"},
+        ])
+    );
+    let (_, json, _) = find_json(&tmp, &["running"]);
+    assert_eq!(json["results"][0]["matches"][0]["text"], "run");
+    let (_, json, _) = find_json(&tmp, &["日本語"]);
+    assert_eq!(json["results"][0]["matches"][0]["text"], "日本語Docker入門");
+    let (_, json, _) = find_json(&tmp, &["Häuser", "--language", "german"]);
+    assert_eq!(
+        json["results"][0]["matches"],
+        serde_json::json!([
+            {"line": 4, "section": "", "text": "Haus"}
+        ])
+    );
+    let (_, json, _) = find_json(&tmp, &["\"run fast\""]);
+    assert_eq!(
+        json["results"][0]["matches"],
+        serde_json::json!([
+            {"line": 11, "section": "## Other", "text": "run fast"}
+        ])
+    );
+    let (_, json, _) = find_json(&tmp, &["rust", "--section", "Other"]);
+    assert_eq!(
+        json["results"][0]["matches"],
+        serde_json::json!([
+            {"line": 14, "section": "## Other", "text": "```rust"},
+            {"line": 15, "section": "## Other", "text": "# rust code"},
+            {"line": 17, "section": "## Other", "text": "%% rust comment %%"}
+        ])
+    );
+    for query in ["titleonly", "\"alpha beta\""] {
+        let (_, json, _) = find_json(&tmp, &[query]);
+        for result in json["results"].as_array().unwrap() {
+            assert_eq!(result["matches"], serde_json::json!([]));
+        }
+    }
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .args(["find", "running", "--format", "text"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let text = String::from_utf8(output.stdout).unwrap();
+    assert!(text.contains("line 5 (# Guide): run"), "{text}");
+}
+
 // ---------------------------------------------------------------------------
 // Vault fixture
 // ---------------------------------------------------------------------------

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -4,6 +4,18 @@
 //! - [`StemLanguage`]: enum of supported stemming languages with [`parse_language`]
 //! - [`resolve_language`]: language precedence logic (frontmatter > CLI > config > English)
 //! - [`tokenize`]: Unicode-aware tokenization + stemming pipeline
+//!
+//! Ranked snippet qualification (iteration 283): a body line qualifies when it
+//! contains a positive query clause: any stemmed token for plain AND/OR terms,
+//! or the complete consecutive stemmed sequence for a quoted phrase. OR accepts
+//! any positive side; excluded terms never supply snippets. Query tokens use the
+//! query language; body tokens use the document language, exactly as scoring does.
+//! CJK uses the same overlapping bigrams, including single-character unigrams.
+//! Frontmatter never qualifies, but raw body code/fence/comment lines do. Phrases
+//! spanning lines and title-only hits may therefore have an empty matches array.
+//! Within section scope, prioritize the number of distinct positive query tokens
+//! present on each qualifying line, then document order, keeping at most three.
+//! Snippets keep original text, one-based full-file lines and heading context.
 //! - [`Bm25InvertedIndex`]: serializable in-memory BM25 index built from [`DocumentInput`] values
 
 use std::collections::{HashMap, HashSet};
@@ -285,6 +297,25 @@ pub struct DocumentInput {
     pub language: StemLanguage,
 }
 
+/// Authored title used by the ranked corpus: frontmatter string, then first H1.
+/// A filename fallback is useful for display, but has never been part of the
+/// persisted BM25 token stream. Share this rule so disk scores agree with it.
+pub fn document_title<'a>(
+    properties: &'a indexmap::IndexMap<String, serde_json::Value>,
+    sections: &'a [crate::types::OutlineSection],
+) -> &'a str {
+    properties
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| {
+            sections
+                .iter()
+                .find(|s| s.level == 1)
+                .and_then(|s| s.heading.as_deref())
+                .unwrap_or("")
+        })
+}
+
 /// Tokenize a [`DocumentInput`] into a [`PreTokenizedInput`].
 ///
 /// Applies the same tokenization pipeline as [`Bm25InvertedIndex::build`]: Unicode-aware
@@ -329,6 +360,154 @@ enum Clause {
 #[derive(Debug, Clone)]
 struct BooleanQuery {
     clauses: Vec<Clause>,
+}
+
+/// Positive clauses compiled once for ranked body snippets. Shares scoring's
+/// query parser, so operators, negation, phrases and CJK never drift.
+pub struct SnippetQuery {
+    clauses: Vec<Vec<String>>,
+    terms: HashSet<String>,
+}
+
+impl SnippetQuery {
+    /// Compile with the query-time stemming language (no document override).
+    pub fn new(query: &str, language: StemLanguage) -> Self {
+        let clauses: Vec<_> = parse_boolean_query(query, &create_stemmer(language))
+            .clauses
+            .into_iter()
+            .filter_map(|clause| match clause {
+                Clause::Must(terms) | Clause::Should(terms) => Some(terms),
+                Clause::MustNot(_) => None,
+            })
+            .collect();
+        let terms = clauses.iter().flatten().cloned().collect();
+        Self { clauses, terms }
+    }
+
+    /// Number of distinct positive query tokens on a qualifying line, or zero.
+    /// Body stemming must use the same document language as the BM25 corpus.
+    fn distinct_tokens(&self, line: &str, stemmer: &Stemmer) -> usize {
+        let tokens = tokenize(line, stemmer);
+        if !self
+            .clauses
+            .iter()
+            .any(|clause| tokens.windows(clause.len()).any(|window| window == clause))
+        {
+            return 0;
+        }
+        tokens
+            .iter()
+            .filter(|token| self.terms.contains(*token))
+            .collect::<HashSet<_>>()
+            .len()
+    }
+
+    /// Stream one selected result's raw body and keep the best three lines.
+    /// Call only after result filtering, sorting and limiting. Snapshot tokens
+    /// have no original text or file-line offsets, so cannot supply snippets.
+    pub fn snippets(
+        &self,
+        path: &std::path::Path,
+        language: StemLanguage,
+        sections: &[crate::types::OutlineSection],
+        scope: &[crate::heading::SectionRange],
+    ) -> anyhow::Result<Vec<crate::types::ContentMatch>> {
+        use crate::scanner::{
+            FileVisitor, LineOutcome, MAX_BODY_LINE_BYTES, ScanAction, read_line_capped,
+        };
+        let mut visitor = SnippetVisitor {
+            query: self,
+            stemmer: create_stemmer(language),
+            sections,
+            scope,
+            best: Vec::with_capacity(4),
+        };
+        let file = std::fs::File::open(path)?;
+        if file.metadata()?.len() > crate::scanner::MAX_FILE_SIZE {
+            return Ok(Vec::new());
+        }
+        let mut reader = std::io::BufReader::new(file);
+        let mut buf = String::new();
+        let (n, outcome) = read_line_capped(&mut reader, &mut buf, MAX_BODY_LINE_BYTES)?;
+        if n == 0 {
+            return Ok(Vec::new());
+        }
+        let fm_lines = crate::frontmatter::skip_frontmatter(&mut reader, &buf)?;
+        let mut line = fm_lines.max(1);
+        if fm_lines == 0 && outcome == LineOutcome::Complete {
+            visitor.on_raw_body_line(buf.trim_end_matches(['\r', '\n']), line);
+        }
+        loop {
+            buf.clear();
+            let (n, outcome) = read_line_capped(&mut reader, &mut buf, MAX_BODY_LINE_BYTES)?;
+            if n == 0 {
+                break;
+            }
+            line += 1;
+            if outcome == LineOutcome::Complete
+                && visitor.on_raw_body_line(buf.trim_end_matches(['\r', '\n']), line)
+                    == ScanAction::Stop
+            {
+                break;
+            }
+        }
+        Ok(visitor.best.into_iter().map(|(_, m)| m).collect())
+    }
+}
+
+struct SnippetVisitor<'a> {
+    query: &'a SnippetQuery,
+    stemmer: Stemmer,
+    sections: &'a [crate::types::OutlineSection],
+    scope: &'a [crate::heading::SectionRange],
+    best: Vec<(usize, crate::types::ContentMatch)>,
+}
+
+impl crate::scanner::FileVisitor for SnippetVisitor<'_> {
+    fn on_raw_body_line(&mut self, raw: &str, line: usize) -> crate::scanner::ScanAction {
+        use crate::scanner::ScanAction;
+        if !self.scope.is_empty() && !crate::heading::in_scope(self.scope, line) {
+            return ScanAction::Continue;
+        }
+        let count = self.query.distinct_tokens(raw, &self.stemmer);
+        if count == 0 || (self.best.len() == 3 && self.best[2].0 >= count) {
+            return ScanAction::Continue;
+        }
+        let section = self
+            .sections
+            .iter()
+            .rev()
+            .find(|s| s.line <= line && s.heading.is_some())
+            .and_then(|s| {
+                s.heading
+                    .as_ref()
+                    .map(|heading| format!("{} {heading}", "#".repeat(usize::from(s.level))))
+            })
+            .unwrap_or_default();
+        self.best.push((
+            count,
+            crate::types::ContentMatch {
+                line,
+                section,
+                text: raw.to_owned(),
+            },
+        ));
+        self.best
+            .sort_by_key(|(count, m)| (std::cmp::Reverse(*count), m.line));
+        self.best.truncate(3);
+        // Nothing later can beat three lines carrying every distinct query
+        // token; equal coverage loses on document order. Particularly useful
+        // for common single-term searches over long indexed documents.
+        if self.best.len() == 3 && self.best[2].0 == self.query.terms.len() {
+            ScanAction::Stop
+        } else {
+            ScanAction::Continue
+        }
+    }
+
+    fn needs_frontmatter(&self) -> bool {
+        false
+    }
 }
 
 impl BooleanQuery {

--- a/crates/hyalo-core/src/frontmatter/mod.rs
+++ b/crates/hyalo-core/src/frontmatter/mod.rs
@@ -502,7 +502,7 @@ Body.
     #[test]
     fn streaming_budget_boundary_bytes_at_limit() {
         // Build frontmatter whose content is exactly MAX_FRONTMATTER_BYTES.
-        // skip_frontmatter counts raw bytes from read_line (including \n).
+        // skip_frontmatter counts normalized content bytes (including LF).
         // Use a single long line: "x: " (3 bytes) + value + "\n" = MAX_FRONTMATTER_BYTES
         use super::MAX_FRONTMATTER_BYTES;
         let value = "a".repeat(MAX_FRONTMATTER_BYTES - 4); // "x: " (3) + value + "\n" = limit
@@ -540,6 +540,32 @@ Body.
                 .to_string()
                 .contains("frontmatter too large")
         );
+    }
+
+    #[test]
+    fn skip_frontmatter_crlf_uses_scanner_normalized_byte_budget() {
+        // Many CRLF comment lines fit in the scanner's normalized 64 KiB
+        // budget even though their on-disk representation exceeds 64 KiB.
+        let line = format!("#{}", "a".repeat(63));
+        let comments = format!("{line}\n").repeat(1000);
+        let title = "title: Boundary\n";
+        let remaining = MAX_FRONTMATTER_BYTES - comments.len() - title.len();
+        for extra in [0, 1] {
+            let tail = format!("#{}\n", "b".repeat(remaining - 2 + extra));
+            let lf = format!("---\n{title}{comments}{tail}---\nbody\n");
+            let crlf = lf.replace('\n', "\r\n");
+            for text in [&lf, &crlf] {
+                let mut reader = std::io::BufReader::with_capacity(3, text.as_bytes());
+                let mut first = String::new();
+                std::io::BufRead::read_line(&mut reader, &mut first).unwrap();
+                assert_eq!(skip_frontmatter(&mut reader, &first).is_ok(), extra == 0);
+                let mut visitor = crate::scanner::FrontmatterCollector::new(false);
+                assert_eq!(
+                    crate::scanner::scan_slice_multi(text.as_bytes(), &mut [&mut visitor]).is_ok(),
+                    extra == 0
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/hyalo-core/src/frontmatter/parse.rs
+++ b/crates/hyalo-core/src/frontmatter/parse.rs
@@ -1061,7 +1061,9 @@ pub fn skip_frontmatter<R: BufRead>(reader: &mut R, first_line: &str) -> Result<
         if is_closing_delimiter(trimmed) {
             break;
         }
-        total_bytes += n;
+        // Match the scanner's normalized YAML buffer: CRLF and LF each
+        // contribute one newline byte, not the transport's raw byte count.
+        total_bytes += trimmed.len() + 1;
         if line_count - 1 > MAX_FRONTMATTER_LINES || total_bytes > MAX_FRONTMATTER_BYTES {
             parse_bail!(
                 "frontmatter too large (no closing `---` found within {MAX_FRONTMATTER_LINES} lines / {MAX_FRONTMATTER_BYTES} bytes); run `hyalo lint <file>` for details"

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -2358,16 +2358,7 @@ pub(crate) fn scan_one_file(
         let body = body_collector.into_body();
 
         // Resolve title: frontmatter property > first H1 heading.
-        let title: &str = props
-            .get("title")
-            .and_then(|v| v.as_str())
-            .unwrap_or_else(|| {
-                sections
-                    .iter()
-                    .find(|s| s.level == 1)
-                    .and_then(|s| s.heading.as_deref())
-                    .unwrap_or("")
-            });
+        let title = crate::bm25::document_title(&props, &sections);
 
         // Resolve stemming language: frontmatter > config default > English.
         let fm_lang = props.get("language").and_then(|v| v.as_str());

--- a/crates/hyalo-core/src/scanner/mod.rs
+++ b/crates/hyalo-core/src/scanner/mod.rs
@@ -715,104 +715,69 @@ pub fn read_line_capped<R: BufRead>(
     buf: &mut String,
     limit: usize,
 ) -> std::io::Result<(usize, LineOutcome)> {
-    let mut total = 0usize;
-    loop {
-        // Inspect the internal buffer to find a newline and measure how many
-        // bytes are available.  We extract the indices we need *before*
-        // releasing the borrow so that we can then call `consume`.
-        let (newline_pos, chunk_len) = loop {
+    // A BufRead chunk may end inside a UTF-8 codepoint. Reuse the caller's
+    // allocation as bounded raw bytes, then validate the complete retained
+    // line, never individual I/O chunks. Only a terminating LF may exceed
+    // the content-byte quota.
+    let mut bytes = std::mem::take(buf).into_bytes();
+    let mut total = 0;
+    let truncated = loop {
+        let available = loop {
             match reader.fill_buf() {
-                Ok([]) => return Ok((total, LineOutcome::Complete)),
-                Ok(b) => {
-                    let nl = b.iter().position(|&byte| byte == b'\n');
-                    let len = b.len();
-                    break (nl, len);
-                }
                 Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-
-                Err(e) => return Err(e),
+                result => break result?,
             }
         };
-
-        // How many bytes we will consume from the reader this iteration.
-        let consume = match newline_pos {
-            Some(pos) => pos + 1, // include the '\n'
-            None => chunk_len,
-        };
-
-        if buf.len() >= limit {
-            // Quota was exactly filled by a previous iteration. If the very
-            // next byte is the newline (`pos == 0`), the line's content is
-            // exactly `limit` bytes — nothing was actually discarded, so this
-            // is not a truncation, just a line landing on the boundary.
-            if newline_pos == Some(0) {
-                reader.consume(1);
-                total += 1;
-                // Keep parity with the other complete paths, which
-                // include the terminating newline in `buf`.
-                buf.push('\n');
-                return Ok((total, LineOutcome::Complete));
-            }
-            // Otherwise there is more line content beyond the quota — drain it.
-            reader.consume(consume);
-            total += consume;
-            if newline_pos.is_some() {
-                return Ok((total, LineOutcome::Truncated));
-            }
-            drain_until_newline(reader)?;
-            return Ok((total, LineOutcome::Truncated));
+        if available.is_empty() {
+            break false;
         }
-
-        // Within quota: copy up to `to_copy` bytes into a temporary Vec so we
-        // can release the `fill_buf` borrow before calling `consume`.
-        let remaining_quota = limit - buf.len();
-        let to_copy = consume.min(remaining_quota);
-
-        // Copy the bytes out while the immutable borrow is still live.
-        let chunk: Vec<u8> = {
-            let available = reader.fill_buf()?;
-            available[..to_copy].to_vec()
-        };
-        // Now release the borrow and advance the reader.
+        let newline = available.iter().position(|&byte| byte == b'\n');
+        let content_len = newline.unwrap_or(available.len());
+        let consume = newline.map_or(available.len(), |pos| pos + 1);
+        let copied = content_len.min(limit.saturating_sub(bytes.len()));
+        bytes.extend_from_slice(&available[..copied]);
+        let truncated = copied < content_len;
+        if newline.is_some() && !truncated {
+            bytes.push(b'\n');
+        }
         reader.consume(consume);
         total += consume;
-
-        // Validate UTF-8; invalid bytes are a distinct skip cause so callers
-        // can report the real problem (F-5, iter-246) instead of blaming the
-        // byte limit.
-        if let Ok(s) = std::str::from_utf8(&chunk) {
-            buf.push_str(s);
-        } else {
-            if newline_pos.is_none() {
-                drain_until_newline(reader)?;
-            }
-            return Ok((total, LineOutcome::InvalidUtf8));
-        }
-
-        let truncated = to_copy < consume;
-        if newline_pos.is_some() {
-            // The newline was within the consumed range — line is complete.
-            // If quota was hit before the newline, we already consumed past it,
-            // so no further draining is needed.
-            return Ok((
-                total,
-                if truncated {
-                    LineOutcome::Truncated
-                } else {
-                    LineOutcome::Complete
-                },
-            ));
-        }
         if truncated {
-            // Quota hit on a chunk with no newline — drain the rest of the line.
-            drain_until_newline(reader)?;
-            return Ok((total, LineOutcome::Truncated));
+            if newline.is_none() {
+                total += drain_until_newline(reader)?;
+            }
+            break true;
         }
-    }
+        if newline.is_some() {
+            break false;
+        }
+    };
+    let outcome = match String::from_utf8(bytes) {
+        Ok(line) => {
+            *buf = line;
+            if truncated {
+                LineOutcome::Truncated
+            } else {
+                LineOutcome::Complete
+            }
+        }
+        Err(error) => {
+            // A quota can cut a valid codepoint. An incomplete final sequence
+            // then means truncation; definitively invalid bytes before the
+            // quota still retain their distinct InvalidUtf8 diagnosis.
+            if truncated && error.utf8_error().error_len().is_none() {
+                LineOutcome::Truncated
+            } else {
+                LineOutcome::InvalidUtf8
+            }
+        }
+    };
+    Ok((total, outcome))
 }
 
 /// Consume bytes from `reader` until (and including) a `\n`, or until EOF.
-fn drain_until_newline<R: BufRead>(reader: &mut R) -> std::io::Result<()> {
+fn drain_until_newline<R: BufRead>(reader: &mut R) -> std::io::Result<usize> {
+    let mut total = 0;
     loop {
         let available = match reader.fill_buf() {
             Ok(b) => b,
@@ -820,14 +785,15 @@ fn drain_until_newline<R: BufRead>(reader: &mut R) -> std::io::Result<()> {
             Err(e) => return Err(e),
         };
         if available.is_empty() {
-            return Ok(());
+            return Ok(total);
         }
         if let Some(pos) = available.iter().position(|&b| b == b'\n') {
             reader.consume(pos + 1);
-            return Ok(());
+            return Ok(total + pos + 1);
         }
         let n = available.len();
         reader.consume(n);
+        total += n;
     }
 }
 
@@ -1973,6 +1939,62 @@ code only
             "subsequent line must be read normally"
         );
         assert_eq!(buf, "next\n");
+    }
+
+    #[test]
+    fn read_line_capped_utf8_is_independent_of_buffer_boundaries() {
+        for text in ["é", "日本語", "🦀"] {
+            for capacity in 1..=9 {
+                for padding in 0..=9 {
+                    for ending in ["", "\n", "\r\n"] {
+                        let input = format!("{}{text}{ending}", "a".repeat(padding));
+                        let mut reader =
+                            std::io::BufReader::with_capacity(capacity, input.as_bytes());
+                        let mut buf = String::new();
+                        let (n, outcome) = read_line_capped(&mut reader, &mut buf, 128).unwrap();
+                        assert_eq!(outcome, LineOutcome::Complete, "{capacity}, {input:?}");
+                        assert_eq!(n, input.len());
+                        assert_eq!(buf, input);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn read_line_capped_unicode_quota_and_incomplete_eof() {
+        for capacity in 1..=16 {
+            for limit in 0..=8 {
+                let input = "a日本\nnext\n";
+                let mut reader = std::io::BufReader::with_capacity(capacity, input.as_bytes());
+                let mut buf = String::new();
+                let (n, outcome) = read_line_capped(&mut reader, &mut buf, limit).unwrap();
+                assert_eq!(n, "a日本\n".len());
+                assert_eq!(
+                    outcome,
+                    if limit < 7 {
+                        LineOutcome::Truncated
+                    } else {
+                        LineOutcome::Complete
+                    }
+                );
+                assert!(buf.len() <= limit + 1);
+                buf.clear();
+                assert_eq!(
+                    read_line_capped(&mut reader, &mut buf, 32).unwrap().1,
+                    LineOutcome::Complete
+                );
+                assert_eq!(buf, "next\n");
+            }
+            for input in [&b"bad \xe6\x97"[..], &b"bad \xffrest\nnext\n"[..]] {
+                let mut reader = std::io::BufReader::with_capacity(capacity, input);
+                let mut buf = String::new();
+                assert_eq!(
+                    read_line_capped(&mut reader, &mut buf, 128).unwrap().1,
+                    LineOutcome::InvalidUtf8
+                );
+            }
+        }
     }
 
     #[test]

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -6272,3 +6272,84 @@ Winkler-floor rejection and unchanged basename admission. Existing iteration
 
 See [[iterations/iteration-282-directory-token-dominance-rule]] for the corpus
 comparison and validation outcome.
+
+## DEC-330: ranked snippets share BM25 query semantics (2026-09-07)
+
+**Decision:** Ranked `find PATTERN` returns both `score` and a non-null `matches`
+array of at most three `{line, section, text}` objects. The existing regex mode
+and renderer retain their behavior; text mode uses `line N (section): text`.
+
+A body line qualifies if it contains a positive stemmed query token, or the
+complete consecutive stemmed sequence of a quoted phrase. AND queries still
+require all terms at the document level, but an individual snippet may show one
+term; OR accepts either positive side. Negated terms never supply snippets.
+The query uses its configured language and each body uses its effective document
+language, just as BM25 scoring does. CJK uses the same overlapping bigrams.
+
+Among qualifying lines, count distinct positive query tokens, prefer greater
+coverage, then earlier document lines. Repetition of one token cannot outrank a
+line containing two different query tokens. Keep at most three snippets. Once
+three lines each carry every positive token, scanning can stop: later lines
+cannot improve coverage and lose the document-order tie.
+
+Frontmatter never qualifies. Raw body lines include code, fence delimiters and
+Obsidian comments, because the ranked corpus includes those lines too. Section
+context comes from the existing structural outline, so a heading inside code
+is not a new section. `--section` limits eligibility before snippet ranking.
+Line numbers are one-based positions in the original complete file, and text
+preserves the original body line. Title-only matches and phrases that span lines
+can produce an empty array without changing the file's BM25 score or eligibility.
+
+**Index boundary:** The snapshot has stemmed token positions, but neither original
+text nor file-line offsets. Recover original snippet text by streaming only the
+final selected files, after every filter, sort and limit. An empty final selection
+reads no snippet bodies. CLI `--limit 0` requests unlimited results; the default
+cap is 50, including JSON output. No snapshot schema change or CLI flag is needed.
+
+**Where:** `hyalo_core::bm25::SnippetQuery` reuses the scoring query parser and
+tokenizer; its raw-body visitor retains only three candidates.
+`hyalo_cli::commands::find` invokes it after final result selection.
+See [[iterations/iteration-283-ranked-search-snippets]] for validation and timing.
+
+**Score parity correction:** The BOM/CRLF German regression fixture exposed an
+existing corpus mismatch: disk scoring included the displayed filename fallback
+for notes lacking both a string title and an H1, but snapshots did not. That
+changed corpus average length and even unrelated results' scores (the fixture's
+`rust` score was 2.041530630546071 on disk versus 2.0292286111667424 indexed).
+Both builders now share the existing indexed authored-title rule through
+`document_title`. Disk scores can consequently change in such corpora; persisted
+scores and snapshot schema remain unchanged, as do displayed title fallbacks.
+
+Selected-file extraction runs in parallel using the existing Rayon pool. Each
+worker owns one result slot, so snippets and file order are stable; errors are
+reported in result order after collection. Parallelism never expands the final
+selected set. This avoids serial body tokenization on unlimited queries.
+
+**Measured:** On the 14,375-file MDN scratch corpus, the primary default query
+`find javascript --index` emits 50 of 4,055 hits. Thirty alternating timing pairs
+give 448.25 ms main versus 454.60 ms candidate (+1.42%), inside the 10% gate.
+Unlimited output (`--limit 0`) emits all 4,055 hits and costs 483.72 → 657.28 ms
+(+35.88%, fifteen pairs); this is a supplemental stress measurement, not the
+default query. Its 174 ms overhead remains well below the 4.090 s main disk scan.
+Both complete disk/index envelopes are byte-identical. All timings use release
+binaries, five warmup pairs for indexed comparisons and unchanged corpus data.
+
+**First review repair:** The bounded reader had validated each I/O chunk as
+UTF-8, incorrectly skipping valid characters split at an 8 KiB boundary. It now
+assembles at most the line quota (plus a terminating LF) in a reusable byte
+buffer and validates the retained line once. Definite invalid bytes still report
+`InvalidUtf8`; a quota splitting an otherwise valid codepoint reports
+`Truncated`. Rejected lines are drained and their full consumed byte count is
+returned. Tests vary buffer capacity, character width, EOF and quota boundaries.
+
+The frontmatter skip helper also counted raw CRLF bytes, whereas the scanner
+budgets normalized content plus one LF per line. It now shares that accounting,
+so valid near-64-KiB CRLF notes remain searchable. At-limit and over-limit LF/CRLF
+fixtures check agreement with the scanner; both reviewer repros have complete
+disk/index CLI regressions with accurate snippet text and line numbers.
+
+Repair timings retain the primary gate: 446.54 → 444.42 ms (-0.48%, thirty
+alternating pairs) for the default 50-result query. Supplemental unlimited
+output is 454.57 → 608.28 ms (+33.81%, fifteen pairs). Complete disk/index
+envelopes still agree in both cases; original implementation measurements are
+retained separately from the repair evidence.

--- a/hyalo-knowledgebase/iterations/iteration-283-ranked-search-snippets.md
+++ b/hyalo-knowledgebase/iterations/iteration-283-ranked-search-snippets.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 283 — Snippets for BM25 ranked search results"
 date: 2026-09-06
-status: planned
+status: completed
 tags: [iteration, search, find]
 branch: iter-283/ranked-search-snippets
 priority: 2
@@ -29,49 +29,155 @@ exists, `--section` scoping already applies to it, and text mode already knows h
 
 ## Tasks
 
-- [ ] TASK-1: read the BM25 path end to end (`bm25_tokenize`, stemming, `OR`, quoted phrases,
+- [x] TASK-1: read the BM25 path end to end (`bm25_tokenize`, stemming, `OR`, quoted phrases,
       the CJK bigram tokenizer, `score_map`) and write down what "a line that matches" means for
       each query form: a line contains at least one stemmed query token; for a quoted phrase,
       the consecutive stemmed sequence; for `OR`, any side. Put the definition in the module doc
       before writing code.
-- [ ] TASK-2: implement snippet extraction for the top results: for each ranked file, select
+- [x] TASK-2: implement snippet extraction for the top results: for each ranked file, select
       the body lines that match per TASK-1, rank them by the number of *distinct* query tokens
       they carry (ties in document order), keep at most 3 per file, and emit them as
       `ContentMatch { line, section, text }` exactly as regex mode does. Honour `--section`
       scoping the way `find/mod.rs:920-923` does for regex. Lines inside frontmatter never
       qualify.
-- [ ] TASK-3: `--index` path: confirm whether the snapshot carries enough to produce snippets
+- [x] TASK-3: `--index` path: confirm whether the snapshot carries enough to produce snippets
       without touching disk. If not, read only the files that made the result set (after
       `--limit`, if any), never the whole vault — the point of the index is that the scan stays
       cheap. Measure MDN `find <term> --index` before and after; the delta must stay well below
       the disk-scan time (DEC-322/323 numbers are the baseline).
-- [ ] TASK-4: text mode prints ranked matches the same way it prints regex matches
+- [x] TASK-4: text mode prints ranked matches the same way it prints regex matches
       (`line N [section]: text`). JSON is unchanged in shape — `matches` simply stops being
       `null` in ranked mode. Update `find --help` (the "per-line 'matches' instead of 'score'"
       sentence is now wrong), `skill-hyalo.md`, `rule-knowledgebase.md`, the command reference,
       and the pi extension's `hyalo_find` description if it mentions the gap.
-- [ ] TASK-5: e2e tests for a single term, a stemmed term (`running` finds a line with `run`),
+- [x] TASK-5: e2e tests for a single term, a stemmed term (`running` finds a line with `run`),
       an `OR` query, a quoted phrase, `--section` scoping, the 3-per-file cap, a CJK query, and
       `--index` parity (same `matches` as the disk scan). One test asserts a match's `line`
       points at the line that actually contains the token.
-- [ ] TASK-6: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] TASK-6: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, every xtask `check-*` gate, `hyalo lint --strict` on the
       knowledgebase. DEC entry for the snippet rule (what qualifies, the cap, the ranking).
 
 ## Acceptance criteria
 
-- [ ] `hyalo find rust --format json` returns, for every result, a non-null `matches` array
+- [x] `hyalo find rust --format json` returns, for every result, a non-null `matches` array
       whose entries have the same `{line, section, text}` shape regex mode emits, each `text`
       containing at least one stemmed query token.
-- [ ] `matches` is capped at 3 per file, ordered by distinct-token count then line number, and
+- [x] `matches` is capped at 3 per file, ordered by distinct-token count then line number, and
       respects `--section`.
-- [ ] `--index` and disk-scan output are byte-identical for the same query.
-- [ ] No new CLI flag. `find --help` and the bundled skill/rule text describe the new behaviour.
-- [ ] MDN `find <term> --index` wall time stays within 10% of `main`.
-- [ ] Gates green.
+- [x] `--index` and disk-scan output are byte-identical for the same query.
+- [x] No new CLI flag. `find --help` and the bundled skill/rule text describe the new behaviour.
+- [x] MDN `find <term> --index` wall time stays within 10% of `main`.
+- [x] Gates green.
 
-## Links
+## Implementation evidence
+
+Baseline release: `4c9310741086ad8bc5f6091bb902b64ad629ba47`, retained with its
+SHA-256 under `.git/ralph-loop/run-20260906-284-287/283/`. MDN's 14,375 markdown
+files (256 MiB) were copied from `/Users/james/devel/mdn/files/en-us` to
+`/tmp/hyalo-iter283-mdn/corpus`; the snapshot lives beside that scratch corpus.
+The source repository is read-only throughout this iteration.
+
+The representative benchmark is the common term `javascript`, with JSON
+output and no explicit limit flag, `--site-prefix en-US/docs`, `--no-hints`, and the same
+scratch snapshot for baseline and candidate. Baseline: 12 runs after 3 warmups,
+mean 480.6 ms (standard deviation 39.7 ms). Commands and raw timings are retained
+in that iteration's run directory. The plan's DEC-323 link concerns bulk writes,
+not indexed search; DEC-322 provides historical index context, while the retained
+main binary supplies this iteration's exact before/after baseline. The 10% gate
+above is unchanged.
+
+The literal default command emits 50 results with `total: 4055`; JSON has the
+same default cap as text. It is the primary performance gate. The additional
+`--limit 0` stress case emits all 4,055 results. These two workloads must not be
+conflated. The default query's complete disk/index JSON envelopes are identical.
+
+The snapshot contains stemmed tokens and token positions, but no original text
+or file-line offsets. Snippets therefore stream only final selected files,
+after filtering, sorting and limiting. Qualification is defined in the BM25
+module documentation and DEC-330 in [[decision-log]].
+
+Full-envelope parity testing also exposed and corrected an older title-token
+mismatch: disk scoring had included the displayed filename fallback, while
+snapshots used only frontmatter string titles or H1 headings. Both now share the
+existing indexed rule. Disk scores change in corpora containing title/H1-less
+notes; indexed scores, display titles and snapshot schema remain unchanged.
+The BOM/CRLF German fixture guards this alongside language and snippet line
+accuracy. Existing text formatting is `line N (section): text`, so the renderer
+is preserved rather than adopting the plan's illustrative bracket spelling.
+
+Pre-review release timings use alternating main/candidate subprocess pairs, five
+warmup pairs, no concurrent builds/tests, and unchanged MDN source data:
+
+| Indexed query | Results emitted / total | Main mean | Candidate mean | Change |
+| --- | --- | --- | --- | --- |
+| `find javascript --index` (30 pairs) | 50 / 4,055 | 448.25 ms | 454.60 ms | +1.42% |
+| Same query plus `--limit 0` (15 pairs) | 4,055 / 4,055 | 483.72 ms | 657.28 ms | +35.88% |
+
+The primary default-query 10% gate passes. The unlimited stress case is
+supplemental evidence, with a real 174 ms cost for reading/tokenizing all
+selected bodies and emitting their snippets. Parallel selected-file extraction
+reduced its candidate mean from the initial serial 1,324.44 ms to 657.28 ms.
+The main disk-scan query averaged 4.090 s (five runs after one warmup), so both
+indexed deltas stay well below disk-scan time. Complete final disk/index JSON
+envelopes compare byte-identically for both the 50-result and 4,055-result runs.
+
+Raw evidence: `paired-timing-default-final.json`,
+`paired-timing-unlimited-final.json`, the Rust benchmark harnesses,
+`mdn-*-final.json`, and per-command logs under the iteration run directory.
+The source repository's before/after status files compare identically.
+
+Implementation validation passed ordered fmt, clippy and workspace tests.
+All ten discovered xtask commands returned zero; dead-primitives and
+todo-annotations explicitly remain unimplemented stubs, and the jq gate cannot
+exercise `madr toc` without this vault's absent ADR directory. Fourteen bundled
+skills passed conformance. Strict configured-KB lint has zero errors and only
+the four pre-existing HYALO002 warnings (270, 271, 277, 281); the two changed KB
+files are clean. Changelog-profile lint retains its existing `2022-04` link
+warning. Candidate dogfooding confirmed ranked Rust snippets and a quoted
+`"ranked snippets"` query scoped to DEC-330 using the existing text renderer.
+
+## First review repair
+
+Both verified boundary findings are addressed in shared helpers: bounded reads
+validate complete retained UTF-8 lines rather than individual buffer chunks,
+and frontmatter skipping counts normalized LF bytes to match the scanner's
+64-KiB budget. Tests cover 2/3/4-byte Unicode at varying buffer boundaries,
+incomplete EOF, actual invalid bytes, exact/over-limit lines, and LF/CRLF
+frontmatter at and above the budget. CLI regressions reproduce the character at
+absolute byte 8191 and the thousand-comment-line CRLF note, checking successful
+ranked results, exact snippet lines and complete disk/index parity.
+
+Repair-specific gates and updated timings are retained separately under
+`repair-1-*` in the iteration run directory; original implementation evidence
+remains intact. See the first-review repair note in DEC-330.
+
+The repaired release passes the same primary timing gate: 30 alternating pairs
+measure 446.54 ms main versus 444.42 ms candidate (-0.48%) for the default
+50-result query. The supplemental unlimited query measures 454.57 → 608.28 ms
+(+33.81%, fifteen pairs). Both use five warmup pairs and no concurrent builds
+or tests. Complete repaired disk/index JSON envelopes remain byte-identical
+for 50/4,055 and 4,055/4,055 emitted/total results. The parent's exact Unicode
+and CRLF repro fixtures now exit zero and report the previously missing lines.
+
+Repair validation reran ordered fmt/clippy/workspace tests, bundled-skill and jq
+runtime gates, strict configured-KB lint, changed-KB lint and changelog-profile
+lint. Existing help/flag/command-reference/package checks and the static journal
+guard are reused because their checked inputs did not change; the two xtask
+stubs remain explicitly unimplemented. Lint retains only the previously recorded
+four KB warnings and one changelog warning; changed KB files remain clean.
+
+## Final review and plan reconciliation — 2026-09-07
+
+A fresh independent review confirmed both boundary repairs and found no actionable issues.
+Final workspace evidence totals 4,878 passing tests and two existing ignored doctests.
+All four upcoming plans were inspected: 285 now names this iteration's byte-parity baseline,
+and 287 includes ranked snippet contract cases. No changes were needed for 286's packaging
+scope or 288's deferred desktop verification. External prerequisites remain unfinished.
+Plan hashes, dispositions, review inputs and command evidence are preserved in the run store.
+
+## Related links
 
 - [[research/npm-package-and-typed-typescript-api]] — "Snippets in ranked mode" open question;
   this iteration is the "ranked mode grows a snippet field" option it prefers
-- [[decision-log]] — DEC-322/323 (index-backed scan baseline)
+- [[decision-log]] — DEC-322 index context and DEC-323 bulk-write context

--- a/hyalo-knowledgebase/iterations/iteration-285-typed-output-structs.md
+++ b/hyalo-knowledgebase/iterations/iteration-285-typed-output-structs.md
@@ -79,8 +79,15 @@ existing wire contract, including specialized budget-error fields. The completed
 also replaces the goal's anticipated causal claim with its evidence-backed limitations.
 The byte-parity outcome and acceptance strength are unchanged.
 
+## Plan reconciliation — 2026-09-07, iteration 283
+
+The byte-parity baseline now includes ranked `FileObject.matches` arrays (including empty
+arrays for title-only or cross-line phrase hits) and the shared authored-title scoring rule.
+Preserve these values and the repaired Unicode/frontmatter boundaries during the output
+refactor. The existing `ContentMatch` shape is unchanged; no additional output type is needed.
+
 ## Links
 
 - [[research/npm-package-and-typed-typescript-api]] — "Precondition: typed output structs"
-- [[iterations/iteration-284-stability-retrospective]] — expected to confirm the defect class
+- [[iterations/iteration-284-stability-retrospective]] — completed defect-class evidence
 - [[iterations/iteration-287-typed-typescript-api]] — consumer of these structs

--- a/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
+++ b/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
@@ -76,6 +76,13 @@ remains required. Both 285 and the full 286 prerequisite remain required; npm pu
 real-platform verification, and the external consumer migration are not completed by
 repository-only work in this batch.
 
+## Plan reconciliation — 2026-09-07, iteration 283
+
+Ranked `find` now returns up to three existing `ContentMatch` objects per result, ordered by
+distinct-token coverage then line number; title-only and cross-line phrase hits can have an
+empty array. Include these cases in the typed `find` contract fixtures. The generated shape
+and the full 285/286 prerequisites remain unchanged.
+
 ## Links
 
 - [[research/npm-package-and-typed-typescript-api]] — decision record

--- a/pi-package/extensions/hyalo.ts
+++ b/pi-package/extensions/hyalo.ts
@@ -267,7 +267,8 @@ export default function (pi: ExtensionAPI) {
     label: "Hyalo Find",
     description:
       "Search/filter a markdown knowledgebase by full-text query, frontmatter " +
-      "properties, tags, glob, or task status. Preferred over the generic hyalo tool for queries.",
+      "properties, tags, glob, or task status. Ranked queries include score and up to 3 body matches " +
+      "with line, section, text. Preferred over the generic hyalo tool for queries.",
     promptSnippet: "hyalo_find: search/filter knowledgebase files (query, property, tag, task status)",
     parameters: hyaloFindParams,
     async execute(_toolCallId, params: Static<typeof hyaloFindParams>, signal) {

--- a/pi-package/skills/hyalo/SKILL.md
+++ b/pi-package/skills/hyalo/SKILL.md
@@ -19,6 +19,13 @@ description: >
 
 # Hyalo CLI — Prime Tool for Markdown Knowledgebases in pi
 
+Ranked queries return `score` and up to three body `matches` with `line`, `section`,
+and `text`; text output displays that context directly. Snippets rank by distinct query
+tokens then line number and share stemming, OR and CJK rules with scoring. Quoted
+phrases must fit on one line. `--section` scopes snippets; frontmatter is excluded,
+so title-only hits can have an empty array. Indexed queries read snippet text only
+for final results after `--limit`.
+
 Hyalo is a fast CLI for querying and mutating YAML frontmatter, tags, tasks, and structure
 in directories of markdown files. If the hyalo pi extension is installed
 (`.pi/extensions/hyalo.ts`), prefer its **typed tools** for the common operations —

--- a/plugins/hyalo/skills/hyalo/SKILL.md
+++ b/plugins/hyalo/skills/hyalo/SKILL.md
@@ -38,6 +38,12 @@ Use `hyalo <command> --help` for exact syntax, advanced filters, links, or bulk 
 `find`'s positional query is ranked search; `-e` is regex. Quote filter expressions
 and paths as single arguments using the active shell's quoting rules.
 
+Ranked results include `score` and up to three body `matches` with `line`, `section`,
+and `text`. Snippets rank by distinct query tokens then line number, share BM25
+stemming/OR/CJK rules, and honor `--section`. Quoted phrases must fit on one line;
+frontmatter is excluded and title-only hits can have an empty array. Indexed queries
+read snippet text only for final results after `--limit`.
+
 Pass `--format text` for compact reading or `--format json` for structured output.
 JSON is an envelope; results live in `.results`. `--jq` operates on that envelope
 and cannot be combined with text format. Respect reported truncation; narrow the query


### PR DESCRIPTION
## Summary

Ranked `find` results now include up to three body snippets with the existing `{line, section, text}` shape. Snippets share query parsing and stemming with BM25, rank by distinct query-token coverage, respect section filters, and read only files selected after sorting and limiting. Help, bundled skills, pi descriptions, the command reference, and DEC-330 describe the behavior.

Disk ranking now shares indexed search's authored-title rule. This fixes full-output parity for notes without a title or H1; their displayed filename fallback no longer affects disk scores. Indexed scores and the snapshot format are unchanged.

The required default MDN query emits 50 of 4,055 matches: mean indexed time is 446.54 → 444.42 ms (-0.48%, 30 alternating pairs). Explicit unlimited output is a separate stress case: 454.57 → 608.28 ms (+33.81%, 15 pairs). Its additional 154 ms is well below the 4.09-second disk-scan baseline.

## Test plan

- [x] Ordered formatting, strict workspace Clippy, and workspace tests: 4,878 passed, two existing ignored doctests.
- [x] Eight implemented xtask gates pass; two additional check commands remain declared unimplemented stubs.
- [x] Complete disk/index envelopes are byte-identical for both the default 50 results and all 4,055 MDN results.
- [x] Tests cover terms, stemming, phrases, OR, CJK, sections, line accuracy, cap/order, title-only and multiline-phrase hits, BOM/CRLF, and reads only after final selection.
- [x] Strict KB lint: zero errors and four existing warnings. Changed KB files have no findings. Changelog lint: zero errors and one existing warning. Whitespace checks pass.
- [x] Fresh independent review confirms both repairs; all upcoming plans reconciled.
- [x] Final metadata/reconciliation review.
- [x] GitHub CI at the final head: formatting, Clippy, quality gates, lint, and Ubuntu/macOS/Windows tests pass. Full-vault lint is push-only and skipped on this PR.

MDN source files were left unchanged; benchmark indexes and copies live in scratch storage. The jq gate's existing MADR-directory recipe is unavailable in this vault.

## Review

The first independent review found Unicode buffer-boundary loss and inconsistent CRLF frontmatter byte limits. Both were reproduced with the release binary and repaired in the shared helpers, with boundary and full-output regression tests. A fresh independent review of the repaired complete patch found no actionable issues and confirmed both fixes. The same independent reviewer verified final head `dd02ce514eeafb8c0c5befd332ae8aa3ba00d38c`: reviewed source bytes are unchanged, completion/reconciliation preserves scope and dependencies, and this report matches the saved evidence.
