### PR TITLE
ci: prepare signed npm bootstrap and registry checks

### DIFF
--- a/.github/workflows/npm-registry.yml
+++ b/.github/workflows/npm-registry.yml
@@ -1,0 +1,105 @@
+name: npm Registry Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Published hyalo version to verify
+        type: string
+        required: true
+        default: 0.22.0
+
+permissions:
+  contents: read
+
+jobs:
+  native:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS arm64
+            runner: macos-15
+            platform: darwin
+            arch: arm64
+            libc: none
+            package: "@ractive-ch/hyalo-darwin-arm64"
+          - name: Linux x64 glibc
+            runner: ubuntu-24.04
+            platform: linux
+            arch: x64
+            libc: glibc
+            package: "@ractive-ch/hyalo-linux-x64"
+          - name: Windows x64
+            runner: windows-2022
+            platform: win32
+            arch: x64
+            libc: none
+            package: "@ractive-ch/hyalo-win32-x64"
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+      - name: Pin npm
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --global npm@11.19.1
+          test "$(npm --version)" = 11.19.1
+      - name: Install and run the published CLI
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          CONSUMER_DIR: ${{ runner.temp }}/hyalo-registry-consumer
+          EXPECTED_PLATFORM: ${{ matrix.platform }}
+          EXPECTED_ARCH: ${{ matrix.arch }}
+          EXPECTED_LIBC: ${{ matrix.libc }}
+          EXPECTED_PLATFORM_PACKAGE: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          mkdir "$CONSUMER_DIR"
+          cd "$CONSUMER_DIR"
+          npm init --yes
+          npm install --ignore-scripts --save-exact \
+            --registry https://registry.npmjs.org "hyalo@$VERSION"
+          node "$GITHUB_WORKSPACE/npm/hyalo/test/registry-smoke.cjs"
+
+  alpine:
+    name: Linux x64 musl
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Install and run the published CLI in Alpine
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          CONSUMER_DIR: ${{ runner.temp }}/hyalo-registry-consumer-alpine
+          ALPINE_IMAGE: node:24.19.0-alpine3.23@sha256:244cc2b53f46f9e876304391d17682b0ddae9ac33491f4857e25e35a36ba7995
+        run: |
+          set -euo pipefail
+          mkdir "$CONSUMER_DIR"
+          docker run --rm --platform linux/amd64 \
+            --env VERSION \
+            --env CONSUMER_DIR=/consumer \
+            --env EXPECTED_PLATFORM=linux \
+            --env EXPECTED_ARCH=x64 \
+            --env EXPECTED_LIBC=musl \
+            --env EXPECTED_PLATFORM_PACKAGE=@ractive-ch/hyalo-linux-x64-musl \
+            --volume "$CONSUMER_DIR:/consumer" \
+            --volume "$GITHUB_WORKSPACE/npm/hyalo/test/registry-smoke.cjs:/registry-smoke.cjs:ro" \
+            --workdir /consumer \
+            "$ALPINE_IMAGE" sh -euxc '
+              npm install --global npm@11.19.1
+              test "$(npm --version)" = 11.19.1
+              npm init --yes
+              npm install --ignore-scripts --save-exact \
+                --registry https://registry.npmjs.org "hyalo@$VERSION"
+              node /registry-smoke.cjs
+            '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,13 @@ on:
         type: boolean
         required: false
         default: false
+      prepare_npm_bootstrap:
+        description: Sign and upload npm tarballs for the initial owner publication
+        type: boolean
+        required: false
+        default: false
       npm_version:
-        description: Cargo version to confirm when publish_npm is enabled
+        description: Cargo version to confirm for npm publication or bootstrap preparation
         type: string
         required: false
 
@@ -93,6 +98,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           PUBLISH_NPM: ${{ inputs.publish_npm }}
+          PREPARE_NPM_BOOTSTRAP: ${{ inputs.prepare_npm_bootstrap }}
           REQUESTED_NPM_VERSION: ${{ inputs.npm_version }}
         run: |
           set -euo pipefail
