### PR TITLE
Define typed command output contracts (iteration 285)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -33,3 +33,5 @@ jobs:
         run: cargo run -p xtask -- check-jq-recipes
       - name: Check mutating commands go through MutationJournal
         run: cargo run -p xtask -- check-mutation-journal
+      - name: Check typed command output contracts
+        run: cargo run -p xtask -- check-typed-output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,9 +2107,11 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",
+ "proc-macro2",
  "serde",
  "serde-saphyr",
  "serde_json",
+ "syn 2.0.117",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "walkdir",

--- a/crates/hyalo-cli/src/commands/append.rs
+++ b/crates/hyalo-cli/src/commands/append.rs
@@ -18,9 +18,13 @@ use hyalo_core::schema::SchemaConfig;
 /// Result of an `append --property K=V` operation across files.
 #[derive(Debug, Serialize)]
 pub(crate) struct AppendPropertyResult {
+    /// User-defined frontmatter property name.
     pub(crate) property: String,
+    /// Requested property value as command-line text.
     pub(crate) value: String,
+    /// Vault-relative files whose content changed.
     pub(crate) modified: Vec<String>,
+    /// Vault-relative files left unchanged.
     pub(crate) skipped: Vec<String>,
     /// `skipped.len()`, restated as a scalar (iter-216 D-1) — the whole
     /// mutation family exposes this key so one query answers "how many were
@@ -32,8 +36,11 @@ pub(crate) struct AppendPropertyResult {
     /// `skipped`, so `modified: []` is no longer ambiguous between "nothing
     /// needed changing" and "nothing could be changed".
     pub(crate) skipped_detail: Vec<crate::commands::mutation::SkippedFile>,
+    /// Total number of considered items.
     pub(crate) total: usize,
+    /// Number of files scanned.
     pub(crate) scanned: usize,
+    /// Whether this result describes a preview without writing changes.
     pub(crate) dry_run: bool,
 }
 

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -9,8 +9,11 @@ use hyalo_core::link_graph::is_self_link;
 
 #[derive(Serialize)]
 struct BacklinkItem {
+    /// Vault-relative file containing the authored link.
     source: String,
+    /// One-based source line number.
     line: usize,
+    /// Resolved or authored link target, according to the command.
     target: String,
     /// The link's own target text, exactly as `LinkGraph::build` left it —
     /// relative path components resolved (so `../target.md` reports
@@ -37,6 +40,7 @@ struct BacklinkItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     property: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Label reported for this result.
     label: Option<String>,
 }
 
@@ -115,7 +119,10 @@ pub fn backlinks(
             label: e.link.label.clone(),
         })
         .collect();
-    let result = serde_json::json!({ "file": rel, "backlinks": items });
+    let result = BacklinksResult {
+        file: &rel,
+        backlinks: &items,
+    };
     Ok(CommandOutcome::success_with_total(
         serde_json::to_string_pretty(&result).context("failed to serialize")?,
         total,
@@ -189,4 +196,13 @@ pub(crate) fn run(
             }
         }
     }
+}
+
+/// Serialized BacklinksResult command contract.
+#[derive(serde::Serialize)]
+struct BacklinksResult<'a> {
+    /// Vault-relative target path.
+    file: &'a str,
+    /// Inbound authored links to the target.
+    backlinks: &'a [BacklinkItem],
 }

--- a/crates/hyalo-cli/src/commands/changelog.rs
+++ b/crates/hyalo-cli/src/commands/changelog.rs
@@ -423,16 +423,22 @@ pub fn run_release(
             .with_context(|| format!("failed to write {display}"))?;
     }
 
-    let payload = serde_json::json!({
-        "command": "changelog release",
-        "apply": apply,
-        "dry_run": !apply,
-        "file": display,
-        "version": version,
-        "date": date_owned,
-        "changed": changed,
-        "hint": crate::commands::profile_lint_hint("changelog", active_profiles, "validate the rotated changelog"),
-    });
+    let payload = crate::output::output_value(
+        &(ChangelogReleaseResult {
+            command: "changelog release",
+            apply,
+            dry_run: !apply,
+            file: &(display),
+            version,
+            date: &(date_owned),
+            changed,
+            hint: &(crate::commands::profile_lint_hint(
+                "changelog",
+                active_profiles,
+                "validate the rotated changelog",
+            )),
+        }),
+    );
     let exit_override = if !apply && changed { Some(1) } else { None };
     Ok((
         CommandOutcome::success_with_total(payload.to_string(), u64::from(changed)),
@@ -588,16 +594,22 @@ pub fn run_add(
             .with_context(|| format!("failed to write {display}"))?;
     }
 
-    let payload = serde_json::json!({
-        "command": "changelog add",
-        "apply": apply,
-        "dry_run": !apply,
-        "file": display,
-        "category": canonical,
-        "message": message.trim(),
-        "changed": changed,
-        "hint": crate::commands::profile_lint_hint("changelog", active_profiles, "validate the changelog"),
-    });
+    let payload = crate::output::output_value(
+        &(ChangelogAddResult {
+            command: "changelog add",
+            apply,
+            dry_run: !apply,
+            file: &(display),
+            category: canonical,
+            message: message.trim(),
+            changed,
+            hint: &(crate::commands::profile_lint_hint(
+                "changelog",
+                active_profiles,
+                "validate the changelog",
+            )),
+        }),
+    );
     let exit_override = if !apply && changed { Some(1) } else { None };
     Ok((
         CommandOutcome::success_with_total(payload.to_string(), u64::from(changed)),
@@ -1475,4 +1487,46 @@ pub(crate) fn run(
             Ok(outcome)
         }
     }
+}
+
+/// Serialized ChangelogReleaseResult command contract.
+#[derive(serde::Serialize)]
+struct ChangelogReleaseResult<'a> {
+    /// Invoked command name.
+    command: &'a str,
+    /// Whether apply was requested.
+    apply: bool,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Changelog path.
+    file: &'a str,
+    /// Released semantic version.
+    version: &'a str,
+    /// Release date.
+    date: &'a str,
+    /// Whether the rendered changelog differs.
+    changed: bool,
+    /// Follow-up profile lint command.
+    hint: &'a str,
+}
+
+/// Serialized ChangelogAddResult command contract.
+#[derive(serde::Serialize)]
+struct ChangelogAddResult<'a> {
+    /// Invoked command name.
+    command: &'a str,
+    /// Whether apply was requested.
+    apply: bool,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Changelog path.
+    file: &'a str,
+    /// Canonical entry category.
+    category: &'a str,
+    /// Trimmed entry text.
+    message: &'a str,
+    /// Whether the rendered changelog differs.
+    changed: bool,
+    /// Follow-up profile lint command.
+    hint: &'a str,
 }

--- a/crates/hyalo-cli/src/commands/config.rs
+++ b/crates/hyalo-cli/src/commands/config.rs
@@ -12,7 +12,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
-use serde_json::json;
 
 use crate::output::{CommandOutcome, Format, format_success};
 
@@ -129,7 +128,7 @@ pub(crate) struct ConfigReport {
 /// two lists per-run and `--first-only` can turn `first_only` on for a run, so
 /// what is reported here is the *baseline* every `links auto` invocation starts
 /// from.
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub(crate) struct LinksAutoReport {
     /// `[links.auto] exclude_titles`.
     pub exclude_titles: Vec<String>,
@@ -155,7 +154,7 @@ impl Default for LinksAutoReport {
 }
 
 /// Effective `[scan]` settings, as `hyalo config` reports them (iter-265).
-#[derive(Debug, Default)]
+#[derive(Debug, Default, serde::Serialize)]
 pub(crate) struct ScanReport {
     /// `[scan] include` — hidden dot-subtrees the walker descends into.
     pub include: Vec<String>,
@@ -304,99 +303,49 @@ pub(crate) fn config_hints(report: &ConfigReport) -> Vec<crate::hints::Hint> {
 ///   latter for compatibility with pre-192 consumers of `hyalo config
 ///   --format json | jq .dir`.
 pub(crate) fn config_envelope(report: &ConfigReport) -> serde_json::Value {
-    let hints: Vec<serde_json::Value> = config_hints(report)
-        .iter()
-        .map(|h| json!({"description": &h.description, "cmd": &h.cmd, "writes": h.writes}))
-        .collect();
-    json!({
-        "results": {
-            "config_path": report.config_path.as_ref().map(|p| p.display().to_string()),
-            // Always present (iter-213, UX-2). `malformed: true` means the
-            // config file exists but could not be parsed, so every sibling
-            // value below is a built-in default; `parse_error` carries the
-            // diagnostic that was previously stderr-only.
-            // A `[schema]` that did not parse counts too (BUG-20, iter-276):
-            // the schema is dropped and validates nothing, which is the same
-            // silent-default state `malformed` exists to expose.
-            // `schema_error` says which of the two it was.
-            "malformed": report.malformed.is_some() || report.schema_error.is_some(),
-            "parse_error": report.malformed.clone().or_else(|| report.schema_error.clone()),
-            "schema_error": report.schema_error,
-            // G4 (iter-276): the snapshot format this binary writes and
-            // accepts. `summary --index` reports the loaded snapshot's own
-            // `index_format_version`; a lower number there means the index
-            // predates this binary and is refused with a fallback to disk.
-            "snapshot_format_version": hyalo_core::index::SNAPSHOT_FORMAT_VERSION,
-            // `true` when `dir` below was salvaged from an otherwise
-            // unusable file rather than defaulted (NEW-17, dogfood pre3) —
-            // meaningful only alongside `malformed: true`.
-            "dir_salvaged": report.dir_salvaged,
-            // `true` when `dir` was refused for resolving outside its own
-            // config directory (H-1, iter-221); `dir_out_of_bounds_reason`
-            // carries the diagnostic. Every other command refuses to run
-            // while this is `true` — `hyalo config` is the exception.
-            "dir_out_of_bounds": report.dir_out_of_bounds.is_some(),
-            "dir_out_of_bounds_reason": report.dir_out_of_bounds,
-            // Only present with --raw; `null` otherwise so the key's shape
-            // never changes between invocations.
-            "raw_contents": report.raw_contents,
-            "cwd": report.cwd.display().to_string(),
-            "dir": report.dir.display().to_string(),
-            "dir_overridden": report.dir_overridden,
-            // `format` is the format this run resolved to (iter-267, UX-18):
-            // always a string, never null, with `format_source` naming where
-            // it came from. `format_configured` keeps the raw `.hyalo.toml`
-            // value (null when the file pins nothing) for consumers that need
-            // to know whether the file said anything at all.
-            "format": report.effective_format,
-            "format_source": report.format_source,
-            "format_configured": report.format,
-            // `hints` is the effective boolean; `hints_enabled` is its
-            // longstanding alias, kept so existing `--jq` filters keep working.
-            "hints": report.hints,
-            "hints_enabled": report.hints,
-            "site_prefix": report.site_prefix,
-            "site_prefix_source": report.site_prefix_source.as_str(),
-            "exempt": report.exempt,
-            // Effective `[links]` link-graph settings (iter-262). `frontmatter`
-            // is always a boolean; `frontmatter_properties` is `null` unless an
-            // explicit allow-list narrows the scan.
-            "links": {
-                "frontmatter": report.frontmatter_links,
-                "frontmatter_properties": report.frontmatter_link_properties,
-                "aliases": report.alias_links,
-                "case_insensitive": report.case_insensitive,
+    {
+        let hints = config_hints(report);
+        let results = ConfigResult {
+            config_path: report.config_path.as_ref().map(|p| p.display().to_string()),
+            malformed: report.malformed.is_some() || report.schema_error.is_some(),
+            parse_error: report
+                .malformed
+                .as_deref()
+                .or(report.schema_error.as_deref()),
+            schema_error: report.schema_error.as_deref(),
+            snapshot_format_version: hyalo_core::index::SNAPSHOT_FORMAT_VERSION,
+            dir_salvaged: report.dir_salvaged,
+            dir_out_of_bounds: report.dir_out_of_bounds.is_some(),
+            dir_out_of_bounds_reason: report.dir_out_of_bounds.as_deref(),
+            raw_contents: report.raw_contents.as_deref(),
+            cwd: report.cwd.display().to_string(),
+            dir: report.dir.display().to_string(),
+            dir_overridden: report.dir_overridden,
+            format: &report.effective_format,
+            format_source: report.format_source,
+            format_configured: report.format.as_deref(),
+            hints: report.hints,
+            hints_enabled: report.hints,
+            site_prefix: report.site_prefix.as_deref(),
+            site_prefix_source: report.site_prefix_source.as_str(),
+            exempt: &report.exempt,
+            links: ConfigLinksResult {
+                frontmatter: report.frontmatter_links,
+                frontmatter_properties: report.frontmatter_link_properties.as_deref(),
+                aliases: report.alias_links,
+                case_insensitive: report.case_insensitive,
             },
-            // Effective `[links.auto]` baseline for `hyalo links auto`
-            // (iter-195a). Always present, empty lists / false when unset, so
-            // consumers never have to distinguish "absent" from "off".
-            // Effective `[scan]` settings (iter-265). `exclude` is the
-            // vault-wide exclusion list every command honours; `include`
-            // re-admits hidden dot-subtrees.
-            "scan": {
-                "include": report.scan.include,
-                "exclude": report.scan.exclude,
-                "verbose_skips": report.scan.verbose_skips,
+            scan: &report.scan,
+            links_auto: &report.links_auto,
+            links_fuzzy_min_confidence: report.fuzzy_min_confidence,
+            pi: ConfigPiResult {
+                session_summary: report.pi_session_summary,
             },
-            "links_auto": {
-                "exclude_titles": report.links_auto.exclude_titles,
-                "exclude_target_globs": report.links_auto.exclude_target_globs,
-                "first_only": report.links_auto.first_only,
-                "warn_common_titles": report.links_auto.warn_common_titles,
-            },
-            // Effective `links fix --apply-fuzzy` confidence floor (iter-212).
-            // Always a number — the built-in default when the key is unset.
-            "links_fuzzy_min_confidence": report.fuzzy_min_confidence,
-            // Effective `[pi]` agent-integration settings (iter-230).
-            // Always present, `false` when unset, so consumers never have to
-            // distinguish "absent" from "off".
-            "pi": {
-                "session_summary": report.pi_session_summary,
-            },
-        },
-        "hints": hints,
-        "dir": report.dir.display().to_string(),
-    })
+        };
+        let mut envelope = crate::output::Envelope::new(results, None, &hints);
+        envelope.dir = Some(report.dir.display().to_string());
+        crate::output::output_value(&envelope)
+    }
 }
 
 /// Run `hyalo config` and return a `CommandOutcome` ready for the output pipeline.
@@ -419,7 +368,7 @@ pub(crate) fn run_config(
 fn run_config_json(report: &ConfigReport, show_hints: bool) -> CommandOutcome {
     let mut envelope = config_envelope(report);
     if !show_hints {
-        envelope["hints"] = json!([]);
+        envelope["hints"] = serde_json::Value::Array(Vec::new());
     }
     CommandOutcome::success(format_success(Format::Json, &envelope))
 }
@@ -600,4 +549,79 @@ fn run_config_text(report: &ConfigReport, show_hints: bool) -> CommandOutcome {
     }
 
     CommandOutcome::RawOutput(out)
+}
+
+/// Serialized ConfigResult command contract.
+#[derive(serde::Serialize)]
+struct ConfigResult<'a> {
+    /// Discovered config path, or null when absent.
+    config_path: Option<String>,
+    /// Whether config or schema parsing failed.
+    malformed: bool,
+    /// Primary parsing diagnostic, or null.
+    parse_error: Option<&'a str>,
+    /// Schema parsing diagnostic, or null.
+    schema_error: Option<&'a str>,
+    /// Snapshot format written and accepted by this binary.
+    snapshot_format_version: u32,
+    /// Effective dir salvaged setting.
+    dir_salvaged: bool,
+    /// Effective dir out of bounds setting.
+    dir_out_of_bounds: bool,
+    /// Effective dir out of bounds reason setting.
+    dir_out_of_bounds_reason: Option<&'a str>,
+    /// Original config text with --raw; null otherwise.
+    raw_contents: Option<&'a str>,
+    /// Effective cwd setting.
+    cwd: String,
+    /// Resolved vault directory, intentionally retained alongside envelope.dir.
+    dir: String,
+    /// Effective dir overridden setting.
+    dir_overridden: bool,
+    /// Effective format setting.
+    format: &'a str,
+    /// Effective format source setting.
+    format_source: &'a str,
+    /// Configured format, or null when unset.
+    format_configured: Option<&'a str>,
+    /// Effective hints setting.
+    hints: bool,
+    /// Compatibility alias of the effective hints setting.
+    hints_enabled: bool,
+    /// Effective site prefix setting.
+    site_prefix: Option<&'a str>,
+    /// Effective site prefix source setting.
+    site_prefix_source: &'a str,
+    /// Effective exempt setting.
+    exempt: &'a [String],
+    /// Effective links setting.
+    links: ConfigLinksResult<'a>,
+    /// Effective scan setting.
+    scan: &'a ScanReport,
+    /// Effective links auto setting.
+    links_auto: &'a LinksAutoReport,
+    /// Effective links fuzzy min confidence setting.
+    links_fuzzy_min_confidence: f64,
+    /// Effective pi setting.
+    pi: ConfigPiResult,
+}
+
+/// Serialized ConfigLinksResult command contract.
+#[derive(serde::Serialize)]
+struct ConfigLinksResult<'a> {
+    /// Whether all frontmatter values contribute graph edges.
+    frontmatter: bool,
+    /// Explicit property allow-list, or null.
+    frontmatter_properties: Option<&'a [String]>,
+    /// Whether authored aliases resolve links.
+    aliases: bool,
+    /// Effective case resolution mode.
+    case_insensitive: &'a str,
+}
+
+/// Effective pi integration settings.
+#[derive(serde::Serialize)]
+struct ConfigPiResult {
+    /// Whether session summaries are enabled.
+    session_summary: bool,
 }

--- a/crates/hyalo-cli/src/commands/create_index.rs
+++ b/crates/hyalo-cli/src/commands/create_index.rs
@@ -5,7 +5,7 @@ use hyalo_core::discovery;
 use hyalo_core::index::{ScanOptions, ScannedIndex, SnapshotIndex, VaultIndex, find_stale_indexes};
 use std::path::{Path, PathBuf};
 
-use crate::output::{CommandOutcome, Format, format_success};
+use crate::output::{CommandOutcome, Format, format_output};
 
 /// Build a snapshot index from disk and write it to `output` (default:
 /// `<dir>/.hyalo-index`).
@@ -165,14 +165,26 @@ pub fn create_index(
     }
 
     let file_count = build.index.entries().len();
-    let mut result = serde_json::json!({
-        "path": index_path.display().to_string(),
-        "files_indexed": file_count,
-        "warnings": build.warnings.len(),
-    });
-    if replacing_existing {
-        result["note"] = serde_json::json!("replaced existing index");
-    }
+    let result = CreateIndexResult {
+        path: index_path.display().to_string(),
+        files_indexed: file_count,
+        warnings: build.warnings.len(),
+        note: replacing_existing.then_some("replaced existing index"),
+    };
 
-    Ok(CommandOutcome::success(format_success(format, &result)))
+    Ok(CommandOutcome::success(format_output(format, &result)))
+}
+
+/// Serialized CreateIndexResult command contract.
+#[derive(serde::Serialize)]
+struct CreateIndexResult<'a> {
+    /// Path of the created index.
+    path: String,
+    /// Number of indexed Markdown files.
+    files_indexed: usize,
+    /// Number of scan warnings.
+    warnings: usize,
+    /// Replacement notice, omitted for a new index.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<&'a str>,
 }

--- a/crates/hyalo-cli/src/commands/drop_index.rs
+++ b/crates/hyalo-cli/src/commands/drop_index.rs
@@ -118,9 +118,11 @@ pub fn drop_index(
         }
     }
 
-    let result = serde_json::json!({
-        "deleted": index_path.display().to_string(),
-    });
+    let result = crate::output::output_value(
+        &(DropIndexResult {
+            deleted: &index_path.display().to_string(),
+        }),
+    );
 
     Ok(CommandOutcome::success(format_success(format, &result)))
 }
