### PR TITLE
fix(npm): scope main package and support bootstrap recovery

### DIFF
--- a/.github/workflows/npm-packages.yml
+++ b/.github/workflows/npm-packages.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir "$PACK_DIR"
+          PUBLISH_DRY_RUN_CACHE=$(mktemp -d "$RUNNER_TEMP/hyalo-npm-dry-run.XXXXXX")
           : > "$PACK_DIR/packages.tsv"
           for package_dir in \
             darwin-arm64 linux-x64 linux-arm64 linux-x64-musl \
@@ -109,8 +110,11 @@ jobs:
             else
               grep -qx 'package/hyalo' <<< "$files"
             fi
-            npm publish "$tarball" --dry-run --ignore-scripts --access public \
-              --registry https://registry.npmjs.org
+            env -u ACTIONS_ID_TOKEN_REQUEST_TOKEN -u ACTIONS_ID_TOKEN_REQUEST_URL \
+              npm publish "$tarball" \
+                --dry-run --offline --cache "$PUBLISH_DRY_RUN_CACHE" \
+                --ignore-scripts --access public \
+                --registry https://registry.npmjs.org
           done < "$PACK_DIR/packages.tsv"
 
           mkdir "$CONSUMER_DIR"

--- a/.github/workflows/npm-registry.yml
+++ b/.github/workflows/npm-registry.yml
@@ -66,7 +66,7 @@ jobs:
           cd "$CONSUMER_DIR"
           npm init --yes
           npm install --ignore-scripts --save-exact \
-            --registry https://registry.npmjs.org "hyalo@$VERSION"
+            --registry https://registry.npmjs.org "@ractive-ch/hyalo@$VERSION"
           node "$GITHUB_WORKSPACE/npm/hyalo/test/registry-smoke.cjs"
 
   alpine:
@@ -100,6 +100,6 @@ jobs:
               test "$(npm --version)" = 11.19.1
               npm init --yes
               npm install --ignore-scripts --save-exact \
-                --registry https://registry.npmjs.org "hyalo@$VERSION"
+                --registry https://registry.npmjs.org "@ractive-ch/hyalo@$VERSION"
               node /registry-smoke.cjs
             '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir "$PACK_DIR"
+          PUBLISH_DRY_RUN_CACHE=$(mktemp -d "$RUNNER_TEMP/hyalo-npm-dry-run.XXXXXX")
           : > "$PACK_DIR/packages.tsv"
           for package_dir in \
             darwin-arm64 linux-x64 linux-arm64 linux-x64-musl \
@@ -217,9 +218,11 @@ jobs:
             test -n "$tarball"
             printf '%s\t%s\n' "$package_dir" "$PACK_DIR/$tarball" \
               >> "$PACK_DIR/packages.tsv"
-            npm publish "$PACK_DIR/$tarball" \
-              --dry-run --ignore-scripts --access public \
-              --registry https://registry.npmjs.org
+            env -u ACTIONS_ID_TOKEN_REQUEST_TOKEN -u ACTIONS_ID_TOKEN_REQUEST_URL \
+              npm publish "$PACK_DIR/$tarball" \
+                --dry-run --offline --cache "$PUBLISH_DRY_RUN_CACHE" \
+                --ignore-scripts --access public \
+                --registry https://registry.npmjs.org
           done
           cargo run -q -p xtask -- plan-npm-publication --pack-json \
             "$PACK_DIR/darwin-arm64.json" \
@@ -242,6 +245,7 @@ jobs:
           set -euo pipefail
           cargo run -q -p xtask -- generate-npm-packages --check
           mkdir "$PACK_DIR"
+          PUBLISH_DRY_RUN_CACHE=$(mktemp -d "$RUNNER_TEMP/hyalo-npm-dry-run.XXXXXX")
           npm pack ./npm/hyalo \
             --pack-destination "$PACK_DIR" --json > "$PACK_DIR/hyalo.json"
           test "$(jq -r 'length' "$PACK_DIR/hyalo.json")" -eq 1
@@ -257,9 +261,11 @@ jobs:
             ] | sort) == $files
           ' "$PACK_DIR/hyalo.json" > /dev/null
           printf 'hyalo\t%s\n' "$PACK_DIR/$tarball" > "$PACK_DIR/packages.tsv"
-          npm publish "$PACK_DIR/$tarball" \
-            --dry-run --ignore-scripts --access public \
-            --registry https://registry.npmjs.org
+          env -u ACTIONS_ID_TOKEN_REQUEST_TOKEN -u ACTIONS_ID_TOKEN_REQUEST_URL \
+            npm publish "$PACK_DIR/$tarball" \
+              --dry-run --offline --cache "$PUBLISH_DRY_RUN_CACHE" \
+              --ignore-scripts --access public \
+              --registry https://registry.npmjs.org
       - name: Sign npm bootstrap tarballs with GitHub OIDC
         if: >-
           github.event_name == 'workflow_dispatch' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         type: boolean
         required: false
         default: false
+      prepare_npm_main_bootstrap:
+        description: Sign and upload only the scoped main npm package without native builds
+        type: boolean
+        required: false
+        default: false
       npm_version:
         description: Cargo version to confirm for npm publication or bootstrap preparation
         type: string
@@ -27,6 +32,9 @@ permissions:
 
 jobs:
   release:
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      !inputs.prepare_npm_main_bootstrap
     uses: ractive/release-workflows/.github/workflows/release.yml@v0.2.0
     secrets: inherit
     with:
@@ -79,6 +87,17 @@ jobs:
 
   npm:
     needs: release
