### PR TITLE
fix: preserve CLI continuation and Pi diagnostic contracts (iter-294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Hyalo does not define how you organize your notes. It works with the structure y
 
 Andrej Karpathy popularized the idea of an [LLM-maintained wiki](https://x.com/karpathy/status/1908527375407042770): instead of asking an LLM the same questions repeatedly, you have it build and maintain a persistent, structured knowledgebase that compounds over time. Every source ingested, every question answered adds to the wiki rather than vanishing with the conversation.
 
-Hyalo is the tooling layer that makes this practical. An LLM agent can use `hyalo find` to search across thousands of notes by metadata, full-text, or regex. It can use `hyalo set` to bulk-update frontmatter, `hyalo mv` to reorganize files while keeping all links intact, and `hyalo lint` to enforce schema consistency — all without ever touching raw files or guessing at YAML syntax.
+Hyalo is the tooling layer that makes this practical. An LLM agent can use `hyalo find` to search across thousands of notes by metadata, full-text, or regex. It can use `hyalo set` to bulk-update frontmatter, `hyalo mv` to reorganize files while reporting any ambiguous or unsupported link rewrites, and `hyalo lint` to enforce schema consistency — without guessing at YAML syntax.
 
 ### What it does
 
@@ -22,7 +22,7 @@ Hyalo is the tooling layer that makes this practical. An LLM agent can use `hyal
 |---|---|
 | **Search** | Full-text search with BM25 ranking, regex, frontmatter filters, tag/section/task queries |
 | **Mutate** | Set, remove, or append to properties and tags — one file or hundreds at once |
-| **Move** | Rename or reorganize files; hyalo rewrites all `[[wikilinks]]` and `[markdown](links)` across the vault |
+| **Move** | Rename or reorganize files; hyalo rewrites supported links and reports ambiguous or unsupported cases |
 | **Fix links** | Detect broken links and auto-repair them with fuzzy matching |
 | **Validate** | Lint frontmatter against type schemas, auto-fix defaults, typos, and date formats |
 | **Overview** | Property/tag distributions, task counts, orphan files, link health at a glance |
@@ -32,7 +32,7 @@ Hyalo is the tooling layer that makes this practical. An LLM agent can use `hyal
 - **Fast.** Parallel scanning, streaming I/O, optional snapshot index. Handles 10,000+ file vaults in under a second.
 - **Structured output.** TTY-aware: compact `text` for terminals, `json` when piped — with built-in `--jq` support. Easy to pipe into scripts, CI, or AI agents.
 - **AI-agent friendly.** Integrates with Claude Code, Codex, and Pi. Set up project workflows with `hyalo init --claude`, `hyalo init --codex`, or `hyalo init --pi`; Codex and Pi also have installable packages.
-- **Safe mutations.** Dry-run mode on all write operations. Preview before committing changes.
+- **Safe mutations.** Bulk repairs, moves, generators, and link rewrites provide documented preview modes. Check `hyalo <cmd> --help` for the exact command contract.
 - **Cross-platform.** Works on macOS, Linux, and Windows. No runtime dependencies.
 
 ## Installation
@@ -193,7 +193,7 @@ hyalo lint --fix     # apply autofixes
 hyalo new --type iteration --file iterations/iter-99-example.md
 ```
 
-Write commands that modify existing files support `--dry-run` to preview changes before applying them, and every command documents its flags: `hyalo <cmd> --help`.
+Commands that expose `--dry-run` preview their documented changes before applying them. Other mutations, including task toggles, report their exact behavior in `hyalo <cmd> --help`.
 
 ### Agent loop: new → edit → lint
 
@@ -273,7 +273,7 @@ below work once v0.21.0 is tagged):
 pi install git:github.com/ractive/hyalo@v0.21.0
 ```
 
-This registers the `hyalo` extension (generic + typed tools: `hyalo_find`, `hyalo_read`, `hyalo_set`, `hyalo_task`, and a post-write lint guardrail) plus the `hyalo` and `hyalo-tidy` skills. A main-HEAD install updates independently of hyalo releases via `pi update --extensions`; a pinned-tag install moves only on an explicit re-pin (`pi install git:…@vX.Y.Z`).
+This registers the `hyalo` extension (generic + typed tools: `hyalo_find`, `hyalo_read`, `hyalo_set`, and `hyalo_task`) plus the `hyalo` and `hyalo-tidy` skills. The extension runs a post-write lint guardrail for typed `hyalo_set`/`hyalo_task` effects and Pi host write/edit events; generic mutation calls retain their normal CLI result and diagnostics. A main-HEAD install updates independently of hyalo releases via `pi update --extensions`; a pinned-tag install moves only on an explicit re-pin (`pi install git:…@vX.Y.Z`).
 
 A `hyalo` binary on `PATH` is required (any recent release; typed tools need ≥ 0.21). See `pi-package/README.md` for details.
 

--- a/crates/hyalo-cli/src/cli/args.rs
+++ b/crates/hyalo-cli/src/cli/args.rs
@@ -890,9 +890,10 @@ pub(crate) struct ReadArgs {
     /// file-absolute, with the frontmatter included.
     #[arg(short, long, value_name = "RANGE")]
     pub lines: Option<String>,
-    /// Include the YAML frontmatter in output
+    /// Return YAML frontmatter only, or combine it with a body selector
     ///
-    /// Text output echoes the block's own bytes between its `---` fences —
+    /// By itself, this omits the body. Combine with --lines or --section to
+    /// return both frontmatter and the selected body. Text output echoes the block's own bytes between its `---` fences —
     /// indentation, quote style and comments exactly as on disk; no YAML is
     /// re-serialized on a read path. JSON keeps the parsed map under
     /// `frontmatter` and adds the raw text as `frontmatter_raw` (null for a
@@ -1121,7 +1122,8 @@ pub(crate) enum Commands {
             Returns the raw text after the YAML frontmatter block. Use --section to extract a \
             specific section by heading (case-insensitive substring match; use leading '#' to \
             pin heading level, e.g. '## Tasks'; use '/regex/' for regex matching; nested subsections are included), \
-            --lines to slice a line range, and --frontmatter to include the YAML frontmatter.\n\n\
+            --lines to slice a line range. --frontmatter by itself returns only the YAML block;\n\
+            combine it with --lines or --section to return frontmatter plus selected body text.\n\n\
             OUTPUT: Defaults to plain text (unlike all other commands which default to JSON). \
             Pass --format json to get \
             {\"results\": {\"file\": \"...\", \"size\": N, \"lines\": N, \"content\": \"...\"}, \"hints\": [...]}. \

--- a/crates/hyalo-cli/src/cli/help.rs
+++ b/crates/hyalo-cli/src/cli/help.rs
@@ -477,8 +477,8 @@ COOKBOOK:
   # Get just file paths (no metadata)
   hyalo find --property status=draft --jq '[.results[].file]'
 
-  # Pipe file paths for scripting (Unix)
-  hyalo find --tag research --jq '.results[].file' | xargs -I{} hyalo set --property reviewed=true --file {}
+  # Preview a native filtered mutation; rerun without --dry-run after review
+  hyalo set --tag reviewed --where-tag research --glob '**/*.md' --dry-run
 
   # Find all files that link to a given note (positional FILE)
   hyalo backlinks decision-log.md
@@ -561,7 +561,8 @@ OUTPUT SHAPES (JSON, default):
   #     links auto: matched)
   #   - top-level results keys are always present (0 / false / [] / null
   #     included); only per-item records inside arrays omit optional keys
-  #   - every mutating command reports dry_run and skipped_count
+  #   - object-shaped mutation results report dry_run where the command supports it;
+  #     skipped_count belongs to the bulk set/remove/append/rename families
 
   # find — results is an array of file objects; these keys are the default
   # set, and `title` is promoted OUT of `properties`. `title_source` rides

--- a/crates/hyalo-cli/src/hints.rs
+++ b/crates/hyalo-cli/src/hints.rs
@@ -4,6 +4,8 @@
 //! commands. All hints are concrete, executable strings — no templates or
 //! placeholders.
 
+pub(crate) mod spec;
+
 /// Maximum number of hints to return from any generator.
 const MAX_HINTS: usize = 5;
 
@@ -76,6 +78,17 @@ impl Hint {
         Self {
             description: description.into(),
             cmd,
+            writes,
+        }
+    }
+
+    /// Build a hint from raw argv and classify its effects through Clap's
+    /// normalized command intent before rendering shell text.
+    pub(crate) fn from_builder(description: impl Into<String>, builder: HintBuilder) -> Self {
+        let writes = crate::mutation::command_argv_writes(builder.argv());
+        Self {
+            description: description.into(),
+            cmd: builder.into_command(),
             writes,
         }
     }
@@ -300,6 +313,10 @@ pub struct HintContext {
     /// guessed; `None` on every non-empty result and whenever the probe found
     /// nothing within its budget.
     pub body_search_suggestion: Option<BodySearchSuggestion>,
+    /// Complete family-specific operation after config/view/files-from
+    /// resolution. Scope-preserving continuations consume this instead of
+    /// reconstructing requests from the partial presentation fields above.
+    pub(crate) resolved: Option<spec::ResolvedHintSpec>,
 }
 
 /// Common global flags captured once per command dispatch and threaded into
@@ -371,6 +388,7 @@ impl HintContext {
             okf_profile_active: false,
             observed_property_values: std::collections::BTreeMap::new(),
             body_search_suggestion: None,
+            resolved: None,
         }
     }
 
@@ -611,7 +629,7 @@ pub use command::{HintBuilder, shell_quote, shorten_index_path_for_hint};
 use command::{
     build_command_no_glob, build_command_with_file, build_command_with_glob,
     build_command_with_glob_and_files, build_find_command_composing,
-    build_find_command_preserving_filters, build_find_command_with_pattern,
+    build_find_command_preserving_filters, build_find_command_with_pattern, find_continuation_hint,
 };
 use config::{
     hints_for_lint_rules_list, hints_for_lint_rules_show, hints_for_new, hints_for_types,

--- a/crates/hyalo-cli/src/hints/command.rs
+++ b/crates/hyalo-cli/src/hints/command.rs
@@ -4,7 +4,7 @@
 //! hotspot). This is a file split only: the items keep the visibility they had
 //! inside the one module, so `hints::...` paths and behaviour are unchanged.
 
-use super::{FindIndexHint, HintContext};
+use super::{FindIndexHint, Hint, HintContext};
 
 // ---------------------------------------------------------------------------
 // Command builder
@@ -20,11 +20,11 @@ use super::{FindIndexHint, HintContext};
 pub(super) fn push_global_flags(parts: &mut Vec<String>, ctx: &HintContext) {
     if let Some(dir) = &ctx.dir {
         parts.push("--dir".to_owned());
-        parts.push(shell_quote(dir));
+        parts.push(dir.clone());
     }
     if let Some(fmt) = &ctx.format {
         parts.push("--format".to_owned());
-        parts.push(shell_quote(fmt));
+        parts.push(fmt.clone());
     }
     if ctx.hints {
         parts.push("--hints".to_owned());
@@ -37,7 +37,7 @@ pub(super) fn push_global_flags(parts: &mut Vec<String>, ctx: &HintContext) {
         && site_prefix_is_global()
     {
         parts.push("--site-prefix".to_owned());
-        parts.push(shell_quote(prefix));
+        parts.push(prefix.clone());
     }
     // iter-274 (UX-2): an indexed run's hints must stay indexed. `--index` /
     // `--index-file` is threaded exactly like `--dir` and `--format` — a hint
@@ -112,7 +112,7 @@ pub(super) fn push_find_graph_filters(parts: &mut Vec<String>, ctx: &HintContext
     }
     if let Some(title) = &ctx.title_filter {
         parts.push("--title".to_owned());
-        parts.push(shell_quote(title));
+        parts.push(title.clone());
     }
 }
 
@@ -124,7 +124,7 @@ pub(super) fn push_find_graph_filters(parts: &mut Vec<String>, ctx: &HintContext
 pub(super) fn push_find_sort(parts: &mut Vec<String>, ctx: &HintContext) {
     if let Some(sort) = &ctx.sort {
         parts.push("--sort".to_owned());
-        parts.push(shell_quote(sort));
+        parts.push(sort.clone());
         if ctx.reverse {
             parts.push("--reverse".to_owned());
         }
@@ -141,8 +141,8 @@ pub(super) fn push_find_sort(parts: &mut Vec<String>, ctx: &HintContext) {
 /// copies of the CLI surface that could (and once did) reference flags the
 /// real command does not accept (`tags --limit 0`), which is exactly why
 /// `tests/e2e/hint_execution.rs` exists. `HintBuilder` is the single path
-/// forward: the command is assembled as an *argv vector* and serialized
-/// through [`shell_quote`], and [`HintBuilder::argv`] exposes that vector so
+/// forward: the command is assembled as a raw *argv vector*, serialized
+/// through [`shell_quote`] only for display, and [`HintBuilder::argv`] exposes that vector so
 /// tests can feed it straight back into the real clap parser
 /// (`crate::cli::args::Cli::try_parse_from`) — a hinted command that would
 /// not run is now a unit-test failure, not an e2e-spawn discovery.
@@ -165,10 +165,10 @@ impl HintBuilder {
         Self { parts }
     }
 
-    /// Append one shell-quoted argument (paths, patterns, values).
+    /// Append one raw argument (paths, patterns, values).
     #[must_use]
     pub fn arg(mut self, arg: &str) -> Self {
-        self.parts.push(shell_quote(arg));
+        self.parts.push(arg.to_owned());
         self
     }
 
@@ -176,8 +176,8 @@ impl HintBuilder {
     /// validated enum values). Use sparingly — prefer [`Self::flag`] and
     /// [`Self::flag_value`].
     #[must_use]
-    pub fn raw(mut self, token: &str) -> Self {
-        self.parts.push(token.to_owned());
+    pub fn raw(mut self, token: impl Into<String>) -> Self {
+        self.parts.push(token.into());
         self
     }
 
@@ -201,7 +201,7 @@ impl HintBuilder {
         S: AsRef<str>,
     {
         for a in args {
-            self.parts.push(shell_quote(a.as_ref()));
+            self.parts.push(a.as_ref().to_owned());
         }
         self
     }
@@ -213,11 +213,25 @@ impl HintBuilder {
         &self.parts
     }
 
-    /// Serialize to the display string: space-joined, each value already
-    /// shell-quoted by [`shell_quote`].
+    /// Serialize to a POSIX-compatible display string. Raw argv is retained
+    /// unchanged for direct execution and every token is quoted only here.
     #[must_use]
     pub fn build(&self) -> String {
-        self.parts.join(" ")
+        self.parts
+            .iter()
+            .map(|part| shell_quote(part))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Serialize and consume the builder after callers have inspected argv.
+    #[must_use]
+    pub(crate) fn into_command(self) -> String {
+        self.parts
+            .into_iter()
+            .map(|part| shell_quote(&part))
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 
     // --- crate-internal plumbing used by the `build_command_*` family ---
@@ -237,15 +251,22 @@ impl HintBuilder {
         self.parts.push(token.to_owned());
     }
 
-    /// Append one shell-quoted token in place.
+    /// Append one raw value token in place. The historical name remains while
+    /// callers migrate; quoting happens only in [`Self::build`].
     pub(crate) fn push_quoted(&mut self, token: &str) {
-        self.parts.push(shell_quote(token));
+        self.parts.push(token.to_owned());
+    }
+
+    /// Append the context's global flags while retaining raw argv.
+    pub(crate) fn with_globals(mut self, ctx: &HintContext) -> Self {
+        push_global_flags(&mut self.parts, ctx);
+        self
     }
 
     /// Append the context's global flags (`--dir`, `--format`, `--hints`) and
     /// serialize. The last thing every derived hint does (iter-213, UX-5).
     pub(crate) fn finish(mut self, ctx: &HintContext) -> String {
-        push_global_flags(&mut self.parts, ctx);
+        self = self.with_globals(ctx);
         self.build()
     }
 }
@@ -318,6 +339,12 @@ pub(super) fn build_find_command_preserving_filters(
     ctx: &HintContext,
     extra_args: &[&str],
 ) -> String {
+    if let Some(super::spec::ResolvedHintSpec::Find(spec)) = &ctx.resolved {
+        return spec
+            .continuation(ctx, extra_args)
+            .map(|builder| builder.build())
+            .unwrap_or_default();
+    }
     let mut b = HintBuilder::cmd("find");
     for pf in &ctx.property_filters {
         b.push_raw("--property");
@@ -345,6 +372,27 @@ pub(super) fn build_find_command_preserving_filters(
         b.push_quoted(glob);
     }
     b.finish(ctx)
+}
+
+/// Build a scope-preserving find hint from the resolved operation. An input
+/// list that cannot fit safely becomes explicit advice instead of a broader
+/// executable command.
+pub(super) fn find_continuation_hint(
+    ctx: &HintContext,
+    description: impl Into<String>,
+    extra_args: &[&str],
+) -> Hint {
+    let description = description.into();
+    if let Some(super::spec::ResolvedHintSpec::Find(spec)) = &ctx.resolved {
+        return match spec.continuation(ctx, extra_args) {
+            Ok(builder) => Hint::from_builder(description, builder),
+            Err(reason) => Hint::without_cmd(format!("{description} — {reason}")),
+        };
+    }
+    Hint::new(
+        description,
+        build_find_command_preserving_filters(ctx, extra_args),
+    )
 }
 
 /// Render a snapshot-index path for a hint command, preferring the shortest
@@ -386,7 +434,7 @@ pub(super) fn push_find_index_file(parts: &mut Vec<String>, ctx: &HintContext) {
         FindIndexHint::Default => parts.push("--index".to_owned()),
         FindIndexHint::File(path) => {
             parts.push("--index-file".to_owned());
-            parts.push(shell_quote(path));
+            parts.push(path.clone());
         }
     }
 }
@@ -397,6 +445,12 @@ pub(super) fn push_find_index_file(parts: &mut Vec<String>, ctx: &HintContext) {
 /// derived hints (narrow-by-tag / filter-by-status) that must compose with the
 /// current query rather than replace it.
 pub(super) fn build_find_command_composing(ctx: &HintContext, extra_args: &[&str]) -> String {
+    if let Some(super::spec::ResolvedHintSpec::Find(spec)) = &ctx.resolved {
+        return spec
+            .continuation(ctx, extra_args)
+            .map(|builder| builder.build())
+            .unwrap_or_default();
+    }
     let mut b = HintBuilder::cmd("find");
     if let Some(pat) = &ctx.body_pattern {
         b.push_quoted(pat);
@@ -464,10 +518,9 @@ pub(super) fn build_find_command_with_pattern(ctx: &HintContext, new_pattern: &s
 /// In that case, emit `--file <path>` (flag form) instead of the bare positional.
 pub(super) fn push_file_positional(parts: &mut Vec<String>, file: &str) {
     if file.starts_with('-') {
-        parts.push("--file".to_owned());
-        parts.push(shell_quote(file));
+        parts.push(format!("--file={file}"));
     } else {
-        parts.push(shell_quote(file));
+        parts.push(file.to_owned());
     }
 }
 

--- a/crates/hyalo-cli/src/hints/find.rs
+++ b/crates/hyalo-cli/src/hints/find.rs
@@ -7,7 +7,7 @@
 use super::{
     Hint, HintBuilder, HintContext, MAX_HINTS, build_command_no_glob, build_command_with_file,
     build_command_with_glob, build_find_command_composing, build_find_command_preserving_filters,
-    build_find_command_with_pattern, status_priority,
+    build_find_command_with_pattern, find_continuation_hint, status_priority,
 };
 
 /// Largest untruncated result set for which `find` still offers
@@ -313,9 +313,10 @@ pub(super) fn hints_for_find(
     {
         let remaining = MAX_HINTS.saturating_sub(hints.len());
         if remaining > 0 {
-            hints.push(Hint::new(
+            hints.push(find_continuation_hint(
+                ctx,
                 format!("Show all {t} results (no limit)"),
-                build_find_command_preserving_filters(ctx, &["--limit", "0"]),
+                &["--limit", "0"],
             ));
         }
     }

--- a/crates/hyalo-cli/src/hints/links.rs
+++ b/crates/hyalo-cli/src/hints/links.rs
@@ -9,6 +9,26 @@ use super::{
     format_confidence, shell_quote,
 };
 
+fn links_fix_apply_hint(
+    ctx: &HintContext,
+    description: impl Into<String>,
+    fuzzy_floor: Option<&str>,
+) -> Hint {
+    let description = description.into();
+    if let Some(super::spec::ResolvedHintSpec::LinksFix(spec)) = &ctx.resolved {
+        return Hint::from_builder(description, spec.apply(ctx, fuzzy_floor));
+    }
+    let mut args = vec!["links", "fix", "--apply"];
+    if fuzzy_floor.is_some() {
+        args.push("--apply-fuzzy");
+    }
+    if let Some(floor) = fuzzy_floor {
+        args.push("--min-confidence");
+        args.push(floor);
+    }
+    Hint::new(description, build_command_with_glob(ctx, &args))
+}
+
 pub(super) fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -> Vec<Hint> {
     let mut hints = Vec::new();
 
@@ -34,9 +54,10 @@ pub(super) fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -
     let applicable = fixable.saturating_sub(unapplied);
 
     if is_dry_run && applicable > 0 {
-        hints.push(Hint::new(
+        hints.push(links_fix_apply_hint(
+            ctx,
             format!("Apply {applicable} fixes"),
-            build_command_with_glob(ctx, &["links", "fix", "--apply"]),
+            None,
         ));
     }
 
@@ -77,16 +98,11 @@ pub(super) fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -
             .get("fuzzy_min_confidence")
             .and_then(serde_json::Value::as_f64)
             .unwrap_or(hyalo_core::link_score::DEFAULT_FUZZY_MIN_CONFIDENCE);
-        let mut cmd_parts = vec!["links", "fix", "--apply", "--apply-fuzzy"];
-        let floor_arg;
-        if (floor - hyalo_core::link_score::DEFAULT_FUZZY_MIN_CONFIDENCE).abs() > f64::EPSILON {
-            floor_arg = format_confidence(floor);
-            cmd_parts.push("--min-confidence");
-            cmd_parts.push(&floor_arg);
-        }
-        hints.push(Hint::new(
+        let floor_arg = format_confidence(floor);
+        hints.push(links_fix_apply_hint(
+            ctx,
             format!("Review then apply {applicable_fuzzy} lower-confidence fuzzy fixes"),
-            build_command_with_glob(ctx, &cmd_parts),
+            Some(&floor_arg),
         ));
     } else if fuzzy > 0 && !fuzzy_applied {
         // Every candidate is below the floor — `--apply-fuzzy` would apply 0
@@ -96,13 +112,21 @@ pub(super) fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -
             .get("fuzzy_min_confidence")
             .and_then(serde_json::Value::as_f64)
             .unwrap_or(0.0);
-        hints.push(Hint::new(
-            format!(
-                "{fuzzy} fuzzy candidates found, all below the confidence floor \
-                 {floor} — review with a lower --min-confidence before applying"
-            ),
-            build_command_with_glob(ctx, &["links", "fix", "--min-confidence", "0"]),
-        ));
+        let description = format!(
+            "{fuzzy} fuzzy candidates found, all below the confidence floor \
+             {floor} — review with a lower --min-confidence before applying"
+        );
+        if let Some(super::spec::ResolvedHintSpec::LinksFix(spec)) = &ctx.resolved {
+            hints.push(Hint::from_builder(
+                description,
+                spec.review_at_floor(ctx, "0"),
+            ));
+        } else {
+            hints.push(Hint::new(
+                description,
+                build_command_with_glob(ctx, &["links", "fix", "--min-confidence", "0"]),
+            ));
+        }
     }
 
     if unfixable > 0 {
@@ -149,10 +173,7 @@ pub(super) fn hints_for_links_fix(ctx: &HintContext, data: &serde_json::Value) -
         } else {
             format!("Apply {case_mismatches} case-mismatch fixes")
         };
-        hints.push(Hint::new(
-            label,
-            build_command_with_glob(ctx, &["links", "fix", "--apply"]),
-        ));
+        hints.push(links_fix_apply_hint(ctx, label, None));
     }
 
     // A vault with nothing broken used to emit no hints whatsoever, making
@@ -194,31 +215,36 @@ pub(super) fn hints_for_links_auto(ctx: &HintContext, data: &serde_json::Value) 
         .unwrap_or(0);
 
     if is_dry_run && total > 0 {
-        // Rebuild the exact command from the preview, preserving all
-        // scope-narrowing flags so the apply doesn't widen the mutation set.
-        let mut args: Vec<&str> = vec!["links", "auto", "--apply"];
-        let min_str;
-        if let Some(ml) = ctx.auto_link_min_length
-            && ml != 3
-        {
-            args.push("--min-length");
-            min_str = ml.to_string();
-            args.push(&min_str);
+        if let Some(super::spec::ResolvedHintSpec::LinksAuto(spec)) = &ctx.resolved {
+            hints.push(Hint::from_builder(
+                format!("Apply {total} auto-links"),
+                spec.apply(ctx),
+            ));
+        } else {
+            // Legacy unit contexts without a resolved spec retain their old
+            // shape; production always takes the resolved branch.
+            let mut args: Vec<&str> = vec!["links", "auto", "--apply"];
+            let min_str;
+            if let Some(ml) = ctx.auto_link_min_length
+                && ml != 3
+            {
+                args.push("--min-length");
+                min_str = ml.to_string();
+                args.push(&min_str);
+            }
+            let cmd = build_command_with_glob(ctx, &args);
+            let mut parts = vec![cmd];
+            if let Some(ref f) = ctx.auto_link_file {
+                parts.push(format!("--file={}", shell_quote(f)));
+            }
+            for et in &ctx.auto_link_exclude_titles {
+                parts.push(format!("--exclude-title {}", shell_quote(et)));
+            }
+            hints.push(Hint::new(
+                format!("Apply {total} auto-links"),
+                parts.join(" "),
+            ));
         }
-        let cmd = build_command_with_glob(ctx, &args);
-        // Append --file and --exclude-title after the builder (they are not
-        // glob-related and aren't handled by build_command_with_glob).
-        let mut parts = vec![cmd];
-        if let Some(ref f) = ctx.auto_link_file {
-            parts.push(format!("--file {}", shell_quote(f)));
-        }
-        for et in &ctx.auto_link_exclude_titles {
-            parts.push(format!("--exclude-title {}", shell_quote(et)));
-        }
-        hints.push(Hint::new(
-            format!("Apply {total} auto-links"),
-            parts.join(" "),
-        ));
     }
 
     // L-11: a non-zero `files_failed` count means some files produced a

--- a/crates/hyalo-cli/src/hints/lint.rs
+++ b/crates/hyalo-cli/src/hints/lint.rs
@@ -4,10 +4,7 @@
 //! hotspot). This is a file split only: the items keep the visibility they had
 //! inside the one module, so `hints::...` paths and behaviour are unchanged.
 
-use super::{
-    Hint, HintBuilder, HintContext, MAX_HINTS, PARSE_ERROR_PREFIX, build_command_no_glob,
-    build_command_with_glob_and_files,
-};
+use super::{Hint, HintBuilder, HintContext, MAX_HINTS, PARSE_ERROR_PREFIX, build_command_no_glob};
 
 /// Ratio threshold for rule dominance (UX-2).
 pub(super) const RULE_DOMINANCE_RATIO: f64 = 0.5;
@@ -21,9 +18,10 @@ pub(super) fn per_rule_hint(
     worst_file: Option<&str>,
 ) -> Option<Hint> {
     match rule_id {
-        "HYALO001" => Some(Hint::new(
+        "HYALO001" => Some(lint_continuation_hint(
+            ctx,
             "Auto-fix HYALO001 violations",
-            build_lint_with_filter_flags(ctx, &["lint", "--rule", "HYALO001", "--fix"]),
+            &["lint", "--rule", "HYALO001", "--fix"],
         )),
         "HYALO002" => worst_file.map(|file| {
             // Use `--file <path>` rather than a positional, since `find`'s
@@ -40,6 +38,12 @@ pub(super) fn per_rule_hint(
 /// Build a lint command that preserves `--rule`, `--rule-prefix`, `--fix-rule`, glob, and
 /// file targets from the current context, then appends `args`.
 pub(super) fn build_lint_with_filter_flags(ctx: &HintContext, args: &[&str]) -> String {
+    if let Some(super::spec::ResolvedHintSpec::Lint(spec)) = &ctx.resolved {
+        return spec
+            .continuation(ctx, args)
+            .map(|builder| builder.build())
+            .unwrap_or_default();
+    }
     let mut b = HintBuilder::empty();
     for arg in args {
         b.push_quoted(arg);
@@ -67,6 +71,21 @@ pub(super) fn build_lint_with_filter_flags(ctx: &HintContext, args: &[&str]) -> 
         b.push_quoted(ft);
     }
     b.finish(ctx)
+}
+
+fn lint_continuation_hint(
+    ctx: &HintContext,
+    description: impl Into<String>,
+    args: &[&str],
+) -> Hint {
+    let description = description.into();
+    if let Some(super::spec::ResolvedHintSpec::Lint(spec)) = &ctx.resolved {
+        return match spec.continuation(ctx, args) {
+            Ok(builder) => Hint::from_builder(description, builder),
+            Err(reason) => Hint::without_cmd(format!("{description} — {reason}")),
+        };
+    }
+    Hint::new(description, build_lint_with_filter_flags(ctx, args))
 }
 
 /// Accumulate rule violation counts from a named array field in a file JSON object.
@@ -197,9 +216,10 @@ pub(super) fn hints_for_lint(
         } else {
             format!("Show all {total_violations} files with issues (no limit)")
         };
-        hints.push(Hint::new(
+        hints.push(lint_continuation_hint(
+            ctx,
             description,
-            build_command_with_glob_and_files(ctx, &["lint", "--limit", "0"]),
+            &["lint", "--limit", "0"],
         ));
     }
 
@@ -231,9 +251,10 @@ pub(super) fn hints_for_lint(
         if has_violations && hints.len() < MAX_HINTS {
             // Preserve --rule / --rule-prefix / --fix-rule from the current
             // invocation so the suggested preview doesn't widen scope.
-            hints.push(Hint::new(
+            hints.push(lint_continuation_hint(
+                ctx,
                 "Preview auto-fixes",
-                build_lint_with_filter_flags(ctx, &["lint", "--fix", "--dry-run"]),
+                &["lint", "--fix", "--dry-run"],
             ));
         }
     } else if is_dry_run {
@@ -251,9 +272,10 @@ pub(super) fn hints_for_lint(
         if has_fixes && hints.len() < MAX_HINTS {
             // Apply hint mirrors the previewed scope — preserve --rule,
             // --rule-prefix, and --fix-rule via the lint-aware builder.
-            hints.push(Hint::new(
+            hints.push(lint_continuation_hint(
+                ctx,
                 "Apply auto-fixes",
-                build_lint_with_filter_flags(ctx, &["lint", "--fix"]),
+                &["lint", "--fix"],
             ));
         }
     }
@@ -353,9 +375,10 @@ pub(super) fn hints_for_lint(
             })
         });
     if has_parse_errors && hints.len() < MAX_HINTS {
-        hints.push(Hint::new(
+        hints.push(lint_continuation_hint(
+            ctx,
             "Show all files with unfixable frontmatter errors",
-            build_command_with_glob_and_files(ctx, &["lint", "--limit", "0"]),
+            &["lint", "--limit", "0"],
         ));
     }
 

--- a/crates/hyalo-cli/src/hints/spec.rs
+++ b/crates/hyalo-cli/src/hints/spec.rs
@@ -1,0 +1,711 @@
+//! Complete resolved operations used by scope-preserving continuations.
+//!
+//! These family-specific specs are built after saved views, configuration
+//! defaults and `--files-from` have been resolved. They deliberately retain
+//! raw argv values; shell quoting belongs only to the display renderer.
+
+use super::{HintBuilder, HintContext};
+use crate::cli::args::{Commands, FindArgs, LinksAction};
+
+const MAX_REPLAY_TARGETS: usize = 64;
+const MAX_REPLAY_TARGET_BYTES: usize = 8 * 1024;
+
+#[derive(Debug, Clone)]
+enum ReplayFiles {
+    Files(Vec<String>),
+    Unreplayable(String),
+}
+
+impl ReplayFiles {
+    fn bounded(files: &[String]) -> Self {
+        let bytes = files.iter().map(String::len).sum::<usize>();
+        if files.len() > MAX_REPLAY_TARGETS || bytes > MAX_REPLAY_TARGET_BYTES {
+            Self::Unreplayable(format!(
+                "the resolved selection has {} paths ({} bytes), which exceeds the safe hint replay budget; rerun the original selection without using a broader command",
+                files.len(),
+                bytes
+            ))
+        } else {
+            Self::Files(files.to_vec())
+        }
+    }
+
+    fn push(&self, mut builder: HintBuilder) -> Result<HintBuilder, &str> {
+        match self {
+            Self::Files(files) => {
+                for file in files {
+                    builder = builder.raw(format!("--file={file}"));
+                }
+                Ok(builder)
+            }
+            Self::Unreplayable(reason) => Err(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FindHintSpec {
+    pattern: Option<String>,
+    regexp: Option<String>,
+    properties: Vec<String>,
+    tags: Vec<String>,
+    task: Option<String>,
+    sections: Vec<String>,
+    files: ReplayFiles,
+    globs: Vec<String>,
+    fields: Vec<String>,
+    sort: Option<String>,
+    reverse: bool,
+    limit: Option<usize>,
+    broken_links: bool,
+    orphan: bool,
+    dead_end: bool,
+    title: Option<String>,
+    language: Option<String>,
+    strict: bool,
+}
+
+impl FindHintSpec {
+    fn from_args(args: &FindArgs, effective_language: Option<&str>) -> Self {
+        let files = if args.file_positional.is_empty() {
+            &args.filters.file
+        } else {
+            &args.file_positional
+        };
+        Self {
+            pattern: args.pattern.clone(),
+            regexp: args.filters.regexp.clone(),
+            properties: args.filters.properties.clone(),
+            tags: args.filters.tag.clone(),
+            task: args.filters.task.clone(),
+            sections: args.filters.sections.clone(),
+            files: ReplayFiles::bounded(files),
+            globs: args.filters.glob.clone(),
+            fields: args.filters.fields.clone(),
+            sort: args.filters.sort.clone(),
+            reverse: args.filters.reverse,
+            limit: args.filters.limit,
+            broken_links: args.filters.broken_links,
+            orphan: args.filters.orphan,
+            dead_end: args.filters.dead_end,
+            title: args.filters.title.clone(),
+            language: args
+                .filters
+                .language
+                .clone()
+                .or_else(|| effective_language.map(str::to_owned)),
+            strict: args.filters.strict,
+        }
+    }
+
+    pub(crate) fn continuation(
+        &self,
+        ctx: &HintContext,
+        extra: &[&str],
+    ) -> Result<HintBuilder, String> {
+        let overrides = |flag: &str| extra.contains(&flag);
+        let mut builder = HintBuilder::cmd("find");
+        if let Some(regexp) = &self.regexp {
+            builder = builder.flag_value("--regexp", regexp);
+        }
+        for property in &self.properties {
+            builder = builder.flag_value("--property", property);
+        }
+        for tag in &self.tags {
+            builder = builder.flag_value("--tag", tag);
+        }
+        if let Some(task) = &self.task {
+            builder = builder.flag_value("--task", task);
+        }
+        for section in &self.sections {
+            builder = builder.flag_value("--section", section);
+        }
+        builder = self.files.push(builder).map_err(str::to_owned)?;
+        for glob in &self.globs {
+            builder = builder.flag_value("--glob", glob);
+        }
+        if !overrides("--fields") && !self.fields.is_empty() {
+            builder = builder.flag_value("--fields", &self.fields.join(","));
+        }
+        if !overrides("--sort")
+            && let Some(sort) = &self.sort
+        {
+            builder = builder.flag_value("--sort", sort);
+            if self.reverse {
+                builder = builder.flag("--reverse");
+            }
+        }
+        if !overrides("--limit")
+            && let Some(limit) = self.limit
+        {
+            builder = builder.flag_value("--limit", &limit.to_string());
+        }
+        if self.broken_links {
+            builder = builder.flag("--broken-links");
+        }
+        if self.orphan {
+            builder = builder.flag("--orphan");
+        }
+        if self.dead_end {
+            builder = builder.flag("--dead-end");
+        }
+        if let Some(title) = &self.title {
+            builder = builder.flag_value("--title", title);
+        }
+        if let Some(language) = &self.language {
+            builder = builder.flag_value("--language", language);
+        }
+        if self.strict {
+            builder = builder.flag("--strict");
+        }
+        for arg in extra {
+            builder = builder.raw(*arg);
+        }
+        builder = builder.with_globals(ctx);
+        if let Some(pattern) = &self.pattern {
+            builder = builder.raw("--").arg(pattern);
+        }
+        Ok(builder)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LintHintSpec {
+    files: ReplayFiles,
+    globs: Vec<String>,
+    file_type: Option<String>,
+    fix: bool,
+    dry_run: bool,
+    limit: Option<usize>,
+    detailed: bool,
+    rule: Option<String>,
+    rule_prefix: Option<String>,
+    max_per_rule: Option<usize>,
+    fix_rules: Vec<String>,
+    strict: bool,
+    profile: Option<String>,
+}
+
+impl LintHintSpec {
+    pub(crate) fn continuation(
+        &self,
+        ctx: &HintContext,
+        extra: &[&str],
+    ) -> Result<HintBuilder, String> {
+        let overrides = |flag: &str| extra.contains(&flag);
+        let mut builder = HintBuilder::cmd("lint");
+        builder = self.files.push(builder).map_err(str::to_owned)?;
+        for glob in &self.globs {
+            builder = builder.flag_value("--glob", glob);
+        }
+        if let Some(file_type) = &self.file_type {
+            builder = builder.flag_value("--type", file_type);
+        }
+        let requested_fix = overrides("--fix");
+        if requested_fix || self.fix {
+            builder = builder.flag("--fix");
+        }
+        if overrides("--dry-run") || self.dry_run && !requested_fix {
+            builder = builder.flag("--dry-run");
+        }
+        if !overrides("--limit")
+            && let Some(limit) = self.limit
+        {
+            builder = builder.flag_value("--limit", &limit.to_string());
+        }
+        if self.detailed {
+            builder = builder.flag("--detailed");
+        }
+        if !overrides("--rule")
+            && let Some(rule) = &self.rule
+        {
+            builder = builder.flag_value("--rule", rule);
+        }
+        if let Some(prefix) = &self.rule_prefix {
+            builder = builder.flag_value("--rule-prefix", prefix);
+        }
+        if let Some(max) = self.max_per_rule {
+            builder = builder.flag_value("--max-per-rule", &max.to_string());
+        }
+        for rule in &self.fix_rules {
+            builder = builder.flag_value("--fix-rule", rule);
+        }
+        if self.strict {
+            builder = builder.flag("--strict");
+        }
+        if let Some(profile) = &self.profile {
+            builder = builder.flag_value("--profile", profile);
+        }
+        for arg in extra {
+            if !matches!(*arg, "lint" | "--fix" | "--dry-run") {
+                builder = builder.raw(*arg);
+            }
+        }
+        Ok(builder.with_globals(ctx))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LinkFixHintSpec {
+    threshold: f64,
+    apply_fuzzy: bool,
+    min_confidence: Option<f64>,
+    globs: Vec<String>,
+    ignore_targets: Vec<String>,
+    expand_short_form: bool,
+    case_insensitive: bool,
+}
+
+impl LinkFixHintSpec {
+    pub(crate) fn apply(&self, ctx: &HintContext, fuzzy_floor: Option<&str>) -> HintBuilder {
+        let mut builder = HintBuilder::cmd("links fix").flag("--apply");
+        if (self.threshold - 0.8).abs() > f64::EPSILON {
+            builder = builder.flag_value("--threshold", &self.threshold.to_string());
+        }
+        if self.apply_fuzzy || fuzzy_floor.is_some() {
+            builder = builder.flag("--apply-fuzzy");
+        }
+        if let Some(floor) = fuzzy_floor {
+            builder = builder.flag_value("--min-confidence", floor);
+        } else if let Some(floor) = self.min_confidence {
+            builder = builder.flag_value("--min-confidence", &floor.to_string());
+        }
+        for glob in &self.globs {
+            builder = builder.flag_value("--glob", glob);
+        }
+        for target in &self.ignore_targets {
+            builder = builder.flag_value("--ignore-target", target);
+        }
+        if self.expand_short_form {
+            builder = builder.flag("--expand-short-form");
+        }
+        if self.case_insensitive {
+            builder = builder.flag("--case-insensitive");
+        }
+        builder.with_globals(ctx)
+    }
+
+    pub(crate) fn review_at_floor(&self, ctx: &HintContext, floor: &str) -> HintBuilder {
+        let mut builder = HintBuilder::cmd("links fix").flag_value("--min-confidence", floor);
+        if (self.threshold - 0.8).abs() > f64::EPSILON {
+            builder = builder.flag_value("--threshold", &self.threshold.to_string());
+        }
+        for glob in &self.globs {
+            builder = builder.flag_value("--glob", glob);
+        }
+        for target in &self.ignore_targets {
+            builder = builder.flag_value("--ignore-target", target);
+        }
+        if self.expand_short_form {
+            builder = builder.flag("--expand-short-form");
+        }
+        if self.case_insensitive {
+            builder = builder.flag("--case-insensitive");
+        }
+        builder.with_globals(ctx)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AutoLinkHintSpec {
+    min_length: usize,
+    exclude_titles: Vec<String>,
+    first_only: bool,
+    exclude_target_globs: Vec<String>,
+    no_warn_common_titles: bool,
+    file: Option<String>,
+    globs: Vec<String>,
+}
+
+impl AutoLinkHintSpec {
+    pub(crate) fn apply(&self, ctx: &HintContext) -> HintBuilder {
+        let mut builder = HintBuilder::cmd("links auto").flag("--apply");
+        if self.min_length != 3 {
+            builder = builder.flag_value("--min-length", &self.min_length.to_string());
+        }
+        for title in &self.exclude_titles {
+            builder = builder.flag_value("--exclude-title", title);
+        }
+        builder = if self.first_only {
+            builder.flag("--first-only")
+        } else {
+            builder.flag("--no-first-only")
+        };
+        for glob in &self.exclude_target_globs {
+            builder = builder.flag_value("--exclude-target-glob", glob);
+        }
+        if self.no_warn_common_titles {
+            builder = builder.flag("--no-warn-common-titles");
+        }
+        if let Some(file) = &self.file {
+            builder = builder.raw(format!("--file={file}"));
+        }
+        for glob in &self.globs {
+            builder = builder.flag_value("--glob", glob);
+        }
+        builder.with_globals(ctx)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ResolvedHintSpec {
+    Find(FindHintSpec),
+    Lint(LintHintSpec),
+    LinksFix(LinkFixHintSpec),
+    LinksAuto(AutoLinkHintSpec),
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct HintResolutionConfig<'a> {
+    pub(crate) language: Option<&'a str>,
+    pub(crate) lint_strict: bool,
+    pub(crate) auto_exclude_titles: &'a [String],
+    pub(crate) auto_exclude_titles_set: bool,
+    pub(crate) auto_exclude_target_globs: &'a [String],
+    pub(crate) auto_first_only: bool,
+    pub(crate) auto_warn_common_titles: bool,
+}
+
+pub(crate) fn resolve_hint_spec(
+    command: &Commands,
+    config: HintResolutionConfig<'_>,
+) -> Option<ResolvedHintSpec> {
+    match command {
+        Commands::Find(args) => Some(ResolvedHintSpec::Find(FindHintSpec::from_args(
+            args,
+            config.language,
+        ))),
+        Commands::Lint {
+            file_positional,
+            file,
+            glob,
+            r#type,
+            fix,
+            dry_run,
+            limit,
+            detailed,
+            rule,
+            rule_prefix,
+            max_per_rule,
+            fix_rule,
+            strict,
+            profile,
+            ..
+        } => {
+            let files = if file_positional.is_empty() {
+                file
+            } else {
+                file_positional
+            };
+            Some(ResolvedHintSpec::Lint(LintHintSpec {
+                files: ReplayFiles::bounded(files),
+                globs: glob.clone(),
+                file_type: r#type.clone(),
+                fix: *fix,
+                dry_run: *dry_run,
+                limit: *limit,
+                detailed: *detailed,
+                rule: rule.clone(),
+                rule_prefix: rule_prefix.clone(),
+                max_per_rule: *max_per_rule,
+                fix_rules: fix_rule.clone(),
+                strict: *strict || config.lint_strict,
+                profile: profile.clone(),
+            }))
+        }
+        Commands::Links {
+            action:
+                Some(LinksAction::Fix {
+                    threshold,
+                    apply_fuzzy,
+                    min_confidence,
+                    glob,
+                    ignore_target,
+                    expand_short_form,
+                    case_insensitive,
+                    ..
+                }),
+        } => Some(ResolvedHintSpec::LinksFix(LinkFixHintSpec {
+            threshold: *threshold,
+            apply_fuzzy: *apply_fuzzy,
+            min_confidence: *min_confidence,
+            globs: glob.clone(),
+            ignore_targets: ignore_target.clone(),
+            expand_short_form: *expand_short_form,
+            case_insensitive: *case_insensitive,
+        })),
+        Commands::Links {
+            action:
+                Some(LinksAction::Auto {
+                    min_length,
+                    exclude_title,
+                    first_only,
+                    no_first_only,
+                    exclude_target_glob,
+                    no_warn_common_titles,
+                    file,
+                    glob,
+                    ..
+                }),
+        } => {
+            let mut titles = config.auto_exclude_titles.to_vec();
+            titles.extend(exclude_title.iter().cloned());
+            titles.sort();
+            titles.dedup();
+            let mut target_globs = config.auto_exclude_target_globs.to_vec();
+            target_globs.extend(exclude_target_glob.iter().cloned());
+            target_globs.sort();
+            target_globs.dedup();
+            let effective_first_only = if *no_first_only {
+                false
+            } else {
+                *first_only || config.auto_first_only
+            };
+            Some(ResolvedHintSpec::LinksAuto(AutoLinkHintSpec {
+                min_length: *min_length,
+                exclude_titles: titles,
+                first_only: effective_first_only,
+                exclude_target_globs: target_globs,
+                no_warn_common_titles: *no_warn_common_titles
+                    || !config.auto_warn_common_titles
+                    || config.auto_exclude_titles_set,
+                file: file.clone(),
+                globs: glob.clone(),
+            }))
+        }
+        Commands::Links { action: None } => Some(ResolvedHintSpec::LinksFix(LinkFixHintSpec {
+            threshold: 0.8,
+            apply_fuzzy: false,
+            min_confidence: None,
+            globs: Vec::new(),
+            ignore_targets: Vec::new(),
+            expand_short_form: false,
+            case_insensitive: false,
+        })),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::Cli;
+    use crate::hints::{FindIndexHint, HintSource};
+    use clap::Parser as _;
+
+    fn config<'a>() -> HintResolutionConfig<'a> {
+        HintResolutionConfig {
+            language: None,
+            lint_strict: false,
+            auto_exclude_titles: &[],
+            auto_exclude_titles_set: false,
+            auto_exclude_target_globs: &[],
+            auto_first_only: false,
+            auto_warn_common_titles: true,
+        }
+    }
+
+    #[test]
+    fn find_continuation_changes_only_limit_and_keeps_raw_paths() {
+        let cli = Cli::try_parse_from([
+            "hyalo",
+            "find",
+            "time out",
+            "--section",
+            "Wanted",
+            "--file=-odd note 'é'.md",
+            "--sort",
+            "title",
+            "--reverse",
+            "--limit",
+            "2",
+            "--language",
+            "english",
+        ])
+        .unwrap();
+        let ResolvedHintSpec::Find(spec) = resolve_hint_spec(&cli.command, config()).unwrap()
+        else {
+            panic!("expected find spec")
+        };
+        let mut ctx = HintContext::new(HintSource::Find);
+        ctx.site_prefix = Some("docs root".to_owned());
+        ctx.find_index = FindIndexHint::File("indexes/current index".to_owned());
+        let hint = spec.continuation(&ctx, &["--limit", "0"]).unwrap();
+        let argv = hint.argv();
+        assert!(argv.contains(&"--file=-odd note 'é'.md".to_owned()));
+        assert_eq!(
+            argv.iter().filter(|arg| arg.as_str() == "--limit").count(),
+            1
+        );
+        assert_eq!(
+            argv.iter().position(|arg| arg == "--").unwrap() + 1,
+            argv.len() - 1
+        );
+        assert_eq!(argv.last().map(String::as_str), Some("time out"));
+        assert!(
+            Cli::try_parse_from(argv).is_ok(),
+            "raw continuation must parse: {argv:?}"
+        );
+        assert!(
+            hint.build()
+                .contains(&crate::hints::shell_quote("--file=-odd note 'é'.md"))
+        );
+    }
+
+    #[test]
+    fn lint_apply_keeps_selection_profile_and_rules_but_drops_preview() {
+        let cli = Cli::try_parse_from([
+            "hyalo",
+            "lint",
+            "--file=a.md",
+            "--profile",
+            "skills",
+            "--rule",
+            "HYALO001",
+            "--rule-prefix",
+            "MD",
+            "--fix-rule",
+            "MD009",
+            "--fix",
+            "--dry-run",
+        ])
+        .unwrap();
+        let ResolvedHintSpec::Lint(spec) = resolve_hint_spec(&cli.command, config()).unwrap()
+        else {
+            panic!("expected lint spec")
+        };
+        let hint = spec
+            .continuation(&HintContext::new(HintSource::Lint), &["--fix"])
+            .unwrap();
+        let argv = hint.argv();
+        for token in [
+            "--file=a.md",
+            "--profile",
+            "skills",
+            "--rule",
+            "HYALO001",
+            "--rule-prefix",
+            "MD",
+            "--fix-rule",
+            "MD009",
+            "--fix",
+        ] {
+            assert!(
+                argv.iter().any(|arg| arg == token),
+                "missing {token}: {argv:?}"
+            );
+        }
+        assert!(!argv.iter().any(|arg| arg == "--dry-run"));
+        assert!(
+            Cli::try_parse_from(argv).is_ok(),
+            "lint continuation must parse: {argv:?}"
+        );
+
+        let type_cli =
+            Cli::try_parse_from(["hyalo", "lint", "--type", "note", "--fix", "--dry-run"]).unwrap();
+        let ResolvedHintSpec::Lint(type_spec) =
+            resolve_hint_spec(&type_cli.command, config()).unwrap()
+        else {
+            panic!("expected lint spec")
+        };
+        let type_argv = type_spec
+            .continuation(&HintContext::new(HintSource::Lint), &["--fix"])
+            .unwrap()
+            .argv()
+            .to_vec();
+        assert!(type_argv.windows(2).any(|pair| pair == ["--type", "note"]));
+        assert!(Cli::try_parse_from(&type_argv).is_ok());
+    }
+
+    #[test]
+    fn links_review_changes_only_the_fuzzy_floor() {
+        let cli = Cli::try_parse_from([
+            "hyalo",
+            "links",
+            "fix",
+            "--threshold",
+            "0.42",
+            "--min-confidence",
+            "0.7",
+            "--ignore-target",
+            "draft",
+            "--case-insensitive",
+        ])
+        .unwrap();
+        let ResolvedHintSpec::LinksFix(spec) = resolve_hint_spec(&cli.command, config()).unwrap()
+        else {
+            panic!("expected links-fix spec")
+        };
+        let argv = spec
+            .review_at_floor(&HintContext::new(HintSource::LinksFix), "0")
+            .argv()
+            .to_vec();
+        assert!(argv.windows(2).any(|pair| pair == ["--threshold", "0.42"]));
+        assert!(
+            argv.windows(2)
+                .any(|pair| pair == ["--min-confidence", "0"])
+        );
+        assert!(
+            argv.windows(2)
+                .any(|pair| pair == ["--ignore-target", "draft"])
+        );
+        assert!(argv.iter().any(|arg| arg == "--case-insensitive"));
+        assert!(Cli::try_parse_from(&argv).is_ok());
+    }
+
+    #[test]
+    fn auto_link_apply_emits_effective_counter_flags_and_exclusions() {
+        let cli = Cli::try_parse_from([
+            "hyalo",
+            "links",
+            "auto",
+            "--no-first-only",
+            "--exclude-target-glob",
+            "drafts/*",
+            "--file=-odd.md",
+        ])
+        .unwrap();
+        let configured_titles = vec!["Home".to_owned()];
+        let configured_globs = vec!["templates/*".to_owned()];
+        let cfg = HintResolutionConfig {
+            auto_exclude_titles: &configured_titles,
+            auto_exclude_target_globs: &configured_globs,
+            auto_first_only: true,
+            ..config()
+        };
+        let ResolvedHintSpec::LinksAuto(spec) = resolve_hint_spec(&cli.command, cfg).unwrap()
+        else {
+            panic!("expected auto-link spec")
+        };
+        let argv = spec
+            .apply(&HintContext::new(HintSource::LinksAuto))
+            .argv()
+            .to_vec();
+        assert!(argv.iter().any(|arg| arg == "--no-first-only"));
+        assert!(argv.iter().any(|arg| arg == "templates/*"));
+        assert!(argv.iter().any(|arg| arg == "drafts/*"));
+        assert!(argv.iter().any(|arg| arg == "--file=-odd.md"));
+        assert!(
+            Cli::try_parse_from(&argv).is_ok(),
+            "auto-link continuation must parse: {argv:?}"
+        );
+    }
+
+    #[test]
+    fn oversized_resolved_selection_refuses_executable_replay() {
+        let mut argv = vec!["hyalo".to_owned(), "lint".to_owned()];
+        for index in 0..=MAX_REPLAY_TARGETS {
+            argv.push(format!("--file=n{index}.md"));
+        }
+        argv.extend(["--fix".to_owned(), "--dry-run".to_owned()]);
+        let cli = Cli::try_parse_from(argv).unwrap();
+        let ResolvedHintSpec::Lint(spec) = resolve_hint_spec(&cli.command, config()).unwrap()
+        else {
+            panic!("expected lint spec")
+        };
+        let reason = spec
+            .continuation(&HintContext::new(HintSource::Lint), &["--fix"])
+            .unwrap_err();
+        assert!(reason.contains("exceeds the safe hint replay budget"));
+    }
+}

--- a/crates/hyalo-cli/src/mutation.rs
+++ b/crates/hyalo-cli/src/mutation.rs
@@ -19,6 +19,7 @@ use crate::cli::args::{
     ChangelogAction, Commands, LinksAction, LintRulesAction, MadrAction, OkfAction,
     PropertiesAction, TagsAction, TaskAction, TypesAction, ViewsAction,
 };
+use clap::Parser as _;
 
 impl Commands {
     /// `true` when this invocation will modify the vault, `.hyalo.toml`, or a
@@ -241,6 +242,12 @@ impl Commands {
             _ => false,
         }
     }
+}
+
+/// Classify a generated continuation from its raw argv through the real Clap
+/// hierarchy. Hints must not infer effects by reparsing their shell rendering.
+pub(crate) fn command_argv_writes(argv: &[String]) -> bool {
+    crate::cli::args::Cli::try_parse_from(argv).is_ok_and(|cli| cli.command.writes())
 }
 
 /// Top-level subcommands (and `group sub` pairs) that write unconditionally.
@@ -468,7 +475,6 @@ fn split_command_line(cmd: &str) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::cli::args::Cli;
-    use clap::Parser as _;
 
     /// Command lines exercised by both classifiers, with the expected verdict.
     const CORPUS: &[(&str, bool)] = &[

--- a/crates/hyalo-cli/src/run.rs
+++ b/crates/hyalo-cli/src/run.rs
@@ -1891,69 +1891,10 @@ fn run_inner() -> Result<(), AppError> {
                 None | Some(crate::cli::args::ViewsAction::List) => {
                     Some(HintContext::from_common(HintSource::ViewsList, &common))
                 }
-                // `views run <name>` is `find --view <name>` under another
-                // name — dispatch.rs merges the saved view with this same
-                // CLI overlay and calls the identical `find_commands::find`.
-                // Reproduce that merge here too (read-only — dispatch.rs's
-                // own resolution is untouched, so there is no risk of
-                // double-merging list filters): otherwise the hint context
-                // would only ever see the overlay, not the view's own saved
-                // filters, and every derived hint would silently drop them
-                // (NEW-18, dogfood pre3; mirrors the `Commands::Find { view:
-                // Some(_), .. }` early-merge above, lines ~976-987).
-                Some(crate::cli::args::ViewsAction::Run {
-                    name,
-                    pattern,
-                    filters: overlay,
-                    ..
-                }) => {
-                    let views = crate::commands::views::load_views(&config_dir);
-                    let mut merged = views.get(name).cloned().unwrap_or_default();
-                    let mut overlay = overlay.clone();
-                    overlay.pattern.clone_from(pattern);
-                    merged.merge_from(&overlay);
-                    let FindFilters {
-                        glob,
-                        regexp,
-                        properties,
-                        tag,
-                        task,
-                        file,
-                        fields,
-                        sort,
-                        reverse,
-                        limit,
-                        sections,
-                        broken_links,
-                        orphan,
-                        dead_end,
-                        title,
-                        pattern: merged_pattern,
-                        ..
-                    } = merged;
-                    let mut ctx = HintContext::from_common(HintSource::Find, &common);
-                    ctx.glob = glob;
-                    ctx.fields = fields;
-                    ctx.sort = sort;
-                    ctx.reverse = reverse;
-                    ctx.has_limit = limit.is_some();
-                    ctx.has_body_search = merged_pattern.is_some();
-                    ctx.body_pattern = merged_pattern;
-                    ctx.has_regex_search = regexp.is_some();
-                    ctx.property_filters = properties;
-                    ctx.tag_filters = tag;
-                    ctx.task_filter = task;
-                    ctx.file_targets = file;
-                    ctx.section_filters = sections;
-                    ctx.broken_links_filter = broken_links;
-                    ctx.orphan_filter = orphan;
-                    ctx.dead_end_filter = dead_end;
-                    ctx.title_filter = title;
-                    ctx.view_name = Some(name.clone());
-                    Some(ctx)
-                }
                 Some(
-                    crate::cli::args::ViewsAction::Set { .. }
+                    // Run is normalized to Commands::Find before config/view resolution.
+                    crate::cli::args::ViewsAction::Run { .. }
+                    | crate::cli::args::ViewsAction::Set { .. }
                     | crate::cli::args::ViewsAction::Remove { .. },
                 ) => None,
             },
@@ -2313,6 +2254,47 @@ fn run_inner() -> Result<(), AppError> {
             return Err(AppError::Internal(e));
         }
     };
+
+    // Build family-specific replay specs only after saved views, config
+    // defaults and --files-from have been resolved. This is the same command
+    // state dispatch consumes; continuation hints no longer reconstruct scope
+    // from the earlier presentation-only HintContext fields.
+    if let Some(ref mut hint) = hint_ctx {
+        hint.resolved = crate::hints::spec::resolve_hint_spec(
+            &cli.command,
+            crate::hints::spec::HintResolutionConfig {
+                language: config_language_owned.as_deref(),
+                lint_strict: lint_strict_from_config,
+                auto_exclude_titles: &auto_link_exclude_titles,
+                auto_exclude_titles_set: auto_link_exclude_titles_set,
+                auto_exclude_target_globs: &auto_link_exclude_target_globs,
+                auto_first_only: auto_link_first_only,
+                auto_warn_common_titles: auto_link_warn_common_titles,
+            },
+        );
+        // Legacy non-continuation hints still read these presentation fields.
+        // Keep them aligned with the resolved selection instead of the raw
+        // --files-from source captured before resolution.
+        match &cli.command {
+            Commands::Find(FindArgs {
+                filters: FindFilters { file, .. },
+                file_positional,
+                ..
+            })
+            | Commands::Lint {
+                file,
+                file_positional,
+                ..
+            } => {
+                hint.file_targets = if file_positional.is_empty() {
+                    file.clone()
+                } else {
+                    file_positional.clone()
+                };
+            }
+            _ => {}
+        }
+    }
 
     let query_reports_counters = matches!(cli.command, Commands::Find(_));
     output_plan.set_counters(

--- a/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
+++ b/crates/hyalo-cli/templates/pi/extensions/hyalo.ts
@@ -6,11 +6,10 @@ import {
   createPiTransport,
   find as hyaloFind,
   lint as hyaloLint,
+  mutationReport as hyaloMutationReport,
   raw as hyaloRaw,
   read as hyaloRead,
-  set as hyaloSet,
   summary as hyaloSummary,
-  task as hyaloTask,
 } from "../lib/hyalo-api.js";
 
 const HYALO_TIMEOUT_MS = 60_000;
@@ -26,6 +25,18 @@ interface HyaloToolArgs {
   jq?: string;
   /** Path to a snapshot index created with `hyalo create-index` */
   indexFile?: string;
+}
+
+function renderSuccess(text: string, diagnostics: readonly string[] = []) {
+  return {
+    content: [
+      { type: "text" as const, text: text || "(no output)" },
+      ...diagnostics
+        .filter((diagnostic) => diagnostic.length > 0)
+        .map((diagnostic) => ({ type: "text" as const, text: `Stderr:\n${diagnostic}` })),
+    ],
+    details: undefined,
+  };
 }
 
 /**
@@ -59,10 +70,7 @@ async function runHyalo(
       };
     }
 
-    return {
-      content: [{ type: "text" as const, text: stdout || "(no output)" }],
-      details: undefined,
-    };
+    return renderSuccess(stdout, [stderr]);
   } catch (error) {
     return {
       content: [
@@ -83,19 +91,14 @@ async function runTyped(
   try {
     const diagnostics: string[] = [];
     const text = await operation((stderr) => { diagnostics.push(stderr); });
-    return {
-      content: [
-        { type: "text" as const, text: text || "(no output)" },
-        ...diagnostics.map((stderr) => ({ type: "text" as const, text: `Stderr:\n${stderr}` })),
-      ],
-      details: undefined,
-    };
+    return renderSuccess(text, diagnostics);
   } catch (error) {
     const value = error as {
       exitCode?: number;
       stderr?: string;
       stdout?: string;
       message?: string;
+      guardrail?: string;
     };
     if (typeof value.exitCode === "number") {
       return {
@@ -103,6 +106,7 @@ async function runTyped(
           { type: "text" as const, text: `hyalo ${command} failed with exit code ${value.exitCode}` },
           ...(value.stderr ? [{ type: "text" as const, text: `Stderr:\n${value.stderr}` }] : []),
           ...(value.stdout ? [{ type: "text" as const, text: `Stdout:\n${value.stdout}` }] : []),
+          ...(value.guardrail ? [{ type: "text" as const, text: value.guardrail }] : []),
         ],
         details: undefined,
       };
@@ -114,9 +118,32 @@ async function runTyped(
   }
 }
 
-/** Whether the argv already carries a value-taking flag (long or short). */
-function hasFlag(argv: string[], long: string, short?: string): boolean {
-  return argv.includes(long) || (short !== undefined && argv.includes(short));
+/** Values supplied for a long option before the positional `--` terminator. */
+function optionValues(argv: string[], option: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") break;
+    if (arg === option) {
+      const value = argv[index + 1];
+      if (value === undefined || value === "--") {
+        throw new TypeError(`${option} requires a value`);
+      }
+      values.push(value);
+      index += 1;
+    } else if (arg.startsWith(`${option}=`)) {
+      values.push(arg.slice(option.length + 1));
+    }
+  }
+  return values;
+}
+
+function oneOptionValue(argv: string[], option: string): string | undefined {
+  const values = optionValues(argv, option);
+  if (values.length > 1) {
+    throw new TypeError(`conflicting duplicate ${option} options`);
+  }
+  return values[0];
 }
 
 function buildCommand(params: HyaloToolArgs): string[] {
@@ -126,14 +153,26 @@ function buildCommand(params: HyaloToolArgs): string[] {
   // Only inject defaults the caller did not supply themselves: the model
   // often repeats `--format text` from the skill's guidance, and a duplicate
   // `--format` is a hard clap error ("cannot be used multiple times").
-  const hasFormat = hasFlag(extraArgs, "--format", "-f");
-  if (formatText && !jq && !hasFormat) {
+  const rawFormat = oneOptionValue(extraArgs, "--format");
+  const rawJq = oneOptionValue(extraArgs, "--jq");
+  const rawIndexFile = oneOptionValue(extraArgs, "--index-file");
+  if (jq !== undefined && rawJq !== undefined && jq !== rawJq) {
+    throw new TypeError("conflicting --jq values supplied by jq and args");
+  }
+  if (indexFile !== undefined && rawIndexFile !== undefined && indexFile !== rawIndexFile) {
+    throw new TypeError("conflicting --index-file values supplied by indexFile and args");
+  }
+  const effectiveJq = jq ?? rawJq;
+  if (effectiveJq !== undefined && rawFormat !== undefined && rawFormat !== "json") {
+    throw new TypeError("--jq cannot be combined with a non-JSON --format");
+  }
+  if (formatText && effectiveJq === undefined && rawFormat === undefined) {
     cmdArgs.push("--format", "text");
   }
-  if (jq && !hasFlag(extraArgs, "--jq")) {
+  if (jq !== undefined && rawJq === undefined) {
     cmdArgs.push("--jq", jq);
   }
-  if (indexFile && !hasFlag(extraArgs, "--index-file")) {
+  if (indexFile !== undefined && rawIndexFile === undefined) {
     cmdArgs.push("--index-file", indexFile);
   }
   cmdArgs.push(...extraArgs);
@@ -148,49 +187,137 @@ function buildCommand(params: HyaloToolArgs): string[] {
  * The agent sees the findings in the same turn and fixes them immediately
  * — schema drift can no longer land silently. Clean files add nothing.
  *
- * The vault directory is resolved once via `hyalo config` and cached for
- * the session; files outside the vault (or a failed config lookup) skip
- * the check entirely, so non-hyalo projects pay zero cost.
+ * A successfully resolved vault directory is cached for the session. A
+ * failed lookup is reported for a successful observed write and retried on
+ * the next mutation, so a transient config failure cannot disable checks for
+ * the rest of the process.
  */
+type HyaloConfigLookup =
+  | { status: "available"; config: Awaited<ReturnType<typeof hyaloConfig>> }
+  | { status: "unavailable"; text: string };
+
 async function loadHyaloConfig(
   transport: ReturnType<typeof createPiTransport>,
-): Promise<Awaited<ReturnType<typeof hyaloConfig>> | null> {
+): Promise<HyaloConfigLookup> {
   const cached = loadHyaloConfig.cache;
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return { status: "available", config: cached };
   try {
     const resolved = await hyaloConfig({ transport, timeoutMs: 10_000 });
     loadHyaloConfig.cache = resolved;
-    return resolved;
-  } catch {
-    // hyalo not installed or no config: no vault, no guardrail.
-    loadHyaloConfig.cache = null;
-    return null;
+    return { status: "available", config: resolved };
+  } catch (error) {
+    const value = error as { message?: string; stderr?: string };
+    return {
+      status: "unavailable",
+      text: value.stderr?.trim() || value.message || String(error),
+    };
   }
 }
 // Module-level cache slot (survives across event handler invocations).
-loadHyaloConfig.cache = undefined as Awaited<ReturnType<typeof hyaloConfig>> | null | undefined;
+loadHyaloConfig.cache = undefined as Awaited<ReturnType<typeof hyaloConfig>> | undefined;
 
 async function findVaultDir(
   transport: ReturnType<typeof createPiTransport>,
-): Promise<string | null> {
-  return (await loadHyaloConfig(transport))?.vaultDir ?? null;
+): Promise<{ status: "available"; vaultDir: string | null } | { status: "unavailable"; text: string }> {
+  const lookup = await loadHyaloConfig(transport);
+  return lookup.status === "available"
+    ? { status: "available", vaultDir: lookup.config.vaultDir ?? null }
+    : lookup;
 }
+
+type LintGuardResult =
+  | { status: "clean" }
+  | { status: "findings"; text: string }
+  | { status: "unavailable"; text: string };
 
 async function lintVaultFile(
   transport: ReturnType<typeof createPiTransport>,
   filePath: string,
   signal: AbortSignal | undefined,
-): Promise<string | null> {
+): Promise<LintGuardResult> {
   try {
     const { stdout, code } = await hyaloLint(filePath, { transport, signal, timeoutMs: 30_000 });
-    // lint exits 0 = clean, 1 = violations found (stdout holds them),
-    // anything else = lint itself failed: stay silent, don't mask the write.
-    if (code !== 0 && code !== 1) return null;
+    if (code !== 0 && code !== 1) {
+      return { status: "unavailable", text: `hyalo lint exited with code ${code}` };
+    }
     // Clean single-file output is "N file checked, no issues".
-    if (/no issues/.test(stdout)) return null;
-    return stdout.trim();
-  } catch {
-    return null;
+    if (code === 0 && /no issues/.test(stdout)) return { status: "clean" };
+    return { status: "findings", text: stdout.trim() };
+  } catch (error) {
+    return {
+      status: "unavailable",
+      text: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+const SURVIVING_EFFECTS = new Set([
+  "committed",
+  "committed_with_finalization_error",
+  "kept",
+  "restore_failed",
+]);
+
+async function lintMutationEffects(
+  transport: ReturnType<typeof createPiTransport>,
+  effects: { paths?: Array<{ file: string; state: string }> } | undefined,
+  signal: AbortSignal | undefined,
+): Promise<string | null> {
+  if (!effects?.paths) return null;
+  const files = [...new Set(effects.paths
+    .filter((effect) => SURVIVING_EFFECTS.has(effect.state) && effect.file.endsWith(".md"))
+    .map((effect) => effect.file))];
+  if (files.length === 0) return null;
+  const vault = await findVaultDir(transport);
+  if (vault.status === "unavailable") {
+    return `⚠ post-write hyalo lint was unavailable for ${files.join(", ")}; ` +
+      `the write succeeded but its lint status is unknown: unable to resolve the vault: ${vault.text}`;
+  }
+  const vaultDir = vault.vaultDir;
+  if (!vaultDir) return null;
+  const vaultAbs = path.resolve(process.cwd(), vaultDir);
+  const messages: string[] = [];
+  for (const file of files) {
+    const fileAbs = path.resolve(vaultAbs, file);
+    if (fileAbs !== vaultAbs && !fileAbs.startsWith(vaultAbs + path.sep)) continue;
+    const lint = await lintVaultFile(transport, file, signal);
+    if (lint.status === "findings") {
+      messages.push(
+        `⚠ hyalo lint found issues in ${file} (the write succeeded; fix the violations now):\n\n${lint.text}`,
+      );
+    } else if (lint.status === "unavailable") {
+      messages.push(
+        `⚠ post-write hyalo lint was unavailable for ${file}; the write succeeded but its lint status is unknown: ${lint.text}`,
+      );
+    }
+  }
+  return messages.length > 0 ? messages.join("\n\n") : null;
+}
+
+async function runObservedMutation(
+  transport: ReturnType<typeof createPiTransport>,
+  argv: string[],
+  signal: AbortSignal | undefined,
+  onDiagnostics: (stderr: string) => void,
+): Promise<string> {
+  try {
+    const report = await hyaloMutationReport<unknown>(argv, {
+      transport,
+      signal,
+      timeoutMs: HYALO_TIMEOUT_MS,
+      onDiagnostics,
+    });
+    const guardrail = await lintMutationEffects(transport, report.effects, signal);
+    const text = JSON.stringify(report.results, null, 2);
+    return guardrail ? `${text}\n\n${guardrail}` : text;
+  } catch (error) {
+    const value = error as {
+      effects?: { paths?: Array<{ file: string; state: string }> };
+      guardrail?: string;
+    };
+    const guardrail = await lintMutationEffects(transport, value.effects, signal);
+    if (guardrail) value.guardrail = guardrail;
+    throw error;
   }
 }
 
@@ -246,10 +373,8 @@ export default function (pi: ExtensionAPI) {
   });
 
   // --- typed tools -------------------------------------------------------
-  // Structured parameters for the ~80% operations. No argv assembly, no
-  // flag spelling, no quoting — the schema is the interface. All route
-  // through runHyalo, so behavior (timeouts, signals, error rendering) is
-  // identical to the generic tool.
+  // Structured parameters for the common operations. The schema is the
+  // interface; adapters assemble raw argv without involving a shell.
 
   const hyaloFindParams = Type.Object({
     query: Type.Optional(
@@ -363,8 +488,10 @@ export default function (pi: ExtensionAPI) {
     parameters: hyaloSetParams,
     async execute(_toolCallId, params: Static<typeof hyaloSetParams>, signal) {
       return runTyped("set", async (onDiagnostics) => {
-        const result = await hyaloSet({ ...params, transport, signal, onDiagnostics });
-        return result.stdout;
+        const argv = ["set", `--property=${params.property}`];
+        if (params.tag !== undefined) argv.push(`--tag=${params.tag}`);
+        argv.push("--", params.file);
+        return runObservedMutation(transport, argv, signal, onDiagnostics);
       });
     },
   });
@@ -392,16 +519,22 @@ export default function (pi: ExtensionAPI) {
     parameters: hyaloTaskParams,
     async execute(_toolCallId, params: Static<typeof hyaloTaskParams>, signal) {
       return runTyped("task", async (onDiagnostics) => {
-        const result = await hyaloTask({
-          file: params.file,
-          mode: params.mode,
-          section: params.section,
-          lines: params.lines,
-          transport,
-          signal,
-          onDiagnostics,
-        });
-        return result.stdout;
+        const argv = ["task", "toggle"];
+        if (params.mode === "section") {
+          if (params.section === undefined) {
+            throw new TypeError("task mode 'section' requires section");
+          }
+          argv.push(`--section=${params.section}`);
+        } else if (params.mode === "line") {
+          if (!params.lines?.length) {
+            throw new TypeError("task mode 'line' requires at least one line");
+          }
+          argv.push(`--line=${params.lines.map(Math.trunc).join(",")}`);
+        } else {
+          argv.push("--all");
+        }
+        argv.push("--", params.file);
+        return runObservedMutation(transport, argv, signal, onDiagnostics);
       });
     },
   });
@@ -414,8 +547,10 @@ export default function (pi: ExtensionAPI) {
   let summaryInjected = false;
   pi.on("session_start", async () => {
     if (summaryInjected) return;
-    const config = await loadHyaloConfig(transport);
-    if (!config?.sessionSummary || !config.vaultDir) return;
+    const lookup = await loadHyaloConfig(transport);
+    if (lookup.status === "unavailable") return;
+    const config = lookup.config;
+    if (!config.sessionSummary || !config.vaultDir) return;
     summaryInjected = true;
     try {
       const snapshot = await hyaloSummary({ transport, timeoutMs: 30_000 });
@@ -444,7 +579,20 @@ export default function (pi: ExtensionAPI) {
     const rawPath = event.input.path;
     if (typeof rawPath !== "string" || !rawPath.endsWith(".md")) return;
 
-    const vaultDir = await findVaultDir(transport);
+    const vault = await findVaultDir(transport);
+    if (vault.status === "unavailable") {
+      return {
+        content: [
+          ...event.content,
+          {
+            type: "text" as const,
+            text: `⚠ post-write hyalo lint was unavailable for ${rawPath}; ` +
+              `the write succeeded but its lint status is unknown: unable to resolve the vault: ${vault.text}`,
+          },
+        ],
+      };
+    }
+    const vaultDir = vault.vaultDir;
     if (!vaultDir) return;
 
     // Vault membership: normalized absolute path containment check.
@@ -453,17 +601,22 @@ export default function (pi: ExtensionAPI) {
     if (fileAbs !== vaultAbs && !fileAbs.startsWith(vaultAbs + path.sep)) return;
 
     const lintOutput = await lintVaultFile(transport, rawPath, ctx.signal);
-    if (!lintOutput) return; // clean or lint unavailable
+    if (lintOutput.status === "clean") return;
+
+    const relative = path.relative(vaultAbs, fileAbs);
+    const message = lintOutput.status === "findings"
+      ? `⚠ hyalo lint found issues in ${relative} ` +
+        `(write succeeded, but fix the violations now — e.g. 'hyalo set' for ` +
+        `frontmatter, 'hyalo lint --fix' for formatting):\n\n${lintOutput.text}`
+      : `⚠ post-write hyalo lint was unavailable for ${relative}; ` +
+        `the write succeeded but its lint status is unknown: ${lintOutput.text}`;
 
     return {
       content: [
         ...event.content,
         {
           type: "text" as const,
-          text:
-            `⚠ hyalo lint found issues in ${path.relative(vaultAbs, fileAbs)} ` +
-            `(write succeeded, but fix the violations now — e.g. 'hyalo set' for ` +
-            `frontmatter, 'hyalo lint --fix' for formatting):\n\n${lintOutput}`,
+          text: message,
         },
       ],
     };

--- a/crates/hyalo-cli/templates/pi/lib/hyalo-api.d.ts
+++ b/crates/hyalo-cli/templates/pi/lib/hyalo-api.d.ts
@@ -1259,9 +1259,10 @@ type ReadArgs = {
      */
     lines?: string;
     /**
-     * Include the YAML frontmatter in output
+     * Return YAML frontmatter only, or combine it with a body selector
      *
-     * Text output echoes the block's own bytes between its `---` fences —
+     * By itself, this omits the body. Combine with --lines or --section to
+     * return both frontmatter and the selected body. Text output echoes the block's own bytes between its `---` fences —
      * indentation, quote style and comments exactly as on disk; no YAML is
      * re-serialized on a read path. JSON keeps the parsed map under
      * `frontmatter` and adds the raw text as `frontmatter_raw` (null for a

--- a/crates/hyalo-cli/templates/pi/skills/hyalo-tidy/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo-tidy/SKILL.md
@@ -46,13 +46,19 @@ hyalo summary --format text
 # 2. Create snapshot index (one scan, reused by all subsequent queries)
 hyalo create-index --format text
 
-# 3. Save recurring diagnostic queries as views for reuse
-hyalo views set stale-in-progress --property status=in-progress --fields tasks --format text
-hyalo views set missing-status --property '!status' --format text
-hyalo views set missing-type --property '!type' --format text
-hyalo views set orphans --orphan --fields backlinks --format text
-hyalo views set completed-with-todos --property status=completed --task todo --fields tasks --format text
+# 3. Inspect existing saved views without rewriting configuration
+hyalo views list --format text
+
+# Use a matching saved view when present; otherwise keep diagnostics inline
+hyalo find --property status=in-progress --fields tasks --index --format text
+hyalo find --property '!status' --index --format text
+hyalo find --property '!type' --index --format text
+hyalo find --orphan --fields backlinks --index --format text
+hyalo find --property status=completed --task todo --fields tasks --index --format text
 ```
+
+Do not create or replace saved views during a tidy unless the user explicitly asks;
+the diagnostic phase must leave existing definitions byte-for-byte unchanged.
 
 The snapshot index captures every file's metadata in a binary file (`.hyalo-index`).
 All read-only queries in Phase 2 and Phase 3 should use `--index` to

--- a/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
+++ b/crates/hyalo-cli/templates/pi/skills/hyalo/SKILL.md
@@ -277,9 +277,9 @@ is required.
 
 ### Bulk Status Updates
 ```bash
-# Update all planned iterations older than 30 days to deferred
-hyalo find --property status=planned --property type=iteration --jq '.results | map(select(.properties.date < "2026-06-01")) | map(.file)' \
-  | xargs -I {} hyalo set {} --property status=deferred --format text
+# Preview a native filtered update; rerun without --dry-run after review
+hyalo set --glob 'iterations/*.md' --where-property status=planned \
+  --property status=deferred --dry-run --format text
 ```
 
 ### Health Dashboard

--- a/crates/hyalo-cli/templates/skill-hyalo.md
+++ b/crates/hyalo-cli/templates/skill-hyalo.md
@@ -419,10 +419,12 @@ Use `hyalo read` to extract file content without opening the full file:
 hyalo read my-note.md                              # full body (no frontmatter)
 hyalo read my-note.md --section "Tasks"            # extract one section
 hyalo read my-note.md --lines 1:20                 # line range (1-based)
-hyalo read my-note.md --frontmatter                # include YAML frontmatter (verbatim)
+hyalo read my-note.md --frontmatter                # frontmatter only (verbatim)
+hyalo read my-note.md --frontmatter --lines 1:     # frontmatter plus the full body
 ```
 
-`--frontmatter` echoes the block's **own bytes** between its `---` fences — indentation,
+Standalone `--frontmatter` omits the body. Combine it with `--lines` or `--section` to
+request both. It echoes the block's **own bytes** between its `---` fences — indentation,
 quote style and comments exactly as on disk. Nothing is re-serialized on a read path. In JSON
 the parsed map stays under `.results.frontmatter` and the raw text sits beside it as
 `.results.frontmatter_raw` (`null` for a file with no frontmatter block).

--- a/crates/hyalo-cli/tests/e2e/iteration294_continuation_contracts.rs
+++ b/crates/hyalo-cli/tests/e2e/iteration294_continuation_contracts.rs
@@ -1,0 +1,305 @@
+//! Iteration 294: execute scope-preserving continuation hints as advertised.
+
+use super::common::hyalo;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    hyalo()
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("run hyalo")
+}
+
+fn hint_command(value: &serde_json::Value, needle: &str) -> String {
+    value["hints"]
+        .as_array()
+        .expect("hints array")
+        .iter()
+        .find(|hint| {
+            hint["description"]
+                .as_str()
+                .is_some_and(|description| description.contains(needle))
+        })
+        .and_then(|hint| hint["cmd"].as_str())
+        .filter(|command| !command.is_empty())
+        .unwrap_or_else(|| panic!("missing executable {needle:?} hint: {value}"))
+        .to_owned()
+}
+
+fn run_advertised_shell(root: &Path, command: &str) -> Output {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_hyalo"));
+    let bin_dir = binary.parent().expect("binary parent");
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let joined = std::env::join_paths(
+        std::iter::once(bin_dir.to_path_buf()).chain(std::env::split_paths(&path)),
+    )
+    .expect("PATH");
+    Command::new("sh")
+        .args(["-c", command])
+        .current_dir(root)
+        .env("PATH", joined)
+        .output()
+        .expect("execute advertised shell command")
+}
+
+#[test]
+fn lint_apply_hint_keeps_files_from_scope_and_sentinel_bytes() {
+    let project = TempDir::new().unwrap();
+    let vault = project.path().join("vault");
+    fs::create_dir(&vault).unwrap();
+    fs::write(project.path().join(".hyalo.toml"), "dir = \"vault\"\n").unwrap();
+    let bad = "---\ntitle: selected\n---\n\ntrailing spaces   \n";
+    fs::write(vault.join("a note.md"), bad).unwrap();
+    fs::write(vault.join("b sentinel.md"), bad).unwrap();
+    fs::write(project.path().join("changed.txt"), "vault/a note.md\n").unwrap();
+    let sentinel = fs::read(vault.join("b sentinel.md")).unwrap();
+
+    let preview = run(
+        project.path(),
+        &[
+            "lint",
+            "--files-from",
+            "changed.txt",
+            "--fix",
+            "--dry-run",
+            "--fix-rule",
+            "MD009",
+            "--format",
+            "json",
+            "--hints",
+        ],
+    );
+    assert!(
+        preview.status.success(),
+        "{}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&preview.stdout).unwrap();
+    let apply = hint_command(&json, "Apply");
+    assert!(apply.contains("--file='a note.md'") || apply.contains("'--file=a note.md'"));
+    assert!(!apply.contains("--files-from"));
+    let applied = run_advertised_shell(project.path(), &apply);
+    assert!(
+        applied.status.success(),
+        "{apply}\n{}",
+        String::from_utf8_lossy(&applied.stderr)
+    );
+    assert_ne!(fs::read(vault.join("a note.md")).unwrap(), bad.as_bytes());
+    assert_eq!(fs::read(vault.join("b sentinel.md")).unwrap(), sentinel);
+}
+
+#[test]
+fn find_show_all_shell_hint_keeps_query_section_and_exact_result_set() {
+    let project = TempDir::new().unwrap();
+    let vault = project.path().join("vault");
+    fs::create_dir(&vault).unwrap();
+    fs::write(
+        project.path().join(".hyalo.toml"),
+        "dir = \"vault\"\ndefault_limit = 2\n",
+    )
+    .unwrap();
+    for index in 0..3 {
+        fs::write(
+            vault.join(format!("match {index}.md")),
+            format!("# Other\n\ntimeout outside\n\n## Wanted\n\ntimeout selected {index}\n"),
+        )
+        .unwrap();
+    }
+    fs::write(
+        vault.join("wrong-section.md"),
+        "# Other\n\ntimeout only here\n",
+    )
+    .unwrap();
+    fs::write(vault.join("no-match.md"), "## Wanted\n\nunrelated\n").unwrap();
+
+    let limited = run(
+        project.path(),
+        &[
+            "find",
+            "timeout",
+            "--section",
+            "Wanted",
+            "--sort",
+            "title",
+            "--format",
+            "json",
+            "--hints",
+        ],
+    );
+    assert!(limited.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&limited.stdout).unwrap();
+    assert_eq!(json["results"].as_array().unwrap().len(), 2);
+    assert_eq!(json["total"], 3);
+    let show_all = hint_command(&json, "Show all 3");
+    assert!(show_all.contains("--section Wanted"));
+    assert!(show_all.contains("--limit 0"));
+    assert!(show_all.ends_with("-- timeout"));
+    let output = run_advertised_shell(project.path(), &show_all);
+    assert!(
+        output.status.success(),
+        "{show_all}\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let all: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let mut files: Vec<_> = all["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|result| result["file"].as_str().unwrap().to_owned())
+        .collect();
+    files.sort();
+    assert_eq!(files, ["match 0.md", "match 1.md", "match 2.md"]);
+}
+
+#[test]
+fn auto_link_apply_shell_hint_keeps_first_only_and_target_exclusion() {
+    let project = TempDir::new().unwrap();
+    let vault = project.path().join("vault");
+    fs::create_dir_all(vault.join("templates")).unwrap();
+    fs::write(project.path().join(".hyalo.toml"), "dir = \"vault\"\n").unwrap();
+    fs::write(vault.join("target.md"), "---\ntitle: QuasarTarget\n---\n").unwrap();
+    fs::write(
+        vault.join("templates/template.md"),
+        "---\ntitle: ExcludedWidget\n---\n",
+    )
+    .unwrap();
+    fs::write(
+        vault.join("source.md"),
+        "---\ntitle: Source\n---\n\nQuasarTarget appears. QuasarTarget repeats. ExcludedWidget remains.\n",
+    )
+    .unwrap();
+    let preview = run(
+        project.path(),
+        &[
+            "links",
+            "auto",
+            "--file",
+            "source.md",
+            "--first-only",
+            "--exclude-target-glob",
+            "templates/*",
+            "--format",
+            "json",
+            "--hints",
+        ],
+    );
+    assert!(
+        preview.status.success(),
+        "{}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&preview.stdout).unwrap();
+    let apply = hint_command(&json, "Apply");
+    assert!(apply.contains("--first-only"));
+    assert!(apply.contains("--exclude-target-glob 'templates/*'"));
+    let output = run_advertised_shell(project.path(), &apply);
+    assert!(
+        output.status.success(),
+        "{apply}\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let source = fs::read_to_string(vault.join("source.md")).unwrap();
+    assert_eq!(
+        source.matches("[[target|QuasarTarget]]").count(),
+        1,
+        "{source}"
+    );
+    assert!(source.contains("QuasarTarget repeats"), "{source}");
+    assert_eq!(source.matches("ExcludedWidget").count(), 1, "{source}");
+    assert!(!source.contains("[[ExcludedWidget]]"), "{source}");
+}
+
+#[test]
+fn links_fix_shell_hints_preserve_ordinary_and_fuzzy_scope() {
+    let fuzzy = TempDir::new().unwrap();
+    fs::write(
+        fuzzy.path().join(".hyalo.toml"),
+        "dir = \".\"\n[links]\ncase_insensitive = \"false\"\n",
+    )
+    .unwrap();
+    fs::write(fuzzy.path().join("draft-note.md"), "# Draft\n").unwrap();
+    fs::write(fuzzy.path().join("other-note.md"), "# Other\n").unwrap();
+    fs::write(
+        fuzzy.path().join("source.md"),
+        "[[draft-noet]] and [[other-noet]]\n",
+    )
+    .unwrap();
+    let preview = run(
+        fuzzy.path(),
+        &[
+            "links",
+            "fix",
+            "--ignore-target",
+            "draft",
+            "--case-insensitive",
+            "--format",
+            "json",
+            "--hints",
+        ],
+    );
+    assert!(
+        preview.status.success(),
+        "{}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&preview.stdout).unwrap();
+    let fuzzy_apply = hint_command(&json, "lower-confidence fuzzy fixes");
+    for token in [
+        "--apply-fuzzy",
+        "--ignore-target draft",
+        "--case-insensitive",
+    ] {
+        assert!(fuzzy_apply.contains(token), "{token}: {fuzzy_apply}");
+    }
+    let output = run_advertised_shell(fuzzy.path(), &fuzzy_apply);
+    assert!(
+        output.status.success(),
+        "{fuzzy_apply}\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let source = fs::read_to_string(fuzzy.path().join("source.md")).unwrap();
+    assert!(
+        source.contains("[[draft-noet]]"),
+        "ignored target changed: {source}"
+    );
+    assert!(
+        source.contains("[[other-note]]"),
+        "fuzzy target was not repaired: {source}"
+    );
+
+    let ordinary = TempDir::new().unwrap();
+    fs::create_dir(ordinary.path().join("sub")).unwrap();
+    fs::write(ordinary.path().join(".hyalo.toml"), "dir = \".\"\n").unwrap();
+    fs::write(ordinary.path().join("sub/Corina.md"), "# Corina\n").unwrap();
+    fs::write(ordinary.path().join("source.md"), "[[Corina]]\n").unwrap();
+    let preview = run(
+        ordinary.path(),
+        &[
+            "links",
+            "fix",
+            "--expand-short-form",
+            "--format",
+            "json",
+            "--hints",
+        ],
+    );
+    let json: serde_json::Value = serde_json::from_slice(&preview.stdout).unwrap();
+    let apply = hint_command(&json, "Apply 1 fixes");
+    assert!(apply.contains("links fix --apply"), "{apply}");
+    assert!(!apply.contains("--apply-fuzzy"), "{apply}");
+    assert!(apply.contains("--expand-short-form"), "{apply}");
+    let output = run_advertised_shell(ordinary.path(), &apply);
+    assert!(
+        output.status.success(),
+        "{apply}\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(ordinary.path().join("source.md")).unwrap(),
+        "[[sub/Corina]]\n"
+    );
+}

--- a/crates/hyalo-cli/tests/e2e/mod.rs
+++ b/crates/hyalo-cli/tests/e2e/mod.rs
@@ -106,3 +106,4 @@ mod windows_paths;
 
 mod iteration290_foundations;
 mod iteration293_mutation_safety;
+mod iteration294_continuation_contracts;

--- a/crates/xtask/src/jq_recipes.rs
+++ b/crates/xtask/src/jq_recipes.rs
@@ -128,6 +128,90 @@ fn comment_start(cmd: &str) -> Option<usize> {
     None
 }
 
+/// Extract one continued `hyalo` command from the fenced example following a
+/// named heading. The executable documentation contracts use only this small
+/// shell subset: argv quoting plus a trailing `\` line continuation.
+fn fenced_command_after(body: &str, heading: &str, prefix: &str) -> Option<String> {
+    let section = body.split_once(heading)?.1;
+    let section = section.split("\n##").next().unwrap_or(section);
+    let mut in_fence = false;
+    let mut command = String::new();
+    let mut collecting = false;
+    for line in section.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            if collecting && !command.is_empty() {
+                return Some(command);
+            }
+            in_fence = !in_fence;
+            continue;
+        }
+        if !in_fence || trimmed.starts_with('#') || trimmed.is_empty() {
+            continue;
+        }
+        if !collecting {
+            if !trimmed.starts_with(prefix) {
+                continue;
+            }
+            collecting = true;
+        }
+        let continued = trimmed.ends_with('\\');
+        let part = trimmed.strip_suffix('\\').unwrap_or(trimmed).trim_end();
+        if !command.is_empty() {
+            command.push(' ');
+        }
+        command.push_str(part);
+        if !continued {
+            return Some(command);
+        }
+    }
+    collecting.then_some(command).filter(|cmd| !cmd.is_empty())
+}
+
+/// Detect the unsafe legacy shape where JSON output was handed to `xargs` as
+/// filenames. Pipes inside the quoted jq program do not count.
+fn has_unsafe_hyalo_xargs_pipeline(body: &str) -> bool {
+    let body = body.replace("\\\n", " ");
+    body.lines().any(|line| {
+        let mut quote = None;
+        for (offset, ch) in line.char_indices() {
+            match quote {
+                Some(current) if ch == current => quote = None,
+                Some(_) => {}
+                None if ch == '\'' || ch == '"' => quote = Some(ch),
+                None if ch == '|' => {
+                    let left = &line[..offset];
+                    let right = line[offset + ch.len_utf8()..].trim_start();
+                    if left.contains("hyalo ")
+                        && left.contains("--jq")
+                        && (right == "xargs" || right.starts_with("xargs "))
+                    {
+                        return true;
+                    }
+                }
+                None => {}
+            }
+        }
+        false
+    })
+}
+
+/// Extract the ordinary shell body from the OKF GitHub Actions `run: |`
+/// example. The block is executed by Bash as a whole; its individual commands
+/// are deliberately not interpreted or replaced in Rust.
+fn okf_ci_shell_block(body: &str) -> Option<String> {
+    let section = body.split_once("## OKF reserved-file drift check")?.1;
+    let section = section.split("\n## ").next().unwrap_or(section);
+    let mut lines = section.lines();
+    lines.find(|line| matches!(line.trim(), "- run: |" | "run: |"))?;
+    let commands: Vec<_> = lines
+        .take_while(|line| !line.trim().starts_with("```"))
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    (!commands.is_empty()).then(|| commands.join("\n"))
+}
+
 /// Split a documented command line into argv, honouring single and double
 /// quotes (the only quoting the recipes use).
 pub fn split_argv(cmd: &str) -> Vec<String> {
@@ -227,6 +311,8 @@ pub fn run_with_root(root: &Path) -> Result<bool> {
         }
     }
 
+    failures.extend(documentation_contract_failures(root)?);
+
     if failures.is_empty() {
         println!(
             "check-jq-recipes: {checked} shipped --jq recipe(s) execute against the vault \
@@ -244,6 +330,297 @@ pub fn run_with_root(root: &Path) -> Result<bool> {
         );
         Ok(false)
     }
+}
+
+/// Execute the mutation/CI/view recipes whose contract cannot be established
+/// by merely proving that an embedded jq expression parses.
+fn documentation_contract_failures(root: &Path) -> Result<Vec<String>> {
+    let mut failures = Vec::new();
+    let skill = std::fs::read_to_string(root.join("pi-package/skills/hyalo/SKILL.md"))?;
+    let tmp = tempfile::tempdir().context("creating documentation recipe fixture")?;
+    let vault = tmp.path().join("vault");
+    std::fs::create_dir_all(vault.join("iterations"))?;
+    let config = "dir = \"vault\"\n\n[views.existing]\nproperties = [\"status=planned\"]\n";
+    std::fs::write(tmp.path().join(".hyalo.toml"), config)?;
+    let selected = vault.join("iterations/planned note.md");
+    let sentinel = vault.join("iterations/completed.md");
+    std::fs::write(
+        &selected,
+        "---\ntitle: Planned\nstatus: planned\n---\nbody\n",
+    )?;
+    std::fs::write(
+        &sentinel,
+        "---\ntitle: Completed\nstatus: completed\n---\nsentinel\n",
+    )?;
+    let selected_before = std::fs::read(&selected)?;
+    let sentinel_before = std::fs::read(&sentinel)?;
+
+    match fenced_command_after(&skill, "### Bulk Status Updates", "hyalo set ") {
+        Some(recipe) => {
+            let argv = split_argv(&recipe);
+            if argv.first().map(String::as_str) != Some("hyalo")
+                || !argv.iter().any(|arg| arg == "--dry-run")
+            {
+                failures
+                    .push("bulk status recipe must be an executable dry-run hyalo command".into());
+            } else {
+                let preview_args: Vec<_> = argv.iter().skip(1).map(String::as_str).collect();
+                let preview = run_hyalo(root, tmp.path(), &preview_args)?;
+                if !preview.status.success()
+                    || std::fs::read(&selected)? != selected_before
+                    || std::fs::read(&sentinel)? != sentinel_before
+                {
+                    failures.push(
+                        "documented native bulk recipe did not preview without changing bytes"
+                            .into(),
+                    );
+                }
+                let apply_args: Vec<_> = preview_args
+                    .iter()
+                    .copied()
+                    .filter(|arg| *arg != "--dry-run")
+                    .collect();
+                let applied = run_hyalo(root, tmp.path(), &apply_args)?;
+                let selected_after = std::fs::read_to_string(&selected)?;
+                if !applied.status.success()
+                    || !selected_after.contains("status: deferred")
+                    || std::fs::read(&sentinel)? != sentinel_before
+                {
+                    failures.push(
+                        "documented native bulk recipe changed the wrong selected set".into(),
+                    );
+                }
+
+                // The same shipped preview must be safe when its filter selects
+                // nothing; this is also the state after the apply above.
+                let selected_after = std::fs::read(&selected)?;
+                let empty_preview = run_hyalo(root, tmp.path(), &preview_args)?;
+                if !empty_preview.status.success()
+                    || std::fs::read(&selected)? != selected_after
+                    || std::fs::read(&sentinel)? != sentinel_before
+                {
+                    failures.push(
+                        "documented native bulk recipe mishandled an empty selected set".into(),
+                    );
+                }
+
+                // Negative control: removing the documented filter must make
+                // this fixture catch the broadened write through the sentinel.
+                let unfiltered = recipe.replace("--where-property status=planned ", "");
+                let unfiltered_argv = split_argv(&unfiltered);
+                let unfiltered_args: Vec<_> = unfiltered_argv
+                    .iter()
+                    .skip(1)
+                    .map(String::as_str)
+                    .filter(|arg| *arg != "--dry-run")
+                    .collect();
+                let negative = tempfile::tempdir().context("creating unfiltered recipe control")?;
+                let negative_vault = negative.path().join("vault/iterations");
+                std::fs::create_dir_all(&negative_vault)?;
+                std::fs::write(negative.path().join(".hyalo.toml"), "dir = \"vault\"\n")?;
+                std::fs::write(
+                    negative_vault.join("planned note.md"),
+                    "---\ntitle: Planned\nstatus: planned\n---\nbody\n",
+                )?;
+                let negative_sentinel = negative_vault.join("completed.md");
+                std::fs::write(
+                    &negative_sentinel,
+                    "---\ntitle: Completed\nstatus: completed\n---\nsentinel\n",
+                )?;
+                let negative_before = std::fs::read(&negative_sentinel)?;
+                let broadened = run_hyalo(root, negative.path(), &unfiltered_args)?;
+                if !broadened.status.success()
+                    || std::fs::read(&negative_sentinel)? == negative_before
+                {
+                    failures.push(
+                        "bulk recipe fixture no longer rejects removal of the selection filter"
+                            .into(),
+                    );
+                }
+            }
+        }
+        None => failures.push("canonical Pi skill has no executable bulk status recipe".into()),
+    }
+
+    let config_before = std::fs::read(tmp.path().join(".hyalo.toml"))?;
+    let views = run_hyalo(
+        root,
+        tmp.path(),
+        &["views", "list", "--format", "json", "--no-hints"],
+    )?;
+    if !views.status.success() || std::fs::read(tmp.path().join(".hyalo.toml"))? != config_before {
+        failures.push("tidy orientation did not preserve saved views byte-for-byte".into());
+    }
+
+    let ci = std::fs::read_to_string(root.join("docs/ci.md"))?;
+    failures.extend(okf_ci_contract_failures(root, &ci)?);
+    if has_unsafe_hyalo_xargs_pipeline(&skill) {
+        failures.push("canonical Pi skill pipes JSON output into xargs filenames".into());
+    }
+    let empty = run_hyalo(
+        root,
+        tmp.path(),
+        &[
+            "find",
+            "--property",
+            "status=missing",
+            "--jq",
+            ".results",
+            "--no-hints",
+        ],
+    )?;
+    let empty_stdout = String::from_utf8_lossy(&empty.stdout);
+    let mut unsafe_args = vec!["set"];
+    unsafe_args.extend(empty_stdout.split_whitespace());
+    unsafe_args.extend(["--property", "status=deferred", "--dry-run"]);
+    let unsafe_consumer = run_hyalo(root, tmp.path(), &unsafe_args)?;
+    if !empty.status.success() || empty_stdout.trim() != "[]" || unsafe_consumer.status.success() {
+        failures.push(
+            "empty-result control no longer proves that JSON [] is unsafe filename input".into(),
+        );
+    }
+    let tidy = std::fs::read_to_string(root.join("pi-package/skills/hyalo-tidy/SKILL.md"))?;
+    if tidy.contains("hyalo views set") {
+        failures.push("tidy orientation still overwrites saved views".into());
+    }
+    Ok(failures)
+}
+
+fn okf_ci_contract_failures(root: &Path, ci: &str) -> Result<Vec<String>> {
+    let mut failures = Vec::new();
+    let Some(script) = okf_ci_shell_block(ci) else {
+        return Ok(vec!["OKF CI block has no executable run script".into()]);
+    };
+    let tmp = tempfile::tempdir().context("creating OKF CI recipe fixture")?;
+    let vault = tmp.path().join("vault");
+    std::fs::create_dir_all(&vault)?;
+    std::fs::write(tmp.path().join(".hyalo.toml"), "dir = \"vault\"\n")?;
+    std::fs::write(
+        vault.join("concept.md"),
+        "---\ntype: Concept\ntitle: Example\n---\nBody\n",
+    )?;
+
+    let drift = run_okf_ci_shell(root, tmp.path(), &script)?;
+    if let Some(failure) = shell_status_failure(&drift, false, "actual drift") {
+        failures.push(failure);
+    }
+
+    // Negative control for the review finding: `set +e` makes the first
+    // failing test ignorable and lets the later successful test overwrite the
+    // block status. The same status validator used above must reject it.
+    let ignored_check = format!("set +e\n{script}");
+    let ignored = run_okf_ci_shell(root, tmp.path(), &ignored_check)?;
+    if shell_status_failure(&ignored, false, "ignored-check negative control").is_none() {
+        failures.push("OKF shell gate did not reject an ignored drift check".into());
+    }
+
+    let applied = run_hyalo(
+        root,
+        tmp.path(),
+        &["okf", "index", "--format", "json", "--no-hints", "--apply"],
+    )?;
+    let clean = run_okf_ci_shell(root, tmp.path(), &script)?;
+    if !applied.status.success() {
+        failures.push("preparing the clean OKF shell fixture failed".into());
+    }
+    if let Some(failure) = shell_status_failure(&clean, true, "clean generated bundle") {
+        failures.push(failure);
+    }
+
+    std::fs::write(
+        vault.join("index.md"),
+        "# Index\n\n<!-- okf:index:begin -->\nhand prose\n",
+    )?;
+    let skipped = run_okf_ci_shell(root, tmp.path(), &script)?;
+    if let Some(failure) = shell_status_failure(&skipped, false, "skipped marker") {
+        failures.push(failure);
+    }
+
+    std::fs::write(tmp.path().join(".hyalo.toml"), "dir = \"missing\"\n")?;
+    let failed = run_okf_ci_shell(root, tmp.path(), &script)?;
+    if let Some(failure) = shell_status_failure(&failed, false, "configuration failure") {
+        failures.push(failure);
+    }
+    Ok(failures)
+}
+
+fn shell_status_failure(
+    output: &std::process::Output,
+    expected_success: bool,
+    scenario: &str,
+) -> Option<String> {
+    (output.status.success() != expected_success).then(|| {
+        format!(
+            "documented OKF shell block returned {} for {scenario}; stderr: {}",
+            output.status,
+            first_error_line(
+                &String::from_utf8_lossy(&output.stdout),
+                &String::from_utf8_lossy(&output.stderr)
+            )
+        )
+    })
+}
+
+fn run_okf_ci_shell(root: &Path, cwd: &Path, script: &str) -> Result<std::process::Output> {
+    let executable = [
+        root.join("target")
+            .join("release")
+            .join(if cfg!(windows) { "hyalo.exe" } else { "hyalo" }),
+        root.join("target")
+            .join("debug")
+            .join(if cfg!(windows) { "hyalo.exe" } else { "hyalo" }),
+    ]
+    .into_iter()
+    .find(|path| path.is_file())
+    .context("check-jq-recipes needs a built hyalo binary")?;
+    let binary_dir = executable
+        .parent()
+        .context("built hyalo binary has no parent directory")?;
+    let existing_path = std::env::var_os("PATH").unwrap_or_default();
+    let path = std::env::join_paths(
+        std::iter::once(binary_dir.to_path_buf()).chain(std::env::split_paths(&existing_path)),
+    )
+    .context("constructing PATH for documented OKF shell block")?;
+    Command::new("bash")
+        .args(["-euo", "pipefail", "-c", script])
+        .env("PATH", path)
+        .current_dir(cwd)
+        .output()
+        .context(
+            "running documented OKF CI block (requires Bash and jq; GitHub ubuntu-latest provides both)",
+        )
+}
+
+fn run_hyalo(root: &Path, cwd: &Path, args: &[&str]) -> Result<std::process::Output> {
+    let release =
+        root.join("target")
+            .join("release")
+            .join(if cfg!(windows) { "hyalo.exe" } else { "hyalo" });
+    let mut command = if release.is_file() {
+        Command::new(release)
+    } else {
+        let mut cargo = Command::new("cargo");
+        cargo.args([
+            "run",
+            "-q",
+            "--manifest-path",
+            &root.join("Cargo.toml").to_string_lossy(),
+            "-p",
+            "hyalo-cli",
+            "--",
+        ]);
+        cargo
+    };
+    command
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .with_context(|| {
+            format!(
+                "running documentation contract recipe: hyalo {}",
+                args.join(" ")
+            )
+        })
 }
 
 /// What running one recipe proved.
@@ -383,5 +760,41 @@ mod tests {
             Some("set")
         );
         assert_eq!(subcommand_of(&split_argv("hyalo --dir kb find")), None);
+    }
+
+    #[test]
+    fn extracts_the_actual_continued_bulk_recipe() {
+        let body = "### Bulk Status Updates\n```bash\n# Preview\nhyalo set --glob 'iterations/*.md' --where-property status=planned \\\n  --property status=deferred --dry-run --format text\n```";
+        assert_eq!(
+            fenced_command_after(body, "### Bulk Status Updates", "hyalo set ").as_deref(),
+            Some(
+                "hyalo set --glob 'iterations/*.md' --where-property status=planned --property status=deferred --dry-run --format text"
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_filename_consumers_across_spacing_and_lines() {
+        assert!(has_unsafe_hyalo_xargs_pipeline(
+            "hyalo find --jq '.results' \\\n              |   xargs hyalo set --property status=done"
+        ));
+        assert!(!has_unsafe_hyalo_xargs_pipeline(
+            "hyalo find --jq '.results[] | .file'"
+        ));
+    }
+
+    #[test]
+    fn extracts_the_complete_okf_ci_shell_block() {
+        let command = "report=\"$(hyalo okf index --format json --no-hints)\"";
+        let changed = "test \"$(jq '.results.changed' <<<\"$report\")\" -eq 0";
+        let markers = "test \"$(jq '.results.skipped_markers' <<<\"$report\")\" -eq 0";
+        let docs = format!(
+            "## OKF reserved-file drift check\n\n```yaml\n      - run: |\n          {command}\n          {changed}\n          {markers}\n```\n\n## Next"
+        );
+        let expected = format!("{command}\n{changed}\n{markers}");
+        assert_eq!(
+            okf_ci_shell_block(&docs).as_deref(),
+            Some(expected.as_str())
+        );
     }
 }

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -49,10 +49,13 @@ Three-dot `origin/<base>...HEAD` diffs against the *merge-base* of the PR base a
 
 ## OKF reserved-file drift check
 
-For **OKF** vaults, add a reserved-file drift check — `hyalo okf index` is dry-run by default and exits non-zero when any `index.md` is stale:
+For **OKF** vaults, add a reserved-file drift check. `hyalo okf index` is dry-run by default and reports drift in `results.changed`; marker problems are reported in `results.skipped_markers`. The dry run itself exits 0 for both clean and drift states, while an actual command failure remains non-zero. This GitHub Actions example requires Bash and `jq` (both are available on `ubuntu-latest`); keep the block under the runner's default fail-fast Bash settings:
 
 ```yaml
-      - run: hyalo okf index   # dry-run; non-zero exit on drift
+      - run: |
+          report="$(hyalo okf index --format json --no-hints)"
+          test "$(jq '.results.changed' <<<"$report")" -eq 0
+          test "$(jq '.results.skipped_markers' <<<"$report")" -eq 0
 ```
 
 ## `@claude` agent on GitHub (claude-code-action)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ default_limit = 100       # max results for list commands (default: 50; 0 = unli
 [links]
 frontmatter_properties = ["related", "depends-on"]   # list properties that contribute to the link graph
 case_insensitive = "auto"                             # "auto", "true", or "false"
-aliases = true                                        # frontmatter `aliases:` resolve wikilinks (default: true)
+aliases = false                                       # opt in to resolving frontmatter `aliases:` as link targets
 fuzzy_min_confidence = 0.8                            # confidence floor for links fix --apply-fuzzy (default: 0.8)
 
 [links.auto]
@@ -147,7 +147,7 @@ aliases:
 ---
 ```
 
-`[[Leah]]` written anywhere in the vault then resolves to that note. The rules
+With `[links] aliases = true`, `[[Leah]]` written anywhere in the vault resolves to that note. The rules
 (DEC-296):
 
 - Only the `aliases` property is read, in either shape Obsidian writes — a list
@@ -167,7 +167,7 @@ aliases:
   fuzzy-matches one; `mv` leaves alias-written links alone, because the alias
   travels with the note.
 
-Set `aliases = false` to restore filename-only resolution.
+The default is `aliases = false`: alias-written links remain unresolved and link repair can propose an explicit filename/title target without silently repointing them. Set `aliases = true` only for a workflow whose link resolver treats frontmatter aliases as targets.
 `hyalo config --jq '.results.links.aliases'` reports the effective value.
 
 Under `"auto"`, hyalo detects case behaviour with **stat calls only**: it looks

--- a/hyalo-knowledgebase/iterations/iteration-294-cli-agent-and-documentation-contracts.md
+++ b/hyalo-knowledgebase/iterations/iteration-294-cli-agent-and-documentation-contracts.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 294 — CLI, agent and documentation contracts
 date: 2026-09-10
-status: planned
+status: in-progress
 tags:
   - iteration
   - rust
@@ -50,42 +50,42 @@ consolidation changes execution granularity, not scope.
 
 ### Stage 1: Resolved scope drives execution and hints
 
-- [ ] Introduce command-family resolved specs for find, lint, link fix and auto-link. Merge
+- [x] Introduce command-family resolved specs for find, lint, link fix and auto-link. Merge
   saved views/config/defaults once; retain provenance where needed for effective counter-flags
   and explicit empty inputs.
 
-- [ ] Carry resolved target selection, query pattern/regex, sections, filters, sort,
+- [x] Carry resolved target selection, query pattern/regex, sections, filters, sort,
   profile/rules, site-prefix, language and index context in the relevant spec. Preserve only
   supported fields per family, not a universal bag of optional booleans.
 
-- [ ] Make continuation transforms explicit: with_limit(0), with_apply(true), or a specific
+- [x] Make continuation transforms explicit: with_limit(0), with_apply(true), or a specific
   drilldown. Scope-preserving continuations must not rebuild their operation from partial
   HintContext fields.
 
-- [ ] Rework HintBuilder to store raw OsString/String arguments, not shell-quoted tokens. Shell
+- [x] Rework HintBuilder to store raw OsString/String arguments, not shell-quoted tokens. Shell
   quoting is a renderer; --file=value and -- terminators protect option-looking paths. Test raw
   argv without executing through a shell.
 
-- [ ] For files-from stdin or long target lists, never emit a broader apply hint. Re-emit
+- [x] For files-from stdin or long target lists, never emit a broader apply hint. Re-emit
   bounded resolved targets or omit the executable hint with a clear explanation when safe replay
   cannot fit; do not add implicit manifest writes during a preview.
 
-- [ ] Thread hint demand into execution so discarded hints do not trigger body probes. Migrate
+- [x] Thread hint demand into execution so discarded hints do not trigger body probes. Migrate
   find show-all and lint apply first, then both link families, and delete duplicated view
   resolution.
 
 Acceptance for this stage (focused checks):
 
-- [ ] Executing show-all retains the exact query and changes only limit; executing apply retains
+- [x] Executing show-all retains the exact query and changes only limit; executing apply retains
   preview files, rules and effective exclusions.
 
-- [ ] Tests cover config counter-flags, named views, stdin selections, leading hyphens, spaces,
+- [x] Tests cover config counter-flags, named views, stdin selections, leading hyphens, spaces,
   quotes and empty targets.
 
-- [ ] Hint argv round-trips through Clap and resolves to the same semantic request; tests
+- [x] Hint argv round-trips through Clap and resolves to the same semantic request; tests
   compare effects/result sets rather than only string snapshots.
 
-- [ ] --no-hints, --jq and typed API calls perform no body I/O solely for a discarded
+- [x] --no-hints, --jq and typed API calls perform no body I/O solely for a discarded
   suggestion.
 
 Scope: No promise that a later command sees an unchanged filesystem. Replay preserves operation
@@ -94,40 +94,40 @@ unsupported universal SDK command abstraction.
 
 ### Stage 2: Close hint scope, empty-output and cardinality gaps
 
-- [ ] C02: lint --files-from changed.txt --fix --dry-run on only a.md must produce an apply
+- [x] C02: lint --files-from changed.txt --fix --dry-run on only a.md must produce an apply
   command that never changes eligible b.md. Repeat with --type, --profile, rule/fix-rule and
   stdin input.
 
-- [ ] C03: auto-link preview with --first-only and --exclude-target-glob templates/* must not
+- [x] C03: auto-link preview with --first-only and --exclude-target-glob templates/* must not
   apply repeated mentions or excluded templates; include config and counter-flags.
 
-- [ ] C04: fuzzy links-fix preview with --ignore-target draft must leave draft-noet.md untouched
+- [x] C04: fuzzy links-fix preview with --ignore-target draft must leave draft-noet.md untouched
   while repairing other-noet.md. Include case-insensitive behavior and ordinary versus fuzzy
   apply hints.
 
-- [ ] C06: find timeout --section Wanted with limit 2 and three matches in a five-file vault
+- [x] C06: find timeout --section Wanted with limit 2 and three matches in a five-file vault
   must show exactly those three under its show-all hint. Cover regex, language, sort,
   site-prefix and index context.
 
-- [ ] C07: empty files-from with --filenames0 or --filenames-only returns zero bytes. Execute a
+- [x] C07: empty files-from with --filenames0 or --filenames-only returns zero bytes. Execute a
   downstream filename consumer to prove no JSON envelope or [] becomes a path.
 
-- [ ] A02/A03: repeated files for single-file read/backlinks/task-read fail consistently; empty
+- [x] A02/A03: repeated files for single-file read/backlinks/task-read fail consistently; empty
   input messaging agrees with exit status. Every hint for --file=-odd.md must parse and target
   that same file, including spaces/quotes/Unicode variants.
 
 Acceptance for this stage (focused checks):
 
-- [ ] Execute emitted raw argv and advertised shell commands on disposable fixtures; compare
+- [x] Execute emitted raw argv and advertised shell commands on disposable fixtures; compare
   exact selected sets, rules and resulting bytes.
 
-- [ ] Unselected sentinel files remain unchanged after every apply hint; unreplayable
+- [x] Unselected sentinel files remain unchanged after every apply hint; unreplayable
   oversized/stdin selections yield advice, never broadened executable commands.
 
-- [ ] Empty filename outputs are byte-exact; cardinality errors and missing targets honor
+- [x] Empty filename outputs are byte-exact; cardinality errors and missing targets honor
   selected error format.
 
-- [ ] Capabilities and writes labels derive from normalized command intent rather than
+- [x] Capabilities and writes labels derive from normalized command intent rather than
   shell-string reparsing.
 
 Scope: Do not add an implicit persistent replay file or silently replay stdin. No new shell
@@ -135,44 +135,44 @@ dialect guarantee without tests.
 
 ### Stage 3: Unify Pi diagnostics, argv and post-write checks
 
-- [ ] C08: use one result-rendering helper for generic/typed successful calls so original stderr
+- [x] C08: use one result-rendering helper for generic/typed successful calls so original stderr
   diagnostics are visible exactly once, without corrupting structured stdout. Test actual
   malformed-note/stale-index warnings with a real binary.
 
-- [ ] C09: normalize raw --format=value, --format value, --jq and --index-file forms before
+- [x] C09: normalize raw --format=value, --format value, --jq and --index-file forms before
   injecting defaults. -f means file, not format; honor -- and reject conflicting duplicates
   clearly. Prefer shared option parsing helpers over new string heuristics.
 
-- [ ] C10: make the post-write guardrail run for hyalo_set (and audit other exposed mutation
+- [x] C10: make the post-write guardrail run for hyalo_set (and audit other exposed mutation
   tools) using committed effect paths, not only host write/edit events. Avoid double linting and
   recursive hooks; no writes means no guardrail work. Use the internal JSON report accessor from
   typed outcomes; preserve existing public npm set()/task() text ProcessResult return contracts.
 
-- [ ] Configure an iteration status enum including completed and a note with an unchecked task.
+- [x] Configure an iteration status enum including completed and a note with an unchecked task.
   Invoke hyalo_set status=completed and assert visible HYALO002 output while preserving
   successful-write status; distinguish lint unavailable/error from a clean result.
 
-- [ ] Regenerate Pi runtime/declarations and embedded copies using existing tools. Verify
+- [x] Regenerate Pi runtime/declarations and embedded copies using existing tools. Verify
   source-package, offline init installation and live Pi loading; keep TypeBox parameters and npm
   public result types compatible. Validate real TypeBox schemas and distinguish binary-backed
   host simulation from actual live-Pi loading. If live Pi is unavailable, record that acceptance
   pending; do not count a proxy TypeBox/mock host as live verification.
 
-- [ ] Add cancellation/timeout/partial-error tests through the shared outcome path and document
+- [x] Add cancellation/timeout/partial-error tests through the shared outcome path and document
   exactly which mutations receive checks.
 
 Acceptance for this stage (focused checks):
 
-- [ ] Generic and typed successful diagnostics are observable once; quiet mode preserves CLI
+- [x] Generic and typed successful diagnostics are observable once; quiet mode preserves CLI
   semantics.
 
-- [ ] Valid equals flags work without duplicate injections; positional option-looking values
+- [x] Valid equals flags work without duplicate injections; positional option-looking values
   remain literal.
 
-- [ ] The configured hyalo_set fixture visibly reports the real lint violation; no unsupported
+- [x] The configured hyalo_set fixture visibly reports the real lint violation; no unsupported
   automatic-guardrail claim remains.
 
-- [ ] npm typecheck/build/tests, TS/Pi freshness and source/offline integration tests pass
+- [x] npm typecheck/build/tests, TS/Pi freshness and source/offline integration tests pass
   against the same final binary.
 
 Scope: Do not rebuild the transport stack or add a server. No package publication or external
@@ -180,54 +180,54 @@ account changes are part of this iteration.
 
 ### Stage 4: Make docs, help and skills executable contracts
 
-- [ ] C11: replace JSON-array-to-xargs bulk recipes with native filtered mutation or correctly
+- [x] C11: replace JSON-array-to-xargs bulk recipes with native filtered mutation or correctly
   encoded files-from input. Execute nonempty/empty fixtures and paths with whitespace; assert
   only selected notes change. Update canonical skills and generated/embedded copies.
 
-- [ ] C12: keep OKF dry-run exit semantics and make CI explicitly check results.changed and
+- [x] C12: keep OKF dry-run exit semantics and make CI explicitly check results.changed and
   results.skipped_markers. Execute clean, drift, marker-skipped and actual-failure scenarios;
   help and README must describe the same gate.
 
-- [ ] C14: remove unconditional views set from tidy orientation. Use inline diagnostic queries
+- [x] C14: remove unconditional views set from tidy orientation. Use inline diagnostic queries
   or inspect/reuse existing views; a tidy run must preserve all existing saved definitions
   byte-for-byte unless the user explicitly requested a replacement.
 
-- [ ] C15: document aliases=false by default and condition alias resolution/no-rewrite promises
+- [x] C15: document aliases=false by default and condition alias resolution/no-rewrite promises
   on aliases=true. Test config inspection and a repair example under both modes.
 
-- [ ] A06: replace all-write dry-run/all-links-preserved/universal-JSON claims with exact
+- [x] A06: replace all-write dry-run/all-links-preserved/universal-JSON claims with exact
   command-supported guarantees. Correct read whole-file measurements, ambiguity exceptions, jq
   limits and automatic lint coverage in help, README, skills, templates and relevant comments.
 
-- [ ] Extend executable recipe gates to assert selected files, bytes changed, result fields and
+- [x] Extend executable recipe gates to assert selected files, bytes changed, result fields and
   failure status, including shell consumers. Provide controlled fixture data for every case;
   syntax-only jq execution is not proof a pipeline works.
 
-- [ ] Lead agent discovery with short help plus focused examples; retain comprehensive long help
+- [x] Lead agent discovery with short help plus focused examples; retain comprehensive long help
   for reference. Update docs from verified behavior, removing historical/promotional claims
   unsupported by tests.
 
-- [ ] Document read --frontmatter as frontmatter-only unless a section or line selection also
+- [x] Document read --frontmatter as frontmatter-only unless a section or line selection also
   requests the body. Execute separate body-only, frontmatter-only and combined --frontmatter
   --lines 1: examples; do not describe the standalone flag as simply including YAML in a
   full-file read.
 
-- [ ] Describe jq guarantees that actually exist when this block lands. Do not advertise the
+- [x] Describe jq guarantees that actually exist when this block lands. Do not advertise the
   future isolation work from iteration 295; that block must update the claims after its own
   tests pass.
 
 Acceptance for this stage (focused checks):
 
-- [ ] Each reviewed recipe executes against a disposable fixture and achieves its stated
+- [x] Each reviewed recipe executes against a disposable fixture and achieves its stated
   outcome, including empty input and intentional drift/failure.
 
-- [ ] Existing saved views survive the prescribed tidy workflow; no setup writes are disguised
+- [x] Existing saved views survive the prescribed tidy workflow; no setup writes are disguised
   as observation.
 
-- [ ] CLI help, README, configuration docs, npm/Pi/Codex instructions and embedded copies agree
+- [x] CLI help, README, configuration docs, npm/Pi/Codex instructions and embedded copies agree
   on defaults, limits, exits and supported guarantees.
 
-- [ ] Recipe tests fail when a filter is removed, [] is piped as a filename, or a CI drift check
+- [x] Recipe tests fail when a filter is removed, [] is piped as a filename, or a CI drift check
   stops inspecting its fields.
 
 Scope: Preserve historical completed iteration records as history; correct active docs and
@@ -262,20 +262,20 @@ marketing language true.
 
 ## One block completion gate
 
-- [ ] Finish all stage acceptance checks and record per-finding evidence. Preserve unrelated
+- [x] Finish all stage acceptance checks and record per-finding evidence. Preserve unrelated
   edits; public API/format changes must be explicit and tested. No whole-vault crash-transaction
   or concurrent-adversary guarantee is implied by the new types.
 
-- [ ] Obtain one fresh independent read-only review of the integrated block. Resolve actionable
+- [x] Obtain one fresh independent read-only review of the integrated block. Resolve actionable
   findings; re-review repaired behavior where necessary. Review stages as one final change
   rather than automatically launching a reviewer for every checklist item.
 
-- [ ] Before the final implementation commit/PR run, in order: cargo fmt; cargo clippy
+- [x] Before the final implementation commit/PR run, in order: cargo fmt; cargo clippy
   --workspace --all-targets -- -D warnings; cargo test --workspace -q. Run affected implemented
   xtask and package gates once for the integrated candidate, using actual dependencies and final
   generated assets.
 
-- [ ] For npm/Pi/assets changes run their typecheck/build/tests and TS/Pi/Codex freshness checks
+- [x] For npm/Pi/assets changes run their typecheck/build/tests and TS/Pi/Codex freshness checks
   against the same final binary. Build cargo build --release once after final asset generation,
   then use target/release/hyalo for changed-document inspection/strict lint and run git diff
   --check. Do not rebuild an unchanged binary between documentation-only internal stages.
@@ -285,7 +285,7 @@ marketing language true.
   checkpoint internal stages. This planning request itself authorizes no implementation or
   publication.
 
-- [ ] Reconcile the remaining five-or-fewer block plans once after final review/verification,
+- [x] Reconcile the remaining five-or-fewer block plans once after final review/verification,
   preserving scope and dependencies. Record exact revision, commands, review/CI evidence and
   limits; mark only fulfilled tasks complete. Keep iteration 287 external consumer work
   deferred.
@@ -397,3 +397,29 @@ unchanged. Actual live Pi loading and model-backed guardrail evidence remain
 required; host simulations and static checks cannot fulfill them. Use the final
 293 review and native CI evidence recorded by the supervisor, without inferring
 platform execution from cross-compilation or an earlier local run.
+
+
+## Verified implementation — 2026-09-10
+
+The integrated candidate passed independent Astra review after two repair passes.
+Resolved continuation specs preserve the selected operation; raw arguments remain
+bounded and round-trip through Clap. Lower-confidence link review also retains
+the original candidate threshold. Pi surfaces diagnostics once, checks actual
+surviving typed-mutation effects and reports unavailable lint when configuration
+lookup fails, retrying lookup on a later call without replaying a mutation.
+Public npm text result contracts remain unchanged.
+
+The final release is bound to SHA-256
+`5c00c61d65688c20fae1e925a50e4b895b679e585eda3ca7b3ab40d971ed1f73`.
+Local verification records 5,135 Rust passes, strict Clippy, npm typecheck/build
+and 38 tests, generated-asset checks, and actual live Pi loading and guardrails
+using Pi 0.84.4 with Sol/high. Executable recipe validation includes selected and
+unselected file bytes, empty input, and the actual documented OKF Bash checks
+for clean, drift, skipped-marker and command-failure states. Its executed
+ignored-check control detects suppressed drift failure.
+
+Two ignored Rust tests, the two existing stub gates and the unavailable MADR
+recipe are excluded from coverage. Feature-fanout help checks are not behavioral
+capability proof. Iteration 295 retains the stronger gates and resource work;
+current jq, filesystem and partial-write limitations remain in force.
+Native PR checks and the final remote checkpoint are still pending.

--- a/hyalo-knowledgebase/iterations/iteration-294-cli-agent-and-documentation-contracts.md
+++ b/hyalo-knowledgebase/iterations/iteration-294-cli-agent-and-documentation-contracts.md
@@ -2,7 +2,7 @@
 type: iteration
 title: Iteration 294 — CLI, agent and documentation contracts
 date: 2026-09-10
-status: in-progress
+status: completed
 tags:
   - iteration
   - rust
@@ -280,7 +280,7 @@ marketing language true.
   then use target/release/hyalo for changed-document inspection/strict lint and run git diff
   --check. Do not rebuild an unchanged binary between documentation-only internal stages.
 
-- [ ] In an authorized remote run, publish one PR and wait for required CI on its final head;
+- [x] In an authorized remote run, publish one PR and wait for required CI on its final head;
   preserve required multi-platform jobs and GitHub merge checks. Avoid draft pushes merely to
   checkpoint internal stages. This planning request itself authorizes no implementation or
   publication.
@@ -422,4 +422,7 @@ Two ignored Rust tests, the two existing stub gates and the unavailable MADR
 recipe are excluded from coverage. Feature-fanout help checks are not behavioral
 capability proof. Iteration 295 retains the stronger gates and resource work;
 current jq, filesystem and partial-write limitations remain in force.
-Native PR checks and the final remote checkpoint are still pending.
+All 11 required native PR checks passed on implementation commit
+`824c7d1db1bb617ce5fb97e0bb929331460e3ee0` in PR #350, including Linux,
+macOS and Windows tests and launcher checks. This completion-only update must
+pass its own final-head CI before the GitHub merge checkpoint.

--- a/hyalo-knowledgebase/iterations/iteration-295-resource-safety-and-final-verification.md
+++ b/hyalo-knowledgebase/iterations/iteration-295-resource-safety-and-final-verification.md
@@ -293,3 +293,46 @@ the 50-row/49-group ledger remain unchanged. Live model unavailability leaves it
 acceptance pending. Cover normal authored Markdown mistakes with useful
 diagnostics and safe refusal; no exhaustive gibberish/fuzz or exotic-file campaign
 is added. Iteration 287's external consumer task remains deferred.
+
+
+## Iteration 294 reconciliation — 2026-09-10
+
+Carry the reviewed family-specific hint specs from `hints/spec.rs` into final
+behavioral gates. They are built after selection/view/config resolution; raw
+`HintBuilder` argv is quoted only for display and classified for writes by the
+real Clap tree. Replay is bounded to 64 targets/8192 bytes and becomes advice on
+overflow. Preserve the resolved candidate threshold in lower-confidence link
+review and zero hint-only body reads when demand is suppressed.
+
+Pi typed set/task checks consume internal `mutationReport()` or `HyaloError`
+effects and lint actual surviving note paths. Generic/typed successful diagnostics
+appear exactly once; public npm text `ProcessResult` contracts are unchanged.
+Successful config lookups are cached; failures report lint unavailable and permit
+a later lookup retry, never a mutation retry. Generic mutation automatic lint
+remains unsupported. Preserve partial/finalization effects and existing guardrail
+exclusions instead of inferring writes from requested targets.
+
+Retain the executable bulk filter/empty/whitespace/sentinel regressions and direct
+execution of the documented OKF Bash/jq block, including numeric `changed` and
+`skipped_markers`, all four scenario statuses and the executed `set +e` negative
+control. Include the new `jq_recipes.rs` binary lookup in existing R16 artifact
+ownership alongside the scale runner: honor Cargo paths, executable suffix,
+`CARGO_TARGET_DIR` and explicit targets with actual native runtime evidence.
+Bash/jq availability is the documented ubuntu-latest recipe contract.
+
+Final review3 is clean. Supplied local evidence records 5,135 Rust passes, two
+ignored tests, 38 npm passes and live Pi 0.84.4 with Sol/high against release SHA-256
+`5c00c61d65688c20fae1e925a50e4b895b679e585eda3ca7b3ab40d971ed1f73`.
+The 41 executed jq recipes exclude MADR. Help-only feature fanout, both
+success-returning stubs and ignored tests remain outside behavioral proof.
+This is not native CI, publication or iteration-295 completion evidence.
+
+Astra retains A04 jq/resource implementation; after its writer freezes, fresh Sol
+owns remaining gates, documentation and the actual held-out model comparison.
+Keep all 26 original checkbox texts, A04/R16 ownership, the 294 dependency and the
+50-row/49-group ledger; R05 is the single S13 duplicate. Update resource promises
+only after supported platform tests pass. Preserve normal authored Markdown,
+broken frontmatter and common-mistake diagnostics with safe refusal without
+corruption; no exhaustive fuzz/gibberish or exotic-file campaign is added.
+Iteration 287's external consumer task stays deferred. Native CI and publication
+remain supervisor-owned and pending at this handoff.

--- a/hyalo-knowledgebase/research/rust-architecture-review-2026-09-10.md
+++ b/hyalo-knowledgebase/research/rust-architecture-review-2026-09-10.md
@@ -704,3 +704,43 @@ frontmatter, missing delimiters and incomplete edits: provide useful diagnostics
 and safe refusal without corruption where processing cannot continue. No
 exhaustive gibberish/fuzz or exotic-file campaign, new design or external
 Homefinder work is added.
+
+
+## Iteration 294 handoff — 2026-09-10
+
+The final candidate is bound to `294-review-attempt-3-manifest.json` and its clean
+independent review. Final repairs preserve the candidate threshold during
+lower-confidence hint review, distinguish unavailable configuration from cached
+success, and execute the actual documented OKF shell block with an executed
+`set +e` negative control. The earlier source-interface handoff is qualified by
+both repair dispositions and `294-repair2-supervisor-binding.json`.
+
+CLI family specs own post-selection/view/config resolved continuation scope.
+`HintBuilder` owns raw argv; display owns quoting and real Clap command intent
+owns writes classification. Explicit replay is bounded to 64 targets/8192 bytes;
+overflow yields advice. Pi typed set/task uses internal observed reports and
+surviving note paths while preserving public npm text returns. Generic/typed
+success stderr is rendered once. Config successes cache; failure is explicitly
+unavailable and retryable on later lookup, with no mutation replay. Generic
+mutation automatic lint remains unsupported.
+
+The final release SHA-256 is
+`5c00c61d65688c20fae1e925a50e4b895b679e585eda3ca7b3ab40d971ed1f73`.
+Supplied local evidence records 5,135 Rust passes, 38 npm passes and actual Pi
+0.84.4 Sol/high loading and guardrails. The recipe gate executes bulk selection,
+empty/whitespace/sentinel cases and the documented Bash/jq numeric OKF checks;
+41 executed recipes exclude MADR. Two ignored tests, help-token feature fanout
+and both success-returning stubs are not behavioral coverage. Native CI and
+publication remain pending; this note does not claim a merged 294 checkpoint.
+
+295 retains A04/R16 and all original acceptance texts: Astra implements
+jq/resource work, then fresh Sol owns remaining gates, docs and the actual
+held-out model comparison. Existing R16 artifact ownership includes the new
+`jq_recipes.rs` binary lookup as well as scale, preserving Cargo target-dir,
+explicit-target and executable-suffix behavior with native runtime proof.
+Retain parent-owned effects, tested resource limits and honest unsupported cases;
+update active guarantees only after those tests pass. The 50-row/49-group ledger,
+single R05/S13 duplicate and serial dependencies are unchanged. Normal authored
+Markdown, broken frontmatter and common mistakes require useful diagnostics and
+safe refusal without corruption; no exhaustive fuzz/gibberish or exotic-file
+campaign or external Homefinder work is added. Iteration 287 stays deferred.

--- a/npm/hyalo/src/generated/ReadArgs.ts
+++ b/npm/hyalo/src/generated/ReadArgs.ts
@@ -21,9 +21,10 @@ section?: string,
  */
 lines?: string,
 /**
- * Include the YAML frontmatter in output
+ * Return YAML frontmatter only, or combine it with a body selector
  *
- * Text output echoes the block's own bytes between its `---` fences —
+ * By itself, this omits the body. Combine with --lines or --section to
+ * return both frontmatter and the selected body. Text output echoes the block's own bytes between its `---` fences —
  * indentation, quote style and comments exactly as on disk; no YAML is
  * re-serialized on a read path. JSON keeps the parsed map under
  * `frontmatter` and adds the raw text as `frontmatter_raw` (null for a

--- a/npm/hyalo/test/pi.test.js
+++ b/npm/hyalo/test/pi.test.js
@@ -12,6 +12,20 @@ const execFileAsync = promisify(execFile);
 const root = path.resolve(__dirname, '../../..');
 const binary = process.env.HYALO_BIN || path.join(root, `target/release/hyalo${process.platform === 'win32' ? '.exe' : ''}`);
 
+async function bundleSourceExtension(scratch, name = 'extension') {
+  const outfile = path.join(scratch, `${name}.mjs`);
+  await build({
+    entryPoints: [path.join(root, 'pi-package/extensions/hyalo.ts')], outfile,
+    bundle: true, platform: 'node', format: 'esm',
+    plugins: [{ name: 'schema-only-typebox', setup(builder) {
+      builder.onResolve({ filter: /^typebox$/ }, () => ({ path: 'typebox', namespace: 'fixture' }));
+      builder.onLoad({ filter: /.*/, namespace: 'fixture' }, () => ({ contents:
+        'export const Type = new Proxy({}, { get: () => (...args) => args[0] });' }));
+    } }],
+  });
+  return outfile;
+}
+
 test('Pi source and offline init tools display successful warnings as separate text', async () => {
   const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hyalo-pi-diagnostics-'));
   try {
@@ -33,9 +47,16 @@ test('Pi source and offline init tools display successful warnings as separate t
       let stderr = 'warning: index older than vault\n';
       let code = 0;
       const pi = {
-        exec: async (_command, argv) => ({ code, stderr, killed: false, stdout: argv[0] === 'find'
-          ? '{"results":[],"total":0,"hints":[]}'
-          : argv[0] === 'read' ? '{"results":{"content":"body"},"hints":[]}' : 'updated' }),
+        exec: async (_command, argv) => {
+          if (argv[0] === 'config') return { code: 0, stderr: '', killed: false,
+            stdout: '{"results":{"dir":null,"pi":{"session_summary":false}},"hints":[]}' };
+          if (argv[0] === 'set' || argv[0] === 'task') return { code, stderr, killed: false,
+            stdout: JSON.stringify({ results: { modified: ['note.md'] }, hints: [],
+              effects: { paths: [{ file: 'note.md', state: 'committed' }] } }) };
+          return { code, stderr, killed: false, stdout: argv[0] === 'find'
+            ? '{"results":[],"total":0,"hints":[]}'
+            : argv[0] === 'read' ? '{"results":{"content":"body"},"hints":[]}' : 'updated' };
+        },
         registerTool: (tool) => tools.set(tool.name, tool),
         registerCommand() {}, on() {}, sendMessage() {},
       };
@@ -44,8 +65,8 @@ test('Pi source and offline init tools display successful warnings as separate t
         ['hyalo_find', {}, '{\n  "results": [],\n  "total": 0,\n  "hints": []\n}'],
         ['hyalo_find', { countOnly: true }, '0'],
         ['hyalo_read', { file: 'note.md' }, 'body'],
-        ['hyalo_set', { file: 'note.md', property: 'status=done' }, 'updated'],
-        ['hyalo_task', { file: 'note.md', mode: 'all' }, 'updated'],
+        ['hyalo_set', { file: 'note.md', property: 'status=done' }, '{\n  "modified": [\n    "note.md"\n  ]\n}'],
+        ['hyalo_task', { file: 'note.md', mode: 'all' }, '{\n  "modified": [\n    "note.md"\n  ]\n}'],
       ]) {
         const result = await tools.get(name).execute('id', params);
         assert.deepEqual(result.content, [
@@ -59,5 +80,177 @@ test('Pi source and offline init tools display successful warnings as separate t
       const failed = await tools.get('hyalo_find').execute('id', {});
       assert.equal(failed.content.filter((item) => item.text.includes(stderr)).length, 1);
     }
+  } finally { await fs.rm(scratch, { recursive: true, force: true }); }
+});
+
+test('Pi generic argv normalization and mutation guardrail use observed effects', async () => {
+  const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hyalo-pi-contracts-'));
+  try {
+    const outfile = await bundleSourceExtension(scratch);
+    const tools = new Map();
+    const calls = [];
+    let mode = 'normal';
+    const pi = {
+      exec: async (_command, argv, options) => {
+        calls.push(argv);
+        if (mode === 'timeout') return { code: 2, stdout: '', stderr: '', killed: true };
+        if (mode === 'abort') {
+          assert.equal(options.signal.aborted, true);
+          return { code: 2, stdout: '', stderr: '', killed: true };
+        }
+        if (argv[0] === 'config') return { code: 0, stderr: '', killed: false,
+          stdout: JSON.stringify({ results: { dir: scratch, pi: {} }, hints: [] }) };
+        if (argv[0] === 'lint') return { code: 1, stderr: '', killed: false,
+          stdout: 'note.md:5: HYALO002 completed document has an unchecked task' };
+        if (argv.includes('--internal-mutation-report')) {
+          if (mode === 'unchanged') return { code: 0, stderr: '', killed: false,
+            stdout: JSON.stringify({ results: { modified: [] }, hints: [], effects: {
+              paths: [{ file: 'note.md', state: 'unchanged' }],
+            } }) };
+          if (mode === 'partial') return { code: 1, stdout: '', killed: false,
+            stderr: JSON.stringify({ error: 'finalization failed', category: 'mutation_failure',
+              effects: { paths: [
+                { file: 'note.md', state: 'kept' },
+                { file: 'restored.md', state: 'restored' },
+                { file: '.hyalo-index', state: 'committed' },
+              ] } }) };
+          return { code: 0, stderr: 'authored-frontmatter warning\n', killed: false,
+            stdout: JSON.stringify({ results: { modified: ['note.md'] }, hints: [], effects: {
+              paths: [
+                { file: 'note.md', state: 'committed' },
+                { file: 'restored.md', state: 'restored' },
+                { file: '.hyalo-index', state: 'committed' },
+              ],
+            } }) };
+        }
+        return { code: 0, stderr: 'generic warning\n', killed: false,
+          stdout: '{"results":[],"total":0,"hints":[]}' };
+      },
+      registerTool: (tool) => tools.set(tool.name, tool),
+      registerCommand() {}, on() {}, sendMessage() {},
+    };
+    (await import(pathToFileURL(outfile).href)).default(pi);
+
+    const generic = tools.get('hyalo');
+    await generic.execute('id', { subcommand: 'find',
+      args: ['--format=json', '--jq=.total', '--', '--format=text'] });
+    assert.deepEqual(calls.at(-1), ['find', '--format=json', '--jq=.total', '--', '--format=text']);
+    await generic.execute('id', { subcommand: 'find', args: ['-f', '-odd.md'] });
+    assert.deepEqual(calls.at(-1), ['find', '--format', 'text', '-f', '-odd.md']);
+    await assert.rejects(
+      generic.execute('id', { subcommand: 'find', args: ['--format=json', '--format', 'text'] }),
+      /conflicting duplicate --format options/,
+    );
+
+    const setResult = await tools.get('hyalo_set').execute('id', {
+      file: 'note.md', property: 'status=completed',
+    });
+    assert.equal(setResult.content.filter((item) => item.text.includes('authored-frontmatter warning')).length, 1);
+    assert.equal(setResult.content.filter((item) => item.text.includes('HYALO002')).length, 1);
+    const lintCalls = calls.filter((argv) => argv[0] === 'lint');
+    assert.equal(lintCalls.length, 1);
+    assert.equal(lintCalls[0].at(-1), 'note.md');
+
+    mode = 'partial';
+    const partial = await tools.get('hyalo_set').execute('id', {
+      file: 'requested.md', property: 'status=completed',
+    });
+    assert.match(partial.content.map((item) => item.text).join('\n'), /finalization failed/);
+    assert.match(partial.content.map((item) => item.text).join('\n'), /HYALO002/);
+    assert.equal(calls.filter((argv) => argv[0] === 'lint').at(-1).at(-1), 'note.md');
+
+    mode = 'unchanged';
+    const checksBefore = calls.filter((argv) => argv[0] === 'config' || argv[0] === 'lint').length;
+    await tools.get('hyalo_set').execute('id', { file: 'note.md', property: 'status=completed' });
+    assert.equal(calls.filter((argv) => argv[0] === 'config' || argv[0] === 'lint').length, checksBefore);
+
+    mode = 'timeout';
+    const timedOut = await tools.get('hyalo_find').execute('id', {});
+    assert.match(timedOut.content[0].text, /timed out after 60000ms/);
+    mode = 'abort';
+    const controller = new AbortController(); controller.abort();
+    const aborted = await tools.get('hyalo_find').execute('id', {}, controller.signal);
+    assert.match(aborted.content[0].text, /aborted/);
+  } finally { await fs.rm(scratch, { recursive: true, force: true }); }
+});
+
+test('Pi observed mutation reports unavailable config and retries the lookup', async () => {
+  const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hyalo-pi-config-retry-'));
+  try {
+    const outfile = await bundleSourceExtension(scratch, 'config-retry');
+    const tools = new Map();
+    let configAttempts = 0;
+    let lintCalls = 0;
+    const pi = {
+      exec: async (_command, argv) => {
+        if (argv[0] === 'config') {
+          configAttempts += 1;
+          if (configAttempts === 1) {
+            return { code: 2, stdout: '', stderr: 'temporary config failure', killed: false };
+          }
+          return { code: 0, stderr: '', killed: false,
+            stdout: JSON.stringify({ results: { dir: scratch, pi: {} }, hints: [] }) };
+        }
+        if (argv[0] === 'lint') {
+          lintCalls += 1;
+          return { code: 1, stderr: '', killed: false,
+            stdout: 'note.md:5: HYALO002 completed document has an unchecked task' };
+        }
+        assert.ok(argv.includes('--internal-mutation-report'));
+        return { code: 0, stderr: '', killed: false,
+          stdout: JSON.stringify({ results: { modified: ['note.md'] }, hints: [], effects: {
+            paths: [{ file: 'note.md', state: 'committed' }],
+          } }) };
+      },
+      registerTool: (tool) => tools.set(tool.name, tool),
+      registerCommand() {}, on() {}, sendMessage() {},
+    };
+    (await import(pathToFileURL(outfile).href)).default(pi);
+
+    const first = await tools.get('hyalo_set').execute('id', {
+      file: 'note.md', property: 'status=completed',
+    });
+    const firstText = first.content.map((item) => item.text).join('\n');
+    assert.match(firstText, /write succeeded but its lint status is unknown/);
+    assert.match(firstText, /temporary config failure/);
+    assert.equal(lintCalls, 0);
+
+    const second = await tools.get('hyalo_set').execute('id', {
+      file: 'note.md', property: 'status=completed',
+    });
+    assert.match(second.content.map((item) => item.text).join('\n'), /HYALO002/);
+    assert.equal(configAttempts, 2, 'a transient config failure must not be cached');
+    assert.equal(lintCalls, 1);
+  } finally { await fs.rm(scratch, { recursive: true, force: true }); }
+});
+
+test('Pi typed diagnostics and set guardrail use the real hyalo binary', async () => {
+  const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hyalo-pi-real-'));
+  try {
+    await fs.writeFile(path.join(scratch, '.hyalo.toml'), `dir = "."\n\n[schema.types.note]\nrequired = ["title", "status"]\n\n[schema.types.note.properties.status]\ntype = "enum"\nvalues = ["draft", "completed"]\n\n[lint.rules.HYALO002]\nenabled = true\nseverity = "warning"\n`);
+    await fs.writeFile(path.join(scratch, 'note.md'), '---\ntitle: Guarded\ntype: note\nstatus: draft\n---\n\n- [ ] unfinished\n');
+    await fs.writeFile(path.join(scratch, 'broken.md'), '---\ntitle: [broken\n---\nbody\n');
+    const outfile = await bundleSourceExtension(scratch, 'real');
+    const tools = new Map();
+    const pi = {
+      exec: (_command, argv, options) => new Promise((resolve) => {
+        execFile(binary, argv, { cwd: scratch, signal: options.signal, timeout: options.timeout },
+          (error, stdout, stderr) => resolve({
+            code: typeof error?.code === 'number' ? error.code : error ? 2 : 0,
+            stdout, stderr, killed: error?.killed === true,
+          }));
+      }),
+      registerTool: (tool) => tools.set(tool.name, tool),
+      registerCommand() {}, on() {}, sendMessage() {},
+    };
+    (await import(pathToFileURL(outfile).href)).default(pi);
+    const find = await tools.get('hyalo_find').execute('id', {});
+    assert.equal(find.content.filter((item) => item.text.includes('unparsable frontmatter')).length, 1);
+    const set = await tools.get('hyalo_set').execute('id', {
+      file: 'note.md', property: 'status=completed',
+    });
+    const text = set.content.map((item) => item.text).join('\n');
+    assert.match(text, /HYALO002/);
+    assert.match(await fs.readFile(path.join(scratch, 'note.md'), 'utf8'), /status: completed/);
   } finally { await fs.rm(scratch, { recursive: true, force: true }); }
 });

--- a/pi-extension-e2e.sh
+++ b/pi-extension-e2e.sh
@@ -48,6 +48,12 @@ done
 [[ -f "$PI_PKG/package.json" ]] || fail "could not locate pi package.json from $PI_BIN"
 [[ -f "$PI_PKG/dist/index.d.ts" ]] || fail "pi package at $PI_PKG has no dist/index.d.ts"
 echo "pi package: $PI_PKG ($(node -p "require('$PI_PKG/package.json').version"))"
+PI_VERSION="$($PI_BIN --version)"
+PI_PROVIDER="openrouter"
+PI_MODEL="openai/gpt-5.6-sol"
+PI_THINKING="high"
+PI_MODEL_ARGS=(--provider "$PI_PROVIDER" --model "$PI_MODEL" --thinking "$PI_THINKING")
+echo "live model: provider=$PI_PROVIDER model=$PI_MODEL thinking=$PI_THINKING pi=$PI_VERSION"
 
 [[ -f "$TEMPLATE" ]] || fail "template not found: $TEMPLATE"
 [[ -f "$RUNTIME" ]] || fail "API runtime not found beside template: $RUNTIME"
@@ -102,7 +108,34 @@ EOF
 
 (cd "$WORK" && npm exec --package=typescript@5 -- tsc -p tsconfig.json) \
     || fail "template does not type-check against installed pi ($PI_PKG) — extension API drift"
-echo "type-check OK"
+cat > "$WORK/validate-entry.ts" <<'EOF'
+import extension from "./extensions/extension-hyalo.js";
+import { Value } from "typebox/value";
+const tools = new Map<string, { parameters: unknown }>();
+extension({
+  exec: async () => ({ code: 0, stdout: "", stderr: "", killed: false }),
+  registerTool: (tool: { name: string; parameters: unknown }) => tools.set(tool.name, tool),
+  registerCommand() {}, on() {}, sendMessage() {},
+} as never);
+const valid: Record<string, unknown> = {
+  hyalo: { subcommand: "find", args: ["--count"] },
+  hyalo_find: { property: ["status=planned"], limit: 2 },
+  hyalo_read: { file: "note.md" },
+  hyalo_set: { file: "note.md", property: "status=completed" },
+  hyalo_task: { file: "note.md", mode: "line", lines: [7] },
+};
+for (const [name, value] of Object.entries(valid)) {
+  const tool = tools.get(name);
+  if (!tool || !Value.Check(tool.parameters as never, value)) throw new Error(`${name}: valid fixture rejected`);
+}
+if (Value.Check(tools.get("hyalo_task")!.parameters as never, { file: "note.md", mode: "bogus" })) {
+  throw new Error("hyalo_task: invalid enum accepted");
+}
+EOF
+"$REPO_ROOT/npm/hyalo/node_modules/.bin/esbuild" "$WORK/validate-entry.ts" \
+    --bundle --platform=node --format=esm --outfile="$WORK/validate-entry.mjs" >/dev/null
+node "$WORK/validate-entry.mjs" || fail "real TypeBox schemas rejected expected fixtures"
+echo "type-check and real TypeBox validation OK"
 
 # --- layer 2: live e2e with builtin tools disabled ----------------------
 echo
@@ -110,7 +143,7 @@ echo "== [3/5] live e2e: forcing the hyalo tool (no bash fallback possible) =="
 # Query must return a plain count. Vault contents change, but the term
 # "iteration" always matches in hyalo's own knowledgebase and test vaults
 # that run this script; --count output is a bare number.
-OUT="$(pi -ne --no-builtin-tools -e "$TEMPLATE" -p \
+OUT="$(pi -ne "${PI_MODEL_ARGS[@]}" --no-builtin-tools -e "$TEMPLATE" -p \
     'Call the hyalo tool with subcommand "find" and args ["\"iteration\"", "--count"]. Reply with ONLY the number the tool returned, nothing else.')" \
     || fail "pi run failed (extension may not have loaded — check registerTool/registerCommand API)"
 
@@ -131,7 +164,7 @@ echo
 echo "== [4/5] guardrail e2e: lint findings appended to write result =="
 GUARD_FILE="hyalo-knowledgebase/.pi-e2e-guard.md"
 rm -f "$GUARD_FILE"
-OUT="$(pi -ne -t write -e "$TEMPLATE" -p "Use the write tool to create $GUARD_FILE with exactly this content:
+OUT="$(pi -ne "${PI_MODEL_ARGS[@]}" -t write -e "$TEMPLATE" -p "Use the write tool to create $GUARD_FILE with exactly this content:
 ---
 title: Guardrail test
 ---
@@ -178,7 +211,7 @@ EOF
 run_typed() {
     local label="$1" prompt="$2" needle="$3"
     local out
-    out="$(pi -ne --no-builtin-tools -e "$TEMPLATE" -p "$prompt")" \
+    out="$(pi -ne "${PI_MODEL_ARGS[@]}" --no-builtin-tools -e "$TEMPLATE" -p "$prompt")" \
         || fail "typed tool '$label': pi run failed (tool may not be registered)"
     if ! grep -q "$needle" <<<"$out"; then
         fail "typed tool '$label': expected output containing '$needle', got: $out"
@@ -202,6 +235,65 @@ run_typed hyalo_task \
 grep -q '\[x\]' "$SCRATCH" || fail "hyalo_task ran but no checkbox toggled to [x]"
 rm -rf "$(dirname "$SCRATCH")"
 echo "typed-tool e2e OK: all four typed tools answered structured calls"
+
+# Exact model-backed C10 fixture: the enum accepts `completed`, the write
+# succeeds, and the resulting open task makes HYALO002 visible once through
+# the typed tool's effect-based guardrail.
+LIVE_VAULT="$WORK/live-vault"
+mkdir "$LIVE_VAULT"
+cat > "$LIVE_VAULT/.hyalo.toml" <<'EOF'
+dir = "."
+
+[schema.types.iteration]
+required = ["title", "status"]
+
+[schema.types.iteration.properties.status]
+type = "enum"
+values = ["planned", "in-progress", "completed"]
+
+[lint.rules.HYALO002]
+enabled = true
+severity = "warning"
+EOF
+cat > "$LIVE_VAULT/guarded.md" <<'EOF'
+---
+title: Guarded iteration
+type: iteration
+status: planned
+---
+
+- [ ] unfinished acceptance
+EOF
+LIVE_EVENTS="$WORK/live-guardrail-events.jsonl"
+(cd "$LIVE_VAULT" && pi --mode json --print --no-session --offline --no-extensions --no-skills \
+    "${PI_MODEL_ARGS[@]}" --no-builtin-tools -e "$TEMPLATE" \
+    'Call hyalo_set exactly once with file "guarded.md" and property "status=completed". The write must remain successful. Then reply with the complete tool result verbatim, including any post-write lint warning. Do not call another tool and do not fix the task.' \
+    >"$LIVE_EVENTS") || fail "model-backed typed guardrail run failed"
+OUT="$(node - "$LIVE_EVENTS" <<'NODE'
+const fs = require("node:fs");
+const events = fs.readFileSync(process.argv[2], "utf8").trim().split("\n").map(JSON.parse);
+const end = [...events].reverse().find((event) => event.type === "message_end" && event.message?.role === "assistant");
+if (!end) process.exit(2);
+process.stdout.write(end.message.content.filter((part) => part.type === "text").map((part) => part.text).join("\n"));
+NODE
+)" || fail "could not extract final assistant text from live Pi JSON events"
+grep -q 'status: completed' "$LIVE_VAULT/guarded.md" \
+    || fail "model-backed hyalo_set did not persist the accepted enum value"
+HYALO002_COUNT="$(grep -o 'HYALO002' <<<"$OUT" | wc -l | tr -d '[:space:]')"
+[[ "$HYALO002_COUNT" == "1" ]] \
+    || fail "expected visible HYALO002 exactly once after successful typed write, got $HYALO002_COUNT: $OUT"
+node - "$LIVE_EVENTS" <<'NODE'
+const fs = require("node:fs");
+const events = fs.readFileSync(process.argv[2], "utf8").trim().split("\n").map(JSON.parse);
+const end = [...events].reverse().find((event) => event.type === "message_end" && event.message?.role === "assistant");
+const message = end?.message;
+if (!message?.usage) process.exit(2);
+const usage = message.usage;
+console.log(`model-backed usage: provider=${message.provider} model=${message.model} ` +
+  `input=${usage.input} output=${usage.output} cacheRead=${usage.cacheRead} ` +
+  `cacheWrite=${usage.cacheWrite} reasoning=${usage.reasoning ?? 0} totalTokens=${usage.totalTokens}`);
+NODE
+echo "model-backed typed guardrail OK: successful write retained and HYALO002 visible exactly once"
 
 echo
 echo "PASS: template is compatible with installed pi; generic + typed tools and lint guardrail work"

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -22,7 +22,8 @@ pi install git:github.com/ractive/hyalo@v0.21.0
 (The tag form needs ≥ v0.21.0; earlier release tags predate the root package
 manifest that git installs require.) This registers the `hyalo` extension
 (generic + typed tools: `hyalo_find`,
-`hyalo_read`, `hyalo_set`, `hyalo_task`, and a post-write lint guardrail) plus
+`hyalo_read`, `hyalo_set`, and `hyalo_task`) plus a post-write lint guardrail for
+typed set/task effects and Pi host write/edit events, plus
 the `hyalo` and `hyalo-tidy` skills. A main-HEAD install updates with
 `pi update --extensions`; a pinned-tag install moves only when you re-pin
 with a new `pi install git:…@vX.Y.Z` (pi reconciles pinned refs but never

--- a/pi-package/extensions/hyalo.ts
+++ b/pi-package/extensions/hyalo.ts
@@ -6,11 +6,10 @@ import {
   createPiTransport,
   find as hyaloFind,
   lint as hyaloLint,
+  mutationReport as hyaloMutationReport,
   raw as hyaloRaw,
   read as hyaloRead,
-  set as hyaloSet,
   summary as hyaloSummary,
-  task as hyaloTask,
 } from "../lib/hyalo-api.js";
 
 const HYALO_TIMEOUT_MS = 60_000;
@@ -26,6 +25,18 @@ interface HyaloToolArgs {
   jq?: string;
   /** Path to a snapshot index created with `hyalo create-index` */
   indexFile?: string;
+}
+
+function renderSuccess(text: string, diagnostics: readonly string[] = []) {
+  return {
+    content: [
+      { type: "text" as const, text: text || "(no output)" },
+      ...diagnostics
+        .filter((diagnostic) => diagnostic.length > 0)
+        .map((diagnostic) => ({ type: "text" as const, text: `Stderr:\n${diagnostic}` })),
+    ],
+    details: undefined,
+  };
 }
 
 /**
@@ -59,10 +70,7 @@ async function runHyalo(
       };
     }
 
-    return {
-      content: [{ type: "text" as const, text: stdout || "(no output)" }],
-      details: undefined,
-    };
+    return renderSuccess(stdout, [stderr]);
   } catch (error) {
     return {
       content: [
@@ -83,19 +91,14 @@ async function runTyped(
   try {
     const diagnostics: string[] = [];
     const text = await operation((stderr) => { diagnostics.push(stderr); });
-    return {
-      content: [
-        { type: "text" as const, text: text || "(no output)" },
-        ...diagnostics.map((stderr) => ({ type: "text" as const, text: `Stderr:\n${stderr}` })),
-      ],
-      details: undefined,
-    };
+    return renderSuccess(text, diagnostics);
   } catch (error) {
     const value = error as {
       exitCode?: number;
       stderr?: string;
       stdout?: string;
       message?: string;
+      guardrail?: string;
     };
     if (typeof value.exitCode === "number") {
       return {
@@ -103,6 +106,7 @@ async function runTyped(
           { type: "text" as const, text: `hyalo ${command} failed with exit code ${value.exitCode}` },
           ...(value.stderr ? [{ type: "text" as const, text: `Stderr:\n${value.stderr}` }] : []),
           ...(value.stdout ? [{ type: "text" as const, text: `Stdout:\n${value.stdout}` }] : []),
+          ...(value.guardrail ? [{ type: "text" as const, text: value.guardrail }] : []),
         ],
         details: undefined,
       };
@@ -114,9 +118,32 @@ async function runTyped(
   }
 }
 
-/** Whether the argv already carries a value-taking flag (long or short). */
-function hasFlag(argv: string[], long: string, short?: string): boolean {
-  return argv.includes(long) || (short !== undefined && argv.includes(short));
+/** Values supplied for a long option before the positional `--` terminator. */
+function optionValues(argv: string[], option: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") break;
+    if (arg === option) {
+      const value = argv[index + 1];
+      if (value === undefined || value === "--") {
+        throw new TypeError(`${option} requires a value`);
+      }
+      values.push(value);
+      index += 1;
+    } else if (arg.startsWith(`${option}=`)) {
+      values.push(arg.slice(option.length + 1));
+    }
+  }
+  return values;
+}
+
+function oneOptionValue(argv: string[], option: string): string | undefined {
+  const values = optionValues(argv, option);
+  if (values.length > 1) {
+    throw new TypeError(`conflicting duplicate ${option} options`);
+  }
+  return values[0];
 }
 
 function buildCommand(params: HyaloToolArgs): string[] {
@@ -126,14 +153,26 @@ function buildCommand(params: HyaloToolArgs): string[] {
   // Only inject defaults the caller did not supply themselves: the model
   // often repeats `--format text` from the skill's guidance, and a duplicate
   // `--format` is a hard clap error ("cannot be used multiple times").
-  const hasFormat = hasFlag(extraArgs, "--format", "-f");
-  if (formatText && !jq && !hasFormat) {
+  const rawFormat = oneOptionValue(extraArgs, "--format");
+  const rawJq = oneOptionValue(extraArgs, "--jq");
+  const rawIndexFile = oneOptionValue(extraArgs, "--index-file");
+  if (jq !== undefined && rawJq !== undefined && jq !== rawJq) {
+    throw new TypeError("conflicting --jq values supplied by jq and args");
+  }
+  if (indexFile !== undefined && rawIndexFile !== undefined && indexFile !== rawIndexFile) {
+    throw new TypeError("conflicting --index-file values supplied by indexFile and args");
+  }
+  const effectiveJq = jq ?? rawJq;
+  if (effectiveJq !== undefined && rawFormat !== undefined && rawFormat !== "json") {
+    throw new TypeError("--jq cannot be combined with a non-JSON --format");
+  }
+  if (formatText && effectiveJq === undefined && rawFormat === undefined) {
     cmdArgs.push("--format", "text");
   }
-  if (jq && !hasFlag(extraArgs, "--jq")) {
+  if (jq !== undefined && rawJq === undefined) {
     cmdArgs.push("--jq", jq);
   }
-  if (indexFile && !hasFlag(extraArgs, "--index-file")) {
+  if (indexFile !== undefined && rawIndexFile === undefined) {
     cmdArgs.push("--index-file", indexFile);
   }
   cmdArgs.push(...extraArgs);
@@ -148,49 +187,137 @@ function buildCommand(params: HyaloToolArgs): string[] {
  * The agent sees the findings in the same turn and fixes them immediately
  * — schema drift can no longer land silently. Clean files add nothing.
  *
- * The vault directory is resolved once via `hyalo config` and cached for
- * the session; files outside the vault (or a failed config lookup) skip
- * the check entirely, so non-hyalo projects pay zero cost.
+ * A successfully resolved vault directory is cached for the session. A
+ * failed lookup is reported for a successful observed write and retried on
+ * the next mutation, so a transient config failure cannot disable checks for
+ * the rest of the process.
  */
+type HyaloConfigLookup =
+  | { status: "available"; config: Awaited<ReturnType<typeof hyaloConfig>> }
+  | { status: "unavailable"; text: string };
+
 async function loadHyaloConfig(
   transport: ReturnType<typeof createPiTransport>,
-): Promise<Awaited<ReturnType<typeof hyaloConfig>> | null> {
+): Promise<HyaloConfigLookup> {
   const cached = loadHyaloConfig.cache;
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return { status: "available", config: cached };
   try {
     const resolved = await hyaloConfig({ transport, timeoutMs: 10_000 });
     loadHyaloConfig.cache = resolved;
-    return resolved;
-  } catch {
-    // hyalo not installed or no config: no vault, no guardrail.
-    loadHyaloConfig.cache = null;
-    return null;
+    return { status: "available", config: resolved };
+  } catch (error) {
+    const value = error as { message?: string; stderr?: string };
+    return {
+      status: "unavailable",
+      text: value.stderr?.trim() || value.message || String(error),
+    };
   }
 }
 // Module-level cache slot (survives across event handler invocations).
-loadHyaloConfig.cache = undefined as Awaited<ReturnType<typeof hyaloConfig>> | null | undefined;
+loadHyaloConfig.cache = undefined as Awaited<ReturnType<typeof hyaloConfig>> | undefined;
 
 async function findVaultDir(
   transport: ReturnType<typeof createPiTransport>,
-): Promise<string | null> {
-  return (await loadHyaloConfig(transport))?.vaultDir ?? null;
+): Promise<{ status: "available"; vaultDir: string | null } | { status: "unavailable"; text: string }> {
+  const lookup = await loadHyaloConfig(transport);
+  return lookup.status === "available"
+    ? { status: "available", vaultDir: lookup.config.vaultDir ?? null }
+    : lookup;
 }
+
+type LintGuardResult =
+  | { status: "clean" }
+  | { status: "findings"; text: string }
+  | { status: "unavailable"; text: string };
 
 async function lintVaultFile(
   transport: ReturnType<typeof createPiTransport>,
   filePath: string,
   signal: AbortSignal | undefined,
-): Promise<string | null> {
+): Promise<LintGuardResult> {
   try {
     const { stdout, code } = await hyaloLint(filePath, { transport, signal, timeoutMs: 30_000 });
-    // lint exits 0 = clean, 1 = violations found (stdout holds them),
-    // anything else = lint itself failed: stay silent, don't mask the write.
-    if (code !== 0 && code !== 1) return null;
+    if (code !== 0 && code !== 1) {
+      return { status: "unavailable", text: `hyalo lint exited with code ${code}` };
+    }
     // Clean single-file output is "N file checked, no issues".
-    if (/no issues/.test(stdout)) return null;
-    return stdout.trim();
-  } catch {
-    return null;
+    if (code === 0 && /no issues/.test(stdout)) return { status: "clean" };
+    return { status: "findings", text: stdout.trim() };
+  } catch (error) {
+    return {
+      status: "unavailable",
+      text: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+const SURVIVING_EFFECTS = new Set([
+  "committed",
+  "committed_with_finalization_error",
+  "kept",
+  "restore_failed",
+]);
+
+async function lintMutationEffects(
+  transport: ReturnType<typeof createPiTransport>,
+  effects: { paths?: Array<{ file: string; state: string }> } | undefined,
+  signal: AbortSignal | undefined,
+): Promise<string | null> {
+  if (!effects?.paths) return null;
+  const files = [...new Set(effects.paths
+    .filter((effect) => SURVIVING_EFFECTS.has(effect.state) && effect.file.endsWith(".md"))
+    .map((effect) => effect.file))];
+  if (files.length === 0) return null;
+  const vault = await findVaultDir(transport);
+  if (vault.status === "unavailable") {
+    return `⚠ post-write hyalo lint was unavailable for ${files.join(", ")}; ` +
+      `the write succeeded but its lint status is unknown: unable to resolve the vault: ${vault.text}`;
+  }
+  const vaultDir = vault.vaultDir;
+  if (!vaultDir) return null;
+  const vaultAbs = path.resolve(process.cwd(), vaultDir);
+  const messages: string[] = [];
+  for (const file of files) {
+    const fileAbs = path.resolve(vaultAbs, file);
+    if (fileAbs !== vaultAbs && !fileAbs.startsWith(vaultAbs + path.sep)) continue;
+    const lint = await lintVaultFile(transport, file, signal);
+    if (lint.status === "findings") {
+      messages.push(
+        `⚠ hyalo lint found issues in ${file} (the write succeeded; fix the violations now):\n\n${lint.text}`,
+      );
+    } else if (lint.status === "unavailable") {
+      messages.push(
+        `⚠ post-write hyalo lint was unavailable for ${file}; the write succeeded but its lint status is unknown: ${lint.text}`,
+      );
+    }
+  }
+  return messages.length > 0 ? messages.join("\n\n") : null;
+}
+
+async function runObservedMutation(
+  transport: ReturnType<typeof createPiTransport>,
+  argv: string[],
+  signal: AbortSignal | undefined,
+  onDiagnostics: (stderr: string) => void,
+): Promise<string> {
+  try {
+    const report = await hyaloMutationReport<unknown>(argv, {
+      transport,
+      signal,
+      timeoutMs: HYALO_TIMEOUT_MS,
+      onDiagnostics,
+    });
+    const guardrail = await lintMutationEffects(transport, report.effects, signal);
+    const text = JSON.stringify(report.results, null, 2);
+    return guardrail ? `${text}\n\n${guardrail}` : text;
+  } catch (error) {
+    const value = error as {
+      effects?: { paths?: Array<{ file: string; state: string }> };
+      guardrail?: string;
+    };
+    const guardrail = await lintMutationEffects(transport, value.effects, signal);
+    if (guardrail) value.guardrail = guardrail;
+    throw error;
   }
 }
 
@@ -246,10 +373,8 @@ export default function (pi: ExtensionAPI) {
   });
 
   // --- typed tools -------------------------------------------------------
-  // Structured parameters for the ~80% operations. No argv assembly, no
-  // flag spelling, no quoting — the schema is the interface. All route
-  // through runHyalo, so behavior (timeouts, signals, error rendering) is
-  // identical to the generic tool.
+  // Structured parameters for the common operations. The schema is the
+  // interface; adapters assemble raw argv without involving a shell.
 
   const hyaloFindParams = Type.Object({
     query: Type.Optional(
@@ -363,8 +488,10 @@ export default function (pi: ExtensionAPI) {
     parameters: hyaloSetParams,
     async execute(_toolCallId, params: Static<typeof hyaloSetParams>, signal) {
       return runTyped("set", async (onDiagnostics) => {
-        const result = await hyaloSet({ ...params, transport, signal, onDiagnostics });
-        return result.stdout;
+        const argv = ["set", `--property=${params.property}`];
+        if (params.tag !== undefined) argv.push(`--tag=${params.tag}`);
+        argv.push("--", params.file);
+        return runObservedMutation(transport, argv, signal, onDiagnostics);
       });
     },
   });
@@ -392,16 +519,22 @@ export default function (pi: ExtensionAPI) {
     parameters: hyaloTaskParams,
     async execute(_toolCallId, params: Static<typeof hyaloTaskParams>, signal) {
       return runTyped("task", async (onDiagnostics) => {
-        const result = await hyaloTask({
-          file: params.file,
-          mode: params.mode,
-          section: params.section,
-          lines: params.lines,
-          transport,
-          signal,
-          onDiagnostics,
-        });
-        return result.stdout;
+        const argv = ["task", "toggle"];
+        if (params.mode === "section") {
+          if (params.section === undefined) {
+            throw new TypeError("task mode 'section' requires section");
+          }
+          argv.push(`--section=${params.section}`);
+        } else if (params.mode === "line") {
+          if (!params.lines?.length) {
+            throw new TypeError("task mode 'line' requires at least one line");
+          }
+          argv.push(`--line=${params.lines.map(Math.trunc).join(",")}`);
+        } else {
+          argv.push("--all");
+        }
+        argv.push("--", params.file);
+        return runObservedMutation(transport, argv, signal, onDiagnostics);
       });
     },
   });
@@ -414,8 +547,10 @@ export default function (pi: ExtensionAPI) {
   let summaryInjected = false;
   pi.on("session_start", async () => {
     if (summaryInjected) return;
-    const config = await loadHyaloConfig(transport);
-    if (!config?.sessionSummary || !config.vaultDir) return;
+    const lookup = await loadHyaloConfig(transport);
+    if (lookup.status === "unavailable") return;
+    const config = lookup.config;
+    if (!config.sessionSummary || !config.vaultDir) return;
     summaryInjected = true;
     try {
       const snapshot = await hyaloSummary({ transport, timeoutMs: 30_000 });
@@ -444,7 +579,20 @@ export default function (pi: ExtensionAPI) {
     const rawPath = event.input.path;
     if (typeof rawPath !== "string" || !rawPath.endsWith(".md")) return;
 
-    const vaultDir = await findVaultDir(transport);
+    const vault = await findVaultDir(transport);
+    if (vault.status === "unavailable") {
+      return {
+        content: [
+          ...event.content,
+          {
+            type: "text" as const,
+            text: `⚠ post-write hyalo lint was unavailable for ${rawPath}; ` +
+              `the write succeeded but its lint status is unknown: unable to resolve the vault: ${vault.text}`,
+          },
+        ],
+      };
+    }
+    const vaultDir = vault.vaultDir;
     if (!vaultDir) return;
 
     // Vault membership: normalized absolute path containment check.
@@ -453,17 +601,22 @@ export default function (pi: ExtensionAPI) {
     if (fileAbs !== vaultAbs && !fileAbs.startsWith(vaultAbs + path.sep)) return;
 
     const lintOutput = await lintVaultFile(transport, rawPath, ctx.signal);
-    if (!lintOutput) return; // clean or lint unavailable
+    if (lintOutput.status === "clean") return;
+
+    const relative = path.relative(vaultAbs, fileAbs);
+    const message = lintOutput.status === "findings"
+      ? `⚠ hyalo lint found issues in ${relative} ` +
+        `(write succeeded, but fix the violations now — e.g. 'hyalo set' for ` +
+        `frontmatter, 'hyalo lint --fix' for formatting):\n\n${lintOutput.text}`
+      : `⚠ post-write hyalo lint was unavailable for ${relative}; ` +
+        `the write succeeded but its lint status is unknown: ${lintOutput.text}`;
 
     return {
       content: [
         ...event.content,
         {
           type: "text" as const,
-          text:
-            `⚠ hyalo lint found issues in ${path.relative(vaultAbs, fileAbs)} ` +
-            `(write succeeded, but fix the violations now — e.g. 'hyalo set' for ` +
-            `frontmatter, 'hyalo lint --fix' for formatting):\n\n${lintOutput}`,
+          text: message,
         },
       ],
     };

--- a/pi-package/lib/hyalo-api.d.ts
+++ b/pi-package/lib/hyalo-api.d.ts
@@ -1259,9 +1259,10 @@ type ReadArgs = {
      */
     lines?: string;
     /**
-     * Include the YAML frontmatter in output
+     * Return YAML frontmatter only, or combine it with a body selector
      *
-     * Text output echoes the block's own bytes between its `---` fences —
+     * By itself, this omits the body. Combine with --lines or --section to
+     * return both frontmatter and the selected body. Text output echoes the block's own bytes between its `---` fences —
      * indentation, quote style and comments exactly as on disk; no YAML is
      * re-serialized on a read path. JSON keeps the parsed map under
      * `frontmatter` and adds the raw text as `frontmatter_raw` (null for a

--- a/pi-package/skills/hyalo-tidy/SKILL.md
+++ b/pi-package/skills/hyalo-tidy/SKILL.md
@@ -46,13 +46,19 @@ hyalo summary --format text
 # 2. Create snapshot index (one scan, reused by all subsequent queries)
 hyalo create-index --format text
 
-# 3. Save recurring diagnostic queries as views for reuse
-hyalo views set stale-in-progress --property status=in-progress --fields tasks --format text
-hyalo views set missing-status --property '!status' --format text
-hyalo views set missing-type --property '!type' --format text
-hyalo views set orphans --orphan --fields backlinks --format text
-hyalo views set completed-with-todos --property status=completed --task todo --fields tasks --format text
+# 3. Inspect existing saved views without rewriting configuration
+hyalo views list --format text
+
+# Use a matching saved view when present; otherwise keep diagnostics inline
+hyalo find --property status=in-progress --fields tasks --index --format text
+hyalo find --property '!status' --index --format text
+hyalo find --property '!type' --index --format text
+hyalo find --orphan --fields backlinks --index --format text
+hyalo find --property status=completed --task todo --fields tasks --index --format text
 ```
+
+Do not create or replace saved views during a tidy unless the user explicitly asks;
+the diagnostic phase must leave existing definitions byte-for-byte unchanged.
 
 The snapshot index captures every file's metadata in a binary file (`.hyalo-index`).
 All read-only queries in Phase 2 and Phase 3 should use `--index` to

--- a/pi-package/skills/hyalo/SKILL.md
+++ b/pi-package/skills/hyalo/SKILL.md
@@ -277,9 +277,9 @@ is required.
 
 ### Bulk Status Updates
 ```bash
-# Update all planned iterations older than 30 days to deferred
-hyalo find --property status=planned --property type=iteration --jq '.results | map(select(.properties.date < "2026-06-01")) | map(.file)' \
-  | xargs -I {} hyalo set {} --property status=deferred --format text
+# Preview a native filtered update; rerun without --dry-run after review
+hyalo set --glob 'iterations/*.md' --where-property status=planned \
+  --property status=deferred --dry-run --format text
 ```
 
 ### Health Dashboard


### PR DESCRIPTION
## Summary

Continuation hints now retain the resolved query, selected files, rules and link settings. Bounded raw arguments round-trip through Clap; oversized selections produce advice instead of a broader apply command.

Pi displays successful stderr diagnostics once and uses actual committed effects for typed mutation lint checks, preserving public npm text results. Transient configuration failures report unavailable lint and remain retryable. Help, README and shipped skills describe actual dry-run, read, alias, JSON and resource behavior; executable documentation fixtures check selected files, bytes and CI failure statuses.

## Validation

- Literal formatting, strict workspace Clippy and 5,135 passing workspace tests.
- npm typecheck/build/38 tests, generated asset freshness and actual Pi 0.84.4 live integration with Sol/high and the final release binary.
- Implemented xtask checks and 41 executed jq recipes plus semantic shell fixtures; clean fresh independent Astra review after two repair passes.
- Native Linux/macOS/Windows checks must pass on the final PR head before merge.

Two ignored tests, two existing stub gates and the unavailable MADR recipe are excluded from coverage. Iteration 295 retains jq/resource isolation and the stronger behavioral/scale gates. No whole-vault crash transaction or universal memory cap is claimed.
