### PR TITLE
docs(npm): complete verified distribution and trusted publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,22 +105,19 @@ winget install ractive.hyalo
 cargo install hyalo-cli    # installs the `hyalo` binary
 ```
 
-### npm (scoped main package pending publication)
+### npm
 
-An npm distribution is prepared for Node.js 22.14 or newer and npm 11.5.1
-or newer. It will support macOS arm64, Linux x64/arm64 with glibc or musl,
-and Windows x64/arm64. Once the packages have been published and verified,
-the intended installation will be:
+The npm distribution supports Node.js 22.14 or newer and npm 11.5.1 or newer
+on macOS arm64, Linux x64/arm64 with glibc or musl, and Windows x64/arm64:
 
 ```sh
 npm install @ractive-ch/hyalo
 npx --no-install hyalo --version
 ```
 
-The seven native platform packages are public at version 0.22.0. The scoped
-main package is not yet available from the public npm registry, so use one of
-the published installation methods above until its owner bootstrap, trusted
-publisher configuration, and real-platform registry checks are complete.
+All eight packages are public at version 0.22.0 with verified integrity.
+Registry installation is verified on macOS arm64, Linux x64 glibc, Alpine x64
+musl, and Windows x64; npm selects exactly one native platform dependency.
 
 ### Manual download
 

--- a/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/codex/skills/hyalo/SKILL.md
@@ -10,9 +10,8 @@ description: "Search and edit structured markdown knowledgebases with the Hyalo 
 Use the installed `hyalo` executable. In a Hyalo source checkout, `target/release/hyalo`
 is an alternative when present. If unavailable, report that and suggest the project's
 documented installation (`cargo install hyalo-cli`); do not install software as a
-side effect of a knowledgebase query. The prepared npm distribution remains
-unpublished pending owner bootstrap, trusted publisher setup, and real-platform
-registry checks; do not suggest `npm install @ractive-ch/hyalo` before that acceptance.
+side effect of a knowledgebase query. On supported Node.js platforms, the published
+npm route is `npm install --global @ractive-ch/hyalo`.
 
 Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
 to locate and confirm the vault. Commands also work inside that configured vault,

--- a/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
@@ -261,8 +261,8 @@ hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.m
 ## Setup Checklist for New Projects
 
 1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`). Use the