+    if: >-
+      always() &&
+      !cancelled() &&
+      (
+        needs.release.result == 'success' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.prepare_npm_main_bootstrap &&
+          needs.release.result == 'skipped'
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -99,6 +118,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           PUBLISH_NPM: ${{ inputs.publish_npm }}
           PREPARE_NPM_BOOTSTRAP: ${{ inputs.prepare_npm_bootstrap }}
+          PREPARE_NPM_MAIN_BOOTSTRAP: ${{ inputs.prepare_npm_main_bootstrap }}
           REQUESTED_NPM_VERSION: ${{ inputs.npm_version }}
         run: |
           set -euo pipefail
@@ -114,24 +134,32 @@ jobs:
             echo "release tag '$RELEASE_TAG' does not match Cargo version '$version'" >&2
             exit 1
           fi
-          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$PUBLISH_NPM" = true ] && \
-             [ "$PREPARE_NPM_BOOTSTRAP" = true ]; then
-            echo "publish_npm and prepare_npm_bootstrap are mutually exclusive" >&2
+          selected_modes=0
+          for selected in \
+            "$PUBLISH_NPM" "$PREPARE_NPM_BOOTSTRAP" "$PREPARE_NPM_MAIN_BOOTSTRAP"; do
+            if [ "$selected" = true ]; then
+              selected_modes=$((selected_modes + 1))
+            fi
+          done
+          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$selected_modes" -gt 1 ]; then
+            echo "publish_npm, prepare_npm_bootstrap, and prepare_npm_main_bootstrap are mutually exclusive" >&2
             exit 1
           fi
           if [ "$EVENT_NAME" = workflow_dispatch ] && \
-             { [ "$PUBLISH_NPM" = true ] || [ "$PREPARE_NPM_BOOTSTRAP" = true ]; } && \
+             [ "$selected_modes" -eq 1 ] && \
              [ "$REQUESTED_NPM_VERSION" != "$version" ]; then
             echo "npm_version '$REQUESTED_NPM_VERSION' does not match Cargo version '$version'" >&2
             exit 1
           fi
           echo "CARGO_VERSION=$version" >> "$GITHUB_ENV"
       - name: Download native release archives
+        if: ${{ !inputs.prepare_npm_main_bootstrap }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: hyalo-*
           path: ${{ runner.temp }}/hyalo-release-artifacts
       - name: Extract exact release binaries and stage npm packages
+        if: ${{ !inputs.prepare_npm_main_bootstrap }}
         shell: bash
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/hyalo-release-artifacts
@@ -171,6 +199,7 @@ jobs:
           cargo run -p xtask -- generate-npm-packages \
             --stage "$STAGE_DIR" --binaries "$BINARY_INPUT"
       - name: Pack and dry-run all publications
+        if: ${{ !inputs.prepare_npm_main_bootstrap }}
         shell: bash
         env:
           STAGE_DIR: ${{ runner.temp }}/hyalo-npm-stage
@@ -202,13 +231,43 @@ jobs:
             "$PACK_DIR/win32-arm64.json" \
             "$PACK_DIR/hyalo.json" \
             > "$PACK_DIR/publication-plan.json"
-      - name: Sign npm bootstrap tarballs with GitHub OIDC
+      - name: Pack and dry-run scoped main bootstrap
         if: >-
           github.event_name == 'workflow_dispatch' &&
-          inputs.prepare_npm_bootstrap
+          inputs.prepare_npm_main_bootstrap
         shell: bash
         env:
           PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs
+        run: |
+          set -euo pipefail
+          cargo run -q -p xtask -- generate-npm-packages --check
+          mkdir "$PACK_DIR"
+          npm pack ./npm/hyalo \
+            --pack-destination "$PACK_DIR" --json > "$PACK_DIR/hyalo.json"
+          test "$(jq -r 'length' "$PACK_DIR/hyalo.json")" -eq 1
+          test "$(jq -r '.[0].name' "$PACK_DIR/hyalo.json")" = @ractive-ch/hyalo
+          test "$(jq -r '.[0].version' "$PACK_DIR/hyalo.json")" = "$CARGO_VERSION"
+          tarball=$(jq -r '.[0].filename' "$PACK_DIR/hyalo.json")
+          test "$tarball" = "ractive-ch-hyalo-$CARGO_VERSION.tgz"
+          jq -e '
+            ([.[0].files[].path] | sort) as $files |
+            ([
+              "LICENSE", "README.md", "bin/hyalo.js", "lib/resolve-platform.js",
+              "lib/run-child.js", "package.json", "platforms.json"
+            ] | sort) == $files
+          ' "$PACK_DIR/hyalo.json" > /dev/null
+          printf 'hyalo\t%s\n' "$PACK_DIR/$tarball" > "$PACK_DIR/packages.tsv"
+          npm publish "$PACK_DIR/$tarball" \
+            --dry-run --ignore-scripts --access public \
+            --registry https://registry.npmjs.org
+      - name: Sign npm bootstrap tarballs with GitHub OIDC
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          (inputs.prepare_npm_bootstrap || inputs.prepare_npm_main_bootstrap)
+        shell: bash
+        env:
+          PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs
+          MAIN_ONLY: ${{ inputs.prepare_npm_main_bootstrap }}
         run: |
           set -euo pipefail
           NPM_PACKAGE_DIR="$(npm root --global)/npm"
@@ -234,10 +293,12 @@ jobs:
             'libnpmpublish/lib/provenance.js'
           )
 
-          const packageDirs = [
-            'darwin-arm64', 'linux-x64', 'linux-arm64', 'linux-x64-musl',
-            'linux-arm64-musl', 'win32-x64', 'win32-arm64', 'hyalo',
-          ]
+          const packageDirs = process.env.MAIN_ONLY === 'true'
+            ? ['hyalo']
+            : [
+                'darwin-arm64', 'linux-x64', 'linux-arm64', 'linux-x64-musl',
+                'linux-arm64-musl', 'win32-x64', 'win32-arm64', 'hyalo',
+              ]
           const rows = (await readFile(path.join(packDir, 'packages.tsv'), 'utf8'))
             .trimEnd().split('\n').map((row) => row.split('\t'))
           assert.deepEqual(rows.map(([packageDir]) => packageDir), packageDirs)
@@ -254,6 +315,9 @@ jobs:
             assert.equal(manifest.name, pack.name)
             assert.equal(manifest.version, pack.version)
             assert.equal(manifest.version, process.env.CARGO_VERSION)
+            if (packageDir === 'hyalo') {
+              assert.equal(manifest.name, '@ractive-ch/hyalo')
+            }
 
             const tarballBytes = await readFile(tarball)
             const digest = createHash('sha512').update(tarballBytes).digest()
@@ -272,7 +336,7 @@ jobs:
       - name: Upload signed npm bootstrap packages
         if: >-
           github.event_name == 'workflow_dispatch' &&
-          inputs.prepare_npm_bootstrap
+          (inputs.prepare_npm_bootstrap || inputs.prepare_npm_main_bootstrap)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: npm-bootstrap-${{ env.CARGO_VERSION }}
@@ -311,5 +375,5 @@ jobs:
             jq -r '.[7] | [.action, .name, .tarball] | @tsv' \
               "$PACK_DIR/publication-plan.json"
           )