@@ -109,6 +115,12 @@ jobs:
             exit 1
           fi
           if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$PUBLISH_NPM" = true ] && \
+             [ "$PREPARE_NPM_BOOTSTRAP" = true ]; then
+            echo "publish_npm and prepare_npm_bootstrap are mutually exclusive" >&2
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = workflow_dispatch ] && \
+             { [ "$PUBLISH_NPM" = true ] || [ "$PREPARE_NPM_BOOTSTRAP" = true ]; } && \
              [ "$REQUESTED_NPM_VERSION" != "$version" ]; then
             echo "npm_version '$REQUESTED_NPM_VERSION' does not match Cargo version '$version'" >&2
             exit 1
@@ -190,6 +202,82 @@ jobs:
             "$PACK_DIR/win32-arm64.json" \
             "$PACK_DIR/hyalo.json" \
             > "$PACK_DIR/publication-plan.json"
+      - name: Sign npm bootstrap tarballs with GitHub OIDC
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.prepare_npm_bootstrap
+        shell: bash
+        env:
+          PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs
+        run: |
+          set -euo pipefail
+          NPM_PACKAGE_DIR="$(npm root --global)/npm"
+          export NPM_PACKAGE_DIR
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict'
+          import { execFileSync } from 'node:child_process'
+          import { createHash } from 'node:crypto'
+          import { readFile, writeFile } from 'node:fs/promises'
+          import { createRequire } from 'node:module'
+          import path from 'node:path'
+
+          const packDir = process.env.PACK_DIR
+          const npmPackageDir = process.env.NPM_PACKAGE_DIR
+          assert(packDir && npmPackageDir && process.env.CARGO_VERSION)
+
+          const npmPackagePath = path.join(npmPackageDir, 'package.json')
+          const npmManifest = JSON.parse(await readFile(npmPackagePath, 'utf8'))
+          assert.equal(npmManifest.version, '11.19.1')
+          const requireFromNpm = createRequire(npmPackagePath)
+          const npa = requireFromNpm('npm-package-arg')
+          const { generateProvenance } = requireFromNpm(
+            'libnpmpublish/lib/provenance.js'
+          )
+
+          const packageDirs = [
+            'darwin-arm64', 'linux-x64', 'linux-arm64', 'linux-x64-musl',
+            'linux-arm64-musl', 'win32-x64', 'win32-arm64', 'hyalo',
+          ]
+          const rows = (await readFile(path.join(packDir, 'packages.tsv'), 'utf8'))
+            .trimEnd().split('\n').map((row) => row.split('\t'))
+          assert.deepEqual(rows.map(([packageDir]) => packageDir), packageDirs)
+
+          for (const [packageDir, tarball, ...extra] of rows) {
+            assert.equal(extra.length, 0)
+            const [pack] = JSON.parse(await readFile(
+              path.join(packDir, `${packageDir}.json`), 'utf8'
+            ))
+            assert.equal(path.basename(tarball), pack.filename)
+            const manifest = JSON.parse(execFileSync(
+              'tar', ['-xOf', tarball, 'package/package.json'], { encoding: 'utf8' }
+            ))
+            assert.equal(manifest.name, pack.name)
+            assert.equal(manifest.version, pack.version)
+            assert.equal(manifest.version, process.env.CARGO_VERSION)
+
+            const tarballBytes = await readFile(tarball)
+            const digest = createHash('sha512').update(tarballBytes).digest()
+            assert.equal(pack.integrity, `sha512-${digest.toString('base64')}`)
+            const subject = {
+              name: npa.toPurl(npa.resolve(manifest.name, manifest.version)),
+              digest: { sha512: digest.toString('hex') },
+            }
+            const bundle = await generateProvenance([subject], {})
+            const bundlePath = tarball.replace(/\.tgz$/, '.sigstore.json')
+            assert.notEqual(bundlePath, tarball)
+            await writeFile(bundlePath, `${JSON.stringify(bundle)}\n`, { flag: 'wx' })
+            console.log(`Signed ${path.basename(tarball)}`)
+          }
+          NODE
+      - name: Upload signed npm bootstrap packages
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.prepare_npm_bootstrap
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: npm-bootstrap-${{ env.CARGO_VERSION }}
+          path: ${{ runner.temp }}/hyalo-npm-packs
+          if-no-files-found: error
       - name: Publish platform packages, then main package
         if: >-
           github.event_name == 'release' ||

