### PR TITLE
feat: prepare npm CLI distribution

### DIFF
--- a/.github/workflows/npm-packages.yml
+++ b/.github/workflows/npm-packages.yml
@@ -1,0 +1,129 @@
+name: npm Packages
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "npm/**"
+      - "crates/xtask/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/npm-packages.yml"
+      - ".github/workflows/release.yml"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  npm-launcher:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+      - name: Install launcher dependencies
+        run: npm --prefix npm/hyalo install --ignore-scripts --omit=optional --package-lock=false
+      - name: Test launcher
+        run: npm --prefix npm/hyalo test
+
+  npm-packaging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+      - name: Pin npm
+        run: npm install --global npm@11.19.1
+      - name: Test generator and build host CLI
+        run: |
+          cargo test -p xtask npm_package
+          cargo run -p xtask -- generate-npm-packages --check
+          cargo build --release -p hyalo-cli
+      - name: Stage all eight packages
+        shell: bash
+        env:
+          BINARY_INPUT: ${{ runner.temp }}/hyalo-npm-binaries
+          STAGE_DIR: ${{ runner.temp }}/hyalo-npm-stage
+        run: |
+          set -euo pipefail
+          [ ! -e "$BINARY_INPUT" ]
+          [ ! -e "$STAGE_DIR" ]
+          jq -r '.[] | [.target, (if .os == "win32" then "hyalo.exe" else "hyalo" end)] | @tsv' npm/hyalo/platforms.json |
+            while IFS=$'\t' read -r target binary; do
+              mkdir -p "$BINARY_INPUT/$target"
+              printf 'packaging-only fixture for %s\n' "$target" > "$BINARY_INPUT/$target/$binary"
+            done
+          install -m 755 target/release/hyalo \
+            "$BINARY_INPUT/x86_64-unknown-linux-gnu/hyalo"
+          cargo run -p xtask -- generate-npm-packages \
+            --stage "$STAGE_DIR" --binaries "$BINARY_INPUT"
+      - name: Pack, inspect, and dry-run publication
+        shell: bash
+        env:
+          STAGE_DIR: ${{ runner.temp }}/hyalo-npm-stage
+          PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs
+          CONSUMER_DIR: ${{ runner.temp }}/hyalo-npm-consumer
+        run: |
+          set -euo pipefail
+          mkdir "$PACK_DIR"
+          : > "$PACK_DIR/packages.tsv"
+          for package_dir in \
+            darwin-arm64 linux-x64 linux-arm64 linux-x64-musl \
+            linux-arm64-musl win32-x64 win32-arm64 hyalo; do
+            npm pack "$STAGE_DIR/$package_dir" \
+              --pack-destination "$PACK_DIR" --json > "$PACK_DIR/$package_dir.json"
+            tarball=$(jq -r '.[0].filename' "$PACK_DIR/$package_dir.json")
+            test -n "$tarball"
+            printf '%s\t%s\n' "$package_dir" "$PACK_DIR/$tarball" \
+              >> "$PACK_DIR/packages.tsv"
+          done
+
+          while IFS=$'\t' read -r package_dir tarball; do
+            files=$(tar -tzf "$tarball")
+            grep -qx 'package/package.json' <<< "$files"
+            grep -qx 'package/LICENSE' <<< "$files"
+            grep -qx 'package/README.md' <<< "$files"
+            if [ "$package_dir" = hyalo ]; then
+              grep -qx 'package/bin/hyalo.js' <<< "$files"
+              grep -qx 'package/lib/resolve-platform.js' <<< "$files"
+              grep -qx 'package/lib/run-child.js' <<< "$files"
+              grep -qx 'package/platforms.json' <<< "$files"
+            elif [[ "$package_dir" == win32-* ]]; then
+              grep -qx 'package/hyalo.exe' <<< "$files"
+            else
+              grep -qx 'package/hyalo' <<< "$files"
+            fi
+            npm publish "$tarball" --dry-run --ignore-scripts --access public \
+              --registry https://registry.npmjs.org
+          done < "$PACK_DIR/packages.tsv"
+
+          mkdir "$CONSUMER_DIR"
+          cd "$CONSUMER_DIR"
+          npm init --yes
+          main_tarball=$(awk -F '\t' '$1 == "hyalo" {print $2}' "$PACK_DIR/packages.tsv")
+          host_tarball=$(awk -F '\t' '$1 == "linux-x64" {print $2}' "$PACK_DIR/packages.tsv")
+          npm install --ignore-scripts --omit=optional "$main_tarball" "$host_tarball"
+          expected=$(cargo metadata --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" \
+            --no-deps --format-version 1 |
+            jq -r '.packages[] | select(.name == "hyalo-cli") | .version')
+          actual=$(npx --no-install hyalo --version)
+          case "$actual" in
+            "hyalo $expected"*) ;;
+            *) echo "unexpected hyalo version output: $actual" >&2; exit 1 ;;
+          esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,148 @@ jobs:
           {"target": "x86_64-pc-windows-msvc", "os": "windows-latest", "cross": false, "run_tests": true},
           {"target": "aarch64-pc-windows-msvc", "os": "windows-latest", "cross": false, "run_tests": false}
         ]
+
+  npm:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+      - name: Pin npm and resolve Cargo version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          npm install --global npm@11.19.1
+          metadata=$(cargo metadata --no-deps --format-version 1)
+          version=$(jq -r '.packages[] | select(.name == "hyalo-cli") | .version' \
+            <<< "$metadata")
+          if [ -z "$version" ] || [ "$version" = null ]; then
+            echo "hyalo-cli version was not found in cargo metadata" >&2
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = release ] && [ "$RELEASE_TAG" != "v$version" ]; then
+            echo "release tag '$RELEASE_TAG' does not match Cargo version '$version'" >&2
+            exit 1
+          fi
+          echo "CARGO_VERSION=$version" >> "$GITHUB_ENV"
+      - name: Download native release archives
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: hyalo-*
+          path: ${{ runner.temp }}/hyalo-release-artifacts
+      - name: Extract exact release binaries and stage npm packages
+        shell: bash
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/hyalo-release-artifacts
+          BINARY_INPUT: ${{ runner.temp }}/hyalo-npm-binaries
+          STAGE_DIR: ${{ runner.temp }}/hyalo-npm-stage
+        run: |
+          set -euo pipefail
+          [ ! -e "$BINARY_INPUT" ]
+          [ ! -e "$STAGE_DIR" ]
+          mkdir "$BINARY_INPUT"
+          jq -r '.[] | [.target, .os] | @tsv' npm/hyalo/platforms.json |
+            while IFS=$'\t' read -r target os; do
+              artifact="$ARTIFACT_DIR/hyalo-$target"
+              if [ "$os" = win32 ]; then
+                archive="hyalo-v$CARGO_VERSION-$target.zip"
+                binary="hyalo.exe"
+              else
+                archive="hyalo-v$CARGO_VERSION-$target.tar.gz"
+                binary="hyalo"
+              fi
+              test -d "$artifact"
+              count=$(find "$artifact" -maxdepth 1 -type f -name "$archive" | wc -l)
+              test "$count" -eq 1
+              unpack="$RUNNER_TEMP/hyalo-unpack-$target"
+              mkdir "$unpack"
+              if [ "$os" = win32 ]; then
+                unzip -q "$artifact/$archive" -d "$unpack"
+              else
+                tar -xzf "$artifact/$archive" -C "$unpack"
+              fi
+              test -f "$unpack/$binary"
+              test -f "$unpack/LICENSE"
+              test -f "$unpack/README.md"
+              mkdir "$BINARY_INPUT/$target"
+              install -m 755 "$unpack/$binary" "$BINARY_INPUT/$target/$binary"
+            done
+          cargo run -p xtask -- generate-npm-packages \
+            --stage "$STAGE_DIR" --binaries "$BINARY_INPUT"
+      - name: Pack and dry-run all publications
+        shell: bash
+        env:
+          STAGE_DIR: ${{ runner.temp }}/hyalo-npm-stage
+          PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs
+        run: |
+          set -euo pipefail
+          mkdir "$PACK_DIR"
+          : > "$PACK_DIR/packages.tsv"
+          for package_dir in \
+            darwin-arm64 linux-x64 linux-arm64 linux-x64-musl \
+            linux-arm64-musl win32-x64 win32-arm64 hyalo; do
+            npm pack "$STAGE_DIR/$package_dir" \
+              --pack-destination "$PACK_DIR" --json > "$PACK_DIR/$package_dir.json"
+            tarball=$(jq -r '.[0].filename' "$PACK_DIR/$package_dir.json")
+            test -n "$tarball"
+            printf '%s\t%s\n' "$package_dir" "$PACK_DIR/$tarball" \
+              >> "$PACK_DIR/packages.tsv"
+            npm publish "$PACK_DIR/$tarball" \
+              --dry-run --ignore-scripts --access public \
+              --registry https://registry.npmjs.org
+          done
+          cargo run -q -p xtask -- plan-npm-publication --pack-json \
+            "$PACK_DIR/darwin-arm64.json" \
+            "$PACK_DIR/linux-x64.json" \
+            "$PACK_DIR/linux-arm64.json" \
+            "$PACK_DIR/linux-x64-musl.json" \
+            "$PACK_DIR/linux-arm64-musl.json" \
+            "$PACK_DIR/win32-x64.json" \
+            "$PACK_DIR/win32-arm64.json" \
+            "$PACK_DIR/hyalo.json" \
+            > "$PACK_DIR/publication-plan.json"
+      - name: Publish platform packages, then main package
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs
+        run: |
+          set -euo pipefail
+          publish_or_skip() {
+            local action=$1
+            local name=$2
+            local tarball=$3
+            test -f "$tarball"
+            if [ "$action" = skip ]; then
+              echo "Skipping $name: identical immutable version already published"
+            elif [ "$action" = publish ]; then
+              npm publish "$tarball" \
+                --provenance --access public --ignore-scripts \
+                --registry https://registry.npmjs.org
+            else
+              echo "unexpected publication action '$action' for $name" >&2
+              return 1
+            fi
+          }
+          while IFS=$'\t' read -r action name tarball; do
+            publish_or_skip "$action" "$name" "$tarball"
+          done < <(jq -r '.[0:7][] | [.action, .name, .tarball] | @tsv' \
+            "$PACK_DIR/publication-plan.json")
+          IFS=$'\t' read -r action name tarball < <(
+            jq -r '.[7] | [.action, .name, .tarball] | @tsv' \
+              "$PACK_DIR/publication-plan.json"
+          )
+          test "$name" = hyalo
+          publish_or_skip "$action" "$name" "$tarball"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/target
+**/node_modules
 .env
 .obsidian
 .claude/memory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ Do *not* merge with "--squash".
 - No `.unwrap()` / `.expect()` outside of tests — use `anyhow::Context` with `?`
 - No `clone()` unless the borrow checker demands it — try references first
 - No unnecessary `pub` on struct fields