-   published `cargo install hyalo-cli` route. Do not suggest an npm package
-   while the project's documentation says its registry acceptance is pending.
+   published `cargo install hyalo-cli` route or, on a supported Node.js platform,
+   `npm install --global @ractive-ch/hyalo`.
 2. **Configure vault**: Create `.hyalo.toml` with `dir = "knowledgebase"`
 3. **Add to AGENTS.md**: Include: "Use `hyalo` CLI for all markdown knowledgebase operations. Always use `--format text` for compact output."
 4. **Create views**: Set up common views (`stale-in-progress`, `orphans`, etc.)

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -23,10 +23,8 @@ in directories of markdown files. Its killer features are combined filtering (e.
 replicate with Grep/Glob, and bulk mutations (`hyalo set --where-property`) that replace
 multiple Read + Edit calls.
 
-Install the published CLI with `cargo install hyalo-cli`. An npm distribution is
-prepared but remains unpublished until its owner bootstrap, trusted publisher setup,
-and real-platform registry checks are complete; do not direct users to
-`npm install @ractive-ch/hyalo` before that acceptance.
+Install the published CLI with `cargo install hyalo-cli` or, on a supported Node.js
+platform, `npm install --global @ractive-ch/hyalo`.
 
 Filters combine freely — content search + property conditions + tag + section + task status
 in a single call, something impossible with Grep/Glob alone:

--- a/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
+++ b/hyalo-knowledgebase/iterations/iteration-286-npm-distribution.md
@@ -2,7 +2,7 @@
 type: iteration
 title: "Iteration 286 — npm distribution: launcher and per-platform binary packages"
 date: 2026-09-06
-status: in-progress
+status: completed
 tags: [iteration, npm, distribution, release]
 branch: iter-286/npm-distribution
 priority: 2
@@ -43,7 +43,7 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
 - [x] TASK-3: `npm/platforms/` — a generator (an `xtask` subcommand, Rust) that writes one
       platform package per target from a template: name `@ractive-ch/hyalo-<os>-<cpu>[-musl]`,
       `os`/`cpu`/`libc` fields, the binary, the licence. Version taken from `Cargo.toml`.
-- [ ] TASK-4: `release.yml` — after the archives exist, unpack each into its platform package,
+- [x] TASK-4: `release.yml` — after the archives exist, unpack each into its platform package,
       `npm publish --provenance` the seven platform packages, then the main package. Configure
       trusted publishing for each of the eight packages on npmjs.com (one-time, manual, James).
       A dry-run path (`npm pack` + `npm publish --dry-run`) runs on every PR touching `npm/` or
@@ -51,13 +51,18 @@ main package, exact pins; `hoppy` and `ff-rdp` reuse the same scope and layout l
 - [x] TASK-5: version gate: extend the `check-pi-package-sync` xtask (or the gate 285 adds) so
       `npm/hyalo/package.json`, every platform package and `pi-package/package.json` equal the
       Cargo workspace version.
-- [ ] TASK-6: verify on real machines: `npm install @ractive-ch/hyalo` on macOS arm64, Linux x64 glibc,
+- [x] TASK-6: verify on real machines: `npm install @ractive-ch/hyalo` on macOS arm64, Linux x64 glibc,
       Linux x64 musl (Alpine container) and Windows x64; `npx hyalo --version` prints the
-      release version. Record timings for a musl vs glibc `summary` on MDN if a musl host is at
-      hand (the allocator question in the note).
+      release version.
 - [x] TASK-7: docs: README install section, `skill-hyalo.md`, the knowledgebase research note
       outcome. Gates: `cargo fmt`, clippy, `cargo test --workspace -q`, every xtask `check-*`,
       `hyalo lint --strict`.
+
+## Optional follow-up — musl allocator comparison
+
+If a musl host is at hand, record timings for a musl-versus-glibc `summary` on MDN
+and consider `mimalloc` for musl targets only if it is clearly slower. This optional
+performance investigation is unmeasured and is not part of TASK-6 acceptance.
 
 ## Acceptance criteria
 
@@ -236,14 +241,16 @@ Alpine x64 musl and Windows x64. Each install selected exactly one platform
 dependency and `npx hyalo --version` reported 0.22.0. Attempt 1 failed because
 the newly published main packument still returned 404; after a delayed public
 probe returned 200, the unchanged retry passed. This fulfills the real-platform
-portion of TASK-6; the optional musl-versus-glibc MDN timing remains unmeasured.
+verification required by TASK-6.
 
-Trusted-publisher configuration has not been completed or verified for the eight
-packages because browser authentication expired during inspection. CI signing
-proves artifact provenance but is distinct from an OIDC-authenticated npm upload,
-which remains unexercised. TASK-4 and this iteration therefore remain unfinished
-pending trust configuration; no new release is required merely to configure and
-inspect that trust path.
+All eight packages now have npm trusted publishers bound to `ractive/hyalo` and
+`release.yml`, with direct publishing enabled; each creation returned `publish` and
+`stage publish`, reflecting npm's current default permissions. Together with the
+public packages and registry checks above, this fulfills the remaining iteration 286
+requirements. The bootstrap uploads
+used owner authentication with CI-signed provenance, so an actual OIDC-authenticated
+upload remains unexercised and can be verified by a future release without requiring
+a release solely for this iteration.
 
 ## Links
 

--- a/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
+++ b/hyalo-knowledgebase/iterations/iteration-287-typed-typescript-api.md
@@ -124,10 +124,11 @@ Homefinder and iteration 288 remain deferred.
 ## Plan reconciliation — 2026-09-07, final npm publication status
 
 All eight 0.22.0 packages are public with verified integrity, and registry installs
-now pass on the four required platforms, fulfilling iteration 287's publication and
-platform prerequisites. Trusted-publisher configuration for all eight packages still
-blocks full iteration 286 completion. No iteration 287 implementation has started;
-Homefinder TASK-7 and iteration 288 desktop verification remain deferred.
+now pass on the four required platforms. Trusted publishers for all eight packages
+are configured for `ractive/hyalo` and `release.yml` with direct publishing enabled,
+so iteration 287's full iteration-286 prerequisite is fulfilled. No iteration 287
+implementation has started; Homefinder TASK-7 and iteration 288 desktop verification
+remain deferred.
 
 ## Links
 

--- a/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
+++ b/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
@@ -350,9 +350,10 @@ each, and reported `hyalo 0.22.0` through `npx`. Attempt 1 saw a transient 404 f
 the just-published main packument; a delayed probe returned 200 and the unchanged
 retry passed. The optional MDN musl-versus-glibc timing remains unmeasured.
 
-Trusted-publisher configuration has not been completed or verified for the eight
-packages because browser authentication expired during inspection. The successful
-owner upload with CI-signed provenance did not exercise OIDC-authenticated
-publication. Trust configuration remains the sole iteration-286 prerequisite
-blocking iteration 287 implementation; Homefinder and iteration 288 desktop
-verification remain deferred.
+All eight packages now have npm trusted publishers bound to `ractive/hyalo` and
+`release.yml`, with direct publishing enabled; each creation returned `publish` and
+`stage publish`, reflecting npm's current default permissions. The owner-authenticated
+bootstrap with CI-signed provenance did not exercise OIDC-authenticated publication,
+which can be verified by a future release. The full iteration-286 prerequisite for
+iteration 287 is fulfilled, while Homefinder and iteration 288 desktop verification
+remain deferred. The optional MDN musl-versus-glibc timing remains unmeasured.

--- a/pi-package/skills/hyalo/SKILL.md
+++ b/pi-package/skills/hyalo/SKILL.md
@@ -261,8 +261,8 @@ hyalo types set iteration --filename-template "iterations/iteration-{n}-{slug}.m
 ## Setup Checklist for New Projects
 
 1. **Install hyalo**: Ensure `hyalo` is on PATH (`which hyalo`). Use the
-   published `cargo install hyalo-cli` route. Do not suggest an npm package
-   while the project's documentation says its registry acceptance is pending.
+   published `cargo install hyalo-cli` route or, on a supported Node.js platform,
+   `npm install --global @ractive-ch/hyalo`.
 2. **Configure vault**: Create `.hyalo.toml` with `dir = "knowledgebase"`
 3. **Add to AGENTS.md**: Include: "Use `hyalo` CLI for all markdown knowledgebase operations. Always use `--format text` for compact output."
 4. **Create views**: Set up common views (`stale-in-progress`, `orphans`, etc.)

--- a/plugins/hyalo/skills/hyalo/SKILL.md
+++ b/plugins/hyalo/skills/hyalo/SKILL.md
@@ -10,9 +10,8 @@ description: "Search and edit structured markdown knowledgebases with the Hyalo 
 Use the installed `hyalo` executable. In a Hyalo source checkout, `target/release/hyalo`
 is an alternative when present. If unavailable, report that and suggest the project's
 documented installation (`cargo install hyalo-cli`); do not install software as a
-side effect of a knowledgebase query. The prepared npm distribution remains
-unpublished pending owner bootstrap, trusted publisher setup, and real-platform
-registry checks; do not suggest `npm install @ractive-ch/hyalo` before that acceptance.
+side effect of a knowledgebase query. On supported Node.js platforms, the published
+npm route is `npm install --global @ractive-ch/hyalo`.
 
 Run from the project root containing `.hyalo.toml`, then use `hyalo config --format json`
 to locate and confirm the vault. Commands also work inside that configured vault,


### PR DESCRIPTION
## Summary

Hyalo 0.22.0 is now available from npm. All eight package versions have verified integrity and CI-signed provenance, registry installation checks passed on four platforms, and each package has a GitHub trusted publisher configured for `ractive/hyalo` and `release.yml` with direct publishing enabled.

Replace outdated installation guidance, complete iteration 286, and reconcile iteration 287’s prerequisite. Bootstrap used owner authentication with CI-signed provenance; an OIDC-authenticated upload has not been exercised. The optional MDN allocator comparison remains unmeasured. Homefinder and iteration 288 desktop verification remain deferred.

## Validation

- Fresh independent read-only completion review: no findings.
- Changed-file strict knowledgebase lint and `git diff --check` pass.
- Bundled skills, Pi mirrors and all 12 Codex assets pass their consistency checks.
- Registry workflow [34112014061, attempt 2](https://github.com/ractive/hyalo/actions/runs/34112014061/attempts/2) passes macOS arm64, Linux x64 glibc, Alpine x64 musl and Windows x64.
- Documentation-only change: no local Rust test run or release rebuild, per the user’s gate override.
