### PR TITLE
ci: add guarded npm-only publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,17 @@ name: Release
 on:
   release:
     types: [published]
-  workflow_dispatch: # dry run - builds + packages everything, publishes nothing
+  workflow_dispatch:
+    inputs:
+      publish_npm:
+        description: Publish only the npm packages after building and dry-running everything
+        type: boolean
+        required: false
+        default: false
+      npm_version:
+        description: Cargo version to confirm when publish_npm is enabled
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -82,6 +92,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PUBLISH_NPM: ${{ inputs.publish_npm }}
+          REQUESTED_NPM_VERSION: ${{ inputs.npm_version }}
         run: |
           set -euo pipefail
           npm install --global npm@11.19.1
@@ -94,6 +106,11 @@ jobs:
           fi
           if [ "$EVENT_NAME" = release ] && [ "$RELEASE_TAG" != "v$version" ]; then
             echo "release tag '$RELEASE_TAG' does not match Cargo version '$version'" >&2
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$PUBLISH_NPM" = true ] && \
+             [ "$REQUESTED_NPM_VERSION" != "$version" ]; then
+            echo "npm_version '$REQUESTED_NPM_VERSION' does not match Cargo version '$version'" >&2
             exit 1
           fi
           echo "CARGO_VERSION=$version" >> "$GITHUB_ENV"
@@ -174,7 +191,9 @@ jobs:
             "$PACK_DIR/hyalo.json" \
             > "$PACK_DIR/publication-plan.json"
       - name: Publish platform packages, then main package
-        if: github.event_name == 'release'
+        if: >-
+          github.event_name == 'release' ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish_npm)
         shell: bash
         env:
           PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs

--- a/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
@@ -115,6 +115,20 @@ versions before publishing: npm versions are immutable. Retain this noncompleted
 status until external acceptance is fulfilled. Iteration 287 remains blocked by the
 full iteration-286 prerequisite.
 
+## Hyalo-only publishing preparation — 2026-09-07
+
+PR #336 merged the repository preparation after all eleven runnable GitHub checks
+passed. The ordinary release workflow also publishes to other distribution channels
+and repositories. To preserve the Hyalo-only scope, manual dispatch now has an
+explicit `publish_npm` option, defaulting to false, with `npm_version` required to
+match Cargo before publication. Every manual dispatch keeps the reusable native
+release workflow in dry-run mode; only npm publication can opt in. Default manual
+runs remain unpublished, and normal published-release behavior is unchanged.
+
+This prepares the restricted publishing path; it does not complete owner bootstrap,
+trusted publishing, actual publication or registry platform verification. The user
+explicitly deferred `homefinder-eco-mcp`; iteration 287's consumer task remains open.
+
 ## Links
 
 - [[research/npm-package-and-typed-typescript-api]] — proposal, naming table, settled section