-- All code stays in Rust — no polyglot tooling (no Bun, Node, Python scripts)
+- General repository tooling stays in Rust. The `npm/` and `pi-package/` trees may contain
+  JavaScript/TypeScript because they are shipped JavaScript deliverables (DEC-332); native
+  tests for those deliverables are part of their package contracts.
 - New crates go in `crates/` with naming convention `hyalo-<domain>`
 
 ## PR Discipline

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ winget install ractive.hyalo
 cargo install hyalo-cli    # installs the `hyalo` binary
 ```
 
+### npm (prepared, not yet published)
+
+An npm distribution is prepared for Node.js 22.14 or newer and npm 11.5.1
+or newer. It will support macOS arm64, Linux x64/arm64 with glibc or musl,
+and Windows x64/arm64. Once the packages have been published and verified,
+the intended installation will be:
+
+```sh
+npm install hyalo
+npx --no-install hyalo --version
+```
+
+The packages are not yet available from the public npm registry. Use one of
+the published installation methods above until the owner bootstrap, trusted
+publisher configuration, and real-platform registry checks are complete.
+
 ### Manual download
 
 Every [GitHub Release](https://github.com/ractive/hyalo/releases) publishes:

--- a/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
@@ -10,7 +10,9 @@ description: "Search and edit structured markdown knowledgebases with the Hyalo 
 Use the installed `hyalo` executable. In a Hyalo source checkout, `target/release/hyalo`
 is an alternative when present. If unavailable, report that and suggest the project's
 documented installation (`cargo install hyalo-cli`); do not install software as a
-side effect of a knowledgebase query.
+side effect of a knowledgebase query. The prepared npm distribution remains
+unpublished pending owner bootstrap, trusted publisher setup, and real-platform
+registry checks; do not suggest `npm install hyalo` before that acceptance.
 
 Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
 to locate and confirm the vault. Commands also work inside that configured vault,

--- a/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
@@ -260,7 +260,10 @@ hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.m
 
 ## Setup Checklist for New Projects
 
-1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`)
+1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`). Use the
+   published `cargo install hyalo-cli` route; the prepared npm distribution
+   remains unpublished until owner bootstrap, trusted publisher setup, and
+   real-platform registry checks are complete.
 2. **Configure vault**: Create `.hyalo.toml` with `dir = "knowledgebase"`
 3. **Add to AGENTS.md**: Include: "Use `hyalo` CLI for all markdown knowledgebase operations. Always use `--format text` for compact output."
 4. **Create views**: Set up common views (`stale-in-progress`, `orphans`, etc.)

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -23,6 +23,11 @@ in directories of markdown files. Its killer features are combined filtering (e.
 replicate with Grep/Glob, and bulk mutations (`hyalo set --where-property`) that replace
 multiple Read + Edit calls.
 
+Install the published CLI with `cargo install hyalo-cli`. An npm distribution is
+prepared but remains unpublished until its owner bootstrap, trusted publisher setup,
+and real-platform registry checks are complete; do not direct users to
+`npm install hyalo` before that acceptance.
+
 Filters combine freely — content search + property conditions + tag + section + task status
 in a single call, something impossible with Grep/Glob alone:
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -8,6 +8,7 @@ mod feature_fanout;
 mod help_drift;
 mod jq_recipes;
 mod mutation_journal;
+mod npm_package;
 mod pi_package_sync;
 mod stubs;
 mod typed_output;
@@ -37,6 +38,10 @@ enum Commands {
     /// Gate: verify the vendored `crates/hyalo-cli/templates/pi/` copies
     /// match the canonical `pi-package/` files byte-for-byte.
     CheckPiPackageSync,
+    /// Generate or verify npm launcher/platform package metadata.
+    GenerateNpmPackages(npm_package::NpmArgs),
+    /// Plan an immutable npm publication from npm pack integrity metadata.
+    PlanNpmPublication(npm_package::NpmPublishPlanArgs),
     /// Reject ad-hoc JSON macros in production command output.
     CheckTypedOutput,
     /// Verify Codex plugin assets, metadata, and embedded-copy parity.
@@ -67,6 +72,8 @@ fn main() {
         Commands::CheckCommandReference => command_reference::run(),
         Commands::CheckBundledSkills => bundled_skills::run(),
         Commands::CheckPiPackageSync => pi_package_sync::run(),
+        Commands::GenerateNpmPackages(args) => npm_package::run(args),
+        Commands::PlanNpmPublication(args) => npm_package::run_publication_plan(args),
         Commands::CheckTypedOutput => typed_output::run(),
         Commands::CheckCodexPackage => codex_package::run(false),
         Commands::SyncCodexPackage => codex_package::run(true),

--- a/crates/xtask/src/npm_package.rs
+++ b/crates/xtask/src/npm_package.rs
@@ -1,0 +1,1106 @@
+//! npm package metadata generation and release staging.
+
+use anyhow::{Context, Result, bail};
+use clap::{ArgGroup, Args};
+use serde_json::{Value, json};
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("mode")
+        .required(true)
+        .args(["check", "generate", "stage"])
+))]
+pub struct NpmArgs {
+    /// Check tracked metadata against canonical generated values.
+    #[arg(long)]
+    pub check: bool,
+    /// Write canonical metadata and licenses into the repository.
+    #[arg(long)]
+    pub generate: bool,
+    /// Stage all packages into a new, separate output directory.
+    #[arg(long, requires = "binaries")]
+    pub stage: Option<PathBuf>,
+    /// Directory containing unpacked target archives, keyed by Rust target.
+    #[arg(long, requires = "stage")]
+    pub binaries: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub struct NpmPublishPlanArgs {
+    /// Ordered npm pack --json output files: seven platforms, then main.
+    #[arg(long, required = true, num_args = 1..)]
+    pub pack_json: Vec<PathBuf>,
+}
+
+#[derive(Clone, Copy)]
+struct Platform {
+    target: &'static str,
+    name: &'static str,
+    os: &'static str,
+    cpu: &'static str,
+    libc: Option<&'static str>,
+    binary: &'static str,
+}
+
+const PLATFORMS: [Platform; 7] = [
+    Platform {
+        target: "aarch64-apple-darwin",
+        name: "darwin-arm64",
+        os: "darwin",
+        cpu: "arm64",
+        libc: None,
+        binary: "hyalo",
+    },
+    Platform {
+        target: "x86_64-unknown-linux-gnu",
+        name: "linux-x64",
+        os: "linux",
+        cpu: "x64",
+        libc: Some("glibc"),
+        binary: "hyalo",
+    },
+    Platform {
+        target: "aarch64-unknown-linux-gnu",
+        name: "linux-arm64",
+        os: "linux",
+        cpu: "arm64",
+        libc: Some("glibc"),
+        binary: "hyalo",
+    },
+    Platform {
+        target: "x86_64-unknown-linux-musl",
+        name: "linux-x64-musl",
+        os: "linux",
+        cpu: "x64",
+        libc: Some("musl"),
+        binary: "hyalo",
+    },
+    Platform {
+        target: "aarch64-unknown-linux-musl",
+        name: "linux-arm64-musl",
+        os: "linux",
+        cpu: "arm64",
+        libc: Some("musl"),
+        binary: "hyalo",
+    },
+    Platform {
+        target: "x86_64-pc-windows-msvc",
+        name: "win32-x64",
+        os: "win32",
+        cpu: "x64",
+        libc: None,
+        binary: "hyalo.exe",
+    },
+    Platform {
+        target: "aarch64-pc-windows-msvc",
+        name: "win32-arm64",
+        os: "win32",
+        cpu: "arm64",
+        libc: None,
+        binary: "hyalo.exe",
+    },
+];
+
+pub fn run(args: NpmArgs) -> Result<bool> {
+    let root = crate::workspace::workspace_root()?;
+    let version = workspace_version(&root)?;
+    if let Some(out) = args.stage {
+        let input = args
+            .binaries
+            .as_deref()
+            .context("--stage requires --binaries")?;
+        stage(&root, &out, input, &version)?;
+        return Ok(true);
+    }
+    if args.generate {
+        generate_metadata(&root, &version)?;
+    }
+    check_metadata_with_version(&root, &version)
+}
+
+pub(crate) fn check_metadata(root: &Path) -> Result<bool> {
+    let version = workspace_version(root)?;
+    check_metadata_with_version(root, &version)
+}
+
+pub fn run_publication_plan(args: NpmPublishPlanArgs) -> Result<bool> {
+    let root = crate::workspace::workspace_root()?;
+    let version = workspace_version(&root)?;
+    let artifacts = read_pack_artifacts(&args.pack_json)?;
+    let plan = build_publication_plan(&artifacts, &version, query_npm_registry)?;
+    println!("{}", serde_json::to_string_pretty(&plan)?);
+    Ok(true)
+}
+
+#[derive(Debug)]
+struct PackArtifact {
+    name: String,
+    version: String,
+    tarball: PathBuf,
+    integrity: String,
+}
+
+#[derive(serde::Deserialize)]
+struct PackEntry {
+    name: String,
+    version: String,
+    filename: String,
+    integrity: String,
+}
+
+#[derive(Debug, PartialEq)]
+enum RegistryState {
+    MissingVersion,
+    Published(String),
+}
+
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum PublicationAction {
+    Publish,
+    Skip,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct PublicationPlan {
+    name: String,
+    version: String,
+    tarball: String,
+    integrity: String,
+    action: PublicationAction,
+}
+
+fn read_pack_artifacts(paths: &[PathBuf]) -> Result<Vec<PackArtifact>> {
+    paths
+        .iter()
+        .map(|path| {
+            let bytes = fs::read(path)
+                .with_context(|| format!("reading npm pack metadata {}", path.display()))?;
+            let entries: Vec<PackEntry> = serde_json::from_slice(&bytes)
+                .with_context(|| format!("parsing npm pack metadata {}", path.display()))?;
+            let [entry] = entries.as_slice() else {
+                bail!(
+                    "npm pack metadata {} must contain exactly one entry",
+                    path.display()
+                );
+            };
+            if entry.integrity.is_empty() {
+                bail!("npm pack metadata {} has no integrity", path.display());
+            }
+            let parent = path.parent().context("npm pack metadata has no parent")?;
+            let tarball = parent.join(&entry.filename);
+            if !tarball.is_file() {
+                bail!("npm pack tarball is missing: {}", tarball.display());
+            }
+            Ok(PackArtifact {
+                name: entry.name.clone(),
+                version: entry.version.clone(),
+                tarball,
+                integrity: entry.integrity.clone(),
+            })
+        })
+        .collect()
+}
+
+fn build_publication_plan<F>(
+    artifacts: &[PackArtifact],
+    version: &str,
+    mut query: F,
+) -> Result<Vec<PublicationPlan>>
+where
+    F: FnMut(&str, &str) -> Result<RegistryState>,
+{
+    let expected_names = PLATFORMS
+        .iter()
+        .map(|platform| package_name(*platform))
+        .chain(std::iter::once("hyalo".to_owned()))
+        .collect::<Vec<_>>();
+    if artifacts.len() != expected_names.len() {
+        bail!(
+            "publication plan requires exactly {} ordered packages, got {}",
+            expected_names.len(),
+            artifacts.len()
+        );
+    }
+    let mut plan = Vec::with_capacity(artifacts.len());
+    for (artifact, expected_name) in artifacts.iter().zip(&expected_names) {
+        if artifact.name != *expected_name {
+            bail!(
+                "publication package order mismatch: expected {expected_name}, got {}",
+                artifact.name
+            );
+        }
+        if artifact.version != version {
+            bail!(
+                "{} version {} differs from Cargo workspace {version}",
+                artifact.name,
+                artifact.version
+            );
+        }
+        let action = match query(&artifact.name, &artifact.version)? {
+            RegistryState::MissingVersion => PublicationAction::Publish,
+            RegistryState::Published(integrity) if integrity == artifact.integrity => {
+                PublicationAction::Skip
+            }
+            RegistryState::Published(integrity) => {
+                bail!(
+                    "{}@{} already exists with integrity {integrity}, local tarball is {}",
+                    artifact.name,
+                    artifact.version,
+                    artifact.integrity
+                );
+            }
+        };
+        plan.push(PublicationPlan {
+            name: artifact.name.clone(),
+            version: artifact.version.clone(),
+            tarball: artifact.tarball.to_string_lossy().into_owned(),
+            integrity: artifact.integrity.clone(),
+            action,
+        });
+    }
+    Ok(plan)
+}
+
+fn query_npm_registry(name: &str, version: &str) -> Result<RegistryState> {
+    #[cfg(windows)]
+    const NPM: &str = "npm.cmd";
+    #[cfg(not(windows))]
+    const NPM: &str = "npm";
+    query_npm_registry_with(Path::new(NPM), name, version)
+}
+
+fn query_npm_registry_with(npm: &Path, name: &str, version: &str) -> Result<RegistryState> {
+    let package_version = format!("{name}@{version}");
+    let output = Command::new(npm)
+        .args([
+            "view",
+            &package_version,
+            "dist.integrity",
+            "--json",
+            "--registry",
+            "https://registry.npmjs.org",
+        ])
+        .output()
+        .with_context(|| format!("querying npm registry for {package_version}"))?;
+    classify_registry_output(
+        &package_version,
+        output.status.success(),
+        &output.stdout,
+        &output.stderr,
+    )
+}
+
+fn classify_registry_output(
+    package_version: &str,
+    success: bool,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<RegistryState> {
+    if success {
+        let value: Value = serde_json::from_slice(stdout)
+            .with_context(|| format!("parsing npm registry response for {package_version}"))?;
+        let integrity = value
+            .as_str()
+            .filter(|value| !value.is_empty())
+            .with_context(|| {
+                format!("npm registry returned {package_version} without a valid dist.integrity")
+            })?;
+        return Ok(RegistryState::Published(integrity.to_owned()));
+    }
+    let diagnostics = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(stdout),
+        String::from_utf8_lossy(stderr)
+    );
+    let error_code = serde_json::from_slice::<Value>(stdout)
+        .ok()
+        .and_then(|value| value["error"]["code"].as_str().map(str::to_owned));
+    if matches!(error_code.as_deref(), Some("E401" | "E403"))
+        || diagnostics.contains("E401")
+        || diagnostics.contains("E403")
+    {
+        bail!("npm registry authorization failed for {package_version}: {diagnostics}");
+    }
+    if error_code.as_deref() == Some("E404") {
+        return Ok(RegistryState::MissingVersion);
+    }
+    bail!("npm registry query failed for {package_version}: {diagnostics}")
+}
+
+fn workspace_version(root: &Path) -> Result<String> {
+    let path = root.join("Cargo.toml");
+    let text = fs::read_to_string(&path)
+        .with_context(|| format!("reading workspace manifest {}", path.display()))?;
+    let value: toml::Value = toml::from_str(&text)
+        .with_context(|| format!("parsing workspace manifest {}", path.display()))?;
+    value
+        .get("workspace")
+        .and_then(|v| v.get("package"))
+        .and_then(|v| v.get("version"))
+        .and_then(toml::Value::as_str)
+        .map(str::to_owned)
+        .context("missing workspace.package.version")
+}
+
+fn package_name(platform: Platform) -> String {
+    format!("@ractive-ch/hyalo-{}", platform.name)
+}
+
+fn platform_manifest(platform: Platform, version: &str) -> Value {
+    let mut manifest = json!({
+        "name": package_name(platform),
+        "version": version,
+        "description": "Hyalo CLI native binary for this platform",
+        "license": "MIT",
+        "os": [platform.os],
+        "cpu": [platform.cpu],
+        "files": [platform.binary, "LICENSE", "README.md"],
+        "repository": {
+            "type": "git",
+            "url": "https://github.com/ractive/hyalo.git",
+            "directory": format!("npm/platforms/{}", platform.name)
+        },
+        "publishConfig": {"access": "public"}
+    });
+    if let Some(libc) = platform.libc {
+        manifest["libc"] = json!([libc]);
+    }
+    manifest
+}
+
+fn main_manifest(version: &str) -> Value {
+    let mut optional = serde_json::Map::new();
+    for platform in PLATFORMS {
+        optional.insert(package_name(platform), json!(version));
+    }
+    json!({
+        "name": "hyalo",
+        "version": version,
+        "description": "Hyalo knowledgebase CLI",
+        "license": "MIT",
+        "bin": {"hyalo": "bin/hyalo.js"},
+        "files": ["bin", "lib", "README.md", "LICENSE", "platforms.json"],
+        "engines": {"node": ">=22.14.0", "npm": ">=11.5.1"},
+        "dependencies": {"detect-libc": "2.1.2"},
+        "optionalDependencies": optional,
+        "scripts": {"test": "node --test test/*.test.js"},
+        "repository": {
+            "type": "git",
+            "url": "https://github.com/ractive/hyalo.git",
+            "directory": "npm/hyalo"
+        },
+        "publishConfig": {"access": "public"}
+    })
+}
+
+fn platform_map() -> Value {
+    json!(
+        PLATFORMS
+            .iter()
+            .map(|platform| json!({
+                "target": platform.target,
+                "package": package_name(*platform),
+                "os": platform.os,
+                "cpu": platform.cpu,
+                "libc": platform.libc
+            }))
+            .collect::<Vec<_>>()
+    )
+}
+
+fn json_bytes(value: &Value) -> Result<Vec<u8>> {
+    Ok(format!("{}\n", serde_json::to_string_pretty(value)?).into_bytes())
+}
+
+fn platform_readme(platform: Platform) -> Vec<u8> {
+    format!(
+        "# {}\n\nNative Hyalo CLI binary for {}.\n",
+        package_name(platform),
+        platform.target
+    )
+    .into_bytes()
+}
+
+fn expected_metadata(root: &Path, version: &str) -> Result<Vec<(PathBuf, Vec<u8>)>> {
+    let license = fs::read(root.join("LICENSE")).context("reading repository LICENSE")?;
+    let mut expected = vec![
+        (
+            root.join("npm/hyalo/package.json"),
+            json_bytes(&main_manifest(version))?,
+        ),
+        (
+            root.join("npm/hyalo/platforms.json"),
+            json_bytes(&platform_map())?,
+        ),
+        (root.join("npm/hyalo/LICENSE"), license.clone()),
+    ];
+    for platform in PLATFORMS {
+        let dir = root.join("npm/platforms").join(platform.name);
+        expected.push((
+            dir.join("package.json"),
+            json_bytes(&platform_manifest(platform, version))?,
+        ));
+        expected.push((dir.join("LICENSE"), license.clone()));
+        expected.push((dir.join("README.md"), platform_readme(platform)));
+    }
+    Ok(expected)
+}
+
+fn generate_metadata(root: &Path, version: &str) -> Result<()> {
+    for (path, contents) in expected_metadata(root, version)? {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(&path, contents).with_context(|| format!("writing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn generated_text_matches(actual: &[u8], expected: &[u8]) -> bool {
+    fn next_byte(bytes: &[u8], index: &mut usize) -> Option<u8> {
+        let byte = *bytes.get(*index)?;
+        *index += 1;
+        if byte == b'\r' && bytes.get(*index) == Some(&b'\n') {
+            *index += 1;
+            Some(b'\n')
+        } else {
+            Some(byte)
+        }
+    }
+
+    let mut actual_index = 0;
+    let mut expected_index = 0;
+    loop {
+        match (
+            next_byte(actual, &mut actual_index),
+            next_byte(expected, &mut expected_index),
+        ) {
+            (Some(actual), Some(expected)) if actual == expected => {}
+            (None, None) => return true,
+            _ => return false,
+        }
+    }
+}
+
+fn check_metadata_with_version(root: &Path, version: &str) -> Result<bool> {
+    let mut ok = true;
+    for (path, expected) in expected_metadata(root, version)? {
+        match fs::read(&path) {
+            Ok(actual) if generated_text_matches(&actual, &expected) => {}
+            Ok(_) => {
+                eprintln!("npm metadata mismatch: {}", display_path(root, &path));
+                ok = false;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("npm metadata missing: {}", display_path(root, &path));
+                ok = false;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("reading {}", path.display()));
+            }
+        }
+    }
+    for path in [
+        root.join("npm/hyalo/README.md"),
+        root.join("npm/hyalo/bin/hyalo.js"),
+        root.join("npm/hyalo/lib/resolve-platform.js"),
+        root.join("npm/hyalo/lib/run-child.js"),
+    ] {
+        if !path.is_file() {
+            eprintln!("npm package source missing: {}", display_path(root, &path));
+            ok = false;
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let launcher = root.join("npm/hyalo/bin/hyalo.js");
+        if launcher.is_file() && fs::metadata(&launcher)?.permissions().mode() & 0o111 == 0 {
+            eprintln!(
+                "npm launcher is not executable: {}",
+                display_path(root, &launcher)
+            );
+            ok = false;
+        }
+    }
+    Ok(ok)
+}
+
+fn display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn stage(root: &Path, out: &Path, input: &Path, version: &str) -> Result<()> {
+    validate_staging_paths(root, out, input)?;
+    if out.exists() {
+        bail!("staging output already exists: {}", out.display());
+    }
+    if !input.is_dir() {
+        bail!("binary input directory does not exist: {}", input.display());
+    }
+    if !check_metadata_with_version(root, version)? {
+        bail!("tracked npm metadata is missing or stale; run generate-npm-packages --generate");
+    }
+    preflight_package_sources(root)?;
+    for platform in PLATFORMS {
+        let source = input.join(platform.target).join(platform.binary);
+        if !source.is_file() {
+            bail!(
+                "missing binary for {} at {}",
+                platform.target,
+                source.display()
+            );
+        }
+    }
+
+    fs::create_dir(out).with_context(|| format!("creating staging output {}", out.display()))?;
+    let main = out.join("hyalo");
+    fs::create_dir(&main).with_context(|| format!("creating {}", main.display()))?;
+    for name in ["README.md", "LICENSE", "package.json", "platforms.json"] {
+        copy_file(&root.join("npm/hyalo").join(name), &main.join(name))?;
+    }
+    copy_tree(&root.join("npm/hyalo/bin"), &main.join("bin"))?;
+    copy_tree(&root.join("npm/hyalo/lib"), &main.join("lib"))?;
+    set_executable(&main.join("bin/hyalo.js"))?;
+
+    for platform in PLATFORMS {
+        let dir = out.join(platform.name);
+        fs::create_dir(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        let binary = dir.join(platform.binary);
+        copy_file(&input.join(platform.target).join(platform.binary), &binary)?;
+        set_executable(&binary)?;
+        for name in ["package.json", "LICENSE", "README.md"] {
+            copy_file(
+                &root.join("npm/platforms").join(platform.name).join(name),
+                &dir.join(name),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn preflight_package_sources(root: &Path) -> Result<()> {
+    for path in [
+        root.join("npm/hyalo/README.md"),
+        root.join("npm/hyalo/LICENSE"),
+        root.join("npm/hyalo/package.json"),
+        root.join("npm/hyalo/platforms.json"),
+        root.join("npm/hyalo/bin/hyalo.js"),
+    ] {
+        if !path.is_file() {
+            bail!("missing main package file {}", path.display());
+        }
+    }
+    for path in [root.join("npm/hyalo/bin"), root.join("npm/hyalo/lib")] {
+        if !path.is_dir() {
+            bail!("missing main package directory {}", path.display());
+        }
+    }
+    for platform in PLATFORMS {
+        for name in ["package.json", "LICENSE", "README.md"] {
+            let path = root.join("npm/platforms").join(platform.name).join(name);
+            if !path.is_file() {
+                bail!("missing platform package file {}", path.display());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_staging_paths(root: &Path, out: &Path, input: &Path) -> Result<()> {
+    let root = canonicalize_allow_missing(root)?;
+    let out = canonicalize_allow_missing(out)?;
+    let input = canonicalize_allow_missing(input)?;
+    for (label, path) in [("repository root", &root), ("binary input", &input)] {
+        if out.starts_with(path) || path.starts_with(&out) {
+            bail!(
+                "staging output {} overlaps {label} {}",
+                out.display(),
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut base = absolute.as_path();
+    let mut suffix = Vec::<OsString>::new();
+    while !base.exists() {
+        suffix.push(
+            base.file_name()
+                .context("path has no existing ancestor")?
+                .to_owned(),
+        );
+        base = base.parent().context("path has no existing ancestor")?;
+    }
+    let mut resolved = fs::canonicalize(base)
+        .with_context(|| format!("canonicalizing existing path {}", base.display()))?;
+    for component in suffix.iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
+}
+
+fn copy_file(source: &Path, target: &Path) -> Result<()> {
+    fs::copy(source, target)
+        .with_context(|| format!("copying {} to {}", source.display(), target.display()))?;
+    Ok(())
+}
+
+fn copy_tree(source: &Path, target: &Path) -> Result<()> {
+    if !source.is_dir() {
+        bail!("missing directory {}", source.display());
+    }
+    fs::create_dir(target).with_context(|| format!("creating {}", target.display()))?;
+    for entry in fs::read_dir(source).with_context(|| format!("reading {}", source.display()))? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_tree(&source_path, &target_path)?;
+        } else if file_type.is_file() {
+            copy_file(&source_path, &target_path)?;
+        } else {
+            bail!("unsupported package source entry {}", source_path.display());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(permissions.mode() | 0o111);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VERSION: &str = "1.2.3";
+
+    fn fixture_root() -> Result<tempfile::TempDir> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path();
+        fs::write(
+            root.join("Cargo.toml"),
+            format!("[workspace.package]\nversion = \"{VERSION}\"\n"),
+        )?;
+        fs::write(root.join("LICENSE"), b"fixture license\n")?;
+        fs::create_dir_all(root.join("npm/hyalo/bin/nested"))?;
+        fs::create_dir_all(root.join("npm/hyalo/lib/nested"))?;
+        fs::write(root.join("npm/hyalo/README.md"), b"# fixture main\n")?;
+        fs::write(
+            root.join("npm/hyalo/bin/hyalo.js"),
+            b"#!/usr/bin/env node\n",
+        )?;
+        fs::write(root.join("npm/hyalo/bin/nested/helper.js"), b"bin helper\n")?;
+        fs::write(
+            root.join("npm/hyalo/lib/resolve-platform.js"),
+            b"resolver\n",
+        )?;
+        fs::write(root.join("npm/hyalo/lib/run-child.js"), b"runner\n")?;
+        fs::write(root.join("npm/hyalo/lib/nested/helper.js"), b"helper\n")?;
+        set_executable(&root.join("npm/hyalo/bin/hyalo.js"))?;
+        generate_metadata(root, VERSION)?;
+        Ok(temp)
+    }
+
+    fn fixture_binaries(parent: &Path) -> Result<PathBuf> {
+        let input = parent.join("binaries");
+        for platform in PLATFORMS {
+            let dir = input.join(platform.target);
+            fs::create_dir_all(&dir)?;
+            fs::write(
+                dir.join(platform.binary),
+                format!("binary bytes for {}", platform.target),
+            )?;
+        }
+        Ok(input)
+    }
+
+    fn metadata_snapshot(root: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>> {
+        expected_metadata(root, VERSION)?
+            .into_iter()
+            .map(|(path, _)| {
+                let relative = path.strip_prefix(root)?.to_owned();
+                Ok((relative, fs::read(path)?))
+            })
+            .collect()
+    }
+
+    fn with_crlf(bytes: &[u8]) -> Vec<u8> {
+        let mut converted = Vec::with_capacity(bytes.len());
+        for &byte in bytes {
+            if byte == b'\n' {
+                converted.push(b'\r');
+            }
+            converted.push(byte);
+        }
+        converted
+    }
+
+    #[test]
+    fn generation_is_deterministic_and_check_detects_every_manifest_version() -> Result<()> {
+        let temp = fixture_root()?;
+        let root = temp.path();
+        let first = metadata_snapshot(root)?;
+        generate_metadata(root, VERSION)?;
+        assert_eq!(metadata_snapshot(root)?, first);
+        assert!(check_metadata(root)?);
+
+        let manifests = std::iter::once(root.join("npm/hyalo/package.json")).chain(
+            PLATFORMS.iter().map(|platform| {
+                root.join("npm/platforms")
+                    .join(platform.name)
+                    .join("package.json")
+            }),
+        );
+        for manifest in manifests {
+            let mut value: Value = serde_json::from_slice(&fs::read(&manifest)?)?;
+            value["version"] = json!("9.9.9");
+            fs::write(&manifest, json_bytes(&value)?)?;
+            assert!(
+                !check_metadata(root)?,
+                "version drift was accepted for {}",
+                manifest.display()
+            );
+            generate_metadata(root, VERSION)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn check_rejects_missing_platform_pin_map_and_license_drift() -> Result<()> {
+        let temp = fixture_root()?;
+        let root = temp.path();
+
+        let removed = root.join("npm/platforms/linux-arm64/package.json");
+        fs::remove_file(&removed)?;
+        assert!(!check_metadata(root)?);
+        generate_metadata(root, VERSION)?;
+
+        let main_path = root.join("npm/hyalo/package.json");
+        let mut main: Value = serde_json::from_slice(&fs::read(&main_path)?)?;
+        main["optionalDependencies"]["@ractive-ch/hyalo-linux-x64"] = json!("1.2.4");
+        fs::write(&main_path, json_bytes(&main)?)?;
+        assert!(!check_metadata(root)?);
+        generate_metadata(root, VERSION)?;
+
+        let map_path = root.join("npm/hyalo/platforms.json");
+        let mut map: Value = serde_json::from_slice(&fs::read(&map_path)?)?;
+        map[0]["package"] = json!("@ractive-ch/wrong");
+        fs::write(&map_path, json_bytes(&map)?)?;
+        assert!(!check_metadata(root)?);
+        generate_metadata(root, VERSION)?;
+
+        fs::write(root.join("npm/platforms/darwin-arm64/LICENSE"), b"stale\n")?;
+        assert!(!check_metadata(root)?);
+        Ok(())
+    }
+
+    #[test]
+    fn check_and_stage_accept_crlf_generated_metadata_without_masking_drift() -> Result<()> {
+        let temp = fixture_root()?;
+        let root = temp.path();
+        let generated_paths = expected_metadata(root, VERSION)?
+            .into_iter()
+            .map(|(path, _)| path)
+            .collect::<Vec<_>>();
+        for path in &generated_paths {
+            fs::write(path, with_crlf(&fs::read(path)?))?;
+        }
+
+        assert!(check_metadata(root)?);
+
+        let outside = tempfile::tempdir()?;
+        let input = fixture_binaries(outside.path())?;
+        let output = outside.path().join("stage");
+        stage(root, &output, &input, VERSION)?;
+        assert!(
+            fs::read(output.join("linux-x64/README.md"))?
+                .windows(2)
+                .any(|pair| pair == b"\r\n")
+        );
+
+        let readme = root.join("npm/platforms/linux-x64/README.md");
+        fs::write(&readme, b"# wrong package\r\n")?;
+        assert!(!check_metadata(root)?);
+
+        generate_metadata(root, VERSION)?;
+        fs::remove_file(root.join("npm/hyalo/platforms.json"))?;
+        assert!(!check_metadata(root)?);
+
+        assert!(generated_text_matches(b"line\r\nnext\n", b"line\nnext\r\n"));
+        assert!(!generated_text_matches(b"line\rnext\n", b"line\nnext\n"));
+        assert!(!generated_text_matches(b"value \xff\n", b"value \xfe\r\n"));
+        Ok(())
+    }
+
+    #[test]
+    fn staging_copies_complete_main_tree_and_all_platform_binaries() -> Result<()> {
+        let temp = fixture_root()?;
+        let root = temp.path();
+        let outside = tempfile::tempdir()?;
+        let input = fixture_binaries(outside.path())?;
+        let output = outside.path().join("stage");
+
+        stage(root, &output, &input, VERSION)?;
+        assert_eq!(
+            fs::read(output.join("hyalo/bin/nested/helper.js"))?,
+            b"bin helper\n"
+        );
+        assert_eq!(
+            fs::read(output.join("hyalo/lib/nested/helper.js"))?,
+            b"helper\n"
+        );
+        assert_eq!(
+            fs::read(output.join("hyalo/package.json"))?,
+            fs::read(root.join("npm/hyalo/package.json"))?
+        );
+        for platform in PLATFORMS {
+            let staged = output.join(platform.name).join(platform.binary);
+            assert_eq!(
+                fs::read(&staged)?,
+                format!("binary bytes for {}", platform.target).as_bytes()
+            );
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                assert_ne!(fs::metadata(&staged)?.permissions().mode() & 0o111, 0);
+            }
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_ne!(
+                fs::metadata(output.join("hyalo/bin/hyalo.js"))?
+                    .permissions()
+                    .mode()
+                    & 0o111,
+                0
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn staging_missing_binary_leaves_no_partial_output() -> Result<()> {
+        let temp = fixture_root()?;
+        let outside = tempfile::tempdir()?;
+        let input = fixture_binaries(outside.path())?;
+        let missing = PLATFORMS[3];
+        fs::remove_file(input.join(missing.target).join(missing.binary))?;
+        let output = outside.path().join("stage");
+
+        let error = stage(temp.path(), &output, &input, VERSION)
+            .expect_err("missing binary should fail staging");
+        assert!(error.to_string().contains(missing.target));
+        assert!(!output.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn staging_refuses_existing_output_without_touching_it() -> Result<()> {
+        let temp = fixture_root()?;
+        let outside = tempfile::tempdir()?;
+        let input = fixture_binaries(outside.path())?;
+        let output = outside.path().join("stage");
+        fs::create_dir(&output)?;
+        let sentinel = output.join("sentinel");
+        fs::write(&sentinel, b"keep me")?;
+
+        let error = stage(temp.path(), &output, &input, VERSION)
+            .expect_err("existing staging output should be refused");
+        assert!(error.to_string().contains("already exists"));
+        assert_eq!(fs::read(sentinel)?, b"keep me");
+        Ok(())
+    }
+
+    #[test]
+    fn staging_rejects_output_overlapping_repository_or_input() -> Result<()> {
+        let temp = fixture_root()?;
+        let root = temp.path();
+        let outside = tempfile::tempdir()?;
+        let input = fixture_binaries(outside.path())?;
+
+        let repository_output = root.join("stage");
+        let error = stage(root, &repository_output, &input, VERSION)
+            .expect_err("repository child should be refused");
+        assert!(error.to_string().contains("repository root"));
+
+        let input_output = input.join("stage");
+        let error = stage(root, &input_output, &input, VERSION)
+            .expect_err("binary-input child should be refused");
+        assert!(error.to_string().contains("binary input"));
+        Ok(())
+    }
+
+    fn publication_artifacts() -> Vec<PackArtifact> {
+        PLATFORMS
+            .iter()
+            .enumerate()
+            .map(|(index, platform)| PackArtifact {
+                name: package_name(*platform),
+                version: VERSION.to_owned(),
+                tarball: PathBuf::from(format!("platform-{index}.tgz")),
+                integrity: format!("sha512-local-{index}"),
+            })
+            .chain(std::iter::once(PackArtifact {
+                name: "hyalo".to_owned(),
+                version: VERSION.to_owned(),
+                tarball: PathBuf::from("hyalo.tgz"),
+                integrity: "sha512-local-main".to_owned(),
+            }))
+            .collect()
+    }
+
+    #[test]
+    fn registry_response_distinguishes_missing_version_from_missing_integrity() -> Result<()> {
+        assert_eq!(
+            classify_registry_output("hyalo@1.2.3", true, br#""sha512-published""#, b"")?,
+            RegistryState::Published("sha512-published".to_owned())
+        );
+        let missing_version = br#"{
+          "error": {
+            "code": "E404",
+            "summary": "No match found for version 9999.0.0",
+            "detail": ""
+          }
+        }"#;
+        assert_eq!(
+            classify_registry_output("detect-libc@9999.0.0", false, missing_version, b"")?,
+            RegistryState::MissingVersion
+        );
+        assert!(
+            classify_registry_output(
+                "hyalo@1.2.3",
+                false,
+                b"",
+                b"network proxy mentioned E404 without registry JSON"
+            )
+            .is_err()
+        );
+        let missing_integrity = classify_registry_output("hyalo@1.2.3", true, b"null", b"")
+            .expect_err("a successful version lookup without integrity must fail");
+        assert!(missing_integrity.to_string().contains("dist.integrity"));
+        Ok(())
+    }
+
+    #[test]
+    fn registry_response_fails_closed_on_auth_network_and_malformed_data() {
+        for diagnostics in [
+            b"npm error code E401".as_slice(),
+            b"npm error code E403".as_slice(),
+            b"npm error code ENETUNREACH".as_slice(),
+        ] {
+            assert!(classify_registry_output("hyalo@1.2.3", false, b"", diagnostics).is_err());
+        }
+        assert!(classify_registry_output("hyalo@1.2.3", true, b"not json", b"").is_err());
+    }
+
+    #[test]
+    fn publication_plan_resumes_partial_success_in_platforms_first_order() -> Result<()> {
+        let artifacts = publication_artifacts();
+        let mut query_index = 0usize;
+        let plan = build_publication_plan(&artifacts, VERSION, |_, _| {
+            let artifact = &artifacts[query_index];
+            let state = if query_index < 3 {
+                RegistryState::Published(artifact.integrity.clone())
+            } else {
+                RegistryState::MissingVersion
+            };
+            query_index += 1;
+            Ok(state)
+        })?;
+        assert_eq!(
+            plan.iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>(),
+            artifacts
+                .iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            plan[..3]
+                .iter()
+                .all(|entry| entry.action == PublicationAction::Skip)
+        );
+        assert!(
+            plan[3..]
+                .iter()
+                .all(|entry| entry.action == PublicationAction::Publish)
+        );
+        assert_eq!(plan.last().map(|entry| entry.name.as_str()), Some("hyalo"));
+        Ok(())
+    }
+
+    #[test]
+    fn publication_plan_rejects_existing_version_with_different_integrity() {
+        let artifacts = publication_artifacts();
+        let error = build_publication_plan(&artifacts, VERSION, |_, _| {
+            Ok(RegistryState::Published("sha512-other".to_owned()))
+        })
+        .expect_err("an immutable version mismatch must fail");
+        assert!(error.to_string().contains("already exists with integrity"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_registry_query_executes_offline_fixture() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let npm = temp.path().join("npm");
+        fs::write(
+            &npm,
+            "#!/bin/sh\nprintf '%s\\n' '\"sha512-unix-fixture\"'\n",
+        )?;
+        set_executable(&npm)?;
+        assert_eq!(
+            query_npm_registry_with(&npm, "hyalo", VERSION)?,
+            RegistryState::Published("sha512-unix-fixture".to_owned())
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_registry_query_executes_cmd_shim() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let npm = temp.path().join("npm.cmd");
+        fs::write(
+            &npm,
+            "@echo off\r\necho \"sha512-windows-cmd-fixture\"\r\nexit /b 0\r\n",
+        )?;
+        assert_eq!(
+            query_npm_registry_with(&npm, "hyalo", VERSION)?,
+            RegistryState::Published("sha512-windows-cmd-fixture".to_owned())
+        );
+        Ok(())
+    }
+}

--- a/crates/xtask/src/pi_package_sync.rs
+++ b/crates/xtask/src/pi_package_sync.rs
@@ -91,6 +91,7 @@ pub fn run() -> Result<bool> {
     }
 
     let mut all_ok = versions_match(&root)?;
+    all_ok &= crate::npm_package::check_metadata(&root)?;
     let mut checked = 0usize;
     for (source, vendored_copy) in &pairs {
         checked += 1;
@@ -157,6 +158,11 @@ fn versions_match(root: &Path) -> Result<bool> {
         "pi-package/package.json",
         "crates/hyalo-cli/templates/pi/package.json",
     ] {
+        if !root.join(manifest).is_file() {
+            matches = false;
+            eprintln!("check-pi-package-sync: missing required manifest {manifest}");
+            continue;
+        }
         let package: serde_json::Value =
             serde_json::from_slice(&std::fs::read(root.join(manifest))?)
                 .with_context(|| format!("parsing {manifest}"))?;

--- a/hyalo-knowledgebase/decision-log.md
+++ b/hyalo-knowledgebase/decision-log.md
@@ -6375,3 +6375,12 @@ alternating pairs) for the default 50-result query. Supplemental unlimited
 output is 454.57 → 608.28 ms (+33.81%, fifteen pairs). Complete disk/index
 envelopes still agree in both cases; original implementation measurements are
 retained separately from the repair evidence.
+
+## DEC-332: JavaScript is permitted for shipped npm and pi deliverables (2026-09-07)
+
+The repository's Rust-only tooling rule is narrowed to general repository tooling.
+The `npm/` launcher, package metadata and native Node tests, together with the
+existing `pi-package/` TypeScript extension, are shipped JavaScript deliverables
+and may use their native language. Rust remains the implementation language for
+the CLI and xtask generators and gates. This exception keeps package consumers
+testable without introducing a general-purpose polyglot scripting layer.

--- a/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 286 — npm distribution: launcher and per-platform binary packages"
 date: 2026-09-06
-status: planned
+status: in-progress
 tags: [iteration, npm, distribution, release]
 branch: iter-286/npm-distribution
 priority: 2
@@ -31,16 +31,16 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
 
 ## Tasks
 
-- [ ] TASK-1: DEC weakening the "all code stays in Rust — no polyglot tooling" rule: it was
+- [x] TASK-1: DEC weakening the "all code stays in Rust — no polyglot tooling" rule: it was
       written against Bun tests verifying Rust code; `npm/` and `pi-package/` may hold
       TypeScript because they *are* the JavaScript deliverable. Update `CLAUDE.md` in the same
       PR.
-- [ ] TASK-2: `npm/hyalo/` — `package.json` (`bin`, `optionalDependencies` for the seven
+- [x] TASK-2: `npm/hyalo/` — `package.json` (`bin`, `optionalDependencies` for the seven
       targets, `engines`, `files`), `bin/hyalo.js` launcher that resolves the platform package,
       execs the binary with inherited stdio and exit code, and fails with a clear message naming
       `os`/`cpu`/`libc` and pointing at `cargo install hyalo-cli` when no package matches (Intel
       macOS, unsupported libc). README with install and the platform table.
-- [ ] TASK-3: `npm/platforms/` — a generator (an `xtask` subcommand, Rust) that writes one
+- [x] TASK-3: `npm/platforms/` — a generator (an `xtask` subcommand, Rust) that writes one
       platform package per target from a template: name `@ractive-ch/hyalo-<os>-<cpu>[-musl]`,
       `os`/`cpu`/`libc` fields, the binary, the licence. Version taken from `Cargo.toml`.
 - [ ] TASK-4: `release.yml` — after the archives exist, unpack each into its platform package,
@@ -48,14 +48,14 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
       trusted publishing for each of the eight packages on npmjs.com (one-time, manual, James).
       A dry-run path (`npm pack` + `npm publish --dry-run`) runs on every PR touching `npm/` or
       the workflow.
-- [ ] TASK-5: version gate: extend the `check-pi-package-sync` xtask (or the gate 285 adds) so
+- [x] TASK-5: version gate: extend the `check-pi-package-sync` xtask (or the gate 285 adds) so
       `npm/hyalo/package.json`, every platform package and `pi-package/package.json` equal the
       Cargo workspace version.
 - [ ] TASK-6: verify on real machines: `npm install hyalo` on macOS arm64, Linux x64 glibc,
       Linux x64 musl (Alpine container) and Windows x64; `npx hyalo --version` prints the
       release version. Record timings for a musl vs glibc `summary` on MDN if a musl host is at
       hand (the allocator question in the note).
-- [ ] TASK-7: docs: README install section, `skill-hyalo.md`, the knowledgebase research note
+- [x] TASK-7: docs: README install section, `skill-hyalo.md`, the knowledgebase research note
       outcome. Gates: `cargo fmt`, clippy, `cargo test --workspace -q`, every xtask `check-*`,
       `hyalo lint --strict`.
 
@@ -63,12 +63,12 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
 
 - [ ] `npm install hyalo && npx hyalo --version` works on the four verified platforms with
       exactly one platform package installed.
-- [ ] On an unsupported platform the launcher exits non-zero with the message naming the
+- [x] On an unsupported platform the launcher exits non-zero with the message naming the
       platform and the cargo fallback.
 - [ ] A release publishes eight packages at the Cargo version, platforms first, with provenance.
-- [ ] The version gate fails CI when any `package.json` disagrees with Cargo.
-- [ ] The polyglot DEC is filed and `CLAUDE.md` reflects it.
-- [ ] Gates green.
+- [x] The version gate fails CI when any `package.json` disagrees with Cargo.
+- [x] The polyglot DEC is filed and `CLAUDE.md` reflects it.
+- [x] Gates green.
 
 ## Plan reconciliation — 2026-09-07, iteration 285
 
@@ -77,6 +77,43 @@ canonical pi and embedded pi manifests, now all 0.22.0. TASK-5 should extend tha
 gate to the eight npm packages and their exact platform dependency pins. The launcher
 does not depend on the new typed output contracts. Publishing, trusted-publisher setup
 and real-platform registry installation remain unfinished external requirements.
+
+## Partial implementation — 2026-09-07
+
+DEC-332, the launcher, seven platform manifests, Rust metadata/staging generator,
+version checks, PR packaging checks, release workflow and installation documentation
+are implemented on `iter-286/npm-distribution` as repository preparation. The
+iteration remains `in-progress` until the external acceptance criteria are verified.
+
+Local validation passed: 4,894 Rust tests, zero failures and two existing ignored
+doctests; strict workspace Clippy; Windows-target xtask compilation; nine launcher
+tests; actionlint; all implemented xtask gates; package-content checks and publication
+dry runs for all eight packages. A temporary local macOS arm64 tarball installation
+ran the real CLI. Foreign-target fixture bytes verify packaging only. The two existing
+stub gates remain unimplemented; the jq gate cannot exercise its MADR recipe without
+`docs/decisions`; full-vault lint retains four existing warnings.
+
+Independent review fixes cover launcher cancellation, integrity-verified publication
+retries, Windows command selection and compilation, and CRLF metadata comparison.
+The generator now accepts LF/CRLF differences while preserving all other bytes.
+Regression coverage verifies CRLF metadata checking and staging, rejects real content
+drift and missing files, and preserves lone-CR and invalid-byte distinctions. Fresh
+full review found no actionable defects in the repository-preparation changes.
+
+TASK-4 is partial: workflow and local dry runs exist, but owner bootstrap, trusted
+publisher configuration and actual publication have not happened. TASK-6 is unperformed:
+public-registry installs on macOS arm64, Linux x64 glibc, Alpine musl and Windows x64
+are still required. Local fixtures and compilation checks do not satisfy these tasks.
+The owner reports npm login as `ractive.ch`; publication and trust changes still need
+separate authority. No token secret is required for the planned GitHub OIDC publisher.
+
+Resume external completion only with the required authority and real native artifacts.
+Bootstrap the eight package names, configure GitHub OIDC for `ractive/hyalo` and
+`release.yml` with direct publishing enabled, publish an authorized release, and
+record the four-platform registry checks and provenance. Agree on bootstrap/release
+versions before publishing: npm versions are immutable. Retain this noncompleted
+status until external acceptance is fulfilled. Iteration 287 remains blocked by the
+full iteration-286 prerequisite.
 
 ## Links
 

--- a/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
+++ b/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
@@ -95,6 +95,20 @@ the documented dynamic JSON fields as `unknown`, optional omissions and singular
 the external consumer migration remain unfinished; this reconciliation does not start
 the TypeScript implementation.
 
+## Plan reconciliation — 2026-09-07, iteration 286
+
+The repository-preparation branch introduces a CommonJS launcher and an internal
+binary resolver at `npm/hyalo/lib/resolve-platform.js`. TASK-3 should share that
+resolver while spawning the native binary directly. The Rust npm generator owns
+`npm/hyalo/package.json`; adding API exports, type entrypoints or build metadata
+must update the generator and its tests as well as the generated manifest.
+
+Iteration 286's repository preparation has passed fresh review, including its
+CRLF metadata-check fix. npm bootstrap, trusted publishing, actual publication and
+four-platform registry installation checks remain outstanding. Both full prerequisites remain
+required; no TypeScript implementation has started. TASK-7 still requires separate
+authority to modify `homefinder-eco-mcp` and is not waived by repository-only work.
+
 ## Links
 
 - [[research/npm-package-and-typed-typescript-api]] — decision record

--- a/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
+++ b/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
@@ -227,3 +227,86 @@ Three separate iterations, not one, preceded by the stability retrospective
    platform binary directly, vitest contract tests against the freshly built
    binary. Port `pi-package/extensions/hyalo.ts` onto it. Then switch
    `homefinder-eco-mcp` to `npm install hyalo`.
+
+## Added 2026-09-07 — a generic markdown-KB MCP server?
+
+From the follow-up discussion in the eco-mcp session (findings recorded in
+that repo's `RUNTIME-KB-REFRESH.md`, section "2026-09-07"):
+
+- The consumer expects mapl-memory to grow to **thousands of pages**. The
+  eco-mcp ingests one product subtree; other product teams will want the
+  same over theirs, and none of that is ecosystem-specific. That argues for
+  a **generic markdown-KB MCP server**: repo + ref + paths in, hyalo for
+  search, index and page reads, `create-index` after every pull, queries
+  with `--index`. Since James owns hyalo, this is plausibly a hyalo feature
+  (a `hyalo mcp` / `hyalo serve --mcp` subcommand, or a separate package on
+  top of the npm wrapper from iteration 287) rather than a Comparis one.
+  Not planned; decide before the consumer builds its ingest twice.
+- Two consumer-side lessons that shape what such a server must do:
+  never put page names into a tool-description enum (the eco-mcp does, and
+  it does not survive thousands of pages); and derive the page list/titles
+  from hyalo's index rather than opening every file.
+- The consumer's provenance-comment bug is fixed on their side
+  (comment now after the closing `---`). The possible lint rule
+  "frontmatter present but not at byte 0" remains an idea here.
+
+## Outcome — iteration 286 repository preparation (2026-09-07)
+
+Iteration 285 completed the typed Rust output models and strengthened
+`check-pi-package-sync` so the three existing package manifests must match
+the Cargo workspace version. Iteration 286 extends that gate through one
+canonical Rust npm platform table: the main manifest, all seven platform
+manifests, exact optional-dependency pins, generated platform map, licenses,
+and target READMEs are checked byte-for-byte. The generator also stages an
+explicit seven-target binary input into a new output tree without deleting or
+overwriting tracked sources.
+
+The CommonJS launcher selects from the generated table, resolves the installed
+optional package, and spawns the binary with inherited stdio, unchanged
+arguments, numeric exit status, and signal propagation. Native `node:test`
+coverage exercises all seven mappings, unsupported and missing-package errors,
+and real child-process behavior.
+
+Local packaging evidence on macOS arm64 used npm 11.19.1 to stage and pack all
+eight packages, inspect every tarball allowlist, and run `npm publish --dry-run`
+for each. A temporary consumer installed the local main and Darwin arm64
+tarballs with optional registry packages omitted, then
+`npx --no-install hyalo --version` ran the release binary and reported
+`hyalo 0.22.0`. Foreign-target files were clearly labeled fixture bytes and
+prove package layout only. The PR workflow repeats launcher tests on GitHub
+Linux, macOS, and Windows runners and performs the packaging smoke with a real
+Linux x64 glibc binary. These workflow jobs have not yet run.
+
+The release workflow is prepared to consume the seven exact archives produced
+by `ractive/release-workflows/.github/workflows/release.yml@v0.2.0`, dry-run
+all eight packages on manual dispatch, and publish platform packages before the
+main package only for a published release. No workflow was dispatched and no
+package was published during this work.
+
+Publication retries are fail-closed: a Rust gate compares each local
+`npm pack` integrity with the exact version's `dist.integrity` at
+`https://registry.npmjs.org`. An explicit missing-version 404 remains
+publishable, an identical immutable artifact is skipped, and mismatched
+integrity, authorization, network, or malformed responses stop the job before
+publication. This allows a partial platform-package success to resume without
+attempting to overwrite earlier immutable versions, while keeping the main
+package last.
+
+External acceptance remains open. The owner must bootstrap all eight packages,
+configure each existing package's trusted publisher for `ractive/hyalo` and
+`release.yml`, explicitly allow direct publishing where new configurations
+default to staged publishing, authorize a release, and verify public-registry
+installs on macOS arm64, Linux x64 glibc, Linux x64 musl, and Windows x64. The
+2026-09-07 public metadata requests returned 404 for all eight names; that
+shows only that no public metadata existed, not ownership or private-package
+state.
+
+Authoritative references:
+
+- npm trusted publishing:
+  <https://docs.npmjs.com/trusted-publishers/>
+- npm 11 `npm trust` prerequisites:
+  <https://docs.npmjs.com/cli/v11/commands/npm-trust/>
+- Reusable release workflow source:
+  `ractive/release-workflows/.github/workflows/release.yml@v0.2.0`,
+  Git blob `300705e94fa0090441861a653ccd7f05c36a749a`

