### PR TITLE
chore(release): prepare npm 0.23.0 with typed API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -496,6 +496,23 @@ and this project adheres to
 - CommonMark autolinks (`<https://…>`, `<obsidian://…>`) are inventoried in `--fields links` as `external`, so an external-target histogram is complete.
 - `hyalo find <existing-file.md>` with no other filters hints both the `--file` form and `hyalo read` instead of answering "No results".
 
+## [0.23.0] - 2026-09-08
+
+### Added
+
+- The `@ractive-ch/hyalo` npm package now includes a typed TypeScript API for
+  `find`, `read`, `summary`, and `config`, with ESM and CommonJS exports and
+  declarations generated from Rust types. `raw` supports other CLI commands;
+  callers can choose a binary or transport and control cancellation and timeouts.
+
+### Fixed
+
+- Successful API calls forward diagnostics to stderr or an `onDiagnostics`
+  callback. Pi displays those warnings alongside typed tool results.
+- Ranked search checks vault containment before live snippet and fallback reads.
+  Indexed searches verify the stored corpus and language metadata before reusing
+  token data, preserving disk-scan ranking when the index is incompatible.
+
 ## [0.21.0] - 2026-08-28
 
 ### Added
@@ -2668,6 +2685,7 @@ already complied (`total = modified + skipped`) and are unchanged.
   crafted files.
 
 [Unreleased]: https://github.com/ractive/hyalo/compare/v0.17.0...HEAD
+[0.23.0]: https://www.npmjs.com/package/@ractive-ch/hyalo/v/0.23.0
 [0.21.0]: TBD
 [0.20.0]: TBD
 [0.19.0]: TBD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-cli"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "hyalo-mdlint"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -2936,7 +2936,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xtask"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ members = ["crates/*"]
 default-members = ["crates/hyalo-cli"]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ractive/hyalo"
 
 [workspace.dependencies]
 # Internal crates
-hyalo-core = { path = "crates/hyalo-core", version = "0.22.0" }
-hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.22.0" }
+hyalo-core = { path = "crates/hyalo-core", version = "0.23.0" }
+hyalo-mdlint = { path = "crates/hyalo-mdlint", version = "0.23.0" }
 
 # External dependencies
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -115,12 +115,11 @@ npm install @ractive-ch/hyalo
 npx --no-install hyalo --version
 ```
 
-All eight packages are public at version 0.22.0 with verified integrity.
-Registry installation is verified on macOS arm64, Linux x64 glibc, Alpine x64
-musl, and Windows x64; npm selects exactly one native platform dependency.
-That immutable version is CLI-only. The typed TypeScript API in `npm/hyalo/src`
-is available from a source build and will require a future release before it is
-available from the registry.
+Version 0.23.0 adds a typed TypeScript API with ESM and CommonJS entrypoints
+alongside the CLI. Import `find`, `read`, `summary`, and `config` directly from
+`@ractive-ch/hyalo`; see the [API documentation](npm/hyalo/README.md).
+npm selects exactly one native platform dependency at the same version.
+The earlier 0.22.0 distribution contains the CLI launcher only.
 
 ### Manual download
 
@@ -281,8 +280,8 @@ A `hyalo` binary on `PATH` is required (any recent release; typed tools need ≥
 **Vendored fallback** — if you prefer no git dependency, `hyalo init --pi` writes
 the same extension, generated API runtime, declarations, and skills into your
 vault's `.pi/` directory. The runtime is self-contained and calls the `hyalo`
-binary on `PATH`; it does not install or import the CLI-only public npm 0.22.0
-API. The vendored copy only changes when you upgrade hyalo and re-run the
+binary on `PATH` without installing the npm package. The vendored copy only
+changes when you upgrade hyalo and re-run the
 command, so the package install above is the recommended path.
 
 ## Profiles

--- a/crates/hyalo-cli/templates/pi/package.json
+++ b/crates/hyalo-cli/templates/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyalo-pi",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
   "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
   "pi": {

--- a/npm/hyalo/README.md
+++ b/npm/hyalo/README.md
@@ -11,10 +11,8 @@ npx --no-install hyalo --version
 npm selects one exact-version native package through `optionalDependencies`.
 The launcher requires Node.js 22.14 or newer and npm 11.5.1 or newer.
 
-The public `0.22.0` package contains the CLI launcher only. The typed API below
-is implemented in this repository for a future, separately authorized release;
-build and test it from this source tree rather than expecting it from public
-`0.22.0`.
+Version `0.23.0` adds the typed API below alongside the CLI launcher.
+The earlier `0.22.0` package contains the CLI launcher only.
 
 | Rust target | npm package | os | cpu | libc |
 | --- | --- | --- | --- | --- |
@@ -28,8 +26,8 @@ build and test it from this source tree rather than expecting it from public
 
 ## Typed API
 
-After `npm ci && npm run build` in this directory, ESM and CommonJS consumers
-can import the same API:
+ESM and CommonJS consumers can import the same API directly from the installed
+package:
 
 ```ts
 import { config, find, read, summary } from "@ractive-ch/hyalo";