--- a/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
@@ -104,8 +104,9 @@ TASK-4 is partial: workflow and local dry runs exist, but owner bootstrap, trust
 publisher configuration and actual publication have not happened. TASK-6 is unperformed:
 public-registry installs on macOS arm64, Linux x64 glibc, Alpine musl and Windows x64
 are still required. Local fixtures and compilation checks do not satisfy these tasks.
-The owner reports npm login as `ractive.ch`; publication and trust changes still need
-separate authority. No token secret is required for the planned GitHub OIDC publisher.
+The owner login was verified as `ractive.ch`. On 2026-09-07 the user authorized
+Hyalo's eight-package npm bootstrap, publication and GitHub trusted-publisher setup.
+No token secret is required for the planned GitHub OIDC publisher.
 
 Resume external completion only with the required authority and real native artifacts.
 Bootstrap the eight package names, configure GitHub OIDC for `ractive/hyalo` and
@@ -128,6 +129,20 @@ runs remain unpublished, and normal published-release behavior is unchanged.
 This prepares the restricted publishing path; it does not complete owner bootstrap,
 trusted publishing, actual publication or registry platform verification. The user
 explicitly deferred `homefinder-eco-mcp`; iteration 287's consumer task remains open.
+
+## Authorized bootstrap preparation — 2026-09-07
+
+The npm-only bootstrap path builds the real 0.22.0 native archives, packs all eight
+packages and signs their exact tarball digests in GitHub Actions. The npm owner can
+then upload those unchanged tarballs with `--provenance-file` before configuring
+trusted publishers. This initial upload uses owner authentication and CI provenance;
+it does not demonstrate OIDC-authenticated publication. No placeholder version is
+needed. Keep publication and platform acceptance unchecked until verified.
+
+A separate manual registry workflow will install the public package on macOS arm64,
+Linux x64 glibc, Windows x64 and Alpine x64 musl, checking the actual installed native
+dependency and CLI version. It does not publish packages. These preparations preserve
+iteration 287's full prerequisite and iteration 288's deferred desktop verification.
 
 ## Links
 

--- a/npm/hyalo/README.md
+++ b/npm/hyalo/README.md
@@ -41,6 +41,12 @@ tarball contents, dry-runs every publication, and runs the real host binary
 through a temporary local install. Foreign-target fixture bytes in that job
 verify package layout only.
 
+After a version is public, the dispatch-only `.github/workflows/npm-registry.yml`
+installs that exact version from the npm registry in fresh consumers and runs
+the installed CLI on macOS arm64, Linux x64 glibc, Linux x64 musl, and Windows
+x64. The musl check runs in a pinned Node Alpine image. This acceptance workflow
+does not publish or change registry state.
+
 `.github/workflows/release.yml` downloads the seven native archives produced
 by the pinned reusable release workflow. By default, a manual workflow dispatch
 builds the native archives, packs all eight npm packages, and dry-runs every
@@ -55,6 +61,19 @@ publication. A published release remains the broad release path: it validates
 the release tag against the Cargo version, runs the configured reusable release
 publishing, and publishes the npm packages.
 
+For the initial owner upload, enable `prepare_npm_bootstrap` instead and enter
+the same exact `npm_version`. That option and `publish_npm` are mutually
+exclusive. The job builds and packs the same artifacts, then signs each final
+tarball with the workflow's GitHub OIDC identity and uploads
+`npm-bootstrap-<version>`. It does not publish to npm and needs no npm registry
+credential. The default manual dispatch remains the unchanged dry run.
+
+Bootstrap signing deliberately calls the provenance generator and
+`npm-package-arg` bundled inside the workflow's pinned npm 11.19.1. This is an
+internal npm API, so an npm pin update must review the inline signing script
+against that exact release. Signing creates public Sigstore provenance and a
+transparency-log entry even though the npm packages remain unpublished.
+
 Both npm publishing paths use the same staged tarballs and publication plan:
 all seven platform packages are handled first, followed by `hyalo`, using npm
 provenance and GitHub OIDC without a repository token fallback.
