### PR TITLE
Unify resolution and index coherence (iter-292)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "predicates",
  "rayon",
  "regex",
+ "rmp-serde",
  "serde",
  "serde-saphyr",
  "serde_json",

--- a/crates/hyalo-cli/Cargo.toml
+++ b/crates/hyalo-cli/Cargo.toml
@@ -46,6 +46,7 @@ tempfile = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
+rmp-serde = { workspace = true }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 ts-rs = { workspace = true }

--- a/crates/hyalo-cli/src/commands/backlinks.rs
+++ b/crates/hyalo-cli/src/commands/backlinks.rs
@@ -164,6 +164,7 @@ pub(crate) fn run(
             default_language: None,
             frontmatter_link_props: ctx.frontmatter_link_props,
         },
+        hyalo_core::links_case_insensitive(ctx.case_insensitive_mode),
     )? {
         IndexResolution::Resolved(resolved) => backlinks(
             resolved.as_index(),

--- a/crates/hyalo-cli/src/commands/find/mod.rs
+++ b/crates/hyalo-cli/src/commands/find/mod.rs
@@ -14,9 +14,8 @@ use std::path::Path;
 use crate::output::{CommandOutcome, Format};
 use hyalo_core::CaseInsensitiveIndex;
 use hyalo_core::bm25::{
-    Bm25InvertedIndex, DocumentInput, PreTokenizedInput, TOKENIZER_VERSION, create_stemmer,
-    is_low_discriminative, parse_language, query_is_operator_only, resolve_language,
-    tokenize_document,
+    Bm25InvertedIndex, DocumentInput, PreTokenizedInput, TOKENIZER_VERSION, is_low_discriminative,
+    parse_language, query_is_operator_only, resolve_language, tokenize_document,
 };
 use hyalo_core::content_search::ContentSearchVisitor;
 use hyalo_core::discovery;
@@ -444,8 +443,13 @@ pub(crate) fn find_prepared(
 
     // For BM25 search we run metadata filters first (no I/O), then do a single
     // I/O pass to read bodies and build the corpus.
-    let bm25_score_map: Option<HashMap<String, f64>> = if has_bm25_search {
-        let pat = pattern.unwrap(); // has_bm25_search == pattern.is_some()
+    let compiled_query = pattern.filter(|_| has_bm25_search).map(|pattern| {
+        hyalo_core::bm25::CompiledQuery::new(
+            pattern,
+            resolve_language(None, language, config_language),
+        )
+    });
+    let bm25_score_map: Option<HashMap<String, f64>> = if let Some(query) = &compiled_query {
         'bm25: {
             // Collect entries that pass all metadata filters.
             let mut candidates: Vec<usize> = Vec::new();
@@ -524,11 +528,6 @@ pub(crate) fn find_prepared(
                 candidates.push(idx);
             }
 
-            // Resolve query-time stemmer (language from CLI/config, no per-document override for
-            // the query itself).
-            let query_lang = resolve_language(None, language, config_language);
-            let stemmer = create_stemmer(query_lang);
-
             // Build the candidate set (rel_path strings) for filtering persisted-index results.
             let candidate_paths: std::collections::HashSet<&str> = candidates
                 .iter()
@@ -554,13 +553,14 @@ pub(crate) fn find_prepared(
             // produce until the version check below routes to the live-scan fallback instead.
             // Score all docs, then intersect with metadata-passing candidates.
             if !has_section_filter
+                && scoped_entries.len() == index.entries().len()
                 && let Some(bm25_idx) = index.bm25_index()
                 && bm25_idx.tokenizer_version() == TOKENIZER_VERSION
                 && bm25_idx
                     .document_paths()
                     .all(|path| index.get(path).is_some_and(cached_language_matches))
             {
-                let all_scored = bm25_idx.score(pat, &stemmer);
+                let all_scored = bm25_idx.score_compiled(query);
                 let map: HashMap<String, f64> = all_scored
                     .into_iter()
                     .filter(|m| candidate_paths.contains(m.rel_path.as_str()))
@@ -786,11 +786,11 @@ pub(crate) fn find_prepared(
             let scored_corpus = if doc_inputs.is_empty() {
                 // All entries were pre-tokenized — fast path.
                 let corpus = Bm25InvertedIndex::build_from_tokens(pre_tok_inputs);
-                corpus.score(pat, &stemmer)
+                corpus.score_compiled(query)
             } else if pre_tok_inputs.is_empty() {
                 // All entries need file reads — original slow path.
                 let corpus = Bm25InvertedIndex::build(doc_inputs);
-                corpus.score(pat, &stemmer)
+                corpus.score_compiled(query)
             } else {
                 // Mixed: some entries have pre-tokenized data from the index, others were
                 // read from disk. Tokenize the disk-read entries and combine into a single
@@ -800,7 +800,7 @@ pub(crate) fn find_prepared(
                     all_pre_tok.push(tokenize_document(doc));
                 }
                 let corpus = Bm25InvertedIndex::build_from_tokens(all_pre_tok);
-                corpus.score(pat, &stemmer)
+                corpus.score_compiled(query)
             };
 
             // When no section filter is active, `scored_corpus` was scored against the
@@ -1550,12 +1550,9 @@ pub(crate) fn find_prepared(
 
     // Snapshot tokens cannot recover original lines. Read only final results,
     // after every filter, sort and limit (including an explicit zero limit).
-    if let Some(pat) = pattern.filter(|_| has_bm25_search) {
+    if let Some(compiled) = &compiled_query {
         use rayon::prelude::*;
-        let query = hyalo_core::bm25::SnippetQuery::new(
-            pat,
-            resolve_language(None, language, config_language),
-        );
+        let query = hyalo_core::bm25::SnippetQuery::from_compiled(compiled);
         // Gather references before parallel I/O: VaultIndex need not be Sync,
         // and each worker owns one distinct result slot. Output order is kept.
         let selected: Vec<_> = results

--- a/crates/hyalo-cli/src/commands/find/run.rs
+++ b/crates/hyalo-cli/src/commands/find/run.rs
@@ -189,6 +189,7 @@ pub(crate) fn run(
         } else {
             NamedFilePolicy::Fatal
         },
+        hyalo_core::links_case_insensitive(ctx.case_insensitive_mode),
     )? {
         IndexResolution::Resolved(resolved) => {
             let ci = maybe_case_index(
@@ -252,6 +253,7 @@ pub(crate) fn run(
                     dir,
                     &prop_filters,
                     pattern.is_some() || regexp.is_some(),
+                    ctx.hint_demand,
                 );
             }
             Ok(outcome)
@@ -345,10 +347,31 @@ fn zero_result_body_search(
     dir: &std::path::Path,
     filters: &[hyalo_core::filter::PropertyFilter],
     already_searched_body: bool,
+    demand: crate::prepared::HintDemand,
+) -> Option<crate::hints::BodySearchSuggestion> {
+    zero_result_body_search_with_reader(
+        index,
+        filters,
+        already_searched_body,
+        demand,
+        |rel, budget| {
+            let root = hyalo_core::rooted::VaultRoot::new(dir)?;
+            let name = hyalo_core::rooted::RelativeName::new(rel)?;
+            root.open(&name)?.read_bounded(budget)
+        },
+    )
+}
+
+fn zero_result_body_search_with_reader(
+    index: &dyn hyalo_core::index::VaultIndex,
+    filters: &[hyalo_core::filter::PropertyFilter],
+    already_searched_body: bool,
+    demand: crate::prepared::HintDemand,
+    mut read: impl FnMut(&str, u64) -> anyhow::Result<Vec<u8>>,
 ) -> Option<crate::hints::BodySearchSuggestion> {
     use hyalo_core::filter::PropertyFilter;
 
-    if already_searched_body {
+    if already_searched_body || demand != crate::prepared::HintDemand::Requested {
         return None;
     }
     let (key, pattern) = filters.iter().find_map(|f| match f {
@@ -374,16 +397,15 @@ fn zero_result_body_search(
             return None;
         }
         files_left -= 1;
-        bytes_left -= entry.size;
+        let bytes = read(&entry.rel_path, bytes_left).ok()?;
+        bytes_left = bytes_left.saturating_sub(bytes.len() as u64);
         let mut visitor = BodyProbeVisitor {
             re: &probe,
             hit: false,
         };
         // A file the index knows but the filesystem does not (a snapshot built
         // elsewhere) is skipped, not escalated: this is a hint, not a query.
-        if hyalo_core::scanner::scan_file_multi(&dir.join(&entry.rel_path), &mut [&mut visitor])
-            .is_err()
-        {
+        if hyalo_core::scanner::scan_slice_multi(&bytes, &mut [&mut visitor]).is_err() {
             continue;
         }
         if visitor.hit {
@@ -587,8 +609,14 @@ mod tests {
     fn probe(dir: &std::path::Path, filter: &str, already_searched_body: bool) -> Option<String> {
         let index = probe_index(dir);
         let filters = vec![hyalo_core::filter::parse_property_filter(filter).unwrap()];
-        zero_result_body_search(&index, dir, &filters, already_searched_body)
-            .map(|s| format!("{}:{}", s.key, s.pattern))
+        zero_result_body_search(
+            &index,
+            dir,
+            &filters,
+            already_searched_body,
+            crate::prepared::HintDemand::Requested,
+        )
+        .map(|s| format!("{}:{}", s.key, s.pattern))
     }
 
     /// The motivating case: `DEC-NNN` lives in `##` headings, not in `title`.
@@ -632,7 +660,16 @@ mod tests {
             hyalo_core::filter::parse_property_filter("status=draft").unwrap(),
             hyalo_core::filter::parse_property_filter("!archived").unwrap(),
         ];
-        assert!(zero_result_body_search(&index, tmp.path(), &filters, false).is_none());
+        assert!(
+            zero_result_body_search(
+                &index,
+                tmp.path(),
+                &filters,
+                false,
+                crate::prepared::HintDemand::Requested
+            )
+            .is_none()
+        );
     }
 
     /// An empty regex matches the first body line of the first file, which
@@ -649,7 +686,16 @@ mod tests {
             key: "title".to_owned(),
             pattern: regex::Regex::new("").unwrap(),
         }];
-        assert!(zero_result_body_search(&index, tmp.path(), &filters, false).is_none());
+        assert!(
+            zero_result_body_search(
+                &index,
+                tmp.path(),
+                &filters,
+                false,
+                crate::prepared::HintDemand::Requested
+            )
+            .is_none()
+        );
     }
 
     /// The probe matches fenced code, because `find -e` does.
@@ -712,5 +758,44 @@ mod tests {
             None,
             "non-success outcomes keep their own exit code"
         );
+    }
+    #[test]
+    fn iteration292_hint_demand_counts_actual_body_reads() {
+        use clap::Parser;
+        let tmp = probe_vault(&[("a.md", "---\ntitle: A\n---\nneedle\n")]);
+        let index = probe_index(tmp.path());
+        let filters = [hyalo_core::filter::parse_property_filter("title~=needle").unwrap()];
+        for flags in [
+            vec!["--no-hints"],
+            vec!["--jq", ".results"],
+            vec!["--no-hints", "--format", "json"],
+            vec!["--hints"],
+        ] {
+            // The third shape is emitted by the typed API transport.
+            let mut args = vec!["hyalo", "find", "--property", "title~=needle"];
+            args.extend(flags);
+            let cli = crate::cli::args::Cli::try_parse_from(args).unwrap();
+            let plan = crate::prepared::OutputPlan::new(
+                crate::prepared::OutputPreflight::validated_for_test(&cli),
+                &cli.command,
+                Format::Json,
+                Format::Json,
+                true,
+                !cli.no_hints,
+            )
+            .unwrap();
+            let demand = plan.hint_demand();
+            let mut reads = 0;
+            let suggestion =
+                zero_result_body_search_with_reader(&index, &filters, false, demand, |rel, _| {
+                    reads += 1;
+                    Ok(std::fs::read(tmp.path().join(rel))?)
+                });
+            assert_eq!(
+                reads,
+                usize::from(demand == crate::prepared::HintDemand::Requested)
+            );
+            assert_eq!(suggestion.is_some(), reads == 1);
+        }
     }
 }

--- a/crates/hyalo-cli/src/commands/journal.rs
+++ b/crates/hyalo-cli/src/commands/journal.rs
@@ -37,8 +37,7 @@ use indexmap::IndexMap;
 use serde_json::Value;
 use std::path::Path;
 
-use hyalo_core::filter::extract_tags;
-use hyalo_core::index::{SnapshotIndex, VaultIndex as _, format_modified};
+use hyalo_core::index::{SnapshotIndex, VaultIndex as _};
 
 #[derive(Debug)]
 struct RebuildRequired(&'static str);
@@ -71,6 +70,9 @@ impl<'a> MutationJournal<'a> {
     /// access to the snapshot index — see the module docs for the guard
     /// rationale.
     pub fn new(index: &'a mut Option<SnapshotIndex>, index_path: Option<&'a Path>) -> Self {
+        if let Some(index) = index.as_mut() {
+            index.begin_changes();
+        }
         Self {
             index,
             index_path,
@@ -99,21 +101,9 @@ impl<'a> MutationJournal<'a> {
         self.dirty
     }
 
-    /// Record a frontmatter mutation for `rel_path` (the `set`/`remove`/
-    /// `append` write path).
-    ///
-    /// Patches the entry's `properties`/`tags`/`modified` from the already
-    /// updated in-memory `props`, then re-scans the file so the entry's
-    /// `links` field *and* the persisted link graph's outbound edges for
-    /// this file are current — frontmatter link properties (`related`,
-    /// `depends-on`, …) feed the graph, so a property mutation can change
-    /// outbound edges.
-    ///
-    /// Upserts: if `rel_path` is not yet present (a file created outside
-    /// `hyalo new`, or on disk before the index was built), it is inserted
-    /// from a fresh disk scan rather than silently dropped — a mutation
-    /// under `--index` must never leave the index missing the file it just
-    /// wrote. No-op only when no index is loaded at all.
+    /// Record a published frontmatter mutation by replacing its complete scan product.
+    /// The legacy property argument is consumed for compatibility; disk bytes are authoritative.
+    /// Global structures are rebuilt once by flush, after all file effects are recorded.
     pub fn update_entry(
         &mut self,
         rel_path: &str,
@@ -123,15 +113,8 @@ impl<'a> MutationJournal<'a> {
         let Some(idx) = self.index.as_mut() else {
             return Ok(());
         };
-        if let Some(entry) = idx.get_mut(rel_path) {
-            let new_tags = extract_tags(&props);
-            entry.properties = props;
-            entry.tags = new_tags;
-            entry.modified = format_modified(full_path)?;
-            idx.refresh_links(full_path, rel_path)?;
-        } else {
-            idx.insert_or_replace_entry_with_links(full_path, rel_path)?;
-        }
+        drop(props); // Complete scan replacement is authoritative after publication.
+        idx.insert_or_replace_entry_with_links(full_path, rel_path)?;
         self.dirty = true;
         Ok(())
     }
@@ -261,55 +244,18 @@ impl<'a> MutationJournal<'a> {
             let _ = idx.refresh_entry_and_links(dir, rel);
         }
 
-        // 3. Link graph: targets don't change in a move, only source paths.
-        idx.graph_mut().rename_path(old_rel, new_rel);
-
         self.dirty = true;
         Ok(())
     }
 
-    /// Record a task-checkbox mutation (`task toggle` / `task set`) for one
-    /// file, after all of that file's task writes have landed on disk.
-    ///
-    /// BUG-1 (iter-249 dogfood): this used to patch just the toggled tasks'
-    /// `status`/`done` flags and rebuild section task counts in place,
-    /// leaving `bm25_tokens` untouched. A checkbox flip changes the file's
-    /// raw body bytes (`[ ]` <-> `[x]`), so the stale cached tokens no
-    /// longer matched what a fresh disk scan would tokenize; rebuilding the
-    /// BM25 corpus statistics (`avgdl`) at [`Self::flush`] from that one
-    /// stale doc-length then drifted every score in the corpus by a couple
-    /// of decimal places versus a disk scan. Fixed by re-scanning the file
-    /// via [`hyalo_core::index::SnapshotIndex::refresh_links`] instead —
-    /// the same "full re-index of the mutated file" every other
-    /// parity-preserving write path (`set`/`append`/`mv`) already uses.
-    /// `properties`/`tags` are untouched by a task mutation and are left as
-    /// `refresh_links` leaves them (unchanged); `modified` is not part of
-    /// that refresh, so it is patched here from the file's current mtime.
-    ///
-    /// Batched per file: call once per file after every task line on it has
-    /// been toggled/set, not once per task — the cost is one disk read +
-    /// re-tokenize, so an `--all`/multi-line caller must not pay it per
-    /// task. Nothing is written to disk until [`Self::flush`], so a
-    /// multi-file toggle saves once.
-    ///
-    /// Upserts: if `rel_path` is not yet present, the write this method
-    /// records has already landed on disk (callers invoke this after
-    /// `toggle_tasks`/`set_tasks_status`), so a fresh disk scan already
-    /// reflects the post-toggle state — insert it and register its links
-    /// rather than dropping the mutation. No-op only when no index is
-    /// loaded at all.
+    /// Rescan a file once after all selected task changes have been published.
+    /// Anchors, fields, language/validity metadata and tokens are replaced together.
+    /// Absent entries are inserted; flush performs one global rebuild for the batch.
     pub fn update_task(&mut self, full_path: &Path, rel_path: &str) -> Result<()> {
         let Some(idx) = self.index.as_mut() else {
             return Ok(());
         };
-        if idx.get(rel_path).is_none() {
-            idx.insert_or_replace_entry_with_links(full_path, rel_path)?;
-        } else {
-            idx.refresh_links(full_path, rel_path)?;
-            if let Some(entry) = idx.get_mut(rel_path) {
-                entry.modified = format_modified(full_path)?;
-            }
-        }
+        idx.insert_or_replace_entry_with_links(full_path, rel_path)?;
         self.dirty = true;
         Ok(())
     }
@@ -379,41 +325,9 @@ impl<'a> MutationJournal<'a> {
                     "source could not be verified or published; snapshot is unsafe"
                 ));
             }
-            if hyalo_core::discovery::link_aliases_enabled() {
-                anyhow::bail!(RebuildRequired(
-                    "alias-aware graph maintenance requires a complete index rebuild"
-                ));
-            }
-            for rel in paths {
-                // The legacy incremental graph cannot repair inbound links
-                // after title/alias catalog changes. Invalidate those cases
-                // until the complete catalog generation is owned by 292.
-                let before = self
-                    .index
-                    .as_ref()
-                    .and_then(|index| index.get(rel))
-                    .map(|entry| {
-                        (
-                            entry.properties.get("title").cloned(),
-                            entry.properties.get("aliases").cloned(),
-                        )
-                    });
-                self.add_entry_with_links(&dir.join(rel), rel)?;
-                let after = self
-                    .index
-                    .as_ref()
-                    .and_then(|index| index.get(rel))
-                    .map(|entry| {
-                        (
-                            entry.properties.get("title").cloned(),
-                            entry.properties.get("aliases").cloned(),
-                        )
-                    });
-                if before.is_none() || before != after {
-                    anyhow::bail!(RebuildRequired(
-                        "link target catalog changed; a complete index rebuild is required"
-                    ));
-                }
+            if let Some(index) = self.index.as_mut() {
+                index.apply_changes(dir, paths)?;
+                self.dirty = true;
             }
             self.flush()
         })();
@@ -474,10 +388,12 @@ impl<'a> MutationJournal<'a> {
     /// match a fresh `create-index` build — otherwise `find --index` scores
     /// would drift from a disk scan after every mutation wave.
     pub fn flush(&mut self) -> Result<()> {
+        if let Some(index) = self.index.as_mut() {
+            index.finish_changes();
+        }
         if self.dirty
             && let (Some(idx), Some(idx_path)) = (self.index.as_mut(), self.index_path)
         {
-            idx.rebuild_bm25_index();
             idx.save_to(idx_path)?;
         }
         Ok(())

--- a/crates/hyalo-cli/src/commands/links.rs
+++ b/crates/hyalo-cli/src/commands/links.rs
@@ -2094,6 +2094,7 @@ pub(crate) fn run(
                     default_language: None,
                     frontmatter_link_props: ctx.frontmatter_link_props,
                 },
+                hyalo_core::links_case_insensitive(ctx.case_insensitive_mode),
             )? {
                 IndexResolution::Resolved(resolved) => {
                     // `links fix` is entirely about link resolution.
@@ -2170,6 +2171,7 @@ pub(crate) fn run(
                     default_language: None,
                     frontmatter_link_props: ctx.frontmatter_link_props,
                 },
+                hyalo_core::links_case_insensitive(ctx.case_insensitive_mode),
             )? {
                 IndexResolution::Resolved(resolved) => links_auto(
                     resolved.as_index(),

--- a/crates/hyalo-cli/src/commands/mod.rs
+++ b/crates/hyalo-cli/src/commands/mod.rs
@@ -567,6 +567,7 @@ pub(crate) fn resolve_index<'a>(
     site_prefix: Option<&str>,
     needs_full_vault: bool,
     options: &ScanOptions<'_>,
+    case_insensitive: bool,
 ) -> Result<IndexResolution<'a>> {
     resolve_index_named(
         snapshot,
@@ -578,6 +579,7 @@ pub(crate) fn resolve_index<'a>(
         needs_full_vault,
         options,
         NamedFilePolicy::Skip,
+        case_insensitive,
     )
 }
 
@@ -605,11 +607,12 @@ pub(crate) fn resolve_index_named<'a>(
     needs_full_vault: bool,
     options: &ScanOptions<'_>,
     named_policy: NamedFilePolicy,
+    case_insensitive: bool,
 ) -> Result<IndexResolution<'a>> {
     if let Some(idx) = snapshot {
         return Ok(IndexResolution::Resolved(ResolvedIndex::Snapshot(idx)));
     }
-    let outcome = build_scanned_index_named(
+    let outcome = build_scanned_index_with(
         dir,
         files,
         globs,
@@ -618,6 +621,8 @@ pub(crate) fn resolve_index_named<'a>(
         needs_full_vault,
         options,
         named_policy,
+        resolve_file_user,
+        case_insensitive,
     )?;
     match outcome {
         ScannedIndexOutcome::Index(build) => {
@@ -639,6 +644,7 @@ pub(crate) fn resolve_index_prepared<'a>(
     needs_full_vault: bool,
     options: &ScanOptions<'_>,
     named_policy: NamedFilePolicy,
+    case_insensitive: bool,
 ) -> Result<IndexResolution<'a>> {
     if let Some(index) = snapshot {
         return Ok(IndexResolution::Resolved(ResolvedIndex::Snapshot(index)));
@@ -654,6 +660,7 @@ pub(crate) fn resolve_index_prepared<'a>(
         options,
         named_policy,
         |dir, name| discovery::resolve_normalized_file_ci(dir, name, false),
+        case_insensitive,
     )?;
     Ok(match outcome {
         ScannedIndexOutcome::Index(build) => {
@@ -712,6 +719,7 @@ pub(crate) fn build_scanned_index_named(
         options,
         named_policy,
         resolve_file_user,
+        true,
     )
 }
 
@@ -726,6 +734,7 @@ pub(crate) fn build_scanned_index_with(
     options: &ScanOptions<'_>,
     named_policy: NamedFilePolicy,
     resolve: impl Fn(&Path, &str) -> std::result::Result<(PathBuf, String), FileResolveError>,
+    case_insensitive: bool,
 ) -> Result<ScannedIndexOutcome> {
     // Vault-relative paths of the files the caller named by hand, in the order
     // they resolved. Empty whenever the file list came from a glob or a whole-
@@ -774,7 +783,8 @@ pub(crate) fn build_scanned_index_with(
         }
     };
 
-    let build = ScannedIndex::build(&files, site_prefix, options)?;
+    let build =
+        ScannedIndex::build_with_case_policy(&files, site_prefix, options, case_insensitive)?;
 
     // DEC-301 (iter-273): a path the caller typed is a promise that the answer
     // is about *that* file. Dropping it into the skip summary and exiting 0

--- a/crates/hyalo-cli/src/commands/properties.rs
+++ b/crates/hyalo-cli/src/commands/properties.rs
@@ -604,6 +604,7 @@ pub(crate) fn run(
                 default_language: None,
                 frontmatter_link_props: ctx.frontmatter_link_props,
             },
+            hyalo_core::links_case_insensitive(ctx.case_insensitive_mode),
         )? {
             IndexResolution::Resolved(ResolvedIndex::Snapshot(idx)) => {
                 let filtered = find_commands::filter_index_entries(idx.entries(), &[], glob);

--- a/crates/hyalo-cli/src/commands/summary.rs
+++ b/crates/hyalo-cli/src/commands/summary.rs
@@ -1377,6 +1377,7 @@ pub(crate) fn run(
             default_language: None,
             frontmatter_link_props: ctx.frontmatter_link_props,
         },
+        hyalo_core::links_case_insensitive(ctx.case_insensitive_mode),
     )? {
         IndexResolution::Resolved(resolved) => {
             // Summary always reports orphan/dead-end counts which rely on

--- a/crates/hyalo-cli/src/commands/tags.rs
+++ b/crates/hyalo-cli/src/commands/tags.rs
@@ -889,6 +889,7 @@ pub(crate) fn run(
                 default_language: None,
                 frontmatter_link_props: ctx.frontmatter_link_props,
             },
+            hyalo_core::links_case_insensitive(ctx.case_insensitive_mode),
         )? {
             IndexResolution::Resolved(ResolvedIndex::Snapshot(idx)) => {
                 let filtered = find_commands::filter_index_entries(idx.entries(), &[], glob);

--- a/crates/hyalo-cli/src/dispatch.rs
+++ b/crates/hyalo-cli/src/dispatch.rs
@@ -67,15 +67,16 @@ pub(crate) fn build_case_index_from_dir(dir: &std::path::Path) -> CaseInsensitiv
 /// Build a [`CaseInsensitiveIndex`] from an in-memory snapshot index.
 ///
 /// Equivalent to [`build_case_index_from_dir`] but seeds the stem map from
-/// the snapshot's entries (`rel_path` list) instead of walking the disk.
+/// the snapshot's discovered note identities, including frontmatter skips,
+/// instead of walking the disk.
 /// Cost is a linear scan over `snap.entries()` — about 4 ms for MDN's 14 399
 /// files (iter-256), against seconds for the disk-walk variant. It was 62 ms
 /// until iter-256 removed a quadratic dedupe scan in
 /// [`CaseInsensitiveIndex::insert`]; see FIND-8.
 pub(crate) fn build_case_index_from_snapshot(snap: &SnapshotIndex) -> CaseInsensitiveIndex {
     let mut idx = CaseInsensitiveIndex::with_capacity(snap.entries().len());
-    for entry in snap.entries() {
-        idx.insert(&entry.rel_path);
+    for path in snap.note_paths() {
+        idx.insert(path);
     }
     // iter-261: attachments recorded by `create-index` (empty for a snapshot
     // written by an older hyalo, which simply degrades to the old behaviour).
@@ -91,8 +92,8 @@ pub(crate) fn build_case_index_from_snapshot(snap: &SnapshotIndex) -> CaseInsens
             idx.insert_aliases(&entry.rel_path, aliases);
         }
     }
-    // iter-277 (BUG-13): a snapshot lists every file `create-index` saw, so
-    // link resolution never has to leave it for the filesystem.
+    // Successful metadata coverage and skipped filename identities jointly
+    // retain every note that create-index discovered.
     idx.set_complete(true);
     idx
 }
@@ -152,6 +153,7 @@ pub(crate) fn maybe_case_index(
     // the vault opts out — not "whatever this filesystem does", so the
     // filesystem probe plays no part here.
     idx.set_case_insensitive_paths(hyalo_core::links_case_insensitive(mode));
+    idx.set_aliases_enabled(hyalo_core::discovery::link_aliases_enabled());
     Some(idx)
 }
 

--- a/crates/hyalo-cli/src/prepared.rs
+++ b/crates/hyalo-cli/src/prepared.rs
@@ -210,6 +210,16 @@ pub(crate) struct OutputPreflight {
     internal_report: bool,
 }
 impl OutputPreflight {
+    /// Policy tests start after jq compilation, whose worker protocol is covered by e2e tests.
+    #[cfg(test)]
+    pub(crate) fn validated_for_test(cli: &Cli) -> Self {
+        Self {
+            jq: cli.jq.clone(),
+            count: cli.count,
+            internal_report: cli.internal_mutation_report,
+        }
+    }
+
     pub(crate) fn new(cli: &Cli) -> Result<Self> {
         let capabilities = Capabilities::of(&cli.command);
         if cli.internal_mutation_report
@@ -728,6 +738,11 @@ impl PreparedInvocation {
         &self,
         ctx: &mut crate::dispatch::CommandContext<'_>,
     ) -> Result<()> {
+        let read_fallback = match &self.command {
+            PreparedCommand::Legacy(command) => !command.writes(),
+            PreparedCommand::TaskMutation { .. } => false,
+            _ => true,
+        };
         let Some(index) = ctx.snapshot_index.as_mut() else {
             return Ok(());
         };
@@ -761,6 +776,11 @@ impl PreparedInvocation {
         let refreshed = selection::refresh_named_selection(&root, &selection, index, insert)?;
         if !refreshed.all_current(&selection) && !repairs {
             warn_stale_index(index, ctx.dir);
+            if read_fallback && (refreshed.failed > 0 || refreshed.missing > 0) {
+                // A failed named scan cannot leave old fields/postings available.
+                // Reads use the bounded disk path and its parse/skip diagnostics.
+                *ctx.snapshot_index = None;
+            }
         }
         Ok(())
     }

--- a/crates/hyalo-cli/src/prepared/selection.rs
+++ b/crates/hyalo-cli/src/prepared/selection.rs
@@ -178,7 +178,12 @@ pub(crate) fn refresh_named_selection(
     index: &mut SnapshotIndex,
     insert_missing: bool,
 ) -> Result<RefreshSummary> {
-    refresh_named_with(root, selection, index, insert_missing, scan_checked_target)
+    // Whole-set preflight remains ahead of the first scan or state mutation.
+    selection.precheck(root)?;
+    index.begin_changes();
+    let result = refresh_named_with(root, selection, index, insert_missing, scan_checked_target);
+    index.finish_changes();
+    result
 }
 fn refresh_named_with(
     root: &VaultRoot,

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -2237,7 +2237,15 @@ fn run_inner() -> Result<(), AppError> {
     // snapshot so that per-file refreshes (`rescan_entry` / `rename_entry`) use
     // the same list as the initial index build.
     if let Some(idx) = snapshot_index.as_mut() {
+        if cli.command.writes() {
+            idx.validate_before_changes()?;
+        }
         idx.set_frontmatter_link_props(frontmatter_link_props_owned.clone());
+        idx.set_resolution_options(
+            config.alias_links_enabled,
+            hyalo_core::links_case_insensitive(config.case_insensitive_mode),
+            config.search_language.clone(),
+        );
     }
     // Resolve --files-from before dispatch. This converts the files_from source
     // into the command's `file` list and returns skip counters for the envelope.

--- a/crates/hyalo-cli/tests/e2e/backlinks.rs
+++ b/crates/hyalo-cli/tests/e2e/backlinks.rs
@@ -633,7 +633,7 @@ fn backlinks_target_spelling_is_consistent_across_occurrences() {
         .collect();
     assert_eq!(
         written,
-        vec!["target.md", "target.md", "target"],
+        vec!["../target.md", "/target.md", "../target"],
         "written_target must preserve each occurrence's own spelling: {json}"
     );
 }

--- a/crates/hyalo-cli/tests/e2e/bm25.rs
+++ b/crates/hyalo-cli/tests/e2e/bm25.rs
@@ -1614,6 +1614,7 @@ fn ranked_legacy_language_metadata_falls_back_and_checks_containment() {
     assert_eq!(entry.bm25_language.as_deref(), Some("english"));
     assert!(entry.bm25_tokens.is_none());
     entry.bm25_language = None; // Snapshot shape produced before iteration 289.
+    snapshot.finish_changes(); // Legacy mutable adapter requires coherent publication.
     snapshot.save_to(&snapshot_path).unwrap();
     let output = hyalo_no_hints()
         .arg("--dir")

--- a/crates/hyalo-cli/tests/e2e/iteration290_foundations.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration290_foundations.rs
@@ -269,7 +269,7 @@ fn internal_mutation_protocol_exposes_real_effects_and_rejects_bad_output_before
 }
 
 #[test]
-fn alias_aware_legacy_index_is_invalidated_even_for_unrelated_source_edits() {
+fn alias_aware_index_stays_coherent_after_unrelated_source_edits() {
     let dir = vault();
     fs::write(
         dir.path().join(".hyalo.toml"),
@@ -306,8 +306,8 @@ fn alias_aware_legacy_index_is_invalidated_even_for_unrelated_source_edits() {
         String::from_utf8_lossy(&output.stderr)
     );
     let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(report["effects"]["index"], "invalidated");
-    assert!(!dir.path().join(".hyalo-index").exists());
+    assert_eq!(report["effects"]["index"], "updated");
+    assert!(dir.path().join(".hyalo-index").exists());
     let output = run(&dir, &["backlinks", "target.md", "--index", "--count"]);
     assert!(output.status.success());
     assert_eq!(output.stdout, b"1\n");

--- a/crates/hyalo-cli/tests/e2e/iteration292_coherence.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration292_coherence.rs
@@ -1,0 +1,434 @@
+use super::common::{hyalo_no_hints, write_md};
+use tempfile::TempDir;
+
+fn run(tmp: &TempDir, args: &[&str]) -> serde_json::Value {
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .args(args)
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+fn names(value: &serde_json::Value) -> Vec<String> {
+    let mut paths: Vec<_> = value["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["file"].as_str().unwrap().to_owned())
+        .collect();
+    paths.sort();
+    paths
+}
+#[test]
+fn boolean_phrase_sets_and_scores_agree_on_disk_index_and_named_refresh() {
+    let tmp = TempDir::new().unwrap();
+    for (path, body) in [
+        ("a.md", "green red x blue"),
+        ("b.md", "red"),
+        ("c.md", "red blue"),
+        ("d.md", "neither"),
+        ("e.md", "rust memory allocation"),
+        ("f.md", "rust memory safety"),
+        ("g.md", "rust memory\nsafety"),
+    ] {
+        write_md(tmp.path(), path, body);
+    }
+    run(&tmp, &["create-index"]);
+    for (query, expected) in [
+        ("\"red blue\" OR green", vec!["a.md", "c.md"]),
+        ("rust -\"memory safety\"", vec!["e.md"]),
+    ] {
+        let disk = run(&tmp, &["find", query]);
+        assert_eq!(names(&disk), expected);
+        let indexed = run(&tmp, &["find", query, "--index"]);
+        assert_eq!(indexed["results"], disk["results"]);
+        for path in ["a.md", "b.md", "c.md", "d.md", "e.md", "f.md", "g.md"] {
+            let disk = run(&tmp, &["find", query, "--file", path]);
+            let indexed = run(&tmp, &["find", query, "--file", path, "--index"]);
+            assert_eq!(indexed["results"], disk["results"], "{query} {path}");
+        }
+    }
+}
+#[test]
+fn named_refresh_replaces_equal_size_same_second_tokens() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "oldtoken\n");
+    run(&tmp, &["create-index"]);
+    write_md(tmp.path(), "a.md", "newtoken\n");
+    for query in ["newtoken", "oldtoken"] {
+        let disk = run(&tmp, &["find", query, "--file", "a.md"]);
+        let indexed = run(&tmp, &["find", query, "--file", "a.md", "--index"]);
+        assert_eq!(indexed["results"], disk["results"]);
+        assert_eq!(names(&indexed).len(), usize::from(query == "newtoken"));
+    }
+}
+#[test]
+fn alias_catalog_changes_update_untouched_sources_and_reload() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(".hyalo.toml"),
+        "dir = \".\"\n[links]\naliases = true\n",
+    )
+    .unwrap();
+    write_md(tmp.path(), "target.md", "---\naliases: [Nickname]\n---\n");
+    write_md(
+        tmp.path(),
+        "source.md",
+        "---\nstatus: draft\n---\n[[Nickname]] [[Newname]]\n",
+    );
+    run(&tmp, &["create-index"]);
+    run(
+        &tmp,
+        &["set", "source.md", "--property", "status=done", "--index"],
+    );
+    let disk = run(&tmp, &["backlinks", "target.md"]);
+    assert_eq!(
+        run(&tmp, &["backlinks", "target.md", "--index"])["results"],
+        disk["results"]
+    );
+    run(
+        &tmp,
+        &[
+            "set",
+            "target.md",
+            "--property",
+            "aliases=[Newname]",
+            "--index",
+        ],
+    );
+    let disk = run(&tmp, &["find", "--file", "source.md", "--fields", "links"]);
+    assert_eq!(
+        run(
+            &tmp,
+            &[
+                "find",
+                "--file",
+                "source.md",
+                "--fields",
+                "links",
+                "--index"
+            ]
+        )["results"],
+        disk["results"]
+    );
+    let disk = run(&tmp, &["backlinks", "target.md"]);
+    assert_eq!(
+        run(&tmp, &["backlinks", "target.md", "--index"])["results"],
+        disk["results"]
+    );
+}
+#[test]
+fn relative_link_and_frontmatter_anchor_mutation_parity() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "b.md", "# Root\n");
+    write_md(tmp.path(), "sub/b.md", "# Nested\n");
+    write_md(
+        tmp.path(),
+        "sub/a.md",
+        "# Here\n[b](b.md) [self](#missing)\n- [ ] todo\n",
+    );
+    run(&tmp, &["create-index"]);
+    run(
+        &tmp,
+        &["set", "sub/a.md", "--property", "title=Author", "--index"],
+    );
+    for path in ["b.md", "sub/b.md"] {
+        let disk = run(&tmp, &["backlinks", path]);
+        assert_eq!(
+            run(&tmp, &["backlinks", path, "--index"])["results"],
+            disk["results"]
+        );
+    }
+    for args in [
+        vec![
+            "find",
+            "--file",
+            "sub/a.md",
+            "--fields",
+            "links,tasks,sections,properties",
+        ],
+        vec!["find", "--broken-links"],
+    ] {
+        let disk = run(&tmp, &args);
+        let mut indexed = args;
+        indexed.push("--index");
+        assert_eq!(run(&tmp, &indexed)["results"], disk["results"]);
+    }
+}
+#[test]
+fn broken_authored_frontmatter_never_uses_old_named_search_tokens() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "oldtoken\n");
+    run(&tmp, &["create-index"]);
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: [unfinished\n---\noldtoken\n",
+    );
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .args([
+            "find", "oldtoken", "--file", "a.md", "--index", "--format", "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unparseable frontmatter"));
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.md")).unwrap(),
+        "---\ntitle: [unfinished\n---\noldtoken\n"
+    );
+}
+
+#[test]
+fn append_task_and_move_keep_indexed_scan_products_current() {
+    let tmp = TempDir::new().unwrap();
+    write_md(
+        tmp.path(),
+        "a.md",
+        "---\ntitle: A\n---\n# Heading\n- [ ] todo\n[[b]]\n",
+    );
+    write_md(tmp.path(), "b.md", "# B\n");
+    run(&tmp, &["create-index"]);
+    run(
+        &tmp,
+        &["append", "a.md", "--property", "tags=newtoken", "--index"],
+    );
+    run(&tmp, &["task", "toggle", "a.md", "--all", "--index"]);
+    run(&tmp, &["mv", "b.md", "renamed.md", "--index"]);
+    for args in [
+        vec!["find", "--fields", "links,tasks,sections,properties"],
+        vec!["find", "todo"],
+        vec!["backlinks", "renamed.md"],
+    ] {
+        let disk = run(&tmp, &args);
+        let mut indexed = args;
+        indexed.push("--index");
+        assert_eq!(run(&tmp, &indexed)["results"], disk["results"]);
+    }
+}
+
+#[test]
+fn oversized_snapshot_expansion_refuses_set_before_note_publication() {
+    let tmp = TempDir::new().unwrap();
+    let original = "---\nstatus: draft\n---\nAuthored body\n";
+    write_md(tmp.path(), "a.md", original);
+    run(&tmp, &["create-index"]);
+    let path = tmp.path().join(".hyalo-index");
+    let mut snapshot: serde_json::Value =
+        rmp_serde::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    let term = "x".repeat(8192);
+    snapshot["bm25_index"] = serde_json::json!({"postings": {term: [{"doc_id":0,"term_freq":32768,"positions":(0..32768).collect::<Vec<_>>()}]}, "doc_lengths":[32768], "doc_paths":["a.md"],"avgdl":32768.0,"tokenizer_version":1});
+    std::fs::write(&path, rmp_serde::to_vec_named(&snapshot).unwrap()).unwrap();
+    let output = hyalo_no_hints()
+        .arg("--dir")
+        .arg(tmp.path())
+        .args(["set", "a.md", "--property", "status=done", "--index"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("expansion budget"));
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.md")).unwrap(),
+        original
+    );
+}
+
+#[test]
+fn legacy_reconstruction_omits_bm25_and_uses_real_disk_fallback() {
+    for missing_metadata in [false, true] {
+        let tmp = TempDir::new().unwrap();
+        write_md(tmp.path(), "a.md", "---\nstatus: draft\n---\nalpha\n");
+        write_md(tmp.path(), "b.md", "oldtoken\n");
+        run(&tmp, &["create-index"]);
+        let path = tmp.path().join(".hyalo-index");
+        let mut snapshot: serde_json::Value =
+            rmp_serde::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        if missing_metadata {
+            for entry in snapshot["entries"].as_array_mut().unwrap() {
+                entry["bm25_tokenizer_version"] = serde_json::Value::Null;
+            }
+        } else {
+            snapshot["bm25_index"]["tokenizer_version"] = serde_json::json!(0);
+        }
+        std::fs::write(&path, rmp_serde::to_vec_named(&snapshot).unwrap()).unwrap();
+        run(
+            &tmp,
+            &["set", "a.md", "--property", "status=done", "--index"],
+        );
+        let persisted: serde_json::Value =
+            rmp_serde::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert!(persisted["bm25_index"].is_null());
+        let indexed = run(&tmp, &["find", "oldtoken", "--index"]);
+        assert_eq!(names(&indexed), vec!["b.md"]);
+        assert_eq!(
+            indexed["results"],
+            run(&tmp, &["find", "oldtoken"])["results"]
+        );
+    }
+}
+
+#[test]
+fn configured_case_policy_matches_disk_and_snapshot_graphs() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "folder/Target.md", "target\n");
+    write_md(tmp.path(), "a.md", "[x](folder/target.md)\n");
+    for (policy, expected) in [("false", 0), ("true", 1)] {
+        std::fs::write(
+            tmp.path().join(".hyalo.toml"),
+            format!("dir = \".\"\n[links]\ncase_insensitive = \"{policy}\"\n"),
+        )
+        .unwrap();
+        run(&tmp, &["create-index"]);
+        let disk = run(&tmp, &["backlinks", "folder/Target.md"]);
+        assert_eq!(disk["total"], expected);
+        assert_eq!(
+            run(&tmp, &["backlinks", "folder/Target.md", "--index"]),
+            disk
+        );
+    }
+}
+
+#[test]
+fn broken_frontmatter_keeps_filename_precedence_and_repair_clears_skips() {
+    let tmp = TempDir::new().unwrap();
+    write_md(tmp.path(), "a.md", "[[b]]\n");
+    write_md(tmp.path(), "sub/b.md", "valid\n");
+    write_md(tmp.path(), "b.md", "---\ntitle: [unfinished\n---\nbody\n");
+    write_md(
+        tmp.path(),
+        "other-unfinished.md",
+        "---\ntitle: [unfinished\n---\n",
+    );
+    run(&tmp, &["create-index"]);
+    let disk = run(&tmp, &["find", "--file", "a.md", "--fields", "links"]);
+    assert_eq!(disk["results"][0]["links"][0]["path"], "b.md");
+    assert_eq!(
+        run(
+            &tmp,
+            &["find", "--file", "a.md", "--fields", "links", "--index"]
+        )["results"],
+        disk["results"]
+    );
+    let disk = run(&tmp, &["backlinks", "b.md"]);
+    assert_eq!(disk["total"], 1);
+    assert_eq!(
+        run(&tmp, &["backlinks", "b.md", "--index"])["results"],
+        disk["results"]
+    );
+    assert_eq!(
+        run(&tmp, &["summary", "--index"])["results"]["files"]["skipped"],
+        2
+    );
+    write_md(tmp.path(), "b.md", "---\ntitle: repaired\n---\nbody\n");
+    run(
+        &tmp,
+        &["set", "b.md", "--property", "status=done", "--index"],
+    );
+    let disk = run(&tmp, &["summary"]);
+    let indexed = run(&tmp, &["summary", "--index"]);
+    assert_eq!(indexed["results"]["files"]["skipped"], 1);
+    assert_eq!(indexed["results"]["files"], disk["results"]["files"]);
+    assert_eq!(run(&tmp, &["backlinks", "b.md", "--index"])["total"], 1);
+}
+
+#[test]
+fn boolean_sections_and_projections_cover_disk_fallback_and_named_refresh() {
+    let tmp = TempDir::new().unwrap();
+    for (path, body) in [
+        ("a.md", "green red x blue"),
+        ("b.md", "red"),
+        ("c.md", "red blue"),
+        ("e.md", "rust memory allocation"),
+        ("f.md", "rust memory safety"),
+    ] {
+        write_md(
+            tmp.path(),
+            path,
+            &format!("# Scope\n{body}\n# Other\nred blue rust memory allocation\n"),
+        );
+    }
+    write_md(
+        tmp.path(),
+        "unfinished.md",
+        "---\ntitle: [unfinished\n---\n",
+    );
+    assert_eq!(run(&tmp, &["create-index"])["results"]["warnings"], 1);
+    for indexed in [false, true] {
+        let mut command = hyalo_no_hints();
+        command.arg("--dir").arg(tmp.path()).args([
+            "find",
+            "green",
+            "--section",
+            "Scope",
+            "--fields",
+            "file",
+            "--format",
+            "json",
+        ]);
+        if indexed {
+            command.arg("--index");
+        }
+        let output = command.output().unwrap();
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("skipped 1 file"));
+    }
+    for (query, expected) in [
+        ("\"red blue\" OR green", vec!["a.md", "c.md"]),
+        ("rust -\"memory safety\"", vec!["e.md"]),
+    ] {
+        for fields in ["file", "title,sections"] {
+            let base = ["find", query, "--section", "Scope", "--fields", fields];
+            let disk = run(&tmp, &base);
+            assert_eq!(names(&disk), expected);
+            let mut indexed_args = base.to_vec();
+            indexed_args.push("--index");
+            let indexed = run(&tmp, &indexed_args);
+            assert_eq!(indexed["results"], disk["results"]);
+            // Section selection uses real body fallback even with --index.
+            for path in ["a.md", "c.md", "e.md", "f.md"] {
+                let mut named = base.to_vec();
+                named.extend(["--file", path]);
+                let disk = run(&tmp, &named);
+                named.push("--index");
+                assert_eq!(run(&tmp, &named)["results"], disk["results"]);
+            }
+            for use_index in [false, true] {
+                let mut limited = base.to_vec();
+                limited.extend(["--limit", "1"]);
+                if use_index {
+                    limited.push("--index");
+                }
+                let result = run(&tmp, &limited);
+                assert_eq!(result["total"], expected.len());
+                assert_eq!(names(&result).len(), 1);
+            }
+        }
+    }
+    // Named refresh replaces the section tokens; the old phrase must disappear.
+    write_md(tmp.path(), "c.md", "# Scope\ngreen\n# Other\nred blue\n");
+    let args = [
+        "find",
+        "\"red blue\"",
+        "--section",
+        "Scope",
+        "--fields",
+        "file",
+        "--file",
+        "c.md",
+    ];
+    let disk = run(&tmp, &args);
+    assert!(names(&disk).is_empty());
+    let mut indexed = args.to_vec();
+    indexed.push("--index");
+    assert_eq!(run(&tmp, &indexed)["results"], disk["results"]);
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -63,6 +63,7 @@ mod iteration280_fuzzy_candidacy_gate;
 mod iteration281_dominant_prefix_exemption;
 mod iteration282_directory_token_dominance;
 mod iteration291_document_consistency;
+mod iteration292_coherence;
 mod iteration_ergonomics;
 mod jq;
 mod json_errors;

--- a/crates/hyalo-core/src/bm25.rs
+++ b/crates/hyalo-core/src/bm25.rs
@@ -349,17 +349,67 @@ pub struct Bm25Match {
 enum Clause {
     /// Document must contain these terms (implicit AND).
     /// Single-element for a plain word; multi-element for a quoted phrase.
-    Must(Vec<String>),
+    Must(QueryAtom),
     /// Document may contain these terms (OR group member, contributes score).
-    Should(Vec<String>),
+    Should(QueryAtom),
     /// Document must not contain these terms.
-    MustNot(Vec<String>),
+    MustNot(QueryAtom),
+}
+
+/// Typed normalized atom; quoting survives compilation independently of clause occurrence.
+#[derive(Debug, Clone, PartialEq)]
+enum QueryAtom {
+    Term(String),
+    Phrase(Vec<String>),
+}
+impl QueryAtom {
+    fn terms(&self) -> &[String] {
+        match self {
+            Self::Term(term) => std::slice::from_ref(term),
+            Self::Phrase(terms) => terms,
+        }
+    }
+}
+impl From<Vec<String>> for QueryAtom {
+    fn from(mut terms: Vec<String>) -> Self {
+        if terms.len() == 1 {
+            Self::Term(terms.remove(0))
+        } else {
+            Self::Phrase(terms)
+        }
+    }
+}
+impl std::ops::Deref for QueryAtom {
+    type Target = [String];
+    fn deref(&self) -> &Self::Target {
+        self.terms()
+    }
+}
+impl<'a> IntoIterator for &'a QueryAtom {
+    type Item = &'a String;
+    type IntoIter = std::slice::Iter<'a, String>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.terms().iter()
+    }
 }
 
 /// Parsed boolean query with AND/OR/NOT/phrase support.
 #[derive(Debug, Clone)]
 struct BooleanQuery {
     clauses: Vec<Clause>,
+}
+
+/// One normalized query shared by indexed scoring, disk fallback and snippets.
+pub struct CompiledQuery {
+    query: BooleanQuery,
+}
+impl CompiledQuery {
+    /// Compile flat Boolean/phrase semantics with the effective query language.
+    pub fn new(query: &str, language: StemLanguage) -> Self {
+        Self {
+            query: parse_boolean_query(query, &create_stemmer(language)),
+        }
+    }
 }
 
 /// Positive clauses compiled once for ranked body snippets. Shares scoring's
@@ -393,11 +443,17 @@ pub fn resolve_document_path(
 impl SnippetQuery {
     /// Compile with the query-time stemming language (no document override).
     pub fn new(query: &str, language: StemLanguage) -> Self {
-        let clauses: Vec<_> = parse_boolean_query(query, &create_stemmer(language))
+        Self::from_compiled(&CompiledQuery::new(query, language))
+    }
+
+    /// Build a snippet selector from the same normalized atoms used for scoring.
+    pub fn from_compiled(query: &CompiledQuery) -> Self {
+        let clauses: Vec<_> = query
+            .query
             .clauses
-            .into_iter()
+            .iter()
             .filter_map(|clause| match clause {
-                Clause::Must(terms) | Clause::Should(terms) => Some(terms),
+                Clause::Must(atom) | Clause::Should(atom) => Some(atom.terms().to_vec()),
                 Clause::MustNot(_) => None,
             })
             .collect();
@@ -552,18 +608,6 @@ impl BooleanQuery {
             .iter()
             .any(|c| matches!(c, Clause::Must(_) | Clause::Should(_)))
     }
-
-    /// Collect all `MustNot` terms (flattened) as `&str` slices.
-    fn must_not_terms(&self) -> Vec<&str> {
-        self.clauses
-            .iter()
-            .filter_map(|c| match c {
-                Clause::MustNot(terms) => Some(terms.iter().map(String::as_str)),
-                _ => None,
-            })
-            .flatten()
-            .collect()
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -579,6 +623,7 @@ enum QuerySegment {
     Phrase(String),
     /// A word that was prefixed with `-`; also accepts `-"phrase"`.
     Negated(String),
+    NegatedPhrase(String),
     /// The literal keyword `OR` or `or`.
     Or,
     /// The literal keyword `AND` or `and` (syntactic sugar — treated as whitespace).
@@ -622,7 +667,7 @@ fn tokenize_query_segments(query: &str) -> Vec<QuerySegment> {
                     phrase.push(c);
                 }
                 if !phrase.is_empty() {
-                    segments.push(QuerySegment::Negated(phrase));
+                    segments.push(QuerySegment::NegatedPhrase(phrase));
                 }
             } else {
                 // Negated word: -foo
@@ -678,18 +723,23 @@ fn parse_boolean_query(query: &str, stemmer: &Stemmer) -> BooleanQuery {
         match seg {
             QuerySegment::Or | QuerySegment::And => {}
             QuerySegment::Negated(text) => {
+                for token in tokenize(&text, stemmer) {
+                    clauses.push(Clause::MustNot(QueryAtom::Term(token)));
+                }
+            }
+            QuerySegment::NegatedPhrase(text) => {
                 let tokens = tokenize(&text, stemmer);
                 if !tokens.is_empty() {
-                    clauses.push(Clause::MustNot(tokens));
+                    clauses.push(Clause::MustNot(QueryAtom::Phrase(tokens)));
                 }
             }
             QuerySegment::Phrase(text) => {
                 let tokens = tokenize(&text, stemmer);
                 if !tokens.is_empty() {
                     if has_or {
-                        clauses.push(Clause::Should(tokens));
+                        clauses.push(Clause::Should(QueryAtom::Phrase(tokens)));
                     } else {
-                        clauses.push(Clause::Must(tokens));
+                        clauses.push(Clause::Must(QueryAtom::Phrase(tokens)));
                     }
                 }
             }
@@ -698,9 +748,9 @@ fn parse_boolean_query(query: &str, stemmer: &Stemmer) -> BooleanQuery {
                 if !tokens.is_empty() {
                     for token in tokens {
                         if has_or {
-                            clauses.push(Clause::Should(vec![token]));
+                            clauses.push(Clause::Should(vec![token].into()));
                         } else {
-                            clauses.push(Clause::Must(vec![token]));
+                            clauses.push(Clause::Must(vec![token].into()));
                         }
                     }
                 }
@@ -714,6 +764,9 @@ fn parse_boolean_query(query: &str, stemmer: &Stemmer) -> BooleanQuery {
 // ---------------------------------------------------------------------------
 // BM25 inverted index
 // ---------------------------------------------------------------------------
+
+/// Aggregate expanded-token budget, including temporary reconstruction slots.
+pub(crate) const MAX_EXPANDED_TOKEN_BYTES: usize = 256 * 1024 * 1024;
 
 /// A (doc_id, term_frequency, positions) triple stored in a posting list.
 ///
@@ -876,11 +929,34 @@ impl Bm25InvertedIndex {
             .sum()
     }
 
+    /// Check the complete allocation amplification before reconstructing owned tokens.
+    /// Counts term bytes, owned String slots, and temporary positional storage.
+    pub(crate) fn expansion_within_budget(&self, budget: usize) -> bool {
+        self.postings
+            .iter()
+            .try_fold(0usize, |total, (term, posts)| {
+                let width = term
+                    .len()
+                    .checked_add(std::mem::size_of::<String>())?
+                    .checked_add(std::mem::size_of::<(u32, &str)>())?;
+                posts.iter().try_fold(total, |sum, p| {
+                    let next = sum.checked_add(width.checked_mul(p.positions.len())?)?;
+                    (next <= budget).then_some(next)
+                })
+            })
+            .is_some()
+    }
+
     /// Returns **all** matches for `query`, ranked by BM25 score (highest first).
     ///
     /// Returns an empty vec when `query` produces no positive tokens or has no matches.
     pub fn score(&self, query: &str, stemmer: &Stemmer) -> Vec<Bm25Match> {
-        self.ranked_matches(query, stemmer)
+        self.ranked_matches(&parse_boolean_query(query, stemmer))
+    }
+
+    /// Score already-compiled atoms without repeating query normalization.
+    pub fn score_compiled(&self, query: &CompiledQuery) -> Vec<Bm25Match> {
+        self.ranked_matches(&query.query)
     }
 
     /// Reconstruct every document's full ordered token list from postings.
@@ -914,6 +990,9 @@ impl Bm25InvertedIndex {
         &self,
         include: impl Fn(&str) -> bool,
     ) -> HashMap<&str, Vec<String>> {
+        if !self.expansion_within_budget(MAX_EXPANDED_TOKEN_BYTES) {
+            return HashMap::new();
+        }
         let selected: Vec<_> = self
             .doc_paths
             .iter()
@@ -1025,8 +1104,7 @@ impl Bm25InvertedIndex {
     // ------------------------------------------------------------------
 
     /// Compute BM25 scores for all documents matching the parsed query.
-    fn ranked_matches(&self, query: &str, stemmer: &Stemmer) -> Vec<Bm25Match> {
-        let query = parse_boolean_query(query, stemmer);
+    fn ranked_matches(&self, query: &BooleanQuery) -> Vec<Bm25Match> {
         if query.is_empty() || !query.has_positive_clauses() {
             return Vec::new();
         }
@@ -1035,50 +1113,46 @@ impl Bm25InvertedIndex {
         let n = self.doc_paths.len() as f64;
         let avgdl = self.avgdl;
 
-        // Build excluded doc set from MustNot terms via postings lookup.
-        let must_not_terms = query.must_not_terms();
-        let excluded: HashSet<u32> = must_not_terms
-            .iter()
-            .filter_map(|t| self.postings.get(*t))
-            .flat_map(|posts| posts.iter().map(|p| p.doc_id))
-            .collect();
-
-        // Accumulate BM25 scores across all positive clauses.
-        let mut scores: HashMap<u32, f64> = HashMap::new();
-
-        // For AND semantics: track how many Must clauses each doc satisfies.
-        let must_clause_count = query
+        // Eligibility is computed for whole clauses before any score is accumulated.
+        // In particular, a failed optional phrase contributes neither admission nor score.
+        let evaluated: Vec<_> = query
             .clauses
             .iter()
-            .filter(|c| matches!(c, Clause::Must(_)))
-            .count();
-        let mut must_hits: HashMap<u32, usize> = HashMap::new();
-
-        // Docs that received phrase-term scores but don't satisfy phrase adjacency.
-        // These must have those scores removed in the final filter.
-        let mut phrase_rejected: HashSet<u32> = HashSet::new();
-
-        for clause in &query.clauses {
-            let (terms, is_must) = match clause {
-                Clause::Must(t) => (t, true),
-                Clause::Should(t) => (t, false),
+            .map(|clause| {
+                let terms = match clause {
+                    Clause::Must(t) | Clause::Should(t) | Clause::MustNot(t) => t,
+                };
+                (clause, self.matching_documents(terms))
+            })
+            .collect();
+        let mut eligible = HashSet::new();
+        for (clause, documents) in &evaluated {
+            if !matches!(clause, Clause::MustNot(_)) {
+                eligible.extend(documents);
+            }
+        }
+        for (clause, documents) in &evaluated {
+            match clause {
+                Clause::Must(_) => eligible.retain(|id| documents.contains(id)),
+                Clause::MustNot(_) => eligible.retain(|id| !documents.contains(id)),
+                Clause::Should(_) => {}
+            }
+        }
+        let mut scores: HashMap<u32, f64> = HashMap::new();
+        for (clause, satisfied) in &evaluated {
+            let terms = match clause {
+                Clause::Must(t) | Clause::Should(t) => t,
                 Clause::MustNot(_) => continue,
             };
-
-            let is_phrase = terms.len() > 1;
-
-            // Accumulate BM25 score contribution for each term in this clause.
             for term in terms {
-                let Some(posting_list) = self.postings.get(term) else {
+                let Some(postings) = self.postings.get(term) else {
                     continue;
                 };
-
                 #[allow(clippy::cast_precision_loss)]
-                let nt = posting_list.len() as f64;
+                let nt = postings.len() as f64;
                 let idf = (1.0 + (n - nt + 0.5) / (nt + 0.5)).ln();
-
-                for p in posting_list {
-                    if excluded.contains(&p.doc_id) {
+                for p in postings {
+                    if !eligible.contains(&p.doc_id) || !satisfied.contains(&p.doc_id) {
                         continue;
                     }
                     let tf = f64::from(p.term_freq);
@@ -1088,56 +1162,10 @@ impl Bm25InvertedIndex {
                     *scores.entry(p.doc_id).or_insert(0.0) += idf * tf_norm;
                 }
             }
-
-            // Validate phrase adjacency and record Must clause satisfaction.
-            if is_phrase {
-                let phrase_docs: HashSet<u32> = self
-                    .docs_with_all_terms(terms)
-                    .into_iter()
-                    .filter(|&doc_id| self.has_phrase_at_positions(terms, doc_id))
-                    .collect();
-
-                if is_must {
-                    for &doc_id in &phrase_docs {
-                        *must_hits.entry(doc_id).or_insert(0) += 1;
-                    }
-                }
-
-                // Track docs that got individual term scores but don't match the phrase.
-                // These scores must be excluded so phrases aren't matched as bag-of-words.
-                let all_term_docs: HashSet<u32> = self.docs_with_all_terms(terms);
-                for doc_id in all_term_docs {
-                    if !phrase_docs.contains(&doc_id) {
-                        phrase_rejected.insert(doc_id);
-                    }
-                }
-            } else if is_must {
-                // Single-term Must: presence in posting list is sufficient.
-                if let Some(posting_list) = self.postings.get(&terms[0]) {
-                    for p in posting_list {
-                        *must_hits.entry(p.doc_id).or_insert(0) += 1;
-                    }
-                }
-            }
         }
-
-        // Collect results: exclude negated docs, enforce AND intersection,
-        // and reject docs that only matched phrase terms non-adjacently.
         let mut matches: Vec<Bm25Match> = scores
             .into_iter()
-            .filter(|(doc_id, score)| {
-                if *score <= 0.0 {
-                    return false;
-                }
-                if phrase_rejected.contains(doc_id) {
-                    return false;
-                }
-                if must_clause_count > 0 {
-                    must_hits.get(doc_id).copied().unwrap_or(0) >= must_clause_count
-                } else {
-                    true // pure OR query
-                }
-            })
+            .filter(|(_, score)| *score > 0.0)
             .map(|(doc_id, score)| Bm25Match {
                 rel_path: self.doc_paths[doc_id as usize].clone(),
                 score,
@@ -1159,8 +1187,28 @@ impl Bm25InvertedIndex {
         matches
     }
 
+    fn matching_documents(&self, atom: &QueryAtom) -> HashSet<u32> {
+        match atom {
+            QueryAtom::Term(term) => self
+                .postings
+                .get(term)
+                .into_iter()
+                .flatten()
+                .map(|p| p.doc_id)
+                .collect(),
+            QueryAtom::Phrase(terms) => self
+                .docs_with_all_terms(terms)
+                .into_iter()
+                .filter(|&id| self.has_phrase_at_positions(terms, id))
+                .collect(),
+        }
+    }
+
     /// Returns the set of `doc_id`s that contain **all** given terms.
     fn docs_with_all_terms(&self, terms: &[String]) -> HashSet<u32> {
+        if terms.iter().any(|t| !self.postings.contains_key(t)) {
+            return HashSet::new();
+        }
         let mut iter = terms.iter().filter_map(|t| self.postings.get(t));
         let first = match iter.next() {
             Some(postings) => postings.iter().map(|p| p.doc_id).collect::<HashSet<u32>>(),
@@ -1692,7 +1740,7 @@ mod tests {
         // Single quoted phrase → Must with multiple tokens
         assert_eq!(q.clauses.len(), 1);
         match &q.clauses[0] {
-            Clause::Must(tokens) => {
+            Clause::Must(QueryAtom::Phrase(tokens)) => {
                 assert_eq!(tokens.len(), 2, "phrase should produce two tokens");
             }
             other => panic!("expected Must, got {other:?}"),
@@ -2436,5 +2484,212 @@ mod tests {
             !query_is_operator_only("   "),
             "whitespace-only query should return false"
         );
+    }
+}
+
+#[cfg(test)]
+mod iteration292_tests {
+    use super::*;
+
+    #[test]
+    fn independent_flat_clause_evaluator_matches_small_authored_corpus() {
+        // The reference evaluator scans token windows directly; it does not use
+        // posting intersection, positional lookup or the production query parser.
+        let bodies = [
+            "green red x blue",
+            "red",
+            "red blue",
+            "neither",
+            "rust memory allocation",
+            "rust memory safety",
+            "rust memory\nsafety",
+            "red red blue",
+        ];
+        let stemmer = create_stemmer(StemLanguage::English);
+        let corpus = Bm25InvertedIndex::build(
+            bodies
+                .iter()
+                .enumerate()
+                .map(|(i, body)| DocumentInput {
+                    rel_path: format!("{i}.md"),
+                    title: String::new(),
+                    body: (*body).into(),
+                    language: StemLanguage::English,
+                })
+                .collect(),
+        );
+        let atoms = [
+            "red",
+            "green",
+            "\"red blue\"",
+            "rust",
+            "\"memory safety\"",
+            "\"red red\"",
+            "the",
+        ];
+        for left in atoms {
+            for right in atoms {
+                for or in [false, true] {
+                    for negative in ["", "red", "\"memory safety\""] {
+                        let query = format!(
+                            "{left} {} {right} {}",
+                            if or { "OR" } else { "AND" },
+                            if negative.is_empty() {
+                                String::new()
+                            } else {
+                                format!("-{negative}")
+                            }
+                        );
+                        let mut expected = Vec::new();
+                        for (id, body) in bodies.iter().enumerate() {
+                            let tokens = tokenize(body, &stemmer);
+                            let matches = |atom: &str| {
+                                let needle = tokenize(atom.trim_matches('"'), &stemmer);
+                                !needle.is_empty()
+                                    && tokens.windows(needle.len()).any(|window| window == needle)
+                            };
+                            let positive = if or {
+                                matches(left) || matches(right)
+                            } else {
+                                matches(left) && matches(right)
+                            };
+                            if positive && (negative.is_empty() || !matches(negative)) {
+                                expected.push(format!("{id}.md"));
+                            }
+                        }
+                        let mut actual: Vec<_> = corpus
+                            .score(&query, &stemmer)
+                            .into_iter()
+                            .map(|hit| hit.rel_path)
+                            .collect();
+                        actual.sort();
+                        expected.sort();
+                        assert_eq!(actual, expected, "{query}");
+                    }
+                }
+            }
+        }
+        let or_hits = corpus.score("\"red blue\" OR green", &stemmer);
+        let green = corpus.score("green", &stemmer);
+        assert_eq!(
+            or_hits
+                .iter()
+                .find(|hit| hit.rel_path == "0.md")
+                .unwrap()
+                .score
+                .to_bits(),
+            green[0].score.to_bits()
+        );
+    }
+
+    #[test]
+    fn independent_boolean_reference_covers_language_precedence() {
+        use StemLanguage::{English, German};
+        // Expected precedence is authored here, independently of resolve_language.
+        let settings = [
+            (None, None, English),
+            (None, Some("german"), German),
+            (Some("english"), Some("german"), English),
+            (Some("german"), Some("english"), German),
+        ];
+        let documents = [
+            (None, "running fast"),
+            (Some("english"), "running fast safely"),
+            (Some("german"), "Häuser Häuser running"),
+            (Some("invalid"), "the running slow"),
+        ];
+        assert_ne!(
+            tokenize("running", &create_stemmer(English)),
+            tokenize("running", &create_stemmer(German))
+        );
+        for (cli, config, expected_query_language) in settings {
+            assert_eq!(resolve_language(None, cli, config), expected_query_language);
+            let expected_languages: Vec<_> = documents
+                .iter()
+                .map(|(fm, _)| match fm {
+                    Some("english") => English,
+                    Some("german") => German,
+                    _ => expected_query_language,
+                })
+                .collect();
+            let corpus = Bm25InvertedIndex::build(
+                documents
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (fm, body))| {
+                        let language = resolve_language(*fm, cli, config);
+                        assert_eq!(language, expected_languages[i]);
+                        DocumentInput {
+                            rel_path: format!("{i}.md"),
+                            title: String::new(),
+                            body: (*body).into(),
+                            language,
+                        }
+                    })
+                    .collect(),
+            );
+            for (left, right, either, negative) in [
+                ("run", "fast", false, ""),
+                ("running fast", "Häuser Häuser", true, "running slow"),
+                ("the", "running", true, "fast safely"),
+                ("Häuser Häuser", "running", false, ""),
+            ] {
+                let query = format!(
+                    "\"{left}\" {} \"{right}\" {}",
+                    if either { "OR" } else { "AND" },
+                    if negative.is_empty() {
+                        String::new()
+                    } else {
+                        format!("-\"{negative}\"")
+                    }
+                );
+                let query_stemmer = create_stemmer(expected_query_language);
+                let mut expected = Vec::new();
+                for (i, (_, body)) in documents.iter().enumerate() {
+                    let tokens = tokenize(body, &create_stemmer(expected_languages[i]));
+                    let matches = |atom: &str| {
+                        let needle = tokenize(atom, &query_stemmer);
+                        !needle.is_empty()
+                            && tokens.windows(needle.len()).any(|window| window == needle)
+                    };
+                    let positive = if either {
+                        matches(left) || matches(right)
+                    } else {
+                        matches(left) && matches(right)
+                    };
+                    if positive && (negative.is_empty() || !matches(negative)) {
+                        expected.push(format!("{i}.md"));
+                    }
+                }
+                let mut actual: Vec<_> = corpus
+                    .score_compiled(&CompiledQuery::new(&query, expected_query_language))
+                    .into_iter()
+                    .map(|hit| hit.rel_path)
+                    .collect();
+                expected.sort();
+                actual.sort();
+                assert_eq!(actual, expected, "{cli:?}/{config:?}: {query}");
+            }
+        }
+    }
+
+    #[test]
+    fn checked_expansion_budget_rejects_term_position_product() {
+        let corpus = Bm25InvertedIndex::new_for_test(
+            HashMap::from([(
+                "x".repeat(128),
+                vec![Posting {
+                    doc_id: 0,
+                    term_freq: 32,
+                    positions: (0..32).collect(),
+                }],
+            )]),
+            vec![32],
+            vec!["a.md".into()],
+            32.0,
+        );
+        assert!(!corpus.expansion_within_budget(1024));
+        assert!(corpus.expansion_within_budget(8192));
+        assert_eq!(corpus.reconstruct_all_tokens()["a.md"].len(), 32);
     }
 }

--- a/crates/hyalo-core/src/case_index.rs
+++ b/crates/hyalo-core/src/case_index.rs
@@ -85,6 +85,7 @@ pub struct CaseInsensitiveIndex {
     /// cost 4.65 s (iter-277, BUG-13). A partial index leaves it `false` and
     /// every probe goes to disk exactly as before.
     complete: bool,
+    aliases_enabled: bool,
 }
 
 /// The map key for `s`, borrowed when `s` is already the key (iter-278).
@@ -118,7 +119,18 @@ impl CaseInsensitiveIndex {
             case_insensitive_paths: false,
             alias_map: HashMap::new(),
             complete: false,
+            aliases_enabled: false,
         }
+    }
+
+    /// Set the invocation's explicit alias resolution policy.
+    pub fn set_aliases_enabled(&mut self, enabled: bool) {
+        self.aliases_enabled = enabled;
+    }
+
+    /// Whether declared aliases participate in resolution.
+    pub fn aliases_enabled(&self) -> bool {
+        self.aliases_enabled
     }
 
     /// Declare that this index holds every file in the vault, so a lookup miss

--- a/crates/hyalo-core/src/catalog.rs
+++ b/crates/hyalo-core/src/catalog.rs
@@ -1,0 +1,264 @@
+//! Immutable semantic link identities. Catalog paths are never filesystem write authority.
+use crate::case_index::CaseInsensitiveIndex;
+use crate::links::LinkKind;
+use std::path::Path;
+
+/// Resolution policy is invocation data, independent from filesystem collision policy.
+#[derive(Debug, Clone, Copy)]
+pub struct ResolutionOptions<'a> {
+    /// Permit declared aliases after all filename candidates fail.
+    pub aliases: bool,
+    /// Prefix stripped from site-absolute targets.
+    pub site_prefix: Option<&'a str>,
+}
+
+/// A source-aware semantic result retaining ambiguity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// Canonical catalog note path.
+    Resolved(String),
+    /// An external URI or a target outside the vault.
+    External,
+    /// Attachment target, with its canonical path when known.
+    Attachment(Option<String>),
+    /// No candidate in this catalog.
+    Missing,
+    /// Candidates with equal precedence; never choose one arbitrarily.
+    Ambiguous(Vec<String>),
+}
+impl Resolution {
+    /// Canonical note or attachment path, when uniquely known.
+    pub fn path(&self) -> Option<&str> {
+        match self {
+            Self::Resolved(path) | Self::Attachment(Some(path)) => Some(path),
+            _ => None,
+        }
+    }
+}
+
+/// Frozen paths, stems, directory candidates and alias declarations for a generation.
+#[derive(Debug)]
+pub struct VaultCatalog {
+    index: CaseInsensitiveIndex,
+    generation: u64,
+}
+impl VaultCatalog {
+    /// Freeze a complete or partial lookup independently from selected scan coverage.
+    pub fn new(index: CaseInsensitiveIndex, generation: u64) -> Self {
+        Self { index, generation }
+    }
+    /// Generation of the retained catalog inputs.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+    /// Whether a missing result proves absence from the whole vault.
+    pub fn is_complete(&self) -> bool {
+        self.index.is_complete()
+    }
+    /// Compatibility view for callers migrating from the public case index.
+    pub fn case_index(&self) -> &CaseInsensitiveIndex {
+        &self.index
+    }
+    /// Resolve authored target text without probing the filesystem.
+    pub fn resolve(
+        &self,
+        source: &str,
+        kind: LinkKind,
+        target: &str,
+        options: ResolutionOptions<'_>,
+    ) -> Resolution {
+        resolve(&self.index, source, kind, target, options)
+    }
+}
+
+/// Shared resolver for catalog owners and compatibility case-index callers.
+/// The authored occurrence (kind, text, fragment and source line) stays with its caller.
+pub fn resolve(
+    index: &CaseInsensitiveIndex,
+    source: &str,
+    kind: LinkKind,
+    target: &str,
+    options: ResolutionOptions<'_>,
+) -> Resolution {
+    if crate::links::is_external_target(target) {
+        return Resolution::External;
+    }
+    let raw = target.trim().replace('\\', "/");
+    let raw = raw.split(['#', '?']).next().unwrap_or("").trim_end();
+    if raw.is_empty() {
+        return Resolution::Missing;
+    }
+    let decoded = crate::discovery::percent_decode_path(raw);
+    let raw = decoded.as_deref().unwrap_or(raw);
+    let absolute = raw.starts_with('/');
+    let trailing = raw.ends_with('/');
+    let mut candidates = Vec::with_capacity(2);
+    if absolute {
+        candidates.push(crate::link_graph::strip_site_prefix(
+            raw,
+            options.site_prefix,
+        ));
+    } else if kind == LinkKind::Markdown || raw.starts_with("./") {
+        candidates.push(crate::link_graph::normalize_target(Path::new(source), raw));
+        if kind == LinkKind::Markdown && !raw.contains('/') {
+            candidates.push(raw.to_owned());
+        }
+    } else {
+        candidates.push(raw.to_owned());
+    }
+    // Obsidian permits partially qualified attachment embeds relative to the source.
+    if kind == LinkKind::Wikilink
+        && !absolute
+        && raw.contains('/')
+        && crate::discovery::has_non_md_extension(raw)
+    {
+        candidates.push(crate::link_graph::normalize_target(Path::new(source), raw));
+    }
+    for candidate in &candidates {
+        let candidate = candidate.trim_end_matches('/');
+        if crate::discovery::normalized_target_escapes_vault(candidate) {
+            return Resolution::External;
+        }
+        let resolved = resolve_path(index, candidate, trailing);
+        if !matches!(resolved, Resolution::Missing) {
+            return resolved;
+        }
+    }
+    let bare = raw.trim_end_matches('/');
+    if !absolute && !bare.contains('/') {
+        let stem = strip_md(bare);
+        let paths = index.lookup_stem_all(stem);
+        if !paths.is_empty() {
+            return candidates_result(paths);
+        }
+        if options.aliases {
+            let paths = index.lookup_alias_all(stem);
+            if !paths.is_empty() {
+                return candidates_result(paths);
+            }
+        }
+    }
+    if crate::discovery::has_non_md_extension(raw) {
+        Resolution::Attachment(None)
+    } else {
+        Resolution::Missing
+    }
+}
+fn strip_md(path: &str) -> &str {
+    if path
+        .as_bytes()
+        .get(path.len().saturating_sub(3)..)
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(b".md"))
+    {
+        &path[..path.len() - 3]
+    } else {
+        path
+    }
+}
+fn hit(path: String) -> Resolution {
+    if crate::discovery::has_non_md_extension(&path) {
+        Resolution::Attachment(Some(path))
+    } else {
+        Resolution::Resolved(path)
+    }
+}
+fn candidates_result(paths: &[String]) -> Resolution {
+    match paths {
+        [] => Resolution::Missing,
+        [only] => hit(only.to_owned()),
+        _ => {
+            let mut paths = paths.to_vec();
+            paths.sort();
+            Resolution::Ambiguous(paths)
+        }
+    }
+}
+fn literal(index: &CaseInsensitiveIndex, path: &str) -> Resolution {
+    if index.contains_path(path) {
+        return hit(path.to_owned());
+    }
+    candidates_result(index.lookup_all(path))
+}
+fn resolve_path(index: &CaseInsensitiveIndex, target: &str, trailing: bool) -> Resolution {
+    let direct = literal(index, target);
+    if !matches!(direct, Resolution::Missing) {
+        return direct;
+    }
+    if strip_md(target) != target || crate::discovery::has_non_md_extension(target) {
+        return Resolution::Missing;
+    }
+    for suffix in if trailing {
+        ["/index.md", ".md"]
+    } else {
+        [".md", "/index.md"]
+    } {
+        let result = literal(index, &format!("{target}{suffix}"));
+        if !matches!(result, Resolution::Missing) {
+            return result;
+        }
+    }
+    Resolution::Missing
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn source_relative_precedence_and_explicit_policy() {
+        let mut index = CaseInsensitiveIndex::new();
+        for path in ["b.md", "sub/b.md", "sub/a.md", "page/index.md"] {
+            index.insert(path);
+        }
+        index.insert_aliases("sub/b.md", ["Nick"]);
+        index.set_complete(true);
+        let catalog = VaultCatalog::new(index, 7);
+        let options = ResolutionOptions {
+            aliases: true,
+            site_prefix: Some("docs"),
+        };
+        for (kind, target, expected) in [
+            (LinkKind::Markdown, "b.md", "sub/b.md"),
+            (LinkKind::Markdown, "/docs/b.md", "b.md"),
+            (LinkKind::Wikilink, " b ", "b.md"),
+            (LinkKind::Wikilink, "./b", "sub/b.md"),
+            (LinkKind::Wikilink, "Nick", "sub/b.md"),
+            (LinkKind::Markdown, "/docs/page/", "page/index.md"),
+        ] {
+            assert_eq!(
+                catalog.resolve("sub/a.md", kind, target, options).path(),
+                Some(expected)
+            );
+        }
+        assert_eq!(
+            catalog.resolve(
+                "sub/a.md",
+                LinkKind::Wikilink,
+                "Nick",
+                ResolutionOptions {
+                    aliases: false,
+                    ..options
+                }
+            ),
+            Resolution::Missing
+        );
+        assert!(catalog.is_complete());
+        assert_eq!(catalog.generation(), 7);
+    }
+    #[test]
+    fn ambiguity_outranks_alias_and_survives_catalog_generations() {
+        let mut index = CaseInsensitiveIndex::new();
+        index.insert("one/b.md");
+        index.insert("two/b.md");
+        index.insert_aliases("one/b.md", ["b", "Nick"]);
+        index.insert_aliases("two/b.md", ["Nick"]);
+        let options = ResolutionOptions {
+            aliases: true,
+            site_prefix: None,
+        };
+        for target in ["b", "Nick"] {
+            assert!(
+                matches!(resolve(&index, "a.md", LinkKind::Wikilink, target, options), Resolution::Ambiguous(paths) if paths.len() == 2)
+            );
+        }
+    }
+}

--- a/crates/hyalo-core/src/discovery.rs
+++ b/crates/hyalo-core/src/discovery.rs
@@ -1512,6 +1512,20 @@ pub fn resolve_link_from_source(
     site_prefix: Option<&str>,
     case_index: Option<&CaseInsensitiveIndex>,
 ) -> Option<String> {
+    if let Some(index) = case_index.filter(|index| index.is_complete()) {
+        return crate::catalog::resolve(
+            index,
+            source_rel,
+            kind,
+            target,
+            crate::catalog::ResolutionOptions {
+                aliases: index.aliases_enabled(),
+                site_prefix,
+            },
+        )
+        .path()
+        .map(str::to_owned);
+    }
     let resolved = normalize_link_target(kind, source_rel, target, |src_rel| {
         resolve_target(canonical_dir, src_rel, site_prefix, case_index).is_some()
     });

--- a/crates/hyalo-core/src/index.rs
+++ b/crates/hyalo-core/src/index.rs
@@ -205,6 +205,16 @@ impl ScannedIndex {
         site_prefix: Option<&str>,
         options: &ScanOptions<'_>,
     ) -> Result<ScannedIndexBuild> {
+        Self::build_with_case_policy(files, site_prefix, options, true)
+    }
+
+    /// Build with the invocation's semantic case policy; filesystem identity is separate.
+    pub fn build_with_case_policy(
+        files: &[(PathBuf, String)],
+        site_prefix: Option<&str>,
+        options: &ScanOptions<'_>,
+        case_insensitive: bool,
+    ) -> Result<ScannedIndexBuild> {
         let mut entries = Vec::with_capacity(files.len());
         let mut file_links_vec: Vec<FileLinks> = Vec::with_capacity(files.len());
         let mut warnings: Vec<IndexWarning> = Vec::new();
@@ -251,6 +261,12 @@ impl ScannedIndex {
                     }
                 }
                 Err(e) if frontmatter::is_parse_error(&e) => {
+                    // A parse failure removes scan coverage, never filename identity.
+                    file_links_vec.push(FileLinks {
+                        source: PathBuf::from(&files[i].1),
+                        links: Vec::new(),
+                        self_anchors: Vec::new(),
+                    });
                     warnings.push(IndexWarning {
                         rel_path: files[i].1.clone(),
                         message: e.to_string(),
@@ -281,7 +297,12 @@ impl ScannedIndex {
             } else {
                 Vec::new()
             };
-            let graph_build = LinkGraph::from_file_links(file_links_vec, site_prefix, &aliases);
+            let graph_build = LinkGraph::from_file_links_with_case_policy(
+                file_links_vec,
+                site_prefix,
+                &aliases,
+                case_insensitive,
+            );
             graph_build.graph
         } else {
             LinkGraph::default()
@@ -670,6 +691,12 @@ const MAX_BM25_POSTINGS: usize = 50_000_000;
 /// treated as absent, which routes text queries to the live-scan fallback
 /// exactly as a snapshot without a BM25 index does.
 fn validate_bm25(bm25: &Bm25InvertedIndex, warn: bool) -> bool {
+    if !bm25.expansion_within_budget(crate::bm25::MAX_EXPANDED_TOKEN_BYTES) {
+        if warn {
+            eprintln!("warning: BM25 expanded-token budget exceeded; rebuild the snapshot");
+        }
+        return false;
+    }
     let posting_count = bm25.total_postings();
     if posting_count > MAX_BM25_POSTINGS {
         if warn {
@@ -712,6 +739,8 @@ enum PendingBm25 {
 /// the buffer is dropped as soon as the decode consumes it, so a text query
 /// ends up with the same steady-state footprint as before this change.
 enum Bm25Section {
+    /// A supplied section failed structural/resource validation.
+    Refused,
     /// The snapshot carries no BM25 index, or its section was refused by
     /// [`validate_bm25`].
     Absent,
@@ -739,7 +768,7 @@ impl Bm25Section {
     /// the same way, by falling back to a live scan.
     fn get(&self) -> Option<&Bm25InvertedIndex> {
         match self {
-            Self::Absent => None,
+            Self::Absent | Self::Refused => None,
             Self::Loaded(bm25) => Some(bm25),
             Self::Deferred {
                 raw,
@@ -790,6 +819,35 @@ impl Bm25Section {
     }
 }
 
+/// Complete document replacement produced by the shared scanner.
+struct ScannedDocument {
+    entry: IndexEntry,
+}
+
+/// Observable global work, counted at the actual rebuild boundaries.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RefreshWork {
+    /// Catalog/graph rebuilds in this live owner.
+    pub graph_rebuilds: u64,
+    /// BM25 reconstructions in this live owner.
+    pub search_rebuilds: u64,
+    /// Documents replaced by scans.
+    pub documents: u64,
+}
+
+#[derive(Default)]
+struct LiveState {
+    catalog: Option<crate::catalog::VaultCatalog>,
+    generation: u64,
+    dirty: bool,
+    batching: bool,
+    aliases: bool,
+    case_insensitive: bool,
+    default_language: Option<String>,
+    language_configured: bool,
+    work: RefreshWork,
+}
+
 /// A vault index loaded from a MessagePack snapshot file.
 ///
 /// Created by [`SnapshotIndex::save`] and loaded by [`SnapshotIndex::load`].
@@ -809,13 +867,7 @@ pub struct SnapshotIndex {
     /// [`SnapshotIndex::set_frontmatter_link_props`]; `None` falls back to
     /// [`DEFAULT_FRONTMATTER_LINK_PROPERTIES`].
     frontmatter_link_props: Option<Vec<String>>,
-    /// Lazily built case-insensitive path lookup used by incremental link
-    /// refreshes ([`refresh_links`](Self::refresh_links)). Rebuilding it per
-    /// refreshed file would be O(entries × refreshed files) in bulk loops
-    /// (`lint --fix --index`, `links fix --apply`), so it is cached here and
-    /// invalidated whenever the set of indexed paths changes
-    /// ([`rebuild_path_index`](Self::rebuild_path_index)). Not persisted.
-    case_index_cache: Option<CaseInsensitiveIndex>,
+    live: LiveState,
 }
 
 impl SnapshotIndex {
@@ -828,21 +880,31 @@ impl SnapshotIndex {
         if let Some(&idx) = self.path_index.get(rel_path) {
             self.entries.remove(idx);
             self.rebuild_path_index();
+            self.changed();
         }
     }
 
     /// Insert a new entry (for `mv` new path). Maintains sorted order.
     pub fn insert_entry(&mut self, entry: IndexEntry) {
+        self.clear_frontmatter_skip(&entry.rel_path);
         let pos = self
             .entries
             .binary_search_by(|e| e.rel_path.cmp(&entry.rel_path))
             .unwrap_or_else(|i| i);
-        self.entries.insert(pos, entry);
+        if pos < self.entries.len() && self.entries[pos].rel_path == entry.rel_path {
+            self.entries[pos] = entry;
+        } else {
+            self.entries.insert(pos, entry);
+        }
         self.rebuild_path_index();
+        self.changed();
     }
 
-    /// Get a mutable reference to an entry by path.
+    /// Legacy mutable-entry adapter. Call finish_changes before persistence;
+    /// new callers use complete scanned replacements through apply_changes.
     pub fn get_mut(&mut self, rel_path: &str) -> Option<&mut IndexEntry> {
+        // Legacy adapter: explicit finish_changes is required before persistence.
+        self.live.dirty = true;
         self.path_index
             .get(rel_path)
             .copied()
@@ -851,6 +913,7 @@ impl SnapshotIndex {
 
     /// Get a mutable reference to the link graph for in-place updates.
     pub fn graph_mut(&mut self) -> &mut LinkGraph {
+        self.live.dirty = true;
         &mut self.graph
     }
 
@@ -883,9 +946,13 @@ impl SnapshotIndex {
     fn bm25_scan_args(&self, rel_path: &str) -> (bool, Option<String>) {
         (
             self.bm25.is_present(),
-            self.path_index
-                .get(rel_path)
-                .and_then(|&i| self.entries[i].bm25_language.clone()),
+            if self.live.language_configured {
+                self.live.default_language.clone()
+            } else {
+                self.path_index
+                    .get(rel_path)
+                    .and_then(|&i| self.entries[i].bm25_language.clone())
+            },
         )
     }
 
@@ -908,15 +975,34 @@ impl SnapshotIndex {
         let Some(old) = self.bm25.get() else {
             return;
         };
+        // Do not label legacy or ambiguous validity metadata as current by
+        // reconstructing it with today's builder. Absence invokes the normal
+        // disk fallback, including untouched documents in the scoped corpus.
+        let uncertain: std::collections::HashSet<&str> = self
+            .entries
+            .iter()
+            .filter(|entry| {
+                entry.bm25_tokens.is_none()
+                    && entry.bm25_tokenizer_version != Some(crate::bm25::TOKENIZER_VERSION)
+            })
+            .map(|entry| entry.rel_path.as_str())
+            .collect();
+        if old.tokenizer_version() != crate::bm25::TOKENIZER_VERSION
+            || old.document_paths().any(|path| uncertain.contains(path))
+        {
+            self.bm25 = Bm25Section::Absent;
+            return;
+        }
         let reconstructed = old.reconstruct_all_tokens();
+        self.live.work.search_rebuilds += 1;
         let docs: Vec<crate::bm25::PreTokenizedInput> = self
             .entries
             .iter()
             .filter_map(|e| {
-                let tokens = e
-                    .bm25_tokens
-                    .clone()
-                    .or_else(|| reconstructed.get(e.rel_path.as_str()).cloned())?;
+                let tokens = e.bm25_tokens.clone().or_else(|| {
+                    e.bm25_tokenizer_version
+                        .and_then(|_| reconstructed.get(e.rel_path.as_str()).cloned())
+                })?;
                 Some(crate::bm25::PreTokenizedInput {
                     rel_path: e.rel_path.clone(),
                     tokens,
@@ -935,10 +1021,6 @@ impl SnapshotIndex {
     /// Returns the `FileLinks` for the re-scanned file so the caller can
     /// update the link graph separately. Returns `Ok(None)` if the file
     /// is not in the index.
-    pub(crate) fn rescan_entry(&mut self, dir: &Path, rel_path: &str) -> Result<Option<FileLinks>> {
-        self.rescan_entry_at(&dir.join(rel_path), rel_path)
-    }
-
     /// Shared implementation behind [`rescan_entry`] and [`refresh_links`]:
     /// scan `full_path` from disk and replace the index entry for `rel_path`
     /// wholesale. Returns the file's `FileLinks` for graph updates, or `None`
@@ -958,99 +1040,158 @@ impl SnapshotIndex {
             fm_props.as_deref(),
         )?;
         self.entries[idx] = entry;
+        self.clear_frontmatter_skip(rel_path);
+        self.live.work.documents += 1;
         Ok(file_links)
     }
 
-    /// Build a case-insensitive lookup index from every path currently known
-    /// to this snapshot. Used to resolve bare-basename wikilinks (e.g.
-    /// `[[note]]` matching a unique `sub/note.md`) the same way a full
-    /// [`LinkGraph::build`] does, without persisting the case index in the
-    /// snapshot itself.
-    fn build_case_index(&self) -> CaseInsensitiveIndex {
-        let mut case_index = CaseInsensitiveIndex::new();
-        case_index.set_case_insensitive_paths(true);
-        for entry in &self.entries {
-            case_index.insert(&entry.rel_path);
-        }
-        case_index
-    }
-
-    /// Re-scan the body/frontmatter of `rel_path` (already written to disk at
-    /// `full_path`) and refresh the parts of its index entry and the
-    /// persisted [`LinkGraph`] that are derived from wikilinks: the entry's
-    /// `sections`, `tasks`, and `links` fields, plus the graph's outbound
-    /// edges for this file.
-    ///
-    /// `size` and `lines` are refreshed too (both are derived from the bytes
-    /// on disk, which a body rewrite changes).
-    ///
-    /// `properties`, `tags`, and `modified` are left untouched — callers that
-    /// already know the new values in memory (e.g. `set`/`append`/`remove`)
-    /// should patch those directly, since they don't require a disk read.
-    /// `bm25_tokens`/`bm25_language` are refreshed from the re-scan when the
-    /// snapshot carries a BM25 inverted index (BUG-4, iter-244); without one
-    /// they stay untouched, as only `create-index --bm25` populates them.
-    ///
-    /// This closes the gap where a frontmatter link property (`related`,
-    /// `depends-on`, ...) mutated via `set`/`append`/`remove`/`lint --fix`
-    /// with `--index` left the persisted link graph stale — `backlinks` and
-    /// `find --fields backlinks`/`links` would return pre-mutation results
-    /// until a full `create-index` rebuild.
-    ///
-    /// Returns `Ok(true)` if `rel_path` was found and refreshed, `Ok(false)`
-    /// if it is not in the index (a no-op).
+    /// Compatibility adapter: every refresh replaces the complete scan product.
     pub fn refresh_links(&mut self, full_path: &Path, rel_path: &str) -> Result<bool> {
-        let Some(&idx) = self.path_index.get(rel_path) else {
-            return Ok(false);
-        };
-        let fm_props = self.effective_frontmatter_link_props();
-        let (bm25_tokenize, default_language) = self.bm25_scan_args(rel_path);
-        let (scanned, file_links) = scan_one_file(
-            full_path,
-            rel_path,
-            true,
-            bm25_tokenize,
-            default_language.as_deref(),
-            fm_props.as_deref(),
-        )?;
-
-        let entry = &mut self.entries[idx];
-        entry.sections = scanned.sections;
-        entry.tasks = scanned.tasks;
-        entry.links = scanned.links;
-        // iter-252: `size`/`lines` are body-derived, so every write path that
-        // routes through `refresh_links` (set/append/remove, task toggles)
-        // keeps them in step with the bytes now on disk.
-        entry.size = scanned.size;
-        entry.lines = scanned.lines;
-        // BUG-4 (iter-244): keep BM25 tokens current alongside the body so a
-        // post-mutation rebuild of the inverted index scores this file as a
-        // fresh disk scan would. Only touched when the snapshot is a BM25
-        // snapshot (`scan_one_file` returns `None` otherwise).
-        entry.bm25_tokens = scanned.bm25_tokens;
-        entry.bm25_language = scanned.bm25_language;
-        entry.bm25_tokenizer_version = scanned.bm25_tokenizer_version;
-
-        self.graph.remove_source(rel_path);
-        if let Some(fl) = file_links {
-            self.insert_graph_links(fl);
-        }
-
-        Ok(true)
+        self.refresh_entry_and_links_at(full_path, rel_path)
     }
 
-    /// Insert a file's outbound links into the graph, using (and lazily
-    /// building) the cached case-insensitive index. The cache is taken out
-    /// and put back so `self.graph` and `self.header` can be borrowed
-    /// alongside it.
-    fn insert_graph_links(&mut self, fl: FileLinks) {
-        let case_index = self
-            .case_index_cache
-            .take()
-            .unwrap_or_else(|| self.build_case_index());
-        self.graph
-            .insert_links(fl, self.header.site_prefix.as_deref(), &case_index);
-        self.case_index_cache = Some(case_index);
+    /// Configure a generation explicitly. Re-resolves every retained occurrence.
+    pub fn set_resolution_options(
+        &mut self,
+        aliases: bool,
+        case_insensitive: bool,
+        default_language: Option<String>,
+    ) {
+        self.live.aliases = aliases;
+        self.live.case_insensitive = case_insensitive;
+        self.live.default_language = default_language;
+        self.live.language_configured = true;
+        self.rebuild_graph();
+    }
+
+    /// Defer global work until the entire effect/named-refresh batch is collected.
+    pub fn begin_changes(&mut self) {
+        self.live.batching = true;
+    }
+
+    /// Finish one coherent generation, rebuilding global structures at most once.
+    pub fn finish_changes(&mut self) {
+        self.live.batching = false;
+        if self.live.dirty {
+            self.rebuild_graph();
+            self.rebuild_bm25_index();
+            self.live.dirty = false;
+        }
+    }
+
+    /// Work performed by this live owner (no inferred timing claims).
+    pub fn refresh_work(&self) -> RefreshWork {
+        self.live.work
+    }
+
+    /// Current coherent generation, absent while compatibility mutation is pending.
+    pub fn coherent_generation(&self) -> Option<u64> {
+        (!self.live.dirty).then_some(self.live.generation)
+    }
+
+    fn changed(&mut self) {
+        self.live.dirty = true;
+        if !self.live.batching {
+            self.finish_changes();
+        }
+    }
+
+    fn rebuild_graph(&mut self) {
+        let mut lookup = CaseInsensitiveIndex::with_capacity(self.entries.len());
+        lookup.set_case_insensitive_paths(self.live.case_insensitive);
+        lookup.set_complete(true);
+        lookup.set_aliases_enabled(self.live.aliases);
+        for path in self.note_paths() {
+            lookup.insert(path);
+        }
+        for entry in &self.entries {
+            lookup.insert_aliases(
+                &entry.rel_path,
+                crate::filter::extract_aliases(&entry.properties),
+            );
+        }
+        for path in &self.header.attachments {
+            lookup.insert(path);
+        }
+        self.live.generation += 1;
+        let catalog = crate::catalog::VaultCatalog::new(lookup, self.live.generation);
+        self.graph = LinkGraph::from_catalog(
+            self.entries.iter().map(|entry| FileLinks {
+                source: PathBuf::from(&entry.rel_path),
+                links: entry.links.clone(),
+                self_anchors: entry.self_anchors.clone(),
+            }),
+            &catalog,
+            crate::catalog::ResolutionOptions {
+                aliases: self.live.aliases,
+                site_prefix: self.header.site_prefix.as_deref(),
+            },
+        );
+        self.live.catalog = Some(catalog);
+        self.live.work.graph_rebuilds += 1;
+    }
+
+    /// Discovered note identities, including notes without usable scan coverage.
+    pub fn note_paths(&self) -> impl Iterator<Item = &str> {
+        self.entries
+            .iter()
+            .map(|entry| entry.rel_path.as_str())
+            .chain(self.header.skipped.iter().map(String::as_str))
+    }
+
+    fn clear_frontmatter_skip(&mut self, rel_path: &str) {
+        self.header.skipped.retain(|path| path != rel_path);
+        crate::warn::clear_frontmatter_skip(rel_path);
+    }
+
+    /// Validate deferred search resources before a command publishes any note changes.
+    pub fn validate_before_changes(&self) -> Result<()> {
+        anyhow::ensure!(
+            !self.bm25.is_present() || self.bm25.get().is_some(),
+            "snapshot BM25 data is invalid or exceeds its expansion budget; rebuild the index before modifying notes"
+        );
+        Ok(())
+    }
+
+    /// Refresh a checked set of actual effect paths. Scans all replacements before applying any.
+    /// Unsafe effects must be handled by persistent invalidation, never passed here.
+    pub fn apply_changes(&mut self, dir: &Path, paths: &[String]) -> Result<()> {
+        self.validate_before_changes()?;
+        let root = crate::rooted::VaultRoot::new(dir)?;
+        let mut replacements = Vec::with_capacity(paths.len());
+        let mut seen = std::collections::HashSet::with_capacity(paths.len());
+        for rel in paths {
+            if !seen.insert(rel) {
+                continue;
+            }
+            let name = crate::rooted::RelativeName::new(rel)?;
+            let _opened = root.open(&name)?;
+            let (tokenize, language) = self.bm25_scan_args(rel);
+            let (entry, _) = scan_one_file(
+                &dir.join(rel),
+                rel,
+                true,
+                tokenize,
+                language.as_deref(),
+                self.frontmatter_link_props.as_deref(),
+            )?;
+            replacements.push(ScannedDocument { entry });
+        }
+        for document in replacements {
+            let entry = document.entry;
+            self.clear_frontmatter_skip(&entry.rel_path);
+            if let Some(&id) = self.path_index.get(&entry.rel_path) {
+                self.entries[id] = entry;
+            } else {
+                self.entries.push(entry);
+            }
+            self.live.work.documents += 1;
+        }
+        self.entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+        self.rebuild_path_index();
+        self.live.dirty = true;
+        self.finish_changes();
+        Ok(())
     }
 
     /// Re-scan `rel_path` once and refresh both its full index entry (like
@@ -1077,27 +1218,15 @@ impl SnapshotIndex {
         if !self.path_index.contains_key(rel_path) {
             return Ok(false);
         }
-        let file_links = self.rescan_entry_at(full_path, rel_path)?;
-        self.graph.remove_source(rel_path);
-        if let Some(fl) = file_links {
-            self.insert_graph_links(fl);
-        }
+        self.rescan_entry_at(full_path, rel_path)?;
+        self.changed();
         Ok(true)
     }
 
-    /// Re-scan a single file from disk and replace its index entry in-place.
-    ///
-    /// This updates the entry's properties, tags, sections, tasks, links, and
-    /// modified timestamp. The link graph is **not** touched — callers that
-    /// need graph updates should use [`LinkGraph::rename_path`] separately.
-    ///
-    /// Returns `true` if the entry was found and refreshed, `false` if
-    /// `rel_path` is not in the index.
+    /// Compatibility adapter for complete entry, graph and search refresh.
+    /// Returns false when the path is absent; otherwise replaces the full scan product.
     pub fn refresh_entry(&mut self, dir: &Path, rel_path: &str) -> Result<bool> {
-        match self.rescan_entry(dir, rel_path)? {
-            Some(_) => Ok(true),
-            None => Ok(false),
-        }
+        self.refresh_entry_and_links(dir, rel_path)
     }
 
     /// Scan a file at `full_path` and insert (or replace) its entry under
@@ -1128,6 +1257,8 @@ impl SnapshotIndex {
             self.entries.insert(pos, entry);
             self.rebuild_path_index();
         }
+        self.clear_frontmatter_skip(rel_path);
+        self.live.work.documents += 1;
         Ok(file_links)
     }
 
@@ -1150,6 +1281,7 @@ impl SnapshotIndex {
     /// [`Self::insert_or_replace_entry_with_links`] instead.
     pub fn insert_or_replace_entry(&mut self, full_path: &Path, rel_path: &str) -> Result<()> {
         self.insert_or_replace_entry_impl(full_path, rel_path)?;
+        self.changed();
         Ok(())
     }
 
@@ -1168,27 +1300,14 @@ impl SnapshotIndex {
         full_path: &Path,
         rel_path: &str,
     ) -> Result<()> {
-        let file_links = self.insert_or_replace_entry_impl(full_path, rel_path)?;
-        self.graph.remove_source(rel_path);
-        if let Some(fl) = file_links {
-            self.insert_graph_links(fl);
-        }
+        self.insert_or_replace_entry_impl(full_path, rel_path)?;
+        self.changed();
         Ok(())
     }
 
-    /// Rename an entry: remove the old entry, scan the file at its new path,
-    /// and insert the result — rebuilding the path index only once.
-    ///
-    /// This is the preferred move/rename counterpart of [`refresh_entry`].
-    /// Unlike calling [`remove_entry`] followed by [`insert_entry`] (two
-    /// path-index rebuilds), this method defers the rebuild until both the
-    /// removal and insertion are complete.
-    ///
-    /// The link graph is **not** touched — callers must update it separately
-    /// via [`LinkGraph::rename_path`].
-    ///
-    /// Returns `Ok(true)` if `old_rel` was found and replaced, `Ok(false)` if
-    /// `old_rel` was not in the index (in which case nothing is changed).
+    /// Compatibility move adapter: scan the new path, replace the old entry and
+    /// reconcile the complete graph/search generation. Deferred while a batch is open.
+    /// Returns false when the old path is absent.
     pub fn rename_entry(&mut self, dir: &Path, old_rel: &str, new_rel: &str) -> Result<bool> {
         let Some(&old_idx) = self.path_index.get(old_rel) else {
             return Ok(false);
@@ -1208,6 +1327,8 @@ impl SnapshotIndex {
         )?;
 
         // Remove without triggering a path-index rebuild.
+        self.clear_frontmatter_skip(old_rel);
+        self.clear_frontmatter_skip(new_rel);
         self.entries.remove(old_idx);
 
         // Insert in sorted order.
@@ -1219,16 +1340,15 @@ impl SnapshotIndex {
 
         // Single rebuild covering both the removal and the insertion.
         self.rebuild_path_index();
+        self.changed();
         Ok(true)
     }
 
     /// Rebuild the path → index lookup after insertions/removals.
     ///
-    /// Also drops the cached case-insensitive index: every code path that
-    /// changes the set of indexed paths funnels through here, so this is the
-    /// single invalidation point for [`Self::case_index_cache`].
+    /// Drops the frozen catalog; finishing the batch rebuilds it from all entries.
     fn rebuild_path_index(&mut self) {
-        self.case_index_cache = None;
+        self.live.catalog = None;
         self.path_index = self
             .entries
             .iter()
@@ -1247,6 +1367,11 @@ impl SnapshotIndex {
     /// `lint --fix --index`) would silently delete the search index it was
     /// only ever meant to patch.
     pub fn save_to(&self, path: &Path) -> Result<()> {
+        anyhow::ensure!(
+            !self.live.dirty,
+            "index generation is incomplete; finish changes before saving"
+        );
+        self.validate_before_changes()?;
         write_snapshot(
             self,
             path,
@@ -1412,7 +1537,7 @@ impl SnapshotIndex {
                 if validate_bm25(&bm25, warn) {
                     Bm25Section::Loaded(bm25)
                 } else {
-                    Bm25Section::Absent
+                    Bm25Section::Refused
                 }
             }
             PendingBm25::Deferred(offset) => Bm25Section::Deferred {
@@ -1489,15 +1614,22 @@ impl SnapshotIndex {
         // freshly-deserialized graph has an empty one — rebuild it from
         // the restored index keys so `backlinks_ci` works off snapshots.
         graph.rebuild_lower_index();
-        Some(Self {
+        let mut snapshot = Self {
             entries,
             path_index,
             graph,
             header,
             bm25,
             frontmatter_link_props: None,
-            case_index_cache: None,
-        })
+            live: LiveState {
+                aliases: crate::discovery::link_aliases_enabled(),
+                case_insensitive: true,
+                ..LiveState::default()
+            },
+        };
+        // Persisted graphs from older binaries are derived data, never resolution authority.
+        snapshot.rebuild_graph();
+        Some(snapshot)
     }
 
     /// Load a snapshot from a MessagePack file.
@@ -1566,7 +1698,11 @@ impl SnapshotIndex {
 
     /// Return the persisted BM25 inverted index, if present.
     pub fn bm25_index(&self) -> Option<&Bm25InvertedIndex> {
-        self.bm25.get()
+        if self.live.dirty {
+            None
+        } else {
+            self.bm25.get()
+        }
     }
 
     /// Whether the BM25 section is still undecoded (test-only perf invariant).
@@ -1755,7 +1891,7 @@ impl VaultIndex for SnapshotIndex {
     }
 
     fn bm25_index(&self) -> Option<&Bm25InvertedIndex> {
-        self.bm25.get()
+        Self::bm25_index(self)
     }
 
     fn snapshot_format_version(&self) -> Option<u32> {
@@ -2079,28 +2215,6 @@ pub fn refresh_if_changed_on_disk(index: &mut SnapshotIndex, dir: &Path, rel: &s
 /// Refresh an exact path/key pair without reinterpreting it. The caller owns
 /// confinement; the CLI supplies this pair only through its rooted bridge.
 pub fn refresh_if_changed_at(index: &mut SnapshotIndex, full: &Path, rel: &str) -> bool {
-    let Some(entry) = index.get(rel) else {
-        return false;
-    };
-    let Some(indexed) = parse_iso8601_secs(&entry.modified) else {
-        return false;
-    };
-    let Ok(meta) = std::fs::metadata(full) else {
-        return false;
-    };
-    let Ok(modified) = meta.modified() else {
-        return false;
-    };
-    let Ok(disk) = modified.duration_since(SystemTime::UNIX_EPOCH) else {
-        return false;
-    };
-    // Size is compared too: a same-second edit that changes the length is
-    // invisible to an mtime-only check, and appending is exactly that case.
-    if disk.as_secs() <= indexed.saturating_add(STALENESS_TOLERANCE_SECS)
-        && meta.len() == entry.size
-    {
-        return true;
-    }
     index.refresh_entry_and_links_at(full, rel).unwrap_or(false)
 }
 
@@ -3694,6 +3808,128 @@ Content.
         assert!(
             result.is_none(),
             "oversized index file must return Ok(None)"
+        );
+    }
+    #[test]
+    fn iteration292_complete_replacement_and_batch_work() {
+        for (count, dense) in [(8, false), (32, false), (8, true), (32, true)] {
+            let tmp = tempfile::tempdir().unwrap();
+            let paths: Vec<_> = (0..count).map(|id| format!("n{id}.md")).collect();
+            for (id, path) in paths.iter().enumerate() {
+                let links = if dense {
+                    let mut links = String::new();
+                    for target in &paths {
+                        links.push_str("[[");
+                        links.push_str(target);
+                        links.push_str("]] ");
+                    }
+                    links
+                } else {
+                    format!("[[n{}.md]]", (id + 1) % count)
+                };
+                std::fs::write(
+                    tmp.path().join(path),
+                    format!("# Note\noldtoken {links}\n[self](#note)\n- [ ] task\n"),
+                )
+                .unwrap();
+            }
+            let pairs: Vec<_> = paths
+                .iter()
+                .map(|path| (tmp.path().join(path), path.clone()))
+                .collect();
+            let options = ScanOptions {
+                scan_body: true,
+                bm25_tokenize: true,
+                default_language: None,
+                frontmatter_link_props: None,
+            };
+            let build = ScannedIndex::build(&pairs, None, &options).unwrap();
+            let bm25 = Bm25InvertedIndex::build_from_entries(build.index.entries()).unwrap();
+            let snapshot_path = tmp.path().join(".snapshot");
+            SnapshotIndex::save(
+                &build.index,
+                &snapshot_path,
+                tmp.path().to_str().unwrap(),
+                None,
+                Some(&bm25),
+            )
+            .unwrap();
+            let mut snapshot = SnapshotIndex::load(&snapshot_path).unwrap().unwrap();
+            for path in &paths {
+                let original = std::fs::read_to_string(tmp.path().join(path)).unwrap();
+                std::fs::write(
+                    tmp.path().join(path),
+                    format!(
+                        "---\ntitle: Changed\naliases: [Nickname]\nlanguage: german\n---\n{}",
+                        original.replace("oldtoken", "newtoken")
+                    ),
+                )
+                .unwrap();
+            }
+            let before = snapshot.refresh_work();
+            snapshot.apply_changes(tmp.path(), &paths).unwrap();
+            let after = snapshot.refresh_work();
+            assert_eq!(after.graph_rebuilds - before.graph_rebuilds, 1);
+            assert_eq!(after.search_rebuilds - before.search_rebuilds, 1);
+            assert_eq!(after.documents - before.documents, count as u64);
+            eprintln!(
+                "iteration292 batch: files={count}, edges={}, loaded-snapshot/warm-files, graph_rebuilds=1, search_rebuilds=1",
+                if dense { count * count } else { count }
+            );
+            let fresh = ScannedIndex::build(&pairs, None, &options).unwrap();
+            assert_eq!(
+                serde_json::to_value(snapshot.entries()).unwrap(),
+                serde_json::to_value(fresh.index.entries()).unwrap()
+            );
+            snapshot.save_to(&snapshot_path).unwrap();
+            let loaded = SnapshotIndex::load(&snapshot_path).unwrap().unwrap();
+            let expected = Bm25InvertedIndex::build_from_entries(fresh.index.entries()).unwrap();
+            let stemmer = crate::bm25::create_stemmer(crate::bm25::StemLanguage::German);
+            for query in ["newtoken", "oldtoken"] {
+                let actual: Vec<_> = loaded
+                    .bm25_index()
+                    .unwrap()
+                    .score(query, &stemmer)
+                    .into_iter()
+                    .map(|hit| (hit.rel_path, hit.score))
+                    .collect();
+                let expected: Vec<_> = expected
+                    .score(query, &stemmer)
+                    .into_iter()
+                    .map(|hit| (hit.rel_path, hit.score))
+                    .collect();
+                assert_eq!(actual, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn iteration292_alias_changes_reresolve_unchanged_occurrences() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.md"), "[[Nickname]] [[Later]]").unwrap();
+        std::fs::write(tmp.path().join("b.md"), "---\naliases: [Nickname]\n---\n").unwrap();
+        let (_storage, path, mut snapshot) = build_and_reload_snapshot(tmp.path());
+        snapshot.set_resolution_options(true, true, None);
+        assert_eq!(snapshot.link_graph().backlinks("b.md").len(), 1);
+        std::fs::write(tmp.path().join("b.md"), "---\naliases: [Later]\n---\n").unwrap();
+        snapshot
+            .apply_changes(tmp.path(), &["b.md".into()])
+            .unwrap();
+        let backlinks = snapshot.link_graph().backlinks("b.md");
+        assert_eq!(backlinks.len(), 1);
+        assert_eq!(backlinks[0].link.target, "Later");
+        snapshot.save_to(&path).unwrap();
+        std::fs::write(tmp.path().join("Later.md"), "new destination").unwrap();
+        snapshot
+            .apply_changes(tmp.path(), &["Later.md".into()])
+            .unwrap();
+        assert_eq!(snapshot.link_graph().backlinks("Later.md").len(), 1);
+        assert!(snapshot.link_graph().backlinks("b.md").is_empty());
+        std::fs::write(tmp.path().join("b.md"), "---\naliases: [\n---\n").unwrap();
+        assert!(
+            snapshot
+                .apply_changes(tmp.path(), &["b.md".into()])
+                .is_err()
         );
     }
 }

--- a/crates/hyalo-core/src/lib.rs
+++ b/crates/hyalo-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod anchor;
 pub mod auto_link;
 pub mod bm25;
 pub(crate) mod case_index;
+pub mod catalog;
 pub(crate) mod common_words;
 pub mod content_search;
 pub mod discovery;

--- a/crates/hyalo-core/src/link_graph.rs
+++ b/crates/hyalo-core/src/link_graph.rs
@@ -115,6 +115,7 @@ impl LinkGraph {
         let mut index: HashMap<String, Vec<BacklinkEntry>> = HashMap::with_capacity(files.len());
         let mut warnings: Vec<(PathBuf, String)> = Vec::new();
         let mut case_index = CaseInsensitiveIndex::new();
+        case_index.set_aliases_enabled(discovery::link_aliases_enabled());
         // `LinkGraph::build` returns a comprehensive case index spanning the
         // whole vault. Enable case-insensitive path lookups by default so
         // downstream consumers (e.g. `hyalo mv` link rewriting) can use
@@ -184,15 +185,26 @@ impl LinkGraph {
     ///
     /// Warnings are always empty because callers are expected to handle parse errors
     /// before collecting `FileLinks`.
+    #[cfg(test)]
     pub(crate) fn from_file_links(
         file_links: Vec<FileLinks>,
         site_prefix: Option<&str>,
         aliases: &[(String, Vec<String>)],
     ) -> LinkGraphBuild {
+        Self::from_file_links_with_case_policy(file_links, site_prefix, aliases, true)
+    }
+
+    pub(crate) fn from_file_links_with_case_policy(
+        file_links: Vec<FileLinks>,
+        site_prefix: Option<&str>,
+        aliases: &[(String, Vec<String>)],
+        case_insensitive: bool,
+    ) -> LinkGraphBuild {
         let mut index: HashMap<String, Vec<BacklinkEntry>> =
             HashMap::with_capacity(file_links.len());
         let mut case_index = CaseInsensitiveIndex::new();
-        case_index.set_case_insensitive_paths(true);
+        case_index.set_aliases_enabled(discovery::link_aliases_enabled());
+        case_index.set_case_insensitive_paths(case_insensitive);
         for fl in &file_links {
             let rel_fwd = fl.source.to_string_lossy().replace('\\', "/");
             case_index.insert(&rel_fwd);
@@ -213,6 +225,19 @@ impl LinkGraph {
             // The caller scanned the files and never captured the marker.
             split_frontmatter_candidates: Vec::new(),
         }
+    }
+
+    /// Build once from retained authored occurrences and a frozen catalog.
+    pub(crate) fn from_catalog(
+        file_links: impl IntoIterator<Item = FileLinks>,
+        catalog: &crate::catalog::VaultCatalog,
+        options: crate::catalog::ResolutionOptions<'_>,
+    ) -> Self {
+        let mut index = HashMap::new();
+        for links in file_links {
+            insert_file_links_with_options(&mut index, links, catalog.case_index(), options);
+        }
+        Self::from_index(index)
     }
 
     /// Construct a graph from a fully-populated index, deriving the
@@ -481,6 +506,7 @@ impl LinkGraph {
     /// [`remove_source`] first to clear the old ones, then this method to
     /// insert the new ones (mirroring how a full index build populates the
     /// graph from every file's [`FileLinks`], one file at a time).
+    #[cfg(test)]
     pub(crate) fn insert_links(
         &mut self,
         file_links: FileLinks,
@@ -558,81 +584,6 @@ fn strip_md_extension(s: &str) -> &str {
     }
 }
 
-/// Extra backlink index key for a link target that names a *directory*
-/// (iter-203).
-///
-/// `[x](/foo)`, `[x](foo/)` and `[[foo]]` all resolve to `foo/index.md` when
-/// that file exists, so the graph stores an additional `foo/index` key —
-/// `.md`-stripped, matching how path-form wikilinks are stored — and
-/// `backlinks("foo/index.md")` finds them through its built-in `.md` toggle.
-///
-/// Mirrors `discovery::resolve_target`'s precedence so the graph and the
-/// read-side resolver agree: a target that already names a real file (`foo`
-/// with `foo.md` present) is not a directory reference, unless it was written
-/// with a trailing slash, which is explicit.
-///
-/// `trailing_slash` must describe the target **as written** — normalization
-/// drops it, but it is what makes the reference explicit.
-///
-/// Returns `None` when the target is not a resolvable directory reference.
-fn directory_index_key(
-    target: &str,
-    trailing_slash: bool,
-    case_index: &CaseInsensitiveIndex,
-) -> Option<String> {
-    let trimmed = target.trim_end_matches('/');
-    if trimmed.is_empty() || trimmed.starts_with('/') {
-        return None;
-    }
-    // A target that already carries `.md` names a file, never a directory.
-    if strip_md_extension(trimmed) != trimmed {
-        return None;
-    }
-    let exists =
-        |path: &str| case_index.contains_path(path) || case_index.lookup_unique(path).is_some();
-    if exists(trimmed) {
-        return None;
-    }
-    if !trailing_slash && exists(&format!("{trimmed}.md")) {
-        return None;
-    }
-    let dir_index = format!("{trimmed}/{}", crate::discovery::DIRECTORY_INDEX_FILE);
-    if case_index.contains_path(&dir_index) {
-        return Some(strip_md_extension(&dir_index).to_owned());
-    }
-    let canonical = case_index.lookup_unique(&dir_index)?;
-    Some(strip_md_extension(canonical).to_owned())
-}
-
-/// Whether `target` names a **vault attachment**, for
-/// [`crate::types::is_note_graph_edge`]'s `is_attachment` parameter
-/// (iter-261; index-aware fix in iter-277 review).
-///
-/// This graph's own `case_index` holds notes only (see [`insert_file_links`]),
-/// so a real attachment like `real.png` is never a `contains_path` /
-/// `lookup_unique` / `lookup_stem` hit here — it falls through to the
-/// syntactic fallback below, same as a genuinely missing one. What the index
-/// *does* settle is the opposite case: a note called `Foo.v2.md`, linked as
-/// `[[Foo.v2]]` — `lookup_stem("Foo.v2")` finds the note, so the syntactic
-/// "`v2` looks like an extension" guess never gets a chance to misfire.
-fn target_is_attachment(target: &str, case_index: &CaseInsensitiveIndex) -> bool {
-    let normalized = target.replace('\\', "/");
-    if case_index.contains_path(&normalized) {
-        return !crate::discovery::has_md_extension(&normalized);
-    }
-    if let Some(path) = case_index.lookup_unique(&normalized) {
-        return !crate::discovery::has_md_extension(path);
-    }
-    let basename = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
-    if let Some(path) = case_index.lookup_stem(basename) {
-        return !crate::discovery::has_md_extension(path);
-    }
-    // No index hit at all: resolution never crosses an explicit extension
-    // (DEC-266), so a target that still looks like it carries a non-`.md`
-    // extension can only ever have named an attachment — existing or not.
-    crate::discovery::has_non_md_extension(target)
-}
-
 /// Normalize and insert one file's links into the shared index.
 fn insert_file_links(
     index: &mut HashMap<String, Vec<BacklinkEntry>>,
@@ -640,135 +591,48 @@ fn insert_file_links(
     site_prefix: Option<&str>,
     case_index: &CaseInsensitiveIndex,
 ) {
-    for (line, mut link) in file_links.links {
-        // DEC-318 (iter-277): one predicate decides what an edge is, shared
-        // verbatim with `find --orphan` / `find --dead-end`. It covers the
-        // external URI of iter-261 / BUG-2 (`obsidian://…`, `mailto:…` name
-        // nothing in the vault) and the attachment reference of BUG-5 / BUG-6
-        // (`![[img.png]]`, `[[Books.base]]` — a note whose only outbound link
-        // is an image is still a dead end, and nothing queries
-        // `backlinks img.png`) — decided here by [`target_is_attachment`],
-        // whose fallback keeps it agreeing with `find`'s own verdict even
-        // though this graph's own `case_index` holds notes only (BUG-16).
-        let is_attachment = target_is_attachment(&link.target, case_index);
-        if !crate::types::is_note_graph_edge(&link.target, link.external, is_attachment) {
-            continue;
-        }
-        // Captured before normalization, which drops it: a trailing slash is
-        // what marks a target as an explicit directory reference (iter-203).
-        let raw_trailing_slash = link.target.ends_with('/');
-        // Normalize markdown link targets that contain path separators
-        // so that, for example, `sub/a.md` linking to `../target.md`
-        // is stored as `target.md`, matching how callers query by
-        // vault-relative path.
-        //
-        // Wikilinks are vault-relative by definition — `[[backlog/item]]`
-        // written in any file always refers to `backlog/item.md` at the
-        // vault root, never a path relative to the source file.  They
-        // must NOT be passed through `normalize_target`.
-        //
-        // Exception: `[[./something]]` uses an explicit current-directory
-        // prefix.  Normalize these the same way as markdown links so that
-        // `[[./b]]` in `notes/a.md` is indexed as `notes/b` and matches
-        // a backlink query for `notes/b.md`.
-        // L-23: percent-decode markdown destinations so that a linker who wrote
-        // `[x](my%20dest.md)` is indexed under the decoded key `my dest.md` —
-        // matching how callers query `backlinks "my dest.md"` and stopping
-        // `find --broken-links` from false-positiving. Malformed / non-UTF-8
-        // escapes keep the literal text (helper returns None). Wikilinks are not
-        // decoded (they never carry percent-escapes).
-        if link.kind == LinkKind::Markdown
-            && let Some(decoded) = crate::discovery::percent_decode_path(&link.target)
-        {
-            link.target = decoded;
-        }
-        if link.kind == LinkKind::Wikilink && link.target.starts_with("./") {
-            link.target = normalize_target(&file_links.source, &link.target[2..]);
-        } else if link.kind == LinkKind::Markdown
-            && (link.target.contains('/') || link.target.contains('\\'))
-        {
-            if link.target.starts_with('/') {
-                link.target = strip_site_prefix(&link.target, site_prefix);
-            } else {
-                link.target = normalize_target(&file_links.source, &link.target);
+    insert_file_links_with_options(
+        index,
+        file_links,
+        case_index,
+        crate::catalog::ResolutionOptions {
+            aliases: case_index.aliases_enabled(),
+            site_prefix,
+        },
+    );
+}
+
+fn insert_file_links_with_options(
+    index: &mut HashMap<String, Vec<BacklinkEntry>>,
+    file_links: FileLinks,
+    case_index: &CaseInsensitiveIndex,
+    options: crate::catalog::ResolutionOptions<'_>,
+) {
+    use crate::catalog::Resolution;
+    for (line, link) in file_links.links {
+        let resolved = crate::catalog::resolve(
+            case_index,
+            &file_links.source.to_string_lossy(),
+            link.kind,
+            &link.target,
+            options,
+        );
+        let key = match resolved {
+            Resolution::Resolved(path) => strip_md_extension(&path).to_owned(),
+            Resolution::External | Resolution::Attachment(_) => continue,
+            Resolution::Missing | Resolution::Ambiguous(_) => {
+                if link.kind == LinkKind::Markdown && !link.target.starts_with('/') {
+                    normalize_target(&file_links.source, &link.target)
+                } else {
+                    strip_site_prefix(link.target.trim(), options.site_prefix)
+                }
             }
-        }
-        // iter-211 / BUG-10: a trailing slash is a directory *spelling*, never
-        // part of the key. `normalize_target` already drops it for relative
-        // targets, but `strip_site_prefix` keeps it, so `[b](/baz/)` was
-        // indexed under `baz/` — a key `backlinks baz.md` (which probes `baz.md`
-        // and `baz`) can never hit, even though `find --broken-links` happily
-        // resolved the same link to `baz.md`. Strip it uniformly, after
-        // `raw_trailing_slash` has captured the author's spelling for the
-        // directory-index rule below.
-        while link.target.len() > 1 && link.target.ends_with('/') {
-            link.target.pop();
-        }
-
-        // Compute an extra storage key for bare-basename wikilinks that
-        // unambiguously resolve to a known vault file, so
-        // `backlinks("rdp/resources/reflow.md")` finds `[[reflow]]` written
-        // anywhere in the vault. The canonical path is stored with the `.md`
-        // suffix stripped — matching how path-form wikilinks (`[[a/b]]`) are
-        // stored — so that `backlinks()`'s built-in `.md` toggle handles both
-        // query forms naturally. We skip insertion when the resolved key would
-        // equal the raw target (only `.md`-suffix difference) to avoid
-        // double-counting via the toggle.
-        //
-        // iter-272 Part B (DEC-296): when no file has that stem, a frontmatter
-        // `aliases:` entry can still name one — and an alias-resolved link is
-        // a real graph edge, so `backlinks`, `--orphan`, `--dead-end` and
-        // `summary.links` all agree with what `find --fields links` reports.
-        // A filename always wins: the alias lookup runs only after
-        // `lookup_stem` comes up empty.
-        let resolved_key = (link.kind == LinkKind::Wikilink
-            && !link.target.contains('/')
-            && !link.target.contains('\\'))
-        .then(|| {
-            let stem = strip_md_extension(&link.target);
-            case_index
-                .lookup_stem(stem)
-                .or_else(|| case_index.lookup_alias(stem))
-                .map(|canon| strip_md_extension(canon).to_owned())
-        })
-        .flatten()
-        .filter(|resolved| *resolved != link.target);
-
-        // iter-203: a target naming a directory (`/foo`, `foo`, `foo/`) is a
-        // backlink of `foo/index.md`. Store the extra key so `backlinks` and
-        // `mv` see those edges. Only one extra key is ever added: a target is
-        // either a stem hit or a directory hit, never both.
-        let dir_index_key = resolved_key
-            .is_none()
-            .then(|| directory_index_key(&link.target, raw_trailing_slash, case_index))
-            .flatten()
-            .filter(|resolved| *resolved != link.target);
-
-        let entry = BacklinkEntry {
+        };
+        index.entry(key).or_default().push(BacklinkEntry {
             source: file_links.source.clone(),
             line,
-            link: link.clone(),
-        };
-        // iter-211 / BUG-10 — **one link occurrence, one index key.**
-        //
-        // Resolution above already picked the single file this occurrence
-        // points at, mirroring `discovery::resolve_target`'s precedence. The
-        // graph therefore stores the *resolved* key when there is one and the
-        // written key otherwise — never both. Registering both is what made
-        // a single `[b](foo/)` show up as a backlink of `foo.md` *and*
-        // `foo/index.md` when both files existed, while `links` reported
-        // `ambiguous: 0`.
-        //
-        // This generalizes the narrower L-1 rule it replaces (which suppressed
-        // the written key only when it was an ASCII-case variant of the
-        // canonical one, e.g. `[[NOTE]]` → `note.md`). Nothing is lost:
-        // `backlinks` / `backlinks_ci` probe both the `.md` and stem forms of
-        // the canonical path, and `mv` rewrites from the `BacklinkEntry`,
-        // which still carries the original written link text.
-        let key = resolved_key
-            .or(dir_index_key)
-            .unwrap_or_else(|| link.target.clone());
-        index.entry(key).or_default().push(entry);
+            link,
+        });
     }
 }
 
@@ -2043,6 +1907,7 @@ mod tests {
     fn insert_links_adds_edges_without_touching_other_sources() {
         let mut graph = LinkGraph::default();
         let mut case_index = CaseInsensitiveIndex::new();
+        case_index.set_aliases_enabled(discovery::link_aliases_enabled());
         case_index.set_case_insensitive_paths(true);
         case_index.insert("note.md");
         case_index.insert("target.md");
@@ -2094,6 +1959,7 @@ mod tests {
         );
 
         let mut case_index = CaseInsensitiveIndex::new();
+        case_index.set_aliases_enabled(discovery::link_aliases_enabled());
         case_index.set_case_insensitive_paths(true);
         for p in ["note.md", "old-dep.md", "new-dep.md"] {
             case_index.insert(p);
@@ -2179,6 +2045,7 @@ mod tests {
 
         // insert_links: re-insert a.md with a brand-new target key.
         let mut case_index = CaseInsensitiveIndex::new();
+        case_index.set_aliases_enabled(discovery::link_aliases_enabled());
         case_index.set_case_insensitive_paths(true);
         for p in ["Baz.md", "Bar.md", "a.md", "b.md", "Quux.md"] {
             case_index.insert(p);
@@ -2522,12 +2389,8 @@ mod tests {
         );
 
         // The raw graph entry for the written link "Web/Foo" should exist.
-        let bl = graph.backlinks("Web/Foo");
-        assert_eq!(
-            bl.len(),
-            1,
-            "backlinks for the written key 'Web/Foo' should find 1 entry"
-        );
+        let bl = graph.backlinks("web/foo");
+        assert_eq!(bl.len(), 1, "backlinks use the resolved canonical key");
         assert_eq!(bl[0].source, PathBuf::from("other.md"));
     }
 

--- a/crates/hyalo-core/src/link_resolve.rs
+++ b/crates/hyalo-core/src/link_resolve.rs
@@ -1,26 +1,4 @@
-//! Unified **rewrite-planning** link resolver for `hyalo`'s link-*mutating*
-//! commands (`mv`, auto-link planning).
-//!
-//! [`LinkResolver`] is the write-side resolver: it decides how to *rewrite* a
-//! link when a file moves or a bare title is auto-linked. It is deliberately
-//! **distinct** from the read-side entry points in
-//! [`crate::discovery`] — `resolve_link_from_source` (Exists mode: "does this
-//! link resolve to a vault file?") and `classify_link_from_source` (Classify
-//! mode: the full fix-policy verdict used by `links fix`). A reader auditing for
-//! stray resolution loops should count this module as the sanctioned
-//! rewrite-planning resolver, not a rogue duplicate of those two.
-//!
-//! It consolidates the three independent resolver implementations that existed
-//! before iter-150:
-//! - `StemIndex` (now in `discovery.rs`, formerly `link_fix.rs`)
-//! - `CaseInsensitiveIndex` in `link_graph.rs`
-//! - Ad-hoc canonicalization in `link_rewrite.rs:plan_inbound_rewrites`
-//!
-//! A single ordered precedence for match strategies is applied:
-//! 1. Exact path match (stem or `.md` form).
-//! 2. Case-insensitive path match (through [`CaseInsensitiveIndex`]).
-//! 3. `.md`-suffix tolerance (wikilinks with explicit `.md`).
-//! 4. Bare-basename stem lookup — returns `Ambiguous` when >1 match.
+//! Rewrite policy adapter over the shared source-aware catalog resolver.
 
 use std::path::Path;
 
@@ -72,6 +50,7 @@ pub fn detect_wikilink_form(raw_target: &str) -> WrittenForm {
 pub struct LinkResolver<'a> {
     case_index: &'a CaseInsensitiveIndex,
     site_prefix: Option<&'a str>,
+    aliases: bool,
 }
 
 impl<'a> LinkResolver<'a> {
@@ -80,6 +59,7 @@ impl<'a> LinkResolver<'a> {
         Self {
             case_index,
             site_prefix,
+            aliases: case_index.aliases_enabled(),
         }
     }
 
@@ -98,78 +78,19 @@ impl<'a> LinkResolver<'a> {
         old_rel: &str,
         old_stem: &str,
     ) -> bool {
-        match span.kind {
-            LinkKind::Wikilink => self.wikilink_matches(span, source_rel, old_rel, old_stem),
-            LinkKind::Markdown => self.markdown_matches(span, source_rel, old_rel, old_stem),
-        }
-    }
-
-    fn wikilink_matches(
-        &self,
-        span: &LinkSpan,
-        source_rel: &str,
-        old_rel: &str,
-        old_stem: &str,
-    ) -> bool {
-        let t = &span.link.target;
-        // Normalize `./`-prefixed wikilinks against source dir.
-        let resolved: std::borrow::Cow<str> = if let Some(wo) = t.strip_prefix("./") {
-            std::borrow::Cow::Owned(normalize_target(Path::new(source_rel), wo))
-        } else {
-            std::borrow::Cow::Borrowed(t.as_str())
-        };
-        let t = resolved.as_ref();
-
-        let is_bare = !(t.contains('/') || t.contains('\\'));
-        if is_bare {
-            // Bare wikilinks: only rewrite when unambiguously resolved to old_rel.
-            let t_norm = t.to_ascii_lowercase();
-            let stem = if Path::new(&t_norm)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
-            {
-                &t_norm[..t_norm.len() - 3]
-            } else {
-                &t_norm
-            };
-            let canonical = self.case_index.lookup_stem(stem);
-            canonical == Some(old_rel) || canonical == Some(old_stem)
-        } else if t == old_stem || t == old_rel {
-            true
-        } else {
-            // Case-insensitive path canonicalization.
-            let t_norm = t.replace('\\', "/").to_ascii_lowercase();
-            let canonical = self.case_index.lookup_unique(&t_norm).or_else(|| {
-                let with_md = format!("{t_norm}.md");
-                self.case_index.lookup_unique(&with_md)
-            });
-            canonical == Some(old_rel) || canonical == Some(old_stem)
-        }
-    }
-
-    fn markdown_matches(
-        &self,
-        span: &LinkSpan,
-        source_rel: &str,
-        old_rel: &str,
-        old_stem: &str,
-    ) -> bool {
-        use crate::link_graph::strip_site_prefix;
-
-        let norm = if span.link.target.starts_with('/') {
-            strip_site_prefix(&span.link.target, self.site_prefix)
-        } else {
-            normalize_target(Path::new(source_rel), &span.link.target)
-        };
-        if norm == old_rel || norm == old_stem {
-            return true;
-        }
-        let norm_lower = norm.to_ascii_lowercase();
-        let canonical = self.case_index.lookup_unique(&norm_lower).or_else(|| {
-            let with_md = format!("{norm_lower}.md");
-            self.case_index.lookup_unique(&with_md)
-        });
-        canonical == Some(old_rel) || canonical == Some(old_stem)
+        let _ = old_stem;
+        crate::catalog::resolve(
+            self.case_index,
+            source_rel,
+            span.kind,
+            &span.link.target,
+            crate::catalog::ResolutionOptions {
+                aliases: self.aliases,
+                site_prefix: self.site_prefix,
+            },
+        )
+        .path()
+            == Some(old_rel)
     }
 
     /// Whether `span` is a **directory reference** to `old_rel` (iter-203).
@@ -192,6 +113,21 @@ impl<'a> LinkResolver<'a> {
     ) -> Option<bool> {
         use crate::link_graph::strip_site_prefix;
 
+        if crate::catalog::resolve(
+            self.case_index,
+            source_rel,
+            span.kind,
+            &span.link.target,
+            crate::catalog::ResolutionOptions {
+                aliases: self.aliases,
+                site_prefix: self.site_prefix,
+            },
+        )
+        .path()
+            != Some(old_rel)
+        {
+            return None;
+        }
         let old_dir = crate::discovery::directory_for_index_file(old_rel)?;
 
         let raw = span.link.target.replace('\\', "/");
@@ -259,12 +195,14 @@ impl<'a> LinkResolver<'a> {
     /// Used by the ambiguity-detection path in `mv` to distinguish `Hit` (safe
     /// to rewrite) from `Ambiguous` (warn + skip without `--allow-ambiguous`).
     pub fn resolve_stem(&self, stem: &str) -> Resolution {
-        let stem_lower = stem.to_ascii_lowercase();
-        let candidates = self.case_index.lookup_stem_all(&stem_lower);
-        match candidates.len() {
-            0 => Resolution::Broken,
-            1 => Resolution::Hit {
-                vault_path: candidates[0].clone(),
+        // A move deliberately has a stronger refusal policy than a read: a
+        // root-path winner does not make a multiply declared bare name safe
+        // to rewrite, and a stable alias should keep its authored spelling.
+        let candidates = self.case_index.lookup_stem_all(stem.trim());
+        match candidates {
+            [] => Resolution::Broken,
+            [only] => Resolution::Hit {
+                vault_path: only.to_owned(),
             },
             _ => Resolution::Ambiguous(candidates.to_vec()),
         }

--- a/crates/hyalo-core/src/warn.rs
+++ b/crates/hyalo-core/src/warn.rs
@@ -49,8 +49,8 @@ pub enum SkipKind {
 
 /// Files dropped during this process's scans, in the order they were seen.
 ///
-/// Process-global and never cleared outside tests: one `hyalo` process is one
-/// CLI run. A poisoned lock degrades to "not collected" rather than aborting a
+/// Process-global for one CLI run. A successful rescan clears only the
+/// superseded frontmatter skip for its path. A poisoned lock degrades to "not collected" rather than aborting a
 /// walk.
 static SKIPPED: Mutex<Vec<SkippedFile>> = Mutex::new(Vec::new());
 
@@ -131,6 +131,16 @@ pub fn record_skip(path: impl Into<String>, reason: impl Into<String>, kind: Ski
     }
     if let Ok(mut skipped) = SKIPPED.lock() {
         skipped.push(SkippedFile { path, reason, kind });
+    }
+}
+
+/// A successful rescan supersedes this path's earlier frontmatter diagnostic.
+pub(crate) fn clear_frontmatter_skip(path: &str) {
+    if let Ok(mut skipped) = SKIPPED.lock() {
+        skipped.retain(|file| file.path != path || file.kind != SkipKind::Frontmatter);
+    }
+    if let Ok(mut recorded) = RECORDED.lock() {
+        recorded.retain(|seen| seen != path);
     }
 }
 

--- a/crates/hyalo-core/tests/expansion_budget.rs
+++ b/crates/hyalo-core/tests/expansion_budget.rs
@@ -1,0 +1,67 @@
+use hyalo_core::bm25::Bm25InvertedIndex;
+use hyalo_core::index::SnapshotIndex;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+struct MeasuredAllocator;
+static MEASURE: AtomicBool = AtomicBool::new(false);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+// Safety: all operations delegate the unchanged layout/pointer to System.
+unsafe impl GlobalAlloc for MeasuredAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if MEASURE.load(Ordering::Relaxed) {
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe {
+            System.dealloc(ptr, layout);
+        }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        if MEASURE.load(Ordering::Relaxed) {
+            BYTES.fetch_add(size, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+#[global_allocator]
+static ALLOCATOR: MeasuredAllocator = MeasuredAllocator;
+
+#[test]
+fn compact_snapshot_refuses_expansion_before_effect_refresh_with_measured_allocations() {
+    let tmp = tempfile::tempdir().unwrap();
+    let note = tmp.path().join("a.md");
+    std::fs::write(&note, "unchanged authored note\n").unwrap();
+    let term = "x".repeat(8192);
+    let bm25 = serde_json::json!({"postings": {term: [{"doc_id":0,"term_freq":32768,"positions":(0..32768).collect::<Vec<_>>()}]}, "doc_lengths":[32768], "doc_paths":["a.md"],"avgdl":32768.0,"tokenizer_version":1});
+    let index: Bm25InvertedIndex = serde_json::from_value(bm25.clone()).unwrap();
+    let envelope = serde_json::json!({"header":{"vault_dir":tmp.path(),"site_prefix":null,"created_at":0,"pid":0,"format_version":2},"entries":[],"graph":{"index":{}},"bm25_index":bm25});
+    let path = tmp.path().join(".snapshot");
+    let bytes = rmp_serde::to_vec_named(&envelope).unwrap();
+    assert!(bytes.len() < 200_000);
+    std::fs::write(&path, &bytes).unwrap();
+    BYTES.store(0, Ordering::Relaxed);
+    MEASURE.store(true, Ordering::Relaxed);
+    assert!(index.reconstruct_all_tokens().is_empty());
+    let mut snapshot = SnapshotIndex::load(&path).unwrap().unwrap();
+    assert!(snapshot.bm25_index().is_none());
+    assert!(snapshot.validate_before_changes().is_err());
+    assert!(
+        snapshot
+            .apply_changes(tmp.path(), &["a.md".into()])
+            .is_err()
+    );
+    MEASURE.store(false, Ordering::Relaxed);
+    let allocated = BYTES.load(Ordering::Relaxed);
+    assert!(allocated < 4 * 1024 * 1024, "allocated {allocated} bytes");
+    assert_eq!(
+        std::fs::read_to_string(note).unwrap(),
+        "unchanged authored note\n"
+    );
+    eprintln!(
+        "snapshot_bytes={}, attempted_expansion>256MiB, measured_allocation_bytes={allocated}, budget=4MiB",
+        bytes.len()
+    );
+}

--- a/hyalo-knowledgebase/iterations/iteration-292-query-resolution-and-index-coherence.md
+++ b/hyalo-knowledgebase/iterations/iteration-292-query-resolution-and-index-coherence.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 292 — Query, resolution and index coherence
 date: 2026-09-10
-status: in-progress
+status: completed
 tags:
   - iteration
   - rust
@@ -315,7 +315,7 @@ ambiguous links. Do not conflate graph identity with filesystem move identity.
   then use target/release/hyalo for changed-document inspection/strict lint and run git diff
   --check. Do not rebuild an unchanged binary between documentation-only internal stages.
 
-- [ ] In an authorized remote run, publish one PR and wait for required CI on its final head;
+- [x] In an authorized remote run, publish one PR and wait for required CI on its final head;
   preserve required multi-platform jobs and GitHub merge checks. Avoid draft pushes merely to
   checkpoint internal stages. This planning request itself authorizes no implementation or
   publication.
@@ -402,3 +402,7 @@ measured about 246 KiB allocated against a 4 MiB test budget before rejecting ex
 256 MiB. These observations do not imply universal process-memory isolation, filesystem race
 immunity or a whole-vault crash transaction. Exact interfaces and successor ownership are
 recorded in the architecture handoff and the complete original acceptance/finding ledgers.
+
+PR #348 passed all eleven required checks at implementation head
+8fbe74f3ad140cc003c2db7481612fad4e6297e4, including native platform tests and all npm
+launchers. The completed metadata head must pass its own checks before GitHub merge.

--- a/hyalo-knowledgebase/iterations/iteration-292-query-resolution-and-index-coherence.md
+++ b/hyalo-knowledgebase/iterations/iteration-292-query-resolution-and-index-coherence.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 292 — Query, resolution and index coherence
 date: 2026-09-10
-status: planned
+status: in-progress
 tags:
   - iteration
   - rust
@@ -50,41 +50,41 @@ consolidation changes execution granularity, not scope.
 
 ### Stage 1: One catalog and target-resolution policy
 
-- [ ] Introduce an immutable per-generation VaultCatalog containing canonical paths,
+- [x] Introduce an immutable per-generation VaultCatalog containing canonical paths,
   directory/stem lookup and optional alias declarations. Keep catalog keys independent from
   filesystem entry identity used for writes.
 
-- [ ] Expose Resolution::Resolved/External/Attachment/Missing/Ambiguous (or equivalent existing
+- [x] Expose Resolution::Resolved/External/Attachment/Missing/Ambiguous (or equivalent existing
   types) from a shared source-aware resolver. Preserve authored target text, target kind,
   fragment and source location separately. Pass alias/case/site-prefix options explicitly;
   remove process-global alias mode reads from migrated resolution paths. Represent catalog
   completeness separately from selected-file coverage.
 
-- [ ] Centralize relative/root/site-prefix resolution, case policy, padded wikilinks, alias
+- [x] Centralize relative/root/site-prefix resolution, case policy, padded wikilinks, alias
   opt-in and ambiguity precedence. Migrate graph key construction and rewrite planning to the
   same resolver; semantic link case-folding must not determine filesystem rename collisions.
 
-- [ ] Keep raw outbound occurrences available so a catalog change can re-resolve links from
+- [x] Keep raw outbound occurrences available so a catalog change can re-resolve links from
   unchanged sources, including previously missing/ambiguous references.
 
-- [ ] Unify frontmatter/body link occurrence handoff without making a second YAML parser in
+- [x] Unify frontmatter/body link occurrence handoff without making a second YAML parser in
   graph code. YAML lexical source-span repair belongs to iteration 291 after framing migration.
 
-- [ ] Keep old public helper wrappers where needed for compatibility; remove private duplicate
+- [x] Keep old public helper wrappers where needed for compatibility; remove private duplicate
   normalization and paths-only alias caches after callers migrate.
 
 Acceptance for this stage (focused checks):
 
-- [ ] With root b.md and sub/b.md, sub/a.md `[b](b.md)` resolves identically in find, backlinks,
+- [x] With root b.md and sub/b.md, sub/a.md `[b](b.md)` resolves identically in find, backlinks,
   broken-link checks and move planning.
 
-- [ ] Alias enable/disable, alias collision, new destination, renamed destination and previously
+- [x] Alias enable/disable, alias collision, new destination, renamed destination and previously
   unresolved references use one precedence policy.
 
-- [ ] Read-side ambiguity is retained rather than arbitrarily selecting a candidate; writers
+- [x] Read-side ambiguity is retained rather than arbitrarily selecting a candidate; writers
   preserve documented refusal/skip behavior.
 
-- [ ] Resolution uses retained catalog data without a filesystem stat per link on the normal
+- [x] Resolution uses retained catalog data without a filesystem stat per link on the normal
   indexed path.
 
 Scope: No global mutable resolver cache, new graph database or change to the default alias
@@ -93,18 +93,18 @@ documented version boundary is chosen.
 
 ### Stage 2: Bound snapshot expansion before reconstruction
 
-- [ ] S10: validate checked aggregate expanded-token bytes before accepting/reconstructing BM25
+- [x] S10: validate checked aggregate expanded-token bytes before accepting/reconstructing BM25
   data, in addition to file/posting/doc counts. Prefer compact term IDs or borrowed postings
   while preserving phrase positions; no attacker-controlled product of term length and
   occurrence count may escape the bound.
 
-- [ ] Construct small crafted snapshots with oversized term/position expansion and a low test
+- [x] Construct small crafted snapshots with oversized term/position expansion and a low test
   budget. Reject before allocation and before any indexed mutation writes. Test initial load and
   effect-triggered refresh; do not attempt a 100-GiB allocation.
 
 Acceptance for this stage (focused checks):
 
-- [ ] Crafted snapshot expansion is refused within a small measured allocation budget before
+- [x] Crafted snapshot expansion is refused within a small measured allocation budget before
   content changes; existing valid snapshots remain usable or clearly rebuildable.
 
 Scope: S10 is fully closed in this block before introducing broader index reconstruction. Use
@@ -112,48 +112,48 @@ compact adversarial fixtures and low test budgets, never deliberate host exhaust
 
 ### Stage 3: One owner for complete snapshot updates
 
-- [ ] Before any new reconstruction path is used, enforce checked aggregate expanded-token
+- [x] Before any new reconstruction path is used, enforce checked aggregate expanded-token
   budgets on loaded BM25 data. This prerequisite guard prevents S10 amplification during
   migration; the preceding snapshot-budget stage in this block provides adversarial coverage.
 
-- [ ] Create a complete ScannedDocument replacement value and private owned live index state
+- [x] Create a complete ScannedDocument replacement value and private owned live index state
   with explicit generation/freshness for catalog, graph and search data. Keep serialized
   snapshot DTOs separate from mutable runtime state.
 
-- [ ] Offer one apply_changes/refresh_documents boundary that consumes actual effect records or
+- [x] Offer one apply_changes/refresh_documents boundary that consumes actual effect records or
   named-file refresh requests. Replace every scan-derived field together, including
   self_anchors, token language and validity metadata.
 
-- [ ] When catalog inputs change (paths, aliases, stems or resolution config), rebuild the
+- [x] When catalog inputs change (paths, aliases, stems or resolution config), rebuild the
   catalog and graph once from retained occurrences for all sources. This includes unchanged
   sources and missing/ambiguous edges; updating only modified files is insufficient.
 
-- [ ] On token-affecting changes, rebuild or explicitly invalidate BM25 once per batch. Do not
+- [x] On token-affecting changes, rebuild or explicitly invalidate BM25 once per batch. Do not
   leave old postings marked current after a named-file refresh. Prefer coherent bounded
   reconstruction before a complex fully incremental scorer.
 
-- [ ] Make snapshot persistence consume only coherent state; failures leave the file effects
+- [x] Make snapshot persistence consume only coherent state; failures leave the file effects
   intact but report invalidated/unavailable index disposition. Preserve snapshot wire
   compatibility where possible; version semantic changes deliberately and test old-snapshot
   fallback. Invalidation is an observed persistence operation, not an in-memory label: if
   invalidation fails, report stale state and its error rather than success.
 
-- [ ] Migrate journal and find refresh callers to the owner and remove their selective field
+- [x] Migrate journal and find refresh callers to the owner and remove their selective field
   assignments/direct graph mutation. Public legacy APIs get compatibility adapters rather than
   silent semver breaks.
 
 Acceptance for this stage (focused checks):
 
-- [ ] After set/append/task/move, disk and indexed normalized results agree for fields, anchors,
+- [x] After set/append/task/move, disk and indexed normalized results agree for fields, anchors,
   aliases, link resolution and ranked eligibility.
 
-- [ ] Adding/removing an alias or target updates backlinks from unchanged source notes,
+- [x] Adding/removing an alias or target updates backlinks from unchanged source notes,
   including prior missing/ambiguous targets.
 
-- [ ] Named-file refresh finds new terms and no longer matches removed terms; stale data is
+- [x] Named-file refresh finds new terms and no longer matches removed terms; stale data is
   never silently considered fresh.
 
-- [ ] Instrumented bulk updates rebuild global graph/search structures at most once per batch
+- [x] Instrumented bulk updates rebuild global graph/search structures at most once per batch
   when required, not once per modified file.
 
 Scope: Do not combine this migration with a new snapshot format, new persistence database and
@@ -162,39 +162,39 @@ explicit; performance optimization follows parity.
 
 ### Stage 4: Typed query atoms and eligibility before scoring
 
-- [ ] Represent Term and Phrase atoms distinctly with their required/optional/forbidden
+- [x] Represent Term and Phrase atoms distinctly with their required/optional/forbidden
   occurrence semantics. Preserve the currently documented flat OR behavior; do not silently
   introduce a new operator-precedence grammar.
 
-- [ ] Compile query normalization/stemming once with explicit effective language. Evaluate
+- [x] Compile query normalization/stemming once with explicit effective language. Evaluate
   term/phrase document sets, including positional adjacency for phrases, before ranking eligible
   documents.
 
-- [ ] Compute scores from satisfied positive clauses only. A failed optional phrase must neither
+- [x] Compute scores from satisfied positive clauses only. A failed optional phrase must neither
   veto another satisfied OR clause nor admit documents with only part of the phrase.
 
-- [ ] Reuse compiled term/phrase semantics in disk fallback, indexed evaluation and snippet
+- [x] Reuse compiled term/phrase semantics in disk fallback, indexed evaluation and snippet
   selection where appropriate; retain legitimate empty snippets for title-only/cross-line
   matches.
 
-- [ ] Add a small independent straightforward evaluator for test corpora, then compare optimized
+- [x] Add a small independent straightforward evaluator for test corpora, then compare optimized
   results against it across generated term/phrase/negation combinations.
 
-- [ ] Remove intertwined clause-specific eligibility mutations from the scoring loop after all
+- [x] Remove intertwined clause-specific eligibility mutations from the scoring loop after all
   consumers use the new evaluator.
 
 Acceptance for this stage (focused checks):
 
-- [ ] "red blue" OR green includes green red x blue, excludes red alone, and includes an
+- [x] "red blue" OR green includes green red x blue, excludes red alone, and includes an
   adjacent red blue phrase.
 
-- [ ] rust -"memory safety" includes rust memory allocation and excludes the actual adjacent
+- [x] rust -"memory safety" includes rust memory allocation and excludes the actual adjacent
   phrase.
 
-- [ ] Positive/negative combinations, repeated terms, stopwords, language overrides and existing
+- [x] Positive/negative combinations, repeated terms, stopwords, language overrides and existing
   flat OR grammar agree between indexed and disk paths.
 
-- [ ] Scores/order for unaffected queries retain baseline behavior; intentional corrections are
+- [x] Scores/order for unaffected queries retain baseline behavior; intentional corrections are
   documented separately from ranking policy changes.
 
 Scope: No new search language, new ranking algorithm or learned relevance tuning. Structural
@@ -203,78 +203,78 @@ matrix.
 
 ### Stage 5: Close phrase, Boolean and unnecessary-probe defects
 
-- [ ] R02: build documents with green red x blue, red alone, red blue and neither. Query "red
+- [x] R02: build documents with green red x blue, red alone, red blue and neither. Query "red
   blue" OR green must include the first and third and exclude the partial phrase; failed phrase
   clauses contribute no score.
 
-- [ ] R03: rust -"memory safety" keeps rust memory allocation and excludes adjacent memory
+- [x] R03: rust -"memory safety" keeps rust memory allocation and excludes adjacent memory
   safety. Cover ordering, repeated terms, cross-line token adjacency and negative single terms.
 
-- [ ] Expand the independent small-corpus evaluator to the supported flat OR/AND syntax,
+- [x] Expand the independent small-corpus evaluator to the supported flat OR/AND syntax,
   required/optional clauses, stemming/stopwords and language precedence. Compare exact result
   sets before score/order assertions.
 
-- [ ] C13: zero-result property-regex queries with --no-hints, --jq or the typed API must not
+- [x] C13: zero-result property-regex queries with --no-hints, --jq or the typed API must not
   read bodies solely to prepare suggestions. Use an injected read counter or filesystem access
   observer; do not infer absence of reads from absent output.
 
-- [ ] Keep result completeness and diagnostics under capped/skipped content explicit. Run
+- [x] Keep result completeness and diagnostics under capped/skipped content explicit. Run
   indexed, refreshed-index and disk fallback variants with sections and projections.
 
-- [ ] Consume HintDemand from iteration 290 and enforce zero hint-only body reads here. Hint
+- [x] Consume HintDemand from iteration 290 and enforce zero hint-only body reads here. Hint
   serialization and preview/apply replay remain in iteration 294 and are not prerequisites.
 
 Acceptance for this stage (focused checks):
 
-- [ ] The concrete Boolean/phrase examples return the expected sets through every supported
+- [x] The concrete Boolean/phrase examples return the expected sets through every supported
   search path.
 
-- [ ] Unchanged ranking contracts retain score/order; corrections are isolated from new
+- [x] Unchanged ranking contracts retain score/order; corrections are isolated from new
   relevance tuning.
 
-- [ ] Hint-disabled metadata queries incur zero hint-only body reads, while enabled hints still
+- [x] Hint-disabled metadata queries incur zero hint-only body reads, while enabled hints still
   produce valid suggestions.
 
-- [ ] No grammar-precedence change is silently introduced by replacing the evaluator.
+- [x] No grammar-precedence change is silently introduced by replacing the evaluator.
 
 Scope: This closes and expands this block regressions; if already fixed there, reuse its
 implementation and prove the larger matrix.
 
 ### Stage 6: Close stale index and link-graph inconsistencies
 
-- [ ] R04: build oldtoken snapshot, externally add newtoken, then find newtoken --file a.md
+- [x] R04: build oldtoken snapshot, externally add newtoken, then find newtoken --file a.md
   --index. It must agree with disk; removed terms must disappear too, with honest freshness
   diagnostics.
 
-- [ ] R06: with b.md and sub/b.md present, sub/a.md `[b](b.md)` belongs to sub/b.md backlinks.
+- [x] R06: with b.md and sub/b.md present, sub/a.md `[b](b.md)` belongs to sub/b.md backlinks.
   Add padded wikilinks and ambiguous/root/site-prefix alternatives to resolver parity tests.
 
-- [ ] R07: aliases=true, target alias Nickname and source `[[Nickname]]`; an unrelated indexed
+- [x] R07: aliases=true, target alias Nickname and source `[[Nickname]]`; an unrelated indexed
   property mutation on source must preserve the backlink. Also change an alias on the target and
   verify links from untouched sources.
 
-- [ ] R08: insert frontmatter before a self-anchor and verify indexed line numbers match disk.
+- [x] R08: insert frontmatter before a self-anchor and verify indexed line numbers match disk.
   Cover every scan-derived field with full-value replacement assertions.
 
-- [ ] R15: instrument bulk indexed edits across growing sparse and dense graphs. Remove
+- [x] R15: instrument bulk indexed edits across growing sparse and dense graphs. Remove
   whole-graph traversal per changed source; rebuild once or maintain a tested reverse adjacency
   structure after correctness is established.
 
-- [ ] Test initial/load/refresh/mutate/reload/disk parity, malformed or stale snapshots,
+- [x] Test initial/load/refresh/mutate/reload/disk parity, malformed or stale snapshots,
   resolver config changes, unparseable notes, skipped counters and index persistence failure.
 
 Acceptance for this stage (focused checks):
 
-- [ ] All four correctness reproductions have passing disk/index differential tests, including
+- [x] All four correctness reproductions have passing disk/index differential tests, including
   unchanged sources affected by catalog changes.
 
-- [ ] Bulk graph work scales with one batch rebuild or touched adjacency, rather than N complete
+- [x] Bulk graph work scales with one batch rebuild or touched adjacency, rather than N complete
   edge traversals.
 
-- [ ] Performance evidence includes fixture size/edge count, cold/warm conditions and operation
+- [x] Performance evidence includes fixture size/edge count, cold/warm conditions and operation
   counters; no unmeasured speedup claim.
 
-- [ ] Snapshot fallback/version behavior remains compatible and does not falsely mark stale
+- [x] Snapshot fallback/version behavior remains compatible and does not falsely mark stale
   derived state fresh.
 
 Scope: Do not optimize away source occurrences needed to re-resolve previously missing or
@@ -297,20 +297,20 @@ ambiguous links. Do not conflate graph identity with filesystem move identity.
 
 ## One block completion gate
 
-- [ ] Finish all stage acceptance checks and record per-finding evidence. Preserve unrelated
+- [x] Finish all stage acceptance checks and record per-finding evidence. Preserve unrelated
   edits; public API/format changes must be explicit and tested. No whole-vault crash-transaction
   or concurrent-adversary guarantee is implied by the new types.
 
-- [ ] Obtain one fresh independent read-only review of the integrated block. Resolve actionable
+- [x] Obtain one fresh independent read-only review of the integrated block. Resolve actionable
   findings; re-review repaired behavior where necessary. Review stages as one final change
   rather than automatically launching a reviewer for every checklist item.
 
-- [ ] Before the final implementation commit/PR run, in order: cargo fmt; cargo clippy
+- [x] Before the final implementation commit/PR run, in order: cargo fmt; cargo clippy
   --workspace --all-targets -- -D warnings; cargo test --workspace -q. Run affected implemented
   xtask and package gates once for the integrated candidate, using actual dependencies and final
   generated assets.
 
-- [ ] For npm/Pi/assets changes run their typecheck/build/tests and TS/Pi/Codex freshness checks
+- [x] For npm/Pi/assets changes run their typecheck/build/tests and TS/Pi/Codex freshness checks
   against the same final binary. Build cargo build --release once after final asset generation,
   then use target/release/hyalo for changed-document inspection/strict lint and run git diff
   --check. Do not rebuild an unchanged binary between documentation-only internal stages.
@@ -320,7 +320,7 @@ ambiguous links. Do not conflate graph identity with filesystem move identity.
   checkpoint internal stages. This planning request itself authorizes no implementation or
   publication.
 
-- [ ] Reconcile the remaining five-or-fewer block plans once after final review/verification,
+- [x] Reconcile the remaining five-or-fewer block plans once after final review/verification,
   preserving scope and dependencies. Record exact revision, commands, review/CI evidence and
   limits; mark only fulfilled tasks complete. Keep iteration 287 external consumer work
   deferred.
@@ -378,3 +378,27 @@ Retain malformed/unparseable-note diagnostics, skipped counters and disk/index p
 broken authored frontmatter, missing delimiters and incomplete edits. Safe refusal must
 preserve bytes. Use compact controlled S10 fixtures; do not expand this block into
 random-gibberish/fuzz syntax compatibility work.
+
+
+## Verification record — 2026-09-10
+
+The integrated candidate and first repair passed independent Astra review. The final ordered
+Rust checks passed 5,083 tests (2 ignored), strict Clippy and formatting; release, affected
+source/behavior gates and release reproductions passed. Seven help/package freshness gates
+reuse evidence backed by 175 unchanged input hashes. Ignored tests, stub gates and unexercised
+recipes are excluded from coverage. Remote checks and the merge checkpoint remain separate.
+
+The shared catalog preserves canonical identity, authored occurrences and skipped-note names
+without granting filesystem write authority. Complete replacements reconcile repaired skip
+records while preserving unrelated failures. Index changes defer graph/BM25 work once per
+batch; legacy mutable adapters mark pending state and require finish_changes before save.
+Move adapters retain their stronger ambiguity refusal and authored-alias policy. Old or
+incomplete tokenizer metadata omits BM25 and uses disk fallback.
+
+Validation uses authored Markdown, including broken frontmatter and incomplete edits, with
+clear diagnostics and safe refusal. No random-gibberish or exhaustive syntax campaign was
+added. Sparse/dense fixtures measure rebuild counts; the controlled snapshot expansion test
+measured about 246 KiB allocated against a 4 MiB test budget before rejecting expansion beyond
+256 MiB. These observations do not imply universal process-memory isolation, filesystem race
+immunity or a whole-vault crash transaction. Exact interfaces and successor ownership are
+recorded in the architecture handoff and the complete original acceptance/finding ledgers.

--- a/hyalo-knowledgebase/iterations/iteration-293-mutation-migration-and-data-safety.md
+++ b/hyalo-knowledgebase/iterations/iteration-293-mutation-migration-and-data-safety.md
@@ -396,3 +396,29 @@ corruption. In particular, final-property removal refuses before publication whe
 would become frontmatter. Preserve original bytes on refusal and retain complete effects/index
 disposition after any earlier commit. No exhaustive exotic-YAML or random-gibberish
 compatibility expansion is required.
+
+
+## Iteration 292 reconciliation — 2026-09-10
+
+Iteration 292 supplies `SnapshotIndex::validate_before_changes` before indexed note effects and
+complete `apply_changes(dir, paths)` replacements. Feed actual safe observed paths from
+`ApplyReport`/`finalize_observed`; persistently invalidate unsafe effects without scanning
+them. Exact-path compatibility refreshes belong inside `begin_changes`/`finish_changes`: the
+owner rebuilds graph/search once per dirty batch and re-resolves retained occurrences.
+`get_mut`/`graph_mut` mark pending state; finish explicitly before persistence, and retain
+absent BM25/coherent generation plus refused save while pending. Keep the writer owner
+available for finalization after failed named reads; read-only callers may discard the snapshot
+and fall back to disk.
+
+Capture alias and semantic case policy at invocation boundaries, including
+`ScannedIndex::build_with_case_policy` and `SnapshotIndex::set_resolution_options`; semantic
+catalog identity never authorizes filesystem replacement. `note_paths()` includes discovered
+notes skipped for broken frontmatter, separately from successful metadata entries; only
+successful scan replacement clears that note's current skip diagnostics. Keep conservative move
+refusal for multiple bare stems and preserve stable alias spellings even when reads resolve a
+root-path winner. Extend the existing complete-entry, actual-effect, disk/reloaded-index parity
+and mutable-adapter guards while preserving every original criterion. Normal authored Markdown,
+including broken frontmatter, missing delimiters and incomplete edits, needs useful diagnostics
+and safe refusal without corruption where processing cannot continue; preserve crash, security,
+confinement, resource and partial-write protections without exhaustive random-gibberish/fuzz
+exploration.

--- a/hyalo-knowledgebase/iterations/iteration-294-cli-agent-and-documentation-contracts.md
+++ b/hyalo-knowledgebase/iterations/iteration-294-cli-agent-and-documentation-contracts.md
@@ -340,3 +340,25 @@ corrupting structured stdout. A06/help/README/skills should state that broken fr
 missing delimiters and incomplete edits receive useful diagnostics and no mutation when
 processing cannot continue; do not promise compatibility with arbitrary fuzzed/gibberish
 syntax.
+
+
+## Iteration 292 reconciliation — 2026-09-10
+
+Iteration 292 connects `HintDemand` to the actual injected body-read boundary: no-hints, jq and
+typed-API argv shapes perform zero hint-only reads, while enabled hints use bounded rooted
+reads and the shared 291 syntax. Preserve this measured contract when migrating resolved specs
+and raw-argv continuations; the fixture begins after validated jq preflight and does not
+establish new worker guarantees. Reuse `CompiledQuery::new(query, language)` through
+`score_compiled` and `SnippetQuery::from_compiled`, retaining flat-OR eligibility, language
+precedence and valid empty snippets for title-only/cross-line matches. Keep exact authored
+`written_target` separate from canonical `target`.
+
+C08/C15 and active docs must preserve explicit alias/case policy on disk and snapshots, skipped
+filename identity without claiming metadata coverage or write authority, and diagnostics
+cleared only for successfully repaired notes while other skips remain current. Keep the
+independent language/Boolean and section/projection/cap regressions alongside actual-read
+checks. All original acceptance criteria, ownership and live-Pi requirements remain unchanged.
+Normal authored Markdown includes broken frontmatter, missing delimiters and incomplete edits:
+provide useful diagnostics and safe refusal without corruption where processing cannot
+continue; retain crash, security, confinement, resource and partial-write protections without
+exhaustive random-gibberish/fuzz exploration.

--- a/hyalo-knowledgebase/iterations/iteration-295-resource-safety-and-final-verification.md
+++ b/hyalo-knowledgebase/iterations/iteration-295-resource-safety-and-final-verification.md
@@ -229,3 +229,27 @@ Do not reopen exhaustive random-gibberish/fuzz syntax exploration. Controlled ne
 remain required for crashes, data loss, security, confinement, resource bounds and unsafe
 partial writes. A04, R16, the 50-row/49-group ledger and all original acceptance rows remain
 unchanged.
+
+
+## Iteration 292 reconciliation — 2026-09-10
+
+Carry the reviewed 292 contracts into final behavioral verification: complete owner-managed
+replacements and pending-generation guards; explicit disk/snapshot case and alias policy;
+skipped filename identity distinct from metadata coverage; successful repair clearing only
+current diagnostics for that path; conservative move ambiguity and alias preservation; typed
+Boolean/phrase eligibility shared with snippets; and zero actual hint-only reads for suppressed
+demand. Snapshot wire format remains v2, with real disk fallback when untouched postings lack
+current tokenizer metadata. Retain the S10 crafted-snapshot expansion refusal and
+unchanged-note preflight evidence, plus 8/32-note sparse/dense batch counters and independent
+authored query references; their measured fixtures imply neither universal memory bounds nor
+speedup guarantees.
+
+A04/R16 ownership, the 50-row/49-group ledger and every original criterion remain unchanged.
+Retain `291-ci-resource-observation.json` solely as A04 diagnostic-ordering evidence: the
+failing check passed one retry with no product change, and this observation adds no new scope.
+The 292 review accepted all four repairs; supplied execution records report 5,083 passing
+tests, two ignored tests and a successful release build, not final 295 or remote closure. Use
+normal authored Markdown, including broken frontmatter, missing delimiters and incomplete
+edits, with useful diagnostics and safe refusal without corruption where processing cannot
+continue; preserve crash, security, confinement, resource and partial-write protections without
+exhaustive random-gibberish/fuzz exploration.

--- a/hyalo-knowledgebase/research/rust-architecture-review-2026-09-10.md
+++ b/hyalo-knowledgebase/research/rust-architecture-review-2026-09-10.md
@@ -631,3 +631,25 @@ migrates remaining writers while preserving validation/effects; 294 aligns CLI/P
 diagnostics and guarantees; 295 runs controlled final platform/resource/behavioral gates.
 Review attempt 5 is ready with no findings; the supervisor's final ordered Rust and
 release-safety checks passed.
+
+
+## Iteration 292 handoff — 2026-09-10
+
+The reviewed 292 candidate establishes an immutable semantic catalog with explicit alias/case
+policy, skipped filename identities distinct from successful metadata coverage, complete
+owner-managed snapshot replacements and current skip reconciliation. Writers validate before
+effects, finalize actual safe paths and invalidate unsafe effects; batch begin/finish owns
+graph/search rebuilding, and mutable compatibility adapters remain pending until explicit
+finish. Catalog identity grants no filesystem authority; conservative move ambiguity refusal
+and stable alias spelling remain. Typed `CompiledQuery` supplies eligibility/scoring/snippets,
+and `HintDemand` guards actual body reads. Preserve v2 disk fallback and the measured
+S10/batch/query evidence without universal resource or performance claims.
+
+293 owns remaining writer migration, 294 resolved hints/adapters/docs, and 295 final
+behavioral/resource verification; all original criteria and the 50-row/49-group ledger remain
+authoritative. Carry 291's CI retry observation only as existing A04 diagnostic-ordering
+evidence. Across every future iteration, cover normal authored Markdown, including broken
+frontmatter, missing delimiters and incomplete edits, with useful diagnostics and safe refusal
+without corruption where processing cannot continue. Preserve crash, security, confinement,
+resource and partial-write protections; no exhaustive random-gibberish/fuzz exploration, new
+design, reassignment or external Homefinder work is added.


### PR DESCRIPTION
Iteration 292 consolidates vault target resolution and index ownership. Changed documents replace complete entries, and batches rebuild graph/BM25 state once from retained authored occurrences. Reads retain canonical identity while move operations preserve their stronger ambiguity and alias safeguards.

Ranked queries compile once and match complete typed clauses before scoring. Snapshot reconstruction rejects oversized expansion before allocation, and legacy search metadata uses disk fallback. Suppressed hints avoid hint-only body reads.

Validation so far: 5,083 workspace tests pass (2 ignored), strict Clippy, 151 move compatibility tests, a measured expansion refusal, growing sparse/dense rebuild counters, and disk/index query comparisons. Independent review accepted all four repairs. Release and affected implemented gates passed; seven unchanged help/package checks reuse hashed input evidence. Final PR checks remain required before merge.

Scope remains authored Markdown, including broken frontmatter and incomplete edits, with safe refusal when processing cannot continue. Controlled counters and allocation fixtures are bounded evidence, not universal resource or concurrency guarantees. Original acceptance and finding ledgers are preserved.