@@ -135,4 +137,11 @@ fn index_not_found_error(format: Format, index_path: &Path) -> String {
         Some("create one with `hyalo create-index`"),
         None,
     )
+}
+
+/// Serialized DropIndexResult command contract.
+#[derive(serde::Serialize)]
+struct DropIndexResult<'a> {
+    /// Path of the deleted index.
+    deleted: &'a str,
 }

--- a/crates/hyalo-cli/src/commands/init.rs
+++ b/crates/hyalo-cli/src/commands/init.rs
@@ -211,7 +211,8 @@ impl Report {
     /// strings cannot fail; an empty object is returned instead of panicking.
     #[must_use]
     pub fn to_json(&self) -> serde_json::Value {
-        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
+        serde_json::to_value(self)
+            .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()))
     }
 }
 

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -82,15 +82,14 @@ impl FuzzyApply {
 /// The JSON `strategy` field keeps the PascalCase enum variant for machine
 /// consumers; `rule` is the presentation-level spelling the text renderer
 /// prints in brackets (`[basename-fallback 0.7]`).
-fn fixes_with_rule(fixes: &[hyalo_core::link_fix::FixPlan]) -> Vec<serde_json::Value> {
+fn fixes_with_rule(fixes: &[hyalo_core::link_fix::FixPlan]) -> Vec<FixResult<'_>> {
     fixes
         .iter()
-        .map(|f| {
-            let mut v = serde_json::to_value(f).unwrap_or(serde_json::Value::Null);
-            if let Some(obj) = v.as_object_mut() {
-                obj.insert("rule".to_owned(), serde_json::json!(f.strategy.code()));
-            }
-            v
+        .map(|f| FixResult {
+            plan: f,
+            rule: f.strategy.code(),
+            below_floor: None,
+            col: None,
         })
         .collect()
 }
@@ -517,18 +516,8 @@ pub fn links_fix(
     // fix's own rule code into the payload and let the renderer use it.
     let mut fuzzy_json = fixes_with_rule(&fuzzy_fixes);
     for (v, f) in fuzzy_json.iter_mut().zip(fuzzy_fixes.iter()) {
-        if let Some(obj) = v.as_object_mut() {
-            obj.insert(
-                "below_floor".to_owned(),
-                serde_json::json!(f.confidence < fuzzy.floor()),
-            );
-            // NEW-18 (dogfood pre3): only when it can be found — a stale
-            // proposal whose on-disk text has already changed (or a read
-            // failure) simply omits `col` rather than reporting a wrong one.
-            if let Some(col) = find_column(dir, &f.source, f.line, &f.old_target) {
-                obj.insert("col".to_owned(), serde_json::json!(col));
-            }
-        }
+        v.below_floor = Some(f.confidence < fuzzy.floor());
+        v.col = find_column(dir, &f.source, f.line, &f.old_target);
     }
 
     let unapplied_count = unapplied_fixes.len();
@@ -616,79 +605,39 @@ pub fn links_fix(
     let templated_links = fix_report.templated.clone();
     let templated_count = templated_links.len();
 
-    let output = serde_json::json!({
-        "broken": broken.len(),
-        // NEW-15 / UX-2 (dogfood pre3): counted only when `broken` is empty
-        // (see above) — `Some(0)` either means genuinely no dead anchors, or
-        // that targets are broken too and this run didn't check (targets
-        // take priority; fix those first). `find --broken-links` remains the
-        // source of truth for the full picture including this case. `null`
-        // (PR #251 review L6) means the vault directory itself could not be
-        // canonicalized — a real "could not check", not a clean bill.
-        "broken_anchors": broken_anchor_count,
-        // `fixable`/`fixes` cover only the non-fuzzy (certain) fixes that
-        // plain `--apply` writes. Fuzzy matches are reported exclusively in
-        // the `fuzzy`/`fuzzy_fixes` bucket below — counting them here too
-        // would make "Fixable: N" (and the "Apply N fixes" hint) overpromise
-        // what a plain `--apply` actually writes.
-        "fixable": certain_fixes.len(),
-        "unfixable": unfixable_links.len(),
-        "ignored": ignored_count,
-        "fixes": certain_fixes,
-        "unfixable_links": unfixable_links,
-        "applied": !dry_run && !applied_fixes.is_empty(),
-        // BUG-2 (iter-243): `applied` means "something was actually written",
-        // not "apply mode was requested" — an agent reading `applied: true`
-        // next to `fixes: 0` misread the old meaning and concluded the vault
-        // was repaired. Apply mode is reported by `dry_run: false`; whether
-        // any fix landed is `applied` (and `applied_fixes` lists them).
-        // iter-216 D-4: every other mutating command reports `dry_run`, and a
-        // caller that switches between `links fix`, `links auto` and `set`
-        // should not have to know that this one spells it `applied` inverted.
-        "dry_run": dry_run,
-        "applied_fixes": applied_fixes,
-        "unapplied": unapplied_count,
-        "unapplied_fixes": unapplied_fixes,
-        // L-11: fixes whose durable write failed mid-batch. Non-empty ⇒
-        // partial failure ⇒ non-zero exit code.
-        "failed": failed_count,
-        "failed_fixes": failed_fixes,
-        "case_mismatches": case_mismatch_count,
-        "case_mismatch_fixes": case_mismatch_json,
-        // NEW-13 (dogfood pre3): bare-stem relocations to a different
-        // directory, split out of `case_mismatches` — see
-        // `BrokenLinkReport::relocations`.
-        "relocations": relocation_count,
-        "relocation_fixes": relocation_json,
-        // iter-275 (ALIAS-2, DEC-308): alias-backed rewrites — exact,
-        // confidence 1.0, written by plain `--apply`.
-        "alias_fixes": alias_fix_count,
-        "alias_fix_plans": alias_fix_json,
-        "ambiguous": ambiguous_count,
-        "ambiguous_links": ambiguous,
-        // iter-193: targets resolving above the vault root are out of scope,
-        // not broken. Reported so they stay visible, but excluded from
-        // `broken`/`unfixable` — there is nothing in the vault to fix them to.
-        "out_of_vault": out_of_vault_count,
-        "out_of_vault_links": out_of_vault_links,
-        // iter-207: templated destinations. Reported so they stay visible,
-        // but never rewritten — see `link_fix::is_templated_target`.
-        "templated": templated_count,
-        "templated_links": templated_links,
-        // Fuzzy-match fixes are reported in their own bucket. They are excluded
-        // from --apply unless --apply-fuzzy / --min-confidence opts in; the
-        // `fuzzy_applied` flag tells the caller whether they were written.
-        "fuzzy": fuzzy_fixes.len(),
-        "fuzzy_fixes": fuzzy_json,
-        "fuzzy_applied": fuzzy.enabled(),
-        // The floor actually in force this run — the `--min-confidence` value
-        // when given, otherwise `DEFAULT_FUZZY_MIN_CONFIDENCE` (iter-212).
-        // Always a number, so a consumer never has to know the default.
-        "fuzzy_min_confidence": fuzzy.floor(),
-        // How many of `fuzzy_fixes` fall below that floor and are therefore
-        // reported-but-not-applied even under `--apply-fuzzy`.
-        "fuzzy_below_floor": below_floor,
-    });
+    let output = LinksFixResult {
+        broken: broken.len(),
+        broken_anchors: broken_anchor_count,
+        fixable: certain_fixes.len(),
+        unfixable: unfixable_links.len(),
+        ignored: ignored_count,
+        fixes: &certain_fixes,
+        unfixable_links: &unfixable_links,
+        applied: !dry_run && !applied_fixes.is_empty(),
+        dry_run,
+        applied_fixes: &applied_fixes,
+        unapplied: unapplied_count,
+        unapplied_fixes: &unapplied_fixes,
+        failed: failed_count,
+        failed_fixes: &failed_fixes,
+        case_mismatches: case_mismatch_count,
+        case_mismatch_fixes: &case_mismatch_json,
+        relocations: relocation_count,
+        relocation_fixes: &relocation_json,
+        alias_fixes: alias_fix_count,
+        alias_fix_plans: &alias_fix_json,
+        ambiguous: ambiguous_count,
+        ambiguous_links: &ambiguous,
+        out_of_vault: out_of_vault_count,
+        out_of_vault_links: &out_of_vault_links,
+        templated: templated_count,
+        templated_links: &templated_links,
+        fuzzy: fuzzy_fixes.len(),
+        fuzzy_fixes: &fuzzy_json,
+        fuzzy_applied: fuzzy.enabled(),
+        fuzzy_min_confidence: fuzzy.floor(),
+        fuzzy_below_floor: below_floor,
+    };
 
     let _ = format;
     Ok((
@@ -1314,47 +1263,22 @@ pub fn links_auto(
                 hyalo_core::auto_link::AutoApplyStatus::Failed => (a, s, f + 1),
             });
 
-    let mut output = serde_json::json!({
-        "scanned": report.scanned,
-        // iter-216 D-3: `matched` (was `total`) — `results.total` is reserved
-        // for the denominator, which on this command is `scanned`.
-        "matched": report.matched,
-        "matches": report.matches,
-        "ambiguous_titles": report.ambiguous_titles,
-        "applied": report.applied,
-        // iter-216 D-4: `applied` is not the inverse of `dry_run` here — a
-        // `--apply` run over a vault with no linkable titles also reports
-        // `applied: false`, so without this key a script cannot tell a preview
-        // from an apply that had no work to do.
-        "dry_run": !apply,
-        // L-11: per-file apply outcomes (applied/skipped/failed with reason).
-        // Empty in preview mode. `files_applied`/`files_skipped`/`files_failed`
-        // are the counts; `apply_outcomes` carries the per-file detail.
-        "files_applied": applied_count,
-        "files_skipped": skipped_count,
-        "files_failed": failed_count,
-        "apply_outcomes": report.apply_outcomes,
-        // iter-267 (UX-9, DEC-286): always present so a consumer never has to
-        // distinguish "absent" from "nothing held back" — the lowercased
-        // titles the built-in stop-list removed from this run, and how many
-        // mentions that was. Empty and 0 when the stop-list is off.
-        "default_excluded_titles": default_excluded_titles,
-        "default_excluded_mentions": default_excluded_mentions,
-    });
-    // Omitted when zero, matching the `links.out_of_vault` precedent: the keys
-    // only appear when `[links.auto]` config actually removed candidates.
-    if config_excluded_titles > 0
-        && let Some(obj) = output.as_object_mut()
-    {
-        obj.insert(
-            "config_excluded_titles".to_owned(),
-            serde_json::json!(config_excluded_titles),
-        );
-        obj.insert(
-            "config_excluded_mentions".to_owned(),
-            serde_json::json!(config_excluded_mentions),
-        );
-    }
+    let output = LinksAutoResult {
+        scanned: report.scanned,
+        matched: report.matched,
+        matches: &report.matches,
+        ambiguous_titles: &report.ambiguous_titles,
+        applied: report.applied,
+        dry_run: !apply,
+        files_applied: applied_count,
+        files_skipped: skipped_count,
+        files_failed: failed_count,
+        apply_outcomes: &report.apply_outcomes,
+        default_excluded_titles: &default_excluded_titles,
+        default_excluded_mentions,
+        config_excluded_titles: (config_excluded_titles > 0).then_some(config_excluded_titles),
+        config_excluded_mentions: (config_excluded_titles > 0).then_some(config_excluded_mentions),
+    };
 
     let _ = format;
     Ok((
@@ -2287,4 +2211,122 @@ pub(crate) fn run(
             Ok(outcome)
         }
     }
+}
+
+/// Serialized FixResult command contract.
+#[derive(serde::Serialize)]
+struct FixResult<'a> {
+    /// Typed fix plan, flattened to preserve the existing wire contract.
+    #[serde(flatten)]
+    plan: &'a hyalo_core::link_fix::FixPlan,
+    /// Kebab-case presentation rule code.
+    rule: &'a str,
+    /// Whether a fuzzy proposal falls below the effective confidence floor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    below_floor: Option<bool>,
+    /// One-based Unicode scalar column when the source still matches.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    col: Option<usize>,
+}
+
+/// Serialized LinksFixResult command contract.
+#[derive(serde::Serialize)]
+struct LinksFixResult<'a> {
+    /// Number of broken.
+    broken: usize,
+    /// Broken heading anchors, or null when checking was impossible.
+    broken_anchors: Option<usize>,
+    /// Number of fixable.
+    fixable: usize,
+    /// Number of unfixable.
+    unfixable: usize,
+    /// Number of ignored.
+    ignored: usize,
+    /// Detailed fixes.
+    fixes: &'a [hyalo_core::link_fix::FixPlan],
+    /// Detailed unfixable links.
+    unfixable_links: &'a [hyalo_core::link_fix::BrokenLinkInfo],
+    /// Whether at least one fix was written.
+    applied: bool,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Detailed applied fixes.
+    applied_fixes: &'a [hyalo_core::link_fix::FixPlan],
+    /// Number of unapplied.
+    unapplied: usize,
+    /// Detailed unapplied fixes.
+    unapplied_fixes: &'a [hyalo_core::link_fix::FixPlan],
+    /// Number of failed.
+    failed: usize,
+    /// Detailed failed fixes.
+    failed_fixes: &'a [hyalo_core::link_fix::FailedFix],
+    /// Number of case mismatches.
+    case_mismatches: usize,
+    /// Detailed case mismatch fixes.
+    case_mismatch_fixes: &'a [FixResult<'a>],
+    /// Number of relocations.
+    relocations: usize,
+    /// Detailed relocation fixes.
+    relocation_fixes: &'a [FixResult<'a>],
+    /// Number of alias fixes.
+    alias_fixes: usize,
+    /// Detailed alias fix plans.
+    alias_fix_plans: &'a [FixResult<'a>],
+    /// Number of ambiguous.
+    ambiguous: usize,
+    /// Detailed ambiguous links.
+    ambiguous_links: &'a [hyalo_core::link_fix::BrokenLinkInfo],
+    /// Number of out of vault.
+    out_of_vault: usize,
+    /// Detailed out of vault links.
+    out_of_vault_links: &'a [hyalo_core::link_fix::BrokenLinkInfo],
+    /// Number of templated.
+    templated: usize,
+    /// Detailed templated links.
+    templated_links: &'a [hyalo_core::link_fix::BrokenLinkInfo],
+    /// Number of fuzzy.
+    fuzzy: usize,
+    /// Detailed fuzzy fixes.
+    fuzzy_fixes: &'a [FixResult<'a>],
+    /// Whether fuzzy application was requested.
+    fuzzy_applied: bool,
+    /// Effective confidence floor for fuzzy application.
+    fuzzy_min_confidence: f64,
+    /// Number of fuzzy below floor.
+    fuzzy_below_floor: usize,
+}
+
+/// Serialized LinksAutoResult command contract.
+#[derive(serde::Serialize)]
+struct LinksAutoResult<'a> {
+    /// Effective scanned.
+    scanned: usize,
+    /// Effective matched.
+    matched: usize,
+    /// Detailed matches.
+    matches: &'a [hyalo_core::auto_link::AutoLinkMatch],
+    /// Detailed ambiguous titles.
+    ambiguous_titles: &'a [String],
+    /// Effective applied.
+    applied: bool,
+    /// Effective dry run.
+    dry_run: bool,
+    /// Effective files applied.
+    files_applied: usize,
+    /// Effective files skipped.
+    files_skipped: usize,
+    /// Effective files failed.
+    files_failed: usize,
+    /// Detailed apply outcomes.
+    apply_outcomes: &'a [hyalo_core::auto_link::AutoApplyOutcome],
+    /// Detailed default excluded titles.
+    default_excluded_titles: &'a [String],
+    /// Effective default excluded mentions.
+    default_excluded_mentions: usize,
+    /// Config exclusions; omitted when no titles were excluded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_excluded_titles: Option<usize>,
+    /// Config exclusions; omitted when no titles were excluded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_excluded_mentions: Option<usize>,
 }