-          test "$name" = hyalo
+          test "$name" = @ractive-ch/hyalo
           publish_or_skip "$action" "$name" "$tarball"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ winget install ractive.hyalo
 cargo install hyalo-cli    # installs the `hyalo` binary
 ```
 
-### npm (prepared, not yet published)
+### npm (scoped main package pending publication)
 
 An npm distribution is prepared for Node.js 22.14 or newer and npm 11.5.1
 or newer. It will support macOS arm64, Linux x64/arm64 with glibc or musl,
@@ -113,12 +113,13 @@ and Windows x64/arm64. Once the packages have been published and verified,
 the intended installation will be:
 
 ```sh
-npm install hyalo
+npm install @ractive-ch/hyalo
 npx --no-install hyalo --version
 ```
 
-The packages are not yet available from the public npm registry. Use one of
-the published installation methods above until the owner bootstrap, trusted
+The seven native platform packages are public at version 0.22.0. The scoped
+main package is not yet available from the public npm registry, so use one of
+the published installation methods above until its owner bootstrap, trusted
 publisher configuration, and real-platform registry checks are complete.
 
 ### Manual download

--- a/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
@@ -12,7 +12,7 @@ is an alternative when present. If unavailable, report that and suggest the proj
 documented installation (`cargo install hyalo-cli`); do not install software as a
 side effect of a knowledgebase query. The prepared npm distribution remains
 unpublished pending owner bootstrap, trusted publisher setup, and real-platform
-registry checks; do not suggest `npm install hyalo` before that acceptance.
+registry checks; do not suggest `npm install @ractive-ch/hyalo` before that acceptance.
 
 Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
 to locate and confirm the vault. Commands also work inside that configured vault,

--- a/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
@@ -261,9 +261,8 @@ hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.m
 ## Setup Checklist for New Projects
 
 1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`). Use the
-   published `cargo install hyalo-cli` route; the prepared npm distribution
-   remains unpublished until owner bootstrap, trusted publisher setup, and
-   real-platform registry checks are complete.
+   published `cargo install hyalo-cli` route. Do not suggest an npm package
+   while the project's documentation says its registry acceptance is pending.
 2. **Configure vault**: Create `.hyalo.toml` with `dir = "knowledgebase"`
 3. **Add to AGENTS.md**: Include: "Use `hyalo` CLI for all markdown knowledgebase operations. Always use `--format text` for compact output."
 4. **Create views**: Set up common views (`stale-in-progress`, `orphans`, etc.)

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -26,7 +26,7 @@ multiple Read + Edit calls.
 Install the published CLI with `cargo install hyalo-cli`. An npm distribution is
 prepared but remains unpublished until its owner bootstrap, trusted publisher setup,
 and real-platform registry checks are complete; do not direct users to
-`npm install hyalo` before that acceptance.
+`npm install @ractive-ch/hyalo` before that acceptance.
 
 Filters combine freely — content search + property conditions + tag + section + task status
 in a single call, something impossible with Grep/Glob alone:

--- a/crates/xtask/src/npm_package.rs
+++ b/crates/xtask/src/npm_package.rs
@@ -107,6 +107,8 @@ const PLATFORMS: [Platform; 7] = [
     },
 ];
 