@@ -66,15 +85,45 @@ and stops on mismatched integrity or an inconclusive registry response.
 The npm owner must complete these external steps before the first registry
 release:
 
-1. Bootstrap the unscoped `hyalo` package and all seven scoped packages under
-   `@ractive-ch`; all eight currently lack public registry metadata.
-2. Configure each existing package's trusted publisher for repository
+1. Run the bootstrap-preparation dispatch for the real Cargo version and
+   download its `npm-bootstrap-<version>` artifact. Before uploading anything,
+   verify that every `.sigstore.json` bundle still matches the SHA-512 bytes of
+   its adjacent `.tgz`, and verify the Sigstore certificate identity names
+   repository `ractive/hyalo`, workflow `.github/workflows/release.yml`, and the
+   expected GitHub ref. Keep those reviewed tarball bytes unchanged.
+2. As the npm owner, bootstrap the unscoped `hyalo` package and all seven scoped
+   packages under `@ractive-ch` in platform-first order, followed by `hyalo`:
+
+   ```bash
+   (
+     set -eu
+     version=0.22.0 # replace with the confirmed Cargo version
+     for tarball in \
+       ractive-ch-hyalo-{darwin-arm64,linux-x64,linux-arm64,linux-x64-musl,linux-arm64-musl,win32-x64,win32-arm64}-"$version".tgz \
+       hyalo-"$version".tgz; do
+       npm publish "$tarball" \
+         --provenance-file "${tarball%.tgz}.sigstore.json" \
+         --access public --ignore-scripts --registry https://registry.npmjs.org
+     done
+   )
+   ```
+
+   `--provenance-file` verifies and attaches the prepared bundle. It is
+   mutually exclusive with `--provenance`; do not pass both. All eight packages
+   currently lack public registry metadata. The subshell stops at the first
+   failed upload, so `hyalo` cannot publish after a platform-package failure.
+   Before retrying, inspect the registry's `dist.integrity` for every attempted
+   package and compare it with the preserved tarball. Skip only an immutable
+   version whose integrity matches exactly, then resume in the same order.
+   Never try to overwrite a version or continue past a mismatch, missing proof,
+   or another inconclusive registry response.
+3. Configure each existing package's trusted publisher for repository
    `ractive/hyalo` and workflow `release.yml`.
-3. Explicitly allow direct publishing for each configuration. New trusted
+4. Explicitly allow direct publishing for each configuration. New trusted
    publisher configurations may allow staged publishing only by default.