--- a/npm/hyalo/LICENSE
+++ b/npm/hyalo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/hyalo/README.md
+++ b/npm/hyalo/README.md
@@ -1,0 +1,68 @@
+# hyalo
+
+This package is prepared for publication but is not yet available from the
+public npm registry. Until owner bootstrap, trusted publishing, and registry
+installation checks are complete, install the CLI with:
+
+```sh
+cargo install hyalo-cli
+```
+
+After public acceptance, the intended npm installation will be:
+
+```sh
+npm install hyalo
+npx --no-install hyalo --version
+```
+
+npm selects one exact-version native package through `optionalDependencies`.
+The launcher requires Node.js 22.14 or newer and npm 11.5.1 or newer.
+
+| Rust target | npm package | os | cpu | libc |
+| --- | --- | --- | --- | --- |
+| `aarch64-apple-darwin` | `@ractive-ch/hyalo-darwin-arm64` | darwin | arm64 | — |
+| `x86_64-unknown-linux-gnu` | `@ractive-ch/hyalo-linux-x64` | linux | x64 | glibc |
+| `aarch64-unknown-linux-gnu` | `@ractive-ch/hyalo-linux-arm64` | linux | arm64 | glibc |
+| `x86_64-unknown-linux-musl` | `@ractive-ch/hyalo-linux-x64-musl` | linux | x64 | musl |
+| `aarch64-unknown-linux-musl` | `@ractive-ch/hyalo-linux-arm64-musl` | linux | arm64 | musl |
+| `x86_64-pc-windows-msvc` | `@ractive-ch/hyalo-win32-x64` | win32 | x64 | — |
+| `aarch64-pc-windows-msvc` | `@ractive-ch/hyalo-win32-arm64` | win32 | arm64 | — |
+
+Intel macOS, unsupported CPU combinations, and Linux systems whose libc cannot
+be identified receive an error naming `os`, `cpu`, and `libc`, with
+`cargo install hyalo-cli` as the fallback. The launcher does not download a
+binary or run an install script.
+
+## Packaging and publication
+
+`.github/workflows/npm-packages.yml` tests the launcher on Linux, macOS, and
+Windows pull requests. Its packaging job stages all eight packages, checks their
+tarball contents, dry-runs every publication, and runs the real host binary
+through a temporary local install. Foreign-target fixture bytes in that job
+verify package layout only.
+
+`.github/workflows/release.yml` downloads the seven native archives produced
+by the pinned reusable release workflow. A manual workflow dispatch only packs
+and dry-runs the packages. A published release event is the only path that can
+publish: all seven platform tarballs publish first, followed by `hyalo`, using
+npm provenance and GitHub OIDC without a repository token fallback.
+Before an immutable version is published, the workflow compares the local
+tarball integrity with `dist.integrity` from the public npm registry. A retry
+skips an identical existing artifact, publishes an explicitly missing version,
+and stops on mismatched integrity or an inconclusive registry response.
+
+The npm owner must complete these external steps before the first registry
+release:
+
+1. Bootstrap the unscoped `hyalo` package and all seven scoped packages under
+   `@ractive-ch`; all eight currently lack public registry metadata.
+2. Configure each existing package's trusted publisher for repository
+   `ractive/hyalo` and workflow `release.yml`.
+3. Explicitly allow direct publishing for each configuration. New trusted
+   publisher configurations may allow staged publishing only by default.
+4. Publish an authorized release, then verify a registry install and
+   `npx --no-install hyalo --version` on macOS arm64, Linux x64 glibc,
+   Linux x64 musl, and Windows x64.
+
+See npm's official [trusted publishing guide](https://docs.npmjs.com/trusted-publishers/)
+and [`npm trust` requirements](https://docs.npmjs.com/cli/v11/commands/npm-trust/).

--- a/npm/hyalo/bin/hyalo.js
+++ b/npm/hyalo/bin/hyalo.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+'use strict';
+const { resolveBinary } = require('../lib/resolve-platform');
+const { runBinary } = require('../lib/run-child');
+
+function main() {
+  let resolved;
+  try {
+    resolved = resolveBinary();
+  } catch (error) {
+    console.error(`hyalo: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+  runBinary(resolved.binary, process.argv.slice(2));
+}
+
+main();

--- a/npm/hyalo/lib/resolve-platform.js
+++ b/npm/hyalo/lib/resolve-platform.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const PLATFORMS = Object.freeze(require('../platforms.json'));
+
+function currentPlatform(probe = {}) {
+  const platform = probe.platform || process.platform;
+  const arch = probe.arch || process.arch;
+  const libc = platform === 'linux' ? (probe.libc === undefined ? require('detect-libc').familySync() : probe.libc) : null;
+  return { platform, arch, libc };
+}
+
+function packageFor(p) {
+  return PLATFORMS.find(({ os, cpu, libc }) =>
+    os === p.platform && cpu === p.arch && libc === p.libc);
+}
+
+function resolveBinary(requireResolve = require.resolve, probe) {
+  const current = currentPlatform(probe);
+  const match = packageFor(current);
+  if (!match) {
+    const libc = current.libc || (current.platform === 'linux' ? 'unknown' : 'n/a');
+    throw new Error(`No Hyalo binary package supports os=${current.platform}, cpu=${current.arch}, libc=${libc}. Intel macOS and unknown Linux libc are unsupported; install with cargo install hyalo-cli instead.`);
+  }
+  try {
+    const binaryName = current.platform === 'win32' ? 'hyalo.exe' : 'hyalo';
+    return {
+      packageName: match.package,
+      binary: requireResolve(`${match.package}/${binaryName}`),
+      ...current
+    };
+  } catch (error) {
+    throw new Error(`The optional package ${match.package} is missing for os=${current.platform}, cpu=${current.arch}, libc=${current.libc || 'n/a'}. Ensure npm optional dependencies are enabled, or install with cargo install hyalo-cli.`, { cause: error });
+  }
+}
+
+module.exports = { PLATFORMS, currentPlatform, packageFor, resolveBinary };

--- a/npm/hyalo/lib/run-child.js
+++ b/npm/hyalo/lib/run-child.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { spawn } = require('node:child_process');
+
+function runBinary(binary, argv) {
+  const child = spawn(binary, argv, {
+    stdio: 'inherit',
+    shell: false
+  });
+  const signalHandlers = new Map();
+  let finished = false;
+
+  function removeSignalHandlers() {
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler);
+    }
+    signalHandlers.clear();
+  }
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    const handler = () => {
+      if (!finished) child.kill(signal);
+    };
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  child.once('error', (error) => {
+    if (finished) return;
+    finished = true;
+    removeSignalHandlers();
+    console.error(`hyalo: failed to start ${binary}: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.once('exit', (code, signal) => {
+    if (finished) return;
+    finished = true;
+    removeSignalHandlers();
+    if (signal) {
+      try {
+        process.kill(process.pid, signal);
+      } catch (error) {
+        console.error(`hyalo: child exited with signal ${signal}: ${error.message}`);
+        process.exitCode = 1;
+      }
+      return;
+    }
+    process.exitCode = code ?? 1;
+  });
+}
+
+module.exports = { runBinary };

--- a/npm/hyalo/package.json
+++ b/npm/hyalo/package.json
@@ -1,0 +1,43 @@
+{
+  "bin": {
+    "hyalo": "bin/hyalo.js"
+  },
+  "dependencies": {
+    "detect-libc": "2.1.2"
+  },
+  "description": "Hyalo knowledgebase CLI",
+  "engines": {
+    "node": ">=22.14.0",
+    "npm": ">=11.5.1"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md",
+    "LICENSE",
+    "platforms.json"
+  ],
+  "license": "MIT",
+  "name": "hyalo",
+  "optionalDependencies": {
+    "@ractive-ch/hyalo-darwin-arm64": "0.22.0",
+    "@ractive-ch/hyalo-linux-arm64": "0.22.0",
+    "@ractive-ch/hyalo-linux-arm64-musl": "0.22.0",
+    "@ractive-ch/hyalo-linux-x64": "0.22.0",
+    "@ractive-ch/hyalo-linux-x64-musl": "0.22.0",
+    "@ractive-ch/hyalo-win32-arm64": "0.22.0",
+    "@ractive-ch/hyalo-win32-x64": "0.22.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/hyalo",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "version": "0.22.0"
+}

--- a/npm/hyalo/platforms.json
+++ b/npm/hyalo/platforms.json
@@ -1,0 +1,51 @@
+[
+  {
+    "cpu": "arm64",
+    "libc": null,
+    "os": "darwin",
+    "package": "@ractive-ch/hyalo-darwin-arm64",
+    "target": "aarch64-apple-darwin"
+  },
+  {
+    "cpu": "x64",
+    "libc": "glibc",
+    "os": "linux",
+    "package": "@ractive-ch/hyalo-linux-x64",
+    "target": "x86_64-unknown-linux-gnu"
+  },
+  {
+    "cpu": "arm64",
+    "libc": "glibc",
+    "os": "linux",
+    "package": "@ractive-ch/hyalo-linux-arm64",
+    "target": "aarch64-unknown-linux-gnu"
+  },
+  {
+    "cpu": "x64",
+    "libc": "musl",
+    "os": "linux",
+    "package": "@ractive-ch/hyalo-linux-x64-musl",
+    "target": "x86_64-unknown-linux-musl"
+  },
+  {
+    "cpu": "arm64",
+    "libc": "musl",
+    "os": "linux",
+    "package": "@ractive-ch/hyalo-linux-arm64-musl",
+    "target": "aarch64-unknown-linux-musl"
+  },
+  {
+    "cpu": "x64",
+    "libc": null,
+    "os": "win32",
+    "package": "@ractive-ch/hyalo-win32-x64",
+    "target": "x86_64-pc-windows-msvc"
+  },
+  {
+    "cpu": "arm64",
+    "libc": null,
+    "os": "win32",
+    "package": "@ractive-ch/hyalo-win32-arm64",
+    "target": "aarch64-pc-windows-msvc"
+  }
+]

--- a/npm/hyalo/test/fixtures/child.js
+++ b/npm/hyalo/test/fixtures/child.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const mode = process.argv[2];
+if (mode === 'wait') {
+  process.stdout.write(`ready:${process.pid}\n`);
+  setInterval(() => {}, 1000);
+  return;
+}
+const stdin = [];
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => stdin.push(chunk));
+process.stdin.on('end', () => {
+  if (mode === 'signal') {
+    process.kill(process.pid, 'SIGTERM');
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    argv: process.argv.slice(2),
+    stdin: stdin.join('')
+  }));
+  process.stderr.write('child stderr\n');
+  process.exitCode = Number(process.argv[3]);
+});

--- a/npm/hyalo/test/fixtures/run-child-harness.js
+++ b/npm/hyalo/test/fixtures/run-child-harness.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const path = require('node:path');
+const { runBinary } = require('../../lib/run-child');
+
+if (process.argv[2] === 'missing') {
+  runBinary(path.join(__dirname, 'does-not-exist'), []);
+} else {
+  runBinary(
+    process.execPath,
+    [path.join(__dirname, 'child.js'), ...process.argv.slice(2)]
+  );
+}

--- a/npm/hyalo/test/launcher.test.js
+++ b/npm/hyalo/test/launcher.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+const {
+  PLATFORMS,
+  packageFor,
+  resolveBinary
+} = require('../lib/resolve-platform');
+
+const EXPECTED_PLATFORMS = [
+  { target: 'aarch64-apple-darwin', package: '@ractive-ch/hyalo-darwin-arm64', os: 'darwin', cpu: 'arm64', libc: null },
+  { target: 'x86_64-unknown-linux-gnu', package: '@ractive-ch/hyalo-linux-x64', os: 'linux', cpu: 'x64', libc: 'glibc' },
+  { target: 'aarch64-unknown-linux-gnu', package: '@ractive-ch/hyalo-linux-arm64', os: 'linux', cpu: 'arm64', libc: 'glibc' },
+  { target: 'x86_64-unknown-linux-musl', package: '@ractive-ch/hyalo-linux-x64-musl', os: 'linux', cpu: 'x64', libc: 'musl' },
+  { target: 'aarch64-unknown-linux-musl', package: '@ractive-ch/hyalo-linux-arm64-musl', os: 'linux', cpu: 'arm64', libc: 'musl' },
+  { target: 'x86_64-pc-windows-msvc', package: '@ractive-ch/hyalo-win32-x64', os: 'win32', cpu: 'x64', libc: null },
+  { target: 'aarch64-pc-windows-msvc', package: '@ractive-ch/hyalo-win32-arm64', os: 'win32', cpu: 'arm64', libc: null }
+];
+
+test('generated table and selection match all seven release targets', () => {
+  assert.deepEqual(PLATFORMS, EXPECTED_PLATFORMS);
+  for (const expected of EXPECTED_PLATFORMS) {
+    assert.deepEqual(packageFor({
+      platform: expected.os,
+      arch: expected.cpu,
+      libc: expected.libc
+    }), expected);
+  }
+});
+
+test('resolves the exact binary path in the selected optional package', () => {
+  let requested;
+  const resolved = resolveBinary((specifier) => {
+    requested = specifier;
+    return '/fixture/hyalo';
+  }, { platform: 'linux', arch: 'arm64', libc: 'musl' });
+  assert.equal(requested, '@ractive-ch/hyalo-linux-arm64-musl/hyalo');
+  assert.equal(resolved.packageName, '@ractive-ch/hyalo-linux-arm64-musl');
+  assert.equal(resolved.binary, '/fixture/hyalo');
+});
+
+test('rejects Darwin x64, unsupported CPUs, and unknown Linux libc', () => {
+  assert.throws(
+    () => resolveBinary(() => '', { platform: 'darwin', arch: 'x64' }),
+    /os=darwin, cpu=x64, libc=n\/a.*cargo install hyalo-cli/
+  );
+  assert.throws(
+    () => resolveBinary(() => '', { platform: 'win32', arch: 'ia32' }),
+    /os=win32, cpu=ia32, libc=n\/a.*cargo install hyalo-cli/
+  );
+  assert.throws(
+    () => resolveBinary(() => '', { platform: 'linux', arch: 'x64', libc: null }),
+    /os=linux, cpu=x64, libc=unknown.*cargo install hyalo-cli/
+  );
+});
+
+test('missing optional package names the package, platform, and remedy', () => {
+  assert.throws(
+    () => resolveBinary(() => {
+      throw Object.assign(new Error('not found'), { code: 'MODULE_NOT_FOUND' });
+    }, { platform: 'linux', arch: 'x64', libc: 'glibc' }),
+    /@ractive-ch\/hyalo-linux-x64.*os=linux, cpu=x64, libc=glibc.*optional dependencies.*cargo install hyalo-cli/
+  );
+});
+
+const harness = path.join(__dirname, 'fixtures', 'run-child-harness.js');
+
+test('real child inherits stdio, receives argv unchanged, and exits zero', () => {
+  const args = ['exit', '0', 'plain', 'space value', '"quoted"', "single'quote"];
+  const result = spawnSync(process.execPath, [harness, ...args], {
+    input: 'stdin payload',
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /child stderr/);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.argv, args);
+  assert.equal(output.stdin, 'stdin payload');
+});
+
+test('real child numeric exit status is propagated', () => {
+  const result = spawnSync(process.execPath, [harness, 'exit', '7'], {
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 7);
+});
+
+test('spawn ENOENT is reported once and exits nonzero', () => {
+  const result = spawnSync(process.execPath, [harness, 'missing'], {
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /hyalo: failed to start .*ENOENT/);
+  assert.equal(result.stderr.match(/failed to start/g).length, 1);
+});
+
+test('real child signal termination is propagated on Unix', {
+  skip: process.platform === 'win32'
+}, () => {
+  const result = spawnSync(process.execPath, [harness, 'signal'], {
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, null);
+  assert.equal(result.signal, 'SIGTERM');
+});
+
+test('SIGTERM sent to the launcher PID terminates its real child', {
+  skip: process.platform === 'win32',
+  timeout: 5000
+}, async () => {
+  const runner = spawn(process.execPath, [harness, 'wait'], {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  const childPid = await new Promise((resolve, reject) => {
+    runner.once('error', reject);
+    runner.stdout.once('data', (chunk) => {
+      const match = /^ready:(\d+)/.exec(chunk.toString());
+      if (!match) {
+        reject(new Error(`unexpected child readiness output: ${chunk}`));
+        return;
+      }
+      resolve(Number(match[1]));
+    });
+  });
+  const closed = new Promise((resolve) => {
+    runner.once('close', (code, signal) => resolve({ code, signal }));
+  });
+  process.kill(runner.pid, 'SIGTERM');
+  assert.deepEqual(await closed, { code: null, signal: 'SIGTERM' });
+  assert.throws(
+    () => process.kill(childPid, 0),
+    (error) => error.code === 'ESRCH'
+  );
+});

--- a/npm/platforms/darwin-arm64/LICENSE
+++ b/npm/platforms/darwin-arm64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/platforms/darwin-arm64/README.md
+++ b/npm/platforms/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# @ractive-ch/hyalo-darwin-arm64
+
+Native Hyalo CLI binary for aarch64-apple-darwin.

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "cpu": [
+    "arm64"
+  ],
+  "description": "Hyalo CLI native binary for this platform",
+  "files": [
+    "hyalo",
+    "LICENSE",
+    "README.md"
+  ],
+  "license": "MIT",
+  "name": "@ractive-ch/hyalo-darwin-arm64",
+  "os": [
+    "darwin"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/platforms/darwin-arm64",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "version": "0.22.0"
+}

--- a/npm/platforms/linux-arm64-musl/LICENSE
+++ b/npm/platforms/linux-arm64-musl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/platforms/linux-arm64-musl/README.md
+++ b/npm/platforms/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# @ractive-ch/hyalo-linux-arm64-musl
+
+Native Hyalo CLI binary for aarch64-unknown-linux-musl.

--- a/npm/platforms/linux-arm64-musl/package.json
+++ b/npm/platforms/linux-arm64-musl/package.json
@@ -1,0 +1,28 @@
+{
+  "cpu": [
+    "arm64"
+  ],
+  "description": "Hyalo CLI native binary for this platform",
+  "files": [
+    "hyalo",
+    "LICENSE",
+    "README.md"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "license": "MIT",
+  "name": "@ractive-ch/hyalo-linux-arm64-musl",
+  "os": [
+    "linux"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/platforms/linux-arm64-musl",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "version": "0.22.0"
+}

--- a/npm/platforms/linux-arm64/LICENSE
+++ b/npm/platforms/linux-arm64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/platforms/linux-arm64/README.md
+++ b/npm/platforms/linux-arm64/README.md
@@ -1,0 +1,3 @@
+# @ractive-ch/hyalo-linux-arm64
+
+Native Hyalo CLI binary for aarch64-unknown-linux-gnu.

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -1,0 +1,28 @@
+{
+  "cpu": [
+    "arm64"
+  ],
+  "description": "Hyalo CLI native binary for this platform",
+  "files": [
+    "hyalo",
+    "LICENSE",
+    "README.md"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "license": "MIT",
+  "name": "@ractive-ch/hyalo-linux-arm64",
+  "os": [
+    "linux"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/platforms/linux-arm64",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "version": "0.22.0"
+}

--- a/npm/platforms/linux-x64-musl/LICENSE
+++ b/npm/platforms/linux-x64-musl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/platforms/linux-x64-musl/README.md
+++ b/npm/platforms/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# @ractive-ch/hyalo-linux-x64-musl
+
+Native Hyalo CLI binary for x86_64-unknown-linux-musl.

--- a/npm/platforms/linux-x64-musl/package.json
+++ b/npm/platforms/linux-x64-musl/package.json
@@ -1,0 +1,28 @@
+{
+  "cpu": [
+    "x64"
+  ],
+  "description": "Hyalo CLI native binary for this platform",
+  "files": [
+    "hyalo",
+    "LICENSE",
+    "README.md"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "license": "MIT",
+  "name": "@ractive-ch/hyalo-linux-x64-musl",
+  "os": [
+    "linux"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/platforms/linux-x64-musl",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "version": "0.22.0"
+}

--- a/npm/platforms/linux-x64/LICENSE
+++ b/npm/platforms/linux-x64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/platforms/linux-x64/README.md
+++ b/npm/platforms/linux-x64/README.md
@@ -1,0 +1,3 @@
+# @ractive-ch/hyalo-linux-x64
+
+Native Hyalo CLI binary for x86_64-unknown-linux-gnu.

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -1,0 +1,28 @@
+{
+  "cpu": [
+    "x64"
+  ],
+  "description": "Hyalo CLI native binary for this platform",
+  "files": [
+    "hyalo",
+    "LICENSE",
+    "README.md"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "license": "MIT",
+  "name": "@ractive-ch/hyalo-linux-x64",
+  "os": [
+    "linux"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/platforms/linux-x64",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "version": "0.22.0"
+}

--- a/npm/platforms/win32-arm64/LICENSE
+++ b/npm/platforms/win32-arm64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/platforms/win32-arm64/README.md
+++ b/npm/platforms/win32-arm64/README.md
@@ -1,0 +1,3 @@
+# @ractive-ch/hyalo-win32-arm64
+
+Native Hyalo CLI binary for aarch64-pc-windows-msvc.

--- a/npm/platforms/win32-arm64/package.json
+++ b/npm/platforms/win32-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "cpu": [
+    "arm64"
+  ],
+  "description": "Hyalo CLI native binary for this platform",
+  "files": [
+    "hyalo.exe",
+    "LICENSE",
+    "README.md"
+  ],
+  "license": "MIT",
+  "name": "@ractive-ch/hyalo-win32-arm64",
+  "os": [
+    "win32"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/platforms/win32-arm64",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "version": "0.22.0"
+}

--- a/npm/platforms/win32-x64/LICENSE
+++ b/npm/platforms/win32-x64/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ractive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/platforms/win32-x64/README.md
+++ b/npm/platforms/win32-x64/README.md
@@ -1,0 +1,3 @@
+# @ractive-ch/hyalo-win32-x64
+
+Native Hyalo CLI binary for x86_64-pc-windows-msvc.

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -1,0 +1,25 @@
+{
+  "cpu": [
+    "x64"
+  ],
+  "description": "Hyalo CLI native binary for this platform",
+  "files": [
+    "hyalo.exe",
+    "LICENSE",
+    "README.md"
+  ],
+  "license": "MIT",
+  "name": "@ractive-ch/hyalo-win32-x64",
+  "os": [
+    "win32"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "directory": "npm/platforms/win32-x64",
+    "type": "git",
+    "url": "https://github.com/ractive/hyalo.git"
+  },
+  "version": "0.22.0"
+}

--- a/pi-package/skills/hyalo/SKILL.md
+++ b/pi-package/skills/hyalo/SKILL.md
@@ -260,7 +260,10 @@ hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.m
 
 ## Setup Checklist for New Projects
 
-1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`)
+1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`). Use the
+   published `cargo install hyalo-cli` route; the prepared npm distribution
+   remains unpublished until owner bootstrap, trusted publisher setup, and
+   real-platform registry checks are complete.
 2. **Configure vault**: Create `.hyalo.toml` with `dir = "knowledgebase"`
 3. **Add to AGENTS.md**: Include: "Use `hyalo` CLI for all markdown knowledgebase operations. Always use `--format text` for compact output."
 4. **Create views**: Set up common views (`stale-in-progress`, `orphans`, etc.)

--- a/plugins/hyalo/skills/hyalo/SKILL.md
+++ b/plugins/hyalo/skills/hyalo/SKILL.md
@@ -10,7 +10,9 @@ description: "Search and edit structured markdown knowledgebases with the Hyalo 
 Use the installed `hyalo` executable. In a Hyalo source checkout, `target/release/hyalo`
 is an alternative when present. If unavailable, report that and suggest the project's
 documented installation (`cargo install hyalo-cli`); do not install software as a
-side effect of a knowledgebase query.
+side effect of a knowledgebase query. The prepared npm distribution remains
+unpublished pending owner bootstrap, trusted publisher setup, and real-platform
+registry checks; do not suggest `npm install hyalo` before that acceptance.
 
 Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
 to locate and confirm the vault. Commands also work inside that configured vault,


### PR DESCRIPTION
## Summary

Prepare npm distribution of the Hyalo CLI: one launcher package and seven exact-version native platform packages. npm selects the platform dependency; the launcher forwards arguments, stdio, exit status and cancellation to the native binary.

The Rust generator owns package metadata, checks Cargo-version and dependency-pin drift, and stages complete packages without overwriting existing output. Metadata comparison accepts Git CRLF checkouts while preserving other content differences. PR CI tests the launcher across three operating systems and exercises eight-package packing/dry runs plus a real Linux host installation. The release job consumes native archives, verifies immutable-version integrity on retries, and publishes platforms before the main package with OIDC/provenance.

This is repository preparation. Iteration 286 remains in progress: npm bootstrap/trusted publishers, actual publication and public-registry installation on macOS arm64, Linux x64 glibc, Alpine x64 musl and Windows x64 are unfinished. Iteration 287 remains blocked on full 286 completion; 288 desktop verification remains deferred. No registry publication, trust change or release was performed.

## Test plan

- [x] Ordered Rust formatting, strict workspace Clippy and workspace tests (4,894 passed, zero failures, two existing ignored doctests).
- [x] Generator/version/staging tests, including CRLF checkout and negative drift cases; Windows xtask compilation.
- [x] Nine launcher behavioral tests; actionlint; all implemented xtask gates.
- [x] Eight local package dry runs/content checks and real macOS arm64 tarball installation; foreign platform bytes were packaging fixtures.
- [x] Changed knowledgebase lint and git diff --check; full-vault lint retains four existing warnings.
- [x] All 11 runnable GitHub checks passed at b2c4f4c46c241521dae54bd55937682d8826f58e; the push-only lint-kb-full job is correctly skipped.
- [ ] External npm publication/trusted-publisher configuration and four-platform registry acceptance.

Two xtask commands remain existing stubs, and the jq gate's MADR recipe is unavailable because this vault has no docs/decisions directory.

## Review

Fresh independent full review found no actionable defects in the repository preparation. Prior findings for cancellation forwarding, immutable publication retries, Windows npm.cmd selection, non-Unix compilation and CRLF metadata checks have implementation fixes and regression coverage; all five findings are resolved. Final independent review covers b2c4f4c46c241521dae54bd55937682d8826f58e, including the plan/status reconciliation, with no source coverage gap.