+const MAIN_PACKAGE_NAME: &str = "@ractive-ch/hyalo";
+
 pub fn run(args: NpmArgs) -> Result<bool> {
     let root = crate::workspace::workspace_root()?;
     let version = workspace_version(&root)?;
@@ -219,7 +221,7 @@ where
     let expected_names = PLATFORMS
         .iter()
         .map(|platform| package_name(*platform))
-        .chain(std::iter::once("hyalo".to_owned()))
+        .chain(std::iter::once(MAIN_PACKAGE_NAME.to_owned()))
         .collect::<Vec<_>>();
     if artifacts.len() != expected_names.len() {
         bail!(
@@ -381,7 +383,7 @@ fn main_manifest(version: &str) -> Value {
         optional.insert(package_name(platform), json!(version));
     }
     json!({
-        "name": "hyalo",
+        "name": MAIN_PACKAGE_NAME,
         "version": version,
         "description": "Hyalo knowledgebase CLI",
         "license": "MIT",
@@ -774,6 +776,10 @@ mod tests {
         assert_eq!(metadata_snapshot(root)?, first);
         assert!(check_metadata(root)?);
 
+        let main: Value = serde_json::from_slice(&fs::read(root.join("npm/hyalo/package.json"))?)?;
+        assert_eq!(main["name"], MAIN_PACKAGE_NAME);
+        assert_eq!(main["bin"]["hyalo"], "bin/hyalo.js");
+
         let manifests = std::iter::once(root.join("npm/hyalo/package.json")).chain(
             PLATFORMS.iter().map(|platform| {
                 root.join("npm/platforms")
@@ -972,9 +978,9 @@ mod tests {
                 integrity: format!("sha512-local-{index}"),
             })
             .chain(std::iter::once(PackArtifact {
-                name: "hyalo".to_owned(),
+                name: MAIN_PACKAGE_NAME.to_owned(),
                 version: VERSION.to_owned(),
-                tarball: PathBuf::from("hyalo.tgz"),
+                tarball: PathBuf::from("ractive-ch-hyalo.tgz"),
                 integrity: "sha512-local-main".to_owned(),
             }))
             .collect()
@@ -983,7 +989,12 @@ mod tests {
     #[test]
     fn registry_response_distinguishes_missing_version_from_missing_integrity() -> Result<()> {
         assert_eq!(
-            classify_registry_output("hyalo@1.2.3", true, br#""sha512-published""#, b"")?,
+            classify_registry_output(
+                "@ractive-ch/hyalo@1.2.3",
+                true,
+                br#""sha512-published""#,
+                b"",
+            )?,
             RegistryState::Published("sha512-published".to_owned())
         );
         let missing_version = br#"{
@@ -999,15 +1010,16 @@ mod tests {
         );
         assert!(
             classify_registry_output(
-                "hyalo@1.2.3",
+                "@ractive-ch/hyalo@1.2.3",
                 false,
                 b"",
                 b"network proxy mentioned E404 without registry JSON"
             )
             .is_err()
         );
-        let missing_integrity = classify_registry_output("hyalo@1.2.3", true, b"null", b"")
-            .expect_err("a successful version lookup without integrity must fail");
+        let missing_integrity =
+            classify_registry_output("@ractive-ch/hyalo@1.2.3", true, b"null", b"")
+                .expect_err("a successful version lookup without integrity must fail");
         assert!(missing_integrity.to_string().contains("dist.integrity"));
         Ok(())
     }
@@ -1019,46 +1031,67 @@ mod tests {
             b"npm error code E403".as_slice(),
             b"npm error code ENETUNREACH".as_slice(),
         ] {
-            assert!(classify_registry_output("hyalo@1.2.3", false, b"", diagnostics).is_err());
+            assert!(
+                classify_registry_output("@ractive-ch/hyalo@1.2.3", false, b"", diagnostics)
+                    .is_err()
+            );
         }
-        assert!(classify_registry_output("hyalo@1.2.3", true, b"not json", b"").is_err());
+        assert!(
+            classify_registry_output("@ractive-ch/hyalo@1.2.3", true, b"not json", b"").is_err()
+        );
     }
 
     #[test]
-    fn publication_plan_resumes_partial_success_in_platforms_first_order() -> Result<()> {
+    fn publication_plan_skips_existing_integrity_and_keeps_order() -> Result<()> {
         let artifacts = publication_artifacts();
-        let mut query_index = 0usize;
-        let plan = build_publication_plan(&artifacts, VERSION, |_, _| {
-            let artifact = &artifacts[query_index];
-            let state = if query_index < 3 {
-                RegistryState::Published(artifact.integrity.clone())
-            } else {
-                RegistryState::MissingVersion
-            };
-            query_index += 1;
-            Ok(state)
-        })?;
-        assert_eq!(
-            plan.iter()
-                .map(|entry| entry.name.as_str())
-                .collect::<Vec<_>>(),
-            artifacts
-                .iter()
-                .map(|entry| entry.name.as_str())
-                .collect::<Vec<_>>()
-        );
-        assert!(
-            plan[..3]
-                .iter()
-                .all(|entry| entry.action == PublicationAction::Skip)
-        );
-        assert!(
-            plan[3..]
-                .iter()
-                .all(|entry| entry.action == PublicationAction::Publish)
-        );
-        assert_eq!(plan.last().map(|entry| entry.name.as_str()), Some("hyalo"));
+        for skip_count in [3, PLATFORMS.len()] {
+            let mut query_index = 0usize;
+            let plan = build_publication_plan(&artifacts, VERSION, |_, _| {
+                let artifact = &artifacts[query_index];
+                let state = if query_index < skip_count {
+                    RegistryState::Published(artifact.integrity.clone())
+                } else {
+                    RegistryState::MissingVersion
+                };
+                query_index += 1;
+                Ok(state)
+            })?;
+            assert_eq!(
+                plan.iter()
+                    .map(|entry| entry.name.as_str())
+                    .collect::<Vec<_>>(),
+                artifacts
+                    .iter()
+                    .map(|entry| entry.name.as_str())
+                    .collect::<Vec<_>>()
+            );
+            assert!(
+                plan[..skip_count]
+                    .iter()
+                    .all(|entry| entry.action == PublicationAction::Skip)
+            );
+            assert!(
+                plan[skip_count..]
+                    .iter()
+                    .all(|entry| entry.action == PublicationAction::Publish)
+            );
+            assert_eq!(
+                plan.last().map(|entry| entry.name.as_str()),
+                Some(MAIN_PACKAGE_NAME)
+            );
+        }
         Ok(())
+    }
+
+    #[test]
+    fn publication_plan_rejects_wrong_main_package_name() {
+        let mut artifacts = publication_artifacts();
+        artifacts.last_mut().expect("main package exists").name = "hyalo".to_owned();
+        let error = build_publication_plan(&artifacts, VERSION, |_, _| {
+            Ok(RegistryState::MissingVersion)
+        })
+        .expect_err("an unscoped main package must fail");
+        assert!(error.to_string().contains(MAIN_PACKAGE_NAME));
     }
 
     #[test]
@@ -1082,7 +1115,7 @@ mod tests {
         )?;
         set_executable(&npm)?;
         assert_eq!(
-            query_npm_registry_with(&npm, "hyalo", VERSION)?,
+            query_npm_registry_with(&npm, MAIN_PACKAGE_NAME, VERSION)?,
             RegistryState::Published("sha512-unix-fixture".to_owned())
         );
         Ok(())
@@ -1098,7 +1131,7 @@ mod tests {
             "@echo off\r\necho \"sha512-windows-cmd-fixture\"\r\nexit /b 0\r\n",
         )?;
         assert_eq!(
-            query_npm_registry_with(&npm, "hyalo", VERSION)?,
+            query_npm_registry_with(&npm, MAIN_PACKAGE_NAME, VERSION)?,
             RegistryState::Published("sha512-windows-cmd-fixture".to_owned())
         );
         Ok(())

--- a/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
@@ -17,9 +17,9 @@ related:
 
 ## Goal
 
-`npm install hyalo` on any supported machine, with no Homebrew step and no download script: the
+`npm install @ractive-ch/hyalo` on any supported machine, with no Homebrew step and no download script: the
 esbuild / Biome pattern from [[research/npm-package-and-typed-typescript-api]]. One main
-package `hyalo` whose `bin` is a small JS launcher, plus one package per release target under
+package `@ractive-ch/hyalo` whose `hyalo` bin is a small JS launcher, plus one package per release target under
 the `@ractive-ch` scope (org created 2026-09-06, owner `ractive.ch`, two-factor auth on),
 selected by npm through `os` / `cpu` / `libc` in `optionalDependencies`. Needs **no
 TypeScript types** — it is independent of 285 and 287.
@@ -51,7 +51,7 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
 - [x] TASK-5: version gate: extend the `check-pi-package-sync` xtask (or the gate 285 adds) so
       `npm/hyalo/package.json`, every platform package and `pi-package/package.json` equal the
       Cargo workspace version.
-- [ ] TASK-6: verify on real machines: `npm install hyalo` on macOS arm64, Linux x64 glibc,
+- [ ] TASK-6: verify on real machines: `npm install @ractive-ch/hyalo` on macOS arm64, Linux x64 glibc,
       Linux x64 musl (Alpine container) and Windows x64; `npx hyalo --version` prints the
       release version. Record timings for a musl vs glibc `summary` on MDN if a musl host is at
       hand (the allocator question in the note).
@@ -61,7 +61,7 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
 
 ## Acceptance criteria
 
-- [ ] `npm install hyalo && npx hyalo --version` works on the four verified platforms with
+- [ ] `npm install @ractive-ch/hyalo && npx hyalo --version` works on the four verified platforms with
       exactly one platform package installed.
 - [x] On an unsupported platform the launcher exits non-zero with the message naming the
       platform and the cargo fallback.
@@ -204,6 +204,23 @@ updates plus newly signed main-package bytes. Preserve the seven immutable platf
 versions and their existing artifacts; do not republish rebuilt bytes over them.
 Iteration 287 remains blocked by full iteration 286; Homefinder and iteration 288's
 desktop verification remain deferred. No acceptance requirement is waived.
+
+## Scoped main recovery authorization — 2026-09-07
+
+After npm rejected the unscoped main name as too similar to `yalc`, the user
+authorized `@ractive-ch/hyalo` as the canonical main package. The CLI executable
+remains `hyalo`, and the seven public platform packages remain immutable at 0.22.0
+with their previously verified bytes. Repository recovery must generate and sign
+only the newly scoped main tarball; it must not rebuild or republish those platform
+versions.
+
+The recovery workflow adds a mutually exclusive `prepare_npm_main_bootstrap` mode.
+It skips the reusable native build, verifies generated metadata, packs the tracked
+`npm/hyalo` source as `ractive-ch-hyalo-0.22.0.tgz`, dry-runs publication, signs that
+one tarball and uploads it with the existing `npm-bootstrap-0.22.0` artifact naming.
+Actual scoped publication, all eight trusted-publisher configurations, direct-publish
+settings, and four-platform registry installs remain unchecked external work. This
+does not start iteration 287 or iteration 288, and Homefinder remains deferred.
 
 ## Links
 

--- a/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
+++ b/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
@@ -18,7 +18,7 @@ related:
 
 ## Goal
 
-`import { find, read, summary } from "hyalo"` with result types that come from the Rust
+`import { find, read, summary } from "@ractive-ch/hyalo"` with result types that come from the Rust
 structs, not from a hand-written mirror. Decided in
 [[research/npm-package-and-typed-typescript-api]]: `ts-rs` derives on the output structs from
 [[iterations/iteration-285-typed-output-structs]] and on the clap argument structs; `cargo test`
@@ -55,7 +55,7 @@ built from the same commit. Requires both 285 (structs) and 286 (the package to 
 - [ ] TASK-6: docs: API README with the three calls, the generated-types workflow, how to add a
       command; `skill-hyalo.md` note; research note outcome. Gates: `cargo fmt`, clippy,
       `cargo test --workspace -q`, every xtask `check-*`, `npm test`, `hyalo lint --strict`.
-- [ ] TASK-7 (consumer, outside this repo): switch `homefinder-eco-mcp` to `npm install hyalo`
+- [ ] TASK-7 (consumer, outside this repo): switch `homefinder-eco-mcp` to `npm install @ractive-ch/hyalo`
       and the typed `find`; record what the wrapper lacked.
       Deferred by the user on 2026-09-07 to concentrate on Hyalo; retain this requirement
       as unfinished and do not modify that repository during the current batch.
@@ -110,6 +110,16 @@ CRLF metadata-check fix. npm bootstrap, trusted publishing, actual publication a
 four-platform registry installation checks remain outstanding. Both full prerequisites remain
 required; no TypeScript implementation has started. TASK-7 still requires separate
 authority to modify `homefinder-eco-mcp` and is not waived by repository-only work.
+
+## Plan reconciliation — 2026-09-07, scoped main recovery
+
+The canonical registry spec is now `@ractive-ch/hyalo`; the installed executable,
+source directory `npm/hyalo`, and direct native-binary resolver stay unchanged.
+TASK-2 and TASK-3 must generate exports and build metadata into that scoped package.
+They must also extend the main-only bootstrap package-content check when API files
+are added to the manifest allowlist. Iteration 287 remains blocked until scoped
+publication, trust configuration, and four-platform installation acceptance finish.
+Homefinder and iteration 288 remain deferred.
 
 ## Links
 

--- a/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
+++ b/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
@@ -30,7 +30,7 @@ hyalo is the natural replacement. An unindexed `hyalo find` over the 48
 pages takes 37 ms; the snapshot index is irrelevant at that size.
 
 The question is not *whether* to call hyalo from TypeScript but *how* to
-make that a first-class experience: `npm install hyalo`, `import { find }`,
+make that a first-class experience: `npm install @ractive-ch/hyalo`, `import { find }`,
 typed results, no Homebrew step, no Dockerfile download.
 
 ## Proposal
@@ -38,7 +38,7 @@ typed results, no Homebrew step, no Dockerfile download.
 ### 1. Per-platform npm packages (the esbuild / Biome / Turbo pattern)
 
 Standard, not a hack. npm's `os`, `cpu` and `libc` fields plus
-`optionalDependencies` exist for exactly this. One main package `hyalo`
+`optionalDependencies` exist for exactly this. One main package `@ractive-ch/hyalo`
 lists every platform package as an optional dependency; npm installs only
 the one matching the machine. The main package's `bin` is a tiny JS
 launcher that `require.resolve`s the platform package and spawns the
@@ -174,9 +174,11 @@ see "Settled" below). The two options are kept for the record.
   that is not James (his account is `ractive.ch`) and npm does not transfer
   scopes, so it is gone; the user scope `@ractive.ch` would have worked but
   the dot reads like a domain. The `ractive-ch` org was created on 2026-09-06
-  (free plan, owner `ractive.ch`). The unscoped `hyalo` and `ff-rdp` main
-  packages are free and get claimed by the first real publish, no
-  placeholder; `hoppy` is taken, so hoppy's main package is scoped.
+  (free plan, owner `ractive.ch`). The original plan used an unscoped `hyalo`
+  main package, but npm rejected the verified 0.22.0 upload as too similar to
+  `yalc`. On 2026-09-07 the user authorized `@ractive-ch/hyalo` as the settled
+  canonical main name. `ff-rdp` remains planned as unscoped where available;
+  `hoppy` is taken, so hoppy's main package is scoped.
 - **Types: generated with `ts-rs`**, not schemars + JSON Schema + a Node
   converter. One derive per output struct, `cargo test` writes the `.ts`
   files, `serde_json::Value` becomes `unknown`. No `hyalo schema` command.
@@ -226,7 +228,7 @@ Three separate iterations, not one, preceded by the stability retrospective
    `types.ts` committed, `find`/`read`/`summary` wrappers spawning the
    platform binary directly, vitest contract tests against the freshly built
    binary. Port `pi-package/extensions/hyalo.ts` onto it. Then switch
-   `homefinder-eco-mcp` to `npm install hyalo`.
+   `homefinder-eco-mcp` to `npm install @ractive-ch/hyalo`.
 
 ## Added 2026-09-07 — a generic markdown-KB MCP server?
 
@@ -316,3 +318,19 @@ Authoritative references:
 - Reusable release workflow source:
   `ractive/release-workflows/.github/workflows/release.yml@v0.2.0`,
   Git blob `300705e94fa0090441861a653ccd7f05c36a749a`
+
+## Outcome — scoped main recovery (2026-09-07)
+
+All seven `@ractive-ch/hyalo-<platform>` packages at 0.22.0 were published
+from the verified native artifacts before npm rejected the unscoped main name.
+Their versions and bytes are immutable. The canonical main registry package is
+now `@ractive-ch/hyalo`; its executable remains `hyalo`, and its exact platform
+dependency names and 0.22.0 pins are unchanged.
+
+The repository recovery prepares only `ractive-ch-hyalo-0.22.0.tgz` from the
+tracked main-package source, without a native build. Publication, all eight
+GitHub trusted-publisher relationships with direct publishing, and the four
+real-platform registry installs remain external acceptance work. No external
+check was treated as completed by this repository change. Iteration 287 still
+depends on full iteration 286 completion, while Homefinder and iteration 288
+remain deferred.

--- a/npm/hyalo/README.md
+++ b/npm/hyalo/README.md
@@ -74,10 +74,13 @@ tarball to npm.
 Normal npm publishing handles all seven platform packages first, followed by
 `@ractive-ch/hyalo`, using npm provenance and GitHub OIDC without a repository
 token fallback.
-Before an immutable version is published, the workflow compares the local
-tarball integrity with `dist.integrity` from the public npm registry. A retry
-skips an identical existing artifact, publishes an explicitly missing version,
-and stops on mismatched integrity or an inconclusive registry response.
+Publication dry runs use a fresh offline npm cache and disable OIDC only for
+that process. They validate each local package contract independently of
+immutable registry history. The real publication planner stays online: before
+an immutable version is published, it compares the local tarball integrity with
+`dist.integrity` from the public npm registry. A retry skips an identical
+existing artifact, publishes an explicitly missing version, and stops on
+mismatched integrity or an inconclusive registry response.
 
 For the 0.22.0 scoped-main recovery, the npm owner uses this runbook:
 

--- a/npm/hyalo/README.md
+++ b/npm/hyalo/README.md
@@ -1,17 +1,10 @@
-# hyalo
+# @ractive-ch/hyalo
 
-This package is prepared for publication but is not yet available from the
-public npm registry. Until owner bootstrap, trusted publishing, and registry
-installation checks are complete, install the CLI with:
-
-```sh
-cargo install hyalo-cli
-```
-
-After public acceptance, the intended npm installation will be:
+Hyalo is a command-line toolkit for structured Markdown knowledgebases. Install
+the scoped package and run its `hyalo` executable with:
 
 ```sh
-npm install hyalo
+npm install @ractive-ch/hyalo
 npx --no-install hyalo --version
 ```
 
@@ -61,68 +54,68 @@ publication. A published release remains the broad release path: it validates
 the release tag against the Cargo version, runs the configured reusable release
 publishing, and publishes the npm packages.
 
-For the initial owner upload, enable `prepare_npm_bootstrap` instead and enter
-the same exact `npm_version`. That option and `publish_npm` are mutually
-exclusive. The job builds and packs the same artifacts, then signs each final
-tarball with the workflow's GitHub OIDC identity and uploads
-`npm-bootstrap-<version>`. It does not publish to npm and needs no npm registry
-credential. The default manual dispatch remains the unchanged dry run.
+The original `prepare_npm_bootstrap` mode remains available for a complete new
+eight-package version. For the 0.22.0 scoped-main recovery, enable
+`prepare_npm_main_bootstrap` and enter the same exact `npm_version`. The three
+manual modes are mutually exclusive. Main-only preparation skips the reusable
+native release job and all native artifact handling, verifies the canonical
+metadata, packs `./npm/hyalo`, dry-runs that publication, signs its exact
+tarball with the workflow's GitHub OIDC identity, and uploads
+`npm-bootstrap-<version>`. It does not publish to npm or rebuild any of the
+seven immutable platform packages.
 
 Bootstrap signing deliberately calls the provenance generator and
 `npm-package-arg` bundled inside the workflow's pinned npm 11.19.1. This is an
 internal npm API, so an npm pin update must review the inline signing script
 against that exact release. Signing creates public Sigstore provenance and a
-transparency-log entry even though the npm packages remain unpublished.
+transparency-log entry for the prepared tarball; it does not itself upload that
+tarball to npm.
 
-Both npm publishing paths use the same staged tarballs and publication plan:
-all seven platform packages are handled first, followed by `hyalo`, using npm
-provenance and GitHub OIDC without a repository token fallback.
+Normal npm publishing handles all seven platform packages first, followed by
+`@ractive-ch/hyalo`, using npm provenance and GitHub OIDC without a repository
+token fallback.
 Before an immutable version is published, the workflow compares the local
 tarball integrity with `dist.integrity` from the public npm registry. A retry
 skips an identical existing artifact, publishes an explicitly missing version,
 and stops on mismatched integrity or an inconclusive registry response.
 
-The npm owner must complete these external steps before the first registry
-release:
+For the 0.22.0 scoped-main recovery, the npm owner uses this runbook:
 
-1. Run the bootstrap-preparation dispatch for the real Cargo version and
+1. Run `prepare_npm_main_bootstrap` for the real Cargo version and
    download its `npm-bootstrap-<version>` artifact. Before uploading anything,
-   verify that every `.sigstore.json` bundle still matches the SHA-512 bytes of
-   its adjacent `.tgz`, and verify the Sigstore certificate identity names
+   verify that the main `.sigstore.json` bundle still matches the SHA-512 bytes
+   of `ractive-ch-hyalo-<version>.tgz`, and verify the certificate identity names
    repository `ractive/hyalo`, workflow `.github/workflows/release.yml`, and the
    expected GitHub ref. Keep those reviewed tarball bytes unchanged.
-2. As the npm owner, bootstrap the unscoped `hyalo` package and all seven scoped
-   packages under `@ractive-ch` in platform-first order, followed by `hyalo`:
+2. Confirm the public `dist.integrity` of all seven immutable 0.22.0 platform
+   packages still matches the previously verified artifacts. Do not rebuild or
+   republish them. As the npm owner, bootstrap only the scoped main package:
 
    ```bash
-   (
-     set -eu
-     version=0.22.0 # replace with the confirmed Cargo version
-     for tarball in \
-       ractive-ch-hyalo-{darwin-arm64,linux-x64,linux-arm64,linux-x64-musl,linux-arm64-musl,win32-x64,win32-arm64}-"$version".tgz \
-       hyalo-"$version".tgz; do
-       npm publish "$tarball" \
-         --provenance-file "${tarball%.tgz}.sigstore.json" \
-         --access public --ignore-scripts --registry https://registry.npmjs.org
-     done
-   )
+   version=0.22.0 # replace with the confirmed Cargo version
+   tarball="ractive-ch-hyalo-$version.tgz"
+   npm publish "$tarball" \
+     --provenance-file "${tarball%.tgz}.sigstore.json" \
+     --access public --ignore-scripts --registry https://registry.npmjs.org
    ```
 
    `--provenance-file` verifies and attaches the prepared bundle. It is
-   mutually exclusive with `--provenance`; do not pass both. All eight packages
-   currently lack public registry metadata. The subshell stops at the first
-   failed upload, so `hyalo` cannot publish after a platform-package failure.
-   Before retrying, inspect the registry's `dist.integrity` for every attempted
-   package and compare it with the preserved tarball. Skip only an immutable
-   version whose integrity matches exactly, then resume in the same order.
+   mutually exclusive with `--provenance`; do not pass both. Before retrying,
+   inspect the scoped main version's `dist.integrity` and compare it with the
+   preserved tarball. Skip only an immutable version whose integrity matches.
    Never try to overwrite a version or continue past a mismatch, missing proof,
    or another inconclusive registry response.
-3. Configure each existing package's trusted publisher for repository
+
+   GitHub OIDC authenticates the bootstrap workflow's Sigstore provenance
+   generation. This attended owner upload authenticates to npm separately and
+   therefore does not exercise npm trusted-publisher OIDC; a later workflow
+   publication must verify that path.
+3. Configure all eight existing packages' trusted publishers for repository
    `ractive/hyalo` and workflow `release.yml`.
 4. Explicitly allow direct publishing for each configuration. New trusted
    publisher configurations may allow staged publishing only by default.
-5. Publish an authorized release through the OIDC workflow, then verify a
-   registry install and `npx --no-install hyalo --version` on macOS arm64,
+5. Verify `npm install @ractive-ch/hyalo` and
+   `npx --no-install hyalo --version` on macOS arm64,
    Linux x64 glibc, Linux x64 musl, and Windows x64.
 
 See npm's official [trusted publishing guide](https://docs.npmjs.com/trusted-publishers/)

--- a/npm/hyalo/package.json
+++ b/npm/hyalo/package.json
@@ -18,7 +18,7 @@
     "platforms.json"
   ],
   "license": "MIT",
-  "name": "hyalo",
+  "name": "@ractive-ch/hyalo",
   "optionalDependencies": {
     "@ractive-ch/hyalo-darwin-arm64": "0.22.0",
     "@ractive-ch/hyalo-linux-arm64": "0.22.0",

--- a/npm/hyalo/test/registry-smoke.cjs
+++ b/npm/hyalo/test/registry-smoke.cjs
@@ -31,10 +31,10 @@ assert.equal(process.arch, expectedArch);
 
 const requireFromConsumer = createRequire(path.join(consumerDir, 'package.json'));
 const mainManifest = JSON.parse(readFileSync(
-  requireFromConsumer.resolve('hyalo/package.json'),
+  requireFromConsumer.resolve('@ractive-ch/hyalo/package.json'),
   'utf8'
 ));
-assert.equal(mainManifest.name, 'hyalo');
+assert.equal(mainManifest.name, '@ractive-ch/hyalo');
 assert.equal(mainManifest.version, version);
 
 const scopeDir = path.join(consumerDir, 'node_modules', '@ractive-ch');

--- a/pi-package/skills/hyalo/SKILL.md
+++ b/pi-package/skills/hyalo/SKILL.md
@@ -261,9 +261,8 @@ hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.m
 ## Setup Checklist for New Projects
 
 1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`). Use the
-   published `cargo install hyalo-cli` route; the prepared npm distribution
-   remains unpublished until owner bootstrap, trusted publisher setup, and
-   real-platform registry checks are complete.
+   published `cargo install hyalo-cli` route. Do not suggest an npm package
+   while the project's documentation says its registry acceptance is pending.
 2. **Configure vault**: Create `.hyalo.toml` with `dir = "knowledgebase"`
 3. **Add to AGENTS.md**: Include: "Use `hyalo` CLI for all markdown knowledgebase operations. Always use `--format text` for compact output."
 4. **Create views**: Set up common views (`stale-in-progress`, `orphans`, etc.)

--- a/plugins/hyalo/skills/hyalo/SKILL.md
+++ b/plugins/hyalo/skills/hyalo/SKILL.md
@@ -12,7 +12,7 @@ is an alternative when present. If unavailable, report that and suggest the proj
 documented installation (`cargo install hyalo-cli`); do not install software as a
 side effect of a knowledgebase query. The prepared npm distribution remains
 unpublished pending owner bootstrap, trusted publisher setup, and real-platform
-registry checks; do not suggest `npm install hyalo` before that acceptance.
+registry checks; do not suggest `npm install @ractive-ch/hyalo` before that acceptance.
 
 Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
 to locate and confirm the vault. Commands also work inside that configured vault,


### PR DESCRIPTION
## Summary

npm rejects the unscoped `hyalo` name as too similar to `yalc`. The main package is now `@ractive-ch/hyalo`; the installed command remains `hyalo`, and the seven published platform packages keep their names, version and bytes.

Add `prepare_npm_main_bootstrap` to pack and sign only the scoped main package after checking the Cargo version. This mode skips native builds and cannot publish to npm. Registry installation checks, generated metadata, installation guidance and iteration 287’s import examples use the scoped name. Packaging dry runs use isolated offline caches; actual publication still checks live registry integrity.

Iteration 286 remains in progress until the main package is published, all eight trusted publishers are configured, and the four-platform registry checks pass. Iteration 287 retains that prerequisite; Homefinder and iteration 288’s desktop verification remain deferred.

## Test plan

- [x] Formatting, strict workspace Clippy, 4,900 passing tests; two existing ignored doctests. Release build ran after tests.
- [x] Implemented xtask checks, nine Node tests, scoped tarball content checks and publication dry run; actionlint and changed-file knowledgebase lint.
- [x] Existing unavailable outcomes recorded: two xtask stubs and the jq MADR recipe without `docs/decisions`.
- [x] Fresh independent full review including the final workflow repair; no unresolved findings. Published-platform and scoped-main offline dry runs passed.
- [ ] Main-package publication, npm trusted publishers, and real-platform registry verification after merge.