-4. Publish an authorized release, then verify a registry install and
-   `npx --no-install hyalo --version` on macOS arm64, Linux x64 glibc,
-   Linux x64 musl, and Windows x64.
+5. Publish an authorized release through the OIDC workflow, then verify a
+   registry install and `npx --no-install hyalo --version` on macOS arm64,
+   Linux x64 glibc, Linux x64 musl, and Windows x64.
 
 See npm's official [trusted publishing guide](https://docs.npmjs.com/trusted-publishers/)
 and [`npm trust` requirements](https://docs.npmjs.com/cli/v11/commands/npm-trust/).

--- a/npm/hyalo/test/registry-smoke.cjs
+++ b/npm/hyalo/test/registry-smoke.cjs
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const { readdirSync, readFileSync, statSync } = require('node:fs');
+const path = require('node:path');
+const { createRequire } = require('node:module');
+
+const {
+  CONSUMER_DIR: consumerDir,
+  EXPECTED_ARCH: expectedArch,
+  EXPECTED_LIBC: expectedLibc,
+  EXPECTED_PLATFORM: expectedPlatform,
+  EXPECTED_PLATFORM_PACKAGE: expectedPlatformPackage,
+  VERSION: version
+} = process.env;
+
+for (const [name, value] of Object.entries({
+  CONSUMER_DIR: consumerDir,
+  EXPECTED_ARCH: expectedArch,
+  EXPECTED_LIBC: expectedLibc,
+  EXPECTED_PLATFORM: expectedPlatform,
+  EXPECTED_PLATFORM_PACKAGE: expectedPlatformPackage,
+  VERSION: version
+})) {
+  assert(value, `${name} must be set`);
+}
+
+assert.equal(process.platform, expectedPlatform);
+assert.equal(process.arch, expectedArch);
+
+const requireFromConsumer = createRequire(path.join(consumerDir, 'package.json'));
+const mainManifest = JSON.parse(readFileSync(
+  requireFromConsumer.resolve('hyalo/package.json'),
+  'utf8'
+));
+assert.equal(mainManifest.name, 'hyalo');
+assert.equal(mainManifest.version, version);
+
+const scopeDir = path.join(consumerDir, 'node_modules', '@ractive-ch');
+const installedPlatformPackages = readdirSync(scopeDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && entry.name.startsWith('hyalo-'))
+  .map((entry) => `@ractive-ch/${entry.name}`)
+  .sort();
+assert.deepEqual(installedPlatformPackages, [expectedPlatformPackage]);
+
+const platformManifest = JSON.parse(readFileSync(
+  requireFromConsumer.resolve(`${expectedPlatformPackage}/package.json`),
+  'utf8'
+));
+assert.equal(platformManifest.name, expectedPlatformPackage);
+assert.equal(platformManifest.version, version);
+assert.deepEqual(platformManifest.os, [expectedPlatform]);
+assert.deepEqual(platformManifest.cpu, [expectedArch]);
+if (expectedLibc === 'none') {
+  assert.equal(platformManifest.libc, undefined);
+} else {
+  assert.deepEqual(platformManifest.libc, [expectedLibc]);
+  const detectLibc = requireFromConsumer('detect-libc');
+  assert.equal(detectLibc.familySync(), expectedLibc);
+}
+
+const binaryName = process.platform === 'win32' ? 'hyalo.exe' : 'hyalo';
+const binary = requireFromConsumer.resolve(`${expectedPlatformPackage}/${binaryName}`);
+assert(statSync(binary).isFile(), `resolved binary is not a file: ${binary}`);
+
+const output = process.platform === 'win32'
+  ? execFileSync(process.env.ComSpec || 'cmd.exe', [
+    '/d', '/s', '/c', 'npx.cmd --no-install hyalo --version'
+  ], { cwd: consumerDir, encoding: 'utf8' })
+  : execFileSync('npx', ['--no-install', 'hyalo', '--version'], {
+    cwd: consumerDir,
+    encoding: 'utf8'
+  });
+const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const versionPattern = new RegExp(
+  `^hyalo ${escapedVersion}(?: \\([0-9a-f]{7,12}(?:\\+dirty)? ` +
+  `\\d{4}-\\d{2}-\\d{2}\\))?\\r?\\n?$`
+);
+assert.match(output, versionPattern);
+
+console.log(
+  `Verified hyalo ${version} with ${expectedPlatformPackage} on ` +
+  `${process.platform}/${process.arch}`
+);


### PR DESCRIPTION
Prepare the initial npm publication without placeholder versions: an explicit, version-confirmed manual dispatch signs the eight real package tarballs in GitHub Actions and uploads them for owner publication with provenance. Bootstrap preparation and OIDC publication are mutually exclusive; every manual dispatch keeps other release channels in dry-run mode.

Adds a separate manual check that installs an exact public npm version and runs the CLI on macOS arm64, Linux x64 glibc, Alpine x64 musl and Windows x64. It verifies actual platform-package selection and libc. Iteration 286 remains in progress until publication, trust and public-registry acceptance are verified; Homefinder and iteration 288 desktop checks remain deferred.

Validation: actionlint, extracted signing-module and registry-script syntax, dispatch guard cases, changed-file strict knowledgebase lint, and diff checks passed. Existing Rust and launcher inputs are unchanged from the previously validated merge. Actual CI signing and registry installs require the post-merge workflows; neither is claimed here.

Independent review identified a documented upload-loop failure case; the instructions now stop on the first failed platform upload and require integrity verification before retries. A separate fresh read-only review found no remaining issues in the repair.