--- a/crates/hyalo-cli/src/commands/lint/engine.rs
+++ b/crates/hyalo-cli/src/commands/lint/engine.rs
@@ -578,7 +578,7 @@ pub(super) struct InternalViolation {
     pub(super) column: usize,
     pub(super) message: String,
     pub(super) severity: String,
-    pub(super) fix: Option<serde_json::Value>,
+    pub(super) fix: Option<hyalo_mdlint::DiagFix>,
     /// True when this body diagnostic's fix was successfully applied during
     /// the current fix-mode run. Always `false` for read-only and frontmatter
     /// (SCHEMA) violations — frontmatter fixes are tracked separately via

--- a/crates/hyalo-cli/src/commands/lint/file.rs
+++ b/crates/hyalo-cli/src/commands/lint/file.rs
@@ -776,14 +776,7 @@ pub(super) fn lint_one_file_extended(
     // followed by whatever remains after the loop above (or the single
     // read-only lint pass, when fix-mode is off).
     let diag_to_violation = |d: hyalo_mdlint::Diagnostic, fixed: bool| {
-        let fix = d.fix.as_ref().map(|f| {
-            serde_json::json!({
-                "description": f.description,
-                "start": f.start,
-                "end": f.end,
-                "replacement": f.replacement,
-            })
-        });
+        let fix = d.fix;
         InternalViolation {
             line: to_file_line(d.line),
             column: d.column,

--- a/crates/hyalo-cli/src/commands/lint/types.rs
+++ b/crates/hyalo-cli/src/commands/lint/types.rs
@@ -19,33 +19,45 @@ use std::path::Path;
 /// A group of violations for one rule within one file.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RuleGroup {
+    /// Stable lint rule identifier.
     pub rule: String,
+    /// Number of matching occurrences.
     pub count: usize,
+    /// Number of detailed violations included after limiting.
     pub shown: usize,
+    /// Whether detailed violations were omitted by a limit.
     pub truncated: bool,
+    /// Aggregate severity of this rule group.
     pub severity: String,
+    /// Whether this rule supports automatic fixes.
     pub autofixable: bool,
+    /// Detailed violations included after limiting.
     pub violations: Vec<BodyViolation>,
 }
 
 /// A single body violation.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BodyViolation {
+    /// One-based source line number.
     pub line: usize,
+    /// One-based Unicode scalar column.
     pub column: usize,
     /// Per-violation severity (`"error"` / `"warn"`). Carried alongside the
     /// group severity because a folded group (notably `SCHEMA`) can mix the
     /// two, and the text renderer must label each line with its own severity
     /// so the display agrees with the `errors`/`warnings` counts (BUG-17).
     pub severity: String,
+    /// Human-readable violation diagnostic.
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fix: Option<serde_json::Value>,
+    /// Proposed body-relative byte-range replacement.
+    pub fix: Option<hyalo_mdlint::DiagFix>,
 }
 
 /// Extended lint output for one file (read-only shape).
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct ExtFileLintResult {
+    /// Vault-relative Markdown file path.
     pub file: String,
     /// Frontmatter `type:` discriminator, if the file declared one. Used by
     /// the hint layer to surface `hyalo types show <T>` for SCHEMA failures.
@@ -59,7 +71,9 @@ pub struct ExtFileLintResult {
 /// Includes `violations` so text renderers can show line/message details.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FixedGroup {
+    /// Stable lint rule identifier.
     pub rule: String,
+    /// Number of matching occurrences.
     pub count: usize,
     /// Violations that were fixed (same shape as `RuleGroup.violations`).
     pub violations: Vec<BodyViolation>,
@@ -73,15 +87,18 @@ pub struct FixedGroup {
 /// at (iteration 263, dogfood v0.22.0 UX-16).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ConflictEntry {
+    /// Stable lint rule identifier.
     pub rule: String,
     /// 1-based line of the violation whose fix was skipped.
     pub line: usize,
+    /// Explanation of the reported action or refusal.
     pub reason: String,
 }
 
 /// Extended lint output for one file in fix-mode.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct ExtFileLintFixResult {
+    /// Vault-relative Markdown file path.
     pub file: String,
     /// Frontmatter `type:` discriminator, if the file declared one. Mirrors
     /// [`ExtFileLintResult::doc_type`] so the iter-143 SCHEMA-→-`types show`
@@ -108,6 +125,7 @@ pub struct ExtFileLintFixResult {
 /// here, mirroring [`ExtLintFixOutput`]'s empty-result shape.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ExtLintOutput {
+    /// Per-file lint results.
     pub files: Vec<ExtFileLintResult>,
     /// Total number of violations found across all files.
     ///
@@ -117,10 +135,13 @@ pub struct ExtLintOutput {
     /// `total` on the very same document is the *file* count, so one name
     /// used to carry two quantities in one payload.
     pub violations: usize,
+    /// Number of distinct rules that reported violations.
     pub rules_fired: usize,
+    /// Number of files with at least one violation.
     pub files_with_violations: usize,
     /// Total number of files that were examined (including clean files).
     pub files_checked: usize,
+    /// Whether file results were omitted by a limit.
     pub files_truncated: bool,
     /// Number of error-severity violations.
     pub errors: usize,
@@ -153,10 +174,15 @@ pub struct ExtLintOutput {
 /// path.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ExtLintFixOutput {
+    /// Per-file lint results.
     pub files: Vec<ExtFileLintFixResult>,
+    /// Number of violations fixed.
     pub total_fixed: usize,
+    /// Number of violations remaining.
     pub total_remaining: usize,
+    /// Number of overlapping fixes skipped.
     pub total_conflicts: usize,
+    /// Number of distinct rules that reported violations.
     pub rules_fired: usize,
     /// How many violations each rule actually fixed, keyed by rule id.
     ///
@@ -167,8 +193,11 @@ pub struct ExtLintFixOutput {
     /// present (an empty object when nothing was fixed), like every other
     /// top-level `results` key.
     pub rules_fixed: std::collections::BTreeMap<String, usize>,
+    /// Number of files with at least one violation.
     pub files_with_violations: usize,
+    /// Number of files examined.
     pub files_checked: usize,
+    /// Whether file results were omitted by a limit.
     pub files_truncated: bool,
     /// Error-severity violations left unfixed after this run.
     ///
@@ -180,6 +209,7 @@ pub struct ExtLintFixOutput {
     /// `lint` and `lint --fix` JSON silently got answers to different
     /// questions.
     pub remaining_errors: usize,
+    /// Warning-severity violations left unfixed.
     pub remaining_warnings: usize,
     /// `true` when `--dry-run` previewed fixes without writing them.
     /// Always present (iter-216 D-4) — see [`ExtLintOutput::dry_run`].

--- a/crates/hyalo-cli/src/commands/lint_rules.rs
+++ b/crates/hyalo-cli/src/commands/lint_rules.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::commands::lint::SCHEMA_PSEUDO_RULE;
-use crate::output::{CommandOutcome, Format, format_error, format_success};
+use crate::output::{CommandOutcome, Format, format_error, format_output};
 
 const TOML_FILENAME: &str = ".hyalo.toml";
 
@@ -30,7 +30,7 @@ pub(crate) fn list_rules(
 ) -> CommandOutcome {
     let rules = engine.available_rules();
 
-    let results: Vec<serde_json::Value> = rules
+    let results: Vec<RuleResult> = rules
         .iter()
         .filter(|e| {
             // Apply prefix filter
@@ -54,25 +54,22 @@ pub(crate) fn list_rules(
             let eff_enabled = effective_enabled(e, md_lint);
             let has_override = md_lint.rules.contains_key(&e.id);
             let activation = activation_for(&e.id, schema);
-            let mut entry = serde_json::json!({
-                "id": e.id,
-                "name": e.name,
-                "description": e.description,
-                "default_enabled": e.default_enabled,
-                "default_severity": format!("{}", e.default_severity),
-                "effective_enabled": eff_enabled,
-                "effective_severity": format!("{}", eff_sev),
-                "autofixable": e.autofixable,
-                "source": e.source,
-                "has_override": has_override,
-            });
-            if let Some(act) = activation {
-                entry["activation"] = serde_json::json!({
-                    "predicate": act.predicate,
-                    "satisfied": act.satisfied,
-                });
+            RuleResult {
+                id: &e.id,
+                name: &e.name,
+                description: &e.description,
+                default_enabled: e.default_enabled,
+                default_severity: format!("{}", e.default_severity),
+                effective_enabled: eff_enabled,
+                effective_severity: format!("{eff_sev}"),
+                autofixable: e.autofixable,
+                source: &e.source,
+                has_override: Some(has_override),
+                activation,
+                configurable: None,
+                r#override: None,
+                note: None,
             }
-            entry
         })
         .collect();
 
@@ -88,34 +85,13 @@ pub(crate) fn list_rules(
             .starts_with(&p.to_ascii_lowercase())
     }) && !disabled_only;
     if schema_row_matches {
-        results.push(serde_json::json!({
-            "id": SCHEMA_PSEUDO_RULE,
-            "name": "frontmatter-schema",
-            "description": "Frontmatter validated against the [schema] types in .hyalo.toml: missing required properties, undeclared properties, type and enum constraints, and required sections. Not configurable through lint-rules — edit the schema with `hyalo types set`.",
-            "default_enabled": true,
-            "default_severity": "error",
-            "effective_enabled": true,
-            "effective_severity": "error",
-            "autofixable": false,
-            "source": "hyalo-schema",
-            "has_override": false,
-            "configurable": false,
-        }));
-        results.sort_by(|a, b| {
-            let key = |v: &serde_json::Value| {
-                v.get("id")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_default()
-                    .to_owned()
-            };
-            key(a).cmp(&key(b))
-        });
+        results.push(RuleResult { id: SCHEMA_PSEUDO_RULE, name: "frontmatter-schema", description: "Frontmatter validated against the [schema] types in .hyalo.toml: missing required properties, undeclared properties, type and enum constraints, and required sections. Not configurable through lint-rules — edit the schema with `hyalo types set`.", default_enabled: true, default_severity: "error".to_owned(), effective_enabled: true, effective_severity: "error".to_owned(), autofixable: false, source: "hyalo-schema", has_override: Some(false), configurable: Some(false), activation: None, r#override: None, note: None });
+        results.sort_by(|a, b| a.id.cmp(b.id));
     }
 
     let _ = config_dir; // not used currently, kept for potential future hints
     let total = results.len() as u64;
-    let val = serde_json::json!(results);
-    CommandOutcome::success_with_total(format_success(Format::Json, &val), total)
+    CommandOutcome::success_with_total(format_output(Format::Json, &results), total)
 }
 
 // ---------------------------------------------------------------------------
@@ -133,22 +109,26 @@ pub(crate) fn show_rule(
     // UX-5 (iter-274): `SCHEMA` is listed and selectable, so it must also be
     // inspectable — a catalog entry `show` refuses is worse than no entry.
     if rule_id.eq_ignore_ascii_case(SCHEMA_PSEUDO_RULE) {
-        return CommandOutcome::success(format_success(
+        return CommandOutcome::success(format_output(
             Format::Json,
-            &serde_json::json!({
-                "id": SCHEMA_PSEUDO_RULE,
-                "name": "frontmatter-schema",
-                "description": "Frontmatter validated against the [schema] types in .hyalo.toml: missing required properties, undeclared properties, type and enum constraints, and required sections.",
-                "default_enabled": true,
-                "default_severity": "error",
-                "effective_enabled": true,
-                "effective_severity": "error",
-                "autofixable": false,
-                "source": "hyalo-schema",
-                "configurable": false,
-                "override": serde_json::Value::Null,
-                "note": "not configurable through lint-rules — edit the schema with `hyalo types set`, or exempt files with [schema] exempt",
-            }),
+            &RuleResult {
+                id: SCHEMA_PSEUDO_RULE,
+                name: "frontmatter-schema",
+                description: "Frontmatter validated against the [schema] types in .hyalo.toml: missing required properties, undeclared properties, type and enum constraints, and required sections.",
+                default_enabled: true,
+                default_severity: "error".to_owned(),
+                effective_enabled: true,
+                effective_severity: "error".to_owned(),
+                autofixable: false,
+                source: "hyalo-schema",
+                has_override: None,
+                configurable: Some(false),
+                activation: None,
+                r#override: Some(None),
+                note: Some(
+                    "not configurable through lint-rules — edit the schema with `hyalo types set`, or exempt files with [schema] exempt",
+                ),
+            },
         ));
     }
     let Some(entry) = engine.rule_entry(rule_id) else {
@@ -166,41 +146,27 @@ pub(crate) fn show_rule(
     let override_entry = md_lint.rules.get(rule_id);
     let activation = activation_for(&entry.id, schema);
 
-    let mut val = serde_json::json!({
-        "id": entry.id,
-        "name": entry.name,
-        "description": entry.description,
-        "default_enabled": entry.default_enabled,
-        "default_severity": format!("{}", entry.default_severity),
-        "effective_enabled": eff_enabled,
-        "effective_severity": format!("{}", eff_sev),
-        "autofixable": entry.autofixable,
-        "source": entry.source,
-        // iter-274 (UX-14): report what the override actually SETS. A rule
-        // whose `.hyalo.toml` entry pins only the severity used to render
-        // `enabled: null`, which reads as "unknown" rather than "not
-        // overridden" — and the reader then had to know that `effective_enabled`
-        // is the answer. An unset dimension is now simply absent from the
-        // object, so every key present in `override` is a value the config set.
-        "override": override_entry.map(|ov| {
-            let mut o = serde_json::Map::new();
-            if let Some(enabled) = ov.enabled() {
-                o.insert("enabled".to_owned(), serde_json::json!(enabled));
-            }
-            if let Some(severity) = ov.severity() {
-                o.insert("severity".to_owned(), serde_json::json!(severity));
-            }
-            serde_json::Value::Object(o)
-        }),
-    });
-    if let Some(act) = activation {
-        val["activation"] = serde_json::json!({
-            "predicate": act.predicate,
-            "satisfied": act.satisfied,
-        });
-    }
+    let val = RuleResult {
+        id: &entry.id,
+        name: &entry.name,
+        description: &entry.description,
+        default_enabled: entry.default_enabled,
+        default_severity: format!("{}", entry.default_severity),
+        effective_enabled: eff_enabled,
+        effective_severity: format!("{eff_sev}"),
+        autofixable: entry.autofixable,
+        source: &entry.source,
+        has_override: None,
+        activation,
+        configurable: None,
+        r#override: Some(override_entry.map(|ov| RuleOverrideResult {
+            enabled: ov.enabled(),
+            severity: ov.severity(),
+        })),
+        note: None,
+    };
 
-    CommandOutcome::success(format_success(Format::Json, &val))
+    CommandOutcome::success(format_output(Format::Json, &val))
 }
 
 // ---------------------------------------------------------------------------
@@ -390,25 +356,27 @@ pub(crate) fn set_rule(
         // distinguish a tautological dry-run (no diff) from one that would
         // mutate the file.
         let would_write = new_contents != contents;
-        let val = serde_json::json!({
-            "action": "set",
-            "rule_id": rule_id,
-            "dry_run": true,
-            "enabled": enabled,
-            "severity": severity,
-            "before": {
-                "enabled": before_enabled,
-                "severity": before_severity,
+        let val = RuleMutationResult {
+            action: "set",
+            rule_id,
+            dry_run: true,
+            enabled: Some(enabled),
+            severity: Some(severity),
+            before: RuleStateResult {
+                enabled: before_enabled,
+                severity: &before_severity,
             },
-            "after": {
-                "enabled": after_enabled,
-                "severity": after_severity,
+            after: RuleStateResult {
+                enabled: after_enabled,
+                severity: &after_severity,
             },
-            "config_path": path_str,
-            "preview": new_contents,
-            "wrote": would_write,
-        });
-        return Ok(CommandOutcome::success(format_success(Format::Json, &val)));
+            config_path: &path_str,
+            preview: Some(&new_contents),
+            wrote: Some(would_write),
+            removed: None,
+            reason: None,
+        };
+        return Ok(CommandOutcome::success(format_output(Format::Json, &val)));
     }
 
     // Skip the write when the on-disk content would not change (BUG-2:
@@ -422,24 +390,27 @@ pub(crate) fn set_rule(
         true
     };
 
-    let val = serde_json::json!({
-        "action": "set",
-        "rule_id": rule_id,
-        "dry_run": false,
-        "enabled": enabled,
-        "severity": severity,
-        "before": {
-            "enabled": before_enabled,
-            "severity": before_severity,
+    let val = RuleMutationResult {
+        action: "set",
+        rule_id,
+        dry_run: false,
+        enabled: Some(enabled),
+        severity: Some(severity),
+        before: RuleStateResult {
+            enabled: before_enabled,
+            severity: &before_severity,
         },
-        "after": {
-            "enabled": after_enabled,
-            "severity": after_severity,
+        after: RuleStateResult {
+            enabled: after_enabled,
+            severity: &after_severity,
         },
-        "config_path": path_str,
-        "wrote": wrote,
-    });
-    Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+        config_path: &path_str,
+        preview: None,
+        wrote: Some(wrote),
+        removed: None,
+        reason: None,
+    };
+    Ok(CommandOutcome::success(format_output(Format::Json, &val)))
 }
 
 /// Get (creating if absent) the `[lint.rules]` table as a mutable `Item`.
@@ -525,17 +496,27 @@ pub(crate) fn remove_rule(
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // No config file — nothing to remove
-            let val = serde_json::json!({
-                "action": "remove",
-                "rule_id": rule_id,
-                "dry_run": dry_run,
-                "removed": false,
-                "reason": "no .hyalo.toml found",
-                "before": {"enabled": before_enabled, "severity": before_severity},
-                "after": {"enabled": before_enabled, "severity": before_severity},
-                "config_path": path_str,
-            });
-            return Ok(CommandOutcome::success(format_success(Format::Json, &val)));
+            let val = RuleMutationResult {
+                action: "remove",
+                rule_id,
+                dry_run,
+                enabled: None,
+                severity: None,
+                before: RuleStateResult {
+                    enabled: before_enabled,
+                    severity: &before_severity,
+                },
+                after: RuleStateResult {
+                    enabled: before_enabled,
+                    severity: &before_severity,
+                },
+                config_path: &path_str,
+                preview: None,
+                wrote: None,
+                removed: Some(false),
+                reason: Some("no .hyalo.toml found"),
+            };
+            return Ok(CommandOutcome::success(format_output(Format::Json, &val)));
         }
         Err(e) => return Err(e).with_context(|| format!("reading {}", toml_path.display())),
     };
@@ -552,17 +533,27 @@ pub(crate) fn remove_rule(
     }
 
     if !removed {
-        let val = serde_json::json!({
-            "action": "remove",
-            "rule_id": rule_id,
-            "dry_run": dry_run,
-            "removed": false,
-            "reason": "no override found",
-            "before": {"enabled": before_enabled, "severity": before_severity},
-            "after": {"enabled": before_enabled, "severity": before_severity},
-            "config_path": path_str,
-        });
-        return Ok(CommandOutcome::success(format_success(Format::Json, &val)));
+        let val = RuleMutationResult {
+            action: "remove",
+            rule_id,
+            dry_run,
+            enabled: None,
+            severity: None,
+            before: RuleStateResult {
+                enabled: before_enabled,
+                severity: &before_severity,
+            },
+            after: RuleStateResult {
+                enabled: before_enabled,
+                severity: &before_severity,
+            },
+            config_path: &path_str,
+            preview: None,
+            wrote: None,
+            removed: Some(false),
+            reason: Some("no override found"),
+        };
+        return Ok(CommandOutcome::success(format_output(Format::Json, &val)));
     }
 
     let new_contents = doc.to_string();
@@ -572,31 +563,53 @@ pub(crate) fn remove_rule(
     let after_severity = format!("{}", entry.default_severity);
 
     if dry_run {
-        let val = serde_json::json!({
-            "action": "remove",
-            "rule_id": rule_id,
-            "dry_run": true,
-            "removed": true,
-            "before": {"enabled": before_enabled, "severity": before_severity},
-            "after": {"enabled": after_enabled, "severity": after_severity},
-            "config_path": path_str,
-        });
-        return Ok(CommandOutcome::success(format_success(Format::Json, &val)));
+        let val = RuleMutationResult {
+            action: "remove",
+            rule_id,
+            dry_run: true,
+            enabled: None,
+            severity: None,
+            before: RuleStateResult {
+                enabled: before_enabled,
+                severity: &before_severity,
+            },
+            after: RuleStateResult {
+                enabled: after_enabled,
+                severity: &after_severity,
+            },
+            config_path: &path_str,
+            preview: None,
+            wrote: None,
+            removed: Some(true),
+            reason: None,
+        };
+        return Ok(CommandOutcome::success(format_output(Format::Json, &val)));
     }
 
     std::fs::write(&toml_path, &new_contents)
         .with_context(|| format!("writing {}", toml_path.display()))?;
 
-    let val = serde_json::json!({
-        "action": "remove",
-        "rule_id": rule_id,
-        "dry_run": false,
-        "removed": true,
-        "before": {"enabled": before_enabled, "severity": before_severity},
-        "after": {"enabled": after_enabled, "severity": after_severity},
-        "config_path": path_str,
-    });
-    Ok(CommandOutcome::success(format_success(Format::Json, &val)))
+    let val = RuleMutationResult {
+        action: "remove",
+        rule_id,
+        dry_run: false,
+        enabled: None,
+        severity: None,
+        before: RuleStateResult {
+            enabled: before_enabled,
+            severity: &before_severity,
+        },
+        after: RuleStateResult {
+            enabled: after_enabled,
+            severity: &after_severity,
+        },
+        config_path: &path_str,
+        preview: None,
+        wrote: None,
+        removed: Some(true),
+        reason: None,
+    };
+    Ok(CommandOutcome::success(format_output(Format::Json, &val)))
 }
 
 /// Remove the `[lint.rules.<rule_id>]` entry (or scalar `rule_id = bool` entry)
@@ -670,8 +683,11 @@ fn compute_after_state(
 /// Activation predicate description for rules whose effective behaviour depends
 /// on schema state at runtime. Returns `None` for rules that always run when
 /// enabled.
+#[derive(serde::Serialize)]
 struct Activation {
+    /// Runtime condition required for this rule.
     predicate: String,
+    /// Whether this vault satisfies the runtime condition.
     satisfied: bool,
 }
 
@@ -1069,4 +1085,103 @@ pub(crate) fn run(
             )
         }
     }
+}
+
+/// Serialized RuleResult command contract.
+#[derive(serde::Serialize)]
+struct RuleResult<'a> {
+    /// Stable rule identifier.
+    id: &'a str,
+    /// Rule name.
+    name: &'a str,
+    /// Rule purpose and behavior.
+    description: &'a str,
+    /// Built-in enabled state.
+    default_enabled: bool,
+    /// Built-in severity.
+    default_severity: String,
+    /// Enabled state after overrides.
+    effective_enabled: bool,
+    /// Severity after overrides.
+    effective_severity: String,
+    /// Whether the rule supports automatic fixes.
+    autofixable: bool,
+    /// Rule provider.
+    source: &'a str,
+    /// Whether config overrides exist; list-only field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    has_override: Option<bool>,
+    /// Present and false for the schema pseudo-rule.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    configurable: Option<bool>,
+    /// Runtime activation predicate when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    activation: Option<Activation>,
+    /// Configured override dimensions; null when show finds none.
+    #[serde(rename = "override", skip_serializing_if = "Option::is_none")]
+    #[allow(clippy::option_option)]
+    // Omitted, explicit null, and populated are distinct wire states.
+    r#override: Option<Option<RuleOverrideResult<'a>>>,
+    /// Additional schema configuration guidance.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<&'a str>,
+}
+
+/// Serialized RuleOverrideResult command contract.
+#[derive(serde::Serialize)]
+struct RuleOverrideResult<'a> {
+    /// Configured enabled state, omitted when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    /// Configured severity, omitted when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    severity: Option<&'a str>,
+}
+
+/// Serialized RuleStateResult command contract.
+#[derive(serde::Serialize)]
+struct RuleStateResult<'a> {
+    /// Effective enabled state.
+    enabled: bool,
+    /// Effective severity.
+    severity: &'a str,
+}
+
+/// Serialized RuleMutationResult command contract.
+#[derive(serde::Serialize)]
+struct RuleMutationResult<'a> {
+    /// Set or remove action.
+    action: &'a str,
+    /// Rule being configured.
+    rule_id: &'a str,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Requested enabled setting for set, including null.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[allow(clippy::option_option)]
+    // Omitted, explicit null, and populated are distinct wire states.
+    enabled: Option<Option<bool>>,
+    /// Requested severity for set, including null.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[allow(clippy::option_option)]
+    // Omitted, explicit null, and populated are distinct wire states.
+    severity: Option<Option<&'a str>>,
+    /// Effective state before the mutation.
+    before: RuleStateResult<'a>,
+    /// Effective state after the mutation.
+    after: RuleStateResult<'a>,
+    /// Path of the configuration file.
+    config_path: &'a str,
+    /// Proposed config content in set preview mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preview: Option<&'a str>,
+    /// Whether set writes or would write different content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wrote: Option<bool>,
+    /// Whether remove found an override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    removed: Option<bool>,
+    /// Reason a remove action found nothing to remove.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
 }

--- a/crates/hyalo-cli/src/commands/madr.rs
+++ b/crates/hyalo-cli/src/commands/madr.rs
@@ -122,20 +122,24 @@ pub fn run_toc(
         "unchanged"
     };
 
-    let mut payload = serde_json::json!({
-        "command": "madr toc",
-        "apply": apply,
-        "dry_run": !apply,
-        "adr_dir": adr_rel,
-        "adrs": entries.len(),
-        "changed": changed,
-        "file": plan.rel_path,
-        "action": action,
-        "hint": crate::commands::profile_lint_hint("madr", active_profiles, "validate ADR conformance"),
-    });
-    if action == "adopt" {
-        payload["preserved_lines"] = serde_json::Value::from(plan.old_content.lines().count());
-    }
+    let payload = crate::output::output_value(
+        &(MadrTocResult {
+            command: "madr toc",
+            apply,
+            dry_run: !apply,
+            adr_dir: adr_rel,
+            adrs: entries.len(),
+            changed,
+            file: &(plan.rel_path),
+            action,
+            hint: &(crate::commands::profile_lint_hint(
+                "madr",
+                active_profiles,
+                "validate ADR conformance",
+            )),
+            preserved_lines: (action == "adopt").then(|| plan.old_content.lines().count()),
+        }),
+    );
 
     let exit_override = if !apply && changed { Some(1) } else { None };
 
@@ -633,4 +637,30 @@ pub(crate) fn run(
             Ok(outcome)
         }
     }
+}
+
+/// Serialized MadrTocResult command contract.
+#[derive(serde::Serialize)]
+struct MadrTocResult<'a> {
+    /// Invoked command name.
+    command: &'a str,
+    /// Whether apply was requested.
+    apply: bool,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// ADR directory relative to the vault.
+    adr_dir: &'a str,
+    /// Number of ADR entries.
+    adrs: usize,
+    /// Whether the TOC differs.
+    changed: bool,
+    /// Generated TOC path.
+    file: &'a str,
+    /// Planned or performed action.
+    action: &'a str,
+    /// Follow-up profile lint command.
+    hint: &'a str,
+    /// Existing lines preserved during adoption.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preserved_lines: Option<usize>,
 }

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -902,7 +902,7 @@ pub fn unwrap_single_file_result(
     if files.len() == 1 && results.len() == 1 {
         results.pop().unwrap_or_default()
     } else {
-        serde_json::json!(results)
+        crate::output::output_value(&results)
     }
 }
 

--- a/crates/hyalo-cli/src/commands/mutation.rs
+++ b/crates/hyalo-cli/src/commands/mutation.rs
@@ -22,7 +22,7 @@ pub fn unwrap_single_result(mut results: Vec<Value>) -> Value {
     if results.len() == 1 {
         results.pop().unwrap_or_default()
     } else {
-        serde_json::json!(results)
+        crate::output::output_value(&results)
     }
 }
 

--- a/crates/hyalo-cli/src/commands/mv.rs
+++ b/crates/hyalo-cli/src/commands/mv.rs
@@ -21,11 +21,17 @@ use hyalo_core::link_rewrite::{
 
 #[derive(Serialize)]
 struct MvResult {
+    /// Original path or value.
     from: String,
+    /// Destination path or value.
     to: String,
+    /// Whether this result describes a preview without writing changes.
     dry_run: bool,
+    /// Files with link replacements caused by the move.
     updated_files: Vec<UpdatedFile>,
+    /// Number of files with rewritten links.
     total_files_updated: usize,
+    /// Number of rewritten links.
     total_links_updated: usize,
     /// Links that were skipped because the stem was ambiguous (NEW-3).
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -44,13 +50,17 @@ struct MvResult {
 
 #[derive(Serialize, Clone)]
 struct UpdatedFile {
+    /// Vault-relative Markdown file path.
     file: String,
+    /// Link replacements within this file.
     replacements: Vec<Replacement>,
 }
 
 #[derive(Serialize)]
 struct MoveEntry {
+    /// Original path or value.
     from: String,
+    /// Destination path or value.
     to: String,
     /// Frontmatter wikilinks naming *this* move's source that could not be
     /// rewritten because their `[[…]]` spans a line break (iter-273, MV-2).
@@ -62,8 +72,11 @@ struct MoveEntry {
 
 #[derive(Serialize)]
 struct BatchTotals {
+    /// Number of proposed or performed file moves.
     moves: usize,
+    /// Number of files whose content changed.
     files_changed: usize,
+    /// Number of rewritten link occurrences.
     replacements: usize,
 }
 
@@ -77,32 +90,41 @@ struct BatchTotals {
 /// what `mv --glob` promises).
 #[derive(Serialize)]
 struct Collision {
+    /// Source path whose proposed destination conflicts.
     source: String,
+    /// Conflicting destination path.
     destination: String,
 }
 
 #[derive(Serialize)]
 struct BatchMvResult {
+    /// Proposed or performed file moves.
     moves: Vec<MoveEntry>,
+    /// Files with link replacements caused by the move.
     updated_files: Vec<UpdatedFile>,
+    /// Aggregated move and rewrite counts.
     totals: BatchTotals,
     /// `totals.files_changed` and `totals.replacements` under the names
     /// single-file `mv` uses (iter-275, MV-5). Batch JSON had neither, so a
     /// caller reading `total_links_updated` got `null` from one mode and a
     /// number from the other.
     total_files_updated: usize,
+    /// Number of rewritten links.
     total_links_updated: usize,
     /// Destination collisions, listed rather than fatal in a dry run.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     collisions: Vec<Collision>,
+    /// Whether apply mode was requested.
     applied: bool,
     /// `!applied`, restated under the name the rest of the mutation family
     /// uses (iter-256 COH-9). `applied` predates the convention and is kept
     /// for back-compat; the two are always exact inverses.
     dry_run: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    /// Paths whose conflicting state prevented a change.
     conflicts: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    /// Vault-relative files left unchanged.
     skipped: Vec<String>,
 }
 

--- a/crates/hyalo-cli/src/commands/new.rs
+++ b/crates/hyalo-cli/src/commands/new.rs
@@ -10,7 +10,7 @@ use hyalo_core::schema::{PropertyConstraint, SchemaConfig, expand_default};
 
 use anyhow::Result;
 
-use crate::output::{CommandOutcome, Format, format_error, format_success};
+use crate::output::{CommandOutcome, Format, format_error, format_output};
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -160,16 +160,14 @@ pub(crate) fn create_new(
         let out = match format {
             Format::Text => format!("[dry-run] would create {rel_path}\n\n{content}"),
             Format::Json | Format::Github => {
-                let val = serde_json::json!({
-                    "type": type_name,
-                    "file": rel_path,
-                    "created": false,
-                    "dry_run": true,
-                    // The scaffold itself, so a preview does not require a
-                    // second command to see what would land on disk.
-                    "content": content,
-                });
-                format_success(Format::Json, &val)
+                let val = NewResult {
+                    r#type: type_name,
+                    file: rel_path,
+                    created: false,
+                    dry_run: true,
+                    content: Some(&content),
+                };
+                format_output(Format::Json, &val)
             }
         };
         return Ok(CommandOutcome::success(out));
@@ -214,16 +212,14 @@ pub(crate) fn create_new(
         Format::Text => format!("created {rel_path}\n"),
         // `github` is rejected for non-lint commands upstream; treat as JSON here.
         Format::Json | Format::Github => {
-            let val = serde_json::json!({
-                "type": type_name,
-                "file": rel_path,
-                "created": true,
-                // iter-256 COH-9: `new` has no --dry-run, but the mutation
-                // envelope contract says every object-shaped mutation result
-                // carries `dry_run`, so scripts can branch on one key.
-                "dry_run": false,
-            });
-            format_success(Format::Json, &val)
+            let val = NewResult {
+                r#type: type_name,
+                file: rel_path,
+                created: true,
+                dry_run: false,
+                content: None,
+            };
+            format_output(Format::Json, &val)
         }
     };
     Ok(CommandOutcome::success(out))
@@ -451,4 +447,21 @@ fn yaml_scalar(s: &str) -> String {
     } else {
         s.to_owned()
     }
+}
+
+/// Serialized NewResult command contract.
+#[derive(serde::Serialize)]
+struct NewResult<'a> {
+    /// Document schema type.
+    #[serde(rename = "type")]
+    r#type: &'a str,
+    /// Created or proposed vault-relative path.
+    file: &'a str,
+    /// Whether the file was created.
+    created: bool,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Scaffold source included only in a preview.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<&'a str>,
 }

--- a/crates/hyalo-cli/src/commands/okf.rs
+++ b/crates/hyalo-cli/src/commands/okf.rs
@@ -373,45 +373,39 @@ pub fn run_index(
         }
     }
 
-    let mut results: Vec<serde_json::Value> = changed
+    let mut results: Vec<OkfIndexFileResult> = changed
         .iter()
         .filter(|p| !write_failures.contains(&p.rel_path))
-        .map(|p| {
-            let mut obj = serde_json::json!({
-                "file": p.rel_path,
-                "action": p.action.as_str(),
-            });
-            // On an adopt, report how many existing lines are being preserved so
-            // `--dry-run` can print an explicit "preserving N existing lines"
-            // notice, distinct from a plain update.
-            if p.action == IndexAction::Adopt {
-                obj["preserved_lines"] = serde_json::Value::from(count_lines(&p.old_content));
-            }
-            obj
+        .map(|p| OkfIndexFileResult {
+            file: &p.rel_path,
+            action: p.action.as_str(),
+            preserved_lines: (p.action == IndexAction::Adopt).then(|| count_lines(&p.old_content)),
+            reason: None,
         })
         .collect();
 
     // Report the skipped malformed-marker files so `--dry-run` surfaces them and
     // apply records why they were left alone.
     for plan in &skipped_markers {
-        results.push(serde_json::json!({
-            "file": plan.rel_path,
-            "action": IndexAction::Skip.as_str(),
-            "reason": plan.skip_reason,
-        }));
+        results.push(OkfIndexFileResult {
+            file: &plan.rel_path,
+            action: IndexAction::Skip.as_str(),
+            preserved_lines: None,
+            reason: Some(plan.skip_reason),
+        });
     }
 
-    let payload = serde_json::json!({
-        "command": "okf index",
-        "apply": apply,
-        "dry_run": !apply,
-        "scanned": plans.len(),
-        "changed": changed.len() - write_failures.len(),
-        "skipped_malformed": skipped_malformed,
-        "skipped_markers": skipped_markers.len(),
-        "write_failures": write_failures,
-        "files": results,
-    });
+    let payload = OkfIndexResult {
+        command: "okf index",
+        apply,
+        dry_run: !apply,
+        scanned: plans.len(),
+        changed: changed.len() - write_failures.len(),
+        skipped_malformed,
+        skipped_markers: skipped_markers.len(),
+        write_failures: &write_failures,
+        files: &results,
+    };
 
     // Exit code:
     // - apply with any write failure → non-zero (partial failure, BUG-11).
@@ -433,7 +427,10 @@ pub fn run_index(
     };
 
     Ok((
-        CommandOutcome::success_with_total(payload.to_string(), changed.len() as u64),
+        CommandOutcome::success_with_total(
+            crate::output::output_value(&payload).to_string(),
+            changed.len() as u64,
+        ),
         exit_override,
     ))
 }
@@ -1017,16 +1014,18 @@ pub fn run_log(
             .with_context(|| format!("failed to write {rel_path}"))?;
     }
 
-    let payload = serde_json::json!({
-        "command": "okf log",
-        "apply": apply,
-        "dry_run": !apply,
-        "file": rel_path,
-        "date": today,
-        "entry": entry_line,
-        "created": old_content.is_empty(),
-    });
-    Ok(CommandOutcome::success(payload.to_string()))
+    let payload = OkfLogResult {
+        command: "okf log",
+        apply,
+        dry_run: !apply,
+        file: &(rel_path),
+        date: &(today),
+        entry: &(entry_line),
+        created: old_content.is_empty(),
+    };
+    Ok(CommandOutcome::success(
+        crate::output::output_value(&payload).to_string(),
+    ))
 }
 
 /// Indent the continuation lines of a (possibly multi-line) log message so the
@@ -1846,4 +1845,61 @@ pub(crate) fn run(
             effective_format,
         ),
     }
+}
+
+/// Serialized OkfIndexFileResult command contract.
+#[derive(serde::Serialize)]
+struct OkfIndexFileResult<'a> {
+    /// Vault-relative index path.
+    file: &'a str,
+    /// Planned or performed index action.
+    action: &'a str,
+    /// Existing lines preserved during adoption.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preserved_lines: Option<usize>,
+    /// Reason for skipping malformed markers; absent for other actions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+}
+
+/// Serialized OkfIndexResult command contract.
+#[derive(serde::Serialize)]
+struct OkfIndexResult<'a> {
+    /// Invoked command name.
+    command: &'a str,
+    /// Whether apply was requested.
+    apply: bool,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Number of planned index files.
+    scanned: usize,
+    /// Number of files changed successfully.
+    changed: usize,
+    /// Files skipped for malformed frontmatter.
+    skipped_malformed: usize,
+    /// Files skipped for malformed index markers.
+    skipped_markers: usize,
+    /// Paths whose durable write failed.
+    write_failures: &'a [String],
+    /// Per-file actions and adoption details.
+    files: &'a [OkfIndexFileResult<'a>],
+}
+
+/// Serialized OkfLogResult command contract.
+#[derive(serde::Serialize)]
+struct OkfLogResult<'a> {
+    /// Invoked command name.
+    command: &'a str,
+    /// Whether apply was requested.
+    apply: bool,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Vault-relative log path.
+    file: &'a str,
+    /// Date of the new log entry.
+    date: &'a str,
+    /// Rendered entry source.
+    entry: &'a str,
+    /// Whether the log was newly created.
+    created: bool,
 }

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -102,13 +102,21 @@ pub fn collapse_property_types(
 /// Result of a `properties rename` operation.
 #[derive(Debug, Serialize)]
 pub struct RenamePropertyResult {
+    /// Original path or value.
     pub from: String,
+    /// Destination path or value.
     pub to: String,
+    /// Whether this result describes a preview without writing changes.
     pub dry_run: bool,
+    /// Vault-relative files whose content changed.
     pub modified: Vec<String>,
+    /// Number of files left unchanged.
     pub skipped_count: usize,
+    /// Paths whose conflicting state prevented a change.
     pub conflicts: Vec<String>,
+    /// Total number of considered items.
     pub total: usize,
+    /// Number of files scanned.
     pub scanned: usize,
 }
 

--- a/crates/hyalo-cli/src/commands/read.rs
+++ b/crates/hyalo-cli/src/commands/read.rs
@@ -459,25 +459,14 @@ pub fn run(
         Some(n) => n,
         None => scanner::count_file_lines(&full_path)?,
     };
-    let mut obj = serde_json::json!({
-        "file": rel_path,
-        "size": file_size,
-        "lines": total_lines,
-    });
-    if let Some(ref props) = fm_value {
-        let json_val =
-            serde_json::to_value(props).context("failed to serialize frontmatter as JSON")?;
-        obj["frontmatter"] = json_val;
-        // The parsed map stays the machine-readable shape; `frontmatter_raw`
-        // carries the block's exact source text beside it (iter-266 OUT-1).
-        obj["frontmatter_raw"] = match fm_raw {
-            Some(ref raw) => serde_json::json!(raw),
-            None => serde_json::Value::Null,
-        };
-    }
-    if need_body {
-        obj["content"] = serde_json::json!(content_str);
-    }
+    let obj = ReadResult {
+        file: &rel_path,
+        size: file_size,
+        lines: total_lines,
+        frontmatter: fm_value.as_ref().map(crate::output::output_value),
+        frontmatter_raw: fm_value.as_ref().map(|_| fm_raw.as_deref()),
+        content: need_body.then_some(content_str.as_str()),
+    };
 
     // For JSON user format: return structured JSON (pipeline wraps in envelope).
     // For text user format: return raw text (bypasses pipeline).
@@ -1025,4 +1014,26 @@ pub(crate) fn run_command(
             )
         }
     }
+}
+
+/// Serialized ReadResult command contract.
+#[derive(serde::Serialize)]
+struct ReadResult<'a> {
+    /// Vault-relative file path.
+    file: &'a str,
+    /// Size of the whole file in bytes.
+    size: u64,
+    /// Line count of the whole file, before section selection.
+    lines: usize,
+    /// Parsed user-authored frontmatter, whose keys and values are genuinely dynamic.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frontmatter: Option<serde_json::Value>,
+    /// Exact frontmatter source; null when requested but no source block exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[allow(clippy::option_option)]
+    // Omitted, explicit null, and populated are distinct wire states.
+    frontmatter_raw: Option<Option<&'a str>>,
+    /// Selected body text, omitted for frontmatter-only reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<&'a str>,
 }

--- a/crates/hyalo-cli/src/commands/remove.rs
+++ b/crates/hyalo-cli/src/commands/remove.rs
@@ -16,11 +16,14 @@ use hyalo_core::frontmatter;
 /// Result of a `remove --property K` (or `K=V`) operation across files.
 #[derive(Debug, Serialize)]
 pub(crate) struct RemovePropertyResult {
+    /// User-defined frontmatter property name.
     pub(crate) property: String,
     /// Present when `remove --property K=V` was used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) value: Option<String>,
+    /// Vault-relative files whose content changed.
     pub(crate) modified: Vec<String>,
+    /// Vault-relative files left unchanged.
     pub(crate) skipped: Vec<String>,
     /// `skipped.len()`, restated as a scalar (iter-216 D-1) — the whole
     /// mutation family exposes this key so one query answers "how many were
@@ -32,16 +35,22 @@ pub(crate) struct RemovePropertyResult {
     /// `skipped`, so `modified: []` is no longer ambiguous between "nothing
     /// needed changing" and "nothing could be changed".
     pub(crate) skipped_detail: Vec<crate::commands::mutation::SkippedFile>,
+    /// Total number of considered items.
     pub(crate) total: usize,
+    /// Number of files scanned.
     pub(crate) scanned: usize,
+    /// Whether this result describes a preview without writing changes.
     pub(crate) dry_run: bool,
 }
 
 /// Result of a `remove --tag T` operation across files.
 #[derive(Debug, Serialize)]
 pub(crate) struct RemoveTagResult {
+    /// Tag being added or removed.
     pub(crate) tag: String,
+    /// Vault-relative files whose content changed.
     pub(crate) modified: Vec<String>,
+    /// Vault-relative files left unchanged.
     pub(crate) skipped: Vec<String>,
     /// `skipped.len()`, restated as a scalar (iter-216 D-1) — the whole
     /// mutation family exposes this key so one query answers "how many were
@@ -53,8 +62,11 @@ pub(crate) struct RemoveTagResult {
     /// `skipped`, so `modified: []` is no longer ambiguous between "nothing
     /// needed changing" and "nothing could be changed".
     pub(crate) skipped_detail: Vec<crate::commands::mutation::SkippedFile>,
+    /// Total number of considered items.
     pub(crate) total: usize,
+    /// Number of files scanned.
     pub(crate) scanned: usize,
+    /// Whether this result describes a preview without writing changes.
     pub(crate) dry_run: bool,
 }
 

--- a/crates/hyalo-cli/src/commands/set.rs
+++ b/crates/hyalo-cli/src/commands/set.rs
@@ -17,13 +17,16 @@ use hyalo_core::schema::SchemaConfig;
 /// Result of a `set --property K=V` operation across files.
 #[derive(Debug, Serialize)]
 pub(crate) struct SetPropertyResult {
+    /// User-defined frontmatter property name.
     pub(crate) property: String,
     /// The coerced value that was written to the frontmatter, not the raw input
     /// string. For a list assignment like `x=[a, b]` this echoes the parsed YAML
     /// list `["a", "b"]` rather than the literal `"[a, b]"` the user typed
     /// (iter-181 task 3).
     pub(crate) value: Value,
+    /// Vault-relative files whose content changed.
     pub(crate) modified: Vec<String>,
+    /// Vault-relative files left unchanged.
     pub(crate) skipped: Vec<String>,
     /// `skipped.len()`, restated as a scalar.
     ///
@@ -39,8 +42,11 @@ pub(crate) struct SetPropertyResult {
     /// `skipped`, so `modified: []` is no longer ambiguous between "nothing
     /// needed changing" and "nothing could be changed".
     pub(crate) skipped_detail: Vec<crate::commands::mutation::SkippedFile>,
+    /// Total number of considered items.
     pub(crate) total: usize,
+    /// Number of files scanned.
     pub(crate) scanned: usize,
+    /// Whether this result describes a preview without writing changes.
     pub(crate) dry_run: bool,
     /// Files where this `set` replaced an existing **list** value with a
     /// scalar (iter-262, UX-12 / DEC-270).
@@ -54,14 +60,18 @@ pub(crate) struct SetPropertyResult {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) list_collapsed: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Additional explanation of the mutation outcome.
     pub(crate) note: Option<String>,
 }
 
 /// Result of a `set --tag T` operation across files.
 #[derive(Debug, Serialize)]
 pub(crate) struct SetTagResult {
+    /// Tag being added or removed.
     pub(crate) tag: String,
+    /// Vault-relative files whose content changed.
     pub(crate) modified: Vec<String>,
+    /// Vault-relative files left unchanged.
     pub(crate) skipped: Vec<String>,
     /// `skipped.len()`, restated as a scalar — see [`SetPropertyResult::skipped_count`].
     pub(crate) skipped_count: usize,
@@ -71,8 +81,11 @@ pub(crate) struct SetTagResult {
     /// `skipped`, so `modified: []` is no longer ambiguous between "nothing
     /// needed changing" and "nothing could be changed".
     pub(crate) skipped_detail: Vec<crate::commands::mutation::SkippedFile>,
+    /// Total number of considered items.
     pub(crate) total: usize,
+    /// Number of files scanned.
     pub(crate) scanned: usize,
+    /// Whether this result describes a preview without writing changes.
     pub(crate) dry_run: bool,
 }
 

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -161,22 +161,32 @@ pub fn tags_summary(
 /// appeared in.
 #[derive(Debug, Serialize)]
 pub struct RenamedTag {
+    /// Original path or value.
     pub from: String,
+    /// Destination path or value.
     pub to: String,
+    /// Number of files containing this renamed tag.
     pub files: usize,
 }
 
 /// Result of a `tags rename` operation.
 #[derive(Debug, Serialize)]
 pub struct RenameTagResult {
+    /// Original path or value.
     pub from: String,
+    /// Destination path or value.
     pub to: String,
+    /// Whether this result describes a preview without writing changes.
     pub dry_run: bool,
+    /// Vault-relative files whose content changed.
     pub modified: Vec<String>,
     /// Every tag the rename actually touched, parent and children alike.
     pub renamed_tags: Vec<RenamedTag>,
+    /// Number of files left unchanged.
     pub skipped_count: usize,
+    /// Total number of considered items.
     pub total: usize,
+    /// Number of files scanned.
     pub scanned: usize,
 }
 

--- a/crates/hyalo-cli/src/commands/types.rs
+++ b/crates/hyalo-cli/src/commands/types.rs
@@ -13,7 +13,7 @@ use hyalo_core::discovery;
 use hyalo_core::frontmatter::{read_frontmatter, write_frontmatter_within};
 use hyalo_core::schema::{SchemaConfig, expand_default};
 
-use crate::output::{CommandOutcome, Format, format_error, format_success};
+use crate::output::{CommandOutcome, Format, format_error, format_output, format_success};
 
 const TOML_FILENAME: &str = ".hyalo.toml";
 
@@ -26,22 +26,21 @@ pub(crate) fn list_types(schema: &SchemaConfig) -> CommandOutcome {
     let mut sorted_types: Vec<&str> = schema.types.keys().map(String::as_str).collect();
     sorted_types.sort_unstable();
 
-    let results: Vec<Value> = sorted_types
+    let results: Vec<TypeListResult> = sorted_types
         .iter()
         .map(|name| {
             let ts = &schema.types[*name];
-            serde_json::json!({
-                "type": name,
-                "required": ts.required,
-                "has_filename_template": ts.filename_template.is_some(),
-                "property_count": ts.properties.len(),
-            })
+            TypeListResult {
+                r#type: name,
+                required: &ts.required,
+                has_filename_template: ts.filename_template.is_some(),
+                property_count: ts.properties.len(),
+            }
         })
         .collect();
 
     let total = results.len() as u64;
-    let val = serde_json::json!(results);
-    CommandOutcome::success_with_total(format_success(Format::Json, &val), total)
+    CommandOutcome::success_with_total(format_output(Format::Json, &results), total)
 }
 
 // ---------------------------------------------------------------------------
@@ -62,103 +61,22 @@ pub(crate) fn show_type(type_name: &str, schema: &SchemaConfig, format: Format) 
 
     let merged = schema.merged_schema_for_type(type_name);
 
-    // Serialize property constraints.
-    let props: serde_json::Map<String, Value> = merged
-        .properties
-        .iter()
-        .map(|(k, constraint)| {
-            let c_val = constraint_to_json(constraint);
-            (k.clone(), c_val)
-        })
-        .collect();
-
-    let val = serde_json::json!({
-        "type": type_name,
-        "required": merged.required,
-        "filename_template": merged.filename_template,
-        "defaults": merged.defaults,
-        "properties": props,
-        "required_sections": merged.required_sections,
-    });
+    let val = crate::output::output_value(
+        &(TypeShowResult {
+            r#type: type_name,
+            required: &merged.required,
+            filename_template: merged.filename_template.as_deref(),
+            defaults: &merged.defaults,
+            properties: merged
+                .properties
+                .iter()
+                .map(|(k, c)| (k.as_str(), ConstraintResult::from(c)))
+                .collect(),
+            required_sections: &merged.required_sections,
+        }),
+    );
 
     CommandOutcome::success(format_success(Format::Json, &val))
-}
-
-fn constraint_to_json(c: &hyalo_core::schema::PropertyConstraint) -> Value {
-    use hyalo_core::schema::PropertyConstraint;
-    match c {
-        PropertyConstraint::String {
-            pattern,
-            min_length,
-            max_length,
-        } => {
-            let mut obj = serde_json::Map::new();
-            obj.insert("type".to_owned(), Value::from("string"));
-            if let Some(pat) = pattern {
-                obj.insert("pattern".to_owned(), Value::from(pat.as_str()));
-            }
-            if let Some(min) = min_length {
-                obj.insert("min-length".to_owned(), Value::from(*min));
-            }
-            if let Some(max) = max_length {
-                obj.insert("max-length".to_owned(), Value::from(*max));
-            }
-            Value::Object(obj)
-        }
-        PropertyConstraint::Date => serde_json::json!({"type": "date"}),
-        PropertyConstraint::DateTime => serde_json::json!({"type": "datetime"}),
-        PropertyConstraint::DateTimeTz => serde_json::json!({"type": "datetime-tz"}),
-        PropertyConstraint::Number { minimum, maximum } => {
-            let mut obj = serde_json::Map::new();
-            obj.insert("type".to_owned(), Value::from("number"));
-            if let Some(min) = minimum {
-                obj.insert("minimum".to_owned(), Value::from(*min));
-            }
-            if let Some(max) = maximum {
-                obj.insert("maximum".to_owned(), Value::from(*max));
-            }
-            Value::Object(obj)
-        }
-        PropertyConstraint::Boolean => serde_json::json!({"type": "boolean"}),
-        PropertyConstraint::List => serde_json::json!({"type": "list"}),
-        PropertyConstraint::Enum { values } => {
-            serde_json::json!({"type": "enum", "values": values})
-        }
-        PropertyConstraint::StringList { item_pattern } => {
-            if let Some(pat) = item_pattern {
-                serde_json::json!({"type": "string-list", "item_pattern": pat})
-            } else {
-                serde_json::json!({"type": "string-list"})
-            }
-        }
-        PropertyConstraint::ObjectList {
-            required_keys,
-            allowed_keys,
-            key_patterns,
-        } => {
-            // Key names mirror the TOML spelling so the output doubles as a
-            // template for `.hyalo.toml` (DEC-287).
-            let mut obj = serde_json::Map::new();
-            obj.insert("type".to_owned(), Value::from("object-list"));
-            obj.insert(
-                "required-keys".to_owned(),
-                Value::from(required_keys.clone()),
-            );
-            if let Some(allowed) = allowed_keys {
-                obj.insert("allowed-keys".to_owned(), Value::from(allowed.clone()));
-            }
-            if !key_patterns.is_empty() {
-                // serde_json's map sorts keys, so the JSON (and the text block
-                // rendered from it) lists the patterns alphabetically.
-                let patterns: serde_json::Map<String, Value> = key_patterns
-                    .iter()
-                    .map(|(k, v)| (k.clone(), Value::from(v.as_str())))
-                    .collect();
-                obj.insert("key-patterns".to_owned(), Value::Object(patterns));
-            }
-            Value::Object(obj)
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -205,13 +123,13 @@ pub(crate) fn remove_type(dir: &Path, type_name: &str, format: Format) -> Result
 
     write_toml_doc(&toml_path, &doc)?;
 
-    let val = serde_json::json!({
-        "action": "removed",
-        "type": type_name,
-        // iter-256 COH-9: `types remove` has no --dry-run; the key is still
-        // emitted so `.results.dry_run` answers "did this write?" uniformly.
-        "dry_run": false,
-    });
+    let val = crate::output::output_value(
+        &(TypeRemoveResult {
+            action: "removed",
+            r#type: type_name,
+            dry_run: false,
+        }),
+    );
     Ok(CommandOutcome::success(format_success(Format::Json, &val)))
 }
 
@@ -518,7 +436,7 @@ pub(crate) fn set_type(
     }
 
     // --- Side effects: --default auto-apply ---
-    let mut defaults_applied: Vec<Value> = Vec::new();
+    let mut defaults_applied: Vec<DefaultAppliedOwned> = Vec::new();
 
     if !defaults_map.is_empty() {
         let all_vault_files = discovery::discover_files(dir)?;
@@ -573,12 +491,12 @@ pub(crate) fn set_type(
             let expanded = expanded_defaults.get(key).cloned().unwrap_or_default();
             let applied_files = per_default_files.get(key).cloned().unwrap_or_default();
             let count = applied_files.len();
-            defaults_applied.push(serde_json::json!({
-                "property": key,
-                "value": expanded,
-                "files": applied_files,
-                "count": count,
-            }));
+            defaults_applied.push(DefaultAppliedOwned {
+                property: key.to_owned(),
+                value: expanded,
+                files: applied_files,
+                count,
+            });
         }
     }
 
@@ -586,7 +504,7 @@ pub(crate) fn set_type(
     let needs_violation_check =
         !required_fields.is_empty() || !prop_type_map.is_empty() || !prop_values_map.is_empty();
 
-    let mut constraint_violations: Vec<Value> = Vec::new();
+    let mut constraint_violations: Vec<ConstraintViolationsOwned> = Vec::new();
 
     if needs_violation_check && !dry_run {
         let updated_schema = load_schema_from_doc(&doc)?;
@@ -622,23 +540,29 @@ pub(crate) fn set_type(
         )?;
 
         if counts.errors > 0 || counts.warnings > 0 {
-            constraint_violations.push(serde_json::json!({
-                "file_count": counts.files_with_issues,
-                "error_count": counts.errors,
-                "warning_count": counts.warnings,
-                "message": "Run `hyalo lint` for details.",
-            }));
+            constraint_violations.push(ConstraintViolationsOwned {
+                file_count: counts.files_with_issues,
+                error_count: counts.errors,
+                warning_count: counts.warnings,
+                message: "Run `hyalo lint` for details.",
+            });
         }
     }
 
-    let val = serde_json::json!({
-        "action": if is_new { "created_and_updated" } else { "updated" },
-        "type": type_name,
-        "dry_run": dry_run,
-        "toml_changes": toml_changes,
-        "defaults_applied": defaults_applied,
-        "constraint_violations": constraint_violations,
-    });
+    let val = crate::output::output_value(
+        &(TypeSetResult {
+            action: if is_new {
+                "created_and_updated"
+            } else {
+                "updated"
+            },
+            r#type: type_name,
+            dry_run,
+            toml_changes: &toml_changes,
+            defaults_applied: &defaults_applied,
+            constraint_violations: &constraint_violations,
+        }),
+    );
 
     Ok(CommandOutcome::success(format_success(Format::Json, &val)))
 }
@@ -1532,5 +1456,178 @@ pub(crate) fn run(
             effective_format,
             ctx.case_insensitive_mode,
         ),
+    }
+}
+
+/// Serialized TypeListResult command contract.
+#[derive(serde::Serialize)]
+struct TypeListResult<'a> {
+    /// Schema type name.
+    #[serde(rename = "type")]
+    r#type: &'a str,
+    /// Required property names.
+    required: &'a [String],
+    /// Whether a filename template is configured.
+    has_filename_template: bool,
+    /// Number of local property constraints.
+    property_count: usize,
+}
+
+/// Serialized TypeShowResult command contract.
+#[derive(serde::Serialize)]
+struct TypeShowResult<'a> {
+    /// Schema type name.
+    #[serde(rename = "type")]
+    r#type: &'a str,
+    /// Merged required property names.
+    required: &'a [String],
+    /// Filename template, or null when unset.
+    filename_template: Option<&'a str>,
+    /// User-named property default templates.
+    defaults: &'a HashMap<String, String>,
+    /// Typed constraints keyed by user-defined property name.
+    properties: std::collections::BTreeMap<&'a str, ConstraintResult<'a>>,
+    /// Required body sections in order.
+    required_sections: &'a [String],
+}
+
+/// Serialized TypeRemoveResult command contract.
+#[derive(serde::Serialize)]
+struct TypeRemoveResult<'a> {
+    /// Configuration mutation action.
+    action: &'a str,
+    /// Removed schema type.
+    #[serde(rename = "type")]
+    r#type: &'a str,
+    /// Whether this is a preview; always false for remove.
+    dry_run: bool,
+}
+
+/// Serialized TypeSetResult command contract.
+#[derive(serde::Serialize)]
+struct TypeSetResult<'a> {
+    /// Configuration mutation action.
+    action: &'a str,
+    /// Updated schema type.
+    #[serde(rename = "type")]
+    r#type: &'a str,
+    /// Whether this is a preview.
+    dry_run: bool,
+    /// Descriptions of planned configuration changes.
+    toml_changes: &'a [String],
+    /// Defaults applied to existing documents.
+    defaults_applied: &'a [DefaultAppliedOwned],
+    /// Aggregated violations after updating the schema.
+    constraint_violations: &'a [ConstraintViolationsOwned],
+}
+
+/// A default applied to existing documents.
+#[derive(serde::Serialize)]
+struct DefaultAppliedOwned {
+    /// User-defined property name.
+    property: String,
+    /// Expanded default text.
+    value: String,
+    /// Affected vault-relative files.
+    files: Vec<String>,
+    /// Number of affected files.
+    count: usize,
+}
+/// Aggregated schema violations following a type mutation.
+#[derive(serde::Serialize)]
+struct ConstraintViolationsOwned {
+    /// Number of files with violations.
+    file_count: usize,
+    /// Number of errors.
+    error_count: usize,
+    /// Number of warnings.
+    warning_count: usize,
+    /// Follow-up guidance.
+    message: &'static str,
+}
+
+/// Serialized ConstraintResult command contract.
+#[derive(Default, serde::Serialize)]
+struct ConstraintResult<'a> {
+    /// Constraint kind.
+    #[serde(rename = "type")]
+    r#type: &'a str,
+    /// String pattern when configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pattern: Option<&'a str>,
+    /// Minimum string length.
+    #[serde(rename = "min-length", skip_serializing_if = "Option::is_none")]
+    min_length: Option<usize>,
+    /// Maximum string length.
+    #[serde(rename = "max-length", skip_serializing_if = "Option::is_none")]
+    max_length: Option<usize>,
+    /// Minimum numeric value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minimum: Option<f64>,
+    /// Maximum numeric value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    maximum: Option<f64>,
+    /// Allowed enum values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    values: Option<&'a [String]>,
+    /// Pattern applied to each string-list item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    item_pattern: Option<&'a str>,
+    /// Required keys for object-list entries, including an empty list.
+    #[serde(rename = "required-keys", skip_serializing_if = "Option::is_none")]
+    required_keys: Option<&'a [String]>,
+    /// Allowed keys for object-list entries.
+    #[serde(rename = "allowed-keys", skip_serializing_if = "Option::is_none")]
+    allowed_keys: Option<&'a [String]>,
+    /// Patterns keyed by user-defined object field name.
+    #[serde(rename = "key-patterns", skip_serializing_if = "Option::is_none")]
+    key_patterns: Option<&'a indexmap::IndexMap<String, String>>,
+}
+
+impl<'a> From<&'a hyalo_core::schema::PropertyConstraint> for ConstraintResult<'a> {
+    fn from(c: &'a hyalo_core::schema::PropertyConstraint) -> Self {
+        use hyalo_core::schema::PropertyConstraint;
+        let mut out = Self::default();
+        out.r#type = match c {
+            PropertyConstraint::String {
+                pattern,
+                min_length,
+                max_length,
+            } => {
+                out.pattern = pattern.as_deref();
+                out.min_length = *min_length;
+                out.max_length = *max_length;
+                "string"
+            }
+            PropertyConstraint::Date => "date",
+            PropertyConstraint::DateTime => "datetime",
+            PropertyConstraint::DateTimeTz => "datetime-tz",
+            PropertyConstraint::Number { minimum, maximum } => {
+                out.minimum = *minimum;
+                out.maximum = *maximum;
+                "number"
+            }
+            PropertyConstraint::Boolean => "boolean",
+            PropertyConstraint::List => "list",
+            PropertyConstraint::Enum { values } => {
+                out.values = Some(values);
+                "enum"
+            }
+            PropertyConstraint::StringList { item_pattern } => {
+                out.item_pattern = item_pattern.as_deref();
+                "string-list"
+            }
+            PropertyConstraint::ObjectList {
+                required_keys,
+                allowed_keys,
+                key_patterns,
+            } => {
+                out.required_keys = Some(required_keys);
+                out.allowed_keys = allowed_keys.as_deref();
+                out.key_patterns = (!key_patterns.is_empty()).then_some(key_patterns);
+                "object-list"
+            }
+        };
+        out
     }
 }