--- a/npm/hyalo/package-lock.json
+++ b/npm/hyalo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ractive-ch/hyalo",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ractive-ch/hyalo",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "detect-libc": "2.1.2"
@@ -28,13 +28,13 @@
         "npm": ">=11.5.1"
       },
       "optionalDependencies": {
-        "@ractive-ch/hyalo-darwin-arm64": "0.22.0",
-        "@ractive-ch/hyalo-linux-arm64": "0.22.0",
-        "@ractive-ch/hyalo-linux-arm64-musl": "0.22.0",
-        "@ractive-ch/hyalo-linux-x64": "0.22.0",
-        "@ractive-ch/hyalo-linux-x64-musl": "0.22.0",
-        "@ractive-ch/hyalo-win32-arm64": "0.22.0",
-        "@ractive-ch/hyalo-win32-x64": "0.22.0"
+        "@ractive-ch/hyalo-darwin-arm64": "0.23.0",
+        "@ractive-ch/hyalo-linux-arm64": "0.23.0",
+        "@ractive-ch/hyalo-linux-arm64-musl": "0.23.0",
+        "@ractive-ch/hyalo-linux-x64": "0.23.0",
+        "@ractive-ch/hyalo-linux-x64-musl": "0.23.0",
+        "@ractive-ch/hyalo-win32-arm64": "0.23.0",
+        "@ractive-ch/hyalo-win32-x64": "0.23.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -587,9 +587,8 @@
       }
     },
     "node_modules/@ractive-ch/hyalo-darwin-arm64": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-darwin-arm64/-/hyalo-darwin-arm64-0.22.0.tgz",
-      "integrity": "sha512-LTl73EFbCGafll0eKCYxMRbpxezNjzeGkA2K4rWM2fTIpkT6dHpQ0AGChAvlkuaXVHxFYHgXqugwawzU6YnfDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-darwin-arm64/-/hyalo-darwin-arm64-0.23.0.tgz",
       "cpu": [
         "arm64"
       ],
@@ -600,73 +599,68 @@
       ]
     },
     "node_modules/@ractive-ch/hyalo-linux-arm64": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-arm64/-/hyalo-linux-arm64-0.22.0.tgz",
-      "integrity": "sha512-MuXBHifSi0HyN1DOJNtuS7xYvpRtBr+vFAofX7R9os/CDkeb1vuSqvwaKre6alHzNOKE88CwsCER+lUc9plBWg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-arm64/-/hyalo-linux-arm64-0.23.0.tgz",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@ractive-ch/hyalo-linux-arm64-musl": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-arm64-musl/-/hyalo-linux-arm64-musl-0.22.0.tgz",
-      "integrity": "sha512-iTVFE4X3hZPZ+u4EUKdjEVP116FquMuTHLwd5KG0/pqAz++TtvGKVX3q0tasH6VIih1WuLzTRtHRvNXEP/bHzg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-arm64-musl/-/hyalo-linux-arm64-musl-0.23.0.tgz",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@ractive-ch/hyalo-linux-x64": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-x64/-/hyalo-linux-x64-0.22.0.tgz",
-      "integrity": "sha512-sV9YalHY0+agHugA8T1Yxj76Wcet20WkqlniNcog8mHB9SsK6oLw5GFAi4dEW649AjxfyIXxuWJ3fbp4y+wEMw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-x64/-/hyalo-linux-x64-0.23.0.tgz",
       "cpu": [
         "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "libc": [
         "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
       ]
     },
     "node_modules/@ractive-ch/hyalo-linux-x64-musl": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-x64-musl/-/hyalo-linux-x64-musl-0.22.0.tgz",
-      "integrity": "sha512-foGr8Dbogll135isRSn6BLlinN6N2U2Mr3bIkPPT0KNKkDxWFdXHl6mFYJtoPuH7g/tD94BQF/+rAbK4Ei5i3w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-linux-x64-musl/-/hyalo-linux-x64-musl-0.23.0.tgz",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@ractive-ch/hyalo-win32-arm64": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-win32-arm64/-/hyalo-win32-arm64-0.22.0.tgz",
-      "integrity": "sha512-s4X/YwYFEjmrN3UnM01SVosgoJPsw6FkzzeLZDCB/NGG0yr4jH1z0Kv+2SuEEqJI6+2bC8IiDGluSWuypj05og==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-win32-arm64/-/hyalo-win32-arm64-0.23.0.tgz",
       "cpu": [
         "arm64"
       ],
@@ -677,9 +671,8 @@
       ]
     },
     "node_modules/@ractive-ch/hyalo-win32-x64": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-win32-x64/-/hyalo-win32-x64-0.22.0.tgz",