--- a/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
+++ b/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
@@ -57,6 +57,8 @@ built from the same commit. Requires both 285 (structs) and 286 (the package to 
       `cargo test --workspace -q`, every xtask `check-*`, `npm test`, `hyalo lint --strict`.
 - [ ] TASK-7 (consumer, outside this repo): switch `homefinder-eco-mcp` to `npm install hyalo`
       and the typed `find`; record what the wrapper lacked.
+      Deferred by the user on 2026-09-07 to concentrate on Hyalo; retain this requirement
+      as unfinished and do not modify that repository during the current batch.
 
 ## Acceptance criteria
 

--- a/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
+++ b/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
@@ -257,7 +257,8 @@ Iteration 285 completed the typed Rust output models and strengthened
 the Cargo workspace version. Iteration 286 extends that gate through one
 canonical Rust npm platform table: the main manifest, all seven platform
 manifests, exact optional-dependency pins, generated platform map, licenses,
-and target READMEs are checked byte-for-byte. The generator also stages an
+and target READMEs are checked byte-for-byte apart from equivalent LF/CRLF line
+endings. The generator also stages an
 explicit seven-target binary input into a new output tree without deleting or
 overwriting tracked sources.
 
@@ -275,13 +276,18 @@ tarballs with optional registry packages omitted, then
 `hyalo 0.22.0`. Foreign-target files were clearly labeled fixture bytes and
 prove package layout only. The PR workflow repeats launcher tests on GitHub
 Linux, macOS, and Windows runners and performs the packaging smoke with a real
-Linux x64 glibc binary. These workflow jobs have not yet run.
+Linux x64 glibc binary. These jobs passed on PR #336, together with all other
+runnable checks at its reviewed head.
 
 The release workflow is prepared to consume the seven exact archives produced
 by `ractive/release-workflows/.github/workflows/release.yml@v0.2.0`, dry-run
-all eight packages on manual dispatch, and publish platform packages before the
-main package only for a published release. No workflow was dispatched and no
-package was published during this work.
+all eight packages on default manual dispatch, and publish platform packages before
+the main package for a published release. An explicit npm-only manual option uses
+`publish_npm=true` and an `npm_version` matching Cargo. The reusable workflow stays
+in dry-run mode for every manual dispatch, so native archives are built without
+publishing to crates.io, Homebrew, Scoop, winget, AUR or Cloudsmith. Only the npm
+publication step opts in. No workflow was dispatched and no package was published
+during this preparation.
 
 Publication retries are fail-closed: a Rust gate compares each local
 `npm pack` integrity with the exact version's `dist.integrity` at

--- a/npm/hyalo/README.md
+++ b/npm/hyalo/README.md
@@ -42,10 +42,22 @@ through a temporary local install. Foreign-target fixture bytes in that job
 verify package layout only.
 
 `.github/workflows/release.yml` downloads the seven native archives produced
-by the pinned reusable release workflow. A manual workflow dispatch only packs
-and dry-runs the packages. A published release event is the only path that can
-publish: all seven platform tarballs publish first, followed by `hyalo`, using
-npm provenance and GitHub OIDC without a repository token fallback.
+by the pinned reusable release workflow. By default, a manual workflow dispatch
+builds the native archives, packs all eight npm packages, and dry-runs every
+publication. The reusable workflow remains in dry-run mode for every manual
+dispatch, so it does not publish crates or configured package-manager and Linux
+repository releases.
+
+A manual dispatch can publish only the npm packages by enabling `publish_npm`
+and entering an `npm_version` that exactly matches the `hyalo-cli` Cargo
+version. A missing or mismatched confirmation stops the job before npm
+publication. A published release remains the broad release path: it validates
+the release tag against the Cargo version, runs the configured reusable release
+publishing, and publishes the npm packages.
+
+Both npm publishing paths use the same staged tarballs and publication plan:
+all seven platform packages are handled first, followed by `hyalo`, using npm
+provenance and GitHub OIDC without a repository token fallback.
 Before an immutable version is published, the workflow compares the local
 tarball integrity with `dist.integrity` from the public npm registry. A retry
 skips an identical existing artifact, publishes an explicitly missing version,


### PR DESCRIPTION
## Summary

The standard release also publishes to other distribution channels and repositories. Add an explicit npm-only manual option so Hyalo can publish its eight npm packages while the reusable native release workflow remains in dry-run mode. Manual runs still default to publishing nothing; opting in requires publish_npm=true and npm_version matching Cargo. Normal published-release behavior is preserved.

Record the user's homefinder-eco-mcp deferral and correct the research note's completed CI/CRLF evidence. Iteration 286's bootstrap, trust configuration, publication and public-registry platform checks remain open. No workflow was dispatched or package published.

## Validation

- actionlint and five event/input cases passed, including a wrong-version rejection.
- Changed-file strict KB lint: three files, no findings; git diff --check passed.
- Rust/launcher code and manifests are unchanged from PR336; its ordered Rust gates, 4,894 passing tests and package smoke evidence are reused. All 11 runnable GitHub checks passed at e4170618da99e33b6d7f256c49be98a19323cc48; push-only lint-kb-full was correctly skipped.
- Fresh independent read-only review found no actionable defects; all five reviewed file hashes match the committed PR head.
