### PR TITLE
fix(iter-289): harden ranked search, API warnings, and dry runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,15 @@ jobs:
                 --ignore-scripts --access public \
                 --registry https://registry.npmjs.org
           done
+      - name: Plan immutable npm publication
+        if: >-
+          github.event_name == 'release' ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish_npm)
+        shell: bash
+        env:
+          PACK_DIR: ${{ runner.temp }}/hyalo-npm-packs
+        run: |
+          set -euo pipefail
           cargo run -q -p xtask -- plan-npm-publication --pack-json \
             "$PACK_DIR/darwin-arm64.json" \
             "$PACK_DIR/linux-x64.json" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,13 @@ and this project adheres to
 
 ### Fixed
 
+- Ranked search checks canonical vault containment before snippet and fallback
+  body reads, refusing file and directory symlink escapes. Indexed document
+  languages now honor CLI/config overrides consistently with scoring and snippets.
+- Successful typed API diagnostics reach stderr or `onDiagnostics`; Pi displays
+  them alongside tool results. Non-publishing npm dry runs no longer query
+  registry publication eligibility; real publishing retains immutable-version checks.
+
 - Frontmatter reads and rewrites briefly retry Windows file-open errors 5 and 32,
   which can occur while another process replaces a file. Five attempts add at most
   40 ms of intentional delay; persistent failures keep their original error and

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -508,6 +508,18 @@ pub fn find(
                 .map(|&idx| scoped_entries[idx].rel_path.as_str())
                 .collect();
 
+            // The persisted corpus must use the same effective document languages as
+            // live scoring and snippet extraction, including documents excluded by
+            // metadata filters: their tokens still contribute to corpus statistics.
+            let cached_language_matches = |entry: &hyalo_core::index::IndexEntry| {
+                let fm_lang = entry.properties.get("language").and_then(|v| v.as_str());
+                entry
+                    .bm25_language
+                    .as_deref()
+                    .and_then(|s| parse_language(s).ok())
+                    == Some(resolve_language(fm_lang, language, config_language))
+            };
+
             // Fastest path: use the persisted BM25 inverted index when available, no section
             // filter is active, AND it was built by the current tokenizer (DEC-094 / F-2) — a
             // persisted index from before a `tokenize()` algorithm change (e.g. the CJK-bigram
@@ -517,6 +529,9 @@ pub fn find(
             if !has_section_filter
                 && let Some(bm25_idx) = index.bm25_index()
                 && bm25_idx.tokenizer_version() == TOKENIZER_VERSION
+                && bm25_idx
+                    .document_paths()
+                    .all(|path| index.get(path).is_some_and(cached_language_matches))
             {
                 let all_scored = bm25_idx.score(pat, &stemmer);
                 let map: HashMap<String, f64> = all_scored
@@ -552,6 +567,31 @@ pub fn find(
             //
             // Slow path: read each file from disk for entries that lack stored tokens
             // or when a section filter is active.
+            // Persisted snapshots omit duplicated per-entry token arrays. Recover
+            // compatible documents from the inverted index during mixed-language
+            // fallback instead of reading their bodies again.
+            let cached_tokens_compatible = |entry: &hyalo_core::index::IndexEntry| {
+                cached_language_matches(entry)
+                    && entry.bm25_tokenizer_version == Some(TOKENIZER_VERSION)
+            };
+            let recovery_paths: std::collections::HashSet<&str> = scoped_entries
+                .iter()
+                .filter(|entry| {
+                    !has_section_filter
+                        && entry.bm25_tokens.is_none()
+                        && cached_tokens_compatible(entry)
+                })
+                .map(|entry| entry.rel_path.as_str())
+                .collect();
+            let mut reconstructed = if recovery_paths.is_empty() {
+                HashMap::new()
+            } else {
+                index
+                    .bm25_index()
+                    .filter(|bm25| bm25.tokenizer_version() == TOKENIZER_VERSION)
+                    .map(|bm25| bm25.reconstruct_selected_tokens(&recovery_paths))
+                    .unwrap_or_default()
+            };
             let mut pre_tok_inputs: Vec<PreTokenizedInput> = Vec::new();
             let mut doc_inputs: Vec<DocumentInput> = Vec::new();
 
@@ -561,7 +601,10 @@ pub fn find(
             // block so the closure (and its mutable borrows of `pre_tok_inputs` /
             // `doc_inputs`) is dropped before those vectors are consumed below.
             {
-                let mut collect_entry = |entry: &hyalo_core::index::IndexEntry| {
+                let mut collect_entry = |entry: &hyalo_core::index::IndexEntry| -> std::result::Result<
+                    (),
+                    discovery::FileResolveError,
+                > {
                     // Use pre-tokenized data only when:
                     // 1. The index entry has stored tokens, AND
                     // 2. No section filter is active (section filters require line-level body slicing), AND
@@ -571,30 +614,38 @@ pub fn find(
                     //    CJK-bigram fix) carries tokens a fresh tokenize would never produce,
                     //    so trusting them would silently keep queries broken until the next
                     //    `create-index` — re-tokenize from disk instead, same as a language miss.
-                    if !has_section_filter && let Some(ref tokens) = entry.bm25_tokens {
-                        let fm_lang = entry.properties.get("language").and_then(|v| v.as_str());
-                        let effective_lang = resolve_language(fm_lang, language, config_language);
-                        let cached_lang_matches = entry
-                            .bm25_language
-                            .as_deref()
-                            .and_then(|s| parse_language(s).ok())
-                            == Some(effective_lang);
-                        let cached_tokenizer_current =
-                            entry.bm25_tokenizer_version == Some(TOKENIZER_VERSION);
-
-                        if cached_lang_matches && cached_tokenizer_current {
+                    if !has_section_filter && cached_tokens_compatible(entry) {
+                        // Borrowed per-entry caches need an owned corpus copy;
+                        // recovered tokens are already owned and consumed directly.
+                        let tokens = entry
+                            .bm25_tokens
+                            .clone()
+                            .or_else(|| reconstructed.remove(entry.rel_path.as_str()));
+                        if let Some(tokens) = tokens {
                             pre_tok_inputs.push(PreTokenizedInput {
                                 rel_path: entry.rel_path.clone(),
-                                tokens: tokens.clone(),
+                                tokens,
                             });
-                            return;
+                            return Ok(());
                         }
-                        // Fall through to disk-read tokenization when the language or the
-                        // tokenizer version mismatches.
                     }
 
                     // Slow path: read the file from disk.
-                    let full_path = dir.join(&entry.rel_path);
+                    let full_path =
+                        match hyalo_core::bm25::resolve_document_path(dir, &entry.rel_path) {
+                            Ok(path) => path,
+                            Err(error) => match error.downcast::<discovery::FileResolveError>() {
+                                Ok(error) => return Err(error),
+                                Err(error) => {
+                                    hyalo_core::warn::record_skip(
+                                        entry.rel_path.as_str(),
+                                        format!("{error:#}"),
+                                        hyalo_core::warn::SkipKind::Other,
+                                    );
+                                    return Ok(());
+                                }
+                            },
+                        };
                     let file_content = match std::fs::read_to_string(&full_path) {
                         Ok(s) => s,
                         // UX-3 (iter-255): `read_to_string` reports invalid
@@ -610,7 +661,7 @@ pub fn find(
                                 crate::commands::INVALID_UTF8_CONSEQUENCE,
                                 hyalo_core::warn::SkipKind::Other,
                             );
-                            return;
+                            return Ok(());
                         }
                         Err(e) => {
                             hyalo_core::warn::record_skip(
@@ -618,7 +669,7 @@ pub fn find(
                                 e.to_string(),
                                 hyalo_core::warn::SkipKind::Other,
                             );
-                            return;
+                            return Ok(());
                         }
                     };
                     // Feed only the body (after frontmatter) to BM25 so that frontmatter
@@ -635,7 +686,7 @@ pub fn find(
                         if scope_ranges.is_empty() {
                             // No matching section — this candidate should have been filtered
                             // in Phase 1, but guard here just in case.
-                            return;
+                            return Ok(());
                         }
                         // Index line numbers are 1-based relative to the full file (frontmatter + body).
                         // Count lines in the frontmatter prefix to offset body line numbers correctly.
@@ -670,6 +721,7 @@ pub fn find(
                         body,
                         language: lang,
                     });
+                    Ok(())
                 };
 
                 if has_section_filter {
@@ -678,7 +730,9 @@ pub fn find(
                     // filter is active — so both the --index and no-index runs already build
                     // this exact candidates-only corpus. No cross-path parity gap here.
                     for &idx in &candidates {
-                        collect_entry(scoped_entries[idx]);
+                        if let Err(error) = collect_entry(scoped_entries[idx]) {
+                            return Ok(super::resolve_error_to_outcome(error, format, dir));
+                        }
                     }
                 } else {
                     // H-8 fix: build corpus statistics (N, per-term document frequency, avgdl)
@@ -688,7 +742,9 @@ pub fn find(
                     // whole indexed vault) so --index and no-index runs agree on ranking.
                     // Scoring is intersected with metadata-passing candidates below.
                     for entry in scoped_entries.iter().copied() {
-                        collect_entry(entry);
+                        if let Err(error) = collect_entry(entry) {
+                            return Ok(super::resolve_error_to_outcome(error, format, dir));
+                        }
                     }
                 }
             } // end collect_entry scope
@@ -1489,7 +1545,7 @@ pub fn find(
                 );
                 obj.matches = Some(
                     query
-                        .snippets(&dir.join(&obj.file), doc_language, &entry.sections, &scope)
+                        .snippets(dir, &obj.file, doc_language, &entry.sections, &scope)
                         .with_context(|| format!("reading ranked snippets for {}", obj.file))?,
                 );
                 Ok(())
@@ -1497,7 +1553,12 @@ pub fn find(
             .collect();
         // Report the first failure in result order, independent of scheduling.
         for outcome in outcomes {
-            outcome?;
+            if let Err(error) = outcome {
+                return match error.downcast::<discovery::FileResolveError>() {
+                    Ok(error) => Ok(super::resolve_error_to_outcome(error, format, dir)),
+                    Err(error) => Err(error),
+                };
+            }
         }
     }
 

--- a/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
+++ b/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
@@ -78,12 +78,16 @@ async function runHyalo(
 
 async function runTyped(
   command: string,
-  operation: () => Promise<string>,
+  operation: (onDiagnostics: (stderr: string) => void) => Promise<string>,
 ) {
   try {
-    const text = await operation();
+    const diagnostics: string[] = [];
+    const text = await operation((stderr) => { diagnostics.push(stderr); });
     return {
-      content: [{ type: "text" as const, text: text || "(no output)" }],
+      content: [
+        { type: "text" as const, text: text || "(no output)" },
+        ...diagnostics.map((stderr) => ({ type: "text" as const, text: `Stderr:\n${stderr}` })),
+      ],
       details: undefined,
     };
   } catch (error) {
@@ -295,7 +299,7 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_find: search/filter knowledgebase files (query, property, tag, task status)",
     parameters: hyaloFindParams,
     async execute(_toolCallId, params: Static<typeof hyaloFindParams>, signal) {
-      return runTyped("find", async () => {
+      return runTyped("find", async (onDiagnostics) => {
         const result = await hyaloFind({
           pattern: params.query,
           properties: params.property,
@@ -305,6 +309,7 @@ export default function (pi: ExtensionAPI) {
           limit: params.limit === undefined ? undefined : Math.trunc(params.limit),
           transport,
           signal,
+          onDiagnostics,
         });
         return params.countOnly
           ? String(result.total ?? result.results.length)
@@ -331,8 +336,8 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_read: read a vault file (optionally a single section) as text",
     parameters: hyaloReadParams,
     async execute(_toolCallId, params: Static<typeof hyaloReadParams>, signal) {
-      return runTyped("read", async () => {
-        const result = await hyaloRead({ file: [params.file], section: params.section, transport, signal });
+      return runTyped("read", async (onDiagnostics) => {
+        const result = await hyaloRead({ file: [params.file], section: params.section, transport, signal, onDiagnostics });
         return result.results.content ?? result.results.frontmatter_raw ?? "";
       });
     },
@@ -357,8 +362,8 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_set: set a file's frontmatter property (K=V), optionally add a tag",
     parameters: hyaloSetParams,
     async execute(_toolCallId, params: Static<typeof hyaloSetParams>, signal) {
-      return runTyped("set", async () => {
-        const result = await hyaloSet({ ...params, transport, signal });
+      return runTyped("set", async (onDiagnostics) => {
+        const result = await hyaloSet({ ...params, transport, signal, onDiagnostics });
         return result.stdout;
       });
     },
@@ -386,7 +391,7 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_task: toggle task checkboxes (all / by section / by line)",
     parameters: hyaloTaskParams,
     async execute(_toolCallId, params: Static<typeof hyaloTaskParams>, signal) {
-      return runTyped("task", async () => {
+      return runTyped("task", async (onDiagnostics) => {
         const result = await hyaloTask({
           file: params.file,
           mode: params.mode,
@@ -394,6 +399,7 @@ export default function (pi: ExtensionAPI) {
           lines: params.lines,
           transport,
           signal,
+          onDiagnostics,
         });
         return result.stdout;
       });

--- a/crates/hyalo-cli/templates/pi/lib/hyalo-api.d.ts
+++ b/crates/hyalo-cli/templates/pi/lib/hyalo-api.d.ts
@@ -1523,7 +1523,15 @@ interface TransportOptions {
     stdin?: string | Uint8Array;
 }
 type HyaloTransport = (argv: readonly string[], options: TransportOptions) => Promise<ProcessResult>;
+/** Receives the original successful stderr once; returned promises are awaited. */
+type DiagnosticsCallback = (stderr: string) => void | Promise<void>;
 interface ExecutionOptions {
+    /**
+     * Successful typed-call stderr. Defaults to process.stderr.write.
+     * Empty stderr is ignored. Callback throws/rejections reject the call unchanged.
+     * Failed calls retain diagnostics in their error; raw()/execute() retain streams only.
+     */
+    onDiagnostics?: DiagnosticsCallback;
     /** Explicit native binary. Useful for Cargo/Homebrew installations and tests. */
     binaryPath?: string;
     /** Process transport override. Pi uses this to retain its `pi.exec("hyalo", ...)` path. */

--- a/crates/hyalo-cli/templates/pi/lib/hyalo-api.js
+++ b/crates/hyalo-cli/templates/pi/lib/hyalo-api.js
@@ -762,6 +762,7 @@ function isClosedStdinWriteError(error) {
 }
 function executionOptions(options) {
   return {
+    onDiagnostics: options.onDiagnostics,
     binaryPath: options.binaryPath,
     transport: options.transport,
     cwd: options.cwd,
@@ -974,11 +975,20 @@ function parseEnvelope(result) {
   }
   return parsed;
 }
+async function reportDiagnostics(result, options) {
+  if (!result.stderr) return;
+  if (options.onDiagnostics) await options.onDiagnostics(result.stderr);
+  else process.stderr.write(result.stderr);
+}
 async function jsonCall(argv, options) {
   assertNoOutputTransforms(options);
   const terminator = argv.indexOf("--");
   argv.splice(terminator === -1 ? argv.length : terminator, 0, "--format=json", "--no-hints");
-  return parseEnvelope(await execute(argv, executionOptions(options)));
+  const execution = executionOptions(options);
+  const result = await execute(argv, execution);
+  const envelope = parseEnvelope(result);
+  await reportDiagnostics(result, execution);
+  return envelope;
 }
 function find(options = {}) {
   const values = options;
@@ -1005,6 +1015,7 @@ async function set(options) {
   argv.push("--", options.file);
   const result = await execute(argv, options);
   if (result.code !== 0) throw new HyaloError(result, parseErrorEnvelope(result));
+  await reportDiagnostics(result, options);
   return result;
 }
 async function task(options) {
@@ -1023,6 +1034,7 @@ async function task(options) {
   argv.push("--", options.file);
   const result = await execute(argv, options);
   if (result.code !== 0) throw new HyaloError(result, parseErrorEnvelope(result));
+  await reportDiagnostics(result, options);
   return result;
 }
 async function lint(file, options = {}) {
@@ -1033,6 +1045,7 @@ async function lint(file, options = {}) {
   if (result.code !== 0 && result.code !== 1) {
     throw new HyaloError(result, parseErrorEnvelope(result));
   }
+  if (result.code === 0) await reportDiagnostics(result, options);
   return result;
 }
 function raw(argv, options = {}) {
@@ -1057,6 +1070,7 @@ async function configForPi(options = {}) {
   const nested = typeof top.results === "object" && top.results !== null ? top.results : top;
   const candidateDir = typeof top.dir === "string" ? top.dir : nested.dir;
   const pi = typeof nested.pi === "object" && nested.pi !== null ? nested.pi : void 0;
+  await reportDiagnostics(result, options);
   return {
     vaultDir: typeof candidateDir === "string" && candidateDir ? candidateDir : null,
     sessionSummary: pi?.session_summary === true

--- a/crates/hyalo-cli/tests/e2e/bm25.rs
+++ b/crates/hyalo-cli/tests/e2e/bm25.rs
@@ -1315,3 +1315,417 @@ fn bm25_section_survives_a_mutating_command() {
         "results must still carry a positive BM25 score: {arr:?}"
     );
 }
+
+// Iteration 289: a cached path is not authority to read its current destination.
+fn replace_with_symlink(target: &std::path::Path, link: &std::path::Path, directory: bool) -> bool {
+    #[cfg(unix)]
+    let result = {
+        let _ = directory;
+        std::os::unix::fs::symlink(target, link)
+    };
+    #[cfg(windows)]
+    let result = if directory {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        std::os::windows::fs::symlink_file(target, link)
+    };
+    #[cfg(windows)]
+    if result
+        .as_ref()
+        .is_err_and(|error| error.raw_os_error() == Some(1314))
+    {
+        eprintln!("symlink capability unavailable: Windows requires Developer Mode or privilege");
+        return false;
+    }
+    result.unwrap();
+    true
+}
+
+fn indexed_ranked_fixture() -> TempDir {
+    let vault = TempDir::new().unwrap();
+    std::fs::write(
+        vault.path().join(".hyalo.toml"),
+        "[scan]\nverbose_skips = true\n",
+    )
+    .unwrap();
+    write_md(
+        vault.path(),
+        "notes/note.md",
+        "# Fruit\npineapple safe fixture\n",
+    );
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(vault.path())
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    vault
+}
+
+#[test]
+fn ranked_live_reads_refuse_file_and_directory_symlink_escape() {
+    for directory in [false, true] {
+        let vault = indexed_ranked_fixture();
+        let outside = TempDir::new().unwrap();
+        write_md(
+            outside.path(),
+            "note.md",
+            "# Fruit\npineapple EXTERNAL_FIXTURE_MARKER\n",
+        );
+        let (link, target) = if directory {
+            std::fs::remove_dir_all(vault.path().join("notes")).unwrap();
+            (vault.path().join("notes"), outside.path().to_owned())
+        } else {
+            std::fs::remove_file(vault.path().join("notes/note.md")).unwrap();
+            (
+                vault.path().join("notes/note.md"),
+                outside.path().join("note.md"),
+            )
+        };
+        if !replace_with_symlink(&target, &link, directory) {
+            continue;
+        }
+        // Persisted snippets, section fallback, and language-miss fallback.
+        for extra in [
+            vec![],
+            vec!["--section", "Fruit"],
+            vec!["--language", "german"],
+        ] {
+            let output = hyalo_no_hints()
+                .arg("--dir")
+                .arg(vault.path())
+                .args(["find", "pineapple", "--index"])
+                .args(&extra)
+                .output()
+                .unwrap();
+            assert!(
+                !output.status.success(),
+                "{directory}, {extra:?}: {output:?}"
+            );
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(stderr.contains("outside vault"), "{stderr}");
+            assert!(stderr.contains("notes/note.md"), "{stderr}");
+            assert!(!String::from_utf8_lossy(&output.stdout).contains("EXTERNAL_FIXTURE_MARKER"));
+            assert!(!stderr.contains("EXTERNAL_FIXTURE_MARKER"));
+        }
+        // No selected snippets means no body reads on the compatible fast path.
+        // Public --limit 0 means unlimited, so narrow with metadata instead.
+        let output = hyalo_no_hints()
+            .arg("--dir")
+            .arg(vault.path())
+            .args([
+                "find",
+                "pineapple",
+                "--index",
+                "--limit",
+                "0",
+                "--tag",
+                "absent",
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(result["results"], serde_json::json!([]));
+    }
+}
+
+#[test]
+fn ranked_live_reads_allow_in_vault_symlink_destinations() {
+    for directory in [false, true] {
+        let vault = indexed_ranked_fixture();
+        std::fs::rename(vault.path().join("notes"), vault.path().join("real")).unwrap();
+        let (link, target) = if directory {
+            (vault.path().join("notes"), vault.path().join("real"))
+        } else {
+            std::fs::create_dir(vault.path().join("notes")).unwrap();
+            (
+                vault.path().join("notes/note.md"),
+                vault.path().join("real/note.md"),
+            )
+        };
+        if !replace_with_symlink(&target, &link, directory) {
+            continue;
+        }
+        for extra in [
+            vec![],
+            vec!["--section", "Fruit"],
+            vec!["--language", "german"],
+        ] {
+            let output = hyalo_no_hints()
+                .arg("--dir")
+                .arg(vault.path())
+                .args(["find", "pineapple", "--index"])
+                .args(extra)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "{output:?}");
+            assert!(String::from_utf8_lossy(&output.stdout).contains("pineapple safe fixture"));
+        }
+    }
+}
+
+#[test]
+fn ranked_live_reads_preserve_missing_target_diagnostics() {
+    let vault = indexed_ranked_fixture();
+    std::fs::remove_file(vault.path().join("notes/note.md")).unwrap();
+    for fallback in [false, true] {
+        let mut command = hyalo_no_hints();
+        command
+            .current_dir(vault.path())
+            .arg("--dir")
+            .arg(vault.path())
+            .args(["find", "pineapple", "--index"]);
+        if fallback {
+            command.args(["--section", "Fruit"]);
+        }
+        let output = command.output().unwrap();
+        assert_eq!(output.status.success(), fallback, "{output:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("notes/note.md"), "{stderr}");
+        assert!(!stderr.contains("outside vault"), "{stderr}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn ranked_live_reads_preserve_permission_errors() {
+    use std::os::unix::fs::PermissionsExt;
+    let vault = indexed_ranked_fixture();
+    let note = vault.path().join("notes/note.md");
+    std::fs::set_permissions(&note, std::fs::Permissions::from_mode(0o0)).unwrap();
+    if std::fs::File::open(&note).is_ok() {
+        eprintln!("permission test unavailable: privileged process can read mode-000 fixture");
+        return;
+    }
+    for fallback in [false, true] {
+        let mut command = hyalo_no_hints();
+        command
+            .current_dir(vault.path())
+            .arg("--dir")
+            .arg(vault.path())
+            .args(["find", "pineapple", "--index"]);
+        if fallback {
+            command.args(["--section", "Fruit"]);
+        }
+        let output = command.output().unwrap();
+        assert_eq!(output.status.success(), fallback, "{output:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("Permission denied"), "{stderr}");
+        assert!(!stderr.contains("outside vault"), "{stderr}");
+    }
+    std::fs::set_permissions(note, std::fs::Permissions::from_mode(0o600)).unwrap();
+}
+
+#[test]
+fn ranked_language_overrides_match_live_scoring_and_snippets() {
+    for config_language in ["english", "german"] {
+        let vault = TempDir::new().unwrap();
+        write_md(vault.path(), "default.md", "# Sport\nrunning\n");
+        write_md(
+            vault.path(),
+            "english.md",
+            "---\nlanguage: english\ntags: [selected]\n---\n# Sport\nrunning run\n",
+        );
+        write_md(
+            vault.path(),
+            "german.md",
+            "---\nlanguage: german\n---\n# Sport\nrunning\n",
+        );
+        let output = hyalo_no_hints()
+            .arg("--dir")
+            .arg(vault.path())
+            .arg("create-index")
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        // Change only effective config after indexing with the English default.
+        std::fs::write(
+            vault.path().join(".hyalo.toml"),
+            format!("[search]\nlanguage = \"{config_language}\"\n"),
+        )
+        .unwrap();
+        for args in [
+            vec!["run"],
+            vec!["run", "--language", "english"],
+            vec!["run", "--language", "german"],
+            vec!["run", "--language", "german", "--section", "Sport"],
+            // Candidate language stays English; excluded default.md changes corpus IDF.
+            vec!["run", "--language", "german", "--tag", "selected"],
+            vec!["run", "--language", "german", "--glob", "english.md"],
+        ] {
+            let mut envelopes = Vec::new();
+            for indexed in [false, true] {
+                let mut command = hyalo_no_hints();
+                command
+                    .current_dir(vault.path())
+                    .arg("--dir")
+                    .arg(vault.path())
+                    .args(["find", "--format", "json"])
+                    .args(&args);
+                if indexed {
+                    command.arg("--index");
+                }
+                let output = command.output().unwrap();
+                assert!(
+                    output.status.success(),
+                    "{config_language}, {args:?}: {output:?}"
+                );
+                let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+                let german = args.contains(&"german")
+                    || (config_language == "german" && !args.contains(&"english"));
+                let files: Vec<_> = envelope["results"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|result| result["file"].as_str().unwrap())
+                    .collect();
+                assert!(
+                    files.contains(&"english.md"),
+                    "frontmatter wins: {envelope}"
+                );
+                if german {
+                    assert!(!files.contains(&"default.md"), "{envelope}");
+                }
+                for result in envelope["results"].as_array().unwrap() {
+                    assert!(
+                        !result["matches"].as_array().unwrap().is_empty(),
+                        "{result}"
+                    );
+                }
+                envelopes.push(envelope);
+            }
+            assert_eq!(envelopes[0], envelopes[1], "{config_language}, {args:?}");
+        }
+    }
+}
+
+#[test]
+fn ranked_legacy_language_metadata_falls_back_and_checks_containment() {
+    use hyalo_core::index::SnapshotIndex;
+    let vault = indexed_ranked_fixture();
+    let snapshot_path = vault.path().join(".hyalo-index");
+    let mut snapshot = SnapshotIndex::load(&snapshot_path).unwrap().unwrap();
+    assert!(snapshot.bm25_index().is_some());
+    let entry = snapshot.get_mut("notes/note.md").unwrap();
+    assert_eq!(entry.bm25_language.as_deref(), Some("english"));
+    assert!(entry.bm25_tokens.is_none());
+    entry.bm25_language = None; // Snapshot shape produced before iteration 289.
+    snapshot.save_to(&snapshot_path).unwrap();
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(vault.path())
+        .args(["find", "pineapple", "--index"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).contains("safe fixture"));
+    let outside = TempDir::new().unwrap();
+    write_md(
+        outside.path(),
+        "note.md",
+        "pineapple EXTERNAL_FIXTURE_MARKER\n",
+    );
+    let link = vault.path().join("notes/note.md");
+    std::fs::remove_file(&link).unwrap();
+    if !replace_with_symlink(&outside.path().join("note.md"), &link, false) {
+        return;
+    }
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(vault.path())
+        .args(["find", "pineapple", "--index"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("outside vault"));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("EXTERNAL_FIXTURE_MARKER"));
+}
+
+#[test]
+fn ranked_compatible_persisted_corpus_does_not_read_nonselected_bodies() {
+    let vault = TempDir::new().unwrap();
+    write_md(vault.path(), "keep.md", "pineapple safe\n");
+    write_md(vault.path(), "other.md", "pineapple unrelated\n");
+    // This indexed note has no BM25 tokens/language and does not belong to
+    // the stored corpus; it must not invalidate otherwise compatible languages.
+    std::fs::write(vault.path().join("invalid.md"), b"# Invalid\n\xff\xfe").unwrap();
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(vault.path())
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let query = || {
+        hyalo_no_hints()
+            .arg("--dir")
+            .arg(vault.path())
+            .args([
+                "find",
+                "pineapple",
+                "--index",
+                "--sort",
+                "file",
+                "--limit",
+                "1",
+            ])
+            .output()
+            .unwrap()
+    };
+    let before = query();
+    std::fs::remove_file(vault.path().join("other.md")).unwrap();
+    let after = query();
+    assert!(after.status.success(), "{after:?}");
+    assert_eq!(before.stdout, after.stdout);
+    assert!(!String::from_utf8_lossy(&after.stderr).contains("unreadable"));
+}
+
+#[test]
+fn ranked_language_fallback_reuses_compatible_persisted_document_tokens() {
+    let vault = TempDir::new().unwrap();
+    write_md(
+        vault.path(),
+        "keep.md",
+        "---\nlanguage: english\n---\nrunning run\n",
+    );
+    write_md(
+        vault.path(),
+        "compatible.md",
+        "---\nlanguage: english\n---\nrunning\n",
+    );
+    write_md(vault.path(), "changed.md", "running\n");
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(vault.path())
+        .arg("create-index")
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let query = || {
+        hyalo_no_hints()
+            .arg("--dir")
+            .arg(vault.path())
+            .args([
+                "find",
+                "run",
+                "--index",
+                "--language",
+                "german",
+                "--sort",
+                "file",
+                "--reverse",
+                "--limit",
+                "1",
+            ])
+            .output()
+            .unwrap()
+    };
+    let before = query();
+    std::fs::remove_file(vault.path().join("compatible.md")).unwrap();
+    let after = query();
+    assert!(after.status.success(), "{after:?}");
+    assert_eq!(before.stdout, after.stdout);
+    assert!(!String::from_utf8_lossy(&after.stderr).contains("unreadable"));
+}

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -369,6 +369,27 @@ pub struct SnippetQuery {
     terms: HashSet<String>,
 }
 
+/// Resolve a ranked-search live read using the vault's canonical boundary.
+/// Return the checked destination so callers do not reopen the original symlink.
+/// This is a pre-open check, not a guarantee against concurrent filesystem changes.
+pub fn resolve_document_path(
+    dir: &std::path::Path,
+    rel_path: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    use anyhow::Context;
+    let canonical_dir = crate::discovery::canonicalize_vault_dir(dir)?;
+    let path = dunce::canonicalize(dir.join(rel_path))
+        .with_context(|| format!("resolving ranked document {rel_path}"))?;
+    if !path.starts_with(&canonical_dir) {
+        return Err(crate::discovery::FileResolveError::OutsideVault {
+            path: rel_path.to_owned(),
+            resolved: Some(path.display().to_string()),
+        }
+        .into());
+    }
+    Ok(path)
+}
+
 impl SnippetQuery {
     /// Compile with the query-time stemming language (no document override).
     pub fn new(query: &str, language: StemLanguage) -> Self {
@@ -407,7 +428,8 @@ impl SnippetQuery {
     /// have no original text or file-line offsets, so cannot supply snippets.
     pub fn snippets(
         &self,
-        path: &std::path::Path,
+        dir: &std::path::Path,
+        rel_path: &str,
         language: StemLanguage,
         sections: &[crate::types::OutlineSection],
         scope: &[crate::heading::SectionRange],
@@ -422,6 +444,7 @@ impl SnippetQuery {
             scope,
             best: Vec::with_capacity(4),
         };
+        let path = resolve_document_path(dir, rel_path)?;
         let file = std::fs::File::open(path)?;
         if file.metadata()?.len() > crate::scanner::MAX_FILE_SIZE {
             return Ok(Vec::new());
@@ -865,40 +888,63 @@ impl Bm25InvertedIndex {
     /// One pass over all postings: O(total postings), no per-document scans.
     #[must_use]
     pub fn reconstruct_all_tokens(&self) -> std::collections::HashMap<&str, Vec<String>> {
-        use std::collections::HashMap;
+        self.reconstruct_tokens_where(|_| true)
+    }
 
-        let mut by_doc: HashMap<u32, Vec<(u32, &str)>> = HashMap::new();
+    /// Recover only selected documents, preserving token order and duplicates.
+    /// Empty selections return without traversing postings. Nonempty selections
+    /// use one posting traversal and allocate token storage only for selected docs.
+    #[must_use]
+    pub fn reconstruct_selected_tokens(
+        &self,
+        selected: &HashSet<&str>,
+    ) -> HashMap<&str, Vec<String>> {
+        self.reconstruct_tokens_where(|path| selected.contains(path))
+    }
+
+    fn reconstruct_tokens_where(
+        &self,
+        include: impl Fn(&str) -> bool,
+    ) -> HashMap<&str, Vec<String>> {
+        let selected: Vec<_> = self
+            .doc_paths
+            .iter()
+            .enumerate()
+            .filter(|(_, path)| include(path))
+            .map(|(id, path)| {
+                #[allow(clippy::cast_possible_truncation)]
+                (id as u32, path.as_str())
+            })
+            .collect();
+        if selected.is_empty() {
+            return HashMap::new();
+        }
+        let mut by_doc: HashMap<u32, Vec<(u32, &str)>> =
+            selected.iter().map(|&(id, _)| (id, Vec::new())).collect();
         for (term, posts) in &self.postings {
-            for p in posts {
-                if !p.positions.is_empty() {
-                    let entry = by_doc.entry(p.doc_id).or_default();
-                    for &pos in &p.positions {
-                        entry.push((pos, term.as_str()));
-                    }
+            for posting in posts {
+                if let Some(parts) = by_doc.get_mut(&posting.doc_id) {
+                    parts.extend(posting.positions.iter().map(|&pos| (pos, term.as_str())));
                 }
             }
         }
-
-        let mut out: HashMap<&str, Vec<String>> = HashMap::with_capacity(self.doc_paths.len());
-        for (doc_id, path) in self.doc_paths.iter().enumerate() {
-            #[allow(clippy::cast_possible_truncation)]
-            let doc_id = doc_id as u32;
-            // Each (position, term) pair is unique per doc: a posting pushes
-            // one pair per occurrence, and positions within a posting list are
-            // strictly increasing, so two postings for the same doc can never
-            // claim the same position. A stable sort by position therefore
-            // restores the original token order exactly.
-            if let Some(mut parts) = by_doc.remove(&doc_id) {
-                parts.sort_unstable_by_key(|&(pos, _)| pos);
-                out.insert(
-                    path.as_str(),
-                    parts.into_iter().map(|(_, t)| t.to_owned()).collect(),
-                );
-            } else {
-                out.insert(path.as_str(), Vec::new());
-            }
+        let mut out = HashMap::with_capacity(selected.len());
+        for (doc_id, path) in selected {
+            let mut parts = by_doc.remove(&doc_id).unwrap_or_default();
+            // Positions uniquely identify occurrences, restoring the token order
+            // required for phrase matching while retaining repeated terms.
+            parts.sort_unstable_by_key(|&(pos, _)| pos);
+            out.insert(
+                path,
+                parts.into_iter().map(|(_, term)| term.to_owned()).collect(),
+            );
         }
         out
+    }
+
+    /// Paths of the documents that contribute to this corpus's statistics.
+    pub fn document_paths(&self) -> impl Iterator<Item = &str> {
+        self.doc_paths.iter().map(String::as_str)
     }
 
     /// Returns the total number of documents in the index.
@@ -1233,6 +1279,45 @@ mod tests {
             reconstructed.get("empty.md").unwrap(),
             &Vec::<String>::new()
         );
+    }
+
+    #[test]
+    fn selected_token_reconstruction_preserves_subset_empty_docs_and_unknown_paths() {
+        let index = Bm25InvertedIndex::build_from_tokens(vec![
+            PreTokenizedInput {
+                rel_path: "selected.md".into(),
+                tokens: vec!["beta".into(), "alpha".into(), "beta".into()],
+            },
+            PreTokenizedInput {
+                rel_path: "excluded.md".into(),
+                tokens: vec!["unrelated".into(); 1000],
+            },
+            PreTokenizedInput {
+                rel_path: "empty.md".into(),
+                tokens: vec![],
+            },
+        ]);
+        let selected = HashSet::from(["selected.md", "empty.md", "missing.md"]);
+        let recovered = index.reconstruct_selected_tokens(&selected);
+        assert_eq!(recovered.len(), 2);
+        assert_eq!(recovered["selected.md"], ["beta", "alpha", "beta"]);
+        assert!(recovered["empty.md"].is_empty());
+        assert!(!recovered.contains_key("excluded.md"));
+        assert!(!recovered.contains_key("missing.md"));
+        assert!(
+            index
+                .reconstruct_selected_tokens(&HashSet::new())
+                .is_empty()
+        );
+        assert!(
+            index
+                .reconstruct_selected_tokens(&HashSet::from(["missing.md"]))
+                .is_empty()
+        );
+        let all = index.reconstruct_all_tokens();
+        for path in ["selected.md", "empty.md"] {
+            assert_eq!(recovered[path], all[path]);
+        }
     }
 
     /// Scores must be identical between an index built from the original

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -71,7 +71,8 @@ pub struct IndexEntry {
     pub bm25_tokens: Option<Vec<String>>,
     /// Stemming language used when producing [`bm25_tokens`]. Matches the
     /// `language` frontmatter property of this document (or `"english"` as the
-    /// default). `None` when [`bm25_tokens`] is `None`.
+    /// default). Retained when tokens are stored only in the inverted index;
+    /// older snapshots may omit this metadata and require live re-tokenization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bm25_language: Option<String>,
     /// [`crate::bm25::TOKENIZER_VERSION`] that produced [`bm25_tokens`]. `None`
@@ -1687,7 +1688,7 @@ fn write_snapshot(
             .map(|e| {
                 let mut e = e.clone();
                 e.bm25_tokens = None;
-                e.bm25_language = None;
+                // Keep the language so persisted scoring can validate overrides.
                 e
             })
             .collect();

--- a/crates/xtask/src/npm_package.rs
+++ b/crates/xtask/src/npm_package.rs
@@ -414,7 +414,7 @@ fn main_manifest(version: &str) -> Value {
         },
         "scripts": {
             "build": "node scripts/build.mjs",
-            "test": "node --test test/launcher.test.js && node --test test/package.test.js && vitest run test/api.test.ts",
+            "test": "node --test test/launcher.test.js && node --test test/package.test.js && node --test test/pi.test.js && vitest run test/api.test.ts",
             "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json"
         },
         "repository": {
@@ -753,6 +753,160 @@ fn set_executable(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Evaluate the actual workflow expressions for fixture contexts. Unknown syntax
+    // fails the test instead of silently treating an unfamiliar gate as enabled.
+    fn workflow_condition(
+        expression: &str,
+        event: &str,
+        publish: bool,
+        bootstrap: bool,
+        main: bool,
+    ) -> bool {
+        let mut expression = expression
+            .trim()
+            .trim_start_matches("${{")
+            .trim_end_matches("}}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let release_result = if main { "skipped" } else { "success" };
+        for (atom, value) in [
+            ("github.event_name == 'release'", event == "release"),
+            (
+                "github.event_name == 'workflow_dispatch'",
+                event == "workflow_dispatch",
+            ),
+            (
+                "github.event_name != 'workflow_dispatch'",
+                event != "workflow_dispatch",
+            ),
+            (
+                "needs.release.result == 'success'",
+                release_result == "success",
+            ),
+            (
+                "needs.release.result == 'skipped'",
+                release_result == "skipped",
+            ),
+            ("inputs.prepare_npm_main_bootstrap", main),
+            ("inputs.prepare_npm_bootstrap", bootstrap),
+            ("inputs.publish_npm", publish),
+            ("always()", true),
+            ("cancelled()", false),
+        ] {
+            expression = expression.replace(atom, if value { "1" } else { "0" });
+        }
+        let tokens: Vec<_> = expression.chars().filter(|c| !c.is_whitespace()).collect();
+        fn primary(tokens: &[char], cursor: &mut usize) -> bool {
+            let token = tokens[*cursor];
+            *cursor += 1;
+            match token {
+                '1' => true,
+                '0' => false,
+                '!' => !primary(tokens, cursor),
+                '(' => {
+                    let result = disjunction(tokens, cursor);
+                    assert_eq!(tokens.get(*cursor), Some(&')'));
+                    *cursor += 1;
+                    result
+                }
+                _ => panic!("unsupported workflow expression token {token}"),
+            }
+        }
+        fn conjunction(tokens: &[char], cursor: &mut usize) -> bool {
+            let mut result = primary(tokens, cursor);
+            while tokens.get(*cursor..*cursor + 2) == Some(&['&', '&']) {
+                *cursor += 2;
+                result &= primary(tokens, cursor);
+            }
+            result
+        }
+        fn disjunction(tokens: &[char], cursor: &mut usize) -> bool {
+            let mut result = conjunction(tokens, cursor);
+            while tokens.get(*cursor..*cursor + 2) == Some(&['|', '|']) {
+                *cursor += 2;
+                result |= conjunction(tokens, cursor);
+            }
+            result
+        }
+        let mut cursor = 0;
+        let result = disjunction(&tokens, &mut cursor);
+        assert_eq!(cursor, tokens.len(), "unconsumed expression: {expression}");
+        result
+    }
+
+    #[test]
+    fn release_workflow_separates_offline_validation_from_registry_planning() -> Result<()> {
+        let workflow: Value =
+            serde_saphyr::from_str(include_str!("../../../.github/workflows/release.yml"))?;
+        let npm = &workflow["jobs"]["npm"];
+        let steps = npm["steps"].as_array().context("npm workflow steps")?;
+        for (event, publish, bootstrap, main, planned) in [
+            ("workflow_dispatch", false, false, false, false),
+            ("workflow_dispatch", true, false, false, true),
+            ("workflow_dispatch", false, true, false, false),
+            ("workflow_dispatch", false, false, true, false),
+            ("release", false, false, false, true),
+        ] {
+            let enabled = |value: &Value| {
+                value.as_str().is_none_or(|expression| {
+                    workflow_condition(expression, event, publish, bootstrap, main)
+                })
+            };
+            assert!(
+                enabled(&npm["if"]),
+                "npm job must validate {event}/{publish}/{bootstrap}/{main}"
+            );
+            assert_eq!(enabled(&workflow["jobs"]["release"]["if"]), !main);
+            let active: Vec<_> = steps
+                .iter()
+                .enumerate()
+                .filter(|(_, step)| enabled(&step["if"]))
+                .collect();
+            let scripts: Vec<_> = active
+                .iter()
+                .filter_map(|(i, step)| step["run"].as_str().map(|run| (*i, run)))
+                .collect();
+            let packs: Vec<_> = scripts
+                .iter()
+                .filter(|(_, run)| run.contains("npm pack "))
+                .collect();
+            assert_eq!(packs.len(), 1, "exactly one packing route");
+            assert!(packs[0].1.contains("--dry-run --offline"));
+            assert!(packs[0].1.contains("--pack-destination"));
+            assert!(!packs[0].1.contains("plan-npm-publication"));
+            let plans: Vec<_> = scripts
+                .iter()
+                .filter(|(_, run)| run.contains("plan-npm-publication"))
+                .collect();
+            let publications: Vec<_> = scripts
+                .iter()
+                .filter(|(_, run)| run.contains("--provenance --access public"))
+                .collect();
+            assert_eq!(plans.len(), usize::from(planned));
+            assert_eq!(publications.len(), usize::from(planned));
+            if planned {
+                assert!(packs[0].0 < plans[0].0 && plans[0].0 < publications[0].0);
+                assert!(publications[0].1.contains("publication-plan.json"));
+            }
+            let signing = scripts
+                .iter()
+                .filter(|(_, run)| run.contains("generateProvenance"))
+                .count();
+            assert_eq!(signing, usize::from(bootstrap || main));
+            let uploads = active
+                .iter()
+                .filter(|(_, step)| {
+                    step["uses"]
+                        .as_str()
+                        .is_some_and(|v| v.starts_with("actions/upload-artifact"))
+                })
+                .count();
+            assert_eq!(uploads, usize::from(bootstrap || main));
+        }
+        Ok(())
+    }
 
     const VERSION: &str = "1.2.3";
 

--- a/hyalo-knowledgebase/iterations/iteration-289-integrated-review-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-289-integrated-review-fixes.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 289 — Integrated review fixes before API dogfooding
 date: 2026-09-07
-status: in-progress
+status: completed
 tags:
   - iteration
   - review
@@ -146,7 +146,7 @@ are restated below so a fresh checkout can implement this plan.
     planner's existing simulated-registry tests. No live publish, auth, or
     all-platform release rebuild is needed to verify the gating correction.
 
-- [ ] TASK-5: complete integrated verification, documentation, fresh review, and
+- [x] TASK-5: complete integrated verification, documentation, fresh review, and
       plan reconciliation; record the final PR and actual check results.
   - Add focused regressions to the existing Rust BM25/e2e and npm/Pi suites.
     Symlink tests must run on capable platforms; retain any justified Windows
@@ -185,7 +185,7 @@ are restated below so a fresh checkout can implement this plan.
       callback, and Pi displays them without altering the typed envelope.
 - [x] Non-publishing packaging validation never invokes registry publication
       planning; actual publishing retains all immutable-version safeguards.
-- [ ] All four review findings have regression evidence, required gates and
+- [x] All four review findings have regression evidence, required gates and
       final-head CI pass, independent review is resolved, and plans remain honest.
 
 ## Fresh-session handoff
@@ -239,5 +239,20 @@ All 282 iteration plans were inventoried after the final implementation. There
 are no upcoming plans after 289. The remaining plans 287 and 288 were reread and
 need no changes: their external consumer and desktop tasks remain unfinished,
 and their package identity, wire shapes, and companion-asset paths remain valid.
-TASK-5 and the final acceptance criterion remain open for exact PR-head review,
-CI, and the remote checkpoint.
+The subsequent PR verification below completes the implementation and acceptance
+evidence; the remote checkpoint remains subject to final-head checks.
+
+## PR verification — 2026-09-07
+
+[PR #343](https://github.com/ractive/hyalo/pull/343) contains the reviewed source at
+`3b220a7a8c66927681f7675f4afc3d42fb33c4a7`. A fresh restricted read-only review of
+that exact head found no actionable findings. All 11 applicable CI checks passed:
+formatting, Clippy, Rust tests on Linux/macOS/Windows, quality gates, knowledgebase
+lint, npm/API tests on Linux/macOS/Windows, and npm packaging. The full-vault lint
+job is push-only and was correctly skipped on the PR.
+
+This final plan-status update changes documentation only. Its strict lint and
+diff checks must pass, and the supervisor must verify CI and review coverage at
+the resulting final head before merging through GitHub. The merge SHA and final
+checks are retained in the run ledger rather than predicted here. Iterations
+287 and 288 retain their unfinished external tasks.

--- a/hyalo-knowledgebase/iterations/iteration-289-integrated-review-fixes.md
+++ b/hyalo-knowledgebase/iterations/iteration-289-integrated-review-fixes.md
@@ -1,0 +1,243 @@
+---
+type: iteration
+title: Iteration 289 — Integrated review fixes before API dogfooding
+date: 2026-09-07
+status: in-progress
+tags:
+  - iteration
+  - review
+  - security
+  - npm
+  - api
+branch: iter-289/integrated-review-fixes
+priority: 1
+---
+
+# Iteration 289 — Integrated review fixes before API dogfooding
+
+## Goal
+
+Resolve the four verified findings from the independent review of iterations
+284, 282, 283, 285, 286, and 287. Preserve vault containment during ranked search,
+make indexed scoring and snippets agree on language, expose successful API
+diagnostics, and keep non-publishing release validation independent of registry
+publication eligibility. Deliver one reviewed Hyalo PR with meaningful regressions.
+
+## Baseline and scope
+
+Reviewed baseline: `5f3a91289843d6a97ab822f9dca563abf4ec85d0` through merged main
+`a2654eee130875dfe4c252e006d52bb6debff826`. PRs #332–#342 contain the work; #342 is
+the typed API merge. Reconcile against actual main when starting this iteration.
+
+The prerequisite is the merged Hyalo implementation from
+[[iterations/iteration-283-ranked-search-snippets]],
+[[iterations/iteration-285-typed-output-structs]],
+[[iterations/iteration-286-npm-distribution]], and
+[[iterations/iteration-287-typed-typescript-api]]. Iteration 287 remains in progress
+only because its external consumer task is deferred; that task does not block 289.
+
+Homefinder inspection and local-package dogfooding belong to another agent in
+that project. Do not edit that repository or claim its acceptance here. Leave
+[[iterations/iteration-288-codex-integration]] desktop verification deferred.
+Do not publish packages, bump versions, dispatch release/bootstrap workflows,
+change credentials/trusted publishers, or modify the shared release-workflows
+repository. Public npm 0.22.0 remains immutable and CLI-only; the typed API is
+merged source awaiting a separately authorized release.
+
+Local review evidence is under `.git/reviews/integrated-284-287-20260907/`:
+`review.md`, `review.json`, the three reviewer logs, `reproduce-core.py`,
+`core-probe-results.json`, and `api-pi-verification.json`. These are optional
+supporting artifacts, not committed dependencies. All reproduction requirements
+are restated below so a fresh checkout can implement this plan.
+
+## Tasks
+
+- [x] TASK-1 / P1: enforce vault containment before ranked-search live reads.
+  - Entry points: `crates/hyalo-cli/src/commands/find/mod.rs` snippet pass near
+    line 1492 and `crates/hyalo-core/src/bm25.rs::SnippetQuery::snippets`.
+    The former joins a cached relative path; the latter directly opens it.
+  - Reproduction: create a temporary vault containing `notes/note.md` with body
+    `pineapple safe fixture`; create its index. Replace the note with a symlink
+    to a synthetic file outside the vault containing
+    `pineapple EXTERNAL_FIXTURE_MARKER`. Whole-vault `find pineapple --index`
+    currently returns the external marker with exit 0. Replacing the `notes`
+    directory with a symlink reproduces the same defect.
+  - Reuse the canonical containment/error conventions used by
+    `resolve_file_user` and `read`; verify the current resolved destination
+    before opening content, including selected results from a persisted index.
+    A staleness warning or lexical path check is insufficient. Fail closed with
+    a useful path diagnostic; never read the external fixture to decide whether
+    to exclude it. Preserve unrelated I/O failures and existing vault policy.
+  - Cover file and parent-directory substitutions, valid in-vault destinations,
+    and missing/unreadable targets. Exercise both persisted and affected fallback
+    live-read paths. Keep the final-result filter/limit optimization, including
+    zero-limit behavior. Do not broaden this into a filesystem redesign or claim
+    elimination of every concurrent filesystem race.
+
+- [x] TASK-2 / P2: align scoring and snippet tokenization under language overrides.
+  - Entry points: the persisted BM25 fast path and token-reuse fallback in
+    `commands/find/mod.rs` near lines 511–590, plus the snippet language choice
+    near line 1482. `IndexEntry::bm25_language` records cached document language.
+  - Reproduction: index an English-default note with body `running` and no
+    frontmatter language. `find run --index --language english` returns a scored
+    hit with a `running` snippet. With `--language german`, the same cached hit
+    has an empty `matches` array because scoring uses English document tokens
+    while snippet extraction uses German document tokens.
+  - Preserve the documented frontmatter/CLI/config/default language precedence
+    and the distinction between query language and document language. Prefer
+    bypassing the persisted fast path when cached document languages disagree
+    with effective languages, matching the existing per-entry token-cache check.
+    Use compatible cached tokens without additional body reads when possible.
+    Never make scoring and snippets agree by silently ignoring an override.
+  - Add persisted-index versus live-scan regressions for CLI and config overrides,
+    frontmatter language precedence, and section-filter fallback. In the example,
+    indexed German behavior must agree with a fresh German scan. Preserve scores
+    and order when languages are compatible; retain legitimate empty snippets
+    for title-only and cross-line phrase matches. Any added fallback reads must
+    obey TASK-1's containment policy.
+
+- [x] TASK-3 / P2: expose successful typed-call diagnostics without changing the
+      Rust JSON envelope.
+  - Entry points: `npm/hyalo/src/api.ts::parseEnvelope`, `jsonCall`, and
+    `ExecutionOptions`; Pi typed-tool rendering in `pi-package/extensions/hyalo.ts`.
+  - Reproduction: a transport returns code 0, stdout
+    `{"results":[],"total":0,"hints":[]}`, and a stale-index warning on stderr.
+    `find({ index: true, quiet: false, transport })` currently drops the warning;
+    `raw()` preserves it. The CLI's real stale-index path warns but serves results.
+  - Add a documented optional diagnostics callback to the call options. Deliver
+    the original successful stderr once through that callback; when absent,
+    forward it to the caller's stderr so the default does not silently suppress
+    operational warnings. Empty stderr produces no notification. Do not add
+    diagnostics fields to generated Rust wire types or change typed result shapes.
+  - Keep CLI `quiet` semantics: suppress only what the CLI suppresses, including
+    its existing exceptions. Preserve error objects/raw streams and avoid
+    double-reporting failed-command diagnostics. Specify callback exception
+    behavior explicitly; do not silently swallow consumer failures.
+  - Pass a callback through Pi's typed calls and include collected warnings in
+    their visible tool response without corrupting structured results. Cover
+    native/default output, callback delivery, quiet behavior, and Pi transport.
+    Include a real stale-index or malformed-config success case in addition to
+    deterministic injected-transport tests; avoid timing-dependent sleeps by
+    controlling fixture timestamps if needed.
+  - Update API documentation and public option exports. Regenerate Pi JS and
+    declarations through the existing build, sync the embedded mirrors, and
+    verify both source-package and offline-init layouts. Do not hand-edit bundles.
+
+- [x] TASK-4 / P2: separate offline packaging validation from registry planning.
+  - Entry points: `.github/workflows/release.yml`, currently the
+    `Pack and dry-run all publications` step near line 232, and
+    `crates/xtask/src/npm_package.rs` publication planner tests.
+  - Reproduction by control flow: default `workflow_dispatch`, with all three
+    publish/bootstrap flags false, still calls `plan-npm-publication`. That
+    planner queries the registry and rejects an existing version whose tarball
+    integrity differs. Current source 0.22.0 has API contents that public
+    CLI-only 0.22.0 lacks, so a non-publishing dry run can fail on immutability.
+  - Move registry planning into a distinct step gated on an actual release event
+    or explicit `publish_npm`. Keep pack/content checks and offline dry-run
+    validation active independently. Preserve explicit bootstrap packing/signing
+    behavior and ensure every real publish path obtains a valid plan first.
+  - Retain immutable-version rejection, exact package order, identical-version
+    skip behavior, main-package-last publication, and version/source safeguards.
+    Do not change planner semantics to ignore an integrity mismatch.
+  - Validate the actual workflow conditions for default dispatch, publication,
+    both bootstrap modes, and release events using the repository's tooling and
+    a small meaningful condition/fixture check. Do not add a test that merely
+    searches for an exact YAML line. Run actionlint if available and retain the
+    planner's existing simulated-registry tests. No live publish, auth, or
+    all-platform release rebuild is needed to verify the gating correction.
+
+- [ ] TASK-5: complete integrated verification, documentation, fresh review, and
+      plan reconciliation; record the final PR and actual check results.
+  - Add focused regressions to the existing Rust BM25/e2e and npm/Pi suites.
+    Symlink tests must run on capable platforms; retain any justified Windows
+    capability skip explicitly and keep all other Windows tests active.
+  - Before an implementation commit, run in order: `cargo fmt`,
+    `cargo clippy --workspace --all-targets -- -D warnings`, then
+    `cargo test --workspace -q`. Discover xtask commands from its current help
+    and run every implemented `check-*` gate with the actual base/arguments.
+    Report existing stubs or unavailable checks honestly.
+  - Run npm typecheck, build, and tests in `npm/hyalo`, including packed ESM/CJS
+    consumer coverage. Run npm metadata freshness and Pi sync/runtime freshness.
+    Build the release CLI after the final embedded assets are generated, then
+    run `./pi-extension-e2e.sh` against that binary. Serialize builds and tests
+    that replace/use the CLI; never overlap them. Reuse unaffected passing gates
+    after narrow repairs, rerunning affected gates and mandated sequences.
+  - Use Hyalo for knowledgebase operations and lint changed knowledgebase files
+    with `--strict`; run `git diff --check`. Documentation-only changes require
+    only those checks, with no Rust suite or release rebuild.
+  - Obtain a fresh independent read-only review of the full iteration diff.
+    Give every finding a verified fix or evidence-backed disposition; re-review
+    repaired behavior. Reconcile all upcoming plans without executing them.
+    Keep 287's consumer task and 288's desktop task unfinished.
+  - In authorized PR/remote mode, use scoped commits/pushes, the installed
+    create-pr/review-pr/merge-pr workflows, exact-final-head CI on Linux/macOS/
+    Windows, and a GitHub merge commit. No force push, squash, protection bypass,
+    publication, or unrelated repository changes. Verify merge ancestry/tested
+    tree and clean up only the verified merged feature branch.
+
+## Acceptance criteria
+
+- [x] Neither file nor directory symlink replacement can disclose outside-vault
+      content through ranked snippets; failures identify the affected path.
+- [x] Indexed and live language semantics agree under CLI/config overrides and
+      frontmatter precedence; valid empty-snippet cases remain supported.
+- [x] Successful typed API warnings are observable by default and through a
+      callback, and Pi displays them without altering the typed envelope.
+- [x] Non-publishing packaging validation never invokes registry publication
+      planning; actual publishing retains all immutable-version safeguards.
+- [ ] All four review findings have regression evidence, required gates and
+      final-head CI pass, independent review is resolved, and plans remain honest.
+
+## Fresh-session handoff
+
+Read this plan and repository guidance first. This is a new single-iteration
+run, not a resumption of the completed 284–287 batch or its released lock.
+Treat this planning file as intentional work if still uncommitted; preserve it
+and include it in the scoped iteration branch. Do not rerun npm authentication
+or bootstrap. Verify main and dependencies, then implement tasks in the order
+above on `iter-289/integrated-review-fixes`.
+
+For Ralph execution, use a fresh implementer and independent read-only reviewer,
+with run evidence outside product files. The user previously preferred a cheaper
+model for mechanical implementation; use that preference where supported while
+preserving the configured review model. Start only 289 when explicitly invoked.
+The original planning request did not execute this iteration; the later Ralph
+invocation authorized the remote run recorded below.
+
+## Local verification and reconciliation — 2026-09-07
+
+The authorized remote run implements TASK-1 through TASK-4. Canonical containment
+checks cover both snippet and fallback body reads. Persisted scoring checks the
+actual stored corpus's document languages; new snapshots retain language metadata,
+while older snapshots safely fall back until rebuilt. Mixed-language fallback
+recovers only compatible cached documents and consumes the recovered token vectors.
+
+Successful typed diagnostics reach `onDiagnostics` or stderr by default, with
+callback failures propagated unchanged and Pi warnings displayed separately.
+Release packaging stays offline until an actual publication path requires its
+immutable registry plan. No package was published and no version changed.
+
+Final local verification passed ordered `cargo fmt`, strict workspace Clippy, and
+4,951 Rust tests, with two existing ignored doctests. All 11 implemented xtask
+checks passed; dead-primitives and TODO-annotations remain unimplemented stubs.
+The jq gate exercised 42 recipes and retained its existing unavailable MADR TOC
+fixture because this vault has no `docs/decisions` directory. Actionlint, workflow
+condition fixtures, simulated-registry planner tests, metadata and Pi freshness
+checks, and strict changed-document lint passed.
+
+The final release CLI passed npm typechecking, nine launcher tests, packed ESM/CJS
+consumer coverage, source/offline Pi warning-layout tests, and all 21 API tests.
+Live Pi 0.84.4 passed source/offline loading, installed-type compatibility, forced
+generic and typed tool calls, and the post-write lint guardrail.
+
+Fresh independent read-only review found unnecessary full-corpus token recovery.
+Selective reconstruction and its core regressions resolved that finding; a second
+fresh full review returned no actionable findings. Separate attempt reports and
+frozen inputs remain under `.git/ralph-loop/run-20260907T205007Z-289/`.
+
+All 282 iteration plans were inventoried after the final implementation. There
+are no upcoming plans after 289. The remaining plans 287 and 288 were reread and
+need no changes: their external consumer and desktop tasks remain unfinished,
+and their package identity, wire shapes, and companion-asset paths remain valid.
+TASK-5 and the final acceptance criterion remain open for exact PR-head review,
+CI, and the remote checkpoint.

--- a/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
+++ b/hyalo-knowledgebase/research/npm-package-and-typed-typescript-api.md
@@ -384,3 +384,36 @@ API into `pi-package/lib`, outside Pi's extension auto-discovery directory, then
 mirrored into the Rust crate. `init --pi` installs them offline under `.pi/lib`;
 deinit and sync checks cover the same assets. This deliberately avoids depending
 on the public 0.22.0 package, whose immutable bytes contain only the CLI.
+
+## Integrated review corrections — iteration 289
+
+Successful typed calls accept `onDiagnostics(stderr)`, receiving the original
+nonempty stderr once. Without a callback they forward those bytes to the caller's
+stderr. The callback may return a promise; its rejection or synchronous exception
+rejects the call unchanged after CLI success. Empty stderr does not notify.
+`quiet` is passed to the CLI, preserving warnings the CLI deliberately leaves
+visible. Failed commands and invalid envelopes keep stderr in their existing
+error objects without reporting it again. `raw()` and `execute()` preserve streams
+without automatic reporting. Successful `set`, `task`, and `lint` calls also report
+diagnostics while retaining their stream results. Pi's typed tools collect these
+warnings into separate visible text blocks alongside the original response.
+
+Ranked live reads resolve each selected destination against the canonical vault
+boundary before opening content, including fallback scoring reads. This detects
+file and parent-directory symlink substitutions; it does not promise protection
+against every concurrent filesystem race. Ordinary missing or unreadable fallback
+files retain their skip diagnostics, and selected snippet failures retain errors.
+
+Persisted scoring now checks the document language of the entire stored corpus
+against effective frontmatter/CLI/config/default precedence. New snapshots retain
+language metadata when duplicated token arrays are stripped. Earlier snapshots
+without that metadata still load, but use live tokenization until rebuilt with
+`create-index`. Compatible persisted corpora preserve their scoring and read only
+selected snippet bodies. Query language remains distinct from document language.
+
+Offline release packaging and publication planning are separate workflow steps.
+Default manual validation and either bootstrap mode pack and dry-run without
+registry eligibility queries. Release publication and explicit `publish_npm`
+first obtain an immutable publication plan; integrity mismatch rejection and
+platform-first/main-last ordering remain enforced. No package publication or
+version change is part of this iteration; public 0.22.0 remains CLI-only.

--- a/npm/hyalo/README.md
+++ b/npm/hyalo/README.md
@@ -72,6 +72,26 @@ Nonzero typed calls throw `HyaloError`, preserving `exitCode`, `stdout`,
 diagnostics remain plain stderr. Spawn, timeout, abort, invalid JSON, and empty
 JSON failures have distinct error classes.
 
+Successful typed calls forward nonempty stderr to the caller's stderr by default.
+To collect it instead, pass `onDiagnostics`:
+
+```ts
+const warnings: string[] = [];
+const response = await find({
+  pattern: "rust",
+  index: true,
+  onDiagnostics: (stderr) => { warnings.push(stderr); },
+});
+```
+
+The callback receives the original stderr once and may return a promise, which is
+awaited. A throw or rejection rejects the call unchanged after CLI success. Empty
+stderr does not notify. `quiet` follows the CLI's suppression rules and exceptions.
+Failed calls and invalid envelopes preserve stderr in their error objects without
+reporting it again. Successful `set`, `task`, and `lint` calls also report while
+retaining their stream results. `raw()` and `execute()` only return streams.
+Pi renders collected typed-tool warnings as separate text alongside the result.
+
 ## Generated types
 
 Rust owns the serialized contracts. Test-only `ts-rs` derives export declarations

--- a/npm/hyalo/package.json
+++ b/npm/hyalo/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
-    "test": "node --test test/launcher.test.js && node --test test/package.test.js && vitest run test/api.test.ts",
+    "test": "node --test test/launcher.test.js && node --test test/package.test.js && node --test test/pi.test.js && vitest run test/api.test.ts",
     "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json"
   },
   "types": "./dist/index.d.ts",

--- a/npm/hyalo/src/api.ts
+++ b/npm/hyalo/src/api.ts
@@ -32,7 +32,16 @@ export type HyaloTransport = (
   options: TransportOptions,
 ) => Promise<ProcessResult>;
 
+/** Receives the original successful stderr once; returned promises are awaited. */
+export type DiagnosticsCallback = (stderr: string) => void | Promise<void>;
+
 export interface ExecutionOptions {
+  /**
+   * Successful typed-call stderr. Defaults to process.stderr.write.
+   * Empty stderr is ignored. Callback throws/rejections reject the call unchanged.
+   * Failed calls retain diagnostics in their error; raw()/execute() retain streams only.
+   */
+  onDiagnostics?: DiagnosticsCallback;
   /** Explicit native binary. Useful for Cargo/Homebrew installations and tests. */
   binaryPath?: string;
   /** Process transport override. Pi uses this to retain its `pi.exec("hyalo", ...)` path. */
@@ -137,6 +146,7 @@ export function isClosedStdinWriteError(
 
 function executionOptions(options: Record<string, unknown>): ExecutionOptions {
   return {
+    onDiagnostics: options.onDiagnostics as DiagnosticsCallback | undefined,
     binaryPath: options.binaryPath as string | undefined,
     transport: options.transport as HyaloTransport | undefined,
     cwd: options.cwd as string | undefined,
@@ -393,11 +403,22 @@ function parseEnvelope<T>(result: ProcessResult): Envelope<T> {
   return parsed as Envelope<T>;
 }
 
+/** @internal Report only a successfully interpreted typed call, never failed/raw streams. */
+export async function reportDiagnostics(result: ProcessResult, options: ExecutionOptions): Promise<void> {
+  if (!result.stderr) return;
+  if (options.onDiagnostics) await options.onDiagnostics(result.stderr);
+  else process.stderr.write(result.stderr);
+}
+
 async function jsonCall<T>(argv: string[], options: Record<string, unknown>): Promise<Envelope<T>> {
   assertNoOutputTransforms(options);
   const terminator = argv.indexOf("--");
   argv.splice(terminator === -1 ? argv.length : terminator, 0, "--format=json", "--no-hints");
-  return parseEnvelope<T>(await execute(argv, executionOptions(options)));
+  const execution = executionOptions(options);
+  const result = await execute(argv, execution);
+  const envelope = parseEnvelope<T>(result);
+  await reportDiagnostics(result, execution);
+  return envelope;
 }
 
 export function find(options: FindCallOptions = {}): Promise<Envelope<FindResult>> {
@@ -435,6 +456,7 @@ export async function set(options: SetOptions): Promise<ProcessResult> {
   argv.push("--", options.file);
   const result = await execute(argv, options);
   if (result.code !== 0) throw new HyaloError(result, parseErrorEnvelope(result));
+  await reportDiagnostics(result, options);
   return result;
 }
 
@@ -461,6 +483,7 @@ export async function task(options: TaskOptions): Promise<ProcessResult> {
   argv.push("--", options.file);
   const result = await execute(argv, options);
   if (result.code !== 0) throw new HyaloError(result, parseErrorEnvelope(result));
+  await reportDiagnostics(result, options);
   return result;
 }
 
@@ -475,6 +498,7 @@ export async function lint(
   if (result.code !== 0 && result.code !== 1) {
     throw new HyaloError(result, parseErrorEnvelope(result));
   }
+  if (result.code === 0) await reportDiagnostics(result, options);
   return result;
 }
 

--- a/npm/hyalo/src/index.ts
+++ b/npm/hyalo/src/index.ts
@@ -18,6 +18,7 @@ export {
 } from "./api.js";
 export type {
   ConfigCallOptions,
+  DiagnosticsCallback,
   ExecutionOptions,
   FindCallOptions,
   HyaloTransport,

--- a/npm/hyalo/src/pi-runtime.ts
+++ b/npm/hyalo/src/pi-runtime.ts
@@ -3,6 +3,7 @@ import {
   HyaloError,
   HyaloParseError,
   raw,
+  reportDiagnostics,
 } from "./api.js";
 
 /** The only configuration fields consumed by the Pi extension. */
@@ -39,6 +40,7 @@ export async function configForPi(options: ExecutionOptions = {}): Promise<PiCon
   const pi = typeof nested.pi === "object" && nested.pi !== null
     ? nested.pi as Record<string, unknown>
     : undefined;
+  await reportDiagnostics(result, options);
   return {
     vaultDir: typeof candidateDir === "string" && candidateDir ? candidateDir : null,
     sessionSummary: pi?.session_summary === true,

--- a/npm/hyalo/test/api.test.ts
+++ b/npm/hyalo/test/api.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterAll, beforeAll, describe, expect, expectTypeOf, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import {
   HyaloAbortError,
@@ -330,5 +330,86 @@ describe("Pi adapters", () => {
     const untouched = await read({ file: ["control.md"], frontmatter: true, ...real() });
     expect(changed.results.frontmatter).toMatchObject({ status: "-active" });
     expect(untouched.results.frontmatter).toMatchObject({ status: "planned" });
+  });
+});
+
+
+describe("successful diagnostics", () => {
+  const warning = "warning: index older than vault\nsecond diagnostic\n";
+  const stdout = '{"results":[],"total":0,"hints":[]}';
+  const transport: HyaloTransport = async () => ({ code: 0, stdout, stderr: warning });
+
+  it("delivers original stderr once, awaits callbacks, and preserves the envelope", async () => {
+    const seen: string[] = [];
+    const output = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      const result = await find({ index: true, quiet: false, transport, onDiagnostics: async (stderr) => {
+        await Promise.resolve();
+        seen.push(stderr);
+      } });
+      expect(seen).toEqual([warning]);
+      expect(result).toEqual(JSON.parse(stdout));
+      expect(output).not.toHaveBeenCalled();
+      await find({ transport });
+      expect(output.mock.calls).toEqual([[warning]]);
+    } finally { output.mockRestore(); }
+  });
+
+  it("does not suppress quiet exceptions, notify empty stderr, or double-report failures/raw calls", async () => {
+    const onDiagnostics = vi.fn();
+    await find({ quiet: true, transport, onDiagnostics });
+    expect(onDiagnostics.mock.calls).toEqual([[warning]]);
+    onDiagnostics.mockClear();
+    await find({ transport: async () => ({ code: 0, stdout, stderr: "" }), onDiagnostics });
+    await expect(find({ transport: async () => ({ code: 1, stdout, stderr: warning }), onDiagnostics }))
+      .rejects.toMatchObject({ stderr: warning, stdout, exitCode: 1 });
+    await expect(find({ transport: async () => ({ code: 0, stdout: "bad JSON", stderr: warning }), onDiagnostics }))
+      .rejects.toMatchObject({ stderr: warning, stdout: "bad JSON" });
+    expect(await raw([], { transport, onDiagnostics })).toEqual({ code: 0, stdout, stderr: warning });
+    expect(onDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it("propagates consumer exceptions unchanged for sync and async callbacks", async () => {
+    const failure = new Error("consumer callback failed");
+    await expect(find({ transport, onDiagnostics: () => { throw failure; } })).rejects.toBe(failure);
+    await expect(find({ transport, onDiagnostics: async () => { throw failure; } })).rejects.toBe(failure);
+  });
+
+  it("reports successful mutation diagnostics and leaves their raw streams intact", async () => {
+    const onDiagnostics = vi.fn();
+    const options = { file: "note.md", transport, onDiagnostics };
+    expect((await set({ ...options, property: "status=done" })).stderr).toBe(warning);
+    expect((await task({ ...options, mode: "all" })).stderr).toBe(warning);
+    expect(onDiagnostics.mock.calls).toEqual([[warning], [warning]]);
+  });
+
+  it("forwards native malformed-config success diagnostics with exact CLI quiet behavior", async () => {
+    const cwd = path.join(scratch, "success malformed config");
+    await mkdir(path.join(cwd, "vault"), { recursive: true });
+    await writeFile(path.join(cwd, ".hyalo.toml"), "not = [valid\n");
+    await writeFile(path.join(cwd, "vault", "note.md"), "# Note\ncontent\n");
+    const output = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      for (const quiet of [false, true]) {
+        const baseline = await raw(["read", "--dir=vault", "--format=json", "--no-hints", ...(quiet ? ["--quiet"] : []), "--", "note.md"], { binaryPath: binary, cwd });
+        expect(baseline.code).toBe(0);
+        // Malformed configuration is a deliberate CLI quiet-mode exception.
+        expect(baseline.stderr).toContain("warning: malformed .hyalo.toml");
+        const onDiagnostics = vi.fn();
+        const result = await read({ file: ["note.md"], dir: "vault", quiet, binaryPath: binary, cwd, onDiagnostics });
+        expect(result).toEqual(JSON.parse(baseline.stdout));
+        expect(onDiagnostics.mock.calls).toEqual(baseline.stderr ? [[baseline.stderr]] : []);
+        output.mockClear();
+        await read({ file: ["note.md"], dir: "vault", quiet, binaryPath: binary, cwd });
+        expect(output.mock.calls).toEqual(baseline.stderr ? [[baseline.stderr]] : []);
+      }
+    } finally { output.mockRestore(); }
+  });
+
+  it("preserves diagnostics through Pi transport", async () => {
+    const onDiagnostics = vi.fn();
+    const piTransport = createPiTransport({ exec: async () => ({ code: 0, stdout, stderr: warning, killed: false }) });
+    await find({ transport: piTransport, onDiagnostics });
+    expect(onDiagnostics.mock.calls).toEqual([[warning]]);
   });
 });

--- a/npm/hyalo/test/pi.test.js
+++ b/npm/hyalo/test/pi.test.js
@@ -1,0 +1,63 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const { pathToFileURL } = require('node:url');
+const { build } = require('esbuild');
+const execFileAsync = promisify(execFile);
+const root = path.resolve(__dirname, '../../..');
+const binary = process.env.HYALO_BIN || path.join(root, `target/release/hyalo${process.platform === 'win32' ? '.exe' : ''}`);
+
+test('Pi source and offline init tools display successful warnings as separate text', async () => {
+  const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hyalo-pi-diagnostics-'));
+  try {
+    await execFileAsync(binary, ['init', '--pi', '--dir', 'vault'], { cwd: scratch });
+    for (const [layout, extension] of [
+      ['source', path.join(root, 'pi-package/extensions/hyalo.ts')],
+      ['offline', path.join(scratch, '.pi/extensions/hyalo.ts')],
+    ]) {
+      const outfile = path.join(scratch, `${layout}.mjs`);
+      await build({
+        entryPoints: [extension], outfile, bundle: true, platform: 'node', format: 'esm',
+        plugins: [{ name: 'schema-only-typebox', setup(builder) {
+          builder.onResolve({ filter: /^typebox$/ }, () => ({ path: 'typebox', namespace: 'fixture' }));
+          builder.onLoad({ filter: /.*/, namespace: 'fixture' }, () => ({ contents:
+            'export const Type = new Proxy({}, { get: () => (...args) => args[0] });' }));
+        } }],
+      });
+      const tools = new Map();
+      let stderr = 'warning: index older than vault\n';
+      let code = 0;
+      const pi = {
+        exec: async (_command, argv) => ({ code, stderr, killed: false, stdout: argv[0] === 'find'
+          ? '{"results":[],"total":0,"hints":[]}'
+          : argv[0] === 'read' ? '{"results":{"content":"body"},"hints":[]}' : 'updated' }),
+        registerTool: (tool) => tools.set(tool.name, tool),
+        registerCommand() {}, on() {}, sendMessage() {},
+      };
+      (await import(pathToFileURL(outfile).href)).default(pi);
+      for (const [name, params, expected] of [
+        ['hyalo_find', {}, '{\n  "results": [],\n  "total": 0,\n  "hints": []\n}'],
+        ['hyalo_find', { countOnly: true }, '0'],
+        ['hyalo_read', { file: 'note.md' }, 'body'],
+        ['hyalo_set', { file: 'note.md', property: 'status=done' }, 'updated'],
+        ['hyalo_task', { file: 'note.md', mode: 'all' }, 'updated'],
+      ]) {
+        const result = await tools.get(name).execute('id', params);
+        assert.deepEqual(result.content, [
+          { type: 'text', text: expected }, { type: 'text', text: `Stderr:\n${stderr}` },
+        ], `${layout}: ${name}`);
+        assert.equal(result.details, undefined);
+      }
+      stderr = '';
+      assert.equal((await tools.get('hyalo_find').execute('id', {})).content.length, 1);
+      code = 1; stderr = 'failed diagnostic';
+      const failed = await tools.get('hyalo_find').execute('id', {});
+      assert.equal(failed.content.filter((item) => item.text.includes(stderr)).length, 1);
+    }
+  } finally { await fs.rm(scratch, { recursive: true, force: true }); }
+});

--- a/pi-package/extensions/hyalo.ts
+++ b/pi-package/extensions/hyalo.ts
@@ -78,12 +78,16 @@ async function runHyalo(
 
 async function runTyped(
   command: string,
-  operation: () => Promise<string>,
+  operation: (onDiagnostics: (stderr: string) => void) => Promise<string>,
 ) {
   try {
-    const text = await operation();
+    const diagnostics: string[] = [];
+    const text = await operation((stderr) => { diagnostics.push(stderr); });
     return {
-      content: [{ type: "text" as const, text: text || "(no output)" }],
+      content: [
+        { type: "text" as const, text: text || "(no output)" },
+        ...diagnostics.map((stderr) => ({ type: "text" as const, text: `Stderr:\n${stderr}` })),
+      ],
       details: undefined,
     };
   } catch (error) {
@@ -295,7 +299,7 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_find: search/filter knowledgebase files (query, property, tag, task status)",
     parameters: hyaloFindParams,
     async execute(_toolCallId, params: Static<typeof hyaloFindParams>, signal) {
-      return runTyped("find", async () => {
+      return runTyped("find", async (onDiagnostics) => {
         const result = await hyaloFind({
           pattern: params.query,
           properties: params.property,
@@ -305,6 +309,7 @@ export default function (pi: ExtensionAPI) {
           limit: params.limit === undefined ? undefined : Math.trunc(params.limit),
           transport,
           signal,
+          onDiagnostics,
         });
         return params.countOnly
           ? String(result.total ?? result.results.length)
@@ -331,8 +336,8 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_read: read a vault file (optionally a single section) as text",
     parameters: hyaloReadParams,
     async execute(_toolCallId, params: Static<typeof hyaloReadParams>, signal) {
-      return runTyped("read", async () => {
-        const result = await hyaloRead({ file: [params.file], section: params.section, transport, signal });
+      return runTyped("read", async (onDiagnostics) => {
+        const result = await hyaloRead({ file: [params.file], section: params.section, transport, signal, onDiagnostics });
         return result.results.content ?? result.results.frontmatter_raw ?? "";
       });
     },
@@ -357,8 +362,8 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_set: set a file's frontmatter property (K=V), optionally add a tag",
     parameters: hyaloSetParams,
     async execute(_toolCallId, params: Static<typeof hyaloSetParams>, signal) {
-      return runTyped("set", async () => {
-        const result = await hyaloSet({ ...params, transport, signal });
+      return runTyped("set", async (onDiagnostics) => {
+        const result = await hyaloSet({ ...params, transport, signal, onDiagnostics });
         return result.stdout;
       });
     },
@@ -386,7 +391,7 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "hyalo_task: toggle task checkboxes (all / by section / by line)",
     parameters: hyaloTaskParams,
     async execute(_toolCallId, params: Static<typeof hyaloTaskParams>, signal) {
-      return runTyped("task", async () => {
+      return runTyped("task", async (onDiagnostics) => {
         const result = await hyaloTask({
           file: params.file,
           mode: params.mode,
@@ -394,6 +399,7 @@ export default function (pi: ExtensionAPI) {
           lines: params.lines,
           transport,
           signal,
+          onDiagnostics,
         });
         return result.stdout;
       });

--- a/pi-package/lib/hyalo-api.d.ts
+++ b/pi-package/lib/hyalo-api.d.ts
@@ -1523,7 +1523,15 @@ interface TransportOptions {
     stdin?: string | Uint8Array;
 }
 type HyaloTransport = (argv: readonly string[], options: TransportOptions) => Promise<ProcessResult>;
+/** Receives the original successful stderr once; returned promises are awaited. */
+type DiagnosticsCallback = (stderr: string) => void | Promise<void>;
 interface ExecutionOptions {
+    /**
+     * Successful typed-call stderr. Defaults to process.stderr.write.
+     * Empty stderr is ignored. Callback throws/rejections reject the call unchanged.
+     * Failed calls retain diagnostics in their error; raw()/execute() retain streams only.
+     */
+    onDiagnostics?: DiagnosticsCallback;
     /** Explicit native binary. Useful for Cargo/Homebrew installations and tests. */
     binaryPath?: string;
     /** Process transport override. Pi uses this to retain its `pi.exec("hyalo", ...)` path. */

--- a/pi-package/lib/hyalo-api.js
+++ b/pi-package/lib/hyalo-api.js
@@ -762,6 +762,7 @@ function isClosedStdinWriteError(error) {
 }
 function executionOptions(options) {
   return {
+    onDiagnostics: options.onDiagnostics,
     binaryPath: options.binaryPath,
     transport: options.transport,
     cwd: options.cwd,
@@ -974,11 +975,20 @@ function parseEnvelope(result) {
   }
   return parsed;
 }
+async function reportDiagnostics(result, options) {
+  if (!result.stderr) return;
+  if (options.onDiagnostics) await options.onDiagnostics(result.stderr);
+  else process.stderr.write(result.stderr);
+}
 async function jsonCall(argv, options) {
   assertNoOutputTransforms(options);
   const terminator = argv.indexOf("--");
   argv.splice(terminator === -1 ? argv.length : terminator, 0, "--format=json", "--no-hints");
-  return parseEnvelope(await execute(argv, executionOptions(options)));
+  const execution = executionOptions(options);
+  const result = await execute(argv, execution);
+  const envelope = parseEnvelope(result);
+  await reportDiagnostics(result, execution);
+  return envelope;
 }
 function find(options = {}) {
   const values = options;
@@ -1005,6 +1015,7 @@ async function set(options) {
   argv.push("--", options.file);
   const result = await execute(argv, options);
   if (result.code !== 0) throw new HyaloError(result, parseErrorEnvelope(result));
+  await reportDiagnostics(result, options);
   return result;
 }
 async function task(options) {
@@ -1023,6 +1034,7 @@ async function task(options) {
   argv.push("--", options.file);
   const result = await execute(argv, options);
   if (result.code !== 0) throw new HyaloError(result, parseErrorEnvelope(result));
+  await reportDiagnostics(result, options);
   return result;
 }
 async function lint(file, options = {}) {
@@ -1033,6 +1045,7 @@ async function lint(file, options = {}) {
   if (result.code !== 0 && result.code !== 1) {
     throw new HyaloError(result, parseErrorEnvelope(result));
   }
+  if (result.code === 0) await reportDiagnostics(result, options);
   return result;
 }
 function raw(argv, options = {}) {
@@ -1057,6 +1070,7 @@ async function configForPi(options = {}) {
   const nested = typeof top.results === "object" && top.results !== null ? top.results : top;
   const candidateDir = typeof top.dir === "string" ? top.dir : nested.dir;
   const pi = typeof nested.pi === "object" && nested.pi !== null ? nested.pi : void 0;
+  await reportDiagnostics(result, options);
   return {
     vaultDir: typeof candidateDir === "string" && candidateDir ? candidateDir : null,
     sessionSummary: pi?.session_summary === true


### PR DESCRIPTION
## Summary

Ranked searches now validate live-read destinations against the vault boundary and honor effective document languages when reusing an index. Compatible cached tokens remain reusable without redundant corpus reconstruction. Successful typed API diagnostics reach a callback or stderr, and Pi displays them alongside tool results. Release dry runs perform offline packaging validation independently of registry publication planning.

## Validation

- Ordered formatting, strict workspace Clippy, and 4,951 Rust tests passed; two existing doctests remain ignored.
- All 11 implemented xtask gates passed. The two existing check stubs remain unimplemented; the jq gate exercised 42 recipes with its existing unavailable MADR TOC fixture.
- Actionlint, semantic release-condition fixtures, simulated-registry planner tests, npm metadata, Pi mirror/runtime freshness, and changed-knowledgebase lint passed.
- npm typecheck/build, all 21 API tests, nine launcher tests, packed ESM/CJS consumers, and source/offline Pi warning layouts passed. Live Pi 0.84.4 passed all five validation layers.

## Review

Fresh independent read-only review identified unnecessary full-corpus token reconstruction. Selective recovery now skips incompatible documents and consumes recovered vectors; fresh full re-review found no remaining actionable findings. A fresh exact-head PR review and review of the final metadata-only delta found no actionable findings. All 11 applicable CI checks passed at final head `06e95e559b9c6cc32b55797832575447a5dacdf5`, including native Rust and npm/API checks on Linux, macOS, and Windows; push-only full-vault lint was correctly skipped.

Iteration 289 only. Iteration 287's external consumer task and 288's desktop verification remain deferred. This change does not publish packages or change versions.