--- a/crates/hyalo-cli/src/commands/views.rs
+++ b/crates/hyalo-cli/src/commands/views.rs
@@ -53,17 +53,12 @@ pub(crate) fn load_views(dir: &Path) -> HashMap<String, FindFilters> {
 /// List all saved views.
 pub(crate) fn list_views(dir: &Path, _format: Format) -> Result<CommandOutcome> {
     let views = load_views(dir);
-    let mut items: Vec<serde_json::Value> = Vec::new();
+    let mut items: Vec<ViewResult> = Vec::new();
     let mut sorted_keys: Vec<&String> = views.keys().collect();
     sorted_keys.sort();
     for name in sorted_keys {
         let filters = &views[name];
-        let filters_json =
-            serde_json::to_value(filters).context("failed to serialize view filters")?;
-        items.push(serde_json::json!({
-            "name": name,
-            "filters": filters_json,
-        }));
+        items.push(ViewResult { name, filters });
     }
     let total = items.len() as u64;
     let output = serde_json::to_string_pretty(&items).context("failed to serialize views list")?;
@@ -135,10 +130,10 @@ pub(crate) fn set_view(
 
     write_toml_doc(&toml_path, &doc)?;
 
-    let output = serde_json::to_string_pretty(&serde_json::json!({
-        "action": "set",
-        "name": name,
-    }))
+    let output = serde_json::to_string_pretty(&ViewMutationResult {
+        action: "set",
+        name,
+    })
     .context("failed to serialize result")?;
     Ok(CommandOutcome::success(output))
 }
@@ -175,10 +170,10 @@ pub(crate) fn remove_view(dir: &Path, name: &str, format: Format) -> Result<Comm
 
     write_toml_doc(&toml_path, &doc)?;
 
-    let output = serde_json::to_string_pretty(&serde_json::json!({
-        "action": "removed",
-        "name": name,
-    }))
+    let output = serde_json::to_string_pretty(&ViewMutationResult {
+        action: "removed",
+        name,
+    })
     .context("failed to serialize result")?;
     Ok(CommandOutcome::success(output))
 }
@@ -658,4 +653,22 @@ pub(crate) fn run(
             }
         }
     }