-      "integrity": "sha512-hbBiG8yITt4V6L6eJ31PNWXjlOOg7QQj3HOnrjAeRkUyVEq8fa0eO8n9ZL4S0xun+OYiBnUc4EF0LS23FGa7Yw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ractive-ch/hyalo-win32-x64/-/hyalo-win32-x64-0.23.0.tgz",
       "cpu": [
         "x64"
       ],

--- a/npm/hyalo/package.json
+++ b/npm/hyalo/package.json
@@ -40,13 +40,13 @@
   "module": "./dist/index.mjs",
   "name": "@ractive-ch/hyalo",
   "optionalDependencies": {
-    "@ractive-ch/hyalo-darwin-arm64": "0.22.0",
-    "@ractive-ch/hyalo-linux-arm64": "0.22.0",
-    "@ractive-ch/hyalo-linux-arm64-musl": "0.22.0",
-    "@ractive-ch/hyalo-linux-x64": "0.22.0",
-    "@ractive-ch/hyalo-linux-x64-musl": "0.22.0",
-    "@ractive-ch/hyalo-win32-arm64": "0.22.0",
-    "@ractive-ch/hyalo-win32-x64": "0.22.0"
+    "@ractive-ch/hyalo-darwin-arm64": "0.23.0",
+    "@ractive-ch/hyalo-linux-arm64": "0.23.0",
+    "@ractive-ch/hyalo-linux-arm64-musl": "0.23.0",
+    "@ractive-ch/hyalo-linux-x64": "0.23.0",
+    "@ractive-ch/hyalo-linux-x64-musl": "0.23.0",
+    "@ractive-ch/hyalo-win32-arm64": "0.23.0",
+    "@ractive-ch/hyalo-win32-x64": "0.23.0"
   },
   "publishConfig": {
     "access": "public"
@@ -62,5 +62,5 @@
     "typecheck": "tsc --noEmit && tsc --project tsconfig.test.json"
   },
   "types": "./dist/index.d.ts",
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -21,5 +21,5 @@
     "type": "git",
     "url": "https://github.com/ractive/hyalo.git"
   },
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/npm/platforms/linux-arm64-musl/package.json
+++ b/npm/platforms/linux-arm64-musl/package.json
@@ -24,5 +24,5 @@
     "type": "git",
     "url": "https://github.com/ractive/hyalo.git"
   },
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -24,5 +24,5 @@
     "type": "git",
     "url": "https://github.com/ractive/hyalo.git"
   },
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/npm/platforms/linux-x64-musl/package.json
+++ b/npm/platforms/linux-x64-musl/package.json
@@ -24,5 +24,5 @@
     "type": "git",
     "url": "https://github.com/ractive/hyalo.git"
   },
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -24,5 +24,5 @@
     "type": "git",
     "url": "https://github.com/ractive/hyalo.git"
   },
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/npm/platforms/win32-arm64/package.json
+++ b/npm/platforms/win32-arm64/package.json
@@ -21,5 +21,5 @@
     "type": "git",
     "url": "https://github.com/ractive/hyalo.git"
   },
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -21,5 +21,5 @@
     "type": "git",
     "url": "https://github.com/ractive/hyalo.git"
   },
-  "version": "0.22.0"
+  "version": "0.23.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyalo-pi",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
   "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
   "private": true,

--- a/pi-package/package.json
+++ b/pi-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyalo-pi",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "keywords": ["pi-package", "hyalo", "knowledgebase", "markdown", "frontmatter"],
   "description": "Hyalo integration for pi - tools and skills for working with markdown knowledgebases",
   "pi": {


### PR DESCRIPTION
## Summary

Prepare `@ractive-ch/hyalo@0.23.0` for npm publication. This release makes the merged typed API available through normal npm installation, with ESM/CommonJS entrypoints, Rust-derived declarations, and matching native binaries.

Synchronize Cargo, Pi, and all eight npm package versions and update installation documentation. Platform lock entries retain their exact upcoming versions and registry URLs without reusing 0.22.0 integrity hashes; a clean install succeeds before publication. Publication uses the existing npm-only workflow after this PR lands. Homefinder consumer acceptance remains open in iteration 287.

## Validation

- `cargo fmt`, strict workspace Clippy, and all 4,951 Rust tests passed (two existing ignored doctests).
- Release build, npm clean install, typecheck, build, launcher/packed-package/Pi tests, and all 21 typed API tests passed.
- All 11 implemented xtask quality gates and npm metadata generation check passed. The jq gate exercised 42 recipes; the existing MADR TOC recipe cannot run without `docs/decisions`.
- `git diff --check` passed.

## Review

Fresh native Codex review ran with read-only permissions and approval disabled against base `14605da278c81b816451d21cfc7ca8bda1b1584f` and head `c88d6996e4ac04dc968f63fa8aa28ca611d09b45`. No actionable findings. GitHub CI is checked at that exact head before merging.