+}
+
+/// Serialized ViewResult command contract.
+#[derive(serde::Serialize)]
+struct ViewResult<'a> {
+    /// Saved view name.
+    name: &'a str,
+    /// Typed saved find filters.
+    filters: &'a FindFilters,
+}
+
+/// Serialized ViewMutationResult command contract.
+#[derive(serde::Serialize)]
+struct ViewMutationResult<'a> {
+    /// Configuration mutation action.
+    action: &'a str,
+    /// Saved view name.
+    name: &'a str,
 }

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -51,9 +51,11 @@ pub struct BodySearchSuggestion {
 }
 
 /// A single drill-down hint: a concrete command plus a short human-readable description.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Hint {
+    /// Human-readable purpose of the suggested command.
     pub(crate) description: String,
+    /// Concrete command to run, or empty for advice-only hints.
     pub(crate) cmd: String,
     /// `true` when running `cmd` would modify the vault or `.hyalo.toml`.
     ///

--- a/crates/hyalo-cli/src/output.rs
+++ b/crates/hyalo-cli/src/output.rs
@@ -1,10 +1,10 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use jaq_core::{Native, data};
 use jaq_json::Val;
 use serde::Serialize;
-use serde_json::json;
 
 // ---------------------------------------------------------------------------
 // Filter cache
@@ -140,7 +140,8 @@ pub(crate) fn sanitize_control_chars(s: &str) -> String {
         .collect()
 }
 
-/// Format a successful JSON value for output.
+/// Format an already-materialized JSON value without copying its tree.
+/// Typed contracts enter through [`format_output`] instead.
 #[must_use]
 pub fn format_success(format: Format, value: &serde_json::Value) -> String {
     match format {
@@ -161,21 +162,113 @@ pub fn format_success(format: Format, value: &serde_json::Value) -> String {
 /// can operate on a uniform representation.
 #[must_use]
 pub fn format_output<T: Serialize>(format: Format, value: &T) -> String {
-    let json = serde_json::to_value(value).expect("derived Serialize impl should not fail");
-    format_success(format, &json)
+    format_success(format, &output_value(value))
 }
 
-/// Serialize one hint for the JSON envelope.
-///
-/// `writes` is always present (never omitted when `false`) so a consumer can
-/// filter on it without having to distinguish "absent" from "read-only"
-/// (iter-201, M-7).
-fn hint_to_json(hint: &crate::hints::Hint) -> serde_json::Value {
-    serde_json::json!({
-        "description": &hint.description,
-        "cmd": &hint.cmd,
-        "writes": hint.writes,
-    })
+/// Convert a derived output contract to the sorted JSON representation used by
+/// the text/jq boundary. This retains the historic alphabetical object ordering.
+/// Output contracts contain only JSON-compatible fields and string map keys.
+pub(crate) fn output_value<T: Serialize>(value: &T) -> serde_json::Value {
+    serde_json::to_value(value).expect("derived Serialize impl should not fail")
+}
+
+/// Successful output contract. Optional metadata is omitted, including all
+/// counters when no file list was supplied; hints are always an array.
+#[derive(Serialize)]
+pub struct Envelope<'a, T: Serialize> {
+    /// Optional vault directory hoisted from the command result.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) dir: Option<String>,
+    /// Missing paths from an explicitly supplied file list, including zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) files_missing: Option<u64>,
+    /// Non-Markdown paths skipped from the supplied file list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) files_skipped_non_md: Option<u64>,
+    /// Paths outside the vault skipped from the supplied file list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) files_skipped_outside_vault: Option<u64>,
+    /// Read-only suggestions and explicitly marked mutation suggestions.
+    pub(crate) hints: &'a [crate::hints::Hint],
+    /// Named command output; arrays contain named result items.
+    pub(crate) results: T,
+    /// Total matching items before pagination, omitted for non-list commands.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) total: Option<u64>,
+}
+
+impl<'a, T: Serialize> Envelope<'a, T> {
+    pub(crate) fn new(results: T, total: Option<u64>, hints: &'a [crate::hints::Hint]) -> Self {
+        Self {
+            dir: None,
+            files_missing: None,
+            files_skipped_non_md: None,
+            files_skipped_outside_vault: None,
+            hints,
+            results,
+            total,
+        }
+    }
+}
+
+impl<'a> Envelope<'a, Cow<'a, serde_json::Value>> {
+    /// Adapt the pipeline's erased result at its boundary, preserving the
+    /// historical summary directory hoist. Results stay borrowed unless the
+    /// hoist requires removing a directory key. Config constructs its envelope
+    /// directly because its inner directory is intentionally retained.
+    pub(crate) fn from_result(
+        value: &'a serde_json::Value,
+        total: Option<u64>,
+        hints: &'a [crate::hints::Hint],
+        counters: Option<&crate::commands::files_from::FilesFromCounters>,
+    ) -> Self {
+        let mut envelope = Self::new(Cow::Borrowed(value), total, hints);
+        if let Some(dir) = value.get("dir").and_then(serde_json::Value::as_str) {
+            envelope.dir = Some(dir.to_owned());
+            if let Some(result) = envelope.results.to_mut().as_object_mut() {
+                result.remove("dir");
+            }
+        }
+        if let Some(c) = counters {
+            envelope.files_missing = Some(c.files_missing);
+            envelope.files_skipped_non_md = Some(c.files_skipped_non_md);
+            envelope.files_skipped_outside_vault = Some(c.files_skipped_outside_vault);
+        }
+        envelope
+    }
+}
+
+/// Exit-1 error contract; the singular `hint` key is intentional.
+#[derive(Serialize)]
+struct ErrorEnvelope<'a> {
+    /// Underlying diagnostic, omitted when there is no additional cause.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cause: Option<&'a str>,
+    /// User-facing description of the failure.
+    error: &'a str,
+    /// Suggested recovery action, omitted when unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hint: Option<&'a str>,
+    /// Relevant path, omitted for failures unrelated to a specific path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<&'a str>,
+}
+
+/// Specialized frontmatter budget refusal, preserving its distinct wire shape.
+#[derive(Serialize)]
+struct BudgetErrorEnvelope<'a> {
+    /// Description of the size-budget failure.
+    error: &'a str,
+    /// Sanitized file path.
+    file: &'a str,
+    /// Maximum allowed frontmatter bytes.
+    limit_bytes: usize,
+    /// Maximum allowed frontmatter lines.
+    limit_lines: usize,
+    /// Proposed frontmatter bytes.
+    would_be_bytes: usize,
+    /// Proposed frontmatter lines.
+    would_be_lines: usize,
 }
 
 /// Append the `-> hyalo …` drill-down block to text output.
@@ -218,44 +311,6 @@ fn append_hint_lines(text: &mut String, hints: &[crate::hints::Hint]) {
     }
 }
 
-/// Build the JSON envelope value: `{"results": ..., "total": <optional>, "hints": [...]}`.
-///
-/// The envelope is always present even when hints is empty (hints becomes `[]`).
-/// `total` is included only when `Some`.
-#[must_use]
-pub fn build_envelope_value(
-    value: &serde_json::Value,
-    total: Option<u64>,
-    hints: &[crate::hints::Hint],
-) -> serde_json::Value {
-    let hints_json: Vec<serde_json::Value> = hints.iter().map(hint_to_json).collect();
-    let mut envelope = serde_json::json!({
-        "results": value,
-        "hints": hints_json,
-    });
-    if let Some(t) = total {
-        envelope["total"] = serde_json::json!(t);
-    }
-    // Hoist a top-level `dir` field when results carry one (e.g. `summary`),
-    // so consumers can read it without traversing into `results`. This matches
-    // the shape of `hyalo config --format json`, which surfaces `dir` at the
-    // top level. After hoisting, strip `dir` from the inner results so it
-    // is not duplicated at both `.dir` and `.results.dir` (NEW-5).
-    if let Some(dir) = value
-        .as_object()
-        .and_then(|o| o.get("dir"))
-        .and_then(serde_json::Value::as_str)
-    {
-        envelope["dir"] = serde_json::json!(dir);
-        // Remove from the results copy (envelope["results"] is already cloned
-        // by the json! macro above so the borrow on `value` is no longer active).
-        if let Some(obj) = envelope["results"].as_object_mut() {
-            obj.remove("dir");
-        }
-    }
-    envelope
-}
-
 /// Format the output envelope for the user.
 ///
 /// - **JSON**: serializes `{"results": ..., "total": <optional>, "hints": [...]}`
@@ -269,7 +324,7 @@ pub fn format_envelope(
 ) -> String {
     match format {
         Format::Json | Format::Github => {
-            let envelope = build_envelope_value(value, total, hints);
+            let envelope = output_value(&Envelope::from_result(value, total, hints, None));
             serde_json::to_string_pretty(&envelope)
                 .expect("serializing serde_json::Value is infallible")
         }
@@ -448,19 +503,15 @@ pub fn format_error(
     cause: Option<&str>,
 ) -> String {
     match format {
-        Format::Json | Format::Github => {
-            let mut obj = json!({"error": error});
-            if let Some(p) = path {
-                obj["path"] = json!(p);
-            }
-            if let Some(h) = hint {
-                obj["hint"] = json!(h);
-            }
-            if let Some(c) = cause {
-                obj["cause"] = json!(c);
-            }
-            serde_json::to_string_pretty(&obj).expect("serializing serde_json::Value is infallible")
-        }
+        Format::Json | Format::Github => format_output(
+            Format::Json,
+            &ErrorEnvelope {
+                cause,
+                error,
+                hint,
+                path,
+            },
+        ),
         Format::Text => {
             // iter-267 (UX-18): lowercase `error:`, matching clap's own parse
             // errors and the Rust CLI convention. The two prefixes used to
@@ -497,17 +548,17 @@ pub fn format_budget_error(
 ) -> String {
     let safe_file = sanitize_control_chars(&e.file);
     match format {
-        Format::Json | Format::Github => {
-            let obj = serde_json::json!({
-                "error": "frontmatter would exceed size budget",
-                "limit_bytes": e.limit_bytes,
-                "would_be_bytes": e.would_be_bytes,
-                "limit_lines": e.limit_lines,
-                "would_be_lines": e.would_be_lines,
-                "file": safe_file,
-            });
-            serde_json::to_string_pretty(&obj).expect("serializing serde_json::Value is infallible")
-        }
+        Format::Json | Format::Github => format_output(
+            Format::Json,
+            &BudgetErrorEnvelope {
+                error: "frontmatter would exceed size budget",
+                file: &safe_file,
+                limit_bytes: e.limit_bytes,
+                limit_lines: e.limit_lines,
+                would_be_bytes: e.would_be_bytes,
+                would_be_lines: e.would_be_lines,
+            },
+        ),
         Format::Text => {
             format!(
                 "error: frontmatter would exceed size budget\n  file: {}\n  would_be_bytes: {} (limit {})\n  would_be_lines: {} (limit {})",

--- a/crates/hyalo-cli/src/output/tests.rs
+++ b/crates/hyalo-cli/src/output/tests.rs
@@ -1483,7 +1483,7 @@ fn envelope_hoists_dir_and_removes_from_results() {
         "files": {"total": 10},
         "other": "value"
     });
-    let envelope = build_envelope_value(&results, None, &[]);
+    let envelope = output_value(&Envelope::from_result(&results, None, &[], None));
     // dir is hoisted to top level.
     assert_eq!(
         envelope["dir"].as_str().unwrap(),
@@ -1505,7 +1505,7 @@ fn envelope_hoists_dir_and_removes_from_results() {
 #[test]
 fn envelope_without_dir_in_results_has_no_top_dir() {
     let results = json!({"files": {"total": 5}});
-    let envelope = build_envelope_value(&results, None, &[]);
+    let envelope = output_value(&Envelope::from_result(&results, None, &[], None));
     assert!(
         envelope.get("dir").is_none() || envelope["dir"].is_null(),
         "no dir should be at envelope root when results has none"
@@ -1547,4 +1547,26 @@ fn a_projected_file_object_still_renders_its_optional_sections() {
     let map = payload.as_object().unwrap().clone();
     let filter = build_file_object_filter(&map);
     assert_eq!(jq(&filter, &payload).unwrap(), "\"a.md\"\n  title: Alpha");
+}
+
+#[test]
+fn envelope_borrows_results_unless_a_directory_must_be_hoisted() {
+    for results in [
+        json!([{"file": "a.md", "content": "body"}]),
+        json!({"dir": null}),
+    ] {
+        let envelope = Envelope::from_result(&results, None, &[], None);
+        assert!(
+            matches!(envelope.results, Cow::Borrowed(value) if std::ptr::eq(value, &raw const results))
+        );
+    }
+    let results = json!({"dir": "/vault", "files": ["a.md"]});
+    let envelope = Envelope::from_result(&results, None, &[], None);
+    assert!(matches!(envelope.results, Cow::Owned(_)));
+    assert_eq!(envelope.dir.as_deref(), Some("/vault"));
+    assert!(envelope.results.get("dir").is_none());
+    assert_eq!(
+        results["dir"], "/vault",
+        "hoisting must not mutate the caller"
+    );
 }

--- a/crates/hyalo-cli/src/output_pipeline.rs
+++ b/crates/hyalo-cli/src/output_pipeline.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use crate::commands::files_from::FilesFromCounters;
 use crate::hints::{FilesFromCounterSummary, HintContext, generate_hints_with_counters};
-use crate::output::{CommandOutcome, Format, apply_jq_filter_result, build_envelope_value};
+use crate::output::{CommandOutcome, Envelope, Format, apply_jq_filter_result, output_value};
 
 /// Error message for `--count` on non-list commands (shared across match arms).
 ///
@@ -37,43 +37,6 @@ pub(crate) struct OutputPipeline<'a> {
     /// resolves annotations against the repo root. Empty when the vault dir is
     /// the CWD. Only consulted when `user_format == Format::Github`.
     pub github_path_prefix: String,
-}
-
-/// Inject `files_missing`, `files_skipped_non_md`, and `files_skipped_outside_vault`
-/// counters as **top-level** envelope keys when `--files-from` was used.
-///
-/// When `counters` is `None` (no `--files-from` on this invocation, and not a
-/// command that always reports them), the envelope is left untouched and the
-/// fields are omitted entirely. When `counters` is `Some`, all three fields are
-/// written — including zero values — so consumers can reliably distinguish
-/// "used `--files-from`, zero skips" from "`--files-from` was not used".
-///
-/// iter-264 (BUG-22): the counters used to live *inside* `results`, which meant
-/// `find --files-from -` promoted its result array to
-/// `{"files": [...], "files_missing": N, …}` while `find --file` returned the
-/// bare array — the same query answered in two shapes, so `.results[0]` worked
-/// for one and not the other. They are siblings of `results` now, next to
-/// `total` and `hints`, and `results` keeps whatever shape the command gives it.
-fn inject_files_from_counters(
-    envelope: &mut serde_json::Value,
-    counters: Option<&FilesFromCounters>,
-) {
-    let Some(c) = counters else { return };
-    let Some(envelope_obj) = envelope.as_object_mut() else {
-        return;
-    };
-    envelope_obj.insert(
-        "files_missing".to_owned(),
-        serde_json::json!(c.files_missing),
-    );
-    envelope_obj.insert(
-        "files_skipped_non_md".to_owned(),
-        serde_json::json!(c.files_skipped_non_md),
-    );
-    envelope_obj.insert(
-        "files_skipped_outside_vault".to_owned(),
-        serde_json::json!(c.files_skipped_outside_vault),
-    );
 }
 
 impl OutputPipeline<'_> {
@@ -190,8 +153,12 @@ impl OutputPipeline<'_> {
 
                 if let Some(filter) = self.jq_filter {
                     // Build the full envelope first so jq can address any field.
-                    let mut envelope = build_envelope_value(&value, total, &hints);
-                    inject_files_from_counters(&mut envelope, self.files_from_counters.as_ref());
+                    let envelope = output_value(&Envelope::from_result(
+                        &value,
+                        total,
+                        &hints,
+                        self.files_from_counters.as_ref(),
+                    ));
                     match apply_jq_filter_result(filter, &envelope) {
                         Ok(filtered) => println!("{filtered}"),
                         Err(e) => {
@@ -207,8 +174,12 @@ impl OutputPipeline<'_> {
                         }
                     }
                 } else {
-                    let mut envelope = build_envelope_value(&value, total, &hints);
-                    inject_files_from_counters(&mut envelope, self.files_from_counters.as_ref());
+                    let envelope = output_value(&Envelope::from_result(
+                        &value,
+                        total,
+                        &hints,
+                        self.files_from_counters.as_ref(),
+                    ));
                     let formatted = crate::output::format_prebuilt_envelope(
                         self.user_format,
                         &envelope,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -89,7 +89,12 @@ fn emit_init_report(
         );
         return Ok(());
     }
-    let envelope = crate::output::build_envelope_value(&report.to_json(), None, &[]);
+    let envelope = crate::output::output_value(&crate::output::Envelope::from_result(
+        &report.to_json(),
+        None,
+        &[],
+        None,
+    ));
     if let Some(filter) = jq {
         return match crate::output::apply_jq_filter_result(filter, &envelope) {
             Ok(filtered) => {

--- a/crates/hyalo-cli/templates/pi/package.json
+++ b/crates/hyalo-cli/templates/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyalo-pi",
-  "version": "0.1.1",
+  "version": "0.22.0",
   "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
   "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
   "pi": {

--- a/crates/hyalo-core/src/link_fix.rs
+++ b/crates/hyalo-core/src/link_fix.rs
@@ -49,8 +49,11 @@ use crate::scanner::{LineClass, LineScanner, MAX_FILE_SIZE, lines_with_rest};
 /// A single broken link with source file, line number, and raw target.
 #[derive(Debug, Clone, Serialize)]
 pub struct BrokenLinkInfo {
+    /// Vault-relative file containing the authored link.
     pub source: String,
+    /// One-based source line number.
     pub line: usize,
+    /// Resolved or authored link target, according to the command.
     pub target: String,
     /// The vault files an *ambiguous* target matches (iter-275, ALIAS-5 /
     /// BUG-26) — two files sharing a basename stem, or two notes declaring
@@ -66,7 +69,9 @@ pub struct BrokenLinkInfo {
 /// Summary of broken link detection across the vault.
 #[derive(Debug, Clone, Serialize)]
 pub struct BrokenLinkReport {
+    /// Total links reported for this result.
     pub total_links: usize,
+    /// Number of unresolved links.
     pub broken: Vec<BrokenLinkInfo>,
     /// Links that resolve via case-insensitive fallback but whose written casing
     /// differs from the canonical on-disk path.  These are NOT broken — the

--- a/crates/hyalo-core/src/types.rs
+++ b/crates/hyalo-core/src/types.rs
@@ -14,9 +14,12 @@ use serde::{Deserialize, Serialize};
 /// Used by `properties` (aggregate summary).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PropertyInfo {
+    /// Name of this entry.
     pub name: String,
     #[serde(rename = "type")]
+    /// Inferred property type name.
     pub prop_type: String,
+    /// User-authored property value; the value shape is genuinely dynamic.
     pub value: serde_json::Value,
 }
 
@@ -24,9 +27,12 @@ pub struct PropertyInfo {
 /// Used by `properties` command and `summary`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PropertySummaryEntry {
+    /// Name of this entry.
     pub name: String,
     #[serde(rename = "type")]
+    /// Inferred property type name.
     pub prop_type: String,
+    /// Number of matching occurrences.
     pub count: usize,
     /// Present only when the property has inconsistent types across files.
     /// Each entry is `(type_name, file_count)` for that type variant.
@@ -39,7 +45,9 @@ pub struct PropertySummaryEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MixedTypeEntry {
     #[serde(rename = "type")]
+    /// Inferred property type name.
     pub prop_type: String,
+    /// Number of matching occurrences.
     pub count: usize,
 }
 
@@ -51,14 +59,18 @@ pub struct MixedTypeEntry {
 /// Used by `tags` command and `summary`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TagSummary {
+    /// Tag occurrence summary.
     pub tags: Vec<TagSummaryEntry>,
+    /// Total number of considered items.
     pub total: usize,
 }
 
 /// A single tag with its file count.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TagSummaryEntry {
+    /// Name of this entry.
     pub name: String,
+    /// Number of matching occurrences.
     pub count: usize,
 }
 
@@ -181,8 +193,11 @@ pub fn is_note_graph_edge(target: &str, external: bool, is_attachment: bool) -> 
 /// Used by `find` (links field).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinkInfo {
+    /// Resolved or authored link target, according to the command.
     pub target: String,
+    /// Path associated with this result.
     pub path: Option<String>,
+    /// Authored link display label, when present.
     pub label: Option<String>,
     /// What this link is: `wikilink` | `embed` | `markdown` | `external` |
     /// `attachment` (iter-261, dogfood UX-6). Always serialized — a link
@@ -262,9 +277,12 @@ pub const LINK_VIA_ALIAS: &str = "alias";
 /// Used by `find` (backlinks field).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BacklinkInfo {
+    /// Vault-relative file containing the authored link.
     pub source: String,
+    /// One-based source line number.
     pub line: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Authored link display label, when present.
     pub label: Option<String>,
 }
 
@@ -275,7 +293,9 @@ pub struct BacklinkInfo {
 /// Task checkbox counts within a section.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskCount {
+    /// Total number of considered items.
     pub total: usize,
+    /// Number of checked tasks.
     pub done: usize,
 }
 
@@ -283,12 +303,18 @@ pub struct TaskCount {
 /// Used by `find` (sections field).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutlineSection {
+    /// ATX heading level (one through six).
     pub level: u8,
+    /// Heading text, or null for the preamble.
     pub heading: Option<String>,
+    /// One-based source line number.
     pub line: usize,
+    /// Link targets occurring within this section.
     pub links: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Task checkbox counts.
     pub tasks: Option<TaskCount>,
+    /// Languages of fenced code blocks in the section.
     pub code_blocks: Vec<String>,
 }
 
@@ -300,9 +326,13 @@ pub struct OutlineSection {
 /// Used by `task read`, `task toggle`, `task set`.
 #[derive(Debug, Clone, Serialize)]
 pub struct TaskInfo {
+    /// One-based source line number.
     pub line: usize,
+    /// Task checkbox marker or grouped status value.
     pub status: char,
+    /// Authored task text without its checkbox marker.
     pub text: String,
+    /// Whether the task is checked.
     pub done: bool,
 }
 
@@ -310,10 +340,15 @@ pub struct TaskInfo {
 /// Used by `task read`, `task toggle`, `task set`.
 #[derive(Debug, Clone, Serialize)]
 pub struct TaskReadResult {
+    /// Vault-relative Markdown file path.
     pub file: String,
+    /// One-based source line number.
     pub line: usize,
+    /// Task checkbox marker or grouped status value.
     pub status: char,
+    /// Authored task text without its checkbox marker.
     pub text: String,
+    /// Whether the task is checked.
     pub done: bool,
 }
 
@@ -323,11 +358,17 @@ pub struct TaskReadResult {
 /// change explicit.
 #[derive(Debug, Clone, Serialize)]
 pub struct TaskDryRunResult {
+    /// Vault-relative Markdown file path.
     pub file: String,
+    /// One-based source line number.
     pub line: usize,
+    /// Task checkbox marker before the proposed change.
     pub old_status: char,
+    /// Task checkbox marker or grouped status value.
     pub status: char,
+    /// Authored task text without its checkbox marker.
     pub text: String,
+    /// Whether the task is checked.
     pub done: bool,
 }
 
@@ -338,7 +379,9 @@ pub struct TaskDryRunResult {
 /// Lint violation counts for the vault summary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LintSummary {
+    /// Number of error-severity violations.
     pub errors: usize,
+    /// Number of warning-severity violations.
     pub warnings: usize,
     /// Number of files with at least one schema violation.
     ///
@@ -354,14 +397,23 @@ pub struct LintSummary {
 pub struct VaultSummary {
     /// Resolved vault directory (display string).
     pub dir: String,
+    /// File counts and directory breakdown.
     pub files: FileCounts,
+    /// Files with neither inbound nor outbound links.
     pub orphans: usize,
+    /// Files with inbound links and no outbound links.
     pub dead_ends: usize,
+    /// Vault-wide link health counts.
     pub links: LinkHealthSummary,
+    /// Property usage and value summaries.
     pub properties: Vec<PropertySummaryEntry>,
+    /// Tag occurrence summary.
     pub tags: TagSummary,
+    /// Task checkbox marker or grouped status value.
     pub status: Vec<StatusGroup>,
+    /// Task checkbox counts.
     pub tasks: TaskCount,
+    /// Files ordered by modification time.
     pub recent_files: Vec<RecentFile>,
     /// Schema lint counts — `None` when no `[schema]` block is configured.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -379,7 +431,9 @@ pub struct VaultSummary {
 /// Vault-wide link health: total links and broken count.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinkHealthSummary {
+    /// Total number of considered items.
     pub total: usize,
+    /// Number of unresolved links.
     pub broken: usize,
     /// Links pointing above the scanned vault root (`../..` escapes). Kept out
     /// of `broken` because the target is out of scope rather than missing
@@ -436,6 +490,7 @@ fn is_zero_broken_anchors(value: &Option<usize>) -> bool {
 /// File counts by directory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileCounts {
+    /// Total number of considered items.
     pub total: usize,
     /// Files the scan found but could not use because their frontmatter would
     /// not parse (iter-265). `summary` reported only `total` before, so a vault
@@ -446,13 +501,16 @@ pub struct FileCounts {
     /// Files dropped before the scan by `[scan] exclude` in `.hyalo.toml`.
     /// Zero unless the vault configures exclusions.
     pub excluded: usize,
+    /// File counts grouped by directory.
     pub directories: Vec<DirectoryCount>,
 }
 
 /// Count of files in a directory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DirectoryCount {
+    /// Vault-relative directory path.
     pub directory: String,
+    /// Number of matching occurrences.
     pub count: usize,
     /// Files under this directory skipped for unparsable frontmatter.
     /// Omitted from JSON when zero, so an all-clean vault's per-directory rows
@@ -470,14 +528,18 @@ fn is_zero_usize(value: &usize) -> bool {
 /// Files grouped by status property value (count only).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatusGroup {
+    /// Authored status property value.
     pub value: String,
+    /// Number of matching occurrences.
     pub count: usize,
 }
 
 /// A recently modified file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecentFile {
+    /// Path associated with this result.
     pub path: String,
+    /// File modification time.
     pub modified: String,
 }
 
@@ -489,18 +551,26 @@ pub struct RecentFile {
 /// Extends `TaskInfo` with section heading information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FindTaskInfo {
+    /// One-based source line number.
     pub line: usize,
+    /// Containing section heading, including its ATX prefix.
     pub section: String,
+    /// Task checkbox marker or grouped status value.
     pub status: char,
+    /// Authored task text without its checkbox marker.
     pub text: String,
+    /// Whether the task is checked.
     pub done: bool,
 }
 
 /// A content search match within a file body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContentMatch {
+    /// One-based source line number.
     pub line: usize,
+    /// Containing section heading, including its ATX prefix.
     pub section: String,
+    /// Matched source line or ranked snippet text.
     pub text: String,
 }
 
@@ -539,21 +609,30 @@ pub struct FileObject {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// User-authored frontmatter properties with genuinely dynamic values.
     pub properties: Option<serde_json::Map<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Frontmatter properties paired with their inferred types.
     pub properties_typed: Option<Vec<PropertyInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Tags authored on this file.
     pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Document outline with section-level metadata.
     pub sections: Option<Vec<OutlineSection>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Tasks in the selected file or sections.
     pub tasks: Option<Vec<FindTaskInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Outbound authored links.
     pub links: Option<Vec<LinkInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Inbound links from other vault files.
     pub backlinks: Option<Vec<BacklinkInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Body matches or ranked snippets; present and empty for title-only ranked hits.
     pub matches: Option<Vec<ContentMatch>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// BM25 relevance score for positional ranked searches.
     pub score: Option<f64>,
 }

--- a/crates/hyalo-mdlint/src/lib.rs
+++ b/crates/hyalo-mdlint/src/lib.rs
@@ -56,7 +56,7 @@ impl std::fmt::Display for DiagSeverity {
 
 /// A byte-range autofix for a single violation in the body portion of a file.
 /// `start`/`end` are byte offsets from the beginning of the **body** (post-frontmatter) content.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DiagFix {
     /// Human-readable description of the fix.
     pub description: String,

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -19,3 +19,5 @@ serde-saphyr = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
 walkdir = { workspace = true }
+syn = { version = "2", features = ["full", "visit"] }
+proc-macro2 = "1"

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -10,6 +10,7 @@ mod jq_recipes;
 mod mutation_journal;
 mod pi_package_sync;
 mod stubs;
+mod typed_output;
 mod workspace;
 
 #[derive(Parser)]
@@ -36,6 +37,8 @@ enum Commands {
     /// Gate: verify the vendored `crates/hyalo-cli/templates/pi/` copies
     /// match the canonical `pi-package/` files byte-for-byte.
     CheckPiPackageSync,
+    /// Reject ad-hoc JSON macros in production command output.
+    CheckTypedOutput,
     /// Verify Codex plugin assets, metadata, and embedded-copy parity.
     CheckCodexPackage,
     /// Refresh the embedded Codex skills from plugins/hyalo/skills.
@@ -64,6 +67,7 @@ fn main() {
         Commands::CheckCommandReference => command_reference::run(),
         Commands::CheckBundledSkills => bundled_skills::run(),
         Commands::CheckPiPackageSync => pi_package_sync::run(),
+        Commands::CheckTypedOutput => typed_output::run(),
         Commands::CheckCodexPackage => codex_package::run(false),
         Commands::SyncCodexPackage => codex_package::run(true),
         Commands::CheckJqRecipes => jq_recipes::run(),

--- a/crates/xtask/src/pi_package_sync.rs
+++ b/crates/xtask/src/pi_package_sync.rs
@@ -90,7 +90,7 @@ pub fn run() -> Result<bool> {
         return Ok(false);
     }
 
-    let mut all_ok = true;
+    let mut all_ok = versions_match(&root)?;
     let mut checked = 0usize;
     for (source, vendored_copy) in &pairs {
         checked += 1;
@@ -138,6 +138,37 @@ pub fn run() -> Result<bool> {
         println!("check-pi-package-sync: {checked} pi-package file(s) match their vendored copies");
     }
     Ok(all_ok)
+}
+
+/// Check each published/embedded pi manifest against the Cargo workspace.
+/// The independently versioned Codex plugin is intentionally outside this set.
+fn versions_match(root: &Path) -> Result<bool> {
+    let cargo: toml::Value = toml::from_str(&std::fs::read_to_string(root.join("Cargo.toml"))?)
+        .context("parsing workspace Cargo.toml")?;
+    let version = cargo
+        .get("workspace")
+        .and_then(|v| v.get("package"))
+        .and_then(|v| v.get("version"))
+        .and_then(toml::Value::as_str)
+        .context("missing workspace.package.version")?;
+    let mut matches = true;
+    for manifest in [
+        "package.json",
+        "pi-package/package.json",
+        "crates/hyalo-cli/templates/pi/package.json",
+    ] {
+        let package: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(root.join(manifest))?)
+                .with_context(|| format!("parsing {manifest}"))?;
+        let actual = package.get("version").and_then(serde_json::Value::as_str);
+        if actual != Some(version) {
+            matches = false;
+            eprintln!(
+                "check-pi-package-sync: {manifest} version {actual:?} differs from Cargo workspace {version}"
+            );
+        }
+    }
+    Ok(matches)
 }
 
 /// The vendored files the gate is responsible for: `skills/*/SKILL.md`,
@@ -232,5 +263,43 @@ mod tests {
 
         fs::write(&b, b"different").expect("write b");
         assert_ne!(fs::read(&a).unwrap(), fs::read(&b).unwrap());
+    }
+}
+
+#[cfg(test)]
+mod version_tests {
+    use super::*;
+
+    #[test]
+    fn detects_each_manifest_mismatch_even_when_pi_copies_agree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace.package]\nversion = \"0.22.0\"\n",
+        )
+        .unwrap();
+        let manifests = [
+            "package.json",
+            "pi-package/package.json",
+            "crates/hyalo-cli/templates/pi/package.json",
+        ];
+        for path in manifests {
+            let full = root.join(path);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            std::fs::write(full, r#"{"version":"0.22.0"}"#).unwrap();
+        }
+        assert!(versions_match(root).unwrap());
+        for path in manifests {
+            std::fs::write(root.join(path), r#"{"version":"0.1.1"}"#).unwrap();
+            assert!(!versions_match(root).unwrap(), "{path}");
+            std::fs::write(root.join(path), r#"{"version":"0.22.0"}"#).unwrap();
+        }
+        for path in manifests {
+            std::fs::write(root.join(path), r#"{"version":"0.1.1"}"#).unwrap();
+        }
+        assert!(!versions_match(root).unwrap());
+        std::fs::write(root.join("pi-package/package.json"), "{}").unwrap();
+        assert!(!versions_match(root).unwrap());
     }
 }

--- a/crates/xtask/src/typed_output.rs
+++ b/crates/xtask/src/typed_output.rs
@@ -1,0 +1,258 @@
+//! Enforce named command output contracts by rejecting production `json!`
+//! calls. Parse Rust syntax instead of truncating at the first test module:
+//! production dispatch handlers frequently follow inline tests in this repo.
+
+use anyhow::{Context, Result};
+use proc_macro2::{TokenStream, TokenTree};
+use std::path::{Path, PathBuf};
+use syn::visit::{self, Visit};
+
+use crate::workspace::workspace_root;
+
+pub fn run() -> Result<bool> {
+    let root = workspace_root()?;
+    let entry = root.join("crates/hyalo-cli/src/commands/mod.rs");
+    let mut violations = Vec::new();
+    inspect_file(&entry, &mut violations)?;
+    for path in &violations {
+        eprintln!(
+            "check-typed-output: production json! call in {}",
+            path.display()
+        );
+    }
+    if violations.is_empty() {
+        println!("check-typed-output: production command modules use no json! macros");
+    }
+    Ok(violations.is_empty())
+}
+
+/// Only an explicit test-only condition excludes a node. Unknown cfg values
+/// remain eligible, so platform/feature-gated production cannot escape checks.
+fn test_only(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("cfg")
+            && attr
+                .parse_args::<syn::Meta>()
+                .is_ok_and(|meta| requires_test(&meta))
+    })
+}
+
+fn requires_test(meta: &syn::Meta) -> bool {
+    match meta {
+        syn::Meta::Path(path) => path.is_ident("test"),
+        syn::Meta::List(list) if list.path.is_ident("all") || list.path.is_ident("any") => {
+            use syn::parse::Parser as _;
+            let parser = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+            let Ok(items) = parser.parse2(list.tokens.clone()) else {
+                return false;
+            };
+            if list.path.is_ident("all") {
+                items.iter().any(requires_test)
+            } else {
+                !items.is_empty() && items.iter().all(requires_test)
+            }
+        }
+        _ => false,
+    }
+}
+
+fn inspect_file(path: &Path, violations: &mut Vec<PathBuf>) -> Result<()> {
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let file = syn::parse_file(&source).with_context(|| format!("parsing {}", path.display()))?;
+    let parent = path.parent().context("command source has no parent")?;
+    let module_dir = if path.file_stem().is_some_and(|s| s == "mod") {
+        parent.to_path_buf()
+    } else {
+        parent.join(path.file_stem().context("command source has no stem")?)
+    };
+    inspect_items(&file.items, path, &module_dir, violations)
+}
+
+fn inspect_items(
+    items: &[syn::Item],
+    path: &Path,
+    module_dir: &Path,
+    violations: &mut Vec<PathBuf>,
+) -> Result<()> {
+    for item in items {
+        if let syn::Item::Mod(module) = item {
+            if test_only(&module.attrs) {
+                continue;
+            }
+            if let Some((_, items)) = &module.content {
+                inspect_items(
+                    items,
+                    path,
+                    &module_dir.join(module.ident.to_string()),
+                    violations,
+                )?;
+            } else {
+                let explicit = module.attrs.iter().find_map(|attr| {
+                    if !attr.path().is_ident("path") {
+                        return None;
+                    }
+                    let syn::Meta::NameValue(value) = &attr.meta else {
+                        return None;
+                    };
+                    let syn::Expr::Lit(lit) = &value.value else {
+                        return None;
+                    };
+                    let syn::Lit::Str(value) = &lit.lit else {
+                        return None;
+                    };
+                    Some(module_dir.join(value.value()))
+                });
+                let flat = module_dir.join(format!("{}.rs", module.ident));
+                let child = explicit.unwrap_or_else(|| {
+                    if flat.is_file() {
+                        flat
+                    } else {
+                        module_dir.join(module.ident.to_string()).join("mod.rs")
+                    }
+                });
+                inspect_file(&child, violations)?;
+            }
+        } else {
+            let mut visitor = ProductionMacros { count: 0 };
+            visitor.visit_item(item);
+            violations.extend(std::iter::repeat_n(path.to_path_buf(), visitor.count));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct ProductionMacros {
+    count: usize,
+}
+
+impl<'ast> Visit<'ast> for ProductionMacros {
+    fn visit_item(&mut self, item: &'ast syn::Item) {
+        // syn does not expose a common attrs accessor for Item.
+        let attrs = match item {
+            syn::Item::Fn(v) => &v.attrs,
+            syn::Item::Const(v) => &v.attrs,
+            syn::Item::Static(v) => &v.attrs,
+            syn::Item::Impl(v) => &v.attrs,
+            syn::Item::Mod(v) => &v.attrs,
+            syn::Item::Macro(v) => &v.attrs,
+            syn::Item::Trait(v) => &v.attrs,
+            _ => return visit::visit_item(self, item),
+        };
+        if !test_only(attrs) {
+            visit::visit_item(self, item);
+        }
+    }
+    fn visit_impl_item_fn(&mut self, item: &'ast syn::ImplItemFn) {
+        if !test_only(&item.attrs) {
+            visit::visit_impl_item_fn(self, item);
+        }
+    }
+    fn visit_local(&mut self, local: &'ast syn::Local) {
+        if !test_only(&local.attrs) {
+            visit::visit_local(self, local);
+        }
+    }
+    fn visit_stmt_macro(&mut self, stmt: &'ast syn::StmtMacro) {
+        if !test_only(&stmt.attrs) {
+            visit::visit_stmt_macro(self, stmt);
+        }
+    }
+    fn visit_expr_macro(&mut self, expr: &'ast syn::ExprMacro) {
+        if !test_only(&expr.attrs) {
+            visit::visit_expr_macro(self, expr);
+        }
+    }
+    fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+        if mac.path.segments.last().is_some_and(|s| s.ident == "json") {
+            self.count += 1;
+        } else {
+            self.count += nested_json_calls(mac.tokens.clone());
+        }
+    }
+}
+
+/// Macro arguments are token streams rather than AST expressions. Inspect
+/// groups so `vec![serde_json::json!({})]` is covered too, without matching
+/// string literals, comments, or documentation containing example code.
+fn nested_json_calls(tokens: TokenStream) -> usize {
+    let tokens: Vec<_> = tokens.into_iter().collect();
+    let direct = tokens
+        .windows(2)
+        .filter(|pair| {
+            matches!(&pair[0], TokenTree::Ident(i) if i == "json")
+                && matches!(&pair[1], TokenTree::Punct(p) if p.as_char() == '!')
+        })
+        .count();
+    direct
+        + tokens
+            .into_iter()
+            .filter_map(|token| match token {
+                TokenTree::Group(group) => Some(nested_json_calls(group.stream())),
+                _ => None,
+            })
+            .sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn count(source: &str) -> usize {
+        let file = syn::parse_file(source).unwrap();
+        let mut visitor = ProductionMacros::default();
+        visitor.visit_file(&file);
+        visitor.count
+    }
+
+    #[test]
+    fn excludes_only_test_nodes_and_keeps_later_production() {
+        assert_eq!(
+            count(
+                r#"
+            #[cfg(test)] mod tests { fn check() { serde_json::json!({}); } }
+            fn production() { serde_json :: json ! ({}); }
+        "#
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                r#"
+            fn production() {
+                #[cfg(test)] let old = serde_json::json!({});
+                let output = vec![serde_json::json!({})];
+            }
+        "#
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                r#"
+            #[cfg(any(test, windows))] fn production() { json!({}); }
+            #[cfg(all(test, unix))] fn tests() { json!({}); }
+            const EXAMPLE: &str = "json!({})";
+            // json!({})
+        "#
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn follows_production_modules_without_scanning_test_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("mod.rs"),
+            "#[cfg(test)] mod tests; mod child;",
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("tests.rs"), "fn f() { json!({}); }").unwrap();
+        std::fs::write(tmp.path().join("child.rs"), "fn f() { json!({}); }").unwrap();
+        let mut violations = Vec::new();
+        inspect_file(&tmp.path().join("mod.rs"), &mut violations).unwrap();
+        assert_eq!(violations, [tmp.path().join("child.rs")]);
+    }
+}

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -10,6 +10,28 @@ status: reference
 
 # Decision Log
 
+## DEC-331: Named output contracts preserve the existing JSON wire format (2026-09-07)
+
+**Decision:** Every command result is a named serializable struct, or a collection
+of named result items. Fixed fields use concrete Rust types; only authored
+frontmatter values retain a documented dynamic JSON value. Shared envelope
+metadata and ordinary errors have typed contracts, including the singular `hint`
+error field. Optional fields distinguish omission from explicit JSON `null`.
+
+`check-typed-output` parses production command modules and rejects `json!` calls,
+while excluding actual test-only syntax. The serialization boundary retains
+alphabetical object ordering and the existing directory-hoist and file-counter
+conventions. The pi manifest gate also compares the canonical, root and embedded
+package versions with the Cargo workspace; the Codex plugin version is independent.
+
+**Why:** Named contracts make field changes reviewable and prepare iteration 287's
+TypeScript API. They do not prove semantic correctness. Iteration 285 compares
+original renderer logic against the new structs on integration-suite fixtures,
+preserves the existing snapshots, and archives temporary parity shims and their
+execution evidence before removing them. See
+[[iterations/iteration-285-typed-output-structs]] and
+[[research/stability-retrospective-2026-09-06]].
+
 ## DEC-327: Codex skills and plugin share one canonical package (2026-09-06)
 
 **Decision:** Ship Codex skills in `plugins/hyalo/skills/` and mirror them inside

--- a/hyalo-knowledgebase/iterations/iteration-285-typed-output-structs.md
+++ b/hyalo-knowledgebase/iterations/iteration-285-typed-output-structs.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 285 — Typed output structs and a typed JSON envelope"
 date: 2026-09-06
-status: planned
+status: completed
 tags: [iteration, output, json, architecture]
 branch: iter-285/typed-output-structs
 priority: 2
@@ -37,39 +37,39 @@ does not establish semantic correctness or explain every output/help defect.
 
 ## Tasks
 
-- [ ] TASK-1: `Envelope<T: Serialize>` with `results`, `total`, `hints`, the optional `dir`
+- [x] TASK-1: `Envelope<T: Serialize>` with `results`, `total`, `hints`, the optional `dir`
       hoist and the three `files_*` counters as typed optional fields, replacing
       `build_envelope_value` and the post-hoc key injection. One `ErrorEnvelope` for the exit-1
       path (`error`, optional `path`, `hint`, and `cause`; preserve the existing singular
       `hint` key). Preserve specialized structured error payloads as well. Serialization must
       be byte-identical to today, including
       key order and which keys are omitted vs `null`; the `results` key conventions in
-      `rule-knowledgebase.md` are the spec.
-- [ ] TASK-2: results structs for `read` and `summary` first (the first two API consumers), then
+      `crates/hyalo-cli/templates/rule-knowledgebase.md` are the spec.
+- [x] TASK-2: results structs for `read` and `summary` first (the first two API consumers), then
       `config`, `links` (all subcommands), `types`, `lint-rules`, `views`, `okf`, `madr`, `new`,
       `tasks`, `changelog`, `create-index`, `drop-index`. Every command's `results` is a named
       struct with `#[derive(Serialize)]` and doc comments on every field (they become JSDoc in
       287). Where a field is genuinely dynamic (frontmatter values) keep `serde_json::Value`
       and say so in the doc comment.
-- [ ] TASK-3: parity guard: a test per command that runs the e2e fixture through the old
+- [x] TASK-3: parity guard: a test per command that runs the e2e fixture through the old
       renderer (kept behind a `#[cfg(test)]` shim for the duration of the branch, deleted at the
       end) and the new struct and asserts byte equality. Existing e2e snapshot tests must not
       change.
-- [ ] TASK-4: fix the `pi-package` version-sync gate: `check-pi-package-sync` compares copies
+- [x] TASK-4: fix the `pi-package` version-sync gate: `check-pi-package-sync` compares copies
       byte for byte but never checks `pi-package/package.json` (`0.1.1`) against the Cargo
       workspace version (`0.22.0`). Extend it to fail on mismatch; bump the package versions.
-- [ ] TASK-5: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
+- [x] TASK-5: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`,
       `cargo test --workspace -q`, every xtask `check-*` gate, `hyalo lint --strict` on the
       knowledgebase. DEC: "every `results` payload is a named struct; `json!` is not allowed in
       command output" — and an xtask or clippy-style grep gate that enforces it.
 
 ## Acceptance criteria
 
-- [ ] `grep -rn 'json!(' crates/hyalo-cli/src/commands` returns zero hits outside tests.
-- [ ] Every e2e JSON snapshot is unchanged; the parity test passes for every command.
-- [ ] `hyalo config --jq`, `--files-from` counters and the `dir` hoist behave exactly as before.
-- [ ] `check-pi-package-sync` fails when `pi-package/package.json` disagrees with Cargo.
-- [ ] Gates green.
+- [x] `grep -rn 'json!(' crates/hyalo-cli/src/commands` returns zero hits outside tests.
+- [x] Every e2e JSON snapshot is unchanged; the parity test passes for every command.
+- [x] `hyalo config --jq`, `--files-from` counters and the `dir` hoist behave exactly as before.
+- [x] `check-pi-package-sync` fails when `pi-package/package.json` disagrees with Cargo.
+- [x] Gates green.
 
 ## Plan reconciliation — 2026-09-06, iteration 284
 
@@ -85,6 +85,28 @@ The byte-parity baseline now includes ranked `FileObject.matches` arrays (includ
 arrays for title-only or cross-line phrase hits) and the shared authored-title scoring rule.
 Preserve these values and the repaired Unicode/frontmatter boundaries during the output
 refactor. The existing `ContentMatch` shape is unchanged; no additional output type is needed.
+
+## Outcome — 2026-09-07
+
+DEC-331 establishes named output contracts and the `check-typed-output` production
+macro gate. `summary` and `tasks` already had named contracts; those were retained and
+documented rather than replaced. The envelope includes typed optional counters and
+preserves singular error `hint`, optional `path`/`cause`, specialized budget errors,
+omissions, nulls, directory hoisting and alphabetical JSON keys. Existing JSON values
+are formatted by reference; typed values are normalized once.
+
+All 35 temporary old-renderer assertion sites executed through 19 fixture drivers;
+the shims were archived and removed. All 64 complete baseline/candidate CLI comparisons
+matched stdout, stderr and exit status, including jq, file counters, errors and ranked
+snippets. Existing e2e sources and snapshots are unchanged. Final validation passed:
+4,882 tests, zero failures, two existing doctest ignores; fmt, clippy and all 11 xtask
+checks (including two pre-existing stubs). Full strict knowledgebase lint retained four
+existing HYALO002 warnings; changed-file lint was clean. The changelog profile retained
+its existing HYALO006 warning. Independent review found two redundant result copies;
+both were repaired and the fresh full review was clean.
+
+All three pi manifests now match Cargo 0.22.0, with a negative version-drift check.
+This does not publish any package or complete the external prerequisites of 286/287.
 
 ## Links
 

--- a/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
@@ -70,6 +70,14 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
 - [ ] The polyglot DEC is filed and `CLAUDE.md` reflects it.
 - [ ] Gates green.
 
+## Plan reconciliation — 2026-09-07, iteration 285
+
+Iteration 285 added Cargo-version enforcement to `check-pi-package-sync` for the root,
+canonical pi and embedded pi manifests, now all 0.22.0. TASK-5 should extend that existing
+gate to the eight npm packages and their exact platform dependency pins. The launcher
+does not depend on the new typed output contracts. Publishing, trusted-publisher setup
+and real-platform registry installation remain unfinished external requirements.
+
 ## Links
 
 - [[research/npm-package-and-typed-typescript-api]] — proposal, naming table, settled section

--- a/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
+++ b/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
@@ -83,6 +83,18 @@ distinct-token coverage then line number; title-only and cross-line phrase hits 
 empty array. Include these cases in the typed `find` contract fixtures. The generated shape
 and the full 285/286 prerequisites remain unchanged.
 
+## Plan reconciliation — 2026-09-07, iteration 285
+
+The named output contracts and typed envelope are implemented. The Rust envelope has a
+borrowed lifetime (`Envelope<'a, T>`); its pipeline adapter borrows existing JSON values
+and copies only when removing the hoisted directory. Keep generated TypeScript focused
+on the serialized contract. With `ts-rs` as a dev-dependency, gate its derives/exports
+to the test build so normal production builds do not require that dependency. Preserve
+the documented dynamic JSON fields as `unknown`, optional omissions and singular error
+`hint`. Existing summary/task models were retained. Both the full 286 prerequisite and
+the external consumer migration remain unfinished; this reconciliation does not start
+the TypeScript implementation.
+
 ## Links
 
 - [[research/npm-package-and-typed-typescript-api]] — decision record

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyalo-pi",
-  "version": "0.1.1",
+  "version": "0.22.0",
   "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
   "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
   "private": true,

--- a/pi-package/package.json
+++ b/pi-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyalo-pi",
-  "version": "0.1.1",
+  "version": "0.22.0",
   "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
   "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
   "pi": {


### PR DESCRIPTION
Ad hoc command JSON construction made output contracts difficult to review and reuse. This replaces those constructors with documented named results and a typed success/error envelope, preserving existing stdout, stderr, exit codes, key order, omissions, counters, and directory hoisting. Existing summary/task models are retained; already-materialized JSON stays borrowed through formatting.

Adds a production `json!` syntax gate in CI and makes all three pi package manifests match the Cargo version (0.22.0), with a negative version-drift check. DEC-331 and iteration 285 are complete; plans 286/287 are reconciled while their external publishing, platform verification, and consumer prerequisites remain unfinished. Iteration 288 desktop verification stays deferred.

Validation:

- Final fmt, clippy, and workspace tests passed on Rust 1.98.1: 4,882 passed, 0 failed, 2 existing doctest ignores.
- All 35 temporary old/new renderer assertion sites executed through 19 fixture drivers; shims were archived and removed. All 64 complete baseline/candidate CLI comparisons matched stdout, stderr, and exit status. Existing e2e sources/snapshots are unchanged.
- All 11 xtask checks passed, including two existing stub checks. Unchanged static gates were reused after focused fixes; affected output/mutation gates were rerun.
- Full strict knowledgebase lint passed with four existing HYALO002 warnings; final changed-file lint and diff check are clean. Changelog profile lint retained its existing HYALO006 warning.
- Fresh independent read-only review is clean after fixing two redundant result copies. Final release build and CLI dogfooding passed; no publishing or releases were performed.
